### PR TITLE
Opaque initialization of Some

### DIFF
--- a/facet-json/src/deserialize.rs
+++ b/facet-json/src/deserialize.rs
@@ -267,7 +267,10 @@ pub(crate) fn deserialize_value<'input, 'mem>(
                             let some_poke =
                                 unsafe { PokeUninit::unchecked_new(some_data, some_shape) };
 
-                            stack.push_front(StackItem::FinishSome { po, some: some_data } );
+                            stack.push_front(StackItem::FinishSome {
+                                po,
+                                some: some_data,
+                            });
                             stack.push_front(StackItem::Value { poke: some_poke });
                         }
                     }
@@ -299,7 +302,8 @@ pub(crate) fn deserialize_value<'input, 'mem>(
             StackItem::FinishSome { po, some } => {
                 trace!("Finished deserializing \x1b[1;36mSome\x1b[0m");
                 result = Some(unsafe {
-                    po.replace_with_some_opaque(some.assume_init().as_const()).build_in_place()
+                    po.replace_with_some_opaque(some.assume_init().as_const())
+                        .build_in_place()
                 });
             }
             StackItem::AfterStructField { index } => {

--- a/facet-json/src/deserialize.rs
+++ b/facet-json/src/deserialize.rs
@@ -3,7 +3,7 @@ use std::num::NonZero;
 use crate::parser::{JsonParseErrorKind, JsonParseErrorWithContext, JsonParser};
 
 use facet_core::{Facet, Opaque, OpaqueUninit};
-use facet_reflect::{PokeList, PokeMap, PokeStruct, PokeUninit, PokeValueUninit};
+use facet_reflect::{PokeList, PokeMap, PokeOption, PokeStruct, PokeUninit, PokeValueUninit};
 use log::trace;
 
 /// Deserializes a JSON string into a value of type `T` that implements `Facet`.
@@ -114,6 +114,10 @@ pub(crate) fn deserialize_value<'input, 'mem>(
         },
         StructField {
             key: String,
+        },
+        FinishSome {
+            po: PokeOption<'mem>,
+            some: OpaqueUninit<'mem>,
         },
         AfterStructField {
             index: usize,
@@ -250,6 +254,23 @@ pub(crate) fn deserialize_value<'input, 'mem>(
                         let opaque = pe.build_in_place();
                         result = Some(opaque);
                     }
+                    PokeUninit::Option(po) => {
+                        trace!("Deserializing \x1b[1;36moption\x1b[0m");
+                        let po = unsafe { po.init_none() };
+                        if let Ok(()) = parser.parse_null() {
+                            trace!("Finished deserializing \x1b[1;36mNone\x1b[0m");
+                            result = Some(po.build_in_place());
+                        } else {
+                            let some_shape = po.def().t;
+                            let some_data =
+                                OpaqueUninit::new(unsafe { std::alloc::alloc(some_shape.layout) });
+                            let some_poke =
+                                unsafe { PokeUninit::unchecked_new(some_data, some_shape) };
+
+                            stack.push_front(StackItem::FinishSome { po, some: some_data } );
+                            stack.push_front(StackItem::Value { poke: some_poke });
+                        }
+                    }
                     _ => todo!("unsupported poke type"),
                 }
             }
@@ -274,6 +295,12 @@ pub(crate) fn deserialize_value<'input, 'mem>(
                         return Err(parser.make_error(JsonParseErrorKind::UnknownField(key)));
                     }
                 }
