### PR TITLE
facet-args: Handle multiple positional args

### DIFF
--- a/facet-args/src/lib.rs
+++ b/facet-args/src/lib.rs
@@ -98,6 +98,9 @@ where
                     .iter()
                     .any(|a| matches!(a, FieldAttribute::Arbitrary(a) if a.contains("positional")))
                 {
+                    if wip.is_field_set(field_index).unwrap() {
+                        continue;
+                    }
                     let field = wip.field(field_index).unwrap();
                     wip = parse_field(field, token).unwrap();
                     break;

--- a/facet-args/tests/simple.rs
+++ b/facet-args/tests/simple.rs
@@ -5,9 +5,12 @@ fn test_arg_parse() {
     facet_testhelpers::setup();
 
     #[derive(Facet)]
-    struct Args {
+    struct Args<'a> {
         #[facet(positional)]
         path: String,
+
+        #[facet(positional)]
+        path_borrow: &'a str,
 
         #[facet(named, short = 'v')]
         verbose: bool,
@@ -16,8 +19,9 @@ fn test_arg_parse() {
         concurrency: usize,
     }
 
-    let args: Args = facet_args::from_slice(&["--verbose", "-j", "14", "example.rs"]);
+    let args: Args = facet_args::from_slice(&["--verbose", "-j", "14", "example.rs", "test.rs"]);
     assert!(args.verbose);
     assert_eq!(args.path, "example.rs");
+    assert_eq!(args.path_borrow, "test.rs");
     assert_eq!(args.concurrency, 14);
 }


### PR DESCRIPTION
## Why?

Setting multiple positional arguments results in a panic due to current code initializing the first positional field again for each additional positional field.

## What?

- Update positional parsing logic to skip over fields that have already been set
- Add use of borrowed string in test for that small extra bit of code coverage