### PR TITLE
Add support for `!Sized` types

### DIFF
--- a/facet-args/src/lib.rs
+++ b/facet-args/src/lib.rs
@@ -40,7 +40,7 @@ where
 {
     log::trace!("Entering from_slice function");
     let mut s = s;
-    let mut wip = Wip::alloc::<T>();
+    let mut wip = Wip::alloc::<T>().expect("failed to allocate");
     log::trace!("Allocated Poke for type T");
 
     while let Some(token) = s.first() {

--- a/facet-core/src/impls_core/array.rs
+++ b/facet-core/src/impls_core/array.rs
@@ -87,7 +87,7 @@ where
                     } else if L <= 32 && T::SHAPE.vtable.default_in_place.is_some() {
                         builder = builder.default_in_place(|target| unsafe {
                             let t_dip = T::SHAPE.vtable.default_in_place.unwrap_unchecked();
-                            let stride = T::SHAPE.layout.pad_to_align().size();
+                            let stride = T::SHAPE.layout.sized_layout().unwrap().pad_to_align().size();
                             for idx in 0..L {
                                 t_dip(target.field_uninit_at(idx * stride));
                             }
@@ -101,7 +101,7 @@ where
                         builder = builder.clone_into(|src, dst| unsafe {
                             let t_cip = T::SHAPE.vtable.clone_into.unwrap_unchecked();
                             let src = src.get::<[T; L]>();
-                            let stride = T::SHAPE.layout.pad_to_align().size();
+                            let stride = T::SHAPE.layout.sized_layout().unwrap().pad_to_align().size();
                             for (idx, src) in src.iter().enumerate() {
                                 (t_cip)(PtrConst::new(src), dst.field_uninit_at(idx * stride));
                             }

--- a/facet-core/src/impls_core/scalar.rs
+++ b/facet-core/src/impls_core/scalar.rs
@@ -154,7 +154,7 @@ macro_rules! impl_facet_for_integer {
 
                             vtable.try_from = Some(|source, source_shape, dest| {
                                 if source_shape == Self::SHAPE {
-                                    return Ok(unsafe { dest.copy_from(source, source_shape) });
+                                    return Ok(unsafe { dest.copy_from(source, source_shape)? });
                                 }
                                 if source_shape == u64::SHAPE {
                                     let value: u64 = *unsafe { source.get::<u64>() };
@@ -199,7 +199,7 @@ macro_rules! impl_facet_for_integer {
 
                             vtable.try_from = Some(|source, source_shape, dest| {
                                 if source_shape == Self::SHAPE {
-                                    return Ok(unsafe { dest.copy_from(source, source_shape) });
+                                    return Ok(unsafe { dest.copy_from(source, source_shape)? });
                                 }
                                 if source_shape == <$type>::SHAPE {
                                     let value: $type = *unsafe { source.get::<$type>() };
@@ -496,7 +496,7 @@ unsafe impl Facet<'_> for f32 {
 
                     vtable.try_from = Some(|source, source_shape, dest| {
                         if source_shape == Self::SHAPE {
-                            return Ok(unsafe { dest.copy_from(source, source_shape) });
+                            return Ok(unsafe { dest.copy_from(source, source_shape)? });
                         }
                         if source_shape == u64::SHAPE {
                             let value: u64 = *unsafe { source.get::<u64>() };
@@ -551,7 +551,7 @@ unsafe impl Facet<'_> for f64 {
 
                     vtable.try_from = Some(|source, source_shape, dest| {
                         if source_shape == Self::SHAPE {
-                            return Ok(unsafe { dest.copy_from(source, source_shape) });
+                            return Ok(unsafe { dest.copy_from(source, source_shape)? });
                         }
                         if source_shape == u64::SHAPE {
                             let value: u64 = *unsafe { source.get::<u64>() };

--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -49,7 +49,7 @@ pub use types::*;
 /// all the serializers, deserializers, the entire ecosystem is unsafe.
 ///
 /// You're responsible for describing the type layout properly, and annotating all the invariants.
-pub unsafe trait Facet<'a>: Sized + 'a {
+pub unsafe trait Facet<'a>: 'a {
     /// The shape of this type
     const SHAPE: &'static Shape;
 

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -198,6 +198,13 @@ impl ShapeBuilder {
         self
     }
 
+    /// Sets the type as unsized
+    #[inline]
+    pub const fn set_unsized(mut self) -> Self {
+        self.layout = Some(ShapeLayout::Unsized);
+        self
+    }
+
     /// Sets the `vtable` field of the `ShapeBuilder`.
     #[inline]
     pub const fn vtable(mut self, vtable: &'static ValueVTable) -> Self {

--- a/facet-core/src/types/value.rs
+++ b/facet-core/src/types/value.rs
@@ -4,6 +4,8 @@ use core::cmp::Ordering;
 
 use crate::Shape;
 
+use super::UnsizedError;
+
 //======== Type Information ========
 
 /// A function that formats the name of a type.
@@ -156,6 +158,8 @@ pub enum TryFromError {
     Unimplemented,
     /// The target shape has a conversion implementation, but it doesn't support converting from this specific source shape
     Incompatible,
+    /// `!Sized` type
+    Unsized,
 }
 
 impl core::fmt::Display for TryFromError {
@@ -167,11 +171,18 @@ impl core::fmt::Display for TryFromError {
                 "Shape doesn't implement any conversions (no try_from function)",
             ),
             TryFromError::Incompatible => write!(f, "Incompatible types"),
+            TryFromError::Unsized => write!(f, "Unsized type"),
         }
     }
 }
 
 impl core::error::Error for TryFromError {}
+
+impl From<UnsizedError> for TryFromError {
+    fn from(_value: UnsizedError) -> Self {
+        Self::Unsized
+    }
+}
 
 //======== Comparison ========
 

--- a/facet-msgpack/src/errors.rs
+++ b/facet-msgpack/src/errors.rs
@@ -20,6 +20,14 @@ pub enum Error {
     UnsupportedShape(String),
     /// Type is not supported for deserialization
     UnsupportedType(String),
+    /// Reflection error
+    ReflectError(facet_reflect::ReflectError),
+}
+
+impl From<facet_reflect::ReflectError> for Error {
+    fn from(err: facet_reflect::ReflectError) -> Self {
+        Self::ReflectError(err)
+    }
 }
 
 impl fmt::Display for Error {
@@ -36,6 +44,9 @@ impl fmt::Display for Error {
             }
             Error::UnsupportedType(typ) => {
                 write!(f, "Unsupported type for deserialization: {}", typ)
+            }
+            Error::ReflectError(err) => {
+                write!(f, "Reflection error: {}", err)
             }
         }
     }

--- a/facet-msgpack/src/from_msgpack.rs
+++ b/facet-msgpack/src/from_msgpack.rs
@@ -31,7 +31,7 @@ use log::trace;
 pub fn from_slice<'input: 'facet, 'facet, T: Facet<'facet>>(
     msgpack: &'input [u8],
 ) -> Result<T, DecodeError> {
-    from_slice_value(Wip::alloc::<T>(), msgpack)?
+    from_slice_value(Wip::alloc::<T>()?, msgpack)?
         .materialize::<T>()
         .map_err(|e| DecodeError::UnsupportedType(e.to_string()))
 }

--- a/facet-pretty/src/display.rs
+++ b/facet-pretty/src/display.rs
@@ -6,7 +6,7 @@ use crate::printer::PrettyPrinter;
 use facet_core::Facet;
 
 /// Display wrapper for any type that implements Facet
-pub struct PrettyDisplay<'a, T: Facet<'a>> {
+pub struct PrettyDisplay<'a, T: Facet<'a> + ?Sized> {
     pub(crate) value: &'a T,
     pub(crate) printer: PrettyPrinter,
 }

--- a/facet-reflect/src/error.rs
+++ b/facet-reflect/src/error.rs
@@ -115,6 +115,12 @@ pub enum ReflectError {
         /// The shape of the value that has a `default` attribute but no default implementation.
         shape: &'static Shape,
     },
+
+    /// The type is unsized
+    Unsized {
+        /// The shape for the type that is unsized
+        shape: &'static Shape,
+    },
 }
 
 impl core::fmt::Display for ReflectError {
@@ -205,6 +211,7 @@ impl core::fmt::Display for ReflectError {
                 "Shape '{}' has a `default` attribute but no default implementation",
                 shape
             ),
+            ReflectError::Unsized { shape } => write!(f, "Shape '{}' is unsized", shape),
         }
     }
 }

--- a/facet-reflect/tests/peek/facts.rs
+++ b/facet-reflect/tests/peek/facts.rs
@@ -86,7 +86,7 @@ where
     }
 
     // Test default_in_place
-    if let Ok(wip) = Wip::alloc::<T>().put_default() {
+    if let Ok(wip) = Wip::alloc::<T>().and_then(|w| w.put_default()) {
         let val = wip.build().unwrap();
         facts.insert(Fact::Default);
         eprintln!("Default:   {}", format_args!("{:?}", val).style(REMARKABLE));

--- a/facet-reflect/tests/wip/compile_tests.rs
+++ b/facet-reflect/tests/wip/compile_tests.rs
@@ -182,7 +182,7 @@ fn test_covariant_growing() {
     let test = CompilationTest {
         name: "covariant_growing",
         source: include_str!("compile_tests/covariant_growing.rs"),
-        expected_errors: &["error[E0521]: borrowed data escapes outside of function"],
+        expected_errors: &["error: lifetime may not live long enough"],
     };
 
     // Run the test
@@ -196,7 +196,7 @@ fn test_invariant_growing() {
     let test = CompilationTest {
         name: "invariant_growing",
         source: include_str!("compile_tests/invariant_growing.rs"),
-        expected_errors: &["error[E0521]: borrowed data escapes outside of function"],
+        expected_errors: &["error: lifetime may not live long enough"],
     };
 
     // Run the test

--- a/facet-reflect/tests/wip/compile_tests/contravariant_shrinking.rs
+++ b/facet-reflect/tests/wip/compile_tests/contravariant_shrinking.rs
@@ -13,7 +13,7 @@ fn main() {
     }
 
     fn scope<'a>(token: ContravariantLifetime<'static>) -> Result<Wrapper<'a>, ReflectError> {
-        Wip::<'a>::alloc::<Wrapper<'a>>()
+        Wip::<'a>::alloc::<Wrapper<'a>>()?
             .field_named("token")?
             .put(token)?
             .pop()?

--- a/facet-reflect/tests/wip/compile_tests/covariant_growing.rs
+++ b/facet-reflect/tests/wip/compile_tests/covariant_growing.rs
@@ -13,7 +13,7 @@ fn main() {
     }
 
     fn scope<'a>(token: CovariantLifetime<'a>) -> Result<Wrapper<'static>, ReflectError> {
-        Wip::<'static>::alloc::<Wrapper<'static>>()
+        Wip::<'static>::alloc::<Wrapper<'static>>()?
             .field_named("token")?
             .put(token)?
             .pop()?

--- a/facet-reflect/tests/wip/compile_tests/invariant_growing.rs
+++ b/facet-reflect/tests/wip/compile_tests/invariant_growing.rs
@@ -13,7 +13,7 @@ fn main() {
     }
 
     fn scope<'a>(token: InvariantLifetime<'a>) -> Result<Wrapper<'static>, ReflectError> {
-        Wip::<'static>::alloc::<Wrapper<'static>>()
+        Wip::<'static>::alloc::<Wrapper<'static>>()?
             .field_named("token")?
             .put(token)?
             .pop()?

--- a/facet-reflect/tests/wip/compile_tests/invariant_shrinking.rs
+++ b/facet-reflect/tests/wip/compile_tests/invariant_shrinking.rs
@@ -13,7 +13,7 @@ fn main() {
     }
 
     fn scope<'a>(token: InvariantLifetime<'static>) -> Result<Wrapper<'a>, ReflectError> {
-        Wip::<'a>::alloc::<Wrapper<'a>>()
+        Wip::<'a>::alloc::<Wrapper<'a>>()?
             .field_named("token")?
             .put(token)?
             .pop()?

--- a/facet-reflect/tests/wip/compile_tests/lifetimes.rs
+++ b/facet-reflect/tests/wip/compile_tests/lifetimes.rs
@@ -7,7 +7,7 @@ struct Foo<'a> {
 }
 
 fn main() -> eyre::Result<()> {
-    let mut wip = Wip::alloc::<Foo>();
+    let mut wip = Wip::alloc::<Foo>()?;
     let wip = {
         let s = "abc".to_string();
         let foo = Foo { s: &s };

--- a/facet-reflect/tests/wip/invariant.rs
+++ b/facet-reflect/tests/wip/invariant.rs
@@ -15,7 +15,7 @@ fn build_with_invariants() -> eyre::Result<()> {
         }
     }
 
-    let wip: MyNonZeroU8 = Wip::alloc::<MyNonZeroU8>()
+    let wip: MyNonZeroU8 = Wip::alloc::<MyNonZeroU8>()?
         .field(0)?
         .put(42u8)?
         .pop()?
@@ -23,7 +23,7 @@ fn build_with_invariants() -> eyre::Result<()> {
         .materialize()?;
     assert_eq!(wip, MyNonZeroU8(42));
 
-    let result = Wip::alloc::<MyNonZeroU8>()
+    let result = Wip::alloc::<MyNonZeroU8>()?
         .field(0)?
         .put(0_u8)?
         .pop()?

--- a/facet-reflect/tests/wip/list_leak.rs
+++ b/facet-reflect/tests/wip/list_leak.rs
@@ -4,7 +4,7 @@ use facet_reflect::Wip;
 fn wip_list_leaktest1() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Vec<i32>>()
+    let _ = Wip::alloc::<Vec<i32>>()?
         .begin_pushback()?
         .push()?
         .put(10)?
@@ -23,7 +23,7 @@ fn wip_list_leaktest1() -> eyre::Result<()> {
 fn wip_list_leaktest2() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Vec<i32>>()
+    let _ = Wip::alloc::<Vec<i32>>()?
         .begin_pushback()?
         .push()?
         .put(10)?
@@ -41,7 +41,7 @@ fn wip_list_leaktest2() -> eyre::Result<()> {
 fn wip_list_leaktest3() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Vec<i32>>()
+    let _ = Wip::alloc::<Vec<i32>>()?
         .begin_pushback()?
         .push()?
         .put(10)?
@@ -58,7 +58,7 @@ fn wip_list_leaktest3() -> eyre::Result<()> {
 fn wip_list_leaktest4() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Vec<i32>>()
+    let _ = Wip::alloc::<Vec<i32>>()?
         .begin_pushback()?
         .push()?
         .put(10)?
@@ -74,7 +74,7 @@ fn wip_list_leaktest4() -> eyre::Result<()> {
 fn wip_list_leaktest5() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Vec<i32>>()
+    let _ = Wip::alloc::<Vec<i32>>()?
         .begin_pushback()?
         .push()?
         .put(10)?
@@ -89,7 +89,7 @@ fn wip_list_leaktest5() -> eyre::Result<()> {
 fn wip_list_leaktest6() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Vec<i32>>()
+    let _ = Wip::alloc::<Vec<i32>>()?
         .begin_pushback()?
         .push()?
         .put(10)?
@@ -103,7 +103,7 @@ fn wip_list_leaktest6() -> eyre::Result<()> {
 fn wip_list_leaktest7() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Vec<i32>>()
+    let _ = Wip::alloc::<Vec<i32>>()?
         .begin_pushback()?
         .push()?
         .put(10)?
@@ -116,7 +116,7 @@ fn wip_list_leaktest7() -> eyre::Result<()> {
 fn wip_list_leaktest8() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Vec<i32>>()
+    let _ = Wip::alloc::<Vec<i32>>()?
         .begin_pushback()?
         .push()?
         .put(10)?
@@ -128,7 +128,10 @@ fn wip_list_leaktest8() -> eyre::Result<()> {
 fn wip_list_leaktest9() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Vec<i32>>().begin_pushback()?.push()?.put(10)?;
+    let _ = Wip::alloc::<Vec<i32>>()?
+        .begin_pushback()?
+        .push()?
+        .put(10)?;
     Ok(())
 }
 
@@ -136,7 +139,7 @@ fn wip_list_leaktest9() -> eyre::Result<()> {
 fn wip_list_leaktest10() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Vec<i32>>().begin_pushback()?.push()?;
+    let _ = Wip::alloc::<Vec<i32>>()?.begin_pushback()?.push()?;
     Ok(())
 }
 
@@ -144,7 +147,7 @@ fn wip_list_leaktest10() -> eyre::Result<()> {
 fn wip_list_leaktest11() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Vec<i32>>().begin_pushback()?;
+    let _ = Wip::alloc::<Vec<i32>>()?.begin_pushback()?;
     Ok(())
 }
 
@@ -152,6 +155,6 @@ fn wip_list_leaktest11() -> eyre::Result<()> {
 fn wip_list_leaktest12() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Vec<i32>>();
+    let _ = Wip::alloc::<Vec<i32>>()?;
     Ok(())
 }

--- a/facet-reflect/tests/wip/map.rs
+++ b/facet-reflect/tests/wip/map.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 fn wip_map_trivial() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let wip = Wip::alloc::<HashMap<String, String>>()
+    let wip = Wip::alloc::<HashMap<String, String>>()?
         .begin_map_insert()?
         .push_map_key()?
         .put::<String>("key".into())?
@@ -34,7 +34,7 @@ fn wip_map_twice() -> eyre::Result<()> {
 
     facet_testhelpers::setup();
 
-    let _wip = Wip::alloc::<MapWrap>()
+    let _wip = Wip::alloc::<MapWrap>()?
         .field_named("map")?
         .begin_map_insert()?
         .push_map_key()?

--- a/facet-reflect/tests/wip/map_leak.rs
+++ b/facet-reflect/tests/wip/map_leak.rs
@@ -7,7 +7,7 @@ use facet_reflect::Wip;
 fn wip_map_leaktest1() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let wip = Wip::alloc::<HashMap<String, String>>()
+    let wip = Wip::alloc::<HashMap<String, String>>()?
         .begin_map_insert()?
         .push_map_key()?
         .put::<String>("key".into())?
@@ -25,7 +25,7 @@ fn wip_map_leaktest1() -> eyre::Result<()> {
 fn wip_map_leaktest2() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let wip = Wip::alloc::<HashMap<String, String>>()
+    let wip = Wip::alloc::<HashMap<String, String>>()?
         .begin_map_insert()?
         .push_map_key()?
         .put::<String>("key".into())?
@@ -42,7 +42,7 @@ fn wip_map_leaktest2() -> eyre::Result<()> {
 fn wip_map_leaktest3() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let wip = Wip::alloc::<HashMap<String, String>>()
+    let wip = Wip::alloc::<HashMap<String, String>>()?
         .begin_map_insert()?
         .push_map_key()?
         .put::<String>("key".into())?
@@ -58,7 +58,7 @@ fn wip_map_leaktest3() -> eyre::Result<()> {
 fn wip_map_leaktest4() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let wip = Wip::alloc::<HashMap<String, String>>()
+    let wip = Wip::alloc::<HashMap<String, String>>()?
         .begin_map_insert()?
         .push_map_key()?
         .put::<String>("key".into())?
@@ -73,7 +73,7 @@ fn wip_map_leaktest4() -> eyre::Result<()> {
 fn wip_map_leaktest5() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let wip = Wip::alloc::<HashMap<String, String>>()
+    let wip = Wip::alloc::<HashMap<String, String>>()?
         .begin_map_insert()?
         .push_map_key()?
         .put::<String>("key".into())?;
@@ -87,7 +87,7 @@ fn wip_map_leaktest5() -> eyre::Result<()> {
 fn wip_map_leaktest6() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let wip = Wip::alloc::<HashMap<String, String>>()
+    let wip = Wip::alloc::<HashMap<String, String>>()?
         .begin_map_insert()?
         .push_map_key()?;
     drop(wip);
@@ -100,7 +100,7 @@ fn wip_map_leaktest6() -> eyre::Result<()> {
 fn wip_map_leaktest7() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let wip = Wip::alloc::<HashMap<String, String>>().begin_map_insert()?;
+    let wip = Wip::alloc::<HashMap<String, String>>()?.begin_map_insert()?;
     drop(wip);
 
     Ok(())
@@ -111,7 +111,7 @@ fn wip_map_leaktest7() -> eyre::Result<()> {
 fn wip_map_leaktest8() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let wip = Wip::alloc::<HashMap<String, String>>();
+    let wip = Wip::alloc::<HashMap<String, String>>()?;
     drop(wip);
 
     Ok(())

--- a/facet-reflect/tests/wip/misc.rs
+++ b/facet-reflect/tests/wip/misc.rs
@@ -17,7 +17,7 @@ struct Inner {
 fn wip_nested() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let v = Wip::alloc::<Outer>()
+    let v = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?
         .pop()?
@@ -47,7 +47,7 @@ fn wip_nested() -> eyre::Result<()> {
 fn wip_nested_out_of_order() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let v = Wip::alloc::<Outer>()
+    let v = Wip::alloc::<Outer>()?
         .field_named("inner")?
         .field_named("x")?
         .put(42)?
@@ -87,7 +87,7 @@ fn readme_sample() -> eyre::Result<()> {
         bar: String,
     }
 
-    let foo_bar = Wip::alloc::<FooBar>()
+    let foo_bar = Wip::alloc::<FooBar>()?
         .field_named("foo")?
         .put(42u64)?
         .pop()?
@@ -119,14 +119,14 @@ fn wip_unit_enum() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Test unit variant A
-    let a = Wip::alloc::<SimpleEnum>()
+    let a = Wip::alloc::<SimpleEnum>()?
         .variant_named("A")?
         .build()?
         .materialize::<SimpleEnum>()?;
     assert_eq!(a, SimpleEnum::A);
 
     // Test unit variant B
-    let b = Wip::alloc::<SimpleEnum>()
+    let b = Wip::alloc::<SimpleEnum>()?
         .variant(1)? // B is at index 1
         .build()?
         .materialize::<SimpleEnum>()?;
@@ -149,14 +149,14 @@ fn wip_enum_with_data() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Test empty variant
-    let empty = Wip::alloc::<EnumWithData>()
+    let empty = Wip::alloc::<EnumWithData>()?
         .variant_named("Empty")?
         .build()?
         .materialize::<EnumWithData>()?;
     assert_eq!(empty, EnumWithData::Empty);
 
     // Test single-field tuple variant
-    let single = Wip::alloc::<EnumWithData>()
+    let single = Wip::alloc::<EnumWithData>()?
         .variant_named("Single")?
         .field(0)? // Access the first field
         .put(42)?
@@ -166,7 +166,7 @@ fn wip_enum_with_data() -> eyre::Result<()> {
     assert_eq!(single, EnumWithData::Single(42));
 
     // Test multi-field tuple variant
-    let tuple = Wip::alloc::<EnumWithData>()
+    let tuple = Wip::alloc::<EnumWithData>()?
         .variant_named("Tuple")?
         .field(0)?
         .put(42)?
@@ -179,7 +179,7 @@ fn wip_enum_with_data() -> eyre::Result<()> {
     assert_eq!(tuple, EnumWithData::Tuple(42, String::from("Hello")));
 
     // Test struct variant
-    let struct_variant = Wip::alloc::<EnumWithData>()
+    let struct_variant = Wip::alloc::<EnumWithData>()?
         .variant_named("Struct")?
         .field_named("x")?
         .put(42)?
@@ -214,14 +214,14 @@ fn wip_enum_with_data_repr_c() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Test empty variant
-    let empty = Wip::alloc::<EnumWithDataReprC>()
+    let empty = Wip::alloc::<EnumWithDataReprC>()?
         .variant_named("Empty")?
         .build()?
         .materialize::<EnumWithDataReprC>()?;
     assert_eq!(empty, EnumWithDataReprC::Empty);
 
     // Test single-field tuple variant
-    let single = Wip::alloc::<EnumWithDataReprC>()
+    let single = Wip::alloc::<EnumWithDataReprC>()?
         .variant_named("Single")?
         .field(0)? // Access the first field
         .put(42)?
@@ -231,7 +231,7 @@ fn wip_enum_with_data_repr_c() -> eyre::Result<()> {
     assert_eq!(single, EnumWithDataReprC::Single(42));
 
     // Test multi-field tuple variant
-    let tuple = Wip::alloc::<EnumWithDataReprC>()
+    let tuple = Wip::alloc::<EnumWithDataReprC>()?
         .variant_named("Tuple")?
         .field(0)?
         .put(42)?
@@ -244,7 +244,7 @@ fn wip_enum_with_data_repr_c() -> eyre::Result<()> {
     assert_eq!(tuple, EnumWithDataReprC::Tuple(42, String::from("Hello")));
 
     // Test struct variant
-    let struct_variant = Wip::alloc::<EnumWithDataReprC>()
+    let struct_variant = Wip::alloc::<EnumWithDataReprC>()?
         .variant_named("Struct")?
         .field_named("x")?
         .put(42)?
@@ -279,14 +279,14 @@ fn wip_enum_with_data_repr_c_i16() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Test empty variant
-    let empty = Wip::alloc::<EnumWithDataReprCI16>()
+    let empty = Wip::alloc::<EnumWithDataReprCI16>()?
         .variant_named("Empty")?
         .build()?
         .materialize::<EnumWithDataReprCI16>()?;
     assert_eq!(empty, EnumWithDataReprCI16::Empty);
 
     // Test single-field tuple variant
-    let single = Wip::alloc::<EnumWithDataReprCI16>()
+    let single = Wip::alloc::<EnumWithDataReprCI16>()?
         .variant_named("Single")?
         .field(0)? // Access the first field
         .put(42)?
@@ -296,7 +296,7 @@ fn wip_enum_with_data_repr_c_i16() -> eyre::Result<()> {
     assert_eq!(single, EnumWithDataReprCI16::Single(42));
 
     // Test multi-field tuple variant
-    let tuple = Wip::alloc::<EnumWithDataReprCI16>()
+    let tuple = Wip::alloc::<EnumWithDataReprCI16>()?
         .variant_named("Tuple")?
         .field(0)?
         .put(42)?
@@ -312,7 +312,7 @@ fn wip_enum_with_data_repr_c_i16() -> eyre::Result<()> {
     );
 
     // Test struct variant
-    let struct_variant = Wip::alloc::<EnumWithDataReprCI16>()
+    let struct_variant = Wip::alloc::<EnumWithDataReprCI16>()?
         .variant_named("Struct")?
         .field_named("x")?
         .put(42)?
@@ -389,7 +389,7 @@ fn test_enum_reprs() -> eyre::Result<()> {
     assert_eq!(field_offsets::<ReprCU8>(), [2, 4]);
 
     fn build<T: Facet<'static>>() -> eyre::Result<T> {
-        let v = Wip::alloc::<T>()
+        let v = Wip::alloc::<T>()?
             .variant(0)?
             .field(0)?
             .put(1u8)?
@@ -416,21 +416,21 @@ fn wip_enum_error_cases() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Test error: trying to access a field without selecting a variant
-    let result = Wip::alloc::<EnumWithData>().field_named("x");
+    let result = Wip::alloc::<EnumWithData>()?.field_named("x");
     assert!(result.is_err());
 
     // Test error: trying to select a non-existent variant
-    let result = Wip::alloc::<EnumWithData>().variant_named("NonExistent");
+    let result = Wip::alloc::<EnumWithData>()?.variant_named("NonExistent");
     assert!(result.is_err());
 
     // Test error: trying to access a non-existent field in a variant
-    let result = Wip::alloc::<EnumWithData>()
+    let result = Wip::alloc::<EnumWithData>()?
         .variant_named("Struct")?
         .field_named("non_existent");
     assert!(result.is_err());
 
     // Test error: trying to build without initializing all fields
-    let result = Wip::alloc::<EnumWithData>()
+    let result = Wip::alloc::<EnumWithData>()?
         .variant_named("Struct")?
         .field_named("x")?
         .put(42)?
@@ -449,7 +449,7 @@ fn wip_switch_enum_variant() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Test switching variants
-    let result = Wip::alloc::<EnumWithData>()
+    let result = Wip::alloc::<EnumWithData>()?
         .variant_named("Single")?
         .field(0)?
         .put(42)?
@@ -476,7 +476,7 @@ fn wip_empty_list() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Create an empty list with put_empty_list
-    let empty_list = Wip::alloc::<Vec<i32>>()
+    let empty_list = Wip::alloc::<Vec<i32>>()?
         .put_empty_list()?
         .build()?
         .materialize::<Vec<i32>>()?;
@@ -492,7 +492,7 @@ fn wip_list_push() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Build a vector by pushing elements one by one
-    let list = Wip::alloc::<Vec<i32>>()
+    let list = Wip::alloc::<Vec<i32>>()?
         .begin_pushback()?
         .push()?
         .put(10)?
@@ -517,7 +517,7 @@ fn wip_list_string() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Build a vector of strings
-    let list = Wip::alloc::<Vec<String>>()
+    let list = Wip::alloc::<Vec<String>>()?
         .begin_pushback()?
         .push()?
         .put("hello".to_string())?
@@ -544,7 +544,7 @@ fn wip_struct_with_list() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Create a struct that contains a list
-    let with_list = Wip::alloc::<WithList>()
+    let with_list = Wip::alloc::<WithList>()?
         .field_named("name")?
         .put("test list".to_string())?
         .pop()?
@@ -579,15 +579,15 @@ fn wip_list_error_cases() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Test error: trying to push to a non-list type
-    let result = Wip::alloc::<i32>().push();
+    let result = Wip::alloc::<i32>()?.push();
     assert!(result.is_err());
 
     // Test error: trying to get element shape from non-list
-    let result = Wip::alloc::<String>().element_shape();
+    let result = Wip::alloc::<String>()?.element_shape();
     assert!(result.is_err());
 
     // Test error: trying to put_empty_list on non-list type
-    let result = Wip::alloc::<i32>().put_empty_list();
+    let result = Wip::alloc::<i32>()?.put_empty_list();
     assert!(result.is_err());
 
     Ok(())
@@ -608,7 +608,7 @@ fn wip_opaque_arc() -> eyre::Result<()> {
         inner: Handle,
     }
 
-    let result = Wip::alloc::<Container>()
+    let result = Wip::alloc::<Container>()?
         .field_named("inner")?
         .put(Handle(std::sync::Arc::new(NotDerivingFacet(35))))?
         .pop()?
@@ -625,7 +625,7 @@ fn wip_put_option_explicit_some() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Test switching variants
-    let result = Wip::alloc::<Option<u64>>()
+    let result = Wip::alloc::<Option<u64>>()?
         .put::<Option<u64>>(Some(42))?
         .build()?
         .materialize::<Option<u64>>()?;
@@ -639,7 +639,7 @@ fn wip_put_option_explicit_some() -> eyre::Result<()> {
 fn wip_put_option_explicit_none() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let result = Wip::alloc::<Option<u64>>()
+    let result = Wip::alloc::<Option<u64>>()?
         .put::<Option<u64>>(None)?
         .build()?
         .materialize::<Option<u64>>()?;
@@ -654,7 +654,7 @@ fn wip_put_option_implicit_some() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Test switching variants
-    let result = Wip::alloc::<Option<u64>>()
+    let result = Wip::alloc::<Option<u64>>()?
         .put::<u64>(42)?
         .build()?
         .materialize::<Option<u64>>()?;
@@ -669,7 +669,7 @@ fn wip_parse_option() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Test switching variants
-    let result = Wip::alloc::<Option<f64>>()
+    let result = Wip::alloc::<Option<f64>>()?
         .parse("8.13")?
         .build()?
         .materialize::<Option<f64>>()?;
@@ -689,7 +689,7 @@ fn wip_option_explicit_some_through_push_some() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
     // Test switching variants
-    let result = Wip::alloc::<Option<Foo>>()
+    let result = Wip::alloc::<Option<Foo>>()?
         .push_some()?
         .field_named("foo")?
         .put::<u32>(42)?
@@ -715,7 +715,7 @@ fn wip_fn_ptr() -> eyre::Result<()> {
         1113
     }
 
-    let result = Wip::alloc::<Foo>()
+    let result = Wip::alloc::<Foo>()?
         .field_named("foo")?
         .put::<fn() -> i32>(f)?
         .pop()?
@@ -725,7 +725,7 @@ fn wip_fn_ptr() -> eyre::Result<()> {
     assert_eq!((result.foo)(), 1113);
 
     assert!(
-        Wip::alloc::<Foo>()
+        Wip::alloc::<Foo>()?
             .field_named("foo")?
             .put::<fn() -> f32>(|| 0.0)
             .is_err()

--- a/facet-reflect/tests/wip/no_uninit.rs
+++ b/facet-reflect/tests/wip/no_uninit.rs
@@ -18,7 +18,7 @@ fn struct_uninit() {
     }
 
     facet_testhelpers::setup();
-    let wip = Wip::alloc::<FooBar>();
+    let wip = Wip::alloc::<FooBar>().unwrap();
     assert!(matches!(
         wip.build(),
         Err(ReflectError::UninitializedField { .. })
@@ -36,16 +36,22 @@ fn enum_uninit() {
     }
 
     facet_testhelpers::setup();
-    let wip = Wip::alloc::<FooBar>();
+    let wip = Wip::alloc::<FooBar>().unwrap();
     assert!(matches!(
         wip.build(),
         Err(ReflectError::NoVariantSelected { .. })
     ),);
 
-    let wip = Wip::alloc::<FooBar>().variant_named("Foo").unwrap();
+    let wip = Wip::alloc::<FooBar>()
+        .unwrap()
+        .variant_named("Foo")
+        .unwrap();
     assert!(wip.build().is_ok());
 
-    let wip = Wip::alloc::<FooBar>().variant_named("Bar").unwrap();
+    let wip = Wip::alloc::<FooBar>()
+        .unwrap()
+        .variant_named("Bar")
+        .unwrap();
     assert!(matches!(
         wip.build(),
         Err(ReflectError::UninitializedEnumField { .. })
@@ -84,7 +90,7 @@ fn smart_pointer_uninit() {
 
 fn test_uninit<T: Facet<'static>>() {
     facet_testhelpers::setup();
-    let wip = Wip::alloc::<T>();
+    let wip = Wip::alloc::<T>().unwrap();
     assert!(
         matches!(wip.build(), Err(ReflectError::UninitializedValue { .. })),
         "Expected UninitializedValue error"

--- a/facet-reflect/tests/wip/option_leak.rs
+++ b/facet-reflect/tests/wip/option_leak.rs
@@ -4,7 +4,7 @@ use facet_reflect::Wip;
 fn wip_option_testleak1() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Option<String>>()
+    let _ = Wip::alloc::<Option<String>>()?
         .push_some()?
         .put(String::from("Hello, world!"))?
         .pop()?
@@ -18,7 +18,7 @@ fn wip_option_testleak1() -> eyre::Result<()> {
 fn wip_option_testleak2() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let wip = Wip::alloc::<Option<String>>();
+    let wip = Wip::alloc::<Option<String>>()?;
     let wip = wip.push_some()?;
     let wip = wip.put(String::from("Hello, world!"))?;
     let wip = wip.pop()?;
@@ -31,7 +31,7 @@ fn wip_option_testleak2() -> eyre::Result<()> {
 fn wip_option_testleak3() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    Wip::alloc::<Option<String>>()
+    Wip::alloc::<Option<String>>()?
         .push_some()?
         .put(String::from("Hello, world!"))?
         .pop()?;
@@ -43,7 +43,7 @@ fn wip_option_testleak3() -> eyre::Result<()> {
 fn wip_option_testleak4() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Option<String>>()
+    let _ = Wip::alloc::<Option<String>>()?
         .push_some()?
         .put(String::from("Hello, world!"));
 
@@ -54,7 +54,7 @@ fn wip_option_testleak4() -> eyre::Result<()> {
 fn wip_option_testleak5() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    Wip::alloc::<Option<String>>().push_some()?;
+    Wip::alloc::<Option<String>>()?.push_some()?;
 
     Ok(())
 }
@@ -63,7 +63,7 @@ fn wip_option_testleak5() -> eyre::Result<()> {
 fn wip_option_testleak6() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    Wip::alloc::<Option<String>>();
+    Wip::alloc::<Option<String>>()?;
 
     Ok(())
 }

--- a/facet-reflect/tests/wip/put_into_tuples.rs
+++ b/facet-reflect/tests/wip/put_into_tuples.rs
@@ -7,7 +7,7 @@ fn test_put_into_tuples() -> eyre::Result<()> {
 
     type T = (u32, String, bool);
 
-    let mut wip = Wip::alloc::<T>();
+    let mut wip = Wip::alloc::<T>()?;
     wip = wip.put::<u32>(42)?;
     wip = wip.put::<String>("hello".to_string())?;
     wip = wip.put::<bool>(true)?;
@@ -24,7 +24,7 @@ fn test_put_into_struct_like_tuple() -> eyre::Result<()> {
     #[derive(Facet)]
     struct Point(u32, u32, String);
 
-    let mut wip = Wip::alloc::<Point>();
+    let mut wip = Wip::alloc::<Point>()?;
     wip = wip.put::<u32>(10)?;
     wip = wip.put::<u32>(20)?;
     wip = wip.put::<String>("point".to_string())?;
@@ -51,7 +51,7 @@ fn test_put_into_enum_variant_with_tuple_fields() -> eyre::Result<()> {
     }
 
     // Test with the ChangeColor variant that has tuple-like fields
-    let mut wip = Wip::alloc::<Message>();
+    let mut wip = Wip::alloc::<Message>()?;
     wip = wip.variant_named("ChangeColor")?;
     wip = wip.put::<i32>(255)?;
     wip = wip.put::<i32>(0)?;
@@ -68,7 +68,7 @@ fn test_put_into_enum_variant_with_tuple_fields() -> eyre::Result<()> {
     }
 
     // Test with the Write variant that has a single tuple field
-    let mut wip = Wip::alloc::<Message>();
+    let mut wip = Wip::alloc::<Message>()?;
     wip = wip.variant_named("Write")?;
     wip = wip.put::<String>("hello".to_string())?;
     let message = wip.build()?.materialize::<Message>()?;

--- a/facet-reflect/tests/wip/put_vec_leak.rs
+++ b/facet-reflect/tests/wip/put_vec_leak.rs
@@ -4,7 +4,7 @@ use facet_reflect::Wip;
 fn put_vec_leaktest1() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let w = Wip::alloc::<Vec<String>>();
+    let w = Wip::alloc::<Vec<String>>()?;
     let w = w.put(vec!["a".to_string()])?;
     drop(w);
     Ok(())
@@ -14,7 +14,7 @@ fn put_vec_leaktest1() -> eyre::Result<()> {
 fn put_vec_leaktest2() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let w = Wip::alloc::<Vec<String>>();
+    let w = Wip::alloc::<Vec<String>>()?;
     let w = w.put(vec!["a".to_string()])?;
     let w = w.build()?;
     // let it drop: the entire value should be deinitialized, and the memory for the Wip should be freed
@@ -26,7 +26,7 @@ fn put_vec_leaktest2() -> eyre::Result<()> {
 fn put_vec_leaktest3() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let w = Wip::alloc::<Vec<String>>();
+    let w = Wip::alloc::<Vec<String>>()?;
     let w = w.put(vec!["a".to_string()])?;
     let w = w.build()?;
     let v = w.materialize::<Vec<String>>()?;

--- a/facet-reflect/tests/wip/struct_leak.rs
+++ b/facet-reflect/tests/wip/struct_leak.rs
@@ -17,7 +17,7 @@ struct Inner {
 fn wip_struct_testleak1() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let v = Wip::alloc::<Outer>()
+    let v = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?
         .pop()?
@@ -47,7 +47,7 @@ fn wip_struct_testleak1() -> eyre::Result<()> {
 fn wip_struct_testleak2() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>()
+    let _ = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?
         .pop()?
@@ -68,7 +68,7 @@ fn wip_struct_testleak2() -> eyre::Result<()> {
 fn wip_struct_testleak3() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>()
+    let _ = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?
         .pop()?
@@ -88,7 +88,7 @@ fn wip_struct_testleak3() -> eyre::Result<()> {
 fn wip_struct_testleak4() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>()
+    let _ = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?
         .pop()?
@@ -107,7 +107,7 @@ fn wip_struct_testleak4() -> eyre::Result<()> {
 fn wip_struct_testleak5() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>()
+    let _ = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?
         .pop()?
@@ -125,7 +125,7 @@ fn wip_struct_testleak5() -> eyre::Result<()> {
 fn wip_struct_testleak6() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>()
+    let _ = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?
         .pop()?
@@ -142,7 +142,7 @@ fn wip_struct_testleak6() -> eyre::Result<()> {
 fn wip_struct_testleak7() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>()
+    let _ = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?
         .pop()?
@@ -158,7 +158,7 @@ fn wip_struct_testleak7() -> eyre::Result<()> {
 fn wip_struct_testleak8() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>()
+    let _ = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?
         .pop()?
@@ -173,7 +173,7 @@ fn wip_struct_testleak8() -> eyre::Result<()> {
 fn wip_struct_testleak9() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>()
+    let _ = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?
         .pop()?
@@ -187,7 +187,7 @@ fn wip_struct_testleak9() -> eyre::Result<()> {
 fn wip_struct_testleak10() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>()
+    let _ = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?
         .pop()?
@@ -200,7 +200,7 @@ fn wip_struct_testleak10() -> eyre::Result<()> {
 fn wip_struct_testleak11() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>()
+    let _ = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?
         .pop()?; // Removed .field_named("inner")?
@@ -212,7 +212,7 @@ fn wip_struct_testleak11() -> eyre::Result<()> {
 fn wip_struct_testleak12() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>()
+    let _ = Wip::alloc::<Outer>()?
         .field_named("name")?
         .put(String::from("Hello, world!"))?; // Removed .pop()?
 
@@ -223,7 +223,7 @@ fn wip_struct_testleak12() -> eyre::Result<()> {
 fn wip_struct_testleak13() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>().field_named("name")?; // Removed .put(String::from("Hello, world!"))?
+    let _ = Wip::alloc::<Outer>()?.field_named("name")?; // Removed .put(String::from("Hello, world!"))?
 
     Ok(())
 }
@@ -232,7 +232,7 @@ fn wip_struct_testleak13() -> eyre::Result<()> {
 fn wip_struct_testleak14() -> eyre::Result<()> {
     facet_testhelpers::setup();
 
-    let _ = Wip::alloc::<Outer>(); // Removed .field_named("name")?
+    let _ = Wip::alloc::<Outer>()?; // Removed .field_named("name")?
 
     Ok(())
 }

--- a/facet-reflect/tests/wip/variance.rs
+++ b/facet-reflect/tests/wip/variance.rs
@@ -26,7 +26,7 @@ fn covariant_works() {
     }
 
     fn scope<'a>(token: CovariantLifetime<'a>) -> Result<Wrapper<'a>, ReflectError> {
-        Wip::<'a>::alloc::<Wrapper<'a>>()
+        Wip::<'a>::alloc::<Wrapper<'a>>()?
             .field_named("token")?
             .put(token)?
             .pop()?
@@ -47,7 +47,7 @@ fn contravariant_works() {
     }
 
     fn scope<'a>(token: ContravariantLifetime<'a>) -> Result<Wrapper<'a>, ReflectError> {
-        Wip::<'a>::alloc::<Wrapper<'a>>()
+        Wip::<'a>::alloc::<Wrapper<'a>>()?
             .field_named("token")?
             .put(token)?
             .pop()?
@@ -68,7 +68,7 @@ fn invariant_works() {
     }
 
     fn scope<'a>(token: InvariantLifetime<'a>) -> Result<Wrapper<'a>, ReflectError> {
-        Wip::<'a>::alloc::<Wrapper<'a>>()
+        Wip::<'a>::alloc::<Wrapper<'a>>()?
             .field_named("token")?
             .put(token)?
             .pop()?

--- a/facet-toml/src/lib.rs
+++ b/facet-toml/src/lib.rs
@@ -49,7 +49,14 @@ pub fn from_str<'input: 'facet, 'facet, T: Facet<'facet>>(
     trace!("Parsing TOML");
 
     // Allocate the type
-    let wip = Wip::alloc::<T>();
+    let wip = Wip::alloc::<T>().map_err(|e| {
+        TomlError::new(
+            toml,
+            TomlErrorKind::GenericReflect(e),
+            None,
+            "$".to_string(),
+        )
+    })?;
 
     // Parse the TOML document
     let docs: ImDocument<String> = toml.parse().map_err(|e: TomlEditError| {

--- a/facet-urlencoded/src/lib.rs
+++ b/facet-urlencoded/src/lib.rs
@@ -71,7 +71,7 @@ mod tests;
 pub fn from_str<'input: 'facet, 'facet, T: Facet<'facet>>(
     urlencoded: &'input str,
 ) -> Result<T, UrlEncodedError> {
-    let val = from_str_value(Wip::alloc::<T>(), urlencoded)?;
+    let val = from_str_value(Wip::alloc::<T>()?, urlencoded)?;
     Ok(val.materialize::<T>()?)
 }
 

--- a/facet-yaml/src/lib.rs
+++ b/facet-yaml/src/lib.rs
@@ -7,7 +7,7 @@ use yaml_rust2::{Yaml, YamlLoader};
 
 /// Deserializes a YAML string into a value of type `T` that implements `Facet`.
 pub fn from_str<'input: 'facet, 'facet, T: Facet<'facet>>(yaml: &'input str) -> Result<T, AnyErr> {
-    let wip = Wip::alloc::<T>();
+    let wip = Wip::alloc::<T>()?;
     let wip = from_str_value(wip, yaml)?;
     let heap_value = wip.build().map_err(|e| AnyErr(e.to_string()))?;
     heap_value
@@ -36,6 +36,12 @@ impl From<String> for AnyErr {
 impl From<&str> for AnyErr {
     fn from(s: &str) -> Self {
         Self(s.to_string())
+    }
+}
+
+impl From<facet_reflect::ReflectError> for AnyErr {
+    fn from(value: facet_reflect::ReflectError) -> Self {
+        Self(format!("Reflection error: {value}"))
     }
 }
 

--- a/facet/tests/derive.rs
+++ b/facet/tests/derive.rs
@@ -11,8 +11,9 @@ fn unit_struct() {
     // Check the name using Display
     assert_eq!(format!("{}", shape), "UnitStruct");
 
-    assert_eq!(shape.layout.size(), 0);
-    assert_eq!(shape.layout.align(), 1);
+    let layout = shape.layout.sized_layout().unwrap();
+    assert_eq!(layout.size(), 0);
+    assert_eq!(layout.align(), 1);
 
     if let Def::Struct(Struct { kind, fields, .. }) = shape.def {
         assert_eq!(kind, StructKind::Unit);
@@ -36,8 +37,10 @@ fn simple_struct() {
         // Check the name using Display
         assert_eq!(format!("{}", shape), "Blah");
 
-        assert_eq!(shape.layout.size(), 32);
-        assert_eq!(shape.layout.align(), 8);
+        let layout = shape.layout.sized_layout().unwrap();
+
+        assert_eq!(layout.size(), 32);
+        assert_eq!(layout.align(), 8);
 
         if let Def::Struct(Struct { kind, fields, .. }) = shape.def {
             assert_eq!(kind, StructKind::Struct);
@@ -45,14 +48,18 @@ fn simple_struct() {
 
             let foo_field = &fields[0];
             assert_eq!(foo_field.name, "foo");
-            assert_eq!(foo_field.shape().layout.size(), 4);
-            assert_eq!(foo_field.shape().layout.align(), 4);
+
+            let foo_layout = foo_field.shape().layout.sized_layout().unwrap();
+            assert_eq!(foo_layout.size(), 4);
+            assert_eq!(foo_layout.align(), 4);
             assert_eq!(foo_field.offset, offset_of!(Blah, foo));
 
             let bar_field = &fields[1];
             assert_eq!(bar_field.name, "bar");
-            assert_eq!(bar_field.shape().layout.size(), 24);
-            assert_eq!(bar_field.shape().layout.align(), 8);
+
+            let bar_layout = bar_field.shape().layout.sized_layout().unwrap();
+            assert_eq!(bar_layout.size(), 24);
+            assert_eq!(bar_layout.align(), 8);
             assert_eq!(bar_field.offset, offset_of!(Blah, bar));
         } else {
             panic!("Expected Struct innards");


### PR DESCRIPTION
We probably need to change the definition of `Def::Slice` to be an actual slice (`[T]`) and not a slice refence (`&[T]`).

Ties into #376 