### PR TITLE
Minor updates to Readme and other docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ happily do it. I will be happier clarifying ahead of time than undoing your stuf
 
 In general, give a high-level overview of your plan and ask for consent before making any edits. Thanks.
 
-Don't edit any `README.md` files directly — edit `templates/README.md.j2` and run `just codegen` to
+Don't edit any `README.md` files directly — edit `README.md.in` and run `just codegen` to
 regenerate the README.
 
 Run `just quickcheck` to make sure that tests pass.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ That one checks for UB, memory unsafety, etc.
 
 ## Generated code
 
-Do not edit `README.md` files directly, edit `README.md.j2` in the respective
+Do not edit `README.md` files directly, edit `README.md.in` in the respective
 folders.
 
 Similarly, don't edit `tuples_impls.rs`, edit the `tuples_impls.rs.j2` next to

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ fn main() {
 
 ```bash
 facet on  main [!?] via 🦀 v1.86.0
-❯ cargo run --example various_vecs
+❯ cargo run --example vec_person
    Compiling facet-pretty v0.1.2 (/Users/amos/bearcove/facet/facet-pretty)
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
-     Running `target/debug/examples/various_vecs`
+     Running `target/debug/examples/vec_person`
 Vec<Person> [
   Person {
     name: Alice,
@@ -285,7 +285,7 @@ eprintln!("args: {}", args.pretty());
 
 ```bash
 facet on  args [!] via 🦀 v1.86.0
-❯ RUST_LOG=info nt run --no-capture test_arg_parse
+❯ RUST_LOG=info cargo nextest run --no-capture test_arg_parse
     Finished `test` profile [unoptimized + debuginfo] target(s) in 0.02s
 ────────────
  Nextest run ID a8ab7183-8333-465f-a94f-6036576f19c2 with nextest profile: default

--- a/README.md.in
+++ b/README.md.in
@@ -94,10 +94,10 @@ fn main() {
 
 ```bash
 facet on  main [!?] via 🦀 v1.86.0
-❯ cargo run --example various_vecs
+❯ cargo run --example vec_person
    Compiling facet-pretty v0.1.2 (/Users/amos/bearcove/facet/facet-pretty)
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
-     Running `target/debug/examples/various_vecs`
+     Running `target/debug/examples/vec_person`
 Vec<Person> [
   Person {
     name: Alice,
@@ -244,7 +244,7 @@ eprintln!("args: {}", args.pretty());
 
 ```bash
 facet on  args [!] via 🦀 v1.86.0
-❯ RUST_LOG=info nt run --no-capture test_arg_parse
+❯ RUST_LOG=info cargo nextest run --no-capture test_arg_parse
     Finished `test` profile [unoptimized + debuginfo] target(s) in 0.02s
 ────────────
  Nextest run ID a8ab7183-8333-465f-a94f-6036576f19c2 with nextest profile: default

--- a/facet/README.md
+++ b/facet/README.md
@@ -135,10 +135,10 @@ fn main() {
 
 ```bash
 facet on  main [!?] via 🦀 v1.86.0
-❯ cargo run --example various_vecs
+❯ cargo run --example vec_person
    Compiling facet-pretty v0.1.2 (/Users/amos/bearcove/facet/facet-pretty)
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
-     Running `target/debug/examples/various_vecs`
+     Running `target/debug/examples/vec_person`
 Vec<Person> [
   Person {
     name: Alice,
@@ -285,7 +285,7 @@ eprintln!("args: {}", args.pretty());
 
 ```bash
 facet on  args [!] via 🦀 v1.86.0
-❯ RUST_LOG=info nt run --no-capture test_arg_parse
+❯ RUST_LOG=info cargo nextest run --no-capture test_arg_parse
     Finished `test` profile [unoptimized + debuginfo] target(s) in 0.02s
 ────────────
  Nextest run ID a8ab7183-8333-465f-a94f-6036576f19c2 with nextest profile: default


### PR DESCRIPTION
I saw a few minor things that could be fixed - nothing significant though.

I assumed `nt` is a private alias to `cargo nextest`?

I think [this](https://github.com/facet-rs/facet/blob/046ca7eccaba9890a0b5f6c3eaf8f065a4ad6b20/CONTRIBUTING.md?plain=1#L22) might be incorrect:

> Similarly, don't edit `tuples_impls.rs`, edit the `tuples_impls.rs.j2` next to
it, and then run `just codegen` — the code is in `facet-codegen/`

There don't seem to be any .j2 templates on this branch. I haven't changed this in this PR, though.

Also, aside, the result of `just codegen` is dependent on the name of the directory that the developer has checked the project out into. For example, if the dev chooses `facet.git` instead of `facet` then the output of `just codegen` will be significantly different. Might be worth mentioning this somewhere, maybe `facet/CONTRIBUTING.md`? Or minor changes to `just codegen` to use a fixed path?