### PR TITLE
Add example to `facet-json-write::to_json_string`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,11 @@ dependencies = [
  "color-backtrace",
  "ctor",
  "env_logger",
+ "facet",
  "facet-core",
  "facet-derive",
  "facet-json-read",
+ "facet-peek",
  "facet-poke",
  "log",
 ]

--- a/facet-json-write/Cargo.toml
+++ b/facet-json-write/Cargo.toml
@@ -19,5 +19,7 @@ log = "0.4.27"
 color-backtrace = "0.7.0"
 ctor = "0.4.1"
 env_logger = "0.11.8"
+facet = { path = "../facet" }
 facet-derive.workspace = true
 facet-json-read = { path = "../facet-json-read" }
+facet-peek = { path = "../facet-peek" }

--- a/facet-json-write/src/serialize.rs
+++ b/facet-json-write/src/serialize.rs
@@ -312,6 +312,27 @@ pub fn to_json<W: Write>(peek: Peek<'_>, writer: &mut W, indent: bool) -> io::Re
 }
 
 /// Serializes any Facet type to JSON and returns it as a String
+///
+/// # Example
+///
+/// ```rust
+/// use facet::Facet;
+/// use facet_peek::Peek;
+///
+/// #[derive(facet::Facet)]
+/// struct Foo {
+///   bar: String,
+///   baz: u32,
+/// }
+///
+/// let foo = Foo {
+///   bar: "Hello, World!".to_string(),
+///   baz: 42,
+/// };
+/// let foo = Peek::new(&foo);
+///
+/// println!("{}", foo);
+/// ```
 pub fn to_json_string(peek: Peek<'_>, indent: bool) -> String {
     let mut buffer = Vec::new();
     to_json(peek, &mut buffer, indent).unwrap();

--- a/facet-json-write/src/serialize.rs
+++ b/facet-json-write/src/serialize.rs
@@ -317,6 +317,7 @@ pub fn to_json<W: Write>(peek: Peek<'_>, writer: &mut W, indent: bool) -> io::Re
 ///
 /// ```rust
 /// use facet::Facet;
+/// use facet_json_write::to_json_string;
 /// use facet_peek::Peek;
 ///
 /// #[derive(facet::Facet)]
@@ -331,7 +332,7 @@ pub fn to_json<W: Write>(peek: Peek<'_>, writer: &mut W, indent: bool) -> io::Re
 /// };
 /// let foo = Peek::new(&foo);
 ///
-/// println!("{}", foo);
+/// println!("{}", to_json_string(foo, true));
 /// ```
 pub fn to_json_string(peek: Peek<'_>, indent: bool) -> String {
     let mut buffer = Vec::new();


### PR DESCRIPTION
Adds an example on how to use `to_json_string` from `facet-json-write`, as the requirement to wrap the value in a `Peek` is not immediately obvious (at least it wasn't to me).