### PR TITLE
Revert changes to pre-commit hook introduced in 4589057

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-cargo run -p facet-dev precommit
+cargo run -p facet-dev -- generate


### PR DESCRIPTION
Noticed this when trying to commit for #438. I just deleted the `pre-commit` then. Looks like this was changed here, https://github.com/facet-rs/facet/commit/45890573d564859e49d1d0916d36af40acb07eb0, and was a find-replace error? `facet-dev` does not currently have any mention of "precommit" anywhere.