+            }
+            StackItem::FinishSome { po, some } => {
+                trace!("Finished deserializing \x1b[1;36mSome\x1b[0m");
+                result = Some(unsafe {
+                    po.replace_with_some_opaque(some.assume_init().as_const()).build_in_place()
+                });
             }
             StackItem::AfterStructField { index } => {
                 trace!("After processing struct field at index: \x1b[1;33m{index}\x1b[0m");

--- a/facet-json/src/deserialize.rs
+++ b/facet-json/src/deserialize.rs
@@ -301,10 +301,12 @@ pub(crate) fn deserialize_value<'input, 'mem>(
             }
             StackItem::FinishSome { po, some } => {
                 trace!("Finished deserializing \x1b[1;36mSome\x1b[0m");
+                let layout = po.def().t.layout;
                 result = Some(unsafe {
                     po.replace_with_some_opaque(some.assume_init().as_const())
                         .build_in_place()
                 });
+                unsafe { std::alloc::dealloc(some.as_mut_bytes(), layout) };
             }
             StackItem::AfterStructField { index } => {
                 trace!("After processing struct field at index: \x1b[1;33m{index}\x1b[0m");

--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -267,6 +267,17 @@ impl<'a> JsonParser<'a> {
         Err(self.make_error(JsonParseErrorKind::InvalidValue))
     }
 
+    pub fn parse_null(&mut self) -> Result<(), JsonParseErrorWithContext<'a>> {
+        self.skip_whitespace();
+        if self.position + 4 <= self.input.len()
+            && &self.input[self.position..self.position + 4] == "null"
+        {
+            self.position += 4;
+            return Ok(());
+        }
+        Err(self.make_error(JsonParseErrorKind::InvalidValue))
+    }
+
     pub fn skip_whitespace(&mut self) {
         while self.position < self.input.len() {
             match self.input.as_bytes()[self.position] {

--- a/facet-json/tests/json-read.rs
+++ b/facet-json/tests/json-read.rs
@@ -171,3 +171,34 @@ fn test_from_json_with_nested_structs() {
     assert_eq!(test_struct.name, "Outer");
     assert_eq!(test_struct.inner.value, 42);
 }
+
+#[test]
+fn test_from_json_with_option() {
+    #[derive(Facet)]
+    struct Options {
+        name: Option<String>,
+        age: Option<u32>,
+        inner: Option<Inner>,
+    }
+
+    #[derive(Facet)]
+    struct Inner {
+        foo: i32,
+    }
+
+    let json = r#"{
+        "name": "Alice",
+        "age": null,
+        "inner": {
+            "foo": 42
+        }
+    }"#;
+
+    let test_struct: Options = match from_str(json) {
+        Ok(s) => s,
+        Err(e) => panic!("Error deserializing JSON: {}", e),
+    };
+    assert_eq!(test_struct.name.as_deref(), Some("Alice"));
+    assert_eq!(test_struct.age, None);
+    assert_eq!(test_struct.inner.as_ref().map(|i| i.foo), Some(42));
+}

--- a/facet-reflect/src/poke/option.rs
+++ b/facet-reflect/src/poke/option.rs
@@ -146,18 +146,10 @@ impl<'mem> PokeOption<'mem> {
         }
     }
 
-    /// Forgets the PokeOption and returns the underlying Opaque data.
-    ///
-    /// This method is only used when the origin is borrowed. If this method is
-    /// not called, and then option is initialized with a `Some(T)`, the `T`
-    /// will be dropped when the PokeOption is dropped.
-    ///
-    /// Note that this function cannot panic, because PokeOption cannot be
-    /// constructed without initializing the option.
+    /// Takes ownership of this `PokeOption` and returns the underlying data.
+    #[inline]
     pub fn build_in_place(self) -> Opaque<'mem> {
-        let data = self.data;
-        core::mem::forget(self);
-        data
+        self.data
     }
 
     /// Builds an `Option<T>` from the PokeOption, then deallocates the memory

--- a/facet-testhelpers/src/lib.rs
+++ b/facet-testhelpers/src/lib.rs
@@ -35,6 +35,6 @@ pub fn setup() {
     #[cfg(not(miri))]
     color_backtrace::install();
     let logger = Box::new(SimpleLogger);
-    log::set_boxed_logger(logger).unwrap();
+    _ = log::set_boxed_logger(logger);
     log::set_max_level(LevelFilter::Trace);
 }


### PR DESCRIPTION
Added `PokeOption::build_in_place()` and `PokeOption::replace_with_some_opaque()` (not sure about the naming).

Also added support for parsing `null` in the JSON parser.

Closes #119 