### PR TITLE
fix(def): add `PeekMap` def getter

### DIFF
--- a/facet-reflect/src/peek/map.rs
+++ b/facet-reflect/src/peek/map.rs
@@ -94,4 +94,9 @@ impl<'mem> PeekMap<'mem> {
         let iter = unsafe { (self.def.vtable.iter_fn)(self.value.data()) };
         PeekMapIter { map: self, iter }
     }
+
+    /// Def getter
+    pub fn def(&self) -> MapDef {
+        self.def
+    }
 }


### PR DESCRIPTION
Please can `PeekMap` have a def getter like `PeekList` and friends? :slightly_smiling_face: 

```bash
louis 🌟 ~/lab/facet/facet/facet-reflect/src/peek $ grep -r 'fn def'
list.rs:    pub fn def(&self) -> ListDef {
option.rs:    pub fn def(self) -> OptionDef {
smartptr.rs:    pub fn def(&self) -> &SmartPointerDef {
struct_.rs:    pub fn def(&self) -> &Struct {
enum_.rs:    pub fn def(self) -> EnumDef {
```

I am writing a proof of concept deserialisation function and this appeared as a cargo build blocker, I hope it's not a problem to add.