### PR TITLE
Serialize all numbers in JSON

### DIFF
--- a/facet-json-write/src/serialize.rs
+++ b/facet-json-write/src/serialize.rs
@@ -40,6 +40,12 @@ fn peek_value_to_json<W: Write>(pv: PeekValue, writer: &mut W) -> io::Result<()>
     } else if pv.shape().is_type::<i128>() {
         let value = unsafe { pv.data().as_ref::<i128>() };
         write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<f32>() {
+        let value = unsafe { pv.data().as_ref::<f32>() };
+        write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<f64>() {
+        let value = unsafe { pv.data().as_ref::<f64>() };
+        write!(writer, "{}", value)?;
     } else if pv.shape().is_type::<String>() {
         let value = unsafe { pv.data().as_ref::<String>() };
         write!(writer, "\"{}\"", value.escape_debug())?;

--- a/facet-json-write/src/serialize.rs
+++ b/facet-json-write/src/serialize.rs
@@ -1,7 +1,53 @@
 use facet_core::ShapeExt as _;
 use facet_poke::{Peek, PeekValue};
+use log::trace;
 use std::collections::VecDeque;
 use std::io::{self, Write};
+
+fn peek_value_to_json<W: Write>(pv: PeekValue, writer: &mut W) -> io::Result<()> {
+    if pv.shape().is_type::<()>() {
+        write!(writer, "null")?;
+    } else if pv.shape().is_type::<bool>() {
+        let value = unsafe { pv.data().as_ref::<bool>() };
+        write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<u8>() {
+        let value = unsafe { pv.data().as_ref::<u8>() };
+        write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<u16>() {
+        let value = unsafe { pv.data().as_ref::<u16>() };
+        write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<u32>() {
+        let value = unsafe { pv.data().as_ref::<u32>() };
+        write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<u64>() {
+        let value = unsafe { pv.data().as_ref::<u64>() };
+        write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<u128>() {
+        let value = unsafe { pv.data().as_ref::<u128>() };
+        write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<i8>() {
+        let value = unsafe { pv.data().as_ref::<i8>() };
+        write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<i16>() {
+        let value = unsafe { pv.data().as_ref::<i16>() };
+        write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<i32>() {
+        let value = unsafe { pv.data().as_ref::<i32>() };
+        write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<i64>() {
+        let value = unsafe { pv.data().as_ref::<i64>() };
+        write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<i128>() {
+        let value = unsafe { pv.data().as_ref::<i128>() };
+        write!(writer, "{}", value)?;
+    } else if pv.shape().is_type::<String>() {
+        let value = unsafe { pv.data().as_ref::<String>() };
+        write!(writer, "\"{}\"", value.escape_debug())?;
+    } else {
+        write!(writer, "\"<unsupported type>\"")?;
+    }
+    Ok(())
+}
 
 /// Serializes any Facet type to JSON
 pub fn to_json<W: Write>(peek: Peek<'_>, writer: &mut W, indent: bool) -> io::Result<()> {
@@ -50,21 +96,7 @@ pub fn to_json<W: Write>(peek: Peek<'_>, writer: &mut W, indent: bool) -> io::Re
             StackItem::Value { peek, level } => {
                 match peek {
                     Peek::Value(pv) => {
-                        if pv.shape().is_type::<()>() {
-                            write!(writer, "null")?;
-                        } else if pv.shape().is_type::<bool>() {
-                            let value = unsafe { pv.data().as_ref::<bool>() };
-                            write!(writer, "{}", value)?;
-                        } else if pv.shape().is_type::<u64>() {
-                            let value = unsafe { pv.data().as_ref::<u64>() };
-                            write!(writer, "{}", value)?;
-                        } else if pv.shape().is_type::<String>() {
-                            let value = unsafe { pv.data().as_ref::<String>() };
-                            write!(writer, "\"{}\"", value.escape_debug())?;
-                        } else {
-                            // For other types, we'll use a placeholder
-                            write!(writer, "\"<unsupported type>\"")?;
-                        }
+                        peek_value_to_json(pv, writer)?;
                     }
                     Peek::Struct(ps) => {
                         write!(writer, "{{")?;
@@ -235,20 +267,8 @@ pub fn to_json<W: Write>(peek: Peek<'_>, writer: &mut W, indent: bool) -> io::Re
                     match temp_item {
                         StackItem::Value { peek, level: _ } => match peek {
                             Peek::Value(pv) => {
-                                if pv.shape().is_type::<()>() {
-                                    write!(&mut temp_writer, "null")?;
-                                } else if pv.shape().is_type::<bool>() {
-                                    let value = unsafe { pv.data().as_ref::<bool>() };
-                                    write!(&mut temp_writer, "{}", value)?;
-                                } else if pv.shape().is_type::<u64>() {
-                                    let value = unsafe { pv.data().as_ref::<u64>() };
-                                    write!(&mut temp_writer, "{}", value)?;
-                                } else if pv.shape().is_type::<String>() {
-                                    let value = unsafe { pv.data().as_ref::<String>() };
-                                    write!(&mut temp_writer, "\"{}\"", value.escape_debug())?;
-                                } else {
-                                    write!(&mut temp_writer, "\"<unsupported type>\"")?;
-                                }
+                                trace!("{:?}", pv.shape());
+                                peek_value_to_json(pv, &mut temp_writer)?;
                             }
                             _ => {
                                 write!(&mut temp_writer, "\"<complex_key>\"")?;

--- a/facet-json-write/tests/json-write.rs
+++ b/facet-json-write/tests/json-write.rs
@@ -23,21 +23,21 @@ fn test_to_json() {
     #[derive(Debug, PartialEq, Clone, Facet)]
     struct LinearFunction {
         variable: String,
-        slope: i32,
-        intercept: u32,
+        slope: f32,
+        intercept: i32,
     }
 
     let test_struct = LinearFunction {
         variable: "x".to_string(),
-        slope: -3,
-        intercept: 5,
+        slope: -3.5,
+        intercept: -5,
     };
 
-    let _expected_json = r#"{"variable":"x","slope":-3,"intercept":5}"#;
+    let _expected_json = r#"{"variable":"x","slope":-3.5,"intercept":-5}"#;
     let expected_json_indented = r#"{
   "variable": "x",
-  "slope": -3,
-  "intercept": 5
+  "slope": -3.5,
+  "intercept": -5
 }"#;
 
     let mut buffer = Vec::new();

--- a/facet-json-write/tests/json-write.rs
+++ b/facet-json-write/tests/json-write.rs
@@ -21,20 +21,23 @@ fn init() {
 #[test]
 fn test_to_json() {
     #[derive(Debug, PartialEq, Clone, Facet)]
-    struct TestStruct {
-        name: String,
-        age: u64,
+    struct LinearFunction {
+        variable: String,
+        slope: i32,
+        intercept: u32,
     }
 
-    let test_struct = TestStruct {
-        name: "Alice".to_string(),
-        age: 30,
+    let test_struct = LinearFunction {
+        variable: "x".to_string(),
+        slope: -3,
+        intercept: 5,
     };
 
-    let _expected_json = r#"{"name":"Alice","age":30}"#;
+    let _expected_json = r#"{"variable":"x","slope":-3,"intercept":5}"#;
     let expected_json_indented = r#"{
-  "name": "Alice",
-  "age": 30
+  "variable": "x",
+  "slope": -3,
+  "intercept": 5
 }"#;
 
     let mut buffer = Vec::new();


### PR DESCRIPTION
Previously, `facet-json-write` only supported `u64` for numbers. This PR adds support for all usigned integers, signed integers and floats.

Fixes #84 