### PR TITLE
Fix `no_std` support

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -29,6 +29,9 @@ nostd:
     cargo check --no-default-features -p facet
     cargo check --no-default-features -p facet-peek
     cargo check --no-default-features -p facet-poke
+    cargo check --no-default-features --features alloc -p facet-core
+    cargo check --no-default-features --features alloc -p facet
+    cargo check --no-default-features --features alloc -p facet-peek
 
 ci:
     #!/usr/bin/env -S bash -euo pipefail

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -15,5 +15,6 @@ impls = "1.0.3"
 bitflags = "2.4.1"
 
 [features]
-std = []
+std = ["alloc"]
+alloc = []
 default = ["std"]

--- a/facet-core/src/_trait/impls/hashmap_impl.rs
+++ b/facet-core/src/_trait/impls/hashmap_impl.rs
@@ -1,5 +1,3 @@
-extern crate alloc;
-
 use alloc::collections::VecDeque;
 use core::{alloc::Layout, hash::Hash};
 use std::collections::HashMap;

--- a/facet-core/src/_trait/impls/mod.rs
+++ b/facet-core/src/_trait/impls/mod.rs
@@ -4,5 +4,5 @@ mod hashmap_impl;
 mod scalar_impls;
 mod slice_impl;
 mod tuples_impls;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod vec_impl;

--- a/facet-core/src/_trait/impls/scalar_impls.rs
+++ b/facet-core/src/_trait/impls/scalar_impls.rs
@@ -35,11 +35,11 @@ unsafe impl Facet for () {
     };
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 unsafe impl Facet for alloc::string::String {
     const SHAPE: &'static Shape = &const {
         Shape::builder()
-            .id(ConstTypeId::of::<String>())
+            .id(ConstTypeId::of::<alloc::string::String>())
             .layout(Layout::new::<Self>())
             .def(Def::Scalar(
                 ScalarDef::builder()
@@ -47,7 +47,10 @@ unsafe impl Facet for alloc::string::String {
                     .affinity(ScalarAffinity::string().max_inline_length(0).build())
                     .build(),
             ))
-            .vtable(value_vtable!(String, |f, _opts| write!(f, "String")))
+            .vtable(value_vtable!(alloc::string::String, |f, _opts| write!(
+                f,
+                "String"
+            )))
             .build()
     };
 }
@@ -67,7 +70,7 @@ unsafe impl Facet for &str {
     };
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 unsafe impl Facet for alloc::borrow::Cow<'_, str> {
     const SHAPE: &'static Shape = &const {
         Shape::builder()

--- a/facet-core/src/_trait/impls/scalar_impls.rs
+++ b/facet-core/src/_trait/impls/scalar_impls.rs
@@ -1,5 +1,3 @@
-extern crate alloc;
-
 use crate::value_vtable;
 use crate::*;
 use core::alloc::Layout;

--- a/facet-core/src/_trait/impls/scalar_impls.rs
+++ b/facet-core/src/_trait/impls/scalar_impls.rs
@@ -436,7 +436,6 @@ unsafe impl Facet for f64 {
     };
 }
 
