### PR TITLE
chore: release v3.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ checksum = "b985e394ee53f8e4c547d5c6fa75b83b243ab6f51563a0323f1475fc8abc8e7f"
 
 [[package]]
 name = "shapely"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "cargo-husky",
  "shapely-core",
@@ -100,11 +100,11 @@ dependencies = [
 
 [[package]]
 name = "shapely-core"
-version = "3.0.0"
+version = "3.0.1"
 
 [[package]]
 name = "shapely-derive"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "shapely-core",
  "unsynn",
@@ -112,14 +112,14 @@ dependencies = [
 
 [[package]]
 name = "shapely-json"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "shapely",
 ]
 
 [[package]]
 name = "shapely-msgpack"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "shapely",
  "shapely-core",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "shapely-pretty"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "shapely",
  "shapely-core",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "shapely-urlencoded"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "form_urlencoded",
  "shapely",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "shapely-yaml"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "shapely",
  "shapely-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shapely", "shapely-core", "shapely-derive", "shapely-json", "shapely
 resolver = "3"
 
 [workspace.package]
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Amos Wenger <amos@bearcove.eu>"]
 edition = "2024"
 rust-version = "1.85"
@@ -22,9 +22,9 @@ keywords = [
 categories = ["encoding", "parsing", "development-tools", "data-structures"]
 
 [workspace.dependencies]
-shapely = { version = "3.0.0", path = "shapely" }
-shapely-core = { version = "3.0.0", path = "shapely-core" }
-shapely-derive = { version = "3.0.0", path = "shapely-derive" }
-shapely-pretty = { version = "3.0.0", path = "shapely-pretty" }
+shapely = { version = "3.0.1", path = "shapely" }
+shapely-core = { version = "3.0.1", path = "shapely-core" }
+shapely-derive = { version = "3.0.1", path = "shapely-derive" }
+shapely-pretty = { version = "3.0.1", path = "shapely-pretty" }
 unsynn = "0.0.25"
 form_urlencoded = "1.2.1"

--- a/shapely-core/CHANGELOG.md
+++ b/shapely-core/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/bearcove/shapely/compare/shapely-core-v3.0.0...shapely-core-v3.0.1) - 2025-03-27
+
+### Other
+
+- Dummy change to test CI speed
+- specific toolchains, reformat code
+- extract shape pretty printing into its own module
+- Improve debug output
+
 ## [3.0.0](https://github.com/bearcove/shapely/compare/shapely-core-v2.0.1...shapely-core-v3.0.0) - 2025-03-11
 
 ### Added

--- a/shapely-json/CHANGELOG.md
+++ b/shapely-json/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/bearcove/shapely/compare/shapely-json-v3.0.0...shapely-json-v3.0.1) - 2025-03-27
+
+### Other
+
+- specific toolchains, reformat code
+- Improve debug output
+- woo
+
 ## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-json-v1.0.0...shapely-json-v2.0.0) - 2025-03-11
 
 ### Other

--- a/shapely-msgpack/CHANGELOG.md
+++ b/shapely-msgpack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/bearcove/shapely/compare/shapely-msgpack-v3.0.0...shapely-msgpack-v3.0.1) - 2025-03-27
+
+### Other
+
+- specific toolchains, reformat code
+
 ## [2.0.1](https://github.com/bearcove/shapely/compare/shapely-msgpack-v2.0.0...shapely-msgpack-v2.0.1) - 2025-03-11
 
 ### Other

--- a/shapely-pretty/CHANGELOG.md
+++ b/shapely-pretty/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/bearcove/shapely/compare/shapely-pretty-v3.0.0...shapely-pretty-v3.0.1) - 2025-03-27
+
+### Other
+
+- specific toolchains, reformat code
+
 ## [3.0.0](https://github.com/bearcove/shapely/compare/shapely-pretty-v2.0.1...shapely-pretty-v3.0.0) - 2025-03-11
 
 ### Added

