### PR TITLE
build(ariadne): add "rich-diagnostics" default feature

### DIFF
--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["encoding", "development-tools"]
 [features]
 std = ["facet-core/std", "facet-reflect/std", "alloc"] # Uses libstd and alloc
 alloc = ["facet-core/alloc", "facet-reflect/alloc"]    # Enables alloc support
-rich-diagnostics = ["ariadne"]
+rich-diagnostics = ["ariadne", "alloc"]
 default = ["std", "rich-diagnostics"]
 
 [dependencies]

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -13,10 +13,11 @@ categories = ["encoding", "development-tools"]
 [features]
 std = ["facet-core/std", "facet-reflect/std", "alloc"] # Uses libstd and alloc
 alloc = ["facet-core/alloc", "facet-reflect/alloc"]    # Enables alloc support
-default = ["std"]
+rich-diagnostics = ["ariadne"]
+default = ["std", "rich-diagnostics"]
 
 [dependencies]
-ariadne = "0.5.1"
+ariadne = { version = "=0.5.1", optional = true }
 facet-core = { version = "0.8.0", path = "../facet-core", default-features = false }
 facet-reflect = { version = "0.8.0", path = "../facet-reflect", default-features = false }
 log = "0.4.27"

--- a/facet-json/src/deserialize.rs
+++ b/facet-json/src/deserialize.rs
@@ -4,7 +4,7 @@ use core::num::{
 };
 
 #[cfg(feature = "rich-diagnostics")]
-use ariadne::{Color, Label, Report, ReportKind, Source};
+use ariadne::{Color, Config, IndexType, Label, Report, ReportKind, Source};
 use facet_core::{Def, Facet, ScalarAffinity};
 use facet_reflect::{HeapValue, Wip};
 use log::trace;
@@ -99,7 +99,8 @@ impl core::fmt::Display for JsonParseErrorWithContext<'_> {
         };
 
         let mut report = Report::build(ReportKind::Error, (source_id, span_start..span_end))
-            .with_message(format!("Error at {}", self.path.fg(Color::Yellow)));
+            .with_message(format!("Error at {}", self.path.fg(Color::Yellow)))
+            .with_config(Config::new().with_index_type(IndexType::Byte));
 
         let label = Label::new((source_id, span_start..span_end))
             .with_message(self.message())

--- a/facet-json/src/deserialize.rs
+++ b/facet-json/src/deserialize.rs
@@ -10,9 +10,8 @@ use facet_reflect::{HeapValue, Wip};
 use log::trace;
 use yansi::Paint as _;
 
-use crate::alloc::string::ToString;
 use alloc::format;
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 /// A JSON parse error, with context. Never would've guessed huh.


### PR DESCRIPTION
- **build(feature-flag): new default feature "rich-diagnostics" to switch on `ariadne` Display for JsonParseErrorWithContext**

- [x] Default feature "rich-diagnostics" for ariadne
  - requested in #258
- [x] Pin ariadne dep
  - requested in #254 (review received after PR had merged)
- [x] Create report using `.with_config(Config::new().with_index_type(IndexType::Byte))` 
  - also from #254