### PR TITLE
fix(pretty): support tuples

### DIFF
--- a/facet-pretty/tests/pretty_print.rs
+++ b/facet-pretty/tests/pretty_print.rs
@@ -133,3 +133,18 @@ fn test_sensitive_fields() {
     assert!(buffer.contains("[REDACTED]"));
     assert!(!buffer.contains("TOP SECRET PASSWORD"));
 }
+
+#[test]
+fn test_tuple() {
+    let printer = PrettyPrinter::new().with_colors(false);
+    assert_eq!(
+        printer.format(&(1, 2)).to_string(),
+        r#"
+(i32, i32) (
+  1,
+  2,
+)
+        "#
+        .trim()
+    );
+}


### PR DESCRIPTION
Before e.g. (1,2) was printed as:

    unsupported peek variant: (1, 2)

where the printed `(1,2)` was just the core::fmt::Debug formatting. This commit adapts the printer to reuse the list printing logic so that e.g. (1,2) becomes:

    (i32, i32) (
      1,
      2,
    )