### PR TITLE
Make de/serialization API lifetimes more permissive 

### DIFF
--- a/facet-args/src/lib.rs
+++ b/facet-args/src/lib.rs
@@ -7,12 +7,14 @@
 use facet_core::{Def, Facet, FieldAttribute};
 use facet_reflect::{ReflectError, Wip};
 
-fn parse_field<'mem>(wip: Wip<'mem>, value: &str) -> Result<Wip<'mem>, ReflectError> {
+fn parse_field<'facet>(wip: Wip<'facet>, value: &'facet str) -> Result<Wip<'facet>, ReflectError> {
     let shape = wip.shape();
     match shape.def {
         Def::Scalar(_) => {
             if shape.is_type::<String>() {
                 wip.put(value.to_string())
+            } else if shape.is_type::<&str>() {
+                wip.put(value)
             } else if shape.is_type::<bool>() {
                 log::trace!("Boolean field detected, setting to true");
                 wip.put(value.to_lowercase() == "true")
@@ -31,7 +33,11 @@ fn parse_field<'mem>(wip: Wip<'mem>, value: &str) -> Result<Wip<'mem>, ReflectEr
 }
 
 /// Parses command-line arguments
-pub fn from_slice<'a, T: Facet<'a>>(s: &[&str]) -> T {
+pub fn from_slice<'input, 'facet, T>(s: &[&'input str]) -> T
+where
+    T: Facet<'facet>,
+    'input: 'facet,
+{
     log::trace!("Entering from_slice function");
     let mut s = s;
     let mut wip = Wip::alloc::<T>();

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -101,14 +101,14 @@ impl Shape {
     }
 
     /// Check if this shape is of the given type
-    pub fn is_type<'a, Other: Facet<'a>>(&'static self) -> bool {
+    pub fn is_type<Other: Facet<'static>>(&'static self) -> bool {
         let l = self;
         let r = Other::SHAPE;
         l == r
     }
 
     /// Assert that this shape is of the given type, panicking if it's not
-    pub fn assert_type<'a, Other: Facet<'a>>(&'static self) {
+    pub fn assert_type<Other: Facet<'static>>(&'static self) {
         assert!(
             self.is_type::<Other>(),
             "Type mismatch: expected {}, found {self}",

--- a/facet-json/src/serialize.rs
+++ b/facet-json/src/serialize.rs
@@ -4,7 +4,7 @@ use facet_reflect::Peek;
 use std::io::{self, Write};
 
 /// Serializes a value to JSON
-pub fn to_string<'a, T: Facet<'a>>(value: &'a T) -> String {
+pub fn to_string<'a, T: Facet<'a>>(value: &T) -> String {
     let peek = Peek::new(value);
     let mut output = Vec::new();
     serialize(&peek, &mut output).unwrap();
@@ -19,7 +19,7 @@ pub fn peek_to_string(peek: &Peek<'_, '_>) -> String {
 }
 
 /// Serializes a value to a writer in JSON format
-pub fn to_writer<'a, T: Facet<'a>, W: Write>(value: &'a T, writer: &mut W) -> io::Result<()> {
+pub fn to_writer<'a, T: Facet<'a>, W: Write>(value: &T, writer: &mut W) -> io::Result<()> {
     let peek = Peek::new(value);
     serialize(&peek, writer)
 }

--- a/facet-json/tests/integration/write/string.rs
+++ b/facet-json/tests/integration/write/string.rs
@@ -3,12 +3,12 @@
 use facet::Facet;
 
 #[test]
-fn test_static_strings() {
+fn test_strings() {
     facet_testhelpers::setup();
 
     #[derive(Debug, PartialEq, Clone, Facet)]
-    struct StaticFoo {
-        foo: &'static str,
+    struct StaticFoo<'a> {
+        foo: &'a str,
     }
 
     let test_struct = StaticFoo { foo: "foo" };
@@ -17,8 +17,8 @@ fn test_static_strings() {
     assert_eq!(json, r#"{"foo":"foo"}"#);
 
     #[derive(Debug, PartialEq, Clone, Facet)]
-    struct OptStaticFoo {
-        foo: Option<&'static str>,
+    struct OptStaticFoo<'a> {
+        foo: Option<&'a str>,
     }
 
     let test_struct = OptStaticFoo { foo: None };
@@ -32,8 +32,8 @@ fn test_static_strings() {
     assert_eq!(json, r#"{"foo":"foo"}"#);
 
     #[derive(Debug, PartialEq, Clone, Facet)]
-    struct CowFoo {
-        foo: std::borrow::Cow<'static, str>,
+    struct CowFoo<'a> {
+        foo: std::borrow::Cow<'a, str>,
     }
 
     let test_struct = CowFoo {

--- a/facet-msgpack/src/from_msgpack.rs
+++ b/facet-msgpack/src/from_msgpack.rs
@@ -28,7 +28,9 @@ use log::trace;
 /// let user: User = from_str(&msgpack_data).unwrap();
 /// assert_eq!(user, User { id: 42, username: "user123".to_string() });
 /// ```
-pub fn from_slice<'a, T: Facet<'a>>(msgpack: &'a [u8]) -> Result<T, DecodeError> {
+pub fn from_slice<'input: 'facet, 'facet, T: Facet<'facet>>(
+    msgpack: &'input [u8],
+) -> Result<T, DecodeError> {
     from_slice_value(Wip::alloc::<T>(), msgpack)?
         .materialize::<T>()
         .map_err(|e| DecodeError::UnsupportedType(e.to_string()))
@@ -36,7 +38,9 @@ pub fn from_slice<'a, T: Facet<'a>>(msgpack: &'a [u8]) -> Result<T, DecodeError>
 
 /// Alias for from_slice for backward compatibility
 #[deprecated(since = "0.1.0", note = "Use from_slice instead")]
-pub fn from_str<'a, T: Facet<'a>>(msgpack: &'a [u8]) -> Result<T, DecodeError> {
+pub fn from_str<'input: 'facet, 'facet, T: Facet<'facet>>(
+    msgpack: &'input [u8],
+) -> Result<T, DecodeError> {
     from_slice(msgpack)
 }
 

--- a/facet-msgpack/src/to_msgpack.rs
+++ b/facet-msgpack/src/to_msgpack.rs
@@ -5,7 +5,7 @@ use log::trace;
 use std::io::{self, Write};
 
 /// Serializes any Facet type to MessagePack bytes
-pub fn to_vec<'a, T: Facet<'a>>(value: &'a T) -> Vec<u8> {
+pub fn to_vec<'a, T: Facet<'a>>(value: &T) -> Vec<u8> {
     let mut buffer = Vec::new();
     let peek = Peek::new(value);
     serialize(peek, &mut buffer).unwrap();

--- a/facet-pretty/src/printer.rs
+++ b/facet-pretty/src/printer.rs
@@ -85,7 +85,7 @@ impl PrettyPrinter {
     }
 
     /// Format a value to a string
-    pub fn format<'a, T: Facet<'a>>(&self, value: &'a T) -> String {
+    pub fn format<'a, T: Facet<'a>>(&self, value: &T) -> String {
         let value = Peek::new(value);
 
         let mut output = String::new();
@@ -98,7 +98,7 @@ impl PrettyPrinter {
     /// Format a value to a formatter
     pub fn format_to<'a, T: Facet<'a>>(
         &self,
-        value: &'a T,
+        value: &T,
         f: &mut fmt::Formatter<'_>,
     ) -> fmt::Result {
         let value = Peek::new(value);

--- a/facet-reflect/src/wip/mod.rs
+++ b/facet-reflect/src/wip/mod.rs
@@ -758,11 +758,25 @@ impl<'facet_lifetime> Wip<'facet_lifetime> {
         res
     }
 
-    /// Checks if the current frame is of type `T`.
-    pub fn current_is_type<T: Facet<'facet_lifetime>>(&self) -> bool {
-        self.frames
-            .last()
-            .is_some_and(|frame| frame.shape == T::SHAPE)
+    /// Puts a value of type `T` into the current frame.
+    ///
+    /// # Arguments
+    ///
+    /// * `t` - The value to put into the frame.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Self)` if the value was successfully put into the frame.
+    /// * `Err(ReflectError)` if there was an error putting the value into the frame.
+    pub fn try_put<T: Facet<'facet_lifetime>>(
+        self,
+        t: T,
+    ) -> Result<Wip<'facet_lifetime>, ReflectError> {
+        let shape = T::SHAPE;
+        let ptr_const = PtrConst::new(&t as *const T as *const u8);
+        let res = self.put_shape(ptr_const, shape);
+        core::mem::forget(t); // avoid double drop; ownership moved into Wip
+        res
     }
 
     /// Puts a value from a `PtrConst` with the given shape into the current frame.

--- a/facet-toml/src/lib.rs
+++ b/facet-toml/src/lib.rs
@@ -43,7 +43,9 @@ macro_rules! reflect {
 }
 
 /// Deserializes a TOML string into a value of type `T` that implements `Facet`.
-pub fn from_str<'a, T: Facet<'a>>(toml: &str) -> Result<T, TomlError<'_>> {
+pub fn from_str<'input: 'facet, 'facet, T: Facet<'facet>>(
+    toml: &'input str,
+) -> Result<T, TomlError<'input>> {
     trace!("Parsing TOML");
 
     // Allocate the type
@@ -80,11 +82,11 @@ pub fn from_str<'a, T: Facet<'a>>(toml: &str) -> Result<T, TomlError<'_>> {
     Ok(result)
 }
 
-fn deserialize_item<'input, 'a>(
+fn deserialize_item<'input, 'facet>(
     toml: &'input str,
-    wip: Wip<'a>,
+    wip: Wip<'facet>,
     item: &Item,
-) -> Result<Wip<'a>, TomlError<'input>> {
+) -> Result<Wip<'facet>, TomlError<'input>> {
     match wip.shape().def {
         Def::Scalar(_) => deserialize_as_scalar(toml, wip, item),
         Def::List(_) => deserialize_as_list(toml, wip, item),

--- a/facet-urlencoded/src/lib.rs
+++ b/facet-urlencoded/src/lib.rs
@@ -68,7 +68,9 @@ mod tests;
 ///     },
 /// });
 /// ```
-pub fn from_str<'a, T: Facet<'a>>(urlencoded: &str) -> Result<T, UrlEncodedError> {
+pub fn from_str<'input: 'facet, 'facet, T: Facet<'facet>>(
+    urlencoded: &'input str,
+) -> Result<T, UrlEncodedError> {
     let val = from_str_value(Wip::alloc::<T>(), urlencoded)?;
     Ok(val.materialize::<T>()?)
 }

--- a/facet-yaml/src/lib.rs
+++ b/facet-yaml/src/lib.rs
@@ -6,7 +6,7 @@ use facet_reflect::Wip;
 use yaml_rust2::{Yaml, YamlLoader};
 
 /// Deserializes a YAML string into a value of type `T` that implements `Facet`.
-pub fn from_str<'a, T: Facet<'a>>(yaml: &str) -> Result<T, AnyErr> {
+pub fn from_str<'input: 'facet, 'facet, T: Facet<'facet>>(yaml: &'input str) -> Result<T, AnyErr> {
     let wip = Wip::alloc::<T>();
     let wip = from_str_value(wip, yaml)?;
     let heap_value = wip.build().map_err(|e| AnyErr(e.to_string()))?;


### PR DESCRIPTION
Follow up to #383, otherwise calling these with things containing lifetimes will tend to fail borrow check.