### PR TITLE
chore(deps): cleanup unused dependecies with cargo-machete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,31 +240,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "ctrlc"
 version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,8 +382,6 @@ dependencies = [
  "fs-err",
  "indicatif",
  "log",
- "num_cpus",
- "rayon",
  "similar",
  "termion",
  "yansi",
@@ -444,7 +417,6 @@ dependencies = [
  "facet",
  "facet-core",
  "facet-derive",
- "facet-reflect",
  "insta",
 ]
 
@@ -452,7 +424,6 @@ dependencies = [
 name = "facet-kdl"
 version = "0.21.0"
 dependencies = [
- "ariadne",
  "facet",
  "facet-core",
  "facet-reflect",
@@ -460,8 +431,6 @@ dependencies = [
  "indoc",
  "kdl",
  "log",
- "num-traits",
- "owo-colors",
 ]
 
 [[package]]
@@ -543,7 +512,6 @@ dependencies = [
  "log",
  "num-traits",
  "toml_edit",
- "toml_write",
  "yansi",
 ]
 
@@ -637,12 +605,6 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown",
 ]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "impls"
@@ -883,16 +845,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,26 +973,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/facet-dev/Cargo.toml
+++ b/facet-dev/Cargo.toml
@@ -16,8 +16,6 @@ facet-testhelpers = { version = "0.17.0", path = "../facet-testhelpers" }
 fs-err = "3.1.0"
 indicatif = "0.17.11"
 log = "0.4.27"
-num_cpus = "1.16.0"
-rayon = "1.10.0"
 similar = { version = "2.7.0", features = ["inline"] }
 yansi = "1.0.1"
 

--- a/facet-jsonschema/Cargo.toml
+++ b/facet-jsonschema/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["development-tools", "encoding"]
 [dependencies]
 facet-core = { version = "0.20.0", path = "../facet-core" }
 facet-derive = { version = "0.18.4", path = "../facet-derive" }
-facet-reflect = { version = "0.18.2", path = "../facet-reflect" }
+
 [dev-dependencies]
 insta = "1.43.1"
 facet = { path = "../facet" }

--- a/facet-kdl/Cargo.toml
+++ b/facet-kdl/Cargo.toml
@@ -12,18 +12,14 @@ keywords = ["kdl", "serialization", "deserialization", "reflection", "facet"]
 categories = ["encoding", "parsing", "data-structures"]
 
 [features]
-std = ["alloc", "facet-core/std", "facet-reflect/std", "num-traits/std"]
+std = ["alloc", "facet-core/std", "facet-reflect/std"]
 alloc = ["facet-core/alloc", "facet-reflect/alloc"]
-rich-diagnostics = ["dep:ariadne", "std"]
-default = ["std", "rich-diagnostics"]
+default = ["std"]
 
 [dependencies]
-ariadne = { version = "=0.5.1", optional = true }
 log = "0.4.27"
-num-traits = { version = "0.2.19", default-features = false }
 facet-core = { version = "0.20.0", path = "../facet-core", default-features = false }
 facet-reflect = { version = "0.18.2", path = "../facet-reflect", default-features = false }
-owo-colors = "4.2.0"
 kdl = { git = "https://github.com/TheLostLambda/kdl-rs.git", branch = "free-of-syn" }
 
 [dev-dependencies]

--- a/facet-toml/Cargo.toml
+++ b/facet-toml/Cargo.toml
@@ -24,7 +24,6 @@ num-traits = { version = "0.2.19", default-features = false }
 toml_edit = { version = "0.22.26", default-features = false, features = [
     "parse",
 ], optional = true }
-toml_write = { version = "0.1.1", default-features = false, optional = true }
 facet-core = { version = "0.20.0", path = "../facet-core", default-features = false }
 facet-reflect = { version = "0.18.2", path = "../facet-reflect", default-features = false }
 facet-serialize = { version = "0.21.0", path = "../facet-serialize", default-features = false, optional = true }


### PR DESCRIPTION
Maybe we can somehow embed cargo-machete in the pipeline? It's a very useful tool.