### PR TITLE
Add facet-toml crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "facet"
 version = "0.1.7"
 dependencies = [
@@ -345,6 +351,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-toml"
+version = "0.1.3"
+dependencies = [
+ "facet-derive",
+ "facet-poke",
+ "facet-trait",
+ "toml_edit",
+]
+
+[[package]]
 name = "facet-trait"
 version = "0.2.3"
 dependencies = [
@@ -427,6 +443,16 @@ name = "impls"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -654,6 +680,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +806,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yaml-rust2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "facet-pretty",
     "facet-samplelibc",
     "facet-spez",
+    "facet-toml",
     "facet-trait",
     "facet-types",
     "facet-yaml",

--- a/facet-toml/Cargo.toml
+++ b/facet-toml/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "facet-toml"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "TOML serialization and deserialization for Facet types"
+keywords = ["toml", "serialization", "deserialization", "reflection", "facet"]
+categories = ["encoding", "parsing", "data-structures"]
+
+[dependencies]
+toml_edit = { version = "0.22.24", default-features = false, features = ["parse"] }
+facet-trait.workspace = true
+facet-poke.workspace = true
+
+[dev-dependencies]
+facet-derive.workspace = true

--- a/facet-toml/README.md
+++ b/facet-toml/README.md
@@ -1,0 +1,45 @@
+
+# facet-toml
+
+[![experimental](https://img.shields.io/badge/status-experimental-yellow)](https://github.com/fasterthanlime/facet)
+[![free of syn](https://img.shields.io/badge/free%20of-syn-hotpink)](https://github.com/fasterthanlime/free-of-syn)
+[![crates.io](https://img.shields.io/crates/v/facet-yaml.svg)](https://crates.io/crates/facet-yaml)
+[![documentation](https://docs.rs/facet-yaml/badge.svg)](https://docs.rs/facet-yaml)
+[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/facet-yaml.svg)](./LICENSE)
+
+Thanks to all individual and corporate sponsors, without whom this work could not exist:
+
+<p> <a href="https://ko-fi.com/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v2/ko-fi-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v2/ko-fi-light.svg" height="40" alt="Ko-fi">
+    </picture>
+</a> <a href="https://github.com/sponsors/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v2/github-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v2/github-light.svg" height="40" alt="GitHub Sponsors">
+    </picture>
+</a> <a href="https://patreon.com/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v2/patreon-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v2/patreon-light.svg" height="40" alt="Patreon">
+    </picture>
+</a> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; <a href="https://zed.dev">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v2/zed-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v2/zed-light.svg" height="40" alt="Zed">
+    </picture>
+</a> </p>
+             
+
+Provides TOML serialization and deserialization for Facet types.
+
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/facet-rs/facet/blob/main/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/facet-rs/facet/blob/main/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/facet-toml/src/lib.rs
+++ b/facet-toml/src/lib.rs
@@ -1,0 +1,106 @@
+#![warn(missing_docs)]
+#![doc = include_str!("../README.md")]
+
+use facet_poke::Poke;
+use facet_trait::{Facet, Opaque, OpaqueConst, ShapeExt};
+use toml_edit::{DocumentMut, Item, TomlError, Value};
+
+#[cfg(test)]
+mod tests;
+
+/// Deserializes a TOML string into a value of type `T` that implements `Facet`.
+pub fn from_str<T: Facet>(toml: &str) -> Result<T, AnyErr> {
+    let (poke, _guard) = Poke::alloc::<T>();
+    let opaque = from_str_opaque(poke, toml)?;
+    Ok(unsafe { opaque.read::<T>() })
+}
+
+/// Any error
+#[derive(Debug, Clone)]
+pub struct AnyErr(String);
+
+impl core::fmt::Display for AnyErr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for AnyErr {}
+
+impl From<String> for AnyErr {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for AnyErr {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+fn toml_to_u64(ty: &Value) -> Result<u64, AnyErr> {
+    match ty {
+        Value::Float(r) => Ok(*r.value() as u64),
+        Value::Integer(i) => Ok(*i.value() as u64),
+        Value::String(s) => s
+            .value()
+            .parse::<u64>()
+            .map_err(|_| AnyErr("Failed to parse string as u64".into())),
+        Value::Boolean(b) => Ok(if *b.value() { 1 } else { 0 }),
+        _ => Err(AnyErr(format!("Cannot convert {} to u64", ty.type_name()))),
+    }
+}
+
+fn from_str_opaque<'mem>(poke: Poke<'mem>, toml: &str) -> Result<Opaque<'mem>, AnyErr> {
+    let docs: DocumentMut = toml.parse().map_err(|e| TomlError::to_string(&e))?;
+    deserialize_item(poke, docs.as_item())
+}
+
+fn deserialize_item<'mem>(poke: Poke<'mem>, value: &Item) -> Result<Opaque<'mem>, AnyErr> {
+    let opaque = match poke {
+        Poke::Scalar(ps) => {
+            if ps.shape().is_type::<u64>() {
+                let v = value
+                    .as_value()
+                    .ok_or_else(|| format!("Expected value, got: {}", value.type_name()))?;
+                let u = toml_to_u64(v)?;
+                let opaque = OpaqueConst::from_ref(&u);
+                unsafe { ps.put(opaque) }
+            } else if ps.shape().is_type::<String>() {
+                let s = value
+                    .as_str()
+                    .ok_or_else(|| AnyErr(format!("Expected string, got: {}", value.type_name())))?
+                    .to_string();
+                let opaque = OpaqueConst::from_ref(&s);
+                let res = unsafe { ps.put(opaque) };
+                core::mem::forget(s);
+                res
+            } else {
+                return Err(format!("Unsupported scalar type: {}", ps.shape()).into());
+            }
+        }
+        Poke::List(_) => todo!(),
+        Poke::Map(_) => todo!(),
+        Poke::Struct(mut ps) => {
+            let table = value.as_table_like().ok_or_else(|| {
+                format!("Expected table like structure, got {}", value.type_name())
+            })?;
+
+            for (k, v) in table.iter() {
+                let (index, field_poke) = ps
+                    .field_by_name(k)
+                    .map_err(|e| format!("Field '{}' error: {}", k, e))?;
+                let _v = deserialize_item(field_poke, v)
+                    .map_err(|e| format!("Error deserializing field '{}': {}", k, e))?;
+                unsafe {
+                    ps.mark_initialized(index);
+                }
+            }
+            ps.build_in_place()
+        }
+        Poke::Enum(_) => todo!(),
+        _ => todo!("unsupported poke type"),
+    };
+    Ok(opaque)
+}

--- a/facet-toml/src/tests.rs
+++ b/facet-toml/src/tests.rs
@@ -1,0 +1,26 @@
+use super::*;
+use facet_derive::Facet;
+use facet_trait as facet;
+
+#[derive(Debug, Facet, PartialEq)]
+struct Person {
+    name: String,
+    age: u64,
+}
+
+#[test]
+fn test_deserialize_person() {
+    let toml = r#"
+            name = "Alice"
+            age = 30
+        "#;
+
+    let person: Person = from_str(toml).expect("Failed to parse TOML");
+    assert_eq!(
+        person,
+        Person {
+            name: "Alice".to_string(),
+            age: 30
+        }
+    );
+}

--- a/facet-toml/templates/README.md.j2
+++ b/facet-toml/templates/README.md.j2
@@ -1,0 +1,5 @@
+{{ header("facet-toml") }}
+
+Provides TOML serialization and deserialization for Facet types.
+
+{{ footer() }}


### PR DESCRIPTION
Almost identical to `facet-yaml`, using the awesome `toml_edit` crate, which also doesn't add any `syn` dependency!

I would like to further flesh out this crate. Should I do that in new PRs, or make this one a draft and implement it here?

What are your thoughts in general on adding different data formats?