### PR TITLE
Do not attempt to parse field types, that's not really our job

### DIFF
--- a/facet-derive/src/lib.rs
+++ b/facet-derive/src/lib.rs
@@ -13,6 +13,7 @@ keyword! {
     KDoc = "doc";
     KRepr = "repr";
     KCrate = "crate";
+    KIn = "in";
     KConst = "const";
     KMut = "mut";
     KFacet = "facet";
@@ -28,6 +29,7 @@ operator! {
 
 /// Parses tokens and groups until `C` is found on the current token tree level.
 type VerbatimUntil<C> = Many<Cons<Except<C>, AngleTokenTree>>;
+type ModPath = Cons<Option<PathSep>, PathSepDelimited<Ident>>;
 
 unsynn! {
     /// Parses either a `TokenTree` or `<...>` grouping (which is not a [`Group`] as far as proc-macros
@@ -41,7 +43,8 @@ unsynn! {
 
     enum Vis {
         Pub(KPub),
-        PubCrate(Cons<KPub, ParenthesisGroupContaining<KCrate>>),
+        /// `pub(in? crate::foo::bar)`/`pub(in? ::foo::bar)`
+        PubIn(Cons<KPub, ParenthesisGroupContaining<Cons<Option<KIn>, ModPath>>>),
     }
 
     struct Attribute {

--- a/facet-derive/src/process_enum.rs
+++ b/facet-derive/src/process_enum.rs
@@ -72,7 +72,7 @@ pub(crate) fn process_enum(parsed: Enum) -> proc_macro::TokenStream {
                     .iter()
                     .enumerate()
                     .map(|(idx, field)| {
-                        let typ = field.value.typ.to_string();
+                        let typ = VerbatimDisplay(&field.value.typ).to_string();
                         format!("_{}: {}", idx, typ)
                     })
                     .collect::<Vec<String>>()
@@ -129,7 +129,7 @@ pub(crate) fn process_enum(parsed: Enum) -> proc_macro::TokenStream {
                     .iter()
                     .map(|field| {
                         let name = field.value.name.to_string();
-                        let typ = field.value.typ.to_string();
+                        let typ = VerbatimDisplay(&field.value.typ).to_string();
                         format!("{}: {}", name, typ)
                     })
                     .collect::<Vec<String>>()

--- a/facet/tests/derive.rs
+++ b/facet/tests/derive.rs
@@ -291,11 +291,12 @@ fn tuple_struct_field_doc_comment() {
 #[test]
 fn tuple_struct_with_pub_field() {
     #[derive(Clone, Hash, PartialEq, Eq, ::facet::Facet)]
-    #[repr(transparent)]
     /// This is a struct for sure
     struct Blah(
-        /// and this is a field
+        /// and this is a public field
         pub u32,
+        /// and this is a crate public field
+        pub(crate) u32,
     );
 }
 


### PR DESCRIPTION
We don't introspect the types in the macro, so there is little reason to reconstruct parsers for them all, we just need to skip past them to parse the following relevant parts.

With this we should automatically support any type specifications in fields