### PR TITLE
fix git hook portability for nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 <picture>
 <source srcset="https://github.com/facet-rs/facet/raw/main/static/logo-v2/logo-only.webp">
 <img src="https://github.com/facet-rs/facet/raw/main/static/logo-v2/logo-only.png" height="35" alt="Facet logo - a reflection library for Rust">
-</picture> &nbsp; facet
+</picture> &nbsp; facet-contrib-fork
 </h1>
 
 [![Coverage Status](https://coveralls.io/repos/github/facet-rs/facet/badge.svg?branch=main)](https://coveralls.io/github/facet-rs/facet?branch=main)
 [![free of syn](https://img.shields.io/badge/free%20of-syn-hotpink)](https://github.com/fasterthanlime/free-of-syn)
-[![crates.io](https://img.shields.io/crates/v/facet.svg)](https://crates.io/crates/facet)
-[![documentation](https://docs.rs/facet/badge.svg)](https://docs.rs/facet)
-[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/facet.svg)](./LICENSE)
+[![crates.io](https://img.shields.io/crates/v/facet-contrib-fork.svg)](https://crates.io/crates/facet-contrib-fork)
+[![documentation](https://docs.rs/facet-contrib-fork/badge.svg)](https://docs.rs/facet-contrib-fork)
+[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/facet-contrib-fork.svg)](./LICENSE)
 
 _Logo by [Misiasart](https://misiasart.com/)_
 

--- a/sample/Cargo.lock
+++ b/sample/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "facet"
-version = "0.1.20"
+version = "0.2.0"
 dependencies = [
  "facet-core",
  "facet-derive",
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bitflags",
  "impls",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "facet-derive"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "facet-core",
  "unsynn",


### PR DESCRIPTION
notes:
- nixos does not have /bin/bash, but it does have /bin/sh and /usr/bin/env
- ...I hope the "command" function is indeed portable to all sh implementations