### PR TITLE
chore: Remove dead code

### DIFF
--- a/facet-core/src/_trait/impls/hashmap_impl.rs
+++ b/facet-core/src/_trait/impls/hashmap_impl.rs
@@ -203,12 +203,6 @@ where
     };
 }
 
-#[allow(dead_code)]
-struct RandomStateInnards {
-    k0: u64,
-    k1: u64,
-}
-
 unsafe impl Facet for RandomState {
     const SHAPE: &'static Shape = &const {
         Shape::builder()


### PR DESCRIPTION
Leftover from the `ARCHETYPE` removal