### PR TITLE
Specify crate versions

### DIFF
--- a/facet-args/Cargo.toml
+++ b/facet-args/Cargo.toml
@@ -12,13 +12,13 @@ keywords = ["cli", "args", "parser", "facet"]
 categories = ["command-line-interface"]
 
 [dependencies]
-facet-poke = { path = "../facet-poke" }
-facet-core = { path = "../facet-core" }
+facet-poke = { path = "../facet-poke", version = "0.6.0" }
+facet-core = { path = "../facet-core", version = "0.4.2" }
 log = "0.4.27"
 
 [dev-dependencies]
 color-backtrace = "0.7.0"
 ctor = "0.4.1"
 env_logger = "0.11.8"
-facet = { path = "../facet" }
-facet-pretty = { path = "../facet-pretty" }
+facet = { path = "../facet", version = "0.1.18" }
+facet-pretty = { path = "../facet-pretty", version = "0.1.11" }

--- a/facet-derive/Cargo.toml
+++ b/facet-derive/Cargo.toml
@@ -24,4 +24,4 @@ unsynn = "0.0.26"
 
 # cf. https://hachyderm.io/@epage/114141126315983016
 [target.'cfg(any())'.dependencies]
-facet-core = { path = "../facet-core" }
+facet-core = { path = "../facet-core", version = "0.4.2" }

--- a/facet-json-read/Cargo.toml
+++ b/facet-json-read/Cargo.toml
@@ -11,12 +11,12 @@ keywords = ["facet", "json", "introspection", "reflection"]
 categories = ["development-tools", "parsing"]
 
 [dependencies]
-facet-poke = { path = "../facet-poke" }
-facet-core = { path = "../facet-core" }
+facet-poke = { path = "../facet-poke", version = "0.6.0" }
+facet-core = { path = "../facet-core", version = "0.4.2" }
 log = "0.4.27"
 
 [dev-dependencies]
 color-backtrace = "0.7.0"
 ctor = "0.4.1"
 env_logger = "0.11.8"
-facet-derive = { path = "../facet-derive" }
+facet-derive = { path = "../facet-derive", version = "0.1.17" }

--- a/facet-json-write/Cargo.toml
+++ b/facet-json-write/Cargo.toml
@@ -11,15 +11,15 @@ keywords = ["facet", "json", "serialization", "introspection"]
 categories = ["development-tools", "encoding"]
 
 [dependencies]
-facet-poke = { path = "../facet-poke" }
-facet-core = { path = "../facet-core" }
+facet-poke = { path = "../facet-poke", version = "0.6.0" }
+facet-core = { path = "../facet-core", version = "0.4.2" }
 log = "0.4.27"
 
 [dev-dependencies]
 color-backtrace = "0.7.0"
 ctor = "0.4.1"
 env_logger = "0.11.8"
-facet = { path = "../facet" }
-facet-derive = { path = "../facet-derive" }
-facet-json-read = { path = "../facet-json-read" }
-facet-peek = { path = "../facet-peek" }
+facet = { path = "../facet", version = "0.1.18" }
+facet-derive = { path = "../facet-derive", version = "0.1.17" }
+facet-json-read = { path = "../facet-json-read", version = "0.1.14" }
+facet-peek = { path = "../facet-peek", version = "0.2.14" }

--- a/facet-msgpack/Cargo.toml
+++ b/facet-msgpack/Cargo.toml
@@ -18,11 +18,11 @@ categories = ["encoding", "parsing", "data-structures"]
 
 [dependencies]
 log = "0.4.27"
-facet-core = { path = "../facet-core" }
-facet-poke = { path = "../facet-poke" }
-facet-peek = { path = "../facet-peek" }
+facet-core = { path = "../facet-core", version = "0.4.2" }
+facet-poke = { path = "../facet-poke", version = "0.6.0" }
+facet-peek = { path = "../facet-peek", version = "0.2.14" }
 [dev-dependencies]
 color-backtrace = "0.7.0"
 ctor = "0.4.1"
-facet = { path = "../facet" }
-facet-derive = { path = "../facet-derive" }
+facet = { path = "../facet", version = "0.1.18" }
+facet-derive = { path = "../facet-derive", version = "0.1.17" }

--- a/facet-peek/Cargo.toml
+++ b/facet-peek/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["reflection", "introspection", "reading", "facet"]
 categories = ["development-tools", "rust-patterns", "parsing"]
 
 [dependencies]
-facet-core = { path = "../facet-core" }
+facet-core = { path = "../facet-core", version = "0.4.2" }
 
 [features]
 std = ["facet-core/std", "alloc"]

--- a/facet-poke/Cargo.toml
+++ b/facet-poke/Cargo.toml
@@ -16,8 +16,8 @@ alloc = ["facet-core/alloc"]
 default = ["std"]
 
 [dependencies]
