### PR TITLE
Add `PeekListLike` abstraction and fix serialize and `get_item_ptr` for arrays

### DIFF
--- a/facet-core/src/impls_core/array.rs
+++ b/facet-core/src/impls_core/array.rs
@@ -150,7 +150,8 @@ where
                                             "Index out of bounds: the len is {L} but the index is {index}"
                                         );
                                     }
-                                    PtrConst::new(ptr.as_ptr::<[T; L]>())
+                                    let array = ptr.get::<[T; L]>();
+                                    PtrConst::new(array.as_ptr().add(index))
                                 })
                                 .build()
                         },

--- a/facet-reflect/src/peek/list_like.rs
+++ b/facet-reflect/src/peek/list_like.rs
@@ -1,0 +1,146 @@
+use facet_core::{PtrConst, Shape};
+
+use super::Peek;
+use core::fmt::Debug;
+
+/// Fields for types which act like lists
+#[derive(Clone, Copy)]
+pub enum ListLikeDef {
+    /// Ordered list of heterogenous values, variable size
+    ///
+    /// e.g. `Vec<T>`
+    List(facet_core::ListDef),
+
+    /// Fixed-size array of heterogenous values
+    ///
+    /// e.g. `[T; 32]`
+    Array(facet_core::ArrayDef),
+
+    /// Slice — a reference to a contiguous sequence of elements
+    ///
+    /// e.g. `&[T]`
+    Slice(facet_core::SliceDef),
+}
+
+impl ListLikeDef {
+    /// Returns the shape of the items in the list
+    pub fn t(&self) -> &'static Shape {
+        match self {
+            ListLikeDef::List(v) => v.t(),
+            ListLikeDef::Array(v) => v.t(),
+            ListLikeDef::Slice(v) => v.t(),
+        }
+    }
+}
+
+/// Iterator over a `PeekListLike`
+pub struct PeekListLikeIter<'mem, 'facet_lifetime> {
+    list: PeekListLike<'mem, 'facet_lifetime>,
+    index: usize,
+    len: usize,
+}
+
+impl<'mem, 'facet_lifetime> Iterator for PeekListLikeIter<'mem, 'facet_lifetime> {
+    type Item = Peek<'mem, 'facet_lifetime>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        let item = self.list.get(self.index);
+        self.index += 1;
+        item
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.len.saturating_sub(self.index);
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for PeekListLikeIter<'_, '_> {}
+
+impl<'mem, 'facet_lifetime> IntoIterator for &'mem PeekListLike<'mem, 'facet_lifetime> {
+    type Item = Peek<'mem, 'facet_lifetime>;
+    type IntoIter = PeekListLikeIter<'mem, 'facet_lifetime>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Lets you read from a list, array or slice
+#[derive(Clone, Copy)]
+pub struct PeekListLike<'mem, 'facet_lifetime> {
+    pub(crate) value: Peek<'mem, 'facet_lifetime>,
+    pub(crate) def: ListLikeDef,
+    len: usize,
+    get_item_ptr: unsafe fn(array: PtrConst, index: usize) -> PtrConst,
+}
+
+impl Debug for PeekListLike<'_, '_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PeekListLike").finish_non_exhaustive()
+    }
+}
+
+impl<'mem, 'facet_lifetime> PeekListLike<'mem, 'facet_lifetime> {
+    /// Creates a new peek list
+    pub fn new(value: Peek<'mem, 'facet_lifetime>, def: ListLikeDef) -> Self {
+        let (len, get_item_ptr) = match def {
+            ListLikeDef::List(v) => (
+                unsafe { (v.vtable.len)(value.data()) },
+                v.vtable.get_item_ptr,
+            ),
+            ListLikeDef::Slice(v) => (
+                unsafe { (v.vtable.len)(value.data()) },
+                v.vtable.get_item_ptr,
+            ),
+            ListLikeDef::Array(v) => (v.n, v.vtable.get_item_ptr),
+        };
+        Self {
+            value,
+            def,
+            len,
+            get_item_ptr,
+        }
+    }
+
+    /// Get the length of the list
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if the list is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get an item from the list at the specified index
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds
+    pub fn get(&self, index: usize) -> Option<Peek<'mem, 'facet_lifetime>> {
+        if index >= self.len() {
+            return None;
+        }
+
+        let item_ptr = unsafe { (self.get_item_ptr)(self.value.data(), index) };
+        Some(unsafe { Peek::unchecked_new(item_ptr, self.def.t()) })
+    }
+
+    /// Returns an iterator over the list
+    pub fn iter(self) -> PeekListLikeIter<'mem, 'facet_lifetime> {
+        PeekListLikeIter {
+            list: self,
+            index: 0,
+            len: self.len(),
+        }
+    }
+
+    /// Def getter
+    pub fn def(&self) -> ListLikeDef {
+        self.def
+    }
+}

