### PR TITLE
feat: support core::ops::Range

### DIFF
--- a/facet-core/src/impls_core/mod.rs
+++ b/facet-core/src/impls_core/mod.rs
@@ -1,5 +1,6 @@
 mod array;
 mod fn_ptr;
+mod ops;
 mod option;
 mod scalar;
 mod slice;

--- a/facet-core/src/impls_core/ops.rs
+++ b/facet-core/src/impls_core/ops.rs
@@ -1,0 +1,64 @@
+use crate::{
+    ConstTypeId, Def, Facet, Field, Shape, StructDef, StructKind, VTableView, ValueVTable,
+};
+use core::{alloc::Layout, mem};
+
+unsafe impl<'a, Idx: Facet<'a>> Facet<'a> for core::ops::Range<Idx> {
+    const SHAPE: &'static crate::Shape = &const {
+        Shape::builder_for_sized::<Self>()
+            .type_params(&[crate::TypeParam {
+                name: "Idx",
+                shape: || Idx::SHAPE,
+            }])
+            .id(ConstTypeId::of::<Self>())
+            .layout(Layout::new::<Self>())
+            .vtable(
+                &const {
+                    let mut builder = ValueVTable::builder::<Self>().type_name(|f, opts| {
+                        write!(f, "Range")?;
+                        if let Some(opts) = opts.for_children() {
+                            write!(f, "<")?;
+                            (Idx::SHAPE.vtable.type_name)(f, opts)?;
+                            write!(f, ">")?;
+                        } else {
+                            write!(f, "<…>")?;
+                        }
+                        Ok(())
+                    });
+
+                    if Idx::SHAPE.is_debug() {
+                        builder = builder.debug(|this, f| {
+                            (<VTableView<Idx>>::of().debug().unwrap())(&this.start, f)?;
+                            write!(f, "..")?;
+                            (<VTableView<Idx>>::of().debug().unwrap())(&this.end, f)?;
+                            Ok(())
+                        });
+                    }
+
+                    builder.build()
+                },
+            )
+            .def(Def::Struct(
+                StructDef::builder()
+                    .kind(StructKind::Struct)
+                    .fields(
+                        &const {
+                            [
+                                Field::builder()
+                                    .name("start")
+                                    .shape(|| Idx::SHAPE)
+                                    .offset(mem::offset_of!(core::ops::Range<Idx>, start))
+                                    .build(),
+                                Field::builder()
+                                    .name("end")
+                                    .shape(|| Idx::SHAPE)
+                                    .offset(mem::offset_of!(core::ops::Range<Idx>, start))
+                                    .build(),
+                            ]
+                        },
+                    )
+                    .build(),
+            ))
+            .build()
+    };
+}


### PR DESCRIPTION
I haven't used Facet much so please review this carefully, I'm likely to have missed something. I'd like to use Facet to build a debugger for the parser I'm building and it's using `core::ops::Range<usize>` so I'd like `Range` to implement `Facet` so that I can derive `Facet` for my struct that's containing the range.

My parser is also using  `core::iter::Peekable` so I'd also like to implement Facet for it but I'm not sure what do about its private fields? Omit them?