### PR TITLE
Return error instead of panicking in `set`/`set_by_name`

### DIFF
--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -290,6 +290,9 @@ pub enum FieldError {
 
     /// `field_by_index` or `field_by_name` was called on a non-struct type.
     NotAStruct,
+
+    /// `set` or `set_by_name` was called with an mismatched type
+    TypeMismatch,
 }
 
 impl core::error::Error for FieldError {}
@@ -301,6 +304,7 @@ impl core::fmt::Display for FieldError {
             FieldError::NoSuchStaticField => write!(f, "No such static field"),
             FieldError::IndexOutOfBounds => write!(f, "Index out of bounds"),
             FieldError::NotAStruct => write!(f, "Not a struct"),
+            FieldError::TypeMismatch => write!(f, "Type mismatch"),
         }
     }
 }

--- a/facet-poke/src/struct_.rs
+++ b/facet-poke/src/struct_.rs
@@ -251,7 +251,9 @@ impl<'mem> PokeStruct<'mem> {
             .get(index)
             .ok_or(FieldError::IndexOutOfBounds)?
             .shape;
-        field_shape.assert_type::<T>();
+        if !field_shape.is_type::<T>() {
+            return Err(FieldError::TypeMismatch);
+        }
 
         unsafe {
             let opaque = OpaqueConst::new(&value);

--- a/facet-poke/tests/struct.rs
+++ b/facet-poke/tests/struct.rs
@@ -61,6 +61,16 @@ fn build_foobar_through_reflection() {
 }
 
 #[test]
+fn set_by_name_type_mismatch() {
+    let (poke, _guard) = PokeUninit::alloc::<FooBar>();
+    let mut poke = poke.into_struct();
+    assert!(matches!(
+        poke.set_by_name("foo", 42u16),
+        Err(facet_core::FieldError::TypeMismatch)
+    ));
+}
+
+#[test]
 #[should_panic(expected = "Field 'bar' was not initialized")]
 fn build_foobar_incomplete() {
     let (poke, guard) = PokeUninit::alloc::<FooBar>();


### PR DESCRIPTION
The docs for `set` and `set_by_name` say that they should return an error if the field shapes don’t match.

However, they currently call `assert_type` and panic instead.

This PR adds a new `FieldError::TypeMismatch`, then returns it if there's a type mismatch.

(The alternative would be to change the docs, but returning an error seems friendlier)