### PR TITLE
feat(poke)!: Future proof for no-alloc support

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -28,10 +28,10 @@ nostd:
     cargo check --no-default-features -p facet-core
     cargo check --no-default-features -p facet
     cargo check --no-default-features -p facet-peek
-    cargo check --no-default-features -p facet-poke
     cargo check --no-default-features --features alloc -p facet-core
     cargo check --no-default-features --features alloc -p facet
     cargo check --no-default-features --features alloc -p facet-peek
+    cargo check --no-default-features --features alloc -p facet-poke
 
 ci:
     #!/usr/bin/env -S bash -euo pipefail

--- a/facet-poke/Cargo.toml
+++ b/facet-poke/Cargo.toml
@@ -11,7 +11,8 @@ keywords = ["reflection", "introspection", "builder", "facet"]
 categories = ["development-tools", "rust-patterns", "memory-management"]
 
 [features]
-std = ["facet-core/std"]
+std = ["facet-core/std", "alloc"]
+alloc = ["facet-core/alloc"]
 default = ["std"]
 
 [dependencies]

--- a/facet-poke/src/lib.rs
+++ b/facet-poke/src/lib.rs
@@ -4,6 +4,9 @@
 #![warn(clippy::std_instead_of_alloc)]
 #![doc = include_str!("../README.md")]
 
+#[cfg(not(feature = "alloc"))]
+compile_error!("`alloc` feature is required at this time");
+
 extern crate alloc;
 
 use core::alloc::Layout;


### PR DESCRIPTION
This adds an `alloc` feature and fails if its not present, making it so when no-alloc support is added in the future, it isn't a breaking change.

This is a follow up to #123

BREAKING CHANGES: `cargo check -p facet-poke --no-default-features` now fails to build