### PR TITLE
fix(args) - unspecified bool arguments should be assumed false 

### DIFF
--- a/facet-args/src/lib.rs
+++ b/facet-args/src/lib.rs
@@ -148,6 +148,17 @@ where
             }
         }
     }
+
+    // If a boolean field is unset the value is set to `false`
+    // This behaviour means `#[facet(default = false)]` does not need to be explicitly set
+    // on each boolean field specified on a Command struct
+    for (field_index, f) in sd.fields.iter().enumerate() {
+        if f.shape().is_type::<bool>() && !wip.is_field_set(field_index).expect("in bounds") {
+            let field = wip.field(field_index).expect("field_index is in bounds");
+            wip = parse_field(field, "false")?;
+        }
+    }
+
     let heap_vale = wip
         .build()
         .map_err(|e| ArgsError::new(ArgsErrorKind::GenericReflect(e)))?;

--- a/facet-args/tests/simple.rs
+++ b/facet-args/tests/simple.rs
@@ -42,10 +42,7 @@ fn test_arg_parse() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_missing_bool_is_false() -> Result<()> {
-    // TODO: bool arg if not set should be assumed false
-    //       current code results in an un-init reflect error
     facet_testhelpers::setup();
 
     #[derive(Facet)]


### PR DESCRIPTION
### Problem

When a command line argument is unset we should fallback to unset defaults for `bool` and `Option<_>` (not in this PR). Currently this results in a reflect error due to uninitialized fields. Which is surprising behaviour in the case of command line arg parsing, where not setting things is explicitly required in some cases for the desired behaviour.

### What

Find any unset bool fields and set them to `"false"`


### Discussion

This feels like a naff solution. The friction I am seeing is the within the core crates, the facet attributes are normally explicitly set-up upfront on the struct i.e `default` etc. which makes sense for a parsers like `json` etc. where you want to be very explicit about the behaviour when something you expect to be present, isn't. In the case of command line arguments there is more implicit behaviour. 

I think a potential ideal would be a `FacetArgs` derive which would set a series of defaults desired `default` for `bool` and `Option<_>` fields, this also moves into things such as no variant attribute set assuming positional behaviour etc. (Note: I am ~probably~ unequipped in ability currently to go in that direction)