### PR TITLE
Make `SmartPointerDef::pointee` optional

### DIFF
--- a/facet-core/src/types/smartptr.rs
+++ b/facet-core/src/types/smartptr.rs
@@ -13,8 +13,8 @@ pub struct SmartPointerDef {
     /// vtable for interacting with the smart pointer
     pub vtable: &'static SmartPointerVTable,
 
-    /// shape of the inner type of the smart pointer
-    pub pointee: &'static Shape,
+    /// shape of the inner type of the smart pointer, if not opaque
+    pub pointee: Option<&'static Shape>,
 
     /// shape of the corresponding strong pointer, if this pointer is weak
     pub weak: Option<fn() -> &'static Shape>,
@@ -122,7 +122,7 @@ impl SmartPointerDefBuilder {
     pub const fn build(self) -> SmartPointerDef {
         SmartPointerDef {
             vtable: self.vtable.unwrap(),
-            pointee: self.pointee.unwrap(),
+            pointee: self.pointee,
             weak: self.weak,
             strong: self.strong,
             flags: self.flags.unwrap(),

--- a/facet-reflect/tests/peek/smartptr.rs
+++ b/facet-reflect/tests/peek/smartptr.rs
@@ -16,7 +16,7 @@ fn test_peek_arc() {
     let def = peek_smart_pointer.def();
 
     // Verify the inner type is correct
-    assert_eq!(def.pointee, i32::SHAPE);
+    assert_eq!(def.pointee, Some(i32::SHAPE));
 }
 
 #[test]
@@ -33,7 +33,7 @@ fn test_peek_arc_with_string() {
     let def = peek_smart_pointer.def();
 
     // Verify the inner type is correct
-    assert_eq!(def.pointee, String::SHAPE);
+    assert_eq!(def.pointee, Some(String::SHAPE));
 }
 
 #[test]
@@ -62,7 +62,7 @@ fn test_peek_arc_in_struct() {
     assert!(def.flags.contains(facet_core::SmartPointerFlags::ATOMIC));
 
     // Verify inner type is String
-    assert_eq!(def.pointee, String::SHAPE);
+    assert_eq!(def.pointee, Some(String::SHAPE));
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn test_peek_arc_in_vec() {
 
         // Test definition
         let def = peek_smart_pointer.def();
-        assert_eq!(def.pointee, i32::SHAPE);
+        assert_eq!(def.pointee, Some(i32::SHAPE));
         assert!(def.flags.contains(facet_core::SmartPointerFlags::ATOMIC));
     }
 }


### PR DESCRIPTION
This is a partial fix for #210: it allows people to manually implement `Facet` for "opaque" smart pointers, where we don't care about introspecting the shape of the pointed-to type.

(There will be a follow-up PR to add a `#[facet(opaque)]` syntax to the derive macro, but that one is messier)

I'm open to adjectives other than "opaque", which is used elsewhere in the codebase with a slightly different meaning.  Looking through a list of synonyms, the only one that I like is "veiled"; other suggestions are welcome.