-facet-peek = { path = "../facet-peek" }
-facet-core = { path = "../facet-core" }
+facet-peek = { path = "../facet-peek", version = "0.2.14" }
+facet-core = { path = "../facet-core", version = "0.4.2" }
 
 [dev-dependencies]
 color-backtrace = { version = "0.7.0", default-features = false, features = [
@@ -25,7 +25,7 @@ color-backtrace = { version = "0.7.0", default-features = false, features = [
 ] }
 ctor = "0.4.1"
 owo-colors = "4.2.0"
-facet-derive = { path = "../facet-derive" }
-facet-samplelibc = { path = "../facet-samplelibc" }
-facet-pretty = { path = "../facet-pretty" }
+facet-derive = { path = "../facet-derive", version = "0.1.17" }
+facet-samplelibc = { path = "../facet-samplelibc", version = "0.1.13" }
+facet-pretty = { path = "../facet-pretty", version = "0.1.11" }
 env_logger = "0.11.8"

--- a/facet-pretty/Cargo.toml
+++ b/facet-pretty/Cargo.toml
@@ -17,8 +17,8 @@ keywords = [
 categories = ["development-tools", "visualization", "command-line-utilities"]
 
 [dependencies]
-facet-core = { path = "../facet-core" }
-facet-peek = { path = "../facet-peek" }
+facet-core = { path = "../facet-core", version = "0.4.2" }
+facet-peek = { path = "../facet-peek", version = "0.2.14" }
 
 [dev-dependencies]
-facet-derive = { path = "../facet-derive" }
+facet-derive = { path = "../facet-derive", version = "0.1.17" }

--- a/facet-samplelibc/Cargo.toml
+++ b/facet-samplelibc/Cargo.toml
@@ -14,4 +14,4 @@ categories = ["development-tools::ffi"]
 cc = "1.2.18"
 
 [dependencies]
-facet = { path = "../facet" }
+facet = { path = "../facet", version = "0.1.18" }

--- a/facet-toml/Cargo.toml
+++ b/facet-toml/Cargo.toml
@@ -15,8 +15,8 @@ num-traits = { version = "0.2.19", default-features = false }
 toml_edit = { version = "0.22.24", default-features = false, features = [
     "parse",
 ] }
-facet-core = { path = "../facet-core" }
-facet-poke = { path = "../facet-poke" }
+facet-core = { path = "../facet-core", version = "0.4.2" }
+facet-poke = { path = "../facet-poke", version = "0.6.0" }
 
 [dev-dependencies]
-facet-derive = { path = "../facet-derive" }
+facet-derive = { path = "../facet-derive", version = "0.1.17" }

--- a/facet-trait/Cargo.toml
+++ b/facet-trait/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["reflection", "traits"]
 categories = ["development-tools"]
 
 [dependencies]
-facet-core = { path = "../facet-core" }
+facet-core = { path = "../facet-core", version = "0.4.2" }
 
 [features]
 std = ["facet-core/std"]

--- a/facet-urlencoded/Cargo.toml
+++ b/facet-urlencoded/Cargo.toml
@@ -11,10 +11,10 @@ categories = ["encoding", "parsing", "data-structures"]
 rust-version.workspace = true
 
 [dependencies]
-facet-core = { path = "../facet-core" }
-facet-poke = { path = "../facet-poke" }
+facet-core = { path = "../facet-core", version = "0.4.2" }
+facet-poke = { path = "../facet-poke", version = "0.6.0" }
 form_urlencoded = "1.2.1"
 log = "0.4.27"
 
 [dev-dependencies]
-facet-derive = { path = "../facet-derive" }
+facet-derive = { path = "../facet-derive", version = "0.1.17" }

--- a/facet-yaml/Cargo.toml
+++ b/facet-yaml/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["encoding", "parsing", "data-structures"]
 
 [dependencies]
 yaml-rust2 = "0.10.0"
-facet-core = { path = "../facet-core" }
-facet-poke = { path = "../facet-poke" }
+facet-core = { path = "../facet-core", version = "0.4.2" }
+facet-poke = { path = "../facet-poke", version = "0.6.0" }
 
 [dev-dependencies]
-facet-derive = { path = "../facet-derive" }
+facet-derive = { path = "../facet-derive", version = "0.1.17" }

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["facet", "introspection", "reflection"]
 categories = ["development-tools"]
 
 [dependencies]
-facet-core = { path = "../facet-core" }
-facet-derive = { path = "../facet-derive" }
+facet-core = { path = "../facet-core", version = "0.4.1" }
+facet-derive = { path = "../facet-derive", version = "0.1.16" }
 
 [features]
 # Does nothing, only used for tests
@@ -22,4 +22,4 @@ alloc = ["facet-core/alloc"]
 default = ["std"]
 
 [dev-dependencies]
-facet-poke = { path = "../facet-poke" }
+facet-poke = { path = "../facet-poke", version = "0.6.0" }

--- a/sample/Cargo.lock
+++ b/sample/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "facet"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "facet-core",
  "facet-derive",
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bitflags",
  "impls",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "facet-derive"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "facet-core",
  "unsynn",


### PR DESCRIPTION
If there are path dependencies without versions, publishing doesn't work.