### PR TITLE
Fix incorrect comment

### DIFF
--- a/facet-reflect/tests/wip/misc.rs
+++ b/facet-reflect/tests/wip/misc.rs
@@ -421,7 +421,6 @@ fn wip_opaque_arc() -> eyre::Result<()> {
         inner: Handle,
     }
 
-    // Test switching variants
     let result = Wip::alloc::<Container>()
         .field_named("inner")?
         .put(Handle(std::sync::Arc::new(NotDerivingFacet(35))))?


### PR DESCRIPTION
This was copy-pasted from an enum test but isn't correct here.