### PR TITLE
Automatically populate `drop_in_place` when vtable building

### DIFF
--- a/facet-core/src/impls_alloc/vec.rs
+++ b/facet-core/src/impls_alloc/vec.rs
@@ -17,7 +17,7 @@ where
             ])
             .vtable(
                 &const {
-                    let mut builder = ValueVTable::builder()
+                    let mut builder = ValueVTable::builder::<Self>()
                         .type_name(|f, opts| {
                             if let Some(opts) = opts.for_children() {
                                 write!(f, "Vec<")?;
@@ -27,13 +27,12 @@ where
                                 write!(f, "Vec<⋯>")
                             }
                         })
-                        .drop_in_place(|value| unsafe { value.drop_in_place::<Vec<T>>() })
                         .default_in_place(|target| unsafe { target.put(Self::default()) })
-                        .clone_into(|src, dst| unsafe { dst.put(src.get::<Vec<T>>()) });
+                        .clone_into(|src, dst| unsafe { dst.put(src.get::<Self>()) });
 
                     if T::SHAPE.vtable.debug.is_some() {
                         builder = builder.debug(|value, f| {
-                            let value = unsafe { value.get::<Vec<T>>() };
+                            let value = unsafe { value.get::<Self>() };
                             write!(f, "[")?;
                             for (i, item) in value.iter().enumerate() {
                                 if i > 0 {
@@ -52,8 +51,8 @@ where
 
                     if T::SHAPE.vtable.eq.is_some() {
                         builder = builder.eq(|a, b| unsafe {
-                            let a = a.get::<Vec<T>>();
-                            let b = b.get::<Vec<T>>();
+                            let a = a.get::<Self>();
+                            let b = b.get::<Self>();
                             if a.len() != b.len() {
                                 return false;
                             }
@@ -72,7 +71,7 @@ where
                     if T::SHAPE.vtable.hash.is_some() {
                         builder = builder.hash(|value, hasher_this, hasher_write_fn| unsafe {
                             use crate::HasherProxy;
-                            let vec = value.get::<Vec<T>>();
+                            let vec = value.get::<Self>();
                             let t_hash = T::SHAPE.vtable.hash.unwrap_unchecked();
                             let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
                             vec.len().hash(&mut hasher);
@@ -101,16 +100,16 @@ where
                                     data.put(Self::with_capacity(capacity))
                                 })
                                 .push(|ptr, item| unsafe {
-                                    let vec = ptr.as_mut::<Vec<T>>();
+                                    let vec = ptr.as_mut::<Self>();
                                     let item = item.read::<T>();
                                     (*vec).push(item);
                                 })
                                 .len(|ptr| unsafe {
-                                    let vec = ptr.get::<Vec<T>>();
+                                    let vec = ptr.get::<Self>();
                                     vec.len()
                                 })
                                 .get_item_ptr(|ptr, index| unsafe {
-                                    let vec = ptr.get::<Vec<T>>();
+                                    let vec = ptr.get::<Self>();
                                     let len = vec.len();
                                     if index >= len {
                                         panic!(

--- a/facet-core/src/impls_core/array.rs
+++ b/facet-core/src/impls_core/array.rs
@@ -15,7 +15,7 @@ where
             ])
             .vtable(
                 &const {
-                    let mut builder = ValueVTable::builder()
+                    let mut builder = ValueVTable::builder::<Self>()
                         .marker_traits(T::SHAPE.vtable.marker_traits)
                         .type_name(|f, opts| {
                             if let Some(opts) = opts.for_children() {
@@ -25,8 +25,7 @@ where
                             } else {
                                 write!(f, "[⋯; {L}]")
                             }
-                        })
-                        .drop_in_place(|value| unsafe { value.drop_in_place::<[T; L]>() });
+                        });
                     if T::SHAPE.vtable.display.is_some() {
                         builder = builder.display(|value, f| {
                             let value = unsafe { value.get::<[T; L]>() };

--- a/facet-core/src/impls_core/fn_ptr.rs
+++ b/facet-core/src/impls_core/fn_ptr.rs
@@ -68,7 +68,7 @@ macro_rules! impl_facet_for_fn_ptr {
                     .id(ConstTypeId::of::<Self>())
                     .layout(Layout::new::<Self>())
                     .vtable(const {
-                        &ValueVTable::builder()
+                        &ValueVTable::builder::<Self>()
                             .type_name(|f, opts| {
                                 write_type_name_list(f, opts, $abi, &[$($args::SHAPE),*], R::SHAPE)
                             })

--- a/facet-core/src/impls_core/slice.rs
+++ b/facet-core/src/impls_core/slice.rs
@@ -39,7 +39,7 @@ where
             ))
             .vtable(
                 &const {
-                    let mut builder = ValueVTable::builder()
+                    let mut builder = ValueVTable::builder::<Self>()
                         .type_name(|f, opts| {
                             if let Some(opts) = opts.for_children() {
                                 write!(f, "&[")?;

--- a/facet-core/src/impls_core/tuple.rs
+++ b/facet-core/src/impls_core/tuple.rs
@@ -97,7 +97,7 @@ macro_rules! impl_facet_for_tuple {
                     .id(ConstTypeId::of::<Self>())
                     .layout(Layout::new::<Self>())
                     .vtable(&const {
-                        let mut builder = ValueVTable::builder()
+                        let mut builder = ValueVTable::builder::<Self>()
                             .type_name(|f, opts| {
                                 write_type_name_list(f, opts, "(", ", ", ")", &[$($elems::SHAPE),+])
                             })

--- a/facet-core/src/impls_std/hashmap.rs
+++ b/facet-core/src/impls_std/hashmap.rs
@@ -39,7 +39,7 @@ where
             ])
             .vtable(
                 &const {
-                    let mut builder = ValueVTable::builder()
+                    let mut builder = ValueVTable::builder::<Self>()
                         .marker_traits({
                             let arg_dependent_traits = MarkerTraits::SEND
                                 .union(MarkerTraits::SYNC)
@@ -59,8 +59,7 @@ where
                             } else {
                                 write!(f, "HashMap<⋯>")
                             }
-                        })
-                        .drop_in_place(|value| unsafe { value.drop_in_place::<HashMap<K, V>>() });
+                        });
 
                     if K::SHAPE.vtable.debug.is_some() && V::SHAPE.vtable.debug.is_some() {
                         builder = builder.debug(|value, f| unsafe {

--- a/facet-core/src/macros.rs
+++ b/facet-core/src/macros.rs
@@ -44,9 +44,8 @@ where
 macro_rules! value_vtable {
     ($type_name:ty, $type_name_fn:expr) => {
         const {
-            let mut builder = $crate::ValueVTable::builder()
-                .type_name($type_name_fn)
-                .drop_in_place(|data| unsafe { data.drop_in_place::<$type_name>() });
+            let mut builder = $crate::ValueVTable::builder::<$type_name>()
+                .type_name($type_name_fn);
 
             if $crate::spez::impls!($type_name: core::fmt::Display) {
                 builder = builder.display(|data, f| {

--- a/facet-dev/src/main.rs
+++ b/facet-dev/src/main.rs
@@ -682,7 +682,7 @@ fn main() {
                 "│                                                                            │"
             );
             error!(
-                "│  GENERATED FILES HAVE CHANGED - RUN `just codegen` TO UPDATE THEM          │"
+                "│  GENERATED FILES HAVE CHANGED - RUN `just gen` TO UPDATE THEM              │"
             );
             error!(
                 "│                                                                            │"
@@ -697,7 +697,7 @@ fn main() {
                 "│  • Don't edit README.md directly - edit the README.md.in template instead  │"
             );
             error!(
-                "│  • Then run `just codegen` to regenerate the README.md files               │"
+                "│  • Then run `just gen` to regenerate the README.md files                   │"
             );
             error!(
                 "│  • A pre-commit hook is set up by cargo-husky to do just that              │"

--- a/facet/src/sample_generated_code.rs
+++ b/facet/src/sample_generated_code.rs
@@ -105,9 +105,8 @@ unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkStruct {
         };
         let vtable = &const {
             let mut vtable = const {
-                let mut builder = ::facet_core::ValueVTable::builder()
-                    .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "KitchenSinkStruct"))
-                    .drop_in_place(|data| unsafe { data.drop_in_place::<Self>() });
+                let mut builder = ::facet_core::ValueVTable::builder::<Self>()
+                    .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "KitchenSinkStruct"));
                 if {
                     /// Fallback trait with `False` for `IMPLS` if the type does not
                     /// implement the given trait.
@@ -462,9 +461,8 @@ unsafe impl<'__facet> crate::Facet<'__facet> for Point {
         };
         let vtable = &const {
             let mut vtable = const {
-                let mut builder = ::facet_core::ValueVTable::builder()
-                    .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "Point"))
-                    .drop_in_place(|data| unsafe { data.drop_in_place::<Self>() });
+                let mut builder = ::facet_core::ValueVTable::builder::<Self>()
+                    .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "Point"));
                 if {
                     /// Fallback trait with `False` for `IMPLS` if the type does not
                     /// implement the given trait.
@@ -1065,11 +1063,10 @@ unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkEnum {
             .vtable(
                 &const {
                     const {
-                        let mut builder = ::facet_core::ValueVTable::builder()
-                            .type_name(|f, _opts| {
+                        let mut builder =
+                            ::facet_core::ValueVTable::builder::<Self>().type_name(|f, _opts| {
                                 ::core::fmt::Write::write_str(f, "KitchenSinkEnum")
-                            })
-                            .drop_in_place(|data| unsafe { data.drop_in_place::<Self>() });
+                            });
                         if {
                             /// Fallback trait with `False` for `IMPLS` if the type does not
                             /// implement the given trait.
@@ -1498,9 +1495,8 @@ unsafe impl<'__facet> crate::Facet<'__facet> for SubEnum {
             .vtable(
                 &const {
                     const {
-                        let mut builder = ::facet_core::ValueVTable::builder()
-                            .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "SubEnum"))
-                            .drop_in_place(|data| unsafe { data.drop_in_place::<Self>() });
+                        let mut builder = ::facet_core::ValueVTable::builder::<Self>()
+                            .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "SubEnum"));
                         if {
                             /// Fallback trait with `False` for `IMPLS` if the type does not
                             /// implement the given trait.


### PR DESCRIPTION
Opposed to manually filling it out. A bunch of our impls are lacking this where drop glue is involved, an example being arrays. While they don't implement `Drop`, they may contain types that are `Drop` and such can potentially have a destructor.