### PR TITLE
Fix repr(C) enums

### DIFF
--- a/facet-derive-emit/src/process_enum.rs
+++ b/facet-derive-emit/src/process_enum.rs
@@ -295,7 +295,7 @@ fn process_c_style_enum(
                     .name({variant_name:?})
                     .discriminant({discriminant_value})
                     .offset(::core::mem::offset_of!({shadow_repr_name}, _fields))
-                    .fields(::facet::Struct::builder().unit().build(),
+                    .fields(::facet::Struct::builder().unit().build())
                     {maybe_doc}
                     .build()",
                 ));
@@ -356,7 +356,7 @@ fn process_c_style_enum(
                             .name({variant_name:?})
                             .discriminant({discriminant_value})
                             .offset(::core::mem::offset_of!({shadow_repr_name}, _fields))
-                            .fields(::facet::Struct::builder().tuple().fields(fields).build(),
+                            .fields(::facet::Struct::builder().tuple().fields(fields).build())
                             {maybe_doc}
                             .build()
                     }}",
@@ -417,7 +417,7 @@ fn process_c_style_enum(
                             .name({variant_name:?})
                             .discriminant(discriminant_value)
                             .offset(::core::mem::offset_of!({shadow_repr_name}, _fields))
-                            .fields(::facet::Struct::builder().struct_().fields(fields).build(),
+                            .fields(::facet::Struct::builder().struct_().fields(fields).build())
                             {maybe_doc}
                             .build()
                     }}",


### PR DESCRIPTION
Fixes #271,
this was a regression I bisected to b0c2d91162093217a68fb8a6c86e6edfd6aa4bfd

We should probably add tests for `repr(C)` enums, since it seems there aren't any. I wanted to add but wasn't sure were to add them
