### PR TITLE
Remove unneeded cfg

### DIFF
--- a/facet-core/src/impls_alloc/smartptr.rs
+++ b/facet-core/src/impls_alloc/smartptr.rs
@@ -44,7 +44,6 @@ unsafe impl<T: Facet> Facet for alloc::sync::Arc<T> {
     };
 }
 
-#[cfg(feature = "alloc")]
 unsafe impl<T: Facet> Facet for alloc::sync::Weak<T> {
     const SHAPE: &'static crate::Shape = &const {
         crate::Shape::builder()


### PR DESCRIPTION
`impls_alloc` is already gated by `feature = "alloc"` at the module level.