### PR TITLE
Support raw identifiers in field names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,10 @@ simply make a note of it and I will take care of it.
 crates like `facet-yaml`, `facet-json`, only have have a _dev_ dependency on
 `facet`. For regular dependencies, they only have `facet-core`, `facet-reflect`.
 This is to keep `facet-derive` out of them.
+
+### Testing Derive Macros
+
+Tests that exercise the `#[derive(Facet)]` macro cannot live in `facet-core`
+because it does not depend on `facet-derive`. Such tests should either be
+snapshot tests in `facet-derive-emit` or integration tests in the main `facet`
+crate, which brings all the necessary components together.

--- a/facet-derive-emit/src/process_enum.rs
+++ b/facet-derive-emit/src/process_enum.rs
@@ -1,3 +1,4 @@
+use super::normalize_ident_str;
 use super::*;
 
 // mirrors facet_core::types::EnumRepr
@@ -363,6 +364,7 @@ fn process_c_style_enum(
                         let field_name = format!("_{idx}");
                         gen_struct_field(
                             &field_name,
+                            &field_name,
                             &field.value.typ.tokens_to_string(),
                             &shadow_struct_name,
                             &facet_bgp,
@@ -429,10 +431,13 @@ fn process_c_style_enum(
                     .0
                     .iter()
                     .map(|field| {
-                        let field_name = field.value.name.to_string();
+                        // Handle raw identifiers (like r#type) by stripping the 'r#' prefix.
+                        let raw_field_name = field.value.name.to_string(); // e.g., "r#type"
+                        let normalized_field_name = normalize_ident_str(&raw_field_name); // e.g., "type"
                         let field_type = field.value.typ.tokens_to_string();
                         gen_struct_field(
-                            &field_name,
+                            &raw_field_name,
+                            normalized_field_name,
                             &field_type,
                             &shadow_struct_name,
                             &facet_bgp,
@@ -561,6 +566,7 @@ fn process_primitive_enum(
                         let field_name = format!("_{idx}");
                         gen_struct_field(
                             &field_name,
+                            &field_name,
                             &field.value.typ.tokens_to_string(),
                             &shadow_struct_name,
                             &facet_bgp,
@@ -627,9 +633,12 @@ fn process_primitive_enum(
                     .0
                     .iter()
                     .map(|field| {
-                        let field_name = field.value.name.to_string();
+                        // Handle raw identifiers (like r#type) by stripping the 'r#' prefix.
+                        let raw_field_name = field.value.name.to_string(); // e.g., "r#type"
+                        let normalized_field_name = normalize_ident_str(&raw_field_name); // e.g., "type"
                         gen_struct_field(
-                            &field_name,
+                            &raw_field_name,
+                            normalized_field_name,
                             &field.value.typ.tokens_to_string(),
                             &shadow_struct_name,
                             &facet_bgp,

--- a/facet-derive-emit/src/process_struct.rs
+++ b/facet-derive-emit/src/process_struct.rs
@@ -1,3 +1,4 @@
+use super::normalize_ident_str;
 use super::*;
 
 /// Processes a regular struct to implement Facet
@@ -45,9 +46,12 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
                 .0
                 .iter()
                 .map(|field| {
-                    let field_name = field.value.name.to_string();
+                    // Handle raw identifiers (like r#type) by stripping the 'r#' prefix.
+                    let raw_field_name = field.value.name.to_string(); // e.g., "r#type"
+                    let normalized_field_name = normalize_ident_str(&raw_field_name); // e.g., "type"
                     gen_struct_field(
-                        &field_name,
+                        &raw_field_name,
+                        normalized_field_name,
                         &field.value.typ.tokens_to_string(),
                         &struct_name,
                         &bgp,
@@ -72,6 +76,7 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
                 .map(|(index, field)| {
                     let field_name = format!("{index}");
                     gen_struct_field(
+                        &field_name,
                         &field_name,
                         &field.value.typ.tokens_to_string(),
                         &struct_name,

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_multiple_attributes_per_variant.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_multiple_attributes_per_variant.snap
@@ -54,7 +54,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ConfigValue {
                         &const {
                             [
                                 ::facet::Field::builder()
-                                    .name("value")
+                                    .name("numValue")
                                     .shape(|| {
                                         ::facet::shape_of(
                                             &|s: &__ShadowConfigValue_Number<'__facet>| &s.value,
@@ -70,7 +70,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ConfigValue {
                                     )
                                     .build(),
                                 ::facet::Field::builder()
-                                    .name("unit")
+                                    .name("unitName")
                                     .shape(|| {
                                         ::facet::shape_of(
                                             &|s: &__ShadowConfigValue_Number<'__facet>| &s.unit,
@@ -80,12 +80,13 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ConfigValue {
                                         __ShadowConfigValue_Number<'__facet>,
                                         unit
                                     ))
-                                    .flags(::facet::FieldFlags::EMPTY)
+                                    .flags(::facet::FieldFlags::SENSITIVE)
                                     .attributes(
                                         &const {
-                                            [::facet::FieldAttribute::Rename(
-                                                "unitName\" , sensitive",
-                                            )]
+                                            [
+                                                ::facet::FieldAttribute::Rename("unitName"),
+                                                ::facet::FieldAttribute::Sensitive,
+                                            ]
                                         },
                                     )
                                     .build(),

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_renamed_variants_and_fields.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_renamed_variants_and_fields.snap
@@ -25,7 +25,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ApiResponse {
                 {
                     let fields: &'static [::facet::Field] = &const {
                         [::facet::Field::builder()
-                            .name("data")
+                            .name("responseData")
                             .shape(|| {
                                 ::facet::shape_of(&|s: &__ShadowApiResponse_Ok<'__facet>| &s.data)
                             })
@@ -54,7 +54,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ApiResponse {
                     let fields: &'static [::facet::Field] = &const {
                         [
                             ::facet::Field::builder()
-                                .name("code")
+                                .name("errorCode")
                                 .shape(|| {
                                     ::facet::shape_of(&|s: &__ShadowApiResponse_Err<'__facet>| {
                                         &s.code
@@ -70,7 +70,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ApiResponse {
                                 )
                                 .build(),
                             ::facet::Field::builder()
-                                .name("message")
+                                .name("errorMessage")
                                 .shape(|| {
                                     ::facet::shape_of(&|s: &__ShadowApiResponse_Err<'__facet>| {
                                         &s.message

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__mixed_rename_and_sensitive_attributes.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__mixed_rename_and_sensitive_attributes.snap
@@ -10,19 +10,24 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for User {
         let fields: &'static [::facet::Field] = &const {
             [
                 ::facet::Field::builder()
-                    .name("name")
+                    .name("userName")
                     .shape(|| ::facet::shape_of(&|s: &User| &s.name))
                     .offset(::core::mem::offset_of!(User, name))
                     .flags(::facet::FieldFlags::EMPTY)
                     .attributes(&const { [::facet::FieldAttribute::Rename("userName")] })
                     .build(),
                 ::facet::Field::builder()
-                    .name("email")
+                    .name("userEmail")
                     .shape(|| ::facet::shape_of(&|s: &User| &s.email))
                     .offset(::core::mem::offset_of!(User, email))
-                    .flags(::facet::FieldFlags::EMPTY)
+                    .flags(::facet::FieldFlags::SENSITIVE)
                     .attributes(
-                        &const { [::facet::FieldAttribute::Rename("userEmail\" , sensitive")] },
+                        &const {
+                            [
+                                ::facet::FieldAttribute::Rename("userEmail"),
+                                ::facet::FieldAttribute::Sensitive,
+                            ]
+                        },
                     )
                     .build(),
                 ::facet::Field::builder()

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_facet_attributes.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_facet_attributes.snap
@@ -14,12 +14,14 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for StructWithAttributes {
                     .name("id")
                     .shape(|| ::facet::shape_of(&|s: &StructWithAttributes| &s.id))
                     .offset(::core::mem::offset_of!(StructWithAttributes, id))
-                    .flags(::facet::FieldFlags::EMPTY)
+                    .flags(::facet::FieldFlags::SENSITIVE)
                     .attributes(
                         &const {
-                            [::facet::FieldAttribute::Arbitrary(
-                                "name = \"identifier\" , default = \"generate_id\" , sensitive",
-                            )]
+                            [
+                                ::facet::FieldAttribute::Arbitrary("name = \"identifier\""),
+                                ::facet::FieldAttribute::Arbitrary("default = \"generate_id\""),
+                                ::facet::FieldAttribute::Sensitive,
+                            ]
                         },
                     )
                     .build(),
@@ -29,7 +31,12 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for StructWithAttributes {
                     .offset(::core::mem::offset_of!(StructWithAttributes, internal_data))
                     .flags(::facet::FieldFlags::EMPTY)
                     .attributes(
-                        &const { [::facet::FieldAttribute::Arbitrary("skip , version = 3")] },
+                        &const {
+                            [
+                                ::facet::FieldAttribute::Arbitrary("skip"),
+                                ::facet::FieldAttribute::Arbitrary("version = 3"),
+                            ]
+                        },
                     )
                     .build(),
                 ::facet::Field::builder()

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_renamed_field.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_renamed_field.snap
@@ -10,14 +10,14 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Person {
         let fields: &'static [::facet::Field] = &const {
             [
                 ::facet::Field::builder()
-                    .name("first_name")
+                    .name("firstName")
                     .shape(|| ::facet::shape_of(&|s: &Person| &s.first_name))
                     .offset(::core::mem::offset_of!(Person, first_name))
                     .flags(::facet::FieldFlags::EMPTY)
                     .attributes(&const { [::facet::FieldAttribute::Rename("firstName")] })
                     .build(),
                 ::facet::Field::builder()
-                    .name("last_name")
+                    .name("lastName")
                     .shape(|| ::facet::shape_of(&|s: &Person| &s.last_name))
                     .offset(::core::mem::offset_of!(Person, last_name))
                     .flags(::facet::FieldFlags::EMPTY)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_with_renamed_field.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_with_renamed_field.snap
@@ -10,21 +10,21 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Point {
         let fields: &'static [::facet::Field] = &const {
             [
                 ::facet::Field::builder()
-                    .name("0")
+                    .name("x_coordinate")
                     .shape(|| ::facet::shape_of(&|s: &Point| &s.0))
                     .offset(::core::mem::offset_of!(Point, 0))
                     .flags(::facet::FieldFlags::EMPTY)
                     .attributes(&const { [::facet::FieldAttribute::Rename("x_coordinate")] })
                     .build(),
                 ::facet::Field::builder()
-                    .name("1")
+                    .name("y_coordinate")
                     .shape(|| ::facet::shape_of(&|s: &Point| &s.1))
                     .offset(::core::mem::offset_of!(Point, 1))
                     .flags(::facet::FieldFlags::EMPTY)
                     .attributes(&const { [::facet::FieldAttribute::Rename("y_coordinate")] })
                     .build(),
                 ::facet::Field::builder()
-                    .name("2")
+                    .name("z_coordinate")
                     .shape(|| ::facet::shape_of(&|s: &Point| &s.2))
                     .offset(::core::mem::offset_of!(Point, 2))
                     .flags(::facet::FieldFlags::EMPTY)

--- a/facet-json/tests/integration/read/rename.rs
+++ b/facet-json/tests/integration/read/rename.rs
@@ -123,6 +123,36 @@ fn test_field_rename_with_unicode_name_emoji() {
     assert_eq!(test_struct, roundtrip);
 }
 
+/// Round-trip serialization/deserialization with raw identifiers as field names
+#[cfg(feature = "std")]
+#[test]
+fn test_raw_identifier_fields_roundtrip() {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct RawIdentifiers {
+        // Use rename because the JSON key won't have the r# prefix
+        #[facet(rename = "type")]
+        r#type: String,
+
+        #[facet(rename = "match")]
+        r#match: bool,
+    }
+
+    let original = RawIdentifiers {
+        r#type: "keyword_value".to_string(),
+        r#match: false,
+    };
+
+    // Serialization should use the renamed keys
+    let json = facet_json::to_string(&original);
+    assert_eq!(json, r#"{"type":"keyword_value","match":false}"#);
+
+    // Deserialization should correctly map back to raw identifiers
+    let roundtrip: RawIdentifiers = facet_json::from_str(&json).unwrap();
+    assert_eq!(original, roundtrip);
+}
+
 /// Serialization and deserialization with Unicode characters in field name (Euro sign)
 #[test]
 #[cfg(feature = "std")]

--- a/tests/derive/raw_identifiers.rs
+++ b/tests/derive/raw_identifiers.rs
@@ -1,0 +1,27 @@
+// facet/tests/derive/raw_identifiers.rs
+use facet::Facet;
+
+#[derive(Facet, Debug, PartialEq, Clone)]
+struct RawIdentifiers {
+    r#type: String,
+    r#enum: String,
+    r#match: bool,
+}
+
+#[test]
+fn test_derive_strips_raw_identifier_prefix() {
+    let shape = RawIdentifiers::SHAPE;
+    let def = shape.def().as_struct().expect("Should be a struct");
+    let fields = def.fields();
+
+    assert_eq!(fields.len(), 3);
+
+    assert_eq!(fields[0].name(), "type");
+    assert_eq!(fields[0].shape().def().as_str(), Some(())); // Check type is String
+
+    assert_eq!(fields[1].name(), "enum");
+    assert_eq!(fields[1].shape().def().as_str(), Some(())); // Check type is String
+
+    assert_eq!(fields[2].name(), "match");
+    assert_eq!(fields[2].shape().def().as_bool(), Some(())); // Check type is bool
+}


### PR DESCRIPTION
Note that there is no way to go back to the original field name.

Closes #402