### PR TITLE
Re-jiggle OpaqueConst, Opaque, OpaqueUninit

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,12 @@ let (poke, guard) = Poke::alloc::<FooBar>();
     // inner code: all we have is a `poke` — our function is not generic,
     // `Poke` is not generic.
     let mut poke = poke.into_struct();
-    poke.set_by_name("foo", OpaqueConst::from_ref(&42u64))
+    poke.set_by_name("foo", OpaqueConst::new(&42u64))
         .unwrap();
 
     {
         let bar = String::from("Hello, World!");
-        poke.set_by_name("bar", OpaqueConst::from_ref(&bar))
+        poke.set_by_name("bar", OpaqueConst::new(&bar))
             .unwrap();
         // bar has been moved out of
         core::mem::forget(bar);

--- a/facet-args/src/lib.rs
+++ b/facet-args/src/lib.rs
@@ -10,12 +10,20 @@ fn parse_field(field: Poke, value: &str, field_index: usize, ps: &mut PokeStruct
 
     if field_shape.is_type::<bool>() {
         log::trace!("Boolean field detected, setting to true");
-        unsafe { field.into_value().put(OpaqueConst::from_ref(&true)) };
+        unsafe {
+            field
+                .into_value()
+                .put(OpaqueConst::new(&true as *const bool))
+        };
         unsafe { ps.mark_initialized(field_index) }
     } else if field_shape.is_type::<String>() {
         log::trace!("String field detected");
         let value = value.to_string();
-        unsafe { field.into_value().put(OpaqueConst::from_ref(&value)) };
+        unsafe {
+            field
+                .into_value()
+                .put(OpaqueConst::new(&value as *const String))
+        };
         unsafe { ps.mark_initialized(field_index) };
         std::mem::forget(value);
     } else {

--- a/facet-codegen/src/tuples_impls.rs.j2
+++ b/facet-codegen/src/tuples_impls.rs.j2
@@ -90,8 +90,9 @@ where
                         write!(f, "(")?;
                         {% for i in range(n) %}{% if i > 0 %}write!(f, ", ")?;
                         {% endif %}unsafe {
+                            let ptr = &value.{{ i }} as *const T{{ i }};
                             (T{{ i }}::SHAPE.vtable.debug.unwrap_unchecked())(
-                                OpaqueConst::from_ref(&value.{{ i }}),
+                                OpaqueConst::from_ptr(ptr),
                                 f,
                             )
                         }?;{% endfor %}
@@ -103,20 +104,22 @@ where
                         let b = unsafe { b.as_ref::<{{ type_name }}>() };
 
                         {% for i in range(n) %}{% if i < n-1 %}// Compare element {{ i }}
-                        if !unsafe {
-                            (T{{ i }}::SHAPE.vtable.eq.unwrap_unchecked())(
-                                OpaqueConst::from_ref(&a.{{ i }}),
-                                OpaqueConst::from_ref(&b.{{ i }}),
-                            )
-                        } {
-                            return false;
+                        unsafe {
+                            let a_ptr = &a.{{ i }} as *const T{{ i }};
+                            let b_ptr = &b.{{ i }} as *const T{{ i }};
+                            if !(T{{ i }}::SHAPE.vtable.eq.unwrap_unchecked())(
+                                OpaqueConst::from_ptr(a_ptr),
+                                OpaqueConst::from_ptr(b_ptr),
+                            ) {
+                                return false;
+                            }
                         }
 
                         {% elif i == n-1 %}// Compare last element
                         unsafe {
                             (T{{ i }}::SHAPE.vtable.eq.unwrap_unchecked())(
-                                OpaqueConst::from_ref(&a.{{ i }}),
-                                OpaqueConst::from_ref(&b.{{ i }}),
+                                OpaqueConst::from_ptr(&a.{{ i }} as *const T{{ i }}),
+                                OpaqueConst::from_ptr(&b.{{ i }} as *const T{{ i }}),
                             )
                         }{% endif %}{% endfor %}
                     });

--- a/facet-codegen/src/tuples_impls.rs.j2
+++ b/facet-codegen/src/tuples_impls.rs.j2
@@ -92,7 +92,7 @@ where
                         {% endif %}unsafe {
                             let ptr = &value.{{ i }} as *const T{{ i }};
                             (T{{ i }}::SHAPE.vtable.debug.unwrap_unchecked())(
-                                OpaqueConst::from_ptr(ptr),
+                                OpaqueConst::new(ptr),
                                 f,
                             )
                         }?;{% endfor %}
@@ -108,8 +108,8 @@ where
                             let a_ptr = &a.{{ i }} as *const T{{ i }};
                             let b_ptr = &b.{{ i }} as *const T{{ i }};
                             if !(T{{ i }}::SHAPE.vtable.eq.unwrap_unchecked())(
-                                OpaqueConst::from_ptr(a_ptr),
-                                OpaqueConst::from_ptr(b_ptr),
+                                OpaqueConst::new(a_ptr),
+                                OpaqueConst::new(b_ptr),
                             ) {
                                 return false;
                             }
@@ -118,8 +118,8 @@ where
                         {% elif i == n-1 %}// Compare last element
                         unsafe {
                             (T{{ i }}::SHAPE.vtable.eq.unwrap_unchecked())(
-                                OpaqueConst::from_ptr(&a.{{ i }} as *const T{{ i }}),
-                                OpaqueConst::from_ptr(&b.{{ i }} as *const T{{ i }}),
+                                OpaqueConst::new(&a.{{ i }} as *const T{{ i }}),
+                                OpaqueConst::new(&b.{{ i }} as *const T{{ i }}),
                             )
                         }{% endif %}{% endfor %}
                     });

--- a/facet-core/src/_trait/impls/array_impl.rs
+++ b/facet-core/src/_trait/impls/array_impl.rs
@@ -31,7 +31,7 @@ where
                             write!(f, "[")?;
                             unsafe {
                                 (T::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value[0]),
+                                    OpaqueConst::new(&value[0] as *const T),
                                     f,
                                 )?;
                             }
@@ -44,8 +44,8 @@ where
                             let b = unsafe { b.as_ref::<[T; 1]>() };
                             unsafe {
                                 (T::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a[0]),
-                                    OpaqueConst::from_ref(&b[0]),
+                                    OpaqueConst::new(&a[0] as *const T),
+                                    OpaqueConst::new(&b[0] as *const T),
                                 )
                             }
                         });
@@ -60,7 +60,7 @@ where
                         builder = builder.clone_into(|src, dst| unsafe {
                             let t_cip = T::SHAPE.vtable.clone_into.unwrap_unchecked();
                             (t_cip)(
-                                OpaqueConst::from_ref(&src.as_ref::<[T; 1]>()[0]),
+                                OpaqueConst::new(&src.as_ref::<[T; 1]>()[0] as *const T),
                                 dst.field_uninit(0),
                             )
                         });
@@ -71,8 +71,8 @@ where
                             let b = unsafe { b.as_ref::<[T; 1]>() };
                             unsafe {
                                 (T::SHAPE.vtable.partial_ord.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a[0]),
-                                    OpaqueConst::from_ref(&b[0]),
+                                    OpaqueConst::new(&a[0] as *const T),
+                                    OpaqueConst::new(&b[0] as *const T),
                                 )
                             }
                         });
@@ -83,8 +83,8 @@ where
                             let b = unsafe { b.as_ref::<[T; 1]>() };
                             unsafe {
                                 (T::SHAPE.vtable.ord.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a[0]),
-                                    OpaqueConst::from_ref(&b[0]),
+                                    OpaqueConst::new(&a[0] as *const T),
+                                    OpaqueConst::new(&b[0] as *const T),
                                 )
                             }
                         });
@@ -94,7 +94,7 @@ where
                             let value = unsafe { value.as_ref::<[T; 1]>() };
                             unsafe {
                                 (T::SHAPE.vtable.hash.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value[0]),
+                                    OpaqueConst::new(&value[0] as *const T),
                                     state,
                                     hasher,
                                 )
@@ -120,7 +120,7 @@ where
                                     "Index out of bounds: the len is 1 but the index is {index}"
                                 );
                             }
-                            OpaqueConst::new_unchecked(ptr.as_ptr::<[T; 1]>())
+                            OpaqueConst::new(ptr.as_ptr::<[T; 1]>())
                         })
                         .build()
                         },

--- a/facet-core/src/_trait/impls/hashmap_impl.rs
+++ b/facet-core/src/_trait/impls/hashmap_impl.rs
@@ -71,9 +71,9 @@ where
                                 if i > 0 {
                                     write!(f, ", ")?;
                                 }
-                                (k_debug)(OpaqueConst::from_ref(key), f)?;
+                                (k_debug)(OpaqueConst::new(key as *const _), f)?;
                                 write!(f, ": ")?;
-                                (v_debug)(OpaqueConst::from_ref(val), f)?;
+                                (v_debug)(OpaqueConst::new(val as *const _), f)?;
                             }
                             write!(f, "}}")
                         });
@@ -95,11 +95,11 @@ where
                                 && a.iter().all(|(key_a, val_a)| {
                                     b.get(key_a).is_some_and(|val_b| {
                                         (k_eq)(
-                                            OpaqueConst::from_ref(key_a),
-                                            OpaqueConst::from_ref(key_a),
+                                            OpaqueConst::new(key_a as *const _),
+                                            OpaqueConst::new(key_a as *const _),
                                         ) && (v_eq)(
-                                            OpaqueConst::from_ref(val_a),
-                                            OpaqueConst::from_ref(val_b),
+                                            OpaqueConst::new(val_a as *const _),
+                                            OpaqueConst::new(val_b as *const _),
                                         )
                                     })
                                 })
@@ -115,8 +115,16 @@ where
                             let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
                             map.len().hash(&mut hasher);
                             for (k, v) in map {
-                                (k_hash)(OpaqueConst::from_ref(k), hasher_this, hasher_write_fn);
-                                (v_hash)(OpaqueConst::from_ref(v), hasher_this, hasher_write_fn);
+                                (k_hash)(
+                                    OpaqueConst::new(k as *const _),
+                                    hasher_this,
+                                    hasher_write_fn,
+                                );
+                                (v_hash)(
+                                    OpaqueConst::new(v as *const _),
+                                    hasher_this,
+                                    hasher_write_fn,
+                                );
                             }
                         });
                     }
