### PR TITLE
fix: typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Vec<u8>
   d4 36 93 a5 e9 b9 00 de 6a 3f 64 b8 49 05 3f 22
 ```
 
-And because we can make this decicsion at runtime, it can be an option on the pretty-printer itself:
+And because we can make this decision at runtime, it can be an option on the pretty-printer itself:
 
 ```rust,ignore
 /// A formatter for pretty-printing Facet types

--- a/facet/README.md
+++ b/facet/README.md
@@ -177,7 +177,7 @@ Vec<u8>
   d4 36 93 a5 e9 b9 00 de 6a 3f 64 b8 49 05 3f 22
 ```
 
-And because we can make this decicsion at runtime, it can be an option on the pretty-printer itself:
+And because we can make this decision at runtime, it can be an option on the pretty-printer itself:
 
 ```rust,ignore
 /// A formatter for pretty-printing Facet types

--- a/facet/templates/README.md.j2
+++ b/facet/templates/README.md.j2
@@ -139,7 +139,7 @@ Vec<u8>
   d4 36 93 a5 e9 b9 00 de 6a 3f 64 b8 49 05 3f 22
 ```
 
-And because we can make this decicsion at runtime, it can be an option on the pretty-printer itself:
+And because we can make this decision at runtime, it can be an option on the pretty-printer itself:
 
 ```rust,ignore
 /// A formatter for pretty-printing Facet types

--- a/templates/README.md.j2
+++ b/templates/README.md.j2
@@ -139,7 +139,7 @@ Vec<u8>
   d4 36 93 a5 e9 b9 00 de 6a 3f 64 b8 49 05 3f 22
 ```
 
-And because we can make this decicsion at runtime, it can be an option on the pretty-printer itself:
+And because we can make this decision at runtime, it can be an option on the pretty-printer itself:
 
 ```rust,ignore
 /// A formatter for pretty-printing Facet types


### PR DESCRIPTION
I've found another typo in README.md, which I don't think is covered in #71.