### PR TITLE
fix derive macro edge cases

### DIFF
--- a/facet-derive-emit/tests/codegen/mod.rs
+++ b/facet-derive-emit/tests/codegen/mod.rs
@@ -146,6 +146,32 @@ fn repr_c_enum() {
 }
 
 #[test]
+fn repr_c_enum_empty_struct_variant() {
+    insta::assert_snapshot!(expand(
+        r#"
+        #[derive(Facet)]
+        #[repr(C)]
+        enum EnumWithEmptyStructVariant {
+            Variant1 { },
+        }
+        "#
+    ));
+}
+
+#[test]
+fn repr_c_enum_lifetime_field() {
+    insta::assert_snapshot!(expand(
+        r#"
+        #[derive(Facet)]
+        #[repr(C)]
+        enum EnumWithLifetimeField {
+            Variant1 { field1: &'static str },
+        }
+        "#
+    ));
+}
+
+#[test]
 fn struct_with_generics_simple() {
     insta::assert_snapshot!(expand(
         r#"

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__repr_c_enum_empty_struct_variant.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__repr_c_enum_empty_struct_variant.snap
@@ -1,0 +1,73 @@
+---
+source: facet-derive-emit/tests/codegen/mod.rs
+expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(C)]\n        enum EnumWithEmptyStructVariant {\n            Variant1 { },\n        }\n        \"#)"
+---
+#[used]
+static ENUM_WITH_EMPTY_STRUCT_VARIANT_SHAPE: &'static ::facet::Shape =
+    <EnumWithEmptyStructVariant as ::facet::Facet>::SHAPE;
+#[automatically_derived]
+#[allow(non_camel_case_types)]
+unsafe impl<'__facet> ::facet::Facet<'__facet> for EnumWithEmptyStructVariant {
+    const SHAPE: &'static ::facet::Shape = &const {
+        #[repr(C)]
+        #[allow(dead_code)]
+        enum __Shadow_CRepr_Discriminant_for_EnumWithEmptyStructVariant {
+            Variant1,
+        }
+        #[repr(C)]
+        #[allow(non_snake_case, dead_code)]
+        union __Shadow_CRepr_Fields_Union_for_EnumWithEmptyStructVariant<'__facet> {
+            Variant1: ::core::mem::ManuallyDrop<
+                __Shadow_CRepr_FieldEnumWithEmptyStructVariant_Variant1<'__facet>,
+            >,
+        }
+        #[repr(C)]
+        #[allow(non_snake_case)]
+        #[allow(dead_code)]
+        struct __Shadow_CRepr_Struct_for_EnumWithEmptyStructVariant<'__facet> {
+            _discriminant: __Shadow_CRepr_Discriminant_for_EnumWithEmptyStructVariant,
+            _phantom: ::core::marker::PhantomData<(*mut &'__facet ())>,
+            _fields: __Shadow_CRepr_Fields_Union_for_EnumWithEmptyStructVariant<'__facet>,
+        }
+        #[repr(C)]
+        #[allow(non_snake_case, dead_code)]
+        struct __Shadow_CRepr_FieldEnumWithEmptyStructVariant_Variant1<'__facet> {
+            _phantom: ::core::marker::PhantomData<(*mut &'__facet ())>,
+        }
+        let __facet_variants: &'static [::facet::Variant] = &const {
+            [{
+                let fields: &'static [::facet::Field] = &const { [] };
+                ::facet::Variant::builder()
+                    .name("Variant1")
+                    .discriminant(0i64)
+                    .fields(
+                        ::facet::StructDef::builder()
+                            .struct_()
+                            .fields(fields)
+                            .build(),
+                    )
+                    .build()
+            }]
+        };
+        ::facet::Shape::builder()
+            .id(::facet::ConstTypeId::of::<Self>())
+            .layout(::core::alloc::Layout::new::<Self>())
+            .vtable(
+                &const {
+                    ::facet::value_vtable!(Self, |f, _opts| ::core::fmt::Write::write_str(
+                        f,
+                        "EnumWithEmptyStructVariant"
+                    ))
+                },
+            )
+            .def(::facet::Def::Enum(
+                ::facet::EnumDef::builder()
+                    .variants(__facet_variants)
+                    .repr(::facet::EnumRepr::from_discriminant_size::<
+                        __Shadow_CRepr_Discriminant_for_EnumWithEmptyStructVariant,
+                    >())
+                    .build(),
+            ))
+            .build()
+    };
+}

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__repr_c_enum_lifetime_field.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__repr_c_enum_lifetime_field.snap
@@ -1,0 +1,96 @@
+---
+source: facet-derive-emit/tests/codegen/mod.rs
+expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(C)]\n        enum EnumWithLifetimeField {\n            Variant1 { field1: &'static str },\n        }\n        \"#)"
+---
+#[used]
+static ENUM_WITH_LIFETIME_FIELD_SHAPE: &'static ::facet::Shape =
+    <EnumWithLifetimeField as ::facet::Facet>::SHAPE;
+#[automatically_derived]
+#[allow(non_camel_case_types)]
+unsafe impl<'__facet> ::facet::Facet<'__facet> for EnumWithLifetimeField {
+    const SHAPE: &'static ::facet::Shape = &const {
+        #[repr(C)]
+        #[allow(dead_code)]
+        enum __Shadow_CRepr_Discriminant_for_EnumWithLifetimeField {
+            Variant1,
+        }
+        #[repr(C)]
+        #[allow(non_snake_case, dead_code)]
+        union __Shadow_CRepr_Fields_Union_for_EnumWithLifetimeField<'__facet> {
+            Variant1: ::core::mem::ManuallyDrop<
+                __Shadow_CRepr_FieldEnumWithLifetimeField_Variant1<'__facet>,
+            >,
+        }
+        #[repr(C)]
+        #[allow(non_snake_case)]
+        #[allow(dead_code)]
+        struct __Shadow_CRepr_Struct_for_EnumWithLifetimeField<'__facet> {
+            _discriminant: __Shadow_CRepr_Discriminant_for_EnumWithLifetimeField,
+            _phantom: ::core::marker::PhantomData<(*mut &'__facet ())>,
+            _fields: __Shadow_CRepr_Fields_Union_for_EnumWithLifetimeField<'__facet>,
+        }
+        #[repr(C)]
+        #[allow(non_snake_case, dead_code)]
+        struct __Shadow_CRepr_FieldEnumWithLifetimeField_Variant1<'__facet> {
+            field1: &'static str,
+            _phantom: ::core::marker::PhantomData<(*mut &'__facet ())>,
+        }
+        let __facet_variants: &'static [::facet::Variant] = &const {
+            [{
+                let fields: &'static [::facet::Field] = &const {
+                    [{
+                        ::facet::Field::builder()
+                            .name("field1")
+                            .shape(|| {
+                                ::facet::shape_of(
+                                    &|s: &__Shadow_CRepr_FieldEnumWithLifetimeField_Variant1<
+                                        '__facet,
+                                    >| &s.field1,
+                                )
+                            })
+                            .offset(
+                                ::core::mem::offset_of!(
+                                    __Shadow_CRepr_Struct_for_EnumWithLifetimeField<'__facet>,
+                                    _fields
+                                ) + ::core::mem::offset_of!(
+                                    __Shadow_CRepr_FieldEnumWithLifetimeField_Variant1<'__facet>,
+                                    field1
+                                ),
+                            )
+                            .build()
+                    }]
+                };
+                ::facet::Variant::builder()
+                    .name("Variant1")
+                    .discriminant(0i64)
+                    .fields(
+                        ::facet::StructDef::builder()
+                            .struct_()
+                            .fields(fields)
+                            .build(),
+                    )
+                    .build()
+            }]
+        };
+        ::facet::Shape::builder()
+            .id(::facet::ConstTypeId::of::<Self>())
+            .layout(::core::alloc::Layout::new::<Self>())
+            .vtable(
+                &const {
+                    ::facet::value_vtable!(Self, |f, _opts| ::core::fmt::Write::write_str(
+                        f,
+                        "EnumWithLifetimeField"
+                    ))
+                },
+            )
+            .def(::facet::Def::Enum(
+                ::facet::EnumDef::builder()
+                    .variants(__facet_variants)
+                    .repr(::facet::EnumRepr::from_discriminant_size::<
+                        __Shadow_CRepr_Discriminant_for_EnumWithLifetimeField,
+                    >())
+                    .build(),
+            ))
+            .build()
+    };
+}


### PR DESCRIPTION
Small fix for #447 (facet-derive-emit), proc macro generation for enums with empty struct variants or lifetime fields + test coverage

```rust
                        // Handle empty fields case explicitly
                        let struct_fields = if fields_with_types.is_empty() {
                            // Only add phantom data for empty struct variants
                            quote! { _phantom: #phantom_data }
                        } else {
                            // Add fields plus phantom data for non-empty struct variants
                            quote! { #(#fields_with_types),*, _phantom: #phantom_data }
                        };
```