### PR TITLE
fix(toml)!: error handling for serialize

### DIFF
--- a/facet-toml/src/deserialize/error.rs
+++ b/facet-toml/src/deserialize/error.rs
@@ -14,9 +14,9 @@ use facet_reflect::ReflectError;
 use yansi::Paint as _;
 
 /// Any error from deserializing TOML.
-pub struct TomlError<'input> {
+pub struct TomlDeError<'input> {
     /// Type of error.
-    pub kind: TomlErrorKind,
+    pub kind: TomlDeErrorKind,
     /// Reference to the TOML source.
     #[cfg_attr(not(feature = "rich-diagnostics"), allow(dead_code))]
     toml: &'input str,
@@ -27,11 +27,11 @@ pub struct TomlError<'input> {
     path: String,
 }
 
-impl<'input> TomlError<'input> {
+impl<'input> TomlDeError<'input> {
     /// Create a new error.
     pub fn new(
         toml: &'input str,
-        kind: TomlErrorKind,
+        kind: TomlDeErrorKind,
         span: Option<Range<usize>>,
         path: String,
     ) -> Self {
@@ -46,11 +46,11 @@ impl<'input> TomlError<'input> {
     /// Message for this specific error.
     pub fn message(&self) -> String {
         match &self.kind {
-            TomlErrorKind::GenericReflect(reflect_error) => {
+            TomlDeErrorKind::GenericReflect(reflect_error) => {
                 format!("Error while reflecting type: {reflect_error}")
             }
-            TomlErrorKind::GenericTomlError(message) => format!("TOML error: {message}"),
-            TomlErrorKind::FailedTypeConversion {
+            TomlDeErrorKind::GenericTomlError(message) => format!("TOML error: {message}"),
+            TomlDeErrorKind::FailedTypeConversion {
                 toml_type_name,
                 rust_type,
                 reason,
@@ -61,26 +61,26 @@ impl<'input> TomlError<'input> {
                     format!("Can't parse type '{rust_type}' from '{toml_type_name}'")
                 }
             }
-            TomlErrorKind::ExpectedType { expected, got } => {
+            TomlDeErrorKind::ExpectedType { expected, got } => {
                 format!("Expected type '{expected}', got type '{got}'")
             }
-            TomlErrorKind::UnrecognizedType(r#type) => format!("Unrecognized type '{type}'"),
-            TomlErrorKind::UnrecognizedScalar(scalar_type) => {
+            TomlDeErrorKind::UnrecognizedType(r#type) => format!("Unrecognized type '{type}'"),
+            TomlDeErrorKind::UnrecognizedScalar(scalar_type) => {
                 format!("Unrecognized Rust scalar type '{scalar_type}'",)
             }
-            TomlErrorKind::InvalidKey(field) => {
+            TomlDeErrorKind::InvalidKey(field) => {
                 format!("Invalid Rust key '{field}'")
             }
-            TomlErrorKind::ExpectedFieldWithName(name) => {
+            TomlDeErrorKind::ExpectedFieldWithName(name) => {
                 format!("Expected field with name '{name}'")
             }
-            TomlErrorKind::ExpectedAtLeastOneField => {
+            TomlDeErrorKind::ExpectedAtLeastOneField => {
                 "Expected at least one field, got zero".to_string()
             }
-            TomlErrorKind::ExpectedExactlyOneField => {
+            TomlDeErrorKind::ExpectedExactlyOneField => {
                 "Expected exactly one field, got multiple".to_string()
             }
-            TomlErrorKind::ParseSingleValueAsMultipleFieldStruct => {
+            TomlDeErrorKind::ParseSingleValueAsMultipleFieldStruct => {
                 "Can't parse a single value as a struct with multiple fields".to_string()
             }
         }
@@ -88,14 +88,14 @@ impl<'input> TomlError<'input> {
 }
 
 #[cfg(not(feature = "rich-diagnostics"))]
-impl core::fmt::Display for TomlError<'_> {
+impl core::fmt::Display for TomlDeError<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{} in path {}", self.message(), self.path)
     }
 }
 
 #[cfg(feature = "rich-diagnostics")]
-impl core::fmt::Display for TomlError<'_> {
+impl core::fmt::Display for TomlDeError<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // Don't print the TOML source if no span is set
         let Some(span) = &self.span else {
@@ -132,10 +132,9 @@ impl core::fmt::Display for TomlError<'_> {
     }
 }
 
-#[cfg(feature = "rich-diagnostics")]
-impl core::error::Error for TomlError<'_> {}
+impl core::error::Error for TomlDeError<'_> {}
 
-impl core::fmt::Debug for TomlError<'_> {
+impl core::fmt::Debug for TomlDeError<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         core::fmt::Display::fmt(self, f)
     }
@@ -143,7 +142,7 @@ impl core::fmt::Debug for TomlError<'_> {
 
 /// Type of error.
 #[derive(Debug, PartialEq)]
-pub enum TomlErrorKind {
+pub enum TomlDeErrorKind {
     /// Any error from facet.
     GenericReflect(ReflectError),
     /// Parsing TOML document error.

--- a/facet-toml/src/serialize/error.rs
+++ b/facet-toml/src/serialize/error.rs
@@ -1,0 +1,36 @@
+//! Errors from parsing TOML documents.
+
+/// Any error from serializing TOML.
+pub enum TomlSerError {
+    /// Could not convert number to i64 representation.
+    InvalidNumberToI64Conversion {
+        /// Type of the number that's trying to be converted.
+        source_type: &'static str,
+    },
+    /// Could not convert type to valid TOML key.
+    InvalidKeyConversion {
+        /// Type of the TOML value that's trying to be converted to a key.
+        toml_type: &'static str,
+    },
+}
+
+impl core::fmt::Display for TomlSerError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidNumberToI64Conversion { source_type } => {
+                write!(f, "Error converting {source_type} to i64, out of range")
+            }
+            Self::InvalidKeyConversion { toml_type } => {
+                write!(f, "Error converting type {toml_type} to TOML key")
+            }
+        }
+    }
+}
+
+impl core::error::Error for TomlSerError {}
+
+impl core::fmt::Debug for TomlSerError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self, f)
+    }
+}

--- a/facet-toml/tests/deserialize/document.rs
+++ b/facet-toml/tests/deserialize/document.rs
@@ -1,6 +1,6 @@
 //! Tests for TOML document parsing.
 
-use facet_toml::TomlErrorKind;
+use facet_toml::TomlDeErrorKind;
 
 #[test]
 fn test_invalid_toml() {
@@ -9,6 +9,6 @@ fn test_invalid_toml() {
     assert!(matches!(
         facet_toml::from_str::<()>("invalid toml").unwrap_err().kind,
         // We don't check on the error message here because it can change upstream
-        TomlErrorKind::GenericTomlError(_)
+        TomlDeErrorKind::GenericTomlError(_)
     ));
 }

--- a/facet-toml/tests/deserialize/enum_.rs
+++ b/facet-toml/tests/deserialize/enum_.rs
@@ -2,7 +2,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_toml::TomlErrorKind;
+use facet_toml::TomlDeErrorKind;
 
 #[test]
 fn test_unit_only_enum() -> Result<()> {
@@ -37,7 +37,7 @@ fn test_unit_only_enum() -> Result<()> {
         facet_toml::from_str::<Root>("values = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedFieldWithName("value")
+        TomlDeErrorKind::ExpectedFieldWithName("value")
     );
 
     Ok(())

--- a/facet-toml/tests/deserialize/list.rs
+++ b/facet-toml/tests/deserialize/list.rs
@@ -2,7 +2,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_toml::TomlErrorKind;
+use facet_toml::TomlDeErrorKind;
 
 #[test]
 fn test_scalar_list() -> Result<()> {
@@ -34,7 +34,7 @@ fn test_scalar_list() -> Result<()> {
         facet_toml::from_str::<Root>("values = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "array",
             got: "boolean"
         }
@@ -78,7 +78,7 @@ fn test_unit_struct_list() -> Result<()> {
         facet_toml::from_str::<Root>("values = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "array",
             got: "boolean"
         }
@@ -87,7 +87,7 @@ fn test_unit_struct_list() -> Result<()> {
         facet_toml::from_str::<Root>("values = [true]")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -96,7 +96,7 @@ fn test_unit_struct_list() -> Result<()> {
         facet_toml::from_str::<Root>("values = [1, true]")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -143,7 +143,7 @@ fn test_nested_lists() -> Result<()> {
         facet_toml::from_str::<Root>("values = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "array",
             got: "boolean"
         }
@@ -152,7 +152,7 @@ fn test_nested_lists() -> Result<()> {
         facet_toml::from_str::<Root>("values = [true]")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "array",
             got: "boolean"
         }
@@ -161,7 +161,7 @@ fn test_nested_lists() -> Result<()> {
         facet_toml::from_str::<Root>("values = [[1], true]")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "array",
             got: "boolean"
         }

--- a/facet-toml/tests/deserialize/map.rs
+++ b/facet-toml/tests/deserialize/map.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use eyre::Result;
 use facet::Facet;
-use facet_toml::TomlErrorKind;
+use facet_toml::TomlDeErrorKind;
 
 #[test]
 fn test_scalar_map() -> Result<()> {
@@ -39,7 +39,7 @@ fn test_scalar_map() -> Result<()> {
         facet_toml::from_str::<Root>("values = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "table like structure",
             got: "boolean"
         }
@@ -48,14 +48,14 @@ fn test_scalar_map() -> Result<()> {
         facet_toml::from_str::<Root>("values.a = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
     );
     assert_eq!(
         facet_toml::from_str::<Root>("[values.a]").unwrap_err().kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "value",
             got: "table"
         }
@@ -106,7 +106,7 @@ fn test_scalar_map_with_other_fields() -> Result<()> {
         facet_toml::from_str::<Root>("values = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "table like structure",
             got: "boolean"
         }
@@ -115,14 +115,14 @@ fn test_scalar_map_with_other_fields() -> Result<()> {
         facet_toml::from_str::<Root>("values.a = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
     );
     assert_eq!(
         facet_toml::from_str::<Root>("[values.a]").unwrap_err().kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "value",
             got: "table"
         }
@@ -170,7 +170,7 @@ fn test_unit_struct_map() -> Result<()> {
         facet_toml::from_str::<Root>("values = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "table like structure",
             got: "boolean"
         }
@@ -179,7 +179,7 @@ fn test_unit_struct_map() -> Result<()> {
         facet_toml::from_str::<Root>("values.a = 10")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "boolean",
             got: "integer"
         }

--- a/facet-toml/tests/deserialize/option.rs
+++ b/facet-toml/tests/deserialize/option.rs
@@ -2,7 +2,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_toml::TomlErrorKind;
+use facet_toml::TomlDeErrorKind;
 
 #[test]
 fn test_option_scalar() -> Result<()> {
@@ -23,7 +23,7 @@ fn test_option_scalar() -> Result<()> {
         facet_toml::from_str::<Root>("value = false")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -53,7 +53,7 @@ fn test_nested_option() -> Result<()> {
         facet_toml::from_str::<Root>("value = false")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -88,7 +88,7 @@ fn test_option_struct() -> Result<()> {
         facet_toml::from_str::<Root>("value.wrong-key = 2")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedFieldWithName("value")
+        TomlDeErrorKind::ExpectedFieldWithName("value")
     );
 
     Ok(())
@@ -120,7 +120,7 @@ fn test_option_struct_with_option() -> Result<()> {
         facet_toml::from_str::<Root>("value.sub = false")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -163,7 +163,7 @@ fn test_option_enum() -> Result<()> {
         facet_toml::from_str::<Root>("value.non-existing = false")
             .unwrap_err()
             .kind,
-        TomlErrorKind::GenericReflect(_)
+        TomlDeErrorKind::GenericReflect(_)
     ));
 
     Ok(())
@@ -213,7 +213,7 @@ fn test_option_enum_option_scalar() -> Result<()> {
 
     assert_eq!(
         facet_toml::from_str::<Root>("A = false").unwrap_err().kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "string",
             got: "boolean"
         }
@@ -222,7 +222,7 @@ fn test_option_enum_option_scalar() -> Result<()> {
         facet_toml::from_str::<Root>("B.b1 = false")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }

--- a/facet-toml/tests/deserialize/scalar.rs
+++ b/facet-toml/tests/deserialize/scalar.rs
@@ -4,7 +4,7 @@ use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use eyre::Result;
 use facet::Facet;
-use facet_toml::TomlErrorKind;
+use facet_toml::TomlDeErrorKind;
 
 #[cfg(feature = "std")]
 #[test]
@@ -24,7 +24,7 @@ fn test_string() -> Result<()> {
     );
     assert_eq!(
         facet_toml::from_str::<Root>("value = 1").unwrap_err().kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "string",
             got: "integer"
         }
@@ -51,7 +51,7 @@ fn test_cow_string() -> Result<()> {
     );
     assert_eq!(
         facet_toml::from_str::<Root>("value = 1").unwrap_err().kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "string",
             got: "integer"
         }
@@ -79,7 +79,7 @@ fn test_bool() -> Result<()> {
     );
     assert_eq!(
         facet_toml::from_str::<Root>("value = 1").unwrap_err().kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "boolean",
             got: "integer"
         }
@@ -88,14 +88,14 @@ fn test_bool() -> Result<()> {
         facet_toml::from_str::<Root>("value = {a = 1}")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "boolean",
             got: "inline table"
         }
     );
     assert_eq!(
         facet_toml::from_str::<Root>("[value]").unwrap_err().kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "value",
             got: "table"
         }
@@ -147,7 +147,7 @@ fn test_ip_addr() -> Result<()> {
     );
     assert_eq!(
         dbg!(facet_toml::from_str::<Root>("value = '127.0.0.1:8000'").unwrap_err()).kind,
-        TomlErrorKind::FailedTypeConversion {
+        TomlDeErrorKind::FailedTypeConversion {
             toml_type_name: "string",
             rust_type: core::net::IpAddr::SHAPE,
             reason: None
@@ -157,7 +157,7 @@ fn test_ip_addr() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "string",
             got: "boolean"
         }
@@ -221,7 +221,7 @@ fn test_f64() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -247,7 +247,7 @@ fn test_f32() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -274,7 +274,7 @@ fn test_usize() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -301,7 +301,7 @@ fn test_u64() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -328,7 +328,7 @@ fn test_u32() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -355,7 +355,7 @@ fn test_u16() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -382,7 +382,7 @@ fn test_u8() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -408,7 +408,7 @@ fn test_isize() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -434,7 +434,7 @@ fn test_i64() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -460,7 +460,7 @@ fn test_i32() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -486,7 +486,7 @@ fn test_i16() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -512,7 +512,7 @@ fn test_i8() -> Result<()> {
         facet_toml::from_str::<Root>("value = 300.0")
             .unwrap_err()
             .kind,
-        TomlErrorKind::FailedTypeConversion {
+        TomlDeErrorKind::FailedTypeConversion {
             toml_type_name: "float",
             rust_type: i8::SHAPE,
             reason: None
@@ -522,7 +522,7 @@ fn test_i8() -> Result<()> {
         facet_toml::from_str::<Root>("value = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -537,6 +537,6 @@ fn test_unparsable_scalar() {
 
     assert_eq!(
         facet_toml::from_str::<()>("value = 1").unwrap_err().kind,
-        TomlErrorKind::UnrecognizedScalar(<()>::SHAPE)
+        TomlDeErrorKind::UnrecognizedScalar(<()>::SHAPE)
     );
 }

--- a/facet-toml/tests/deserialize/struct_.rs
+++ b/facet-toml/tests/deserialize/struct_.rs
@@ -4,7 +4,7 @@ use std::net::Ipv6Addr;
 
 use eyre::Result;
 use facet::Facet;
-use facet_toml::TomlErrorKind;
+use facet_toml::TomlDeErrorKind;
 
 #[test]
 fn test_table_to_struct() -> Result<()> {
@@ -43,7 +43,7 @@ fn test_table_to_struct() -> Result<()> {
         )
         .unwrap_err()
         .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "value",
             got: "table"
         }
@@ -87,7 +87,7 @@ fn test_unit_struct() -> Result<()> {
         )
         .unwrap_err()
         .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -163,7 +163,7 @@ fn test_root_struct_multiple_fields() -> Result<()> {
         )
         .unwrap_err()
         .kind,
-        TomlErrorKind::ExpectedFieldWithName("a")
+        TomlDeErrorKind::ExpectedFieldWithName("a")
     );
 
     Ok(())
@@ -205,13 +205,13 @@ fn test_nested_struct_multiple_fields() -> Result<()> {
 
     assert_eq!(
         facet_toml::from_str::<Root>("a = 1").unwrap_err().kind,
-        TomlErrorKind::ExpectedFieldWithName("nested")
+        TomlDeErrorKind::ExpectedFieldWithName("nested")
     );
     assert_eq!(
         facet_toml::from_str::<Root>("nested = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ParseSingleValueAsMultipleFieldStruct
+        TomlDeErrorKind::ParseSingleValueAsMultipleFieldStruct
     );
 
     Ok(())

--- a/facet-toml/tests/serialize/basic.rs
+++ b/facet-toml/tests/serialize/basic.rs
@@ -17,7 +17,7 @@ fn test_serialize_person() -> Result<()> {
         age: 30,
     };
 
-    let toml = facet_toml::to_string(&person);
+    let toml = facet_toml::to_string(&person)?;
 
     assert_eq!(toml, "name = \"Alice\"\nage = 30\n");
 

--- a/facet-toml/tests/serialize/enum_.rs
+++ b/facet-toml/tests/serialize/enum_.rs
@@ -2,7 +2,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_toml::TomlErrorKind;
+use facet_toml::TomlDeErrorKind;
 
 #[test]
 fn test_unit_only_enum() -> Result<()> {
@@ -37,7 +37,7 @@ fn test_unit_only_enum() -> Result<()> {
         facet_toml::from_str::<Root>("values = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedFieldWithName("value")
+        TomlDeErrorKind::ExpectedFieldWithName("value")
     );
 
     Ok(())

--- a/facet-toml/tests/serialize/list.rs
+++ b/facet-toml/tests/serialize/list.rs
@@ -2,7 +2,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_toml::TomlErrorKind;
+use facet_toml::TomlDeErrorKind;
 
 #[test]
 fn test_scalar_list() -> Result<()> {
@@ -34,7 +34,7 @@ fn test_scalar_list() -> Result<()> {
         facet_toml::from_str::<Root>("values = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "array",
             got: "boolean"
         }
@@ -78,7 +78,7 @@ fn test_unit_struct_list() -> Result<()> {
         facet_toml::from_str::<Root>("values = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "array",
             got: "boolean"
         }
@@ -87,7 +87,7 @@ fn test_unit_struct_list() -> Result<()> {
         facet_toml::from_str::<Root>("values = [true]")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -96,7 +96,7 @@ fn test_unit_struct_list() -> Result<()> {
         facet_toml::from_str::<Root>("values = [1, true]")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -143,7 +143,7 @@ fn test_nested_lists() -> Result<()> {
         facet_toml::from_str::<Root>("values = true")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "array",
             got: "boolean"
         }
@@ -152,7 +152,7 @@ fn test_nested_lists() -> Result<()> {
         facet_toml::from_str::<Root>("values = [true]")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "array",
             got: "boolean"
         }
@@ -161,7 +161,7 @@ fn test_nested_lists() -> Result<()> {
         facet_toml::from_str::<Root>("values = [[1], true]")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "array",
             got: "boolean"
         }

--- a/facet-toml/tests/serialize/map.rs
+++ b/facet-toml/tests/serialize/map.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use eyre::Result;
 use facet::Facet;
+use facet_toml::TomlSerError;
 
 use crate::assert_serialize;
 
@@ -208,6 +209,26 @@ fn test_optional_struct_map() -> Result<()> {
             .into()
         },
     );
+
+    Ok(())
+}
+
+#[test]
+fn test_invalid_map_key() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct Root {
+        value: HashMap<bool, i32>,
+    }
+
+    assert!(matches!(
+        facet_toml::to_string(&Root {
+            value: [(true, 0)].into()
+        })
+        .unwrap_err(),
+        TomlSerError::InvalidKeyConversion { .. }
+    ));
 
     Ok(())
 }

--- a/facet-toml/tests/serialize/mod.rs
+++ b/facet-toml/tests/serialize/mod.rs
@@ -13,7 +13,7 @@ macro_rules! assert_serialize {
         use eyre::WrapErr as _;
 
         let value = $val;
-        let serialized = facet_toml::to_string(&value);
+        let serialized = facet_toml::to_string(&value)?;
         let deserialized: $type = facet_toml::from_str(&serialized)
             // Unfortunately we can't use the error as-is because it has a lifetime bound
             .map_err(|err| eyre::eyre!("{err}"))

--- a/facet-toml/tests/serialize/option.rs
+++ b/facet-toml/tests/serialize/option.rs
@@ -2,7 +2,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_toml::TomlErrorKind;
+use facet_toml::TomlDeErrorKind;
 
 #[test]
 fn test_option_scalar() -> Result<()> {
@@ -23,7 +23,7 @@ fn test_option_scalar() -> Result<()> {
         facet_toml::from_str::<Root>("value = false")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -53,7 +53,7 @@ fn test_nested_option() -> Result<()> {
         facet_toml::from_str::<Root>("value = false")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -88,7 +88,7 @@ fn test_option_struct() -> Result<()> {
         facet_toml::from_str::<Root>("value.wrong-key = 2")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedFieldWithName("value")
+        TomlDeErrorKind::ExpectedFieldWithName("value")
     );
 
     Ok(())
@@ -120,7 +120,7 @@ fn test_option_struct_with_option() -> Result<()> {
         facet_toml::from_str::<Root>("value.sub = false")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }
@@ -163,7 +163,7 @@ fn test_option_enum() -> Result<()> {
         facet_toml::from_str::<Root>("value.non-existing = false")
             .unwrap_err()
             .kind,
-        TomlErrorKind::GenericReflect(_)
+        TomlDeErrorKind::GenericReflect(_)
     ));
 
     Ok(())
@@ -213,7 +213,7 @@ fn test_option_enum_option_scalar() -> Result<()> {
 
     assert_eq!(
         facet_toml::from_str::<Root>("A = false").unwrap_err().kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "string",
             got: "boolean"
         }
@@ -222,7 +222,7 @@ fn test_option_enum_option_scalar() -> Result<()> {
         facet_toml::from_str::<Root>("B.b1 = false")
             .unwrap_err()
             .kind,
-        TomlErrorKind::ExpectedType {
+        TomlDeErrorKind::ExpectedType {
             expected: "number",
             got: "boolean"
         }

--- a/facet-toml/tests/serialize/scalar.rs
+++ b/facet-toml/tests/serialize/scalar.rs
@@ -2,6 +2,7 @@
 
 use alloc::borrow::Cow;
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use facet_toml::TomlSerError;
 
 use eyre::Result;
 use facet::Facet;
@@ -347,6 +348,23 @@ fn test_nested_optional_scalar() -> Result<()> {
         }
     );
     assert_serialize!(Root, Root { value: None });
+
+    Ok(())
+}
+
+#[test]
+fn test_u64_out_of_range() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct Root {
+        value: u64,
+    }
+
+    assert!(matches!(
+        facet_toml::to_string(&Root { value: u64::MAX }).unwrap_err(),
+        TomlSerError::InvalidNumberToI64Conversion { .. }
+    ));
 
     Ok(())
 }


### PR DESCRIPTION
Many renames for the different error type names.