### PR TITLE
Allow json serialization of static string types

### DIFF
--- a/facet-derive/src/lib.rs
+++ b/facet-derive/src/lib.rs
@@ -94,10 +94,17 @@ unsynn! {
     }
 
     enum Type {
+        Reference(ReferenceType),
         Path(PathType),
         Tuple(ParenthesisGroupContaining<CommaDelimitedVec<Box<Type>>>),
         Slice(BracketGroupContaining<Box<Type>>),
         Bare(BareType),
+    }
+
+    struct ReferenceType {
+        _and: And,
+        lifetime: Lifetime,
+        rest: Box<Type>,
     }
 
     struct PathType {
@@ -113,6 +120,7 @@ unsynn! {
 
     struct GenericParams {
         _lt: Lt,
+        lifetimes: CommaDelimitedVec<Lifetime>,
         params: CommaDelimitedVec<Type>,
         _gt: Gt,
     }
@@ -193,6 +201,9 @@ pub fn facet_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 impl core::fmt::Display for Type {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            Type::Reference(reference) => {
+                write!(f, "&{} {}", reference.lifetime, reference.rest)
+            }
             Type::Path(path) => {
                 write!(f, "{}::{}", path.prefix, path.rest)
             }

--- a/facet-json-write/tests/json-write.rs
+++ b/facet-json-write/tests/json-write.rs
@@ -34,18 +34,20 @@ fn test_to_json() {
         intercept: -5,
     };
 
-    let _expected_json = r#"{"variable":"x","slope":-3.5,"intercept":-5}"#;
+    let expected_json = r#"{"variable":"x","slope":-3.5,"intercept":-5}"#;
     let expected_json_indented = r#"{
   "variable": "x",
   "slope": -3.5,
   "intercept": -5
 }"#;
 
-    let mut buffer = Vec::new();
-    let peek = Peek::new(&test_struct);
-    to_json(peek, &mut buffer, true).unwrap();
-    let json = String::from_utf8(buffer).unwrap();
-    assert_eq!(json, expected_json_indented);
+    for (indent, expected) in [(true, expected_json_indented), (false, expected_json)] {
+        let mut buffer = Vec::new();
+        let peek = Peek::new(&test_struct);
+        to_json(peek, &mut buffer, indent).unwrap();
+        let json = String::from_utf8(buffer).unwrap();
+        assert_eq!(json, expected);
+    }
 }
 
 #[test]
@@ -63,4 +65,77 @@ fn test_nonzero() {
     let json = to_json_string(peek, false);
 
     assert_eq!(json, r#"{"foo":1}"#);
+}
+
+#[test]
+fn test_hashmap_to_json() {
+
+    let mut json_data = std::collections::HashMap::<&str, &str>::new();
+    json_data.insert("foo", "bar");
+
+    let expected_json = r#"{"foo":"bar"}"#;
+    let expected_json_indented = r#"{
+  "foo": "bar"
+}"#;
+
+    for (indent, expected) in [(true, expected_json_indented), (false, expected_json)] {
+        let mut buffer = Vec::new();
+        let peek = Peek::new(&json_data);
+        to_json(peek, &mut buffer, indent).unwrap();
+        let json = String::from_utf8(buffer).unwrap();
+        assert_eq!(json, expected);
+    }
+}
+
+#[test]
+fn test_static_strings() {
+    #[derive(Debug, PartialEq, Clone, Facet)]
+    struct StaticFoo {
+        foo: &'static str,
+    }
+
+    let test_struct = StaticFoo {
+        foo: "foo",
+    };
+
+    let peek = Peek::new(&test_struct);
+    let json = to_json_string(peek, false);
+    assert_eq!(json, r#"{"foo":"foo"}"#);
+
+    #[derive(Debug, PartialEq, Clone, Facet)]
+    struct OptStaticFoo {
+        foo: Option<&'static str>,
+    }
+
+    let test_struct = OptStaticFoo {
+        foo: None,
+    };
+
+    let peek = Peek::new(&test_struct);
+    let json = to_json_string(peek, false);
+
+    assert_eq!(json, r#"{"foo":null}"#);
+
+    let test_struct = OptStaticFoo {
+        foo: Some("foo"),
+    };
+
+    let peek = Peek::new(&test_struct);
+    let json = to_json_string(peek, false);
+
+    assert_eq!(json, r#"{"foo":"foo"}"#);
+
+    #[derive(Debug, PartialEq, Clone, Facet)]
+    struct CowFoo {
+        foo: std::borrow::Cow<'static, str>,
+    }
+
+    let test_struct = CowFoo {
+        foo: std::borrow::Cow::from("foo"),
+    };
+
+    let peek = Peek::new(&test_struct);
+    let json = to_json_string(peek, false);
+
+    assert_eq!(json, r#"{"foo":"foo"}"#);
 }


### PR DESCRIPTION
I understand that supporting references properly is still something to be figured out, but it seemed to me that supporting `'static` references (especially for string-like things) should be possible.

This is a "hammer it until it fits without really understanding the `shape`" implementation, so I wont take offense if I'm missing the mark completely, or if this just gets in the way of planned work.

I think on the surface level, it's reasonably safe to support even without proper ref support, as you still cannot `#[derive(Facet)]` on a type that has lifetime annotations (e.g. `struct Struct<'a>(&'a str)`).