### PR TITLE
fix: References are not pointers, also, resuscitate facet-args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-args"
+version = "0.18.5"
+dependencies = [
+ "eyre",
+ "facet",
+ "facet-core",
+ "facet-pretty",
+ "facet-reflect",
+ "facet-testhelpers 0.17.1",
+ "log",
+]
+
+[[package]]
 name = "facet-bench"
 version = "0.23.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
     "facet-testhelpers",
 
     # # formats / ecosystem
-    # "facet-args",
+    "facet-args",
     "facet-json",
     # "facet-msgpack",
     "facet-serialize",

--- a/facet-args/tests/simple.rs
+++ b/facet-args/tests/simple.rs
@@ -70,7 +70,7 @@ fn test_error_non_struct_type_not_supported() -> Result<()> {
     }
     let args: Result<Args, _> = facet_args::from_slice(&["error", "wrong", "type"]);
     let err = args.unwrap_err();
-    assert_eq!(err.message(), "Args error: Expected struct defintion");
+    assert_eq!(err.message(), "Args error: Expected struct type");
 
     Ok(())
 }

--- a/facet-core/src/impls_core/pointer.rs
+++ b/facet-core/src/impls_core/pointer.rs
@@ -124,12 +124,62 @@ impl_facet_for_pointer!(
 impl_facet_for_pointer!(
     Reference: &'a T
         => Shape::builder_for_sized::<Self>()
-        => ValueVTable::builder::<Self>()
-            .marker_traits(
-                MarkerTraits::UNPIN
-                    .union(MarkerTraits::COPY)
-            )
-            .clone_into(|src, dst| unsafe { dst.put(core::ptr::read(src)) })
+        => {
+            let mut builder = ValueVTable::builder::<Self>()
+                .marker_traits(
+                    MarkerTraits::UNPIN
+                        .union(MarkerTraits::COPY)
+                )
+                .clone_into(|src, dst| unsafe { dst.put(core::ptr::read(src)) });
+
+            // Forward trait methods to the underlying type if it implements them
+            if T::VTABLE.debug.is_some() {
+                builder = builder.debug(|value, f| {
+                    let target_ptr = crate::PtrConst::new(value);
+                    unsafe { (T::VTABLE.debug.unwrap())(target_ptr, f) }
+                });
+            }
+
+            if T::VTABLE.display.is_some() {
+                builder = builder.display(|value, f| {
+                    let target_ptr = crate::PtrConst::new(value);
+                    unsafe { (T::VTABLE.display.unwrap())(target_ptr, f) }
+                });
+            }
+
+            if T::VTABLE.eq.is_some() {
+                builder = builder.eq(|a, b| {
+                    let a_ptr = crate::PtrConst::new(a);
+                    let b_ptr = crate::PtrConst::new(b);
+                    unsafe { (T::VTABLE.eq.unwrap())(a_ptr, b_ptr) }
+                });
+            }
+
+            if T::VTABLE.partial_ord.is_some() {
+                builder = builder.partial_ord(|a, b| {
+                    let a_ptr = crate::PtrConst::new(a);
+                    let b_ptr = crate::PtrConst::new(b);
+                    unsafe { (T::VTABLE.partial_ord.unwrap())(a_ptr, b_ptr) }
+                });
+            }
+
+            if T::VTABLE.ord.is_some() {
+                builder = builder.ord(|a, b| {
+                    let a_ptr = crate::PtrConst::new(a);
+                    let b_ptr = crate::PtrConst::new(b);
+                    unsafe { (T::VTABLE.ord.unwrap())(a_ptr, b_ptr) }
+                });
+            }
+
+            if T::VTABLE.hash.is_some() {
+                builder = builder.hash(|value, hasher_this, hasher_write_fn| {
+                    let target_ptr = crate::PtrConst::new(value);
+                    unsafe { (T::VTABLE.hash.unwrap())(target_ptr, hasher_this, hasher_write_fn) }
+                });
+            }
+
+            builder
+        }
         => Reference, false
 );
 
@@ -137,9 +187,59 @@ impl_facet_for_pointer!(
 impl_facet_for_pointer!(
     Reference: &'a mut T
         => Shape::builder_for_sized::<Self>()
-        => ValueVTable::builder::<Self>()
-            .marker_traits(
-                MarkerTraits::UNPIN
-            )
+        => {
+            let mut builder = ValueVTable::builder::<Self>()
+                .marker_traits(
+                    MarkerTraits::UNPIN
+                );
+
+            // Forward trait methods to the underlying type if it implements them
+            if T::VTABLE.debug.is_some() {
+                builder = builder.debug(|value, f| {
+                    let target_ptr = crate::PtrConst::new(value);
+                    unsafe { (T::VTABLE.debug.unwrap())(target_ptr, f) }
+                });
+            }
+
+            if T::VTABLE.display.is_some() {
+                builder = builder.display(|value, f| {
+                    let target_ptr = crate::PtrConst::new(value);
+                    unsafe { (T::VTABLE.display.unwrap())(target_ptr, f) }
+                });
+            }
+
+            if T::VTABLE.eq.is_some() {
+                builder = builder.eq(|a, b| {
+                    let a_ptr = crate::PtrConst::new(a);
+                    let b_ptr = crate::PtrConst::new(b);
+                    unsafe { (T::VTABLE.eq.unwrap())(a_ptr, b_ptr) }
+                });
+            }
+
+            if T::VTABLE.partial_ord.is_some() {
+                builder = builder.partial_ord(|a, b| {
+                    let a_ptr = crate::PtrConst::new(a);
+                    let b_ptr = crate::PtrConst::new(b);
+                    unsafe { (T::VTABLE.partial_ord.unwrap())(a_ptr, b_ptr) }
+                });
+            }
+
+            if T::VTABLE.ord.is_some() {
+                builder = builder.ord(|a, b| {
+                    let a_ptr = crate::PtrConst::new(a);
+                    let b_ptr = crate::PtrConst::new(b);
+                    unsafe { (T::VTABLE.ord.unwrap())(a_ptr, b_ptr) }
+                });
+            }
+
+            if T::VTABLE.hash.is_some() {
+                builder = builder.hash(|value, hasher_this, hasher_write_fn| {
+                    let target_ptr = crate::PtrConst::new(value);
+                    unsafe { (T::VTABLE.hash.unwrap())(target_ptr, hasher_this, hasher_write_fn) }
+                });
+            }
+
+            builder
+        }
         => Reference, true
 );

--- a/facet-core/src/impls_core/pointer.rs
+++ b/facet-core/src/impls_core/pointer.rs
@@ -1,21 +1,45 @@
 use core::{fmt, hash::Hash};
 
 use crate::{
-    Facet, HasherProxy, MarkerTraits, PointerType, Shape, Type, TypeParam, VTableView,
-    ValuePointerType, ValueVTable,
+    Facet, HasherProxy, MarkerTraits, PointerType, Shape, Type, TypeParam, ValuePointerType,
+    ValueVTable,
 };
 
 macro_rules! impl_facet_for_pointer {
-    ($variant:ident: $type:ty => $shape:expr => $vtable_builder:expr => $($ptrkind:tt)+) => {
+    ($variant:ident: $type:ty => $shape:expr => $vtable_builder:expr => $ptr_type:ident, $mutable:expr) => {
         unsafe impl<'a, T: Facet<'a> + ?Sized> Facet<'a> for $type {
             const VTABLE: &'static ValueVTable = &const {
                 $vtable_builder
                     .type_name(|f, opts| {
                         if let Some(opts) = opts.for_children() {
-                            write!(f, stringify!($($ptrkind)+, " "))?;
+                            if stringify!($ptr_type) == "Raw" {
+                                if $mutable {
+                                    write!(f, "*mut ")?;
+                                } else {
+                                    write!(f, "*const ")?;
+                                }
+                            } else {
+                                write!(f, "&")?;
+                                if $mutable {
+                                    write!(f, "mut ")?;
+                                }
+                            }
                             (T::VTABLE.type_name)(f, opts)
                         } else {
-                            write!(f, stringify!($($ptrkind)+, " ⋯"))
+                            if stringify!($ptr_type) == "Raw" {
+                                if $mutable {
+                                    write!(f, "*mut ⋯")
+                                } else {
+                                    write!(f, "*const ⋯")
+                                }
+                            } else {
+                                write!(f, "&")?;
+                                if $mutable {
+                                    write!(f, "mut ⋯")
+                                } else {
+                                    write!(f, "⋯")
+                                }
+                            }
                         }
                     })
                     .build()
@@ -27,115 +51,95 @@ macro_rules! impl_facet_for_pointer {
                         name: "T",
                         shape: || T::SHAPE,
                     }])
-                    .ty(Type::Pointer(PointerType::Raw(ValuePointerType {
-                        mutable: false,
-                        wide: ::core::mem::size_of::<$($ptrkind)* ()>() != ::core::mem::size_of::<Self>(),
-                        target: || T::SHAPE,
-                    })))
+                    .ty({
+                        let is_wide =
+                            ::core::mem::size_of::<$type>() != ::core::mem::size_of::<*const ()>();
+                        let vpt = ValuePointerType {
+                            mutable: $mutable,
+                            wide: is_wide,
+                            target: || T::SHAPE,
+                        };
+
+                        Type::Pointer(PointerType::$ptr_type(vpt))
+                    })
                     .build()
             };
         }
     };
