### PR TITLE
json: Support tuple variants for enums

### DIFF
--- a/facet-json/tests/integration/read/enums.rs
+++ b/facet-json/tests/integration/read/enums.rs
@@ -35,7 +35,7 @@ fn json_read_tuple_variant() {
     #[derive(Facet, Debug, PartialEq)]
     #[repr(u8)]
     enum Point {
-        X(u32),
+        X(u64),
         Y(String),
     }
 

--- a/facet-json/tests/integration/read/enums.rs
+++ b/facet-json/tests/integration/read/enums.rs
@@ -27,3 +27,30 @@ fn json_read_unit_enum_variant() {
     };
     assert_eq!(s_oblique, FontStyle::Oblique);
 }
+
+#[test]
+fn json_read_tuple_variant() {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    #[repr(u8)]
+    enum Point {
+        X(u32),
+        Y(String),
+    }
+
+    let json_x = r#"{ "X": 123 }"#;
+    let json_y = r#"{ "Y": "hello" }"#;
+
+    let p_x: Point = match from_str(json_x) {
+        Ok(s) => s,
+        Err(e) => panic!("Error deserializing JSON: {}", e),
+    };
+    assert_eq!(p_x, Point::X(123));
+
+    let p_y: Point = match from_str(json_y) {
+        Ok(s) => s,
+        Err(e) => panic!("Error deserializing JSON: {}", e),
+    };
+    assert_eq!(p_y, Point::Y("hello".to_string()));
+}

--- a/facet-reflect/src/wip/mod.rs
+++ b/facet-reflect/src/wip/mod.rs
@@ -911,6 +911,8 @@ impl<'a> Wip<'a> {
 
                             let shape = frame.shape;
                             let index = frame.field_index_in_parent;
+
+                            #[allow(unused)]
                             let variant_name = variant.name;
 
                             // If all fields are now initialized, mark the enum itself as initialized

--- a/facet-reflect/tests/wip/mod.rs
+++ b/facet-reflect/tests/wip/mod.rs
@@ -27,3 +27,6 @@ mod put_vec_leak;
 
 #[cfg(feature = "std")]
 mod option_leak;
+
+#[cfg(feature = "std")]
+mod put_into_tuples;

--- a/facet-reflect/tests/wip/put_into_tuples.rs
+++ b/facet-reflect/tests/wip/put_into_tuples.rs
@@ -1,0 +1,84 @@
+use facet::Facet;
+use facet_reflect::Wip;
+
+#[test]
+fn test_put_into_tuples() -> eyre::Result<()> {
+    facet_testhelpers::setup();
+
+    type T = (u32, String, bool);
+
+    let mut wip = Wip::alloc::<T>();
+    wip = wip.put::<u32>(42)?;
+    wip = wip.put::<String>("hello".to_string())?;
+    wip = wip.put::<bool>(true)?;
+    let t = wip.build()?.materialize::<T>()?;
+    assert_eq!(t, (42, "hello".to_string(), true));
+
+    Ok(())
+}
+
+#[test]
+fn test_put_into_struct_like_tuple() -> eyre::Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet)]
+    struct Point(u32, u32, String);
+
+    let mut wip = Wip::alloc::<Point>();
+    wip = wip.put::<u32>(10)?;
+    wip = wip.put::<u32>(20)?;
+    wip = wip.put::<String>("point".to_string())?;
+    let point = wip.build()?.materialize::<Point>()?;
+    assert_eq!(point.0, 10);
+    assert_eq!(point.1, 20);
+    assert_eq!(point.2, "point");
+
+    Ok(())
+}
+
+#[test]
+fn test_put_into_enum_variant_with_tuple_fields() -> eyre::Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    #[allow(dead_code)]
+    enum Message {
+        Quit,
+        Move { x: i32, y: i32 },
+        Write(String),
+        ChangeColor(i32, i32, i32),
+    }
+
+    // Test with the ChangeColor variant that has tuple-like fields
+    let mut wip = Wip::alloc::<Message>();
+    wip = wip.variant_named("ChangeColor")?;
+    wip = wip.put::<i32>(255)?;
+    wip = wip.put::<i32>(0)?;
+    wip = wip.put::<i32>(255)?;
+    let message = wip.build()?.materialize::<Message>()?;
+
+    match message {
+        Message::ChangeColor(r, g, b) => {
+            assert_eq!(r, 255);
+            assert_eq!(g, 0);
+            assert_eq!(b, 255);
+        }
+        _ => panic!("Expected ChangeColor variant"),
+    }
+
+    // Test with the Write variant that has a single tuple field
+    let mut wip = Wip::alloc::<Message>();
+    wip = wip.variant_named("Write")?;
+    wip = wip.put::<String>("hello".to_string())?;
+    let message = wip.build()?.materialize::<Message>()?;
+
+    match message {
+        Message::Write(s) => {
+            assert_eq!(s, "hello");
+        }
+        _ => panic!("Expected Write variant"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
cc @lmmx @tversteeg — this also changes `Wip` in a fun way: see this new test:

```
#[test]
fn test_put_into_tuples() -> eyre::Result<()> {
    facet_testhelpers::setup();

    type T = (u32, String, bool);

    let mut wip = Wip::alloc::<T>();
    wip = wip.put::<u32>(42)?;
    wip = wip.put::<String>("hello".to_string())?;
    wip = wip.put::<bool>(true)?;
    let t = wip.build()?.materialize::<T>()?;
    assert_eq!(t, (42, "hello".to_string(), true));

    Ok(())
}
```

It makes it easier to write deserializers for sure :) Time will tell if it's a good idea.