### PR TITLE
Add bench against Debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
 name = "ariadne"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +106,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +131,58 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "color-backtrace"
@@ -156,6 +235,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +294,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "ctrlc"
@@ -376,6 +497,7 @@ dependencies = [
 name = "facet-pretty"
 version = "0.17.0"
 dependencies = [
+ "criterion",
  "facet",
  "facet-core",
  "facet-reflect",
@@ -496,6 +618,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +650,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "impls"
@@ -563,6 +701,32 @@ dependencies = [
  "once_cell",
  "similar",
 ]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.0",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -657,7 +821,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -687,6 +851,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "ordered-float"
@@ -720,6 +890,34 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -825,6 +1023,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rust-format"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +1077,59 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -932,6 +1212,16 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1044,6 +1334,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1360,7 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
@@ -1107,6 +1408,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,7 @@ version = "0.17.0"
 dependencies = [
  "ariadne",
  "camino",
+ "criterion",
  "eyre",
  "facet",
  "facet-core",
@@ -452,6 +453,8 @@ dependencies = [
  "log",
  "ordered-float",
  "owo-colors 4.2.0",
+ "serde",
+ "serde_json",
  "ulid",
  "uuid",
 ]

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -35,3 +35,11 @@ facet = { path = "../facet" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 insta = { git = "https://github.com/mitsuhiko/insta" }
 ordered-float = "5.0.0"
+
+criterion = { version = "0.5", features = ["html_reports"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[[bench]]
+name = "compare_serde"
+harness = false

--- a/facet-json/benches/compare_serde.rs
+++ b/facet-json/benches/compare_serde.rs
@@ -1,0 +1,318 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use facet::Facet;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested0 {
+    id: u64,
+    name: String,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested1 {
+    id: u64,
+    name: String,
+    child: Nested0,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested2 {
+    id: u64,
+    name: String,
+    child: Nested1,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested3 {
+    id: u64,
+    name: String,
+    child: Nested2,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested4 {
+    id: u64,
+    name: String,
+    child: Nested3,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested5 {
+    id: u64,
+    name: String,
+    child: Nested4,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested6 {
+    id: u64,
+    name: String,
+    child: Nested5,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested7 {
+    id: u64,
+    name: String,
+    child: Nested6,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested8 {
+    id: u64,
+    name: String,
+    child: Nested7,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested9 {
+    id: u64,
+    name: String,
+    child: Nested8,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested10 {
+    id: u64,
+    name: String,
+    child: Nested9,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested11 {
+    id: u64,
+    name: String,
+    child: Nested10,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested12 {
+    id: u64,
+    name: String,
+    child: Nested11,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested13 {
+    id: u64,
+    name: String,
+    child: Nested12,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested14 {
+    id: u64,
+    name: String,
+    child: Nested13,
+}
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+pub struct Nested15 {
+    id: u64,
+    name: String,
+    child: Nested14,
+}
+
+// Wide Structure
+#[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+struct Wide {
+    field01: String,
+    field02: u64,
+    field03: i32,
+    field04: f64,
+    field05: bool,
+    field06: Option<String>,
+    field07: Vec<u32>,
+    field08: String,
+    field09: u64,
+    field10: i32,
+    field11: f64,
+    field12: bool,
+    field13: Option<String>,
+    field14: Vec<u32>,
+    field15: String,
+    field16: u64,
+    field17: i32,
+    field18: f64,
+    field19: bool,
+    field20: Option<String>,
+    field21: Vec<u32>,
+    field22: String,
+    field23: u64,
+    field24: i32,
+    field25: f64,
+    field26: bool,
+    field27: Option<String>,
+    field28: Vec<u32>,
+    field29: HashMap<String, i32>,
+    field30: Nested0,
+}
+
+fn create_wide() -> Wide {
+    let mut map = HashMap::new();
+    map.insert("a".to_string(), 1);
+    map.insert("b".to_string(), 2);
+
+    Wide {
+        field01: "value 01".to_string(),
+        field02: 1234567890123456789,
+        field03: -123456789,
+        field04: 3.141592653589793,
+        field05: true,
+        field06: Some("optional value 06".to_string()),
+        field07: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
+        field08: "value 08".to_string(),
+        field09: 9876543210987654321,
+        field10: 987654321,
+        field11: 2.718281828459045,
+        field12: false,
+        field13: None,
+        field14: vec![0, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+        field15: "value 15".to_string(),
+        field16: 1111111111111111111,
+        field17: -111111111,
+        field18: 1.618033988749895,
+        field19: true,
+        field20: Some("optional value 20".to_string()),
+        field21: vec![10, 20, 30],
+        field22: "value 22".to_string(),
+        field23: 2222222222222222222,
+        field24: -222222222,
+        field25: 0.5772156649015329,
+        field26: false,
+        field27: None,
+        field28: vec![],
+        field29: map,
+        field30: Nested0 {
+            id: 0,
+            name: "Base Nested".to_string(),
+        },
+    }
+}
+
+// Benchmarks
+
+fn bench_nested(c: &mut Criterion) {
+    let data: Nested15 = Nested15 {
+        id: 15,
+        name: "Level 15".to_string(),
+        child: Nested14 {
+            id: 14,
+            name: "Level 14".to_string(),
+            child: Nested13 {
+                id: 13,
+                name: "Level 13".to_string(),
+                child: Nested12 {
+                    id: 12,
+                    name: "Level 12".to_string(),
+                    child: Nested11 {
+                        id: 11,
+                        name: "Level 11".to_string(),
+                        child: Nested10 {
+                            id: 10,
+                            name: "Level 10".to_string(),
+                            child: Nested9 {
+                                id: 9,
+                                name: "Level 9".to_string(),
+                                child: Nested8 {
+                                    id: 8,
+                                    name: "Level 8".to_string(),
+                                    child: Nested7 {
+                                        id: 7,
+                                        name: "Level 7".to_string(),
+                                        child: Nested6 {
+                                            id: 6,
+                                            name: "Level 6".to_string(),
+                                            child: Nested5 {
+                                                id: 5,
+                                                name: "Level 5".to_string(),
+                                                child: Nested4 {
+                                                    id: 4,
+                                                    name: "Level 4".to_string(),
+                                                    child: Nested3 {
+                                                        id: 3,
+                                                        name: "Level 3".to_string(),
+                                                        child: Nested2 {
+                                                            id: 2,
+                                                            name: "Level 2".to_string(),
+                                                            child: Nested1 {
+                                                                id: 1,
+                                                                name: "Level 1".to_string(),
+                                                                child: Nested0 {
+                                                                    id: 0,
+                                                                    name: "Level 0".to_string(),
+                                                                },
+                                                            },
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    let data = vec![data.clone(); 100];
+
+    let json_string =
+        serde_json::to_string(&data).expect("Failed to create nested JSON for depth 15");
+
+    let mut group = c.benchmark_group("Nested (depth=15))");
+
+    group.bench_function("facet_serialize", |b| {
+        b.iter(|| {
+            let _ = black_box(facet_json::to_string(black_box(&data)));
+        })
+    });
+    group.bench_function("serde_serialize", |b| {
+        b.iter(|| {
+            let _ = black_box(serde_json::to_string(black_box(&data)));
+        })
+    });
+
+    group.bench_function("facet_deserialize", |b| {
+        b.iter(|| {
+            let res: Vec<Nested15> =
+                black_box(facet_json::from_str(black_box(&json_string))).unwrap();
+            black_box(res);
+        })
+    });
+    group.bench_function("serde_deserialize", |b| {
+        b.iter(|| {
+            let res: Vec<Nested15> =
+                black_box(serde_json::from_str(black_box(&json_string))).unwrap();
+            black_box(res);
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_wide(c: &mut Criterion) {
+    let data = create_wide();
+    let json_string = serde_json::to_string(&data).expect("Failed to create wide JSON");
+    let num_fields: serde_json::Value = serde_json::from_str(&json_string).unwrap();
+    let num_fields = num_fields.as_object().unwrap().len();
+
+    let mut group = c.benchmark_group(format!("Wide (fields~{})", num_fields));
+
+    group.bench_function("facet_serialize", |b| {
+        b.iter(|| {
+            let _ = black_box(facet_json::to_string(black_box(&data)));
+        })
+    });
+    group.bench_function("serde_serialize", |b| {
+        b.iter(|| {
+            let _ = black_box(serde_json::to_string(black_box(&data)));
+        })
+    });
+
+    group.bench_function("facet_deserialize", |b| {
+        b.iter(|| {
+            let _res: Wide = black_box(facet_json::from_str(black_box(&json_string))).unwrap();
+        })
+    });
+    group.bench_function("serde_deserialize", |b| {
+        b.iter(|| {
+            let _res: Wide = black_box(serde_json::from_str(black_box(&json_string))).unwrap();
+        })
+    });
+
+    group.finish();
+}
+
+// Criterion Setup
+criterion_group!(benches, bench_nested, bench_wide);
+criterion_main!(benches);

--- a/facet-pretty/Cargo.toml
+++ b/facet-pretty/Cargo.toml
@@ -22,3 +22,9 @@ yansi = "1.0.1"
 
 [dev-dependencies]
 facet = { path = "../facet" }
+criterion = "0.5.1"
+
+[[bench]]
+path = "benches/compare_derive_more.rs"
+name = "compare_derive_more"
+harness = false

--- a/facet-pretty/benches/compare_derive_more.rs
+++ b/facet-pretty/benches/compare_derive_more.rs
@@ -1,0 +1,194 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use facet::Facet;
+use facet_pretty::{FacetPretty, PrettyPrinter};
+
+// --- Data Structures for Benchmarking ---
+
+// --- Simple Case ---
+#[derive(Facet, Debug, Clone)]
+struct Simple {
+    a: u32,
+    b: String,
+}
+
+// --- Nested Case ---
+#[derive(Facet, Debug, Clone)]
+struct Inner {
+    x: f64,
+}
+
+#[derive(Facet, Debug, Clone)]
+struct Outer {
+    inner: Inner,
+    name: String,
+    count: usize,
+}
+
+// --- Enum Case ---
+#[derive(Facet, Debug, Clone)]
+#[repr(u8)]
+enum Enum {
+    Unit,
+    Tuple(i32, bool),
+    Struct { a: u8, b: String },
+}
+
+// --- Complex Case (Deeper Nesting, Option, Vec) ---
+#[derive(Facet, Debug, Clone)]
+struct ComplexInner {
+    id: u64,
+    flag: Option<bool>,
+}
+
+#[derive(Facet, Debug, Clone)]
+struct ComplexOuter {
+    name: String,
+    items: Vec<ComplexInner>,
+    maybe_value: Option<i128>,
+    level: u32,
+}
+
+// --- Benchmark Functions ---
+
+fn bench_simple_struct(c: &mut Criterion) {
+    let facet_val = Simple {
+        a: 123,
+        b: "hello world".to_string(),
+    };
+    let facet_printer = PrettyPrinter::new().with_colors(false);
+
+    let mut group = c.benchmark_group("Simple Struct Formatting");
+
+    group.bench_function("facet-pretty", |b| {
+        b.iter(|| {
+            black_box(facet_printer.format(black_box(&facet_val)));
+        })
+    });
+
+    group.bench_function("derive(Debug) + pretty {:#?}", |b| {
+        b.iter(|| {
+            black_box(format!("{:#?}", black_box(&facet_val)));
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_nested_struct(c: &mut Criterion) {
+    let facet_val = Outer {
+        inner: Inner { x: 3.14159 },
+        name: "outer".to_string(),
+        count: 42,
+    };
+    let facet_printer = PrettyPrinter::new().with_colors(false);
+
+    let mut group = c.benchmark_group("Nested Struct Formatting");
+
+    group.bench_function("facet-pretty", |b| {
+        b.iter(|| {
+            black_box(facet_printer.format(black_box(&facet_val)));
+        })
+    });
+
+    group.bench_function("derive(Debug) + pretty {:#?}", |b| {
+        b.iter(|| {
+            black_box(format!("{:#?}", black_box(&facet_val)));
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_enum(c: &mut Criterion) {
+    let facet_unit = Enum::Unit;
+    let facet_tuple = Enum::Tuple(10, true);
+    let facet_struct = Enum::Struct {
+        a: 5,
+        b: "enum struct".to_string(),
+    };
+
+    let facet_printer = PrettyPrinter::new().with_colors(false);
+
+    let mut group = c.benchmark_group("Enum Formatting");
+
+    group.bench_function("facet-pretty (Unit)", |b| {
+        b.iter(|| {
+            black_box(facet_printer.format(black_box(&facet_unit)));
+        })
+    });
+    group.bench_function("derive(Debug) + pretty {:#?} (Unit)", |b| {
+        b.iter(|| {
+            black_box(format!("{:#?}", black_box(&facet_unit)));
+        })
+    });
+
+    group.bench_function("facet-pretty (Tuple)", |b| {
+        b.iter(|| {
+            black_box(facet_printer.format(black_box(&facet_tuple)));
+        })
+    });
+    group.bench_function("derive(Debug) + pretty {:#?} (Tuple)", |b| {
+        b.iter(|| {
+            black_box(format!("{:#?}", black_box(&facet_tuple)));
+        })
+    });
+
+    group.bench_function("facet-pretty (Struct)", |b| {
+        b.iter(|| {
+            black_box(facet_printer.format(black_box(&facet_struct)));
+        })
+    });
+    group.bench_function("derive(Debug) + pretty {:#?} (Struct)", |b| {
+        b.iter(|| {
+            black_box(format!("{:#?}", black_box(&facet_struct)));
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_complex_struct(c: &mut Criterion) {
+    let facet_val = ComplexOuter {
+        name: "complex data structure".to_string(),
+        items: vec![
+            ComplexInner {
+                id: 1,
+                flag: Some(true),
+            },
+            ComplexInner { id: 2, flag: None },
+            ComplexInner {
+                id: 3,
+                flag: Some(false),
+            },
+        ],
+        maybe_value: Some(-1_000_000_000_000_000),
+        level: 5,
+    };
+    let facet_printer = PrettyPrinter::new().with_colors(false);
+
+    let mut group = c.benchmark_group("Complex Struct Formatting");
+
+    group.bench_function("facet-pretty", |b| {
+        b.iter(|| {
+            black_box(facet_printer.format(black_box(&facet_val)));
+        })
+    });
+
+    group.bench_function("derive(Debug) + pretty {:#?}", |b| {
+        b.iter(|| {
+            black_box(format!("{:#?}", black_box(&facet_val)));
+        })
+    });
+
+    group.finish();
+}
+
+// --- Criterion Setup ---
+criterion_group!(
+    benches,
+    bench_simple_struct,
+    bench_nested_struct,
+    bench_enum,
+    bench_complex_struct,
+);
+criterion_main!(benches);


### PR DESCRIPTION
| Test Case                          | facet-pretty   | derive(Debug) + pretty {:#?} |
|-------------------------------------|---------------|------------------------------|
| Simple Struct Formatting            | 470 ns        | 147.71 ns                    |
| Nested Struct Formatting            | 999 ns        | 296.64 ns                    |
| Enum Formatting (Unit)              | 92.6 ns       | 19.82 ns                     |
| Enum Formatting (Tuple)             | 447 ns        | 79.57 ns                     |
| Enum Formatting (Struct)            | 505 ns        | 130.48 ns                    |
| Complex Struct Formatting           | 3.384 µs      | 1.341 µs                     |

```
     Running benches/compare_derive_more.rs (target/release/deps/compare_derive_more-6934998d87bfaa35)
Simple Struct Formatting/facet-pretty
                        time:   [469.05 ns 469.67 ns 470.31 ns]
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe
Simple Struct Formatting/derive(Debug) + pretty {:#?}
                        time:   [147.52 ns 147.71 ns 147.90 ns]
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

Nested Struct Formatting/facet-pretty
                        time:   [997.80 ns 999.20 ns 1.0008 µs]
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
Nested Struct Formatting/derive(Debug) + pretty {:#?}
                        time:   [295.87 ns 296.64 ns 297.43 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Enum Formatting/facet-pretty (Unit)
                        time:   [92.461 ns 92.603 ns 92.781 ns]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
Enum Formatting/derive(Debug) + pretty {:#?} (Unit)
                        time:   [19.791 ns 19.817 ns 19.842 ns]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
Enum Formatting/facet-pretty (Tuple)
                        time:   [446.51 ns 447.20 ns 447.86 ns]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
Enum Formatting/derive(Debug) + pretty {:#?} (Tuple)
                        time:   [79.379 ns 79.570 ns 79.838 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Enum Formatting/facet-pretty (Struct)
                        time:   [504.34 ns 504.86 ns 505.39 ns]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Enum Formatting/derive(Debug) + pretty {:#?} (Struct)
                        time:   [130.12 ns 130.48 ns 130.92 ns]

Complex Struct Formatting/facet-pretty
                        time:   [3.3771 µs 3.3843 µs 3.3922 µs]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
Complex Struct Formatting/derive(Debug) + pretty {:#?}
                        time:   [1.3372 µs 1.3406 µs 1.3442 µs]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe

```

Facet is expactedly slower, but no so much.

facet-msgpack can't serialize nested structs, vecs, or floats yet, so benchmarking it is pretty useless for now :)