### PR TITLE
feat(args) - Handle multi word args

### DIFF
--- a/facet-args/tests/simple.rs
+++ b/facet-args/tests/simple.rs
@@ -17,11 +17,23 @@ fn test_arg_parse() {
 
         #[facet(named, short = 'j')]
         concurrency: usize,
+
+        #[facet(named, short = 'x')]
+        consider_casing: usize,
     }
 
-    let args: Args = facet_args::from_slice(&["--verbose", "-j", "14", "example.rs", "test.rs"]);
+    let args: Args = facet_args::from_slice(&[
+        "--verbose",
+        "-j",
+        "14",
+        "--consider-casing",
+        "0",
+        "example.rs",
+        "test.rs",
+    ]);
     assert!(args.verbose);
     assert_eq!(args.path, "example.rs");
     assert_eq!(args.path_borrow, "test.rs");
     assert_eq!(args.concurrency, 14);
+    assert_eq!(args.consider_casing, 0);
 }


### PR DESCRIPTION
### Problem

Using common casing for multi-word arguments results in error. As the mismatch in common kebab-case used for arguments does not find the snake_case Facet field.

### What

Normalize the keys for non-short named arguments to snake case. This initial work makes 2 assumptions:
- GNU/Unix kebab-casing is the initial norm
- Facet derived struct will be built with snake_cased field names

I will hopefully tackle making these less implicit assumption by aligning with the json crate on how it is tackling this casing aspect

Note: This is stacked on: https://github.com/facet-rs/facet/pull/459 both PRs are so small that I don't think this complicates review.