### PR TITLE
feat(deserialize): handle number shaped StringAffinity

### DIFF
--- a/facet-json/src/deserialize.rs
+++ b/facet-json/src/deserialize.rs
@@ -3,6 +3,7 @@ use facet_core::{Def, Facet, ScalarAffinity};
 use facet_reflect::{HeapValue, Wip};
 use log::trace;
 
+use crate::alloc::string::ToString;
 use alloc::string::String;
 use alloc::vec::Vec;
 

--- a/facet-json/src/deserialize.rs
+++ b/facet-json/src/deserialize.rs
@@ -36,6 +36,8 @@ pub enum JsonErrorKind {
     UnexpectedCharacter(char),
     /// A number is out of range.
     NumberOutOfRange(f64),
+    /// An unexpected String was encountered in the input.
+    StringAsNumber(String),
 }
 
 impl core::fmt::Display for JsonParseErrorWithContext<'_> {
@@ -316,6 +318,14 @@ pub fn from_slice_wip<'input, 'a>(
                                         } else {
                                             bailp!(JsonErrorKind::NumberOutOfRange(number));
                                         }
+                                    }
+                                }
+                                ScalarAffinity::String(_sa) => {
+                                    if shape.is_type::<String>() {
+                                        let value = number.to_string();
+                                        bailp!(JsonErrorKind::StringAsNumber(value));
+                                    } else {
+                                        todo!()
                                     }
                                 }
                                 _ => {


### PR DESCRIPTION
I think there should be errors raised deliberately when we're able to parse (what we expect to be) a number but it's a string in the JSON

This should get the ball rolling by introducing a new type of `JsonErrorKind` for the situation when the number turns out to be a string

I tested it with [facet-validate](https://github.com/lmmx/facet-validate) like so

```rust
use facet::Facet;
use facet_validate::validate_json;

#[derive(Facet)]
struct FooBar {
    foo: u64,
    bar: String,
}

fn main() {
    if result.is_empty() {
        println!("No validation errors detected. The JSON validation didn't work!");
    } else {
        for error in &result {
            println!("{}: {}", error.path, error.message);
        }
    }
}

```

gives

```
{"foo": 42, "bar": 42}
                    ↑ StringAsNumber("42")
```

Suggestions for better enum names / any other feedback welcome :-)