-#[cfg(feature = "std")]
 unsafe impl Facet for core::net::SocketAddr {
     const SHAPE: &'static Shape = &const {
         Shape::builder()

--- a/facet-core/src/_trait/impls/vec_impl.rs
+++ b/facet-core/src/_trait/impls/vec_impl.rs
@@ -1,5 +1,3 @@
-extern crate alloc;
-
 use crate::*;
 use core::{alloc::Layout, hash::Hash as _};
 

--- a/facet-core/src/_trait/impls/vec_impl.rs
+++ b/facet-core/src/_trait/impls/vec_impl.rs
@@ -1,7 +1,6 @@
 use crate::*;
 use core::{alloc::Layout, hash::Hash as _};
 
-#[cfg(feature = "std")]
 use alloc::vec::Vec;
 
 unsafe impl<T> Facet for Vec<T>

--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -4,6 +4,7 @@
 #![warn(clippy::std_instead_of_alloc)]
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 // Opaque pointer utilities

--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -4,6 +4,8 @@
 #![warn(clippy::std_instead_of_alloc)]
 #![doc = include_str!("../README.md")]
 
+extern crate alloc;
+
 // Opaque pointer utilities
 mod opaque;
 pub use opaque::*;

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -259,7 +259,7 @@ impl core::fmt::Display for Shape {
 
 impl Shape {
     /// Heap-allocate a value of this shape
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn allocate(&self) -> crate::opaque::OpaqueUninit<'static> {
         crate::opaque::OpaqueUninit::new(if self.layout.size() == 0 {

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -1,7 +1,5 @@
 //! structs and vtable definitions used by Facet
 
-extern crate alloc;
-
 use core::alloc::Layout;
 use core::fmt;
 

--- a/facet-peek/Cargo.toml
+++ b/facet-peek/Cargo.toml
@@ -14,5 +14,6 @@ categories = ["development-tools", "rust-patterns", "parsing"]
 facet-core.workspace = true
 
 [features]
-std = ["facet-core/std"]
+std = ["facet-core/std", "alloc"]
+alloc = ["facet-core/alloc"]
 default = ["std"]

--- a/facet-peek/src/enum_.rs
+++ b/facet-peek/src/enum_.rs
@@ -186,9 +186,10 @@ impl<'mem> PeekEnum<'mem> {
     }
 
     /// Returns an iterator over fields of a struct or tuple variant with metadata
+    #[cfg(feature = "alloc")]
     pub fn fields_with_metadata(
         self,
-    ) -> Box<
+    ) -> alloc::boxed::Box<
         dyn Iterator<
                 Item = (
                     usize,
@@ -203,40 +204,47 @@ impl<'mem> PeekEnum<'mem> {
 
         match &variant.kind {
             VariantKind::Struct { fields } => {
-                Box::new(fields.iter().enumerate().map(move |(i, field)| {
+                alloc::boxed::Box::new(fields.iter().enumerate().map(move |(i, field)| {
                     let field_data = unsafe { data.field(field.offset) };
                     let field_peek = unsafe { crate::Peek::unchecked_new(field_data, field.shape) };
                     (i, field.name, field_peek, field)
                 }))
             }
             VariantKind::Tuple { fields } => {
-                Box::new(fields.iter().enumerate().map(move |(i, field)| {
+                alloc::boxed::Box::new(fields.iter().enumerate().map(move |(i, field)| {
                     let field_data = unsafe { data.field(field.offset) };
                     let field_peek = unsafe { crate::Peek::unchecked_new(field_data, field.shape) };
                     (i, field.name, field_peek, field)
                 }))
             }
-            _ => Box::new(core::iter::empty()),
+            _ => alloc::boxed::Box::new(core::iter::empty()),
         }
     }
 
     /// Returns an iterator over fields of a struct or tuple variant
-    pub fn fields(self) -> Box<dyn Iterator<Item = (&'static str, crate::Peek<'mem>)> + 'mem> {
+    #[cfg(feature = "alloc")]
+    pub fn fields(
+        self,
+    ) -> alloc::boxed::Box<dyn Iterator<Item = (&'static str, crate::Peek<'mem>)> + 'mem> {
         let variant = self.active_variant();
         let data = self.value.data();
 
         match &variant.kind {
-            VariantKind::Struct { fields } => Box::new(fields.iter().map(move |field| {
-                let field_data = unsafe { data.field(field.offset) };
-                let peek = unsafe { crate::Peek::unchecked_new(field_data, field.shape) };
-                (field.name, peek)
-            })),
-            VariantKind::Tuple { fields } => Box::new(fields.iter().map(move |field| {
-                let field_data = unsafe { data.field(field.offset) };
-                let peek = unsafe { crate::Peek::unchecked_new(field_data, field.shape) };
-                (field.name, peek)
-            })),
-            _ => Box::new(core::iter::empty()),
+            VariantKind::Struct { fields } => {
+                alloc::boxed::Box::new(fields.iter().map(move |field| {
+                    let field_data = unsafe { data.field(field.offset) };
+                    let peek = unsafe { crate::Peek::unchecked_new(field_data, field.shape) };
+                    (field.name, peek)
+                }))
+            }
+            VariantKind::Tuple { fields } => {
+                alloc::boxed::Box::new(fields.iter().map(move |field| {
+                    let field_data = unsafe { data.field(field.offset) };
+                    let peek = unsafe { crate::Peek::unchecked_new(field_data, field.shape) };
+                    (field.name, peek)
+                }))
+            }
+            _ => alloc::boxed::Box::new(core::iter::empty()),
         }
     }
 }

--- a/facet-peek/src/lib.rs
+++ b/facet-peek/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 #![warn(clippy::std_instead_of_core)]
 #![warn(clippy::std_instead_of_alloc)]

--- a/facet-peek/src/lib.rs
+++ b/facet-peek/src/lib.rs
@@ -6,6 +6,9 @@
 
 //! Allows peeking (reading from) shapes
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 use facet_core::{Facet, TypeNameOpts};
 
 mod value;

--- a/facet-poke/Cargo.toml
+++ b/facet-poke/Cargo.toml
@@ -10,6 +10,10 @@ description = "Build and alter arbitrary Facet types"
 keywords = ["reflection", "introspection", "builder", "facet"]
 categories = ["development-tools", "rust-patterns", "memory-management"]
 
+[features]
+std = ["facet-core/std"]
+default = ["std"]
+
 [dependencies]
 facet-peek.workspace = true
 facet-core.workspace = true

--- a/facet-poke/src/enum_.rs
+++ b/facet-poke/src/enum_.rs
@@ -393,11 +393,11 @@ impl<'mem> PokeEnum<'mem> {
     /// This function will panic if:
     /// - Not all fields in the selected variant have been initialized.
     /// - The generic type parameter T does not match the shape that this PokeEnum is building.
-    pub fn build_boxed<T: Facet>(self) -> Box<T> {
+    pub fn build_boxed<T: Facet>(self) -> alloc::boxed::Box<T> {
         self.assert_all_fields_initialized();
         self.assert_matching_shape::<T>();
 
-        let boxed = unsafe { Box::from_raw(self.data.as_mut_bytes() as *mut T) };
+        let boxed = unsafe { alloc::boxed::Box::from_raw(self.data.as_mut_bytes() as *mut T) };
         core::mem::forget(self);
         boxed
     }
@@ -465,7 +465,7 @@ pub enum VariantError {
     NoSuchVariant,
 }
 
-impl std::error::Error for VariantError {}
+impl core::error::Error for VariantError {}
 
 impl core::fmt::Display for VariantError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/facet-poke/src/lib.rs
+++ b/facet-poke/src/lib.rs
@@ -1,5 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
+#![warn(clippy::std_instead_of_core)]
+#![warn(clippy::std_instead_of_alloc)]
 #![doc = include_str!("../README.md")]
+
+extern crate alloc;
 
 use core::alloc::Layout;
 
@@ -55,7 +60,7 @@ impl Drop for Guard {
             return;
         }
         // SAFETY: `ptr` has been allocated via the global allocator with the given layout
-        unsafe { std::alloc::dealloc(self.ptr, self.layout) };
+        unsafe { alloc::alloc::dealloc(self.ptr, self.layout) };
     }
 }
 

--- a/facet-poke/src/struct_.rs
+++ b/facet-poke/src/struct_.rs
@@ -105,11 +105,11 @@ impl<'mem> PokeStruct<'mem> {
     /// This function will panic if:
     /// - Not all the fields have been initialized.
     /// - The generic type parameter T does not match the shape that this PokeStruct is building.
-    pub fn build_boxed<T: crate::Facet>(self) -> Box<T> {
+    pub fn build_boxed<T: crate::Facet>(self) -> alloc::boxed::Box<T> {
         self.assert_all_fields_initialized();
         self.shape.assert_type::<T>();
 
-        let boxed = unsafe { Box::from_raw(self.data.as_mut_bytes() as *mut T) };
+        let boxed = unsafe { alloc::boxed::Box::from_raw(self.data.as_mut_bytes() as *mut T) };
         core::mem::forget(self);
         boxed
     }

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -17,7 +17,8 @@ facet-derive.workspace = true
 [features]
 # Does nothing, only used for tests
 testfeat = []
-std = ["facet-core/std"]
+std = ["facet-core/std", "alloc"]
+alloc = ["facet-core/alloc"]
 default = ["std"]
 
 [dev-dependencies]

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
+#![warn(clippy::std_instead_of_core)]
+#![warn(clippy::std_instead_of_alloc)]
 #![doc = include_str!("../README.md")]
 
 pub use facet_core::*;


### PR DESCRIPTION
Quick summary
- `facet-core` only worked with `alloc` and not `core` because of `extern crate alloc`
- Some libraries were missing `no_std`
- Some std types were being used through the prelude
- `facet-poke` can support `alloc` without `std`
  - I considered adding an `alloc` feature and a `#[cfg(not(feature = "alloc"))] compile_error!("")` but (1) that would be a breaking change and (2) unsure if that future proofing is worth it
  - I considered doing this to other crates as well, like `facet-json` but (1) that would be a breaking change and (2) was unsure how far to go at this stage of facet

