### PR TITLE
Fix some incorrect `Layout`/`ConstTypeId` `Shape` building

### DIFF
--- a/facet-core/src/impls_alloc/arc.rs
+++ b/facet-core/src/impls_alloc/arc.rs
@@ -1,9 +1,7 @@
-use core::alloc::Layout;
-
 use crate::{
-    ConstTypeId, Def, Facet, KnownSmartPointer, PtrConst, PtrMut, PtrUninit, Shape,
-    SmartPointerDef, SmartPointerFlags, SmartPointerVTable, TryBorrowInnerError, TryFromError,
-    TryIntoInnerError, value_vtable,
+    Def, Facet, KnownSmartPointer, PtrConst, PtrMut, PtrUninit, Shape, SmartPointerDef,
+    SmartPointerFlags, SmartPointerVTable, TryBorrowInnerError, TryFromError, TryIntoInnerError,
+    value_vtable,
 };
 
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::sync::Arc<T> {
@@ -48,9 +46,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::sync::Arc<T> {
             T::SHAPE
         }
 
-        crate::Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        crate::Shape::builder_for_sized::<Self>()
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,
@@ -112,9 +108,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::sync::Weak<T> {
             T::SHAPE
         }
 
-        crate::Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        crate::Shape::builder_for_sized::<Self>()
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_alloc/btreemap.rs
+++ b/facet-core/src/impls_alloc/btreemap.rs
@@ -1,4 +1,4 @@
-use core::{alloc::Layout, write};
+use core::write;
 
 use alloc::{
     boxed::Box,
@@ -6,8 +6,8 @@ use alloc::{
 };
 
 use crate::{
-    ConstTypeId, Def, Facet, MapDef, MapIterVTable, MapVTable, MarkerTraits, PtrConst, PtrMut,
-    Shape, ValueVTable,
+    Def, Facet, MapDef, MapIterVTable, MapVTable, MarkerTraits, PtrConst, PtrMut, Shape,
+    ValueVTable,
 };
 
 struct BTreeMapIterator<'mem, K> {
@@ -21,9 +21,7 @@ where
     V: Facet<'a>,
 {
     const SHAPE: &'static crate::Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<BTreeMap<K, V>>())
-            .layout(Layout::new::<BTreeMap<K, V>>())
+        Shape::builder_for_sized::<Self>()
             .type_params(&[
                 crate::TypeParam {
                     name: "K",

--- a/facet-core/src/impls_alloc/rc.rs
+++ b/facet-core/src/impls_alloc/rc.rs
@@ -1,9 +1,7 @@
-use core::alloc::Layout;
-
 use crate::{
-    ConstTypeId, Def, Facet, KnownSmartPointer, PtrConst, PtrMut, PtrUninit, Shape,
-    SmartPointerDef, SmartPointerFlags, SmartPointerVTable, TryBorrowInnerError, TryFromError,
-    TryIntoInnerError, value_vtable,
+    Def, Facet, KnownSmartPointer, PtrConst, PtrMut, PtrUninit, Shape, SmartPointerDef,
+    SmartPointerFlags, SmartPointerVTable, TryBorrowInnerError, TryFromError, TryIntoInnerError,
+    value_vtable,
 };
 
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::rc::Rc<T> {
@@ -48,9 +46,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::rc::Rc<T> {
             T::SHAPE
         }
 
-        crate::Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        crate::Shape::builder_for_sized::<Self>()
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,
@@ -112,9 +108,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::rc::Weak<T> {
             T::SHAPE
         }
 
-        crate::Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        crate::Shape::builder_for_sized::<Self>()
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_alloc/vec.rs
+++ b/facet-core/src/impls_alloc/vec.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use core::{alloc::Layout, hash::Hash as _};
+use core::hash::Hash as _;
 
 use alloc::vec::Vec;
 
@@ -8,9 +8,7 @@ where
     T: Facet<'a>,
 {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Vec<T>>())
-            .layout(Layout::new::<Vec<T>>())
+        Shape::builder_for_sized::<Self>()
             .type_params(&[
                 TypeParam {
                     name: "T",

--- a/facet-core/src/impls_core/array.rs
+++ b/facet-core/src/impls_core/array.rs
@@ -1,5 +1,4 @@
 use crate::*;
-use core::alloc::Layout;
 use core::{cmp::Ordering, iter::zip};
 
 unsafe impl<'a, T, const L: usize> Facet<'a> for [T; L]
@@ -7,9 +6,7 @@ where
     T: Facet<'a>,
 {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<[T; L]>())
-            .layout(Layout::new::<[T; L]>())
+        Shape::builder_for_sized::<Self>()
             .type_params(&[
                 TypeParam {
                     name: "T",

--- a/facet-core/src/impls_core/option.rs
+++ b/facet-core/src/impls_core/option.rs
@@ -1,8 +1,8 @@
-use core::{alloc::Layout, mem::MaybeUninit};
+use core::mem::MaybeUninit;
 
 use crate::{
-    ConstTypeId, Def, Facet, OptionDef, OptionVTable, PtrConst, PtrMut, PtrUninit, Shape,
-    TryBorrowInnerError, TryFromError, TryIntoInnerError, value_vtable,
+    Def, Facet, OptionDef, OptionVTable, PtrConst, PtrMut, PtrUninit, Shape, TryBorrowInnerError,
+    TryFromError, TryIntoInnerError, value_vtable,
 };
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for Option<T> {
     const SHAPE: &'static Shape = &const {
@@ -49,9 +49,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Option<T> {
             T::SHAPE
         }
 
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_core/scalar.rs
+++ b/facet-core/src/impls_core/scalar.rs
@@ -6,9 +6,7 @@ use typeid::ConstTypeId;
 
 unsafe impl Facet<'_> for ConstTypeId {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::opaque().build())
@@ -21,9 +19,7 @@ unsafe impl Facet<'_> for ConstTypeId {
 
 unsafe impl Facet<'_> for () {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::empty().build())
@@ -36,9 +32,7 @@ unsafe impl Facet<'_> for () {
 
 unsafe impl<'a, T: ?Sized + 'a> Facet<'a> for core::marker::PhantomData<T> {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::empty().build())
@@ -53,9 +47,7 @@ unsafe impl<'a, T: ?Sized + 'a> Facet<'a> for core::marker::PhantomData<T> {
 #[cfg(feature = "alloc")]
 unsafe impl Facet<'_> for alloc::string::String {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     // `String` is always on the heap
@@ -69,9 +61,7 @@ unsafe impl Facet<'_> for alloc::string::String {
 
 unsafe impl Facet<'_> for char {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::char().build())
@@ -84,9 +74,7 @@ unsafe impl Facet<'_> for char {
 
 unsafe impl<'a> Facet<'a> for &'a str {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::string().build())
@@ -100,9 +88,7 @@ unsafe impl<'a> Facet<'a> for &'a str {
 #[cfg(feature = "alloc")]
 unsafe impl<'a> Facet<'a> for alloc::borrow::Cow<'a, str> {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::string().build())
@@ -122,9 +108,7 @@ unsafe impl<'a> Facet<'a> for alloc::borrow::Cow<'a, str> {
 
 unsafe impl Facet<'_> for bool {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::boolean().build())
@@ -666,9 +650,7 @@ static EPSILON_F64: f64 = f64::EPSILON;
 
 unsafe impl Facet<'_> for f32 {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<f32>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(
@@ -724,9 +706,7 @@ unsafe impl Facet<'_> for f32 {
 
 unsafe impl Facet<'_> for f64 {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<f64>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(
@@ -782,9 +762,7 @@ unsafe impl Facet<'_> for f64 {
 
 unsafe impl Facet<'_> for core::net::SocketAddr {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::socket_addr().build())
@@ -799,9 +777,7 @@ unsafe impl Facet<'_> for core::net::SocketAddr {
 
 unsafe impl Facet<'_> for core::net::IpAddr {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::ip_addr().build())
@@ -814,9 +790,7 @@ unsafe impl Facet<'_> for core::net::IpAddr {
 
 unsafe impl Facet<'_> for core::net::Ipv4Addr {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::ip_addr().build())
@@ -829,9 +803,7 @@ unsafe impl Facet<'_> for core::net::Ipv4Addr {
 
 unsafe impl Facet<'_> for core::net::Ipv6Addr {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::ip_addr().build())

--- a/facet-core/src/impls_core/slice.rs
+++ b/facet-core/src/impls_core/slice.rs
@@ -1,14 +1,11 @@
 use crate::*;
-use core::alloc::Layout;
 
 unsafe impl<'a, T> Facet<'a> for &'a [T]
 where
     T: Facet<'a>,
 {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<&[T]>())
-            .layout(Layout::new::<&[T]>())
+        Shape::builder_for_sized::<Self>()
             .type_params(&[
                 TypeParam {
                     name: "T",

--- a/facet-core/src/impls_core/smartptr.rs
+++ b/facet-core/src/impls_core/smartptr.rs
@@ -1,15 +1,11 @@
-use core::alloc::Layout;
-
 use crate::{
-    ConstTypeId, Def, Facet, KnownSmartPointer, PtrConst, SmartPointerDef, SmartPointerFlags,
+    Def, Facet, KnownSmartPointer, PtrConst, SmartPointerDef, SmartPointerFlags,
     SmartPointerVTable, value_vtable,
 };
 
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for core::ptr::NonNull<T> {
     const SHAPE: &'static crate::Shape = &const {
-        crate::Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        crate::Shape::builder_for_sized::<Self>()
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_std/hashmap.rs
+++ b/facet-core/src/impls_std/hashmap.rs
@@ -1,13 +1,13 @@
 use alloc::collections::VecDeque;
-use core::{alloc::Layout, hash::Hash};
+use core::hash::Hash;
 use std::collections::HashMap;
 use std::hash::RandomState;
 
 use crate::ptr::{PtrConst, PtrMut};
 
 use crate::{
-    ConstTypeId, Def, Facet, MapDef, MapIterVTable, MapVTable, MarkerTraits, ScalarAffinity,
-    ScalarDef, Shape, TypeParam, ValueVTable, value_vtable,
+    Def, Facet, MapDef, MapIterVTable, MapVTable, MarkerTraits, ScalarAffinity, ScalarDef, Shape,
+    TypeParam, ValueVTable, value_vtable,
 };
 
 struct HashMapIterator<'mem, K> {
@@ -22,9 +22,7 @@ where
     S: Facet<'a> + Default,
 {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<HashMap<K, V, S>>())
-            .layout(Layout::new::<HashMap<K, V>>())
+        Shape::builder_for_sized::<Self>()
             .type_params(&[
                 TypeParam {
                     name: "K",
@@ -196,9 +194,7 @@ where
 
 unsafe impl Facet<'_> for RandomState {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<RandomState>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::opaque().build())

--- a/facet-core/src/impls_std/path.rs
+++ b/facet-core/src/impls_std/path.rs
@@ -1,12 +1,8 @@
 use crate::*;
-use core::alloc::Layout;
-use typeid::ConstTypeId;
 
 unsafe impl Facet<'_> for std::path::PathBuf {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::path().build())
@@ -19,9 +15,7 @@ unsafe impl Facet<'_> for std::path::PathBuf {
 
 unsafe impl<'a> Facet<'a> for &'a std::path::Path {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::path().build())

--- a/facet-core/src/opaque.rs
+++ b/facet-core/src/opaque.rs
@@ -1,6 +1,5 @@
-use crate::{ConstTypeId, Def, ScalarAffinity, ScalarDef, value_vtable};
+use crate::{Def, ScalarAffinity, ScalarDef, value_vtable};
 use crate::{Facet, Shape};
-use core::alloc::Layout;
 
 /// Helper type for opaque members
 #[repr(transparent)]
@@ -8,9 +7,7 @@ pub struct Opaque<T>(T);
 
 unsafe impl<'a, T: 'a> Facet<'a> for Opaque<T> {
     const SHAPE: &'static Shape = &const {
-        Shape::builder()
-            .id(ConstTypeId::of::<Self>())
-            .layout(Layout::new::<Self>())
+        Shape::builder_for_sized::<Self>()
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::opaque().build())

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -156,6 +156,13 @@ impl Shape {
         ShapeBuilder::new()
     }
 
+    /// Returns a builder for a shape for some type `T`.
+    pub const fn builder_for_sized<T>() -> ShapeBuilder {
+        ShapeBuilder::new()
+            .layout(Layout::new::<T>())
+            .id(ConstTypeId::of::<T>())
+    }
+
     /// Check if this shape is of the given type
     pub fn is_type<Other: Facet<'static>>(&'static self) -> bool {
         let l = self;


### PR DESCRIPTION
We should always use `Self` here or we run into risks of forgetting a defaulted type parameter (as happened in the hashmap impl for example).

This also deduplicates some code with a helper.