### PR TITLE
Work on `facet-kdl`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,8 @@ dependencies = [
  "facet-core",
  "facet-reflect",
  "facet-testhelpers",
+ "indoc",
+ "kdl",
  "log",
  "num-traits",
  "owo-colors",
@@ -420,6 +422,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "insta"
 version = "1.43.0"
 source = "git+https://github.com/mitsuhiko/insta#34196da9ee1a33df6d9e0a57a47c5692e3c5de8f"
@@ -427,6 +435,18 @@ dependencies = [
  "console",
  "once_cell",
  "similar",
+]
+
+[[package]]
+name = "kdl"
+version = "6.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661358400b02cbbf1fbd05f0a483335490e8a6bd1867620f2eeb78f304a22f"
+dependencies = [
+ "miette",
+ "num",
+ "thiserror",
+ "winnow 0.6.24",
 ]
 
 [[package]]
@@ -465,10 +485,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "miette"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mutants"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -520,6 +627,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -598,6 +714,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "syn"
+version = "2.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +759,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,7 +792,7 @@ checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.7.6",
 ]
 
 [[package]]
@@ -761,6 +908,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/facet-kdl/Cargo.toml
+++ b/facet-kdl/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "facet-kdl"
 version.workspace = true
-authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+authors = ["Brooks Rady <b.j.rady@gmail.com", "Amos Wenger <amos@bearcove.eu>"]
 description = "KDL serialization and deserialization for Facet types"
 keywords = ["kdl", "serialization", "deserialization", "reflection", "facet"]
 categories = ["encoding", "parsing", "data-structures"]

--- a/facet-kdl/Cargo.toml
+++ b/facet-kdl/Cargo.toml
@@ -23,7 +23,9 @@ num-traits = { version = "0.2.19", default-features = false }
 facet-core = { version = "0.12.0", path = "../facet-core", default-features = false }
 facet-reflect = { version = "0.11.0", path = "../facet-reflect", default-features = false }
 owo-colors = "4.2.0"
+kdl = "6.3.4"
 
 [dev-dependencies]
 facet = { path = "../facet" }
 facet-testhelpers = { path = "../facet-testhelpers" }
+indoc = "2.0.6"

--- a/facet-kdl/src/lib.rs
+++ b/facet-kdl/src/lib.rs
@@ -2,3 +2,62 @@
 #![doc = include_str!("../README.md")]
 
 // cf. facet-toml/facet-json for examples
+
+use std::{
+    any::type_name,
+    fmt::{Debug, Display},
+};
+
+use facet_core::Facet;
+use facet_reflect::Wip;
+use kdl::{KdlDocument, KdlError, KdlNode};
+
+// FIXME: Naming?
+#[derive(Debug)]
+enum State<T> {
+    ExpectingNode,
+    ProcessingNode(KdlNode),
+    Success(T),
+}
+
+// QUESTION: Any interest in making something a bit like `strum` with `facet`? Always nice to have an easy way to get
+// the names of enum variants as strings! This is just a hack for the time being...
+impl<T> Display for State<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = match self {
+            State::ExpectingNode => "ExpectingNode",
+            State::ProcessingNode(_) => "ProcessingNode",
+            State::Success(_) => "Success",
+        };
+
+        write!(f, "{state}")
+    }
+}
+
+pub fn from_str<'input, 'facet, T>(kdl: &'input str) -> Result<T, KdlError>
+where
+    T: Facet<'facet>,
+    'input: 'facet,
+{
+    log::trace!("Entering `from_str` function");
+
+    let kdl: KdlDocument = dbg!(kdl.parse()?);
+    log::trace!("KDL parsed");
+
+    let mut wip = Wip::alloc::<T>().expect("failed to allocate");
+    // QUESTION: Does `facet` provide anything like `type_name`? I think that's important for no-std support and it
+    // would be nice to have something that's a bit more reliable than a "best-effort description"
+    log::trace!("Allocated WIP for type {}", type_name::<T>());
+
+    // TODO: This should depend on `wip`?
+    let mut state = State::ExpectingNode;
+
+    loop {
+        log::trace!("Current state is: {state}");
+        match state {
+            State::ExpectingNode => todo!(),
+            State::ProcessingNode(kdl_node) => todo!(),
+            State::Success(result) => return Ok(result),
+        }
+    }
+}

--- a/facet-kdl/tests/basic.rs
+++ b/facet-kdl/tests/basic.rs
@@ -1,1 +1,23 @@
 // Basic tests go here
+
+use facet::Facet;
+use indoc::indoc;
+
+#[test]
+fn basic_node() {
+    facet_testhelpers::setup();
+
+    #[derive(Facet)]
+    struct Basic {
+        #[facet(argument)]
+        title: String,
+    }
+
+    let kdl = indoc! {r#"
+        title "Hello, World"
+    "#};
+
+    dbg!(Basic::SHAPE);
+
+    let basic: Basic = facet_kdl::from_str(kdl).unwrap();
+}


### PR DESCRIPTION
Sorry this isn't yet in a mergeable state — I've had limited time this week and I'm going to need to pester @zkat to find a way to make `miette-derive` an optional dependency of `kdl-rs` I think... That's currently tripping `just absolve` as it's quite `syn`ful.

I'll focus on getting that super basic test passing, then I'll make sure it passes CI so it can be merged ASAP!