### PR TITLE
pretty: support camino

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
 name = "facet-pretty"
 version = "0.20.0"
 dependencies = [
+ "camino",
  "criterion",
  "facet",
  "facet-core",

--- a/facet-core/src/impls_camino.rs
+++ b/facet-core/src/impls_camino.rs
@@ -57,7 +57,8 @@ unsafe impl Facet<'_> for Utf8PathBuf {
             ))
             .vtable(
                 &const {
-                    let mut vtable = value_vtable!((), |f, _opts| write!(f, "Utf8PathBuf"));
+                    let mut vtable =
+                        value_vtable!(Utf8PathBuf, |f, _opts| write!(f, "Utf8PathBuf"));
                     vtable.parse =
                         Some(|s, target| Ok(unsafe { target.put(Utf8Path::new(s).to_owned()) }));
                     vtable.try_from = Some(try_from);
@@ -100,7 +101,7 @@ unsafe impl<'a> Facet<'a> for &'a Utf8Path {
             ))
             .vtable(
                 &const {
-                    let mut vtable = value_vtable!((), |f, _opts| write!(f, "Utf8Path"));
+                    let mut vtable = value_vtable!(&Utf8Path, |f, _opts| write!(f, "Utf8Path"));
                     vtable.try_from = Some(try_from);
                     vtable
                 },

--- a/facet-pretty/Cargo.toml
+++ b/facet-pretty/Cargo.toml
@@ -15,12 +15,17 @@ keywords = [
 ]
 categories = ["development-tools", "visualization", "command-line-utilities"]
 
+[features]
+alloc = ["facet-core/alloc", "facet-reflect/alloc"]    # Enables alloc support
+camino = ["alloc", "facet-core/camino"]
+
 [dependencies]
 facet-core = { version = "0.19.0", path = "../facet-core" }
 facet-reflect = { version = "0.18.1", path = "../facet-reflect" }
 yansi = "1.0.1"
 
 [dev-dependencies]
+camino = "1.1.9"
 facet = { path = "../facet" }
 criterion = "0.5.1"
 

--- a/facet-pretty/tests/camino.rs
+++ b/facet-pretty/tests/camino.rs
@@ -1,0 +1,34 @@
+#![cfg(feature = "camino")]
+
+use camino::{Utf8Path, Utf8PathBuf};
+use facet::Facet;
+use facet_pretty::PrettyPrinter;
+
+#[derive(Facet)]
+struct TestPathBuf {
+    base: Utf8PathBuf,
+}
+
+#[derive(Facet)]
+struct TestPath<'data> {
+    reference: &'data Utf8Path,
+}
+
+#[test]
+fn test_camino_simple() {
+    let test_pathbuf = TestPathBuf {
+        base: "/somewhere/over/the/rainbow".into(),
+    };
+    let formatted = PrettyPrinter::new().format(&test_pathbuf);
+
+    assert!(formatted.contains("base"));
+    assert!(formatted.contains("/somewhere/over/the/rainbow"));
+
+    let test_path = TestPath {
+        reference: &test_pathbuf.base,
+    };
+    let formatted = PrettyPrinter::new().format(&test_path);
+
+    assert!(formatted.contains("reference"));
+    assert!(formatted.contains("/somewhere/over/the/rainbow"));
+}


### PR DESCRIPTION
Hi,

First of all, thanks again for your work on Facet!

So this is my first attempt at a contribution: make facet-pretty display Utf8PathBuf and Utf8Path values using their implementation of the Display trait.

Please bear in mind that I have no idea what I'm doing, and basing those types' vtables on String and `&str` may very well have broken something or killed the performance of something else that I have no idea about :) So feel free to point out anything that might go wrong or be pessimized as a result of those changes; it's fine if you don't accept them at all.

Thanks again, and keep up the great work!

G'luck,
Peter
