### PR TITLE
Fix `unchecked_set` docs about errors

### DIFF
--- a/facet-reflect/src/poke/struct_.rs
+++ b/facet-reflect/src/poke/struct_.rs
@@ -191,7 +191,6 @@ impl<'mem> PokeStruct<'mem> {
     ///
     /// Returns an error if:
     /// - The index is out of bounds
-    /// - The field shapes don't match
     pub unsafe fn unchecked_set(
         &mut self,
         index: usize,
@@ -226,7 +225,6 @@ impl<'mem> PokeStruct<'mem> {
     ///
     /// Returns an error if:
     /// - The field name doesn't exist
-    /// - The field shapes don't match
     pub unsafe fn unchecked_set_by_name(
         &mut self,
         name: &str,


### PR DESCRIPTION
`unchecked_set` and `unchecked_set_by_name` don't actually check field shapes, so let's remove that from the docstring.