### PR TITLE
fix(utf8): deserialise UTF-8 encoded field names (closes #277)

### DIFF
--- a/facet-json/src/deserialize.rs
+++ b/facet-json/src/deserialize.rs
@@ -48,6 +48,7 @@ impl<'input> JsonParseErrorWithContext<'input> {
             JsonErrorKind::NumberOutOfRange(n) => format!("Number out of range: {}", n),
             JsonErrorKind::StringAsNumber(s) => format!("Expected a string but got number: {}", s),
             JsonErrorKind::UnknownField(f) => format!("Unknown field: {}", f),
+            JsonErrorKind::InvalidUtf8(e) => format!("Invalid UTF-8 encoding: {}", e),
         }
     }
 }
@@ -65,6 +66,8 @@ pub enum JsonErrorKind {
     StringAsNumber(String),
     /// An unexpected field name was encountered in the input.
     UnknownField(String),
+    /// A string that could not be built into valid UTF-8 Unicode
+    InvalidUtf8(String),
 }
 
 #[cfg(not(feature = "rich-diagnostics"))]
@@ -183,7 +186,7 @@ pub fn from_slice_wip<'input, 'a>(
     }
     macro_rules! bail {
         ($kind:expr) => {
-            return err!($kind);
+            return err!($kind)
         };
     }
 
@@ -317,8 +320,8 @@ pub fn from_slice_wip<'input, 'a>(
                     }
                     b'"' => {
                         pos += 1;
-                        // our value is a string
-                        let mut value = String::new();
+                        // Our value is a string: collect bytes first
+                        let mut bytes = Vec::new();
                         loop {
                             let Some(c) = input.get(pos).copied() else {
                                 bail!(JsonErrorKind::UnexpectedEof);
@@ -329,15 +332,33 @@ pub fn from_slice_wip<'input, 'a>(
                                     break;
                                 }
                                 b'\\' => {
-                                    pos += 2;
-                                    value.push('\\');
+                                    // Handle escape sequences
+                                    pos += 1;
+                                    if let Some(next) = input.get(pos) {
+                                        bytes.push(*next);
+                                        pos += 1;
+                                    } else {
+                                        bail!(JsonErrorKind::UnexpectedEof);
+                                    }
                                 }
                                 _ => {
+                                    bytes.push(c);
                                     pos += 1;
-                                    value.push(c as char);
                                 }
                             }
                         }
+
+                        // Convert collected bytes to string at once
+                        let value = match core::str::from_utf8(&bytes) {
+                            Ok(s) => s.to_string(),
+                            Err(e) => {
+                                bail!(JsonErrorKind::InvalidUtf8(format!(
+                                    "Invalid UTF-8 sequence: {}",
+                                    e
+                                )))
+                            }
+                        };
+
                         trace!(
                             "Parsed string value: {:?} for shape {}",
                             value.yellow(),

--- a/facet-json/tests/integration/read.rs
+++ b/facet-json/tests/integration/read.rs
@@ -291,13 +291,12 @@ fn test_field_rename_common_case_styles() {
 /// Serialization and deserialization with special symbol characters in field name
 #[test]
 #[cfg(feature = "std")]
-#[ignore]
 fn test_field_rename_with_symbol_chars_name() {
     facet_testhelpers::setup();
 
     #[derive(Debug, PartialEq, Facet)]
     struct SpecialCharsName {
-        #[facet(rename = "@#$%^&€")]
+        #[facet(rename = "@#$%^&")]
         special_chars: String,
     }
 
@@ -306,9 +305,55 @@ fn test_field_rename_with_symbol_chars_name() {
     };
 
     let json = facet_json::to_string(&test_struct);
-    assert_eq!(json, r#"{"@#$%^&€":"special value"}"#);
+    assert_eq!(json, r#"{"@#$%^&":"special value"}"#);
 
     let roundtrip: SpecialCharsName = facet_json::from_str(&json).unwrap();
+    assert_eq!(test_struct, roundtrip);
+}
+
+/// Serialization and deserialization with Unicode characters in field name (emoji)
+#[test]
+#[cfg(feature = "std")]
+fn test_field_rename_with_unicode_name_emoji() {
+    facet_testhelpers::setup();
+
+    #[derive(Debug, PartialEq, Facet)]
+    struct EmojiCharsName {
+        #[facet(rename = "🏀")]
+        ball: String,
+    }
+
+    let test_struct = EmojiCharsName {
+        ball: "🏆".to_string(),
+    };
+
+    let json = facet_json::to_string(&test_struct);
+    assert_eq!(json, r#"{"🏀":"🏆"}"#);
+
+    let roundtrip: EmojiCharsName = facet_json::from_str(&json).unwrap();
+    assert_eq!(test_struct, roundtrip);
+}
+
+/// Serialization and deserialization with Unicode characters in field name (Euro sign)
+#[test]
+#[cfg(feature = "std")]
+fn test_field_rename_with_unicode_name_special_signs() {
+    facet_testhelpers::setup();
+
+    #[derive(Debug, PartialEq, Facet)]
+    struct EmojiCharsName {
+        #[facet(rename = "€℮↑→↓↔↕")]
+        special_chars: String,
+    }
+
+    let test_struct = EmojiCharsName {
+        special_chars: "...".to_string(),
+    };
+
+    let json = facet_json::to_string(&test_struct);
+    assert_eq!(json, r#"{"€℮↑→↓↔↕":"..."}"#);
+
+    let roundtrip: EmojiCharsName = facet_json::from_str(&json).unwrap();
     assert_eq!(test_struct, roundtrip);
 }
 


### PR DESCRIPTION
- **fix(utf8): properly handle UTF-8 encoding in field names; add tests**
