### PR TITLE
Allow manually defining enum discriminants

### DIFF
--- a/facet-derive-emit/tests/codegen.rs
+++ b/facet-derive-emit/tests/codegen.rs
@@ -60,6 +60,22 @@ fn enum_with_variants() {
 }
 
 #[test]
+fn enum_with_discriminants() {
+    insta::assert_snapshot!(expand(
+        r#"
+        #[repr(u8)]
+        #[derive(Facet)]
+        enum Test {
+          Red,
+          Blue = 7,
+          Green,
+          Yellow = 10,
+        }
+        "#
+    ));
+}
+
+#[test]
 fn repr_c_enum() {
     insta::assert_snapshot!(expand(
         r#"

--- a/facet-derive-emit/tests/snapshots/codegen__enum_with_discriminants.snap
+++ b/facet-derive-emit/tests/snapshots/codegen__enum_with_discriminants.snap
@@ -1,0 +1,48 @@
+---
+source: facet-derive-emit/tests/codegen.rs
+expression: "expand(r#\"\n        #[repr(u8)]\n        #[derive(Facet)]\n        enum Test {\n          Red,\n          Blue = 7,\n          Green,\n          Yellow = 10,\n        }\n        \"#)"
+---
+#[used]
+static TEST_SHAPE: &'static ::facet::Shape = <Test as ::facet::Facet>::SHAPE;
+#[automatically_derived]
+unsafe impl ::facet::Facet for Test {
+    const SHAPE: &'static ::facet::Shape = &const {
+        let __facet_variants: &'static [::facet::Variant] = &const {
+            [
+                ::facet::Variant::builder()
+                    .name("Red")
+                    .discriminant(0)
+                    .fields(::facet::Struct::builder().unit().build())
+                    .build(),
+                ::facet::Variant::builder()
+                    .name("Blue")
+                    .discriminant(7)
+                    .fields(::facet::Struct::builder().unit().build())
+                    .build(),
+                ::facet::Variant::builder()
+                    .name("Green")
+                    .discriminant(8)
+                    .fields(::facet::Struct::builder().unit().build())
+                    .build(),
+                ::facet::Variant::builder()
+                    .name("Yellow")
+                    .discriminant(10)
+                    .fields(::facet::Struct::builder().unit().build())
+                    .build(),
+            ]
+        };
+        ::facet::Shape::builder()
+            .id(::facet::ConstTypeId::of::<Self>())
+            .layout(::core::alloc::Layout::new::<Self>())
+            .vtable(::facet::value_vtable!(Self, |f, _opts| {
+                ::core::fmt::Write::write_str(f, "Test")
+            }))
+            .def(::facet::Def::Enum(
+                ::facet::EnumDef::builder()
+                    .variants(__facet_variants)
+                    .repr(::facet::EnumRepr::U8)
+                    .build(),
+            ))
+            .build()
+    };
+}

--- a/facet-derive-parse/src/lib.rs
+++ b/facet-derive-parse/src/lib.rs
@@ -328,8 +328,17 @@ unsynn! {
         pub body: BraceGroupContaining<CommaDelimitedVec<EnumVariantLike>>,
     }
 
+    /// Represents a variant of an enum, including the optional discriminant value
+    pub struct EnumVariantLike {
+        /// The actual variant
+        pub variant: EnumVariantData,
+        /// The optional discriminant value
+        pub discriminant: Option<Cons<Eq, LiteralInteger>>
+
+    }
+
     /// Represents the different kinds of variants an enum can have.
-    pub enum EnumVariantLike {
+    pub enum EnumVariantData {
         /// A tuple-like variant, e.g., `Variant(u32, String)`.
         Tuple(TupleVariant),
         /// A struct-like variant, e.g., `Variant { field1: u32, field2: String }`.


### PR DESCRIPTION
Fixes #284.

see the reference for how discriminants are assigned
https://doc.rust-lang.org/reference/items/enumerations.html#implicit-discriminants


BTW there is a lot of duplication between processing primitive enums and c-style enums. we should probably merge the code somewhat at some point