-    (*$mutability:tt) => {
-        impl_facet_for_pointer!(
-            Raw: *$mutability T
-                => Shape::builder_for_sized::<Self>()
-                    .inner(|| T::SHAPE)
-                => ValueVTable::builder::<Self>()
-                    .marker_traits(
-                        MarkerTraits::EQ
-                            .union(MarkerTraits::COPY)
-                            .union(MarkerTraits::UNPIN),
-                    )
-                    .debug(|data, f| fmt::Debug::fmt(data, f))
-                    .clone_into(|src, dst| unsafe { dst.put(src.clone()) })
-                    .eq(|left, right| left.cast::<()>().eq(&right.cast::<()>()))
-                    .partial_ord(|&left, &right| {
-                        left.cast::<()>().partial_cmp(&right.cast::<()>())
-                    })
-                    .ord(|&left, &right| left.cast::<()>().cmp(&right.cast::<()>()))
-                    .hash(|value, hasher_this, hasher_write_fn| {
-                        value.hash(&mut unsafe {
-                            HasherProxy::new(hasher_this, hasher_write_fn)
-                        })
-                    })
-                => *$mutability
-        );
-    };
-    (@ $builder:expr => &$($mutability:tt)?) => {
-        impl_facet_for_pointer!(
-            Reference: &'a $($mutability)? T
-                => Shape::builder_for_sized::<Self>()
-                => {
-                    let mut builder = $builder;
+}
 
-                    if T::VTABLE.default_in_place.is_some() {
-                        builder = builder.default_in_place(|value| {
-                            (<VTableView<&$($mutability)? T>>::of_deref().default_in_place().unwrap())(value)
-                        });
-                    }
+// *const pointers
+impl_facet_for_pointer!(
+    Raw: *const T
+        => Shape::builder_for_sized::<Self>()
+            .inner(|| T::SHAPE)
+        => ValueVTable::builder::<Self>()
+            .marker_traits(
+                MarkerTraits::EQ
+                    .union(MarkerTraits::COPY)
+                    .union(MarkerTraits::UNPIN),
+            )
+            .debug(|data, f| fmt::Debug::fmt(data, f))
+            .clone_into(|src, dst| unsafe { dst.put(src.clone()) })
+            .eq(|left, right| left.cast::<()>().eq(&right.cast::<()>()))
+            .partial_ord(|&left, &right| {
+                left.cast::<()>().partial_cmp(&right.cast::<()>())
+            })
+            .ord(|&left, &right| left.cast::<()>().cmp(&right.cast::<()>()))
+            .hash(|value, hasher_this, hasher_write_fn| {
+                value.hash(&mut unsafe {
+                    HasherProxy::new(hasher_this, hasher_write_fn)
+                })
+            })
+        => Raw, false
+);
 
-                    if T::VTABLE.debug.is_some() {
-                        builder = builder.debug(|value, f| {
-                            (<VTableView<&$($mutability)? T>>::of_deref().debug().unwrap())(value, f)
-                        });
-                    }
+// *mut pointers
+impl_facet_for_pointer!(
+    Raw: *mut T
+        => Shape::builder_for_sized::<Self>()
+            .inner(|| T::SHAPE)
+        => ValueVTable::builder::<Self>()
+            .marker_traits(
+                MarkerTraits::EQ
+                    .union(MarkerTraits::COPY)
+                    .union(MarkerTraits::UNPIN),
+            )
+            .debug(|data, f| fmt::Debug::fmt(data, f))
+            .clone_into(|src, dst| unsafe { dst.put(src.clone()) })
+            .eq(|left, right| left.cast::<()>().eq(&right.cast::<()>()))
+            .partial_ord(|&left, &right| {
+                left.cast::<()>().partial_cmp(&right.cast::<()>())
+            })
+            .ord(|&left, &right| left.cast::<()>().cmp(&right.cast::<()>()))
+            .hash(|value, hasher_this, hasher_write_fn| {
+                value.hash(&mut unsafe {
+                    HasherProxy::new(hasher_this, hasher_write_fn)
+                })
+            })
+        => Raw, true
+);
 
-                    if T::VTABLE.display.is_some() {
-                        builder = builder.display(|value, f| {
-                            (<VTableView<&$($mutability)? T>>::of_deref().display().unwrap())(value, f)
-                        });
-                    }
-
-                    if T::VTABLE.eq.is_some() {
-                        builder = builder.eq(|a, b| {
-                            (<VTableView<&$($mutability)? T>>::of_deref().eq().unwrap())(a, b)
-                        });
-                    }
-
-                    if T::VTABLE.ord.is_some() {
-                        builder = builder.ord(|a, b| {
-                            (<VTableView<&$($mutability)? T>>::of_deref().ord().unwrap())(a, b)
-                        });
-                    }
-
-                    if T::VTABLE.partial_ord.is_some() {
-                        builder = builder.partial_ord(|a, b| {
-                            (<VTableView<&$($mutability)? T>>::of_deref().partial_ord().unwrap())(a, b)
-                        });
-                    }
-
-                    if T::VTABLE.hash.is_some() {
-                        builder = builder.hash(|value, state, hasher| {
-                            (<VTableView<&$($mutability)? T>>::of_deref().hash().unwrap())(value, state, hasher)
-                        });
-                    }
-
-                    builder
-                }
-                => &$($mutability)?
-        );
-    };
-    (&) => {
-        impl_facet_for_pointer!(@ ValueVTable::builder::<Self>()
+// &T references
+impl_facet_for_pointer!(
+    Reference: &'a T
+        => Shape::builder_for_sized::<Self>()
+        => ValueVTable::builder::<Self>()
             .marker_traits(
                 MarkerTraits::UNPIN
                     .union(MarkerTraits::COPY)
             )
             .clone_into(|src, dst| unsafe { dst.put(core::ptr::read(src)) })
-        => &);
-    };
-    (&mut) => {
-        impl_facet_for_pointer!(@ ValueVTable::builder::<Self>()
+        => Reference, false
+);
+
+// &mut T references
+impl_facet_for_pointer!(
+    Reference: &'a mut T
+        => Shape::builder_for_sized::<Self>()
+        => ValueVTable::builder::<Self>()
             .marker_traits(
                 MarkerTraits::UNPIN
             )
-        => &mut
-        );
-    };
-}
-
-impl_facet_for_pointer!(*const);
-impl_facet_for_pointer!(*mut);
-impl_facet_for_pointer!(&mut);
-impl_facet_for_pointer!(&);
+        => Reference, true
+);

