### PR TITLE
refactor(serialize): make many trait methods optional

### DIFF
--- a/facet-serialize/src/lib.rs
+++ b/facet-serialize/src/lib.rs
@@ -28,44 +28,17 @@ pub trait Serializer {
     /// The error type returned by serialization methods
     type Error;
 
-    /// Serialize an unsigned 8-bit integer.
-    fn serialize_u8(&mut self, value: u8) -> Result<(), Self::Error>;
-
-    /// Serialize an unsigned 16-bit integer.
-    fn serialize_u16(&mut self, value: u16) -> Result<(), Self::Error>;
-
-    /// Serialize an unsigned 32-bit integer.
-    fn serialize_u32(&mut self, value: u32) -> Result<(), Self::Error>;
-
     /// Serialize an unsigned 64-bit integer.
     fn serialize_u64(&mut self, value: u64) -> Result<(), Self::Error>;
 
     /// Serialize an unsigned 128-bit integer.
     fn serialize_u128(&mut self, value: u128) -> Result<(), Self::Error>;
 
-    /// Serialize a `usize` integer.
-    fn serialize_usize(&mut self, value: usize) -> Result<(), Self::Error>;
-
-    /// Serialize a signed 8-bit integer.
-    fn serialize_i8(&mut self, value: i8) -> Result<(), Self::Error>;
-
-    /// Serialize a signed 16-bit integer.
-    fn serialize_i16(&mut self, value: i16) -> Result<(), Self::Error>;
-
-    /// Serialize a signed 32-bit integer.
-    fn serialize_i32(&mut self, value: i32) -> Result<(), Self::Error>;
-
     /// Serialize a signed 64-bit integer.
     fn serialize_i64(&mut self, value: i64) -> Result<(), Self::Error>;
 
     /// Serialize a signed 128-bit integer.
     fn serialize_i128(&mut self, value: i128) -> Result<(), Self::Error>;
-
-    /// Serialize an `isize` integer.
-    fn serialize_isize(&mut self, value: isize) -> Result<(), Self::Error>;
-
-    /// Serialize a single-precision floating-point value.
-    fn serialize_f32(&mut self, value: f32) -> Result<(), Self::Error>;
 
     /// Serialize a double-precision floating-point value.
     fn serialize_f64(&mut self, value: f64) -> Result<(), Self::Error>;
@@ -133,6 +106,62 @@ pub trait Serializer {
 
     /// Signal the end of serializing a map/dictionary-like value.
     fn end_map(&mut self) -> Result<(), Self::Error>;
+
+    /// Serialize an unsigned 8-bit integer.
+    #[inline(always)]
+    fn serialize_u8(&mut self, value: u8) -> Result<(), Self::Error> {
+        self.serialize_u64(value as u64)
+    }
+
+    /// Serialize an unsigned 16-bit integer.
+    #[inline(always)]
+    fn serialize_u16(&mut self, value: u16) -> Result<(), Self::Error> {
+        self.serialize_u64(value as u64)
+    }
+
+    /// Serialize an unsigned 32-bit integer.
+    #[inline(always)]
+    fn serialize_u32(&mut self, value: u32) -> Result<(), Self::Error> {
+        self.serialize_u64(value as u64)
+    }
+
+    /// Serialize a `usize` integer.
+    #[inline(always)]
+    fn serialize_usize(&mut self, value: usize) -> Result<(), Self::Error> {
+        // We assume `usize` will never be >64 bits
+        self.serialize_u64(value as u64)
+    }
+
+    /// Serialize a signed 8-bit integer.
+    #[inline(always)]
+    fn serialize_i8(&mut self, value: i8) -> Result<(), Self::Error> {
+        self.serialize_i64(value as i64)
+    }
+
+    /// Serialize a signed 16-bit integer.
+    #[inline(always)]
+    fn serialize_i16(&mut self, value: i16) -> Result<(), Self::Error> {
+        self.serialize_i64(value as i64)
+    }
+
+    /// Serialize a signed 32-bit integer.
+    #[inline(always)]
+    fn serialize_i32(&mut self, value: i32) -> Result<(), Self::Error> {
+        self.serialize_i64(value as i64)
+    }
+
+    /// Serialize an `isize` integer.
+    #[inline(always)]
+    fn serialize_isize(&mut self, value: isize) -> Result<(), Self::Error> {
+        // We assume `isize` will never be >64 bits
+        self.serialize_i64(value as i64)
+    }
+
+    /// Serialize a single-precision floating-point value.
+    #[inline(always)]
+    fn serialize_f32(&mut self, value: f32) -> Result<(), Self::Error> {
+        self.serialize_f64(value as f64)
+    }
 
     /// Begin serializing a map key value.
     #[inline(always)]

--- a/facet-serialize/src/lib.rs
+++ b/facet-serialize/src/lib.rs
@@ -84,8 +84,12 @@ pub trait Serializer {
     /// * `len` - The number of fields, if known.
     fn start_object(&mut self, len: Option<usize>) -> Result<(), Self::Error>;
 
-    /// Signal the end of serializing an object/map-like value.
-    fn end_object(&mut self) -> Result<(), Self::Error>;
+    /// Serialize a field name (for objects and maps).
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The field or key name to serialize.
+    fn serialize_field_name(&mut self, name: &'static str) -> Result<(), Self::Error>;
 
     /// Begin serializing an array/sequence-like value.
     ///
@@ -94,18 +98,12 @@ pub trait Serializer {
     /// * `len` - The number of elements, if known.
     fn start_array(&mut self, len: Option<usize>) -> Result<(), Self::Error>;
 
-    /// Signal the end of serializing an array/sequence-like value.
-    fn end_array(&mut self) -> Result<(), Self::Error>;
-
     /// Begin serializing a map/dictionary-like value.
     ///
     /// # Arguments
     ///
     /// * `len` - The number of entries, if known.
     fn start_map(&mut self, len: Option<usize>) -> Result<(), Self::Error>;
-
-    /// Signal the end of serializing a map/dictionary-like value.
-    fn end_map(&mut self) -> Result<(), Self::Error>;
 
     /// Serialize an unsigned 8-bit integer.
     #[inline(always)]
@@ -187,14 +185,23 @@ pub trait Serializer {
         Ok(())
     }
 
-    // For objects/maps
+    /// Signal the end of serializing an object/map-like value.
+    #[inline(always)]
+    fn end_object(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 
-    /// Serialize a field name (for objects and maps).
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The field or key name to serialize.
-    fn serialize_field_name(&mut self, name: &'static str) -> Result<(), Self::Error>;
+    /// Signal the end of serializing an array/sequence-like value.
+    #[inline(always)]
+    fn end_array(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Signal the end of serializing a map/dictionary-like value.
+    #[inline(always)]
+    fn end_map(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 
     /// Signal the end of serializing a field.
     #[inline(always)]

--- a/facet-toml/src/serialize.rs
+++ b/facet-toml/src/serialize.rs
@@ -144,18 +144,6 @@ impl Default for TomlSerializer {
 impl Serializer for TomlSerializer {
     type Error = Infallible;
 
-    fn serialize_u8(&mut self, value: u8) -> Result<(), Self::Error> {
-        self.write_value(value as i64)
-    }
-
-    fn serialize_u16(&mut self, value: u16) -> Result<(), Self::Error> {
-        self.write_value(value as i64)
-    }
-
-    fn serialize_u32(&mut self, value: u32) -> Result<(), Self::Error> {
-        self.write_value(value as i64)
-    }
-
     fn serialize_u64(&mut self, value: u64) -> Result<(), Self::Error> {
         // TODO: handle casting
         self.write_value(value as i64)
@@ -163,23 +151,6 @@ impl Serializer for TomlSerializer {
 
     fn serialize_u128(&mut self, value: u128) -> Result<(), Self::Error> {
         // TODO: handle casting
-        self.write_value(value as i64)
-    }
-
-    fn serialize_usize(&mut self, value: usize) -> Result<(), Self::Error> {
-        // TODO: handle casting
-        self.write_value(value as i64)
-    }
-
-    fn serialize_i8(&mut self, value: i8) -> Result<(), Self::Error> {
-        self.write_value(value as i64)
-    }
-
-    fn serialize_i16(&mut self, value: i16) -> Result<(), Self::Error> {
-        self.write_value(value as i64)
-    }
-
-    fn serialize_i32(&mut self, value: i32) -> Result<(), Self::Error> {
         self.write_value(value as i64)
     }
 
@@ -194,10 +165,6 @@ impl Serializer for TomlSerializer {
 
     fn serialize_isize(&mut self, value: isize) -> Result<(), Self::Error> {
         self.write_value(value as i64)
-    }
-
-    fn serialize_f32(&mut self, value: f32) -> Result<(), Self::Error> {
-        self.write_value(value as f64)
     }
 
     fn serialize_f64(&mut self, value: f64) -> Result<(), Self::Error> {

--- a/facet-toml/src/serialize.rs
+++ b/facet-toml/src/serialize.rs
@@ -213,17 +213,9 @@ impl Serializer for TomlSerializer {
         Ok(())
     }
 
-    fn end_object(&mut self) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
     fn start_array(&mut self, _len: Option<usize>) -> Result<(), Self::Error> {
         self.set_current_item(toml_edit::array());
 
-        Ok(())
-    }
-
-    fn end_array(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -234,10 +226,6 @@ impl Serializer for TomlSerializer {
 
         self.set_current_item(table);
 
-        Ok(())
-    }
-
-    fn end_map(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
 


### PR DESCRIPTION
Many formats don't need to implement everything for all number types, and they can handle beginning and ending of objects differently.