--- a/shapely-urlencoded/CHANGELOG.md
+++ b/shapely-urlencoded/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/bearcove/shapely/compare/shapely-urlencoded-v3.0.0...shapely-urlencoded-v3.0.1) - 2025-03-27
+
+### Other
+
+- specific toolchains, reformat code
+- Improve debug output
+
 ## [2.0.1](https://github.com/bearcove/shapely/compare/shapely-urlencoded-v2.0.0...shapely-urlencoded-v2.0.1) - 2025-03-11
 
 ### Other

--- a/shapely/CHANGELOG.md
+++ b/shapely/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/bearcove/shapely/compare/shapely-v3.0.0...shapely-v3.0.1) - 2025-03-27
+
+### Other
+
+- set up cargo-husky to run cargo fmt
+- specific toolchains, reformat code
+
 ## [3.0.0](https://github.com/bearcove/shapely/compare/shapely-v2.0.1...shapely-v3.0.0) - 2025-03-11
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `shapely-core`: 3.0.0 -> 3.0.1 (✓ API compatible changes)
* `shapely-derive`: 3.0.0 -> 3.0.1
* `shapely`: 3.0.0 -> 3.0.1 (✓ API compatible changes)
* `shapely-json`: 3.0.0 -> 3.0.1 (✓ API compatible changes)
* `shapely-msgpack`: 3.0.0 -> 3.0.1 (✓ API compatible changes)
* `shapely-pretty`: 3.0.0 -> 3.0.1 (✓ API compatible changes)
* `shapely-urlencoded`: 3.0.0 -> 3.0.1 (✓ API compatible changes)
* `shapely-yaml`: 3.0.0 -> 3.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `shapely-core`

<blockquote>

## [3.0.1](https://github.com/bearcove/shapely/compare/shapely-core-v3.0.0...shapely-core-v3.0.1) - 2025-03-27

### Other

- Dummy change to test CI speed
- specific toolchains, reformat code
- extract shape pretty printing into its own module
- Improve debug output
</blockquote>

## `shapely-derive`

<blockquote>

## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-derive-v1.0.0...shapely-derive-v2.0.0) - 2025-03-11

### Other

- Stub out shapely-yaml
- Simplify Shape name function signature
- Change Shape.name from static str to NameFn
- Stability notes
- link to 'free of syn' campaign
- Ensure no syn dependency (and badge about it), closes #9
- Introduce core crate
- Get rid of debug/display, closes #4
</blockquote>

## `shapely`

<blockquote>

## [3.0.1](https://github.com/bearcove/shapely/compare/shapely-v3.0.0...shapely-v3.0.1) - 2025-03-27

### Other

- set up cargo-husky to run cargo fmt
- specific toolchains, reformat code
</blockquote>

## `shapely-json`

<blockquote>

## [3.0.1](https://github.com/bearcove/shapely/compare/shapely-json-v3.0.0...shapely-json-v3.0.1) - 2025-03-27

### Other

- specific toolchains, reformat code
- Improve debug output
- woo
</blockquote>

## `shapely-msgpack`

<blockquote>

## [3.0.1](https://github.com/bearcove/shapely/compare/shapely-msgpack-v3.0.0...shapely-msgpack-v3.0.1) - 2025-03-27

### Other

- specific toolchains, reformat code
</blockquote>

## `shapely-pretty`

<blockquote>

## [3.0.1](https://github.com/bearcove/shapely/compare/shapely-pretty-v3.0.0...shapely-pretty-v3.0.1) - 2025-03-27

### Other

- specific toolchains, reformat code
</blockquote>

## `shapely-urlencoded`

<blockquote>

## [3.0.1](https://github.com/bearcove/shapely/compare/shapely-urlencoded-v3.0.0...shapely-urlencoded-v3.0.1) - 2025-03-27

### Other

- specific toolchains, reformat code
- Improve debug output
</blockquote>

## `shapely-yaml`

<blockquote>

## [2.0.1](https://github.com/bearcove/shapely/compare/shapely-yaml-v2.0.0...shapely-yaml-v2.0.1) - 2025-03-11

### Other

- Add examples to YAML and MessagePack crates, simplify READMEs, and fix doc tests
- Clippy fixes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).