### PR TITLE
feat(reflect): Make wip available on alloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,6 @@ dependencies = [
  "facet-core",
  "facet-samplelibc",
  "facet-testhelpers",
- "indexmap",
  "log",
  "tempfile",
 ]

--- a/facet-reflect/Cargo.toml
+++ b/facet-reflect/Cargo.toml
@@ -12,13 +12,12 @@ categories = ["development-tools", "rust-patterns"]
 
 [features]
 default = ["std"]
-std = ["alloc", "dep:indexmap"]
+std = ["alloc"]
 alloc = []
 
 [dependencies]
 facet-ansi = { path = "../facet-ansi" }
 facet-core = { path = "../facet-core", version = "0.5.3" }
-indexmap = { version = "2.9.0", optional = true }
 log = "0.4.27"
 
 [dev-dependencies]

--- a/facet-reflect/src/lib.rs
+++ b/facet-reflect/src/lib.rs
@@ -10,9 +10,9 @@ extern crate alloc;
 mod error;
 pub use error::*;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod wip;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use wip::*;
 
 mod peek;

--- a/facet-reflect/src/peek/enum_.rs
+++ b/facet-reflect/src/peek/enum_.rs
@@ -1,8 +1,5 @@
 use facet_core::{EnumDef, EnumRepr, Shape, Variant};
 
-#[cfg(feature = "alloc")]
-extern crate alloc;
-
 /// Lets you read from an enum (implements read-only enum operations)
 #[derive(Clone, Copy)]
 pub struct PeekEnum<'mem> {

--- a/facet-reflect/src/peek/mod.rs
+++ b/facet-reflect/src/peek/mod.rs
@@ -1,8 +1,5 @@
 //! Allows reading from shapes
 
-#[cfg(feature = "alloc")]
-extern crate alloc;
-
 mod value;
 pub use value::*;
 

--- a/facet-reflect/src/wip/enum_.rs
+++ b/facet-reflect/src/wip/enum_.rs
@@ -1,5 +1,3 @@
-extern crate alloc;
-
 use facet_ansi::Stylize;
 use facet_core::{Def, FieldError, Variant};
 

--- a/facet-reflect/src/wip/flat_map.rs
+++ b/facet-reflect/src/wip/flat_map.rs
@@ -1,0 +1,123 @@
+#![allow(dead_code)]
+
+use alloc::borrow::Borrow;
+
+/// Flat (Vec) backed map
+///
+/// This preserves insertion order
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FlatMap<K, V> {
+    inner: alloc::vec::Vec<(K, V)>,
+}
+
+impl<K: PartialEq + Eq, V> FlatMap<K, V> {
+    pub(crate) fn new() -> Self {
+        Default::default()
+    }
+
+    pub(crate) fn insert(&mut self, key: K, mut value: V) -> Option<V> {
+        let Some(index) = self.keys().position(|k| *k == key) else {
+            self.insert_unchecked(key, value);
+            return None;
+        };
+
+        core::mem::swap(&mut self.inner[index].1, &mut value);
+        Some(value)
+    }
+
+    pub(crate) fn insert_unchecked(&mut self, key: K, value: V) {
+        self.inner.push((key, value));
+    }
+
+    pub(crate) fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        for existing in self.keys() {
+            if existing.borrow() == key {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&K, &mut V) -> bool,
+    {
+        self.inner.retain_mut(|(k, v)| f(k, v))
+    }
+
+    pub(crate) fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: core::hash::Hash + Eq + ?Sized,
+    {
+        self.remove_entry(key).map(|(_, v)| v)
+    }
+
+    pub(crate) fn remove_entry<Q>(&mut self, key: &Q) -> Option<(K, V)>
+    where
+        K: Borrow<Q>,
+        Q: core::hash::Hash + Eq + ?Sized,
+    {
+        let index = self.keys().position(|k| k.borrow() == key)?;
+        let kv = self.inner.remove(index);
+        Some(kv)
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub(crate) fn len(&mut self) -> usize {
+        self.inner.len()
+    }
+
+    pub(crate) fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        let index = self.keys().position(|k| k.borrow() == key)?;
+        Some(&self.inner[index].1)
+    }
+
+    pub(crate) fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        let index = self.keys().position(|k| k.borrow() == key)?;
+        Some(&mut self.inner[index].1)
+    }
+
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &K> {
+        self.inner.iter().map(|(k, _)| k)
+    }
+
+    pub(crate) fn values(&self) -> impl Iterator<Item = &V> {
+        self.inner.iter().map(|(_, v)| v)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.inner.iter().map(|(k, v)| (k, v))
+    }
+
+    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = (&K, &mut V)> {
+        self.inner.iter_mut().map(|(k, v)| (&*k, v))
+    }
+}
+
+impl<K: PartialEq + Eq, V> Default for FlatMap<K, V> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}

--- a/facet-reflect/src/wip/mod.rs
+++ b/facet-reflect/src/wip/mod.rs
@@ -111,7 +111,7 @@ impl<'a> Wip<'a> {
         };
         Self {
             guard: Some(guard),
-            frames: vec![Frame {
+            frames: alloc::vec![Frame {
                 data,
                 shape,
                 index: None,
@@ -621,7 +621,7 @@ impl Drop for Wip<'_> {
             );
         }
 
-        let mut depths: Vec<usize> = self.istates.values().map(|is| is.depth).collect();
+        let mut depths: alloc::vec::Vec<usize> = self.istates.values().map(|is| is.depth).collect();
         depths.sort_unstable();
         depths.dedup();
 
@@ -629,7 +629,7 @@ impl Drop for Wip<'_> {
             log::trace!("Dropping istates with depth {}", depth.yellow(),);
 
             // Find and drop values at this depth level
-            let mut to_remove = Vec::new();
+            let mut to_remove = alloc::vec::Vec::new();
             self.istates.retain(|id, is| {
                 if is.depth == *depth {
                     log::trace!(

--- a/facet-reflect/src/wip/mod.rs
+++ b/facet-reflect/src/wip/mod.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use crate::{ReflectError, ValueId};
 use core::{alloc::Layout, marker::PhantomData};
 use facet_ansi::Stylize;


### PR DESCRIPTION
I took the `Vec` route.  I carried over the `FlatMap` abstraction from clap but I made it a `Vec<(K, V)>`, rather than `(Vec<K>, Vec<V>)`, so I could get a trivial `retain`.  The latter is nicer for faster searching of keys (as cache lines aren't wasted) and can reduce binary size if you have `Vec<K>` or `Vec<V>` in other places.

Fixes #211