--- a/facet-core/src/impls_core/pointer.rs
+++ b/facet-core/src/impls_core/pointer.rs
@@ -79,8 +79,8 @@ impl_facet_for_pointer!(
                     .union(MarkerTraits::COPY)
                     .union(MarkerTraits::UNPIN),
             )
-            .debug(|data, f| fmt::Debug::fmt(data, f))
-            .clone_into(|src, dst| unsafe { dst.put(src.clone()) })
+            .debug(fmt::Debug::fmt)
+            .clone_into(|src, dst| unsafe { dst.put(*src) })
             .eq(|left, right| left.cast::<()>().eq(&right.cast::<()>()))
             .partial_ord(|&left, &right| {
                 left.cast::<()>().partial_cmp(&right.cast::<()>())
@@ -105,8 +105,8 @@ impl_facet_for_pointer!(
                     .union(MarkerTraits::COPY)
                     .union(MarkerTraits::UNPIN),
             )
-            .debug(|data, f| fmt::Debug::fmt(data, f))
-            .clone_into(|src, dst| unsafe { dst.put(src.clone()) })
+            .debug(fmt::Debug::fmt)
+            .clone_into(|src, dst| unsafe { dst.put(*src) })
             .eq(|left, right| left.cast::<()>().eq(&right.cast::<()>()))
             .partial_ord(|&left, &right| {
                 left.cast::<()>().partial_cmp(&right.cast::<()>())

--- a/facet-core/tests/pointer.rs
+++ b/facet-core/tests/pointer.rs
@@ -1,0 +1,49 @@
+use facet_core::{Facet, PointerType, Type};
+
+#[test]
+fn shape_name_string_slice_const_ptr() -> eyre::Result<()> {
+    facet_testhelpers::setup();
+
+    let shape = <*const str as Facet>::SHAPE;
+    match shape.ty {
+        Type::Pointer(PointerType::Raw(vpt)) => {
+            assert!(!vpt.mutable);
+            assert_eq!((vpt.target)().to_string(), "str");
+        }
+        _ => panic!("wrong type {:?}", shape.ty),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn shape_name_string_slice_mut_ptr() -> eyre::Result<()> {
+    facet_testhelpers::setup();
+
+    let shape = <*mut str as Facet>::SHAPE;
+    match shape.ty {
+        Type::Pointer(PointerType::Raw(vpt)) => {
+            assert!(vpt.mutable);
+            assert_eq!((vpt.target)().to_string(), "str");
+        }
+        _ => panic!("wrong type {:?}", shape.ty),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn shape_name_string_slice_ref() -> eyre::Result<()> {
+    facet_testhelpers::setup();
+
+    let shape = <&str as Facet>::SHAPE;
+    match shape.ty {
+        Type::Pointer(PointerType::Reference(vpt)) => {
+            assert!(!vpt.mutable);
+            assert_eq!((vpt.target)().to_string(), "str");
+        }
+        _ => panic!("wrong type {:?}", shape.ty),
+    }
+
+    Ok(())
+}

--- a/facet-reflect/tests/peek/facts.rs
+++ b/facet-reflect/tests/peek/facts.rs
@@ -436,7 +436,6 @@ fn test_string_traits() {
             .equal_and(false)
             .ord_and(Ordering::Less)
             .clone()
-            .default()
             .build(),
     );
 
@@ -493,7 +492,6 @@ fn test_slice_traits() {
             .equal_and(false)
             .ord_and(Ordering::Less)
             .clone()
-            .default()
             .build(),
     );
 
@@ -506,7 +504,6 @@ fn test_slice_traits() {
             .equal_and(false)
             .ord_and(Ordering::Greater)
             .clone()
-            .default()
             .build(),
     );
 }
@@ -576,7 +573,6 @@ fn test_array_traits() {
             .debug()
             .equal_and(false)
             .ord_and(Ordering::Less)
-            .default()
             .clone()
             .build(),
     );

--- a/facet-reflect/tests/wip/misc.rs
+++ b/facet-reflect/tests/wip/misc.rs
@@ -1,9 +1,6 @@
-use std::{fmt::Pointer, mem::MaybeUninit};
+use std::mem::MaybeUninit;
 
-use facet::{
-    EnumType, Facet, Field, PointerType, PtrConst, PtrUninit, StructType, Type, UserType,
-    ValuePointerType, Variant,
-};
+use facet::{EnumType, Facet, Field, PtrConst, PtrUninit, StructType, Type, UserType, Variant};
 use facet_reflect::{ReflectError, Wip};
 
 #[derive(Facet, PartialEq, Eq, Debug)]

--- a/facet-reflect/tests/wip/misc.rs
+++ b/facet-reflect/tests/wip/misc.rs
@@ -1,6 +1,9 @@
-use std::mem::MaybeUninit;
+use std::{fmt::Pointer, mem::MaybeUninit};
 
-use facet::{EnumType, Facet, Field, PtrConst, PtrUninit, StructType, Type, UserType, Variant};
+use facet::{
+    EnumType, Facet, Field, PointerType, PtrConst, PtrUninit, StructType, Type, UserType,
+    ValuePointerType, Variant,
+};
 use facet_reflect::{ReflectError, Wip};
 
 #[derive(Facet, PartialEq, Eq, Debug)]


### PR DESCRIPTION
Some fallout from #462 — reference types showed up as raw pointer types, the type_name was slightly incorrect, etc. Just following up on these since it's impacting facet-args, for example.