### PR TITLE
feat(json): Allow `deserialize` with just `alloc`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -28,6 +28,7 @@ nostd:
     cargo check --no-default-features --features alloc -p facet-core --target-dir target/nostd-w-alloc
     cargo check --no-default-features --features alloc -p facet --target-dir target/nostd-w-alloc
     cargo check --no-default-features --features alloc -p facet-reflect --target-dir target/nostd-w-alloc
+    cargo check --no-default-features --features alloc -p facet-json --target-dir target/nostd-w-alloc
 
 nostd-ci:
     #!/usr/bin/env -S bash -euo pipefail

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -10,9 +10,14 @@ description = "JSON serialization and deserialization support for Facet traits"
 keywords = ["facet", "json", "serialization", "deserialization"]
 categories = ["encoding", "development-tools"]
 
+[features]
+std = ["facet-core/std", "facet-reflect/std", "alloc"] # Uses libstd and alloc
+alloc = ["facet-core/alloc", "facet-reflect/alloc"]    # Enables alloc support
+default = ["std"]
+
 [dependencies]
-facet-core = { version = "0.5.3", path = "../facet-core" }
-facet-reflect = { version = "0.6.2", path = "../facet-reflect" }
+facet-core = { version = "0.5.3", path = "../facet-core", default-features = false }
+facet-reflect = { version = "0.6.2", path = "../facet-reflect", default-features = false }
 log = "0.4.27"
 
 [dev-dependencies]

--- a/facet-json/src/lib.rs
+++ b/facet-json/src/lib.rs
@@ -1,13 +1,20 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 #![warn(clippy::std_instead_of_core)]
 #![warn(clippy::std_instead_of_alloc)]
 #![deny(unsafe_code)]
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
+
+#[cfg(not(feature = "alloc"))]
+compile_error!("feature `alloc` is required");
 
 mod deserialize;
 pub use deserialize::*;
 
+#[cfg(feature = "std")]
 mod serialize;
+#[cfg(feature = "std")]
 pub use serialize::*;

--- a/facet-json/tests/json-write.rs
+++ b/facet-json/tests/json-write.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "std")]
+
 use std::num::NonZero;
 
 use facet::Facet;


### PR DESCRIPTION
`serialize` requires `std::io::Write`.  `deserialize` can get away without it because it only parses a `&str`.

Looking at `serde_json`
- `Serializer` requires `std` also to use `std::io::Write`
- `Deserializer` uses a custom `Read` trait that they have some custom specialization implemented for so they can work with slices and `std::io::Read`.  Maybe we can repurpose this technique to work for `serialize`. 