### PR TITLE
Fix `Peek` lifetimes

### DIFF
--- a/facet-json/src/serialize.rs
+++ b/facet-json/src/serialize.rs
@@ -12,7 +12,7 @@ pub fn to_string<'a, T: Facet<'a>>(value: &'a T) -> String {
 }
 
 /// Serializes a Peek instance to JSON
-pub fn peek_to_string(peek: &Peek<'_>) -> String {
+pub fn peek_to_string(peek: &Peek<'_, '_>) -> String {
     let mut output = Vec::new();
     serialize(peek, &mut output).unwrap();
     String::from_utf8(output).unwrap()
@@ -25,12 +25,12 @@ pub fn to_writer<'a, T: Facet<'a>, W: Write>(value: &'a T, writer: &mut W) -> io
 }
 
 /// Serializes a Peek instance to a writer in JSON format
-pub fn peek_to_writer<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
+pub fn peek_to_writer<W: Write>(peek: &Peek<'_, '_>, writer: &mut W) -> io::Result<()> {
     serialize(peek, writer)
 }
 
 /// The core serialization function
-fn serialize<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
+fn serialize<W: Write>(peek: &Peek<'_, '_>, writer: &mut W) -> io::Result<()> {
     use facet_core::{
         Struct,
         StructKind::{Tuple, TupleStruct},
@@ -55,7 +55,7 @@ fn serialize<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
 }
 
 /// Serializes a scalar value to JSON
-fn serialize_scalar<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
+fn serialize_scalar<W: Write>(peek: &Peek<'_, '_>, writer: &mut W) -> io::Result<()> {
     // Handle basic scalar types
     if peek.shape().is_type::<bool>() {
         let value = peek.get::<bool>().unwrap();
@@ -150,7 +150,7 @@ fn serialize_scalar<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()>
 }
 
 /// Serializes a struct to JSON
-fn serialize_struct<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
+fn serialize_struct<W: Write>(peek: &Peek<'_, '_>, writer: &mut W) -> io::Result<()> {
     let struct_peek = peek
         .into_struct()
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Not a struct: {}", e)))?;
@@ -191,7 +191,7 @@ fn serialize_struct<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()>
 }
 
 /// Serializes a list to JSON
-fn serialize_list<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
+fn serialize_list<W: Write>(peek: &Peek<'_, '_>, writer: &mut W) -> io::Result<()> {
     let list_peek = peek
         .into_list()
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Not a list: {}", e)))?;
@@ -214,7 +214,7 @@ fn serialize_list<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
 }
 
 /// Serializes a tuple (struct) to JSON
-fn serialize_tuple<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
+fn serialize_tuple<W: Write>(peek: &Peek<'_, '_>, writer: &mut W) -> io::Result<()> {
     let struct_peek = peek
         .into_struct()
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Not a struct: {}", e)))?;
@@ -237,7 +237,7 @@ fn serialize_tuple<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> 
 }
 
 /// Serializes a map to JSON
-fn serialize_map<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
+fn serialize_map<W: Write>(peek: &Peek<'_, '_>, writer: &mut W) -> io::Result<()> {
     let map_peek = peek
         .into_map()
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Not a map: {}", e)))?;
@@ -283,7 +283,7 @@ fn serialize_map<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
 }
 
 /// Serializes an enum to JSON
-fn serialize_enum<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
+fn serialize_enum<W: Write>(peek: &Peek<'_, '_>, writer: &mut W) -> io::Result<()> {
     let enum_peek = peek
         .into_enum()
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Not an enum: {}", e)))?;
@@ -355,7 +355,7 @@ fn serialize_enum<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
 }
 
 /// Serializes an `Option<T>` to JSON
-fn serialize_option<W: Write>(peek: &Peek<'_>, writer: &mut W) -> io::Result<()> {
+fn serialize_option<W: Write>(peek: &Peek<'_, '_>, writer: &mut W) -> io::Result<()> {
     let option_peek = peek
         .into_option()
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Not an option: {}", e)))?;

--- a/facet-msgpack/src/to_msgpack.rs
+++ b/facet-msgpack/src/to_msgpack.rs
@@ -13,7 +13,7 @@ pub fn to_vec<'a, T: Facet<'a>>(value: &'a T) -> Vec<u8> {
 }
 
 /// Serializes any Facet type to a writer in MessagePack format
-fn serialize<W: Write>(pv: Peek<'_>, writer: &mut W) -> io::Result<()> {
+fn serialize<W: Write>(pv: Peek<'_, '_>, writer: &mut W) -> io::Result<()> {
     let shape = pv.shape();
     match shape.def {
         Def::Scalar(_) => {

--- a/facet-pretty/src/printer.rs
+++ b/facet-pretty/src/printer.rs
@@ -47,8 +47,8 @@ enum StackState {
 }
 
 /// Stack item for iterative traversal
-struct StackItem<'a> {
-    value: Peek<'a>,
+struct StackItem<'a, 'facet_lifetime> {
+    value: Peek<'a, 'facet_lifetime>,
     format_depth: usize,
     type_depth: usize,
     state: StackState,
@@ -106,7 +106,7 @@ impl PrettyPrinter {
     }
 
     /// Format a value to a string
-    pub fn format_peek(&self, value: Peek<'_>) -> String {
+    pub fn format_peek(&self, value: Peek<'_, '_>) -> String {
         let mut output = String::new();
         self.format_peek_internal(value, &mut output, &mut HashMap::new())
             .expect("Formatting failed");
@@ -116,7 +116,7 @@ impl PrettyPrinter {
     /// Internal method to format a Peek value
     pub(crate) fn format_peek_internal(
         &self,
-        initial_value: Peek<'_>,
+        initial_value: Peek<'_, '_>,
         f: &mut impl Write,
         visited: &mut HashMap<ValueId, usize>,
     ) -> fmt::Result {
@@ -697,9 +697,9 @@ impl PrettyPrinter {
         let color = self.color_generator.generate_color(hash);
 
         // Display the value
-        struct DisplayWrapper<'a>(&'a Peek<'a>);
+        struct DisplayWrapper<'a, 'facet_lifetime>(&'a Peek<'a, 'facet_lifetime>);
 
-        impl fmt::Display for DisplayWrapper<'_> {
+        impl fmt::Display for DisplayWrapper<'_, '_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 if self.0.shape().is_display() {
                     write!(f, "{}", self.0)?;
@@ -734,7 +734,7 @@ impl PrettyPrinter {
 
     /// Write styled type name to formatter
     fn write_type_name<W: fmt::Write>(&self, f: &mut W, peek: &Peek) -> fmt::Result {
-        struct TypeNameWriter<'a, 'b: 'a>(&'b Peek<'a>);
+        struct TypeNameWriter<'a, 'facet_lifetime>(&'a Peek<'a, 'facet_lifetime>);
 
         impl core::fmt::Display for TypeNameWriter<'_, '_> {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/facet-reflect/src/peek/option.rs
+++ b/facet-reflect/src/peek/option.rs
@@ -2,15 +2,15 @@ use facet_core::{OptionDef, OptionVTable};
 
 /// Lets you read from an option (implements read-only option operations)
 #[derive(Clone, Copy)]
-pub struct PeekOption<'mem> {
+pub struct PeekOption<'mem, 'facet_lifetime> {
     /// the underlying value
-    pub(crate) value: crate::Peek<'mem>,
+    pub(crate) value: crate::Peek<'mem, 'facet_lifetime>,
 
     /// the definition of the option
     pub(crate) def: OptionDef,
 }
 
-impl<'mem> PeekOption<'mem> {
+impl<'mem, 'facet_lifetime> PeekOption<'mem, 'facet_lifetime> {
     /// Returns the option definition
     #[inline(always)]
     pub fn def(self) -> OptionDef {
@@ -36,12 +36,10 @@ impl<'mem> PeekOption<'mem> {
     }
 
     /// Returns the inner value as a Peek if the option is Some, None otherwise
-    pub fn value(self) -> Option<crate::Peek<'mem>> {
+    pub fn value(self) -> Option<crate::Peek<'mem, 'facet_lifetime>> {
         unsafe {
-            (self.vtable().get_value_fn)(self.value.data()).map(|inner_data| crate::Peek {
-                data: inner_data,
-                shape: self.def.t(),
-            })
+            (self.vtable().get_value_fn)(self.value.data())
+                .map(|inner_data| crate::Peek::unchecked_new(inner_data, self.def.t()))
         }
     }
 }

--- a/facet-reflect/src/peek/smartptr.rs
+++ b/facet-reflect/src/peek/smartptr.rs
@@ -5,16 +5,16 @@ use super::Peek;
 /// Represents a smart pointer that can be peeked at during memory inspection.
 ///
 /// This struct holds the value being pointed to and the definition of the smart pointer type.
-pub struct PeekSmartPointer<'mem> {
+pub struct PeekSmartPointer<'mem, 'facet_lifetime> {
     /// The value being pointed to by this smart pointer.
     #[expect(dead_code)]
-    pub(crate) value: Peek<'mem>,
+    pub(crate) value: Peek<'mem, 'facet_lifetime>,
 
     /// The definition of this smart pointer type.
     pub(crate) def: SmartPointerDef,
 }
 
-impl PeekSmartPointer<'_> {
+impl PeekSmartPointer<'_, '_> {
     /// Returns a reference to the smart pointer definition.
     #[must_use]
     pub fn def(&self) -> &SmartPointerDef {

--- a/facet-reflect/src/peek/struct_.rs
+++ b/facet-reflect/src/peek/struct_.rs
@@ -4,15 +4,15 @@ use crate::Peek;
 
 /// Lets you read from a struct (implements read-only struct operations)
 #[derive(Clone, Copy)]
-pub struct PeekStruct<'mem> {
+pub struct PeekStruct<'mem, 'facet_lifetime> {
     /// the underlying value
-    pub(crate) value: Peek<'mem>,
+    pub(crate) value: Peek<'mem, 'facet_lifetime>,
 
     /// the definition of the struct!
     pub(crate) def: Struct,
 }
 
-impl<'mem> PeekStruct<'mem> {
+impl<'mem, 'facet_lifetime> PeekStruct<'mem, 'facet_lifetime> {
     /// Returns the struct definition
     #[inline(always)]
     pub fn def(&self) -> &Struct {
@@ -27,23 +27,20 @@ impl<'mem> PeekStruct<'mem> {
 
     /// Returns the value of the field at the given index
     #[inline(always)]
-    pub fn field(&self, index: usize) -> Result<Peek<'mem>, FieldError> {
+    pub fn field(&self, index: usize) -> Result<Peek<'mem, 'facet_lifetime>, FieldError> {
         self.def
             .fields
             .get(index)
             .map(|field| unsafe {
                 let field_data = self.value.data().field(field.offset);
-                Peek {
-                    data: field_data,
-                    shape: field.shape(),
-                }
+                Peek::unchecked_new(field_data, field.shape())
             })
             .ok_or(FieldError::IndexOutOfBounds)
     }
 
     /// Gets the value of the field with the given name
     #[inline]
-    pub fn field_by_name(&self, name: &str) -> Result<Peek<'mem>, FieldError> {
+    pub fn field_by_name(&self, name: &str) -> Result<Peek<'mem, 'facet_lifetime>, FieldError> {
         for (i, field) in self.def.fields.iter().enumerate() {
             if field.name == name {
                 return self.field(i);
@@ -54,7 +51,9 @@ impl<'mem> PeekStruct<'mem> {
 
     /// Iterates over all fields in this struct, providing both name and value
     #[inline]
-    pub fn fields(&self) -> impl Iterator<Item = (&'static Field, Peek<'mem>)> + '_ {
+    pub fn fields(
+        &self,
+    ) -> impl Iterator<Item = (&'static Field, Peek<'mem, 'facet_lifetime>)> + '_ {
         (0..self.field_count()).filter_map(|i| {
             let field = self.def.fields.get(i)?;
             let value = self.field(i).ok()?;
@@ -64,7 +63,9 @@ impl<'mem> PeekStruct<'mem> {
 
     /// Iterates over thos fields in this struct that should be included when it is serialized.
     #[inline]
-    pub fn fields_for_serialize(&self) -> impl Iterator<Item = (&'static Field, Peek<'mem>)> + '_ {
+    pub fn fields_for_serialize(
+        &self,
+    ) -> impl Iterator<Item = (&'static Field, Peek<'mem, 'facet_lifetime>)> + '_ {
         self.fields().filter(|(field, peek)| {
             for attr in field.attributes {
                 match attr {

--- a/facet-reflect/tests/peek/facts.rs
+++ b/facet-reflect/tests/peek/facts.rs
@@ -6,7 +6,7 @@ use owo_colors::{OwoColorize, Style};
 
 const REMARKABLE: Style = Style::new().blue();
 
-fn collect_facts<'a, 'b, T>(val1: &'b T, val2: &'b T) -> HashSet<Fact>
+fn collect_facts<'a, T>(val1: &T, val2: &T) -> HashSet<Fact>
 where
     T: Facet<'a>,
 {
@@ -874,7 +874,7 @@ fn test_fn_ptr() {
         let name = format!("{}", T::SHAPE);
         eprint!("{}", format_args!("== {name}: ").yellow());
 
-        let facts = collect_facts(&val1, &val2);
+        let facts = collect_facts(&val1, &val1);
         for &fact in facts.iter() {
             if let Fact::EqualAnd { .. } | Fact::OrdAnd { .. } = fact {
                 expected_facts.insert(fact);

--- a/facet-reflect/tests/wip/no_uninit.rs
+++ b/facet-reflect/tests/wip/no_uninit.rs
@@ -82,7 +82,7 @@ fn smart_pointer_uninit() {
     test_uninit::<Arc<u8>>();
 }
 
-fn test_uninit<'a, T: Facet<'a>>() {
+fn test_uninit<T: Facet<'static>>() {
     facet_testhelpers::setup();
     let wip = Wip::alloc::<T>();
     assert!(


### PR DESCRIPTION
This is going to be annoying to fix

The lifetimes as written are incorrect, easpecially `Wip::peek` returns `Peek` that is tied to our invariant lifetime, while it needs to be tied to the `Wip` as we could drop it before the `Peek` causing UB