@@ -154,13 +162,13 @@ where
                                 .get_value_ptr(|ptr, key| unsafe {
                                     let map = ptr.as_ref::<HashMap<K, V>>();
                                     map.get(key.as_ref())
-                                        .map(|v| OpaqueConst::new_unchecked(v as *const _))
+                                        .map(|v| OpaqueConst::new(v as *const _))
                                 })
                                 .iter(|ptr| unsafe {
                                     let map = ptr.as_ref::<HashMap<K, V>>();
                                     let keys: VecDeque<&K> = map.keys().collect();
                                     let iter_state = Box::new(HashMapIterator { map: ptr, keys });
-                                    Opaque::new_unchecked(Box::into_raw(iter_state) as *mut u8)
+                                    Opaque::new(Box::into_raw(iter_state) as *mut u8)
                                 })
                                 .iter_vtable(
                                     MapIterVTable::builder()
@@ -170,10 +178,8 @@ where
                                             while let Some(key) = state.keys.pop_front() {
                                                 if let Some(value) = map.get(key) {
                                                     return Some((
-                                                        OpaqueConst::new_unchecked(key as *const K),
-                                                        OpaqueConst::new_unchecked(
-                                                            value as *const V,
-                                                        ),
+                                                        OpaqueConst::new(key as *const K),
+                                                        OpaqueConst::new(value as *const V),
                                                     ));
                                                 }
                                             }

--- a/facet-core/src/_trait/impls/slice_impl.rs
+++ b/facet-core/src/_trait/impls/slice_impl.rs
@@ -30,7 +30,7 @@ where
                                     "Index out of bounds: the len is {len} but the index is {index}"
                                 );
                             }
-                            OpaqueConst::new_unchecked(slice.as_ptr().add(index))
+                            OpaqueConst::new(slice.as_ptr().add(index))
                         })
                         .build()
                         },
@@ -68,7 +68,7 @@ where
                                 }
                                 unsafe {
                                     (T::SHAPE.vtable.debug.unwrap_unchecked())(
-                                        OpaqueConst::from_ref(item),
+                                        OpaqueConst::new(item as *const _),
                                         f,
                                     )?;
                                 }
