### PR TITLE
Refactor JSON number deserialization to use Wip::try_put_f64

### DIFF
--- a/facet-json/src/deserialize.rs
+++ b/facet-json/src/deserialize.rs
@@ -1,8 +1,3 @@
-use core::num::{
-    NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroIsize, NonZeroU8, NonZeroU16, NonZeroU32,
-    NonZeroU64, NonZeroUsize,
-};
-
 use facet_core::{Characteristic, Def, Facet, FieldAttribute, ScalarAffinity, ShapeAttribute};
 use facet_reflect::{HeapValue, Wip};
 use log::trace;
@@ -366,165 +361,22 @@ pub fn from_slice_wip<'input, 'a>(
                         let number = number.parse::<f64>().unwrap();
                         trace!("Parsed {:?}", number.yellow());
 
-                        let shape = wip.shape();
-                        match shape.def {
-                            Def::Scalar(sd) => match sd.affinity {
-                                ScalarAffinity::Number(_na) => {
-                                    if shape.is_type::<u8>() {
-                                        if number >= 0.0 && number <= u8::MAX as f64 {
-                                            let value = number as u8;
-                                            wip = wip.put::<u8>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<u16>() {
-                                        if number >= 0.0 && number <= u16::MAX as f64 {
-                                            let value = number as u16;
-                                            wip = wip.put::<u16>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<u32>() {
-                                        if number >= 0.0 && number <= u32::MAX as f64 {
-                                            let value = number as u32;
-                                            wip = wip.put::<u32>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<u64>() {
-                                        if number >= 0.0 && number <= u64::MAX as f64 {
-                                            let value = number as u64;
-                                            wip = wip.put::<u64>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<i8>() {
-                                        if number >= i8::MIN as f64 && number <= i8::MAX as f64 {
-                                            let value = number as i8;
-                                            wip = wip.put::<i8>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<i16>() {
-                                        if number >= i16::MIN as f64 && number <= i16::MAX as f64 {
-                                            let value = number as i16;
-                                            wip = wip.put::<i16>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<i32>() {
-                                        if number >= i32::MIN as f64 && number <= i32::MAX as f64 {
-                                            let value = number as i32;
-                                            wip = wip.put::<i32>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<i64>() {
-                                        // Note: f64 might lose precision for large i64 values, but this is a common limitation.
-                                        if number >= i64::MIN as f64 && number <= i64::MAX as f64 {
-                                            let value = number as i64;
-                                            wip = wip.put::<i64>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<f32>() {
-                                        if number >= f32::MIN as f64 && number <= f32::MAX as f64 {
-                                            let value = number as f32;
-                                            wip = wip.put::<f32>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<f64>() {
-                                        wip = wip.put::<f64>(number).unwrap();
-                                    } else if shape.is_type::<NonZeroU8>() {
-                                        if number >= 1.0 && number <= u8::MAX as f64 {
-                                            let value = NonZeroU8::new(number as u8).unwrap();
-                                            wip = wip.put::<NonZeroU8>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<NonZeroU16>() {
-                                        if number >= 1.0 && number <= u16::MAX as f64 {
-                                            let value = NonZeroU16::new(number as u16).unwrap();
-                                            wip = wip.put::<NonZeroU16>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<NonZeroU32>() {
-                                        if number >= 1.0 && number <= u32::MAX as f64 {
-                                            let value = NonZeroU32::new(number as u32).unwrap();
-                                            wip = wip.put::<NonZeroU32>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<NonZeroU64>() {
-                                        if number >= 1.0 && number <= u64::MAX as f64 {
-                                            let value = NonZeroU64::new(number as u64).unwrap();
-                                            wip = wip.put::<NonZeroU64>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<NonZeroUsize>() {
-                                        if number >= 1.0 && number <= usize::MAX as f64 {
-                                            let value = NonZeroUsize::new(number as usize).unwrap();
-                                            wip = wip.put::<NonZeroUsize>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<NonZeroI8>() {
-                                        if number >= 1.0 && number <= i8::MAX as f64 {
-                                            let value = NonZeroI8::new(number as i8).unwrap();
-                                            wip = wip.put::<NonZeroI8>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<NonZeroI16>() {
-                                        if number >= 1.0 && number <= i16::MAX as f64 {
-                                            let value = NonZeroI16::new(number as i16).unwrap();
-                                            wip = wip.put::<NonZeroI16>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<NonZeroI32>() {
-                                        if number >= 1.0 && number <= i32::MAX as f64 {
-                                            let value = NonZeroI32::new(number as i32).unwrap();
-                                            wip = wip.put::<NonZeroI32>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<NonZeroI64>() {
-                                        if number >= 1.0 && number <= i64::MAX as f64 {
-                                            let value = NonZeroI64::new(number as i64).unwrap();
-                                            wip = wip.put::<NonZeroI64>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else if shape.is_type::<NonZeroIsize>() {
-                                        if number >= 1.0 && number <= isize::MAX as f64 {
-                                            let value = NonZeroIsize::new(number as isize).unwrap();
-                                            wip = wip.put::<NonZeroIsize>(value).unwrap();
-                                        } else {
-                                            bail!(JsonErrorKind::NumberOutOfRange(number));
-                                        }
-                                    } else {
-                                        todo!("number type, but unknown")
-                                    }
-                                }
-                                ScalarAffinity::String(_sa) => {
+                        // Prefer try_put_f64 only if actually supported (can_put_f64)
+                        if wip.can_put_f64() {
+                            wip = wip.try_put_f64(number).unwrap();
+                        } else {
+                            // If string affinity (eg, expecting a string, but got number)
+                            let shape = wip.shape();
+                            if let Def::Scalar(sd) = shape.def {
+                                if let ScalarAffinity::String(_) = sd.affinity {
                                     if shape.is_type::<String>() {
                                         let value = number.to_string();
                                         bail!(JsonErrorKind::StringAsNumber(value));
-                                    } else {
-                                        todo!()
                                     }
                                 }
-                                _ => {
-                                    todo!("saw number in JSON but expected.. shape {}?", shape)
-                                }
-                            },
-                            _ => {
-                                todo!("saw number in JSON but expected.. shape {}?", shape)
                             }
+                            // fallback for other shape mismatch (todo! or parse error)
+                            bail!(JsonErrorKind::NumberOutOfRange(number));
                         }
                         finished_value = Some(why);
                     }

--- a/facet-reflect/src/wip/mod.rs
+++ b/facet-reflect/src/wip/mod.rs
@@ -19,6 +19,8 @@ use alloc::string::String;
 mod iset;
 pub use iset::*;
 
+mod put_f64;
+
 mod enum_;
 mod flat_map;
 

--- a/facet-reflect/src/wip/put_f64.rs
+++ b/facet-reflect/src/wip/put_f64.rs
@@ -1,0 +1,255 @@
+use crate::{ReflectError, Wip};
+use core::num::{
+    NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroIsize, NonZeroU8, NonZeroU16, NonZeroU32,
+    NonZeroU64, NonZeroUsize,
+};
+use facet_core::{Def, ScalarAffinity};
+
+impl Wip<'_> {
+    /// Returns true if the current frame can accept a f64 into a supported numeric type.
+    pub fn can_put_f64(&self) -> bool {
+        let shape = self.shape();
+        match shape.def {
+            Def::Scalar(sd) => matches!(sd.affinity, ScalarAffinity::Number(_)),
+            _ => false,
+        }
+    }
+
+    /// Attempts to put a `f64` into the current frame, converting to the underlying numeric type.
+    pub fn try_put_f64(self, number: f64) -> Result<Self, ReflectError> {
+        let shape = self.shape();
+        // Ensure this is a numeric scalar
+        match shape.def {
+            Def::Scalar(sd) => match sd.affinity {
+                ScalarAffinity::Number(_) => {}
+                ScalarAffinity::String(_) => {
+                    return Err(ReflectError::OperationFailed {
+                        shape,
+                        operation: "cannot parse number into string scalar",
+                    });
+                }
+                _ => {
+                    return Err(ReflectError::OperationFailed {
+                        shape,
+                        operation: "tried to put f64 into non-number scalar",
+                    });
+                }
+            },
+            _ => {
+                return Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "tried to put f64 into non-scalar type",
+                });
+            }
+        }
+
+        // Match on the concrete Rust type
+        if shape.is_type::<u8>() {
+            if (0.0..=u8::MAX as f64).contains(&number) {
+                self.put(number as u8)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<u16>() {
+            if (0.0..=u16::MAX as f64).contains(&number) {
+                self.put(number as u16)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<u32>() {
+            if (0.0..=u32::MAX as f64).contains(&number) {
+                self.put(number as u32)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<u64>() {
+            if (0.0..=u64::MAX as f64).contains(&number) {
+                self.put(number as u64)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<usize>() {
+            if (0.0..=usize::MAX as f64).contains(&number) {
+                self.put(number as usize)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<i8>() {
+            if (i8::MIN as f64..=i8::MAX as f64).contains(&number) {
+                self.put(number as i8)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<i16>() {
+            if (i16::MIN as f64..=i16::MAX as f64).contains(&number) {
+                self.put(number as i16)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<i32>() {
+            if (i32::MIN as f64..=i32::MAX as f64).contains(&number) {
+                self.put(number as i32)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<i64>() {
+            if (i64::MIN as f64..=i64::MAX as f64).contains(&number) {
+                self.put(number as i64)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<isize>() {
+            if (isize::MIN as f64..=isize::MAX as f64).contains(&number) {
+                self.put(number as isize)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<f32>() {
+            if (f32::MIN as f64..=f32::MAX as f64).contains(&number) {
+                self.put(number as f32)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<f64>() {
+            self.put(number)
+        } else if shape.is_type::<NonZeroU8>() {
+            if (1.0..=u8::MAX as f64).contains(&number) {
+                let value = NonZeroU8::new(number as u8).unwrap();
+                self.put(value)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<NonZeroU16>() {
+            if (1.0..=u16::MAX as f64).contains(&number) {
+                let value = NonZeroU16::new(number as u16).unwrap();
+                self.put(value)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<NonZeroU32>() {
+            if (1.0..=u32::MAX as f64).contains(&number) {
+                let value = NonZeroU32::new(number as u32).unwrap();
+                self.put(value)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<NonZeroU64>() {
+            if (1.0..=u64::MAX as f64).contains(&number) {
+                let value = NonZeroU64::new(number as u64).unwrap();
+                self.put(value)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<NonZeroUsize>() {
+            if (1.0..=usize::MAX as f64).contains(&number) {
+                let value = NonZeroUsize::new(number as usize).unwrap();
+                self.put(value)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<NonZeroI8>() {
+            if (1.0..=i8::MAX as f64).contains(&number) {
+                let value = NonZeroI8::new(number as i8).unwrap();
+                self.put(value)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<NonZeroI16>() {
+            if (1.0..=i16::MAX as f64).contains(&number) {
+                let value = NonZeroI16::new(number as i16).unwrap();
+                self.put(value)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<NonZeroI32>() {
+            if (1.0..=i32::MAX as f64).contains(&number) {
+                let value = NonZeroI32::new(number as i32).unwrap();
+                self.put(value)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<NonZeroI64>() {
+            if (1.0..=i64::MAX as f64).contains(&number) {
+                let value = NonZeroI64::new(number as i64).unwrap();
+                self.put(value)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else if shape.is_type::<NonZeroIsize>() {
+            if (1.0..=isize::MAX as f64).contains(&number) {
+                let value = NonZeroIsize::new(number as isize).unwrap();
+                self.put(value)
+            } else {
+                Err(ReflectError::OperationFailed {
+                    shape,
+                    operation: "number out of range",
+                })
+            }
+        } else {
+            Err(ReflectError::OperationFailed {
+                shape,
+                operation: "number type not supported by try_put_f64",
+            })
+        }
+    }
+}


### PR DESCRIPTION
Improve handling of number conversion to target Rust types using Wip::can_put_f64 and Wip::try_put_f64, reducing duplicated logic and delegating range checking to facet-reflect. Add put_f64 module to facet-reflect for this purpose.