### PR TITLE
Add `#[facet(opaque)]` annotation for `Arc<T>`

### DIFF
--- a/facet-core/src/impls_alloc/smartptr.rs
+++ b/facet-core/src/impls_alloc/smartptr.rs
@@ -1,8 +1,8 @@
 use core::alloc::Layout;
 
 use crate::{
-    ConstTypeId, Def, Facet, KnownSmartPointer, PtrConst, SmartPointerDef, SmartPointerFlags,
-    SmartPointerVTable, value_vtable,
+    ConstTypeId, Def, Facet, KnownSmartPointer, Opaque, PtrConst, SmartPointerDef,
+    SmartPointerFlags, SmartPointerVTable, value_vtable,
 };
 
 unsafe impl<T: Facet> Facet for alloc::sync::Arc<T> {
@@ -60,6 +60,41 @@ unsafe impl<T: Facet> Facet for alloc::sync::Weak<T> {
                             SmartPointerVTable::builder()
                                 .upgrade_into_fn(|weak, strong| unsafe {
                                     Some(strong.put(weak.get::<Self>().upgrade()?))
+                                })
+                                .build()
+                        },
+                    )
+                    .build(),
+            ))
+            .vtable(value_vtable!(alloc::sync::Arc<T>, |f, _opts| write!(
+                f,
+                "Arc"
+            )))
+            .build()
+    };
+}
+
+unsafe impl<T> Facet for Opaque<alloc::sync::Arc<T>> {
+    const SHAPE: &'static crate::Shape = &const {
+        crate::Shape::builder()
+            .id(ConstTypeId::of::<Self>())
+            .layout(Layout::new::<Self>())
+            .def(Def::SmartPointer(
+                SmartPointerDef::builder()
+                    .flags(SmartPointerFlags::ATOMIC)
+                    .known(KnownSmartPointer::Arc)
+                    .vtable(
+                        &const {
+                            SmartPointerVTable::builder()
+                                .borrow_fn(|opaque| {
+                                    let ptr =
+                                        alloc::sync::Arc::<T>::as_ptr(unsafe { opaque.get() });
+                                    PtrConst::new(ptr)
+                                })
+                                .new_into_fn(|this, ptr| {
+                                    let t = unsafe { ptr.read::<T>() };
+                                    let arc = alloc::sync::Arc::new(t);
+                                    unsafe { this.put(arc) }
                                 })
                                 .build()
                         },

--- a/facet-core/src/macros.rs
+++ b/facet-core/src/macros.rs
@@ -5,6 +5,17 @@ pub const fn shape_of<TStruct, TField: Facet>(_f: &dyn Fn(&TStruct) -> &TField) 
     TField::SHAPE
 }
 
+#[doc(hidden)]
+pub const fn shape_of_opaque<TStruct, TField>(_f: &dyn Fn(&TStruct) -> &TField) -> &'static Shape
+where
+    Opaque<TField>: Facet,
+{
+    Opaque::<TField>::SHAPE
+}
+
+/// Helper type for opaque members
+pub struct Opaque<T>(T);
+
 /// Creates a `ValueVTable` for a given type.
 ///
 /// This macro generates a `ValueVTable` with implementations for various traits

--- a/facet-reflect/tests/wip/misc.rs
+++ b/facet-reflect/tests/wip/misc.rs
@@ -405,3 +405,31 @@ fn wip_map() -> eyre::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn wip_opaque_arc() -> eyre::Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    pub struct NotDerivingFacet(u64);
+
+    #[derive(Facet)]
+    pub struct Handle(#[facet(opaque)] std::sync::Arc<NotDerivingFacet>);
+
+    #[derive(Facet)]
+    pub struct Container {
+        inner: Handle,
+    }
+
+    // Test switching variants
+    let result = Wip::alloc::<Container>()
+        .field_named("inner")?
+        .put(Handle(std::sync::Arc::new(NotDerivingFacet(35))))?
+        .pop()?
+        .build()?
+        .materialize::<Container>()?;
+
+    assert_eq!(*result.inner.0, NotDerivingFacet(35));
+
+    Ok(())
+}

--- a/facet/tests/derive.rs
+++ b/facet/tests/derive.rs
@@ -511,3 +511,24 @@ fn struct_impls_drop() {
     // let bar = bf.bar;
     // drop(bf.foo);
 }
+
+#[test]
+fn opaque_arc() {
+    #[allow(dead_code)]
+    pub struct NotDerivingFacet(u64);
+
+    #[derive(Facet)]
+    pub struct Handle(#[facet(opaque)] std::sync::Arc<NotDerivingFacet>);
+
+    let shape = Handle::SHAPE;
+    match shape.def {
+        Def::Struct(sd) => {
+            assert_eq!(sd.fields.len(), 1);
+            let field = sd.fields[0];
+            let shape_name = format!("{}", field.shape());
+            assert_eq!(shape_name, "Arc");
+            eprintln!("Shape {shape} looks correct");
+        }
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
This closes #210 by letting `#[derive(Facet)]` structures contain an `Arc<T>`, where `T` does _not_ implement `Facet`.

It defines a new type `pub struct OpaqueArc<T>(pub alloc::sync::Arc<T>)`, which implements `Facet` for **all** `T`, and has `pointee: None` in its `SmartPointerDef`.

Then, if there's a `#[facet(opaque)]` annotation, the macro wraps the member in `OpaqueArc` in the closure that's used to extract its `SHAPE`.

This required changing the closure signature in `shape_of` to return a value rather than a reference, since we can't forge a reference to an `OpaqueArc` that isn't in the struct.  I _think_ this is okay; the closure is only used for type inference, and isn't actually called.

I added a unit test for building such a structure:
```rust
    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
    pub struct NotDerivingFacet(u64);

    #[derive(Facet)]
    pub struct Handle(
        #[facet(opaque)]
        std::sync::Arc<NotDerivingFacet>
    );

    #[derive(Facet)]
    pub struct Container {
        inner: Handle,
    }
```

It's now possible to poke a `Handle` into a WIP `Container`.

Note that it's _not_ trivially possible to poke an `Arc<NotDerivingFacet>` into a WIP `Handle`; to do so, the user has to manually wrap it in `OpaqueArc`.  I don't love this, but don't a strategy for avoiding it yet.

--------------------------------------------------------------------------------

I'm open to iteration if you have feedback, e.g. where and how to document this functionality.