@@ -87,8 +87,8 @@ where
                             for (x, y) in a.iter().zip(b.iter()) {
                                 if !unsafe {
                                     (T::SHAPE.vtable.eq.unwrap_unchecked())(
-                                        OpaqueConst::from_ref(x),
-                                        OpaqueConst::from_ref(y),
+                                        OpaqueConst::new(x as *const _),
+                                        OpaqueConst::new(y as *const _),
                                     )
                                 } {
                                     return false;
@@ -105,8 +105,8 @@ where
                             for (x, y) in a.iter().zip(b.iter()) {
                                 let ord = unsafe {
                                     (T::SHAPE.vtable.ord.unwrap_unchecked())(
-                                        OpaqueConst::from_ref(x),
-                                        OpaqueConst::from_ref(y),
+                                        OpaqueConst::new(x as *const _),
+                                        OpaqueConst::new(y as *const _),
                                     )
                                 };
                                 if ord != core::cmp::Ordering::Equal {
@@ -124,8 +124,8 @@ where
                             for (x, y) in a.iter().zip(b.iter()) {
                                 let ord = unsafe {
                                     (T::SHAPE.vtable.partial_ord.unwrap_unchecked())(
-                                        OpaqueConst::from_ref(x),
-                                        OpaqueConst::from_ref(y),
+                                        OpaqueConst::new(x as *const _),
+                                        OpaqueConst::new(y as *const _),
                                     )
                                 };
                                 match ord {
@@ -144,7 +144,7 @@ where
                             for item in value.iter() {
                                 unsafe {
                                     (T::SHAPE.vtable.hash.unwrap_unchecked())(
-                                        OpaqueConst::from_ref(item),
+                                        OpaqueConst::new(item as *const _),
                                         state,
                                         hasher,
                                     )

--- a/facet-core/src/_trait/impls/tuples_impls.rs
+++ b/facet-core/src/_trait/impls/tuples_impls.rs
@@ -71,7 +71,7 @@ where
                             unsafe {
                                 let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -85,8 +85,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(&a.0 as *const T0),
-                                    OpaqueConst::from_ptr(&b.0 as *const T0),
+                                    OpaqueConst::new(&a.0 as *const T0),
+                                    OpaqueConst::new(&b.0 as *const T0),
                                 )
                             }
                         });
@@ -134,7 +134,7 @@ where
                             unsafe {
                                 let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -142,7 +142,7 @@ where
                             unsafe {
                                 let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -158,8 +158,8 @@ where
                                 let a_ptr = &a.0 as *const T0;
                                 let b_ptr = &b.0 as *const T0;
                                 if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -168,8 +168,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(&a.1 as *const T1),
-                                    OpaqueConst::from_ptr(&b.1 as *const T1),
+                                    OpaqueConst::new(&a.1 as *const T1),
+                                    OpaqueConst::new(&b.1 as *const T1),
                                 )
                             }
                         });
@@ -219,7 +219,7 @@ where
                             unsafe {
                                 let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -227,7 +227,7 @@ where
                             unsafe {
                                 let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -235,7 +235,7 @@ where
                             unsafe {
                                 let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -251,8 +251,8 @@ where
                                 let a_ptr = &a.0 as *const T0;
                                 let b_ptr = &b.0 as *const T0;
                                 if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -263,8 +263,8 @@ where
                                 let a_ptr = &a.1 as *const T1;
                                 let b_ptr = &b.1 as *const T1;
                                 if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -273,8 +273,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(&a.2 as *const T2),
-                                    OpaqueConst::from_ptr(&b.2 as *const T2),
+                                    OpaqueConst::new(&a.2 as *const T2),
+                                    OpaqueConst::new(&b.2 as *const T2),
                                 )
                             }
                         });
@@ -341,7 +341,7 @@ where
                             unsafe {
                                 let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -349,7 +349,7 @@ where
                             unsafe {
                                 let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -357,7 +357,7 @@ where
                             unsafe {
                                 let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -365,7 +365,7 @@ where
                             unsafe {
                                 let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -381,8 +381,8 @@ where
                                 let a_ptr = &a.0 as *const T0;
                                 let b_ptr = &b.0 as *const T0;
                                 if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -393,8 +393,8 @@ where
                                 let a_ptr = &a.1 as *const T1;
                                 let b_ptr = &b.1 as *const T1;
                                 if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -405,8 +405,8 @@ where
                                 let a_ptr = &a.2 as *const T2;
                                 let b_ptr = &b.2 as *const T2;
                                 if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -415,8 +415,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(&a.3 as *const T3),
-                                    OpaqueConst::from_ptr(&b.3 as *const T3),
+                                    OpaqueConst::new(&a.3 as *const T3),
+                                    OpaqueConst::new(&b.3 as *const T3),
                                 )
                             }
                         });
@@ -498,7 +498,7 @@ where
                             unsafe {
                                 let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -506,7 +506,7 @@ where
                             unsafe {
                                 let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -514,7 +514,7 @@ where
                             unsafe {
                                 let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -522,7 +522,7 @@ where
                             unsafe {
                                 let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -530,7 +530,7 @@ where
                             unsafe {
                                 let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -546,8 +546,8 @@ where
                                 let a_ptr = &a.0 as *const T0;
                                 let b_ptr = &b.0 as *const T0;
                                 if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -558,8 +558,8 @@ where
                                 let a_ptr = &a.1 as *const T1;
                                 let b_ptr = &b.1 as *const T1;
                                 if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -570,8 +570,8 @@ where
                                 let a_ptr = &a.2 as *const T2;
                                 let b_ptr = &b.2 as *const T2;
                                 if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -582,8 +582,8 @@ where
                                 let a_ptr = &a.3 as *const T3;
                                 let b_ptr = &b.3 as *const T3;
                                 if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -592,8 +592,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(&a.4 as *const T4),
-                                    OpaqueConst::from_ptr(&b.4 as *const T4),
+                                    OpaqueConst::new(&a.4 as *const T4),
+                                    OpaqueConst::new(&b.4 as *const T4),
                                 )
                             }
                         });
@@ -690,7 +690,7 @@ where
                             unsafe {
                                 let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -698,7 +698,7 @@ where
                             unsafe {
                                 let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -706,7 +706,7 @@ where
                             unsafe {
                                 let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -714,7 +714,7 @@ where
                             unsafe {
                                 let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -722,7 +722,7 @@ where
                             unsafe {
                                 let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -730,7 +730,7 @@ where
                             unsafe {
                                 let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -746,8 +746,8 @@ where
                                 let a_ptr = &a.0 as *const T0;
                                 let b_ptr = &b.0 as *const T0;
                                 if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -758,8 +758,8 @@ where
                                 let a_ptr = &a.1 as *const T1;
                                 let b_ptr = &b.1 as *const T1;
                                 if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -770,8 +770,8 @@ where
                                 let a_ptr = &a.2 as *const T2;
                                 let b_ptr = &b.2 as *const T2;
                                 if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -782,8 +782,8 @@ where
                                 let a_ptr = &a.3 as *const T3;
                                 let b_ptr = &b.3 as *const T3;
                                 if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -794,8 +794,8 @@ where
                                 let a_ptr = &a.4 as *const T4;
                                 let b_ptr = &b.4 as *const T4;
                                 if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -804,8 +804,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(&a.5 as *const T5),
-                                    OpaqueConst::from_ptr(&b.5 as *const T5),
+                                    OpaqueConst::new(&a.5 as *const T5),
+                                    OpaqueConst::new(&b.5 as *const T5),
                                 )
                             }
                         });
@@ -908,7 +908,7 @@ where
                             unsafe {
                                 let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -916,7 +916,7 @@ where
                             unsafe {
                                 let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -924,7 +924,7 @@ where
                             unsafe {
                                 let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -932,7 +932,7 @@ where
                             unsafe {
                                 let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -940,7 +940,7 @@ where
                             unsafe {
                                 let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -948,7 +948,7 @@ where
                             unsafe {
                                 let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -956,7 +956,7 @@ where
                             unsafe {
                                 let ptr = &value.6 as *const T6;
                                 (T6::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -972,8 +972,8 @@ where
                                 let a_ptr = &a.0 as *const T0;
                                 let b_ptr = &b.0 as *const T0;
                                 if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -984,8 +984,8 @@ where
                                 let a_ptr = &a.1 as *const T1;
                                 let b_ptr = &b.1 as *const T1;
                                 if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -996,8 +996,8 @@ where
                                 let a_ptr = &a.2 as *const T2;
                                 let b_ptr = &b.2 as *const T2;
                                 if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1008,8 +1008,8 @@ where
                                 let a_ptr = &a.3 as *const T3;
                                 let b_ptr = &b.3 as *const T3;
                                 if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1020,8 +1020,8 @@ where
                                 let a_ptr = &a.4 as *const T4;
                                 let b_ptr = &b.4 as *const T4;
                                 if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1032,8 +1032,8 @@ where
                                 let a_ptr = &a.5 as *const T5;
                                 let b_ptr = &b.5 as *const T5;
                                 if !(T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1042,8 +1042,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T6::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(&a.6 as *const T6),
-                                    OpaqueConst::from_ptr(&b.6 as *const T6),
+                                    OpaqueConst::new(&a.6 as *const T6),
+                                    OpaqueConst::new(&b.6 as *const T6),
                                 )
                             }
                         });
@@ -1153,7 +1153,7 @@ where
                             unsafe {
                                 let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1161,7 +1161,7 @@ where
                             unsafe {
                                 let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1169,7 +1169,7 @@ where
                             unsafe {
                                 let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1177,7 +1177,7 @@ where
                             unsafe {
                                 let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1185,7 +1185,7 @@ where
                             unsafe {
                                 let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1193,7 +1193,7 @@ where
                             unsafe {
                                 let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1201,7 +1201,7 @@ where
                             unsafe {
                                 let ptr = &value.6 as *const T6;
                                 (T6::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1209,7 +1209,7 @@ where
                             unsafe {
                                 let ptr = &value.7 as *const T7;
                                 (T7::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1225,8 +1225,8 @@ where
                                 let a_ptr = &a.0 as *const T0;
                                 let b_ptr = &b.0 as *const T0;
                                 if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1237,8 +1237,8 @@ where
                                 let a_ptr = &a.1 as *const T1;
                                 let b_ptr = &b.1 as *const T1;
                                 if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1249,8 +1249,8 @@ where
                                 let a_ptr = &a.2 as *const T2;
                                 let b_ptr = &b.2 as *const T2;
                                 if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1261,8 +1261,8 @@ where
                                 let a_ptr = &a.3 as *const T3;
                                 let b_ptr = &b.3 as *const T3;
                                 if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1273,8 +1273,8 @@ where
                                 let a_ptr = &a.4 as *const T4;
                                 let b_ptr = &b.4 as *const T4;
                                 if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1285,8 +1285,8 @@ where
                                 let a_ptr = &a.5 as *const T5;
                                 let b_ptr = &b.5 as *const T5;
                                 if !(T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1297,8 +1297,8 @@ where
                                 let a_ptr = &a.6 as *const T6;
                                 let b_ptr = &b.6 as *const T6;
                                 if !(T6::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1307,8 +1307,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T7::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(&a.7 as *const T7),
-                                    OpaqueConst::from_ptr(&b.7 as *const T7),
+                                    OpaqueConst::new(&a.7 as *const T7),
+                                    OpaqueConst::new(&b.7 as *const T7),
                                 )
                             }
                         });
@@ -1424,7 +1424,7 @@ where
                             unsafe {
                                 let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1432,7 +1432,7 @@ where
                             unsafe {
                                 let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1440,7 +1440,7 @@ where
                             unsafe {
                                 let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1448,7 +1448,7 @@ where
                             unsafe {
                                 let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1456,7 +1456,7 @@ where
                             unsafe {
                                 let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1464,7 +1464,7 @@ where
                             unsafe {
                                 let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1472,7 +1472,7 @@ where
                             unsafe {
                                 let ptr = &value.6 as *const T6;
                                 (T6::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1480,7 +1480,7 @@ where
                             unsafe {
                                 let ptr = &value.7 as *const T7;
                                 (T7::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1488,7 +1488,7 @@ where
                             unsafe {
                                 let ptr = &value.8 as *const T8;
                                 (T8::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1504,8 +1504,8 @@ where
                                 let a_ptr = &a.0 as *const T0;
                                 let b_ptr = &b.0 as *const T0;
                                 if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1516,8 +1516,8 @@ where
                                 let a_ptr = &a.1 as *const T1;
                                 let b_ptr = &b.1 as *const T1;
                                 if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1528,8 +1528,8 @@ where
                                 let a_ptr = &a.2 as *const T2;
                                 let b_ptr = &b.2 as *const T2;
                                 if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1540,8 +1540,8 @@ where
                                 let a_ptr = &a.3 as *const T3;
                                 let b_ptr = &b.3 as *const T3;
                                 if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1552,8 +1552,8 @@ where
                                 let a_ptr = &a.4 as *const T4;
                                 let b_ptr = &b.4 as *const T4;
                                 if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1564,8 +1564,8 @@ where
                                 let a_ptr = &a.5 as *const T5;
                                 let b_ptr = &b.5 as *const T5;
                                 if !(T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1576,8 +1576,8 @@ where
                                 let a_ptr = &a.6 as *const T6;
                                 let b_ptr = &b.6 as *const T6;
                                 if !(T6::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1588,8 +1588,8 @@ where
                                 let a_ptr = &a.7 as *const T7;
                                 let b_ptr = &b.7 as *const T7;
                                 if !(T7::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1598,8 +1598,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T8::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(&a.8 as *const T8),
-                                    OpaqueConst::from_ptr(&b.8 as *const T8),
+                                    OpaqueConst::new(&a.8 as *const T8),
+                                    OpaqueConst::new(&b.8 as *const T8),
                                 )
                             }
                         });
@@ -1723,7 +1723,7 @@ where
                             unsafe {
                                 let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1731,7 +1731,7 @@ where
                             unsafe {
                                 let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1739,7 +1739,7 @@ where
                             unsafe {
                                 let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1747,7 +1747,7 @@ where
                             unsafe {
                                 let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1755,7 +1755,7 @@ where
                             unsafe {
                                 let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1763,7 +1763,7 @@ where
                             unsafe {
                                 let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1771,7 +1771,7 @@ where
                             unsafe {
                                 let ptr = &value.6 as *const T6;
                                 (T6::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1779,7 +1779,7 @@ where
                             unsafe {
                                 let ptr = &value.7 as *const T7;
                                 (T7::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1787,7 +1787,7 @@ where
                             unsafe {
                                 let ptr = &value.8 as *const T8;
                                 (T8::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1795,7 +1795,7 @@ where
                             unsafe {
                                 let ptr = &value.9 as *const T9;
                                 (T9::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -1813,8 +1813,8 @@ where
                                 let a_ptr = &a.0 as *const T0;
                                 let b_ptr = &b.0 as *const T0;
                                 if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1825,8 +1825,8 @@ where
                                 let a_ptr = &a.1 as *const T1;
                                 let b_ptr = &b.1 as *const T1;
                                 if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1837,8 +1837,8 @@ where
                                 let a_ptr = &a.2 as *const T2;
                                 let b_ptr = &b.2 as *const T2;
                                 if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1849,8 +1849,8 @@ where
                                 let a_ptr = &a.3 as *const T3;
                                 let b_ptr = &b.3 as *const T3;
                                 if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1861,8 +1861,8 @@ where
                                 let a_ptr = &a.4 as *const T4;
                                 let b_ptr = &b.4 as *const T4;
                                 if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1873,8 +1873,8 @@ where
                                 let a_ptr = &a.5 as *const T5;
                                 let b_ptr = &b.5 as *const T5;
                                 if !(T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1885,8 +1885,8 @@ where
                                 let a_ptr = &a.6 as *const T6;
                                 let b_ptr = &b.6 as *const T6;
                                 if !(T6::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1897,8 +1897,8 @@ where
                                 let a_ptr = &a.7 as *const T7;
                                 let b_ptr = &b.7 as *const T7;
                                 if !(T7::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1909,8 +1909,8 @@ where
                                 let a_ptr = &a.8 as *const T8;
                                 let b_ptr = &b.8 as *const T8;
                                 if !(T8::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -1919,8 +1919,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T9::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(&a.9 as *const T9),
-                                    OpaqueConst::from_ptr(&b.9 as *const T9),
+                                    OpaqueConst::new(&a.9 as *const T9),
+                                    OpaqueConst::new(&b.9 as *const T9),
                                 )
                             }
                         });
@@ -2050,7 +2050,7 @@ where
                             unsafe {
                                 let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2058,7 +2058,7 @@ where
                             unsafe {
                                 let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2066,7 +2066,7 @@ where
                             unsafe {
                                 let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2074,7 +2074,7 @@ where
                             unsafe {
                                 let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2082,7 +2082,7 @@ where
                             unsafe {
                                 let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2090,7 +2090,7 @@ where
                             unsafe {
                                 let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2098,7 +2098,7 @@ where
                             unsafe {
                                 let ptr = &value.6 as *const T6;
                                 (T6::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2106,7 +2106,7 @@ where
                             unsafe {
                                 let ptr = &value.7 as *const T7;
                                 (T7::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2114,7 +2114,7 @@ where
                             unsafe {
                                 let ptr = &value.8 as *const T8;
                                 (T8::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2122,7 +2122,7 @@ where
                             unsafe {
                                 let ptr = &value.9 as *const T9;
                                 (T9::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2130,7 +2130,7 @@ where
                             unsafe {
                                 let ptr = &value.10 as *const T10;
                                 (T10::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2150,8 +2150,8 @@ where
                                 let a_ptr = &a.0 as *const T0;
                                 let b_ptr = &b.0 as *const T0;
                                 if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2162,8 +2162,8 @@ where
                                 let a_ptr = &a.1 as *const T1;
                                 let b_ptr = &b.1 as *const T1;
                                 if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2174,8 +2174,8 @@ where
                                 let a_ptr = &a.2 as *const T2;
                                 let b_ptr = &b.2 as *const T2;
                                 if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2186,8 +2186,8 @@ where
                                 let a_ptr = &a.3 as *const T3;
                                 let b_ptr = &b.3 as *const T3;
                                 if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2198,8 +2198,8 @@ where
                                 let a_ptr = &a.4 as *const T4;
                                 let b_ptr = &b.4 as *const T4;
                                 if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2210,8 +2210,8 @@ where
                                 let a_ptr = &a.5 as *const T5;
                                 let b_ptr = &b.5 as *const T5;
                                 if !(T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2222,8 +2222,8 @@ where
                                 let a_ptr = &a.6 as *const T6;
                                 let b_ptr = &b.6 as *const T6;
                                 if !(T6::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2234,8 +2234,8 @@ where
                                 let a_ptr = &a.7 as *const T7;
                                 let b_ptr = &b.7 as *const T7;
                                 if !(T7::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2246,8 +2246,8 @@ where
                                 let a_ptr = &a.8 as *const T8;
                                 let b_ptr = &b.8 as *const T8;
                                 if !(T8::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2258,8 +2258,8 @@ where
                                 let a_ptr = &a.9 as *const T9;
                                 let b_ptr = &b.9 as *const T9;
                                 if !(T9::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2268,8 +2268,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T10::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(&a.10 as *const T10),
-                                    OpaqueConst::from_ptr(&b.10 as *const T10),
+                                    OpaqueConst::new(&a.10 as *const T10),
+                                    OpaqueConst::new(&b.10 as *const T10),
                                 )
                             }
                         });
@@ -2418,7 +2418,7 @@ where
                             unsafe {
                                 let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2426,7 +2426,7 @@ where
                             unsafe {
                                 let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2434,7 +2434,7 @@ where
                             unsafe {
                                 let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2442,7 +2442,7 @@ where
                             unsafe {
                                 let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2450,7 +2450,7 @@ where
                             unsafe {
                                 let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2458,7 +2458,7 @@ where
                             unsafe {
                                 let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2466,7 +2466,7 @@ where
                             unsafe {
                                 let ptr = &value.6 as *const T6;
                                 (T6::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2474,7 +2474,7 @@ where
                             unsafe {
                                 let ptr = &value.7 as *const T7;
                                 (T7::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2482,7 +2482,7 @@ where
                             unsafe {
                                 let ptr = &value.8 as *const T8;
                                 (T8::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2490,7 +2490,7 @@ where
                             unsafe {
                                 let ptr = &value.9 as *const T9;
                                 (T9::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2498,7 +2498,7 @@ where
                             unsafe {
                                 let ptr = &value.10 as *const T10;
                                 (T10::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2506,7 +2506,7 @@ where
                             unsafe {
                                 let ptr = &value.11 as *const T11;
                                 (T11::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(ptr),
+                                    OpaqueConst::new(ptr),
                                     f,
                                 )
                             }?;
@@ -2526,8 +2526,8 @@ where
                                 let a_ptr = &a.0 as *const T0;
                                 let b_ptr = &b.0 as *const T0;
                                 if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2538,8 +2538,8 @@ where
                                 let a_ptr = &a.1 as *const T1;
                                 let b_ptr = &b.1 as *const T1;
                                 if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2550,8 +2550,8 @@ where
                                 let a_ptr = &a.2 as *const T2;
                                 let b_ptr = &b.2 as *const T2;
                                 if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2562,8 +2562,8 @@ where
                                 let a_ptr = &a.3 as *const T3;
                                 let b_ptr = &b.3 as *const T3;
                                 if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2574,8 +2574,8 @@ where
                                 let a_ptr = &a.4 as *const T4;
                                 let b_ptr = &b.4 as *const T4;
                                 if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2586,8 +2586,8 @@ where
                                 let a_ptr = &a.5 as *const T5;
                                 let b_ptr = &b.5 as *const T5;
                                 if !(T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2598,8 +2598,8 @@ where
                                 let a_ptr = &a.6 as *const T6;
                                 let b_ptr = &b.6 as *const T6;
                                 if !(T6::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2610,8 +2610,8 @@ where
                                 let a_ptr = &a.7 as *const T7;
                                 let b_ptr = &b.7 as *const T7;
                                 if !(T7::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2622,8 +2622,8 @@ where
                                 let a_ptr = &a.8 as *const T8;
                                 let b_ptr = &b.8 as *const T8;
                                 if !(T8::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2634,8 +2634,8 @@ where
                                 let a_ptr = &a.9 as *const T9;
                                 let b_ptr = &b.9 as *const T9;
                                 if !(T9::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2646,8 +2646,8 @@ where
                                 let a_ptr = &a.10 as *const T10;
                                 let b_ptr = &b.10 as *const T10;
                                 if !(T10::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(a_ptr),
-                                    OpaqueConst::from_ptr(b_ptr),
+                                    OpaqueConst::new(a_ptr),
+                                    OpaqueConst::new(b_ptr),
                                 ) {
                                     return false;
                                 }
@@ -2656,8 +2656,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T11::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ptr(&a.11 as *const T11),
-                                    OpaqueConst::from_ptr(&b.11 as *const T11),
+                                    OpaqueConst::new(&a.11 as *const T11),
+                                    OpaqueConst::new(&b.11 as *const T11),
                                 )
                             }
                         });

--- a/facet-core/src/_trait/impls/tuples_impls.rs
+++ b/facet-core/src/_trait/impls/tuples_impls.rs
@@ -69,8 +69,9 @@ where
                             let value = unsafe { value.as_ref::<(T0,)>() };
                             write!(f, "(")?;
                             unsafe {
+                                let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.0),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
@@ -84,8 +85,8 @@ where
                             // Compare last element
                             unsafe {
                                 (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.0),
-                                    OpaqueConst::from_ref(&b.0),
+                                    OpaqueConst::from_ptr(&a.0 as *const T0),
+                                    OpaqueConst::from_ptr(&b.0 as *const T0),
                                 )
                             }
                         });
@@ -131,15 +132,17 @@ where
                             let value = unsafe { value.as_ref::<(T0, T1)>() };
                             write!(f, "(")?;
                             unsafe {
+                                let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.0),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.1),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
@@ -151,20 +154,22 @@ where
                             let b = unsafe { b.as_ref::<(T0, T1)>() };
 
                             // Compare element 0
-                            if !unsafe {
-                                (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.0),
-                                    OpaqueConst::from_ref(&b.0),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.0 as *const T0;
+                                let b_ptr = &b.0 as *const T0;
+                                if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare last element
                             unsafe {
                                 (T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.1),
-                                    OpaqueConst::from_ref(&b.1),
+                                    OpaqueConst::from_ptr(&a.1 as *const T1),
+                                    OpaqueConst::from_ptr(&b.1 as *const T1),
                                 )
                             }
                         });
@@ -212,22 +217,25 @@ where
                             let value = unsafe { value.as_ref::<(T0, T1, T2)>() };
                             write!(f, "(")?;
                             unsafe {
+                                let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.0),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.1),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.2),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
@@ -239,30 +247,34 @@ where
                             let b = unsafe { b.as_ref::<(T0, T1, T2)>() };
 
                             // Compare element 0
-                            if !unsafe {
-                                (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.0),
-                                    OpaqueConst::from_ref(&b.0),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.0 as *const T0;
+                                let b_ptr = &b.0 as *const T0;
+                                if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 1
-                            if !unsafe {
-                                (T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.1),
-                                    OpaqueConst::from_ref(&b.1),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.1 as *const T1;
+                                let b_ptr = &b.1 as *const T1;
+                                if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare last element
                             unsafe {
                                 (T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.2),
-                                    OpaqueConst::from_ref(&b.2),
+                                    OpaqueConst::from_ptr(&a.2 as *const T2),
+                                    OpaqueConst::from_ptr(&b.2 as *const T2),
                                 )
                             }
                         });
@@ -327,29 +339,33 @@ where
                             let value = unsafe { value.as_ref::<(T0, T1, T2, T3)>() };
                             write!(f, "(")?;
                             unsafe {
+                                let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.0),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.1),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.2),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.3),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
@@ -361,40 +377,46 @@ where
                             let b = unsafe { b.as_ref::<(T0, T1, T2, T3)>() };
 
                             // Compare element 0
-                            if !unsafe {
-                                (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.0),
-                                    OpaqueConst::from_ref(&b.0),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.0 as *const T0;
+                                let b_ptr = &b.0 as *const T0;
+                                if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 1
-                            if !unsafe {
-                                (T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.1),
-                                    OpaqueConst::from_ref(&b.1),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.1 as *const T1;
+                                let b_ptr = &b.1 as *const T1;
+                                if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 2
-                            if !unsafe {
-                                (T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.2),
-                                    OpaqueConst::from_ref(&b.2),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.2 as *const T2;
+                                let b_ptr = &b.2 as *const T2;
+                                if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare last element
                             unsafe {
                                 (T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.3),
-                                    OpaqueConst::from_ref(&b.3),
+                                    OpaqueConst::from_ptr(&a.3 as *const T3),
+                                    OpaqueConst::from_ptr(&b.3 as *const T3),
                                 )
                             }
                         });
@@ -474,36 +496,41 @@ where
                             let value = unsafe { value.as_ref::<(T0, T1, T2, T3, T4)>() };
                             write!(f, "(")?;
                             unsafe {
+                                let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.0),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.1),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.2),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.3),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.4),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
@@ -515,50 +542,58 @@ where
                             let b = unsafe { b.as_ref::<(T0, T1, T2, T3, T4)>() };
 
                             // Compare element 0
-                            if !unsafe {
-                                (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.0),
-                                    OpaqueConst::from_ref(&b.0),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.0 as *const T0;
+                                let b_ptr = &b.0 as *const T0;
+                                if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 1
-                            if !unsafe {
-                                (T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.1),
-                                    OpaqueConst::from_ref(&b.1),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.1 as *const T1;
+                                let b_ptr = &b.1 as *const T1;
+                                if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 2
-                            if !unsafe {
-                                (T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.2),
-                                    OpaqueConst::from_ref(&b.2),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.2 as *const T2;
+                                let b_ptr = &b.2 as *const T2;
+                                if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 3
-                            if !unsafe {
-                                (T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.3),
-                                    OpaqueConst::from_ref(&b.3),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.3 as *const T3;
+                                let b_ptr = &b.3 as *const T3;
+                                if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare last element
                             unsafe {
                                 (T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.4),
-                                    OpaqueConst::from_ref(&b.4),
+                                    OpaqueConst::from_ptr(&a.4 as *const T4),
+                                    OpaqueConst::from_ptr(&b.4 as *const T4),
                                 )
                             }
                         });
@@ -653,43 +688,49 @@ where
                             let value = unsafe { value.as_ref::<(T0, T1, T2, T3, T4, T5)>() };
                             write!(f, "(")?;
                             unsafe {
+                                let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.0),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.1),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.2),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.3),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.4),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.5),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
@@ -701,60 +742,70 @@ where
                             let b = unsafe { b.as_ref::<(T0, T1, T2, T3, T4, T5)>() };
 
                             // Compare element 0
-                            if !unsafe {
-                                (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.0),
-                                    OpaqueConst::from_ref(&b.0),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.0 as *const T0;
+                                let b_ptr = &b.0 as *const T0;
+                                if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 1
-                            if !unsafe {
-                                (T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.1),
-                                    OpaqueConst::from_ref(&b.1),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.1 as *const T1;
+                                let b_ptr = &b.1 as *const T1;
+                                if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 2
-                            if !unsafe {
-                                (T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.2),
-                                    OpaqueConst::from_ref(&b.2),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.2 as *const T2;
+                                let b_ptr = &b.2 as *const T2;
+                                if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 3
-                            if !unsafe {
-                                (T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.3),
-                                    OpaqueConst::from_ref(&b.3),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.3 as *const T3;
+                                let b_ptr = &b.3 as *const T3;
+                                if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 4
-                            if !unsafe {
-                                (T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.4),
-                                    OpaqueConst::from_ref(&b.4),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.4 as *const T4;
+                                let b_ptr = &b.4 as *const T4;
+                                if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare last element
                             unsafe {
                                 (T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.5),
-                                    OpaqueConst::from_ref(&b.5),
+                                    OpaqueConst::from_ptr(&a.5 as *const T5),
+                                    OpaqueConst::from_ptr(&b.5 as *const T5),
                                 )
                             }
                         });
@@ -855,50 +906,57 @@ where
                             let value = unsafe { value.as_ref::<(T0, T1, T2, T3, T4, T5, T6)>() };
                             write!(f, "(")?;
                             unsafe {
+                                let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.0),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.1),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.2),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.3),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.4),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.5),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.6 as *const T6;
                                 (T6::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.6),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
@@ -910,70 +968,82 @@ where
                             let b = unsafe { b.as_ref::<(T0, T1, T2, T3, T4, T5, T6)>() };
 
                             // Compare element 0
-                            if !unsafe {
-                                (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.0),
-                                    OpaqueConst::from_ref(&b.0),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.0 as *const T0;
+                                let b_ptr = &b.0 as *const T0;
+                                if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 1
-                            if !unsafe {
-                                (T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.1),
-                                    OpaqueConst::from_ref(&b.1),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.1 as *const T1;
+                                let b_ptr = &b.1 as *const T1;
+                                if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 2
-                            if !unsafe {
-                                (T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.2),
-                                    OpaqueConst::from_ref(&b.2),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.2 as *const T2;
+                                let b_ptr = &b.2 as *const T2;
+                                if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 3
-                            if !unsafe {
-                                (T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.3),
-                                    OpaqueConst::from_ref(&b.3),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.3 as *const T3;
+                                let b_ptr = &b.3 as *const T3;
+                                if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 4
-                            if !unsafe {
-                                (T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.4),
-                                    OpaqueConst::from_ref(&b.4),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.4 as *const T4;
+                                let b_ptr = &b.4 as *const T4;
+                                if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 5
-                            if !unsafe {
-                                (T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.5),
-                                    OpaqueConst::from_ref(&b.5),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.5 as *const T5;
+                                let b_ptr = &b.5 as *const T5;
+                                if !(T5::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare last element
                             unsafe {
                                 (T6::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.6),
-                                    OpaqueConst::from_ref(&b.6),
+                                    OpaqueConst::from_ptr(&a.6 as *const T6),
+                                    OpaqueConst::from_ptr(&b.6 as *const T6),
                                 )
                             }
                         });
@@ -1081,57 +1151,65 @@ where
                                 unsafe { value.as_ref::<(T0, T1, T2, T3, T4, T5, T6, T7)>() };
                             write!(f, "(")?;
                             unsafe {
+                                let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.0),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.1),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.2),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.3),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.4),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.5),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.6 as *const T6;
                                 (T6::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.6),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.7 as *const T7;
                                 (T7::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.7),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
@@ -1143,80 +1221,94 @@ where
                             let b = unsafe { b.as_ref::<(T0, T1, T2, T3, T4, T5, T6, T7)>() };
 
                             // Compare element 0
-                            if !unsafe {
-                                (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.0),
-                                    OpaqueConst::from_ref(&b.0),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.0 as *const T0;
+                                let b_ptr = &b.0 as *const T0;
+                                if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 1
-                            if !unsafe {
-                                (T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.1),
-                                    OpaqueConst::from_ref(&b.1),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.1 as *const T1;
+                                let b_ptr = &b.1 as *const T1;
+                                if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 2
-                            if !unsafe {
-                                (T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.2),
-                                    OpaqueConst::from_ref(&b.2),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.2 as *const T2;
+                                let b_ptr = &b.2 as *const T2;
+                                if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 3
-                            if !unsafe {
-                                (T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.3),
-                                    OpaqueConst::from_ref(&b.3),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.3 as *const T3;
+                                let b_ptr = &b.3 as *const T3;
+                                if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 4
-                            if !unsafe {
-                                (T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.4),
-                                    OpaqueConst::from_ref(&b.4),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.4 as *const T4;
+                                let b_ptr = &b.4 as *const T4;
+                                if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 5
-                            if !unsafe {
-                                (T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.5),
-                                    OpaqueConst::from_ref(&b.5),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.5 as *const T5;
+                                let b_ptr = &b.5 as *const T5;
+                                if !(T5::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 6
-                            if !unsafe {
-                                (T6::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.6),
-                                    OpaqueConst::from_ref(&b.6),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.6 as *const T6;
+                                let b_ptr = &b.6 as *const T6;
+                                if !(T6::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare last element
                             unsafe {
                                 (T7::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.7),
-                                    OpaqueConst::from_ref(&b.7),
+                                    OpaqueConst::from_ptr(&a.7 as *const T7),
+                                    OpaqueConst::from_ptr(&b.7 as *const T7),
                                 )
                             }
                         });
@@ -1330,64 +1422,73 @@ where
                                 unsafe { value.as_ref::<(T0, T1, T2, T3, T4, T5, T6, T7, T8)>() };
                             write!(f, "(")?;
                             unsafe {
+                                let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.0),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.1),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.2),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.3),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.4),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.5),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.6 as *const T6;
                                 (T6::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.6),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.7 as *const T7;
                                 (T7::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.7),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.8 as *const T8;
                                 (T8::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.8),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
@@ -1399,90 +1500,106 @@ where
                             let b = unsafe { b.as_ref::<(T0, T1, T2, T3, T4, T5, T6, T7, T8)>() };
 
                             // Compare element 0
-                            if !unsafe {
-                                (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.0),
-                                    OpaqueConst::from_ref(&b.0),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.0 as *const T0;
+                                let b_ptr = &b.0 as *const T0;
+                                if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 1
-                            if !unsafe {
-                                (T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.1),
-                                    OpaqueConst::from_ref(&b.1),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.1 as *const T1;
+                                let b_ptr = &b.1 as *const T1;
+                                if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 2
-                            if !unsafe {
-                                (T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.2),
-                                    OpaqueConst::from_ref(&b.2),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.2 as *const T2;
+                                let b_ptr = &b.2 as *const T2;
+                                if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 3
-                            if !unsafe {
-                                (T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.3),
-                                    OpaqueConst::from_ref(&b.3),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.3 as *const T3;
+                                let b_ptr = &b.3 as *const T3;
+                                if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 4
-                            if !unsafe {
-                                (T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.4),
-                                    OpaqueConst::from_ref(&b.4),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.4 as *const T4;
+                                let b_ptr = &b.4 as *const T4;
+                                if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 5
-                            if !unsafe {
-                                (T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.5),
-                                    OpaqueConst::from_ref(&b.5),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.5 as *const T5;
+                                let b_ptr = &b.5 as *const T5;
+                                if !(T5::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 6
-                            if !unsafe {
-                                (T6::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.6),
-                                    OpaqueConst::from_ref(&b.6),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.6 as *const T6;
+                                let b_ptr = &b.6 as *const T6;
+                                if !(T6::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 7
-                            if !unsafe {
-                                (T7::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.7),
-                                    OpaqueConst::from_ref(&b.7),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.7 as *const T7;
+                                let b_ptr = &b.7 as *const T7;
+                                if !(T7::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare last element
                             unsafe {
                                 (T8::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.8),
-                                    OpaqueConst::from_ref(&b.8),
+                                    OpaqueConst::from_ptr(&a.8 as *const T8),
+                                    OpaqueConst::from_ptr(&b.8 as *const T8),
                                 )
                             }
                         });
@@ -1604,71 +1721,81 @@ where
                             };
                             write!(f, "(")?;
                             unsafe {
+                                let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.0),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.1),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.2),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.3),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.4),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.5),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.6 as *const T6;
                                 (T6::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.6),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.7 as *const T7;
                                 (T7::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.7),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.8 as *const T8;
                                 (T8::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.8),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.9 as *const T9;
                                 (T9::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.9),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
@@ -1682,100 +1809,118 @@ where
                                 unsafe { b.as_ref::<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)>() };
 
                             // Compare element 0
-                            if !unsafe {
-                                (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.0),
-                                    OpaqueConst::from_ref(&b.0),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.0 as *const T0;
+                                let b_ptr = &b.0 as *const T0;
+                                if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 1
-                            if !unsafe {
-                                (T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.1),
-                                    OpaqueConst::from_ref(&b.1),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.1 as *const T1;
+                                let b_ptr = &b.1 as *const T1;
+                                if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 2
-                            if !unsafe {
-                                (T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.2),
-                                    OpaqueConst::from_ref(&b.2),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.2 as *const T2;
+                                let b_ptr = &b.2 as *const T2;
+                                if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 3
-                            if !unsafe {
-                                (T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.3),
-                                    OpaqueConst::from_ref(&b.3),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.3 as *const T3;
+                                let b_ptr = &b.3 as *const T3;
+                                if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 4
-                            if !unsafe {
-                                (T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.4),
-                                    OpaqueConst::from_ref(&b.4),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.4 as *const T4;
+                                let b_ptr = &b.4 as *const T4;
+                                if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 5
-                            if !unsafe {
-                                (T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.5),
-                                    OpaqueConst::from_ref(&b.5),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.5 as *const T5;
+                                let b_ptr = &b.5 as *const T5;
+                                if !(T5::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 6
-                            if !unsafe {
-                                (T6::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.6),
-                                    OpaqueConst::from_ref(&b.6),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.6 as *const T6;
+                                let b_ptr = &b.6 as *const T6;
+                                if !(T6::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 7
-                            if !unsafe {
-                                (T7::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.7),
-                                    OpaqueConst::from_ref(&b.7),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.7 as *const T7;
+                                let b_ptr = &b.7 as *const T7;
+                                if !(T7::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 8
-                            if !unsafe {
-                                (T8::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.8),
-                                    OpaqueConst::from_ref(&b.8),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.8 as *const T8;
+                                let b_ptr = &b.8 as *const T8;
+                                if !(T8::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare last element
                             unsafe {
                                 (T9::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.9),
-                                    OpaqueConst::from_ref(&b.9),
+                                    OpaqueConst::from_ptr(&a.9 as *const T9),
+                                    OpaqueConst::from_ptr(&b.9 as *const T9),
                                 )
                             }
                         });
@@ -1903,78 +2048,89 @@ where
                             };
                             write!(f, "(")?;
                             unsafe {
+                                let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.0),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.1),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.2),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.3),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.4),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.5),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.6 as *const T6;
                                 (T6::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.6),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.7 as *const T7;
                                 (T7::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.7),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.8 as *const T8;
                                 (T8::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.8),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.9 as *const T9;
                                 (T9::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.9),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.10 as *const T10;
                                 (T10::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.10),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
@@ -1990,110 +2146,130 @@ where
                             };
 
                             // Compare element 0
-                            if !unsafe {
-                                (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.0),
-                                    OpaqueConst::from_ref(&b.0),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.0 as *const T0;
+                                let b_ptr = &b.0 as *const T0;
+                                if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 1
-                            if !unsafe {
-                                (T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.1),
-                                    OpaqueConst::from_ref(&b.1),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.1 as *const T1;
+                                let b_ptr = &b.1 as *const T1;
+                                if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 2
-                            if !unsafe {
-                                (T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.2),
-                                    OpaqueConst::from_ref(&b.2),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.2 as *const T2;
+                                let b_ptr = &b.2 as *const T2;
+                                if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 3
-                            if !unsafe {
-                                (T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.3),
-                                    OpaqueConst::from_ref(&b.3),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.3 as *const T3;
+                                let b_ptr = &b.3 as *const T3;
+                                if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 4
-                            if !unsafe {
-                                (T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.4),
-                                    OpaqueConst::from_ref(&b.4),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.4 as *const T4;
+                                let b_ptr = &b.4 as *const T4;
+                                if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 5
-                            if !unsafe {
-                                (T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.5),
-                                    OpaqueConst::from_ref(&b.5),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.5 as *const T5;
+                                let b_ptr = &b.5 as *const T5;
+                                if !(T5::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 6
-                            if !unsafe {
-                                (T6::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.6),
-                                    OpaqueConst::from_ref(&b.6),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.6 as *const T6;
+                                let b_ptr = &b.6 as *const T6;
+                                if !(T6::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 7
-                            if !unsafe {
-                                (T7::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.7),
-                                    OpaqueConst::from_ref(&b.7),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.7 as *const T7;
+                                let b_ptr = &b.7 as *const T7;
+                                if !(T7::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 8
-                            if !unsafe {
-                                (T8::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.8),
-                                    OpaqueConst::from_ref(&b.8),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.8 as *const T8;
+                                let b_ptr = &b.8 as *const T8;
+                                if !(T8::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 9
-                            if !unsafe {
-                                (T9::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.9),
-                                    OpaqueConst::from_ref(&b.9),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.9 as *const T9;
+                                let b_ptr = &b.9 as *const T9;
+                                if !(T9::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare last element
                             unsafe {
                                 (T10::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.10),
-                                    OpaqueConst::from_ref(&b.10),
+                                    OpaqueConst::from_ptr(&a.10 as *const T10),
+                                    OpaqueConst::from_ptr(&b.10 as *const T10),
                                 )
                             }
                         });
@@ -2240,85 +2416,97 @@ where
                             };
                             write!(f, "(")?;
                             unsafe {
+                                let ptr = &value.0 as *const T0;
                                 (T0::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.0),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.1 as *const T1;
                                 (T1::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.1),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.2 as *const T2;
                                 (T2::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.2),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.3 as *const T3;
                                 (T3::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.3),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.4 as *const T4;
                                 (T4::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.4),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.5 as *const T5;
                                 (T5::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.5),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.6 as *const T6;
                                 (T6::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.6),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.7 as *const T7;
                                 (T7::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.7),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.8 as *const T8;
                                 (T8::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.8),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.9 as *const T9;
                                 (T9::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.9),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.10 as *const T10;
                                 (T10::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.10),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
                             write!(f, ", ")?;
                             unsafe {
+                                let ptr = &value.11 as *const T11;
                                 (T11::SHAPE.vtable.debug.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&value.11),
+                                    OpaqueConst::from_ptr(ptr),
                                     f,
                                 )
                             }?;
@@ -2334,120 +2522,142 @@ where
                             };
 
                             // Compare element 0
-                            if !unsafe {
-                                (T0::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.0),
-                                    OpaqueConst::from_ref(&b.0),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.0 as *const T0;
+                                let b_ptr = &b.0 as *const T0;
+                                if !(T0::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 1
-                            if !unsafe {
-                                (T1::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.1),
-                                    OpaqueConst::from_ref(&b.1),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.1 as *const T1;
+                                let b_ptr = &b.1 as *const T1;
+                                if !(T1::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 2
-                            if !unsafe {
-                                (T2::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.2),
-                                    OpaqueConst::from_ref(&b.2),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.2 as *const T2;
+                                let b_ptr = &b.2 as *const T2;
+                                if !(T2::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 3
-                            if !unsafe {
-                                (T3::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.3),
-                                    OpaqueConst::from_ref(&b.3),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.3 as *const T3;
+                                let b_ptr = &b.3 as *const T3;
+                                if !(T3::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 4
-                            if !unsafe {
-                                (T4::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.4),
-                                    OpaqueConst::from_ref(&b.4),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.4 as *const T4;
+                                let b_ptr = &b.4 as *const T4;
+                                if !(T4::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 5
-                            if !unsafe {
-                                (T5::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.5),
-                                    OpaqueConst::from_ref(&b.5),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.5 as *const T5;
+                                let b_ptr = &b.5 as *const T5;
+                                if !(T5::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 6
-                            if !unsafe {
-                                (T6::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.6),
-                                    OpaqueConst::from_ref(&b.6),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.6 as *const T6;
+                                let b_ptr = &b.6 as *const T6;
+                                if !(T6::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 7
-                            if !unsafe {
-                                (T7::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.7),
-                                    OpaqueConst::from_ref(&b.7),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.7 as *const T7;
+                                let b_ptr = &b.7 as *const T7;
+                                if !(T7::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 8
-                            if !unsafe {
-                                (T8::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.8),
-                                    OpaqueConst::from_ref(&b.8),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.8 as *const T8;
+                                let b_ptr = &b.8 as *const T8;
+                                if !(T8::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 9
-                            if !unsafe {
-                                (T9::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.9),
-                                    OpaqueConst::from_ref(&b.9),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.9 as *const T9;
+                                let b_ptr = &b.9 as *const T9;
+                                if !(T9::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare element 10
-                            if !unsafe {
-                                (T10::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.10),
-                                    OpaqueConst::from_ref(&b.10),
-                                )
-                            } {
-                                return false;
+                            unsafe {
+                                let a_ptr = &a.10 as *const T10;
+                                let b_ptr = &b.10 as *const T10;
+                                if !(T10::SHAPE.vtable.eq.unwrap_unchecked())(
+                                    OpaqueConst::from_ptr(a_ptr),
+                                    OpaqueConst::from_ptr(b_ptr),
+                                ) {
+                                    return false;
+                                }
                             }
 
                             // Compare last element
                             unsafe {
                                 (T11::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(&a.11),
-                                    OpaqueConst::from_ref(&b.11),
+                                    OpaqueConst::from_ptr(&a.11 as *const T11),
+                                    OpaqueConst::from_ptr(&b.11 as *const T11),
                                 )
                             }
                         });

--- a/facet-core/src/_trait/impls/vec_impl.rs
+++ b/facet-core/src/_trait/impls/vec_impl.rs
@@ -37,7 +37,7 @@ where
                                 }
                                 unsafe {
                                     (T::SHAPE.vtable.debug.unwrap_unchecked())(
-                                        OpaqueConst::from_ref(item),
+                                        OpaqueConst::new(item),
                                         f,
                                     )?;
                                 }
@@ -55,8 +55,8 @@ where
                             }
                             for (item_a, item_b) in a.iter().zip(b.iter()) {
                                 if !(T::SHAPE.vtable.eq.unwrap_unchecked())(
-                                    OpaqueConst::from_ref(item_a),
-                                    OpaqueConst::from_ref(item_b),
+                                    OpaqueConst::new(item_a),
+                                    OpaqueConst::new(item_b),
                                 ) {
                                     return false;
                                 }
@@ -73,7 +73,7 @@ where
                             let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
                             vec.len().hash(&mut hasher);
                             for item in vec {
-                                (t_hash)(OpaqueConst::from_ref(item), hasher_this, hasher_write_fn);
+                                (t_hash)(OpaqueConst::new(item), hasher_this, hasher_write_fn);
                             }
                         });
                     }
@@ -118,7 +118,7 @@ where
                                     "Index out of bounds: the len is {len} but the index is {index}"
                                 );
                             }
-                            OpaqueConst::new_unchecked(vec.as_ptr().add(index))
+                            OpaqueConst::new(vec.as_ptr().add(index))
                         })
                         .build()
                         },

--- a/facet-core/src/opaque/mod.rs
+++ b/facet-core/src/opaque/mod.rs
@@ -95,6 +95,16 @@ impl<'mem> OpaqueConst<'mem> {
     ///
     /// # Safety
     ///
+    /// The pointer must be non-null, valid, aligned, and point to initialized memory
+    /// of the correct type, and be valid for lifetime `'mem`.
+    pub unsafe fn from_ptr<T>(ptr: *const T) -> Self {
+        unsafe { Self(NonNull::new_unchecked(ptr as *mut u8), PhantomData) }
+    }
+
+    /// Create a new opaque const pointer from a raw pointer
+    ///
+    /// # Safety
+    ///
     /// The pointer must be valid, aligned, and point to initialized memory
     /// of the correct type, and be valid for lifetime `'mem`.
     pub unsafe fn new_unchecked<T>(ptr: *const T) -> Self {

--- a/facet-json-read/src/deserialize.rs
+++ b/facet-json-read/src/deserialize.rs
@@ -97,51 +97,51 @@ fn deserialize_value<'input, 'mem>(
                         trace!("Deserializing \x1b[1;36mscalar\x1b[0m");
                         let opaque = if pv.shape().is_type::<String>() {
                             let s = parser.parse_string()?;
-                            let data = unsafe { pv.put(OpaqueConst::from_ref(&s)) };
+                            let data = unsafe { pv.put(OpaqueConst::new(&s)) };
                             core::mem::forget(s);
                             data
                         } else if pv.shape().is_type::<bool>() {
                             let b = parser.parse_bool()?;
-                            unsafe { pv.put(OpaqueConst::from_ref(&b)) }
+                            unsafe { pv.put(OpaqueConst::new(&b)) }
                         // Unsigned integers
                         } else if pv.shape().is_type::<u8>() {
                             let n = parser.parse_u64()? as u8;
-                            unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                            unsafe { pv.put(OpaqueConst::new(&n)) }
                         } else if pv.shape().is_type::<u16>() {
                             let n = parser.parse_u64()? as u16;
-                            unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                            unsafe { pv.put(OpaqueConst::new(&n)) }
                         } else if pv.shape().is_type::<u32>() {
                             let n = parser.parse_u64()? as u32;
-                            unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                            unsafe { pv.put(OpaqueConst::new(&n)) }
                         } else if pv.shape().is_type::<u64>() {
                             let n = parser.parse_u64()?;
-                            unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                            unsafe { pv.put(OpaqueConst::new(&n)) }
                         } else if pv.shape().is_type::<u128>() {
                             let n = parser.parse_u64()? as u128;
-                            unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                            unsafe { pv.put(OpaqueConst::new(&n)) }
                         // Signed integers
                         } else if pv.shape().is_type::<i8>() {
                             let n = parser.parse_i64()? as i8;
-                            unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                            unsafe { pv.put(OpaqueConst::new(&n)) }
                         } else if pv.shape().is_type::<i16>() {
                             let n = parser.parse_i64()? as i16;
-                            unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                            unsafe { pv.put(OpaqueConst::new(&n)) }
                         } else if pv.shape().is_type::<i32>() {
                             let n = parser.parse_i64()? as i32;
-                            unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                            unsafe { pv.put(OpaqueConst::new(&n)) }
                         } else if pv.shape().is_type::<i64>() {
                             let n = parser.parse_i64()?;
-                            unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                            unsafe { pv.put(OpaqueConst::new(&n)) }
                         } else if pv.shape().is_type::<i128>() {
                             let n = parser.parse_i64()? as i128;
-                            unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                            unsafe { pv.put(OpaqueConst::new(&n)) }
                         // Floating point
                         } else if pv.shape().is_type::<f32>() {
                             let n = parser.parse_f64()? as f32;
-                            unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                            unsafe { pv.put(OpaqueConst::new(&n)) }
                         } else if pv.shape().is_type::<f64>() {
                             let n = parser.parse_f64()?;
-                            unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                            unsafe { pv.put(OpaqueConst::new(&n)) }
                         } else {
                             panic!("Unknown scalar shape: {}", pv.shape());
                         };
@@ -303,7 +303,7 @@ fn deserialize_value<'input, 'mem>(
                     StackItem::FinishMap { pm } => pm,
                     _ => unreachable!(),
                 };
-                let key_data = Opaque::from_ref(&mut key);
+                let key_data = Opaque::new(&mut key);
                 let value = unsafe { value.assume_init() };
                 unsafe {
                     pm.insert(key_data, value);

--- a/facet-msgpack/src/from_msgpack.rs
+++ b/facet-msgpack/src/from_msgpack.rs
@@ -99,12 +99,12 @@ pub fn from_slice_opaque<'mem>(
                 trace!("Deserializing scalar");
                 if pv.shape().is_type::<String>() {
                     let s = decoder.decode_string()?;
-                    let data = unsafe { pv.put(OpaqueConst::from_ref(&s)) };
+                    let data = unsafe { pv.put(OpaqueConst::new(&s)) };
                     core::mem::forget(s);
                     data
                 } else if pv.shape().is_type::<u64>() {
                     let n = decoder.decode_u64()?;
-                    unsafe { pv.put(OpaqueConst::from_ref(&n)) }
+                    unsafe { pv.put(OpaqueConst::new(&n)) }
                 } else {
                     todo!("Unsupported scalar type: {}", pv.shape())
                 }

--- a/facet-peek/src/lib.rs
+++ b/facet-peek/src/lib.rs
@@ -57,7 +57,7 @@ impl<'mem> Peek<'mem> {
     pub fn new<S: Facet>(s: &'mem S) -> Self {
         // This is safe because we're creating an Opaque pointer to read-only data
         // The pointer will be valid for the lifetime 'mem
-        let data = OpaqueConst::from_ref(s);
+        let data = OpaqueConst::new(s);
         unsafe { Self::unchecked_new(data, S::SHAPE) }
     }
 

--- a/facet-peek/src/map.rs
+++ b/facet-peek/src/map.rs
@@ -70,7 +70,7 @@ impl<'mem> PeekMap<'mem> {
     /// Check if the map contains a key
     pub fn contains_key(&self, key: &impl facet_core::Facet) -> bool {
         unsafe {
-            let key_ptr = OpaqueConst::from_ref(key);
+            let key_ptr = OpaqueConst::new(key);
             (self.def.vtable.contains_key_fn)(self.value.data(), key_ptr)
         }
     }
@@ -78,7 +78,7 @@ impl<'mem> PeekMap<'mem> {
     /// Get a value from the map for the given key
     pub fn get<'k>(&self, key: &'k impl facet_core::Facet) -> Option<Peek<'mem>> {
         unsafe {
-            let key_ptr = OpaqueConst::from_ref(key);
+            let key_ptr = OpaqueConst::new(key);
             let value_ptr = (self.def.vtable.get_value_ptr_fn)(self.value.data(), key_ptr)?;
             Some(Peek::unchecked_new(value_ptr, self.def.v))
         }

--- a/facet-peek/src/value.rs
+++ b/facet-peek/src/value.rs
@@ -206,7 +206,7 @@ impl<'mem> PeekValue<'mem> {
     pub fn hash<H: core::hash::Hasher>(&self, hasher: &mut H) -> bool {
         unsafe {
             if let Some(hash_fn) = self.shape.vtable.hash {
-                let hasher_opaque = Opaque::from_ref(hasher);
+                let hasher_opaque = Opaque::new(hasher);
                 hash_fn(self.data, hasher_opaque, |opaque, bytes| {
                     opaque.as_mut::<H>().write(bytes)
                 });

--- a/facet-poke/src/enum_.rs
+++ b/facet-poke/src/enum_.rs
@@ -73,7 +73,7 @@ impl<'mem> PokeEnumNoVariant<'mem> {
         // Prepare memory for the enum
         unsafe {
             // Zero out the memory first to ensure clean state
-            core::ptr::write_bytes(self.data.as_mut_ptr(), 0, self.shape.layout.size());
+            core::ptr::write_bytes(self.data.as_mut_bytes(), 0, self.shape.layout.size());
 
             // Set up the discriminant (tag)
             // For enums in Rust, the first bytes contain the discriminant
@@ -87,58 +87,58 @@ impl<'mem> PokeEnumNoVariant<'mem> {
             // Write the discriminant value based on the representation
             match self.def.repr {
                 EnumRepr::U8 => {
-                    let tag_ptr = self.data.as_mut_ptr();
+                    let tag_ptr = self.data.as_mut_bytes();
                     *tag_ptr = discriminant_value as u8;
                 }
                 EnumRepr::U16 => {
-                    let tag_ptr = self.data.as_mut_ptr() as *mut u16;
+                    let tag_ptr = self.data.as_mut_bytes() as *mut u16;
                     *tag_ptr = discriminant_value as u16;
                 }
                 EnumRepr::U32 => {
-                    let tag_ptr = self.data.as_mut_ptr() as *mut u32;
+                    let tag_ptr = self.data.as_mut_bytes() as *mut u32;
                     *tag_ptr = discriminant_value as u32;
                 }
                 EnumRepr::U64 => {
-                    let tag_ptr = self.data.as_mut_ptr() as *mut u64;
+                    let tag_ptr = self.data.as_mut_bytes() as *mut u64;
                     *tag_ptr = discriminant_value as u64;
                 }
                 EnumRepr::USize => {
-                    let tag_ptr = self.data.as_mut_ptr() as *mut usize;
+                    let tag_ptr = self.data.as_mut_bytes() as *mut usize;
                     *tag_ptr = discriminant_value as usize;
                 }
                 EnumRepr::I8 => {
-                    let tag_ptr = self.data.as_mut_ptr() as *mut i8;
+                    let tag_ptr = self.data.as_mut_bytes() as *mut i8;
                     *tag_ptr = discriminant_value as i8;
                 }
                 EnumRepr::I16 => {
-                    let tag_ptr = self.data.as_mut_ptr() as *mut i16;
+                    let tag_ptr = self.data.as_mut_bytes() as *mut i16;
                     *tag_ptr = discriminant_value as i16;
                 }
                 EnumRepr::I32 => {
-                    let tag_ptr = self.data.as_mut_ptr() as *mut i32;
+                    let tag_ptr = self.data.as_mut_bytes() as *mut i32;
                     *tag_ptr = discriminant_value as i32;
                 }
                 EnumRepr::I64 => {
-                    let tag_ptr = self.data.as_mut_ptr() as *mut i64;
+                    let tag_ptr = self.data.as_mut_bytes() as *mut i64;
                     *tag_ptr = discriminant_value;
                 }
                 EnumRepr::ISize => {
-                    let tag_ptr = self.data.as_mut_ptr() as *mut isize;
+                    let tag_ptr = self.data.as_mut_bytes() as *mut isize;
                     *tag_ptr = discriminant_value as isize;
                 }
                 EnumRepr::Default => {
                     // Use a heuristic based on the number of variants
                     if self.def.variants.len() <= 256 {
                         // Can fit in a u8
-                        let tag_ptr = self.data.as_mut_ptr();
+                        let tag_ptr = self.data.as_mut_bytes();
                         *tag_ptr = discriminant_value as u8;
                     } else if self.def.variants.len() <= 65536 {
                         // Can fit in a u16
-                        let tag_ptr = self.data.as_mut_ptr() as *mut u16;
+                        let tag_ptr = self.data.as_mut_bytes() as *mut u16;
                         *tag_ptr = discriminant_value as u16;
                     } else {
                         // Default to u32
-                        let tag_ptr = self.data.as_mut_ptr() as *mut u32;
+                        let tag_ptr = self.data.as_mut_bytes() as *mut u32;
                         *tag_ptr = discriminant_value as u32;
                     }
                 }
@@ -298,7 +298,7 @@ impl<'mem> PokeEnum<'mem> {
         self.assert_matching_shape::<T>();
 
         let result = unsafe {
-            let ptr = self.data.as_ptr() as *const T;
+            let ptr = self.data.as_bytes() as *const T;
             core::ptr::read(ptr)
         };
         core::mem::forget(self);
@@ -316,7 +316,7 @@ impl<'mem> PokeEnum<'mem> {
         self.assert_all_fields_initialized();
         self.assert_matching_shape::<T>();
 
-        let boxed = unsafe { Box::from_raw(self.data.as_mut_ptr() as *mut T) };
+        let boxed = unsafe { Box::from_raw(self.data.as_mut_bytes() as *mut T) };
         core::mem::forget(self);
         boxed
     }
@@ -333,7 +333,7 @@ impl<'mem> PokeEnum<'mem> {
         self.assert_all_fields_initialized();
         unsafe {
             core::ptr::copy_nonoverlapping(
-                self.data.as_mut_ptr(),
+                self.data.as_mut_bytes(),
                 target.as_ptr(),
                 self.shape.layout.size(),
             );

--- a/facet-poke/src/lib.rs
+++ b/facet-poke/src/lib.rs
@@ -60,7 +60,7 @@ impl<'mem> Poke<'mem> {
         let data = S::SHAPE.allocate();
         let layout = Layout::new::<S>();
         let guard = Guard {
-            ptr: data.as_mut_ptr(),
+            ptr: data.as_mut_bytes(),
             layout,
             shape: S::SHAPE,
         };
@@ -73,7 +73,7 @@ impl<'mem> Poke<'mem> {
         let data = shape.allocate();
         let layout = shape.layout;
         let guard = Guard {
-            ptr: data.as_mut_ptr(),
+            ptr: data.as_mut_bytes(),
             layout,
             shape,
         };

--- a/facet-poke/src/struct_.rs
+++ b/facet-poke/src/struct_.rs
@@ -90,7 +90,7 @@ impl<'mem> PokeStruct<'mem> {
         }
 
         let result = unsafe {
-            let ptr = this.data.as_mut_ptr() as *const T;
+            let ptr = this.data.as_mut_bytes() as *const T;
             core::ptr::read(ptr)
         };
         guard.take(); // dealloc
@@ -109,7 +109,7 @@ impl<'mem> PokeStruct<'mem> {
         self.assert_all_fields_initialized();
         self.shape.assert_type::<T>();
 
-        let boxed = unsafe { Box::from_raw(self.data.as_mut_ptr() as *mut T) };
+        let boxed = unsafe { Box::from_raw(self.data.as_mut_bytes() as *mut T) };
         core::mem::forget(self);
         boxed
     }
@@ -130,7 +130,7 @@ impl<'mem> PokeStruct<'mem> {
 
         unsafe {
             core::ptr::copy_nonoverlapping(
-                self.data.as_mut_ptr(),
+                self.data.as_mut_bytes(),
                 target.as_ptr(),
                 self.shape.layout.size(),
             );
@@ -197,7 +197,7 @@ impl<'mem> PokeStruct<'mem> {
         unsafe {
             core::ptr::copy_nonoverlapping(
                 value.as_ptr(),
-                self.data.field_uninit(field.offset).as_mut_ptr(),
+                self.data.field_uninit(field.offset).as_mut_bytes(),
                 field_shape.layout.size(),
             );
             self.iset.set(index);
@@ -251,7 +251,7 @@ impl<'mem> PokeStruct<'mem> {
         field_shape.assert_type::<T>();
 
         unsafe {
-            let opaque = OpaqueConst::from_ref(&value);
+            let opaque = OpaqueConst::new(&value);
             let result = self.unchecked_set(index, opaque);
             if result.is_ok() {
                 core::mem::forget(value);

--- a/facet-poke/src/value.rs
+++ b/facet-poke/src/value.rs
@@ -96,7 +96,7 @@ impl<'mem> PokeValue<'mem> {
         unsafe {
             core::ptr::copy_nonoverlapping(
                 source.as_ptr(),
-                self.data.as_mut_ptr(),
+                self.data.as_mut_bytes(),
                 self.shape.layout.size(),
             );
             self.data.assume_init()

--- a/facet-poke/tests/poke_test.rs
+++ b/facet-poke/tests/poke_test.rs
@@ -29,14 +29,14 @@ fn build_foobar_through_reflection() {
     let (poke, guard) = Poke::alloc::<FooBar>();
     let mut poke = poke.into_struct();
     unsafe {
-        poke.unchecked_set_by_name("foo", OpaqueConst::from_ref(&42u64))
+        poke.unchecked_set_by_name("foo", OpaqueConst::new(&42u64))
             .unwrap();
     }
 
     {
         let bar = String::from("Hello, World!");
         unsafe {
-            poke.unchecked_set_by_name("bar", OpaqueConst::from_ref(&bar))
+            poke.unchecked_set_by_name("bar", OpaqueConst::new(&bar))
                 .unwrap();
         }
         // bar has been moved out of
@@ -64,7 +64,7 @@ fn build_foobar_incomplete() {
     let (poke, guard) = Poke::alloc::<FooBar>();
     let mut poke = poke.into_struct();
     unsafe {
-        poke.unchecked_set_by_name("foo", OpaqueConst::from_ref(&42u64))
+        poke.unchecked_set_by_name("foo", OpaqueConst::new(&42u64))
             .unwrap();
     }
 
@@ -98,7 +98,7 @@ fn build_foobar_after_default() {
     {
         let bar = String::from("Hello, World!");
         unsafe {
-            poke.unchecked_set_by_name("bar", OpaqueConst::from_ref(&bar))
+            poke.unchecked_set_by_name("bar", OpaqueConst::new(&bar))
                 .unwrap();
         }
         // bar has been moved out of
@@ -880,7 +880,7 @@ fn build_u64_properly() {
 
     let (poke, _guard) = Poke::alloc::<u64>();
     let poke = poke.into_scalar();
-    let data = unsafe { poke.put(OpaqueConst::from_ref(&42u64)) };
+    let data = unsafe { poke.put(OpaqueConst::new(&42u64)) };
     let value = unsafe { data.read::<u64>() };
 
     // Verify the value was set correctly

--- a/facet-samplelibc/src/lib.rs
+++ b/facet-samplelibc/src/lib.rs
@@ -8,7 +8,7 @@ unsafe extern "C" {
 }
 
 pub fn get_foo_and_shape() -> (Opaque<'static>, &'static Shape) {
-    (unsafe { Opaque::new_unchecked(get_foo()) }, Foo::SHAPE)
+    (unsafe { Opaque::new(get_foo()) }, Foo::SHAPE)
 }
 
 pub fn print_global_foo() {

--- a/facet-toml/src/lib.rs
+++ b/facet-toml/src/lib.rs
@@ -65,14 +65,14 @@ fn deserialize_item<'mem>(poke: Poke<'mem>, value: &Item) -> Result<Opaque<'mem>
                     .as_value()
                     .ok_or_else(|| format!("Expected value, got: {}", value.type_name()))?;
                 let u = toml_to_u64(v)?;
-                let opaque = OpaqueConst::from_ref(&u);
+                let opaque = OpaqueConst::new(&u);
                 unsafe { ps.put(opaque) }
             } else if ps.shape().is_type::<String>() {
                 let s = value
                     .as_str()
                     .ok_or_else(|| AnyErr(format!("Expected string, got: {}", value.type_name())))?
                     .to_string();
-                let opaque = OpaqueConst::from_ref(&s);
+                let opaque = OpaqueConst::new(&s);
                 let res = unsafe { ps.put(opaque) };
                 core::mem::forget(s);
                 res

--- a/facet-urlencoded/src/lib.rs
+++ b/facet-urlencoded/src/lib.rs
@@ -230,13 +230,13 @@ fn deserialize_scalar_field<'mem>(
         Poke::Scalar(ps_scalar) => {
             if ps_scalar.shape().is_type::<String>() {
                 let s = value.to_string();
-                let opaque = OpaqueConst::from_ref(&s);
+                let opaque = OpaqueConst::new(&s);
                 unsafe { ps_scalar.put(opaque) };
                 core::mem::forget(s);
             } else if ps_scalar.shape().is_type::<u64>() {
                 match value.parse::<u64>() {
                     Ok(num) => {
-                        let opaque = OpaqueConst::from_ref(&num);
+                        let opaque = OpaqueConst::new(&num);
                         unsafe { ps_scalar.put(opaque) };
                     }
                     Err(_) => {

--- a/facet-yaml/src/lib.rs
+++ b/facet-yaml/src/lib.rs
@@ -80,14 +80,14 @@ fn deserialize_value<'mem>(poke: Poke<'mem>, value: &Yaml) -> Result<Opaque<'mem
         Poke::Scalar(ps) => {
             if ps.shape().is_type::<u64>() {
                 let u = yaml_to_u64(value)?;
-                let opaque = OpaqueConst::from_ref(&u);
+                let opaque = OpaqueConst::new(&u);
                 unsafe { ps.put(opaque) }
             } else if ps.shape().is_type::<String>() {
                 let s = value
                     .as_str()
                     .ok_or_else(|| AnyErr(format!("Expected string, got: {}", yaml_type(value))))?
                     .to_string();
-                let opaque = OpaqueConst::from_ref(&s);
+                let opaque = OpaqueConst::new(&s);
                 let res = unsafe { ps.put(opaque) };
                 core::mem::forget(s);
                 res

--- a/facet/README.md
+++ b/facet/README.md
@@ -224,12 +224,12 @@ let (poke, guard) = Poke::alloc::<FooBar>();
     // inner code: all we have is a `poke` — our function is not generic,
     // `Poke` is not generic.
     let mut poke = poke.into_struct();
-    poke.set_by_name("foo", OpaqueConst::from_ref(&42u64))
+    poke.set_by_name("foo", OpaqueConst::new(&42u64))
         .unwrap();
 
     {
         let bar = String::from("Hello, World!");
-        poke.set_by_name("bar", OpaqueConst::from_ref(&bar))
+        poke.set_by_name("bar", OpaqueConst::new(&bar))
             .unwrap();
         // bar has been moved out of
         core::mem::forget(bar);

--- a/facet/src/hacking/hacking.md
+++ b/facet/src/hacking/hacking.md
@@ -106,8 +106,8 @@ fn create_array_shape<T: Facet>() {
                 let b = unsafe { b.as_ref::<[T; 1]>() };
                 unsafe {
                     (T::SHAPE.vtable.partial_ord.unwrap_unchecked())(
-                        OpaqueConst::from_ref(&a[0]),
-                        OpaqueConst::from_ref(&b[0]),
+                        OpaqueConst::new(&a[0]),
+                        OpaqueConst::new(&b[0]),
                     )
                 }
             })

--- a/facet/templates/README.md.j2
+++ b/facet/templates/README.md.j2
@@ -186,12 +186,12 @@ let (poke, guard) = Poke::alloc::<FooBar>();
     // inner code: all we have is a `poke` — our function is not generic,
     // `Poke` is not generic.
     let mut poke = poke.into_struct();
-    poke.set_by_name("foo", OpaqueConst::from_ref(&42u64))
+    poke.set_by_name("foo", OpaqueConst::new(&42u64))
         .unwrap();
 
     {
         let bar = String::from("Hello, World!");
-        poke.set_by_name("bar", OpaqueConst::from_ref(&bar))
+        poke.set_by_name("bar", OpaqueConst::new(&bar))
             .unwrap();
         // bar has been moved out of
         core::mem::forget(bar);

--- a/templates/README.md.j2
+++ b/templates/README.md.j2
@@ -186,12 +186,12 @@ let (poke, guard) = Poke::alloc::<FooBar>();
     // inner code: all we have is a `poke` — our function is not generic,
     // `Poke` is not generic.
     let mut poke = poke.into_struct();
-    poke.set_by_name("foo", OpaqueConst::from_ref(&42u64))
+    poke.set_by_name("foo", OpaqueConst::new(&42u64))
         .unwrap();
 
     {
         let bar = String::from("Hello, World!");
-        poke.set_by_name("bar", OpaqueConst::from_ref(&bar))
+        poke.set_by_name("bar", OpaqueConst::new(&bar))
             .unwrap();
         // bar has been moved out of
         core::mem::forget(bar);


### PR DESCRIPTION
This standardizes those types and their function names a little bit and removes the too-close-to-UB ones.