### PR TITLE
Fix facet-dev compilation on windows

### DIFF
--- a/facet-dev/Cargo.toml
+++ b/facet-dev/Cargo.toml
@@ -18,5 +18,7 @@ log = "0.4.27"
 num_cpus = "1.16.0"
 rayon = "1.10.0"
 similar = { version = "2.4.0", features = ["inline"] }
-termion = "4.0.5"
 yansi = "1.0.1"
+
+[target.'cfg(not(windows))'.dependencies]
+termion = "4.0.5"

--- a/facet-dev/src/menu.rs
+++ b/facet-dev/src/menu.rs
@@ -1,4 +1,6 @@
-use yansi::{Paint as _, Style};
+#![cfg_attr(windows, allow(dead_code))]
+
+use yansi::Style;
 
 /// A menu item
 pub struct MenuItem {
@@ -12,12 +14,20 @@ pub struct MenuItem {
     pub action: String,
 }
 
+#[cfg(windows)]
+pub fn show_menu(question: &str, items: &[MenuItem]) -> Option<String> {
+    _ = (question, items);
+    None
+}
+
+#[cfg(not(windows))]
 pub fn show_menu(question: &str, items: &[MenuItem]) -> Option<String> {
     // Requires the 'termion' crate for raw input handling
     use std::io::{self, Write};
     use termion::event::{Event, Key};
     use termion::input::TermRead;
     use termion::raw::IntoRawMode;
+    use yansi::Paint as _;
 
     use termion::color;
     println!("{}", question);


### PR DESCRIPTION
Termion does not support the platform, so this just stubs it out