--- a/facet-reflect/src/peek/mod.rs
+++ b/facet-reflect/src/peek/mod.rs
@@ -12,6 +12,9 @@ pub use enum_::*;
 mod list;
 pub use list::*;
 
+mod list_like;
+pub use list_like::*;
+
 mod map;
 pub use map::*;
 

--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -3,7 +3,7 @@ use facet_core::{Def, Facet, PtrConst, PtrMut, Shape, TypeNameOpts, ValueVTable}
 
 use crate::{ReflectError, ScalarType};
 
-use super::{PeekEnum, PeekList, PeekMap, PeekSmartPointer, PeekStruct};
+use super::{ListLikeDef, PeekEnum, PeekList, PeekListLike, PeekMap, PeekSmartPointer, PeekStruct};
 
 /// A unique identifier for a peek value
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -231,6 +231,19 @@ impl<'mem, 'facet_lifetime> Peek<'mem, 'facet_lifetime> {
                 expected: "list",
                 actual: self.shape,
             })
+        }
+    }
+
+    /// Tries to identify this value as a list, array or slice
+    pub fn into_list_like(self) -> Result<PeekListLike<'mem, 'facet_lifetime>, ReflectError> {
+        match self.shape.def {
+            Def::List(def) => Ok(PeekListLike::new(self, ListLikeDef::List(def))),
+            Def::Array(def) => Ok(PeekListLike::new(self, ListLikeDef::Array(def))),
+            Def::Slice(def) => Ok(PeekListLike::new(self, ListLikeDef::Slice(def))),
+            _ => Err(ReflectError::WasNotA {
+                expected: "list, array or slice",
+                actual: self.shape,
+            }),
         }
     }
 

--- a/facet-reflect/tests/peek/list_like.rs
+++ b/facet-reflect/tests/peek/list_like.rs
@@ -1,0 +1,106 @@
+use facet_reflect::Peek;
+
+#[test]
+fn peek_list_like_list() -> Result<(), Box<dyn std::error::Error>> {
+    facet_testhelpers::setup();
+
+    // Create test Vec instance
+    let test_list = vec![1, 2, 3, 4, 5];
+    let peek_value = Peek::new(&test_list);
+
+    // Convert to list and check we can convert to PeekListLike
+    let peek_list = peek_value.into_list_like()?;
+
+    // Test length
+    assert_eq!(peek_list.len(), 5);
+
+    // Test index access
+    let first = peek_list.get(0).unwrap();
+    let third = peek_list.get(2).unwrap();
+    let last = peek_list.get(4).unwrap();
+
+    // Test element values
+    let first_value = *first.get::<i32>()?;
+    assert_eq!(first_value, 1);
+
+    let third_value = *third.get::<i32>()?;
+    assert_eq!(third_value, 3);
+
+    let last_value = *last.get::<i32>()?;
+    assert_eq!(last_value, 5);
+
+    // Test out of bounds
+    assert!(peek_list.get(5).is_none());
+
+    Ok(())
+}
+
+#[test]
+fn peek_list_like_array() -> Result<(), Box<dyn std::error::Error>> {
+    facet_testhelpers::setup();
+
+    // Create test array instance
+    let test_list = [1, 2, 3, 4, 5];
+    let peek_value = Peek::new(&test_list);
+
+    // Convert to list and check we can convert to PeekListLike
+    let peek_list = peek_value.into_list_like()?;
+
+    // Test length
+    assert_eq!(peek_list.len(), 5);
+
+    // Test index access
+    let first = peek_list.get(0).unwrap();
+    let third = peek_list.get(2).unwrap();
+    let last = peek_list.get(4).unwrap();
+
+    // Test element values
+    let first_value = *first.get::<i32>()?;
+    assert_eq!(first_value, 1);
+
+    let third_value = *third.get::<i32>()?;
+    assert_eq!(third_value, 3);
+
+    let last_value = *last.get::<i32>()?;
+    assert_eq!(last_value, 5);
+
+    // Test out of bounds
+    assert!(peek_list.get(5).is_none());
+
+    Ok(())
+}
+
+#[test]
+fn peek_list_like_slice() -> Result<(), Box<dyn std::error::Error>> {
+    facet_testhelpers::setup();
+
+    // Create test Vec instance
+    let test_list = &[1, 2, 3, 4, 5][..];
+    let peek_value = Peek::new(&test_list);
+
+    // Convert to list and check we can convert to PeekListLike
+    let peek_list = peek_value.into_list_like()?;
+
+    // Test length
+    assert_eq!(peek_list.len(), 5);
+
+    // Test index access
+    let first = peek_list.get(0).unwrap();
+    let third = peek_list.get(2).unwrap();
+    let last = peek_list.get(4).unwrap();
+
+    // Test element values
+    let first_value = *first.get::<i32>()?;
+    assert_eq!(first_value, 1);
+
+    let third_value = *third.get::<i32>()?;
+    assert_eq!(third_value, 3);
+
+    let last_value = *last.get::<i32>()?;
+    assert_eq!(last_value, 5);
+
+    // Test out of bounds
+    assert!(peek_list.get(5).is_none());
+
+    Ok(())
+}

--- a/facet-reflect/tests/peek/mod.rs
+++ b/facet-reflect/tests/peek/mod.rs
@@ -2,6 +2,7 @@ mod enum_;
 #[cfg(feature = "std")]
 mod facts;
 mod list;
+mod list_like;
 mod map;
 mod option;
 mod smartptr;

--- a/facet-serialize/src/lib.rs
+++ b/facet-serialize/src/lib.rs
@@ -11,7 +11,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use facet_core::{Def, Facet, Field, ShapeAttribute, StructKind};
-use facet_reflect::{HasFields, Peek, PeekList, PeekMap, PeekStruct, ScalarType};
+use facet_reflect::{HasFields, Peek, PeekListLike, PeekMap, PeekStruct, ScalarType};
 use log::debug;
 
 mod debug_serializer;
@@ -225,7 +225,7 @@ enum SerializeTask<'mem, 'facet> {
     EndField,
     // Tasks to push sub-elements onto the stack
     ObjectFields(PeekStruct<'mem, 'facet>),
-    ArrayItems(PeekList<'mem, 'facet>),
+    ArrayItems(PeekListLike<'mem, 'facet>),
     TupleStructFields(PeekStruct<'mem, 'facet>),
     MapEntries(PeekMap<'mem, 'facet>),
     // Field-related tasks
@@ -420,7 +420,7 @@ where
                         }
                     }
                     Def::List(_) | Def::Array(_) | Def::Slice(_) => {
-                        let peek_list = cpeek.into_list().unwrap();
+                        let peek_list = cpeek.into_list_like().unwrap();
                         let len = peek_list.len();
                         serializer.start_array(Some(len))?;
                         stack.push(SerializeTask::EndArray);


### PR DESCRIPTION
Lists, arrays and slices are very similar, so this abstracts over `Peek`s of them.

I wasn't sure if I should just modify `facet_reflect/src/peek/list.rs`
since lists may have additional behaviour in the future different from
slices and arrays.

This additionally fixes `get_item_ptr` vtable entry for arrays, since it didn't use
`index` (and just returned the pointer to the original array).