### PR TITLE
Error on incomplete parse in facet-derive

### DIFF
--- a/facet-derive/src/process_struct.rs
+++ b/facet-derive/src/process_struct.rs
@@ -14,33 +14,32 @@ pub(crate) fn process_struct(parsed: Struct) -> proc_macro::TokenStream {
 
     // Generate field definitions
     let kind;
-    let fields = match &parsed.body {
-        Some(body) => match body {
-            StructBody::Struct(body) => {
-                kind = "facet::StructKind::Struct";
-                body.content
-                    .0
-                    .iter()
-                    .map(|field| {
-                        let field_name = field.value.name.to_string();
-                        gen_struct_field(&field_name, &struct_name, &field.value.attributes)
-                    })
-                    .collect::<Vec<String>>()
-            }
-            StructBody::TupleStruct(body) => {
-                kind = "facet::StructKind::TupleStruct";
-                body.content
-                    .0
-                    .iter()
-                    .enumerate()
-                    .map(|(index, field)| {
-                        let field_name = format!("{index}");
-                        gen_struct_field(&field_name, &struct_name, &field.value.attributes)
-                    })
-                    .collect::<Vec<String>>()
-            }
-        },
-        None => {
+    let fields = match &parsed.kind {
+        StructKind::Struct(body) => {
+            kind = "facet::StructKind::Struct";
+            body.content
+                .0
+                .iter()
+                .map(|field| {
+                    let field_name = field.value.name.to_string();
+                    gen_struct_field(&field_name, &struct_name, &field.value.attributes)
+                })
+                .collect::<Vec<String>>()
+        }
+        StructKind::TupleStruct(body) => {
+            kind = "facet::StructKind::TupleStruct";
+            body.first
+                .content
+                .0
+                .iter()
+                .enumerate()
+                .map(|(index, field)| {
+                    let field_name = format!("{index}");
+                    gen_struct_field(&field_name, &struct_name, &field.value.attributes)
+                })
+                .collect::<Vec<String>>()
+        }
+        StructKind::UnitStruct(_) => {
             kind = "facet::StructKind::Unit";
             vec![]
         }


### PR DESCRIPTION
Without this we may accidentally parse something successfully as a different thing due to syntax that we can't yet handle yet (like some specific type syntax for example).

While trying to change a parse rule incorrectly for example the macro resulted in parsing most of the record structs as unit structs without erroring!