### PR TITLE
refactor(facet-args): rely on facet-deserialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "eyre",
  "facet",
  "facet-core",
+ "facet-deserialize",
  "facet-pretty",
  "facet-reflect",
  "facet-testhelpers 0.17.2",

--- a/facet-args/Cargo.toml
+++ b/facet-args/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["command-line-interface"]
 [dependencies]
 facet-reflect = { path = "../facet-reflect", version = "0.25.1" }
 facet-core = { path = "../facet-core", version = "0.25.1" }
+facet-deserialize = { path = "../facet-deserialize", version = "0.24.3" }
 log = "0.4.27"
 
 [dev-dependencies]

--- a/facet-args/src/defaults.rs
+++ b/facet-args/src/defaults.rs
@@ -1,0 +1,45 @@
+use crate::error::{ArgsError, ArgsErrorKind};
+use facet_core::{Type, UserType};
+use facet_deserialize::{PopReason, Span, StackRunner};
+use facet_reflect::{ReflectError, Wip};
+
+/// Applies defaults to uninitialized fields
+///
+/// /// This function leverages the `StackRunner` from `facet-deserialize` to apply default values
+/// to fields that have the `DEFAULT` flag. It preserves the special handling for boolean fields
+/// that's specific to CLI argument parsing.
+///
+/// # Arguments
+///
+/// * `wip` - A working-in-progress value to apply defaults to
+///
+/// # Returns
+///
+/// The `wip` with defaults applied to non-boolean fields
+pub fn apply_field_defaults(wip: Wip<'_>) -> Result<Wip<'_>, ArgsError> {
+    // Guard clause for non-struct types
+    if !matches!(wip.shape().ty, Type::User(UserType::Struct(_))) {
+        return Ok(wip); // Not a struct, return as is
+    }
+
+    // Set up StackRunner for default handling
+    let mut runner = StackRunner {
+        original_input: &[],
+        input: &[],
+        stack: vec![],
+        last_span: Span::new(0, 0),
+    };
+
+    // Capture shape before moving wip
+    let shape = wip.shape();
+
+    // Apply defaults using StackRunner
+    runner.pop(wip, PopReason::TopLevel).map_err(|_e| {
+        ArgsError::new(ArgsErrorKind::GenericReflect(
+            ReflectError::OperationFailed {
+                shape,
+                operation: "applying defaults",
+            },
+        ))
+    })
+}

--- a/facet-args/src/parse.rs
+++ b/facet-args/src/parse.rs
@@ -1,0 +1,107 @@
+use crate::error::{ArgsError, ArgsErrorKind};
+use facet_core::FieldAttribute;
+use facet_reflect::Wip;
+
+/// Process a named argument (--name value)
+pub fn parse_named_arg<'input, 'facet>(
+    wip: Wip<'facet>,
+    key: &str,
+    args: &mut &[&'input str],
+) -> Result<Wip<'facet>, ArgsError>
+where
+    'input: 'facet,
+{
+    // Extract the named argument parsing logic from from_slice
+    let field_index = match wip.field_index(key) {
+        Some(index) => index,
+        None => {
+            return Err(ArgsError::new(ArgsErrorKind::GenericArgsError(format!(
+                "Unknown argument `{key}`",
+            ))));
+        }
+    };
+
+    let field = wip
+        .field(field_index)
+        .expect("field_index should be a valid field bound");
+
+    if field.shape().is_type::<bool>() {
+        crate::parse_field(field, "true")
+    } else {
+        let value = args
+            .first()
+            .ok_or(ArgsError::new(ArgsErrorKind::GenericArgsError(format!(
+                "expected value after argument `{key}`"
+            ))))?;
+        *args = &args[1..]; // Consume the value token
+        crate::parse_field(field, value)
+    }
+}
+
+/// Process a short argument (-n value)
+pub fn parse_short_arg<'input, 'facet>(
+    wip: Wip<'facet>,
+    key: &str,
+    args: &mut &[&'input str],
+    st: &facet_core::StructType,
+) -> Result<Wip<'facet>, ArgsError>
+where
+    'input: 'facet,
+{
+    // Extract the short argument parsing logic from from_slice
+    for (field_index, f) in st.fields.iter().enumerate() {
+        if f.attributes.iter().any(
+            |a| matches!(a, FieldAttribute::Arbitrary(a) if a.contains("short") && a.contains(key)),
+        ) {
+            let field = wip.field(field_index).expect("field_index is in bounds");
+            if field.shape().is_type::<bool>() {
+                return crate::parse_field(field, "true");
+            } else {
+                let value = args
+                    .first()
+                    .ok_or(ArgsError::new(ArgsErrorKind::GenericArgsError(format!(
+                        "expected value after argument `{key}`"
+                    ))))?;
+                *args = &args[1..]; // Consume the value token
+                return crate::parse_field(field, value);
+            }
+        }
+    }
+    // No matching field found
+    Err(ArgsError::new(ArgsErrorKind::GenericArgsError(format!(
+        "Unknown short argument `-{}`",
+        key
+    ))))
+}
+
+/// Process a positional argument
+pub fn parse_positional_arg<'input, 'facet>(
+    wip: Wip<'facet>,
+    token: &'input str,
+    st: &facet_core::StructType,
+) -> Result<Wip<'facet>, ArgsError>
+where
+    'input: 'facet,
+{
+    // Extract the positional argument parsing logic from from_slice
+    for (field_index, f) in st.fields.iter().enumerate() {
+        if f.attributes
+            .iter()
+            .any(|a| matches!(a, FieldAttribute::Arbitrary(a) if a.contains("positional")))
+        {
+            if wip
+                .is_field_set(field_index)
+                .expect("field_index is in bounds")
+            {
+                continue;
+            }
+            let field = wip.field(field_index).expect("field_index is in bounds");
+            return crate::parse_field(field, token);
+        }
+    }
+    // No matching field found
+    Err(ArgsError::new(ArgsErrorKind::GenericArgsError(format!(
+        "No positional argument field available for token `{}`",
+        token
+    ))))
+}

--- a/facet-args/tests/defaults.rs
+++ b/facet-args/tests/defaults.rs
@@ -1,0 +1,127 @@
+#![cfg(test)]
+
+use facet_core::{Type, UserType};
+use facet_reflect::Wip;
+
+use facet::Facet;
+use facet_args::{defaults::apply_field_defaults, parse_field};
+
+#[test]
+fn test_apply_field_defaults() {
+    facet_testhelpers::setup();
+
+    // Test with a struct with default values
+    #[derive(Facet, Debug, PartialEq)]
+    struct TestStruct {
+        #[facet(default = 42)]
+        number: u32,
+        flag: bool, // No default, should be untouched
+    }
+
+    // Create a Wip instance for TestStruct
+    let wip = Wip::alloc::<TestStruct>().unwrap();
+
+    // Apply the defaults
+    let wip = apply_field_defaults(wip).unwrap();
+
+    // Check if the default was applied to 'number' field
+    let Type::User(UserType::Struct(st)) = wip.shape().ty else {
+        panic!("Expected struct type");
+    };
+
+    // Find the index of the 'number' field
+    let number_index = st.fields.iter().position(|f| f.name == "number").unwrap();
+
+    // Check if the 'number' field was initialized
+    assert!(
+        wip.is_field_set(number_index).unwrap(),
+        "number field should be initialized"
+    );
+
+    // Check if the 'flag' field was left uninitialized (we handle booleans separately)
+    let flag_index = st.fields.iter().position(|f| f.name == "flag").unwrap();
+    assert!(
+        !wip.is_field_set(flag_index).unwrap(),
+        "flag field should not be initialized yet"
+    );
+
+    // Complete the boolean field initialization as done in from_slice
+    let field = wip.field(flag_index).unwrap();
+    let wip = parse_field(field, "false").unwrap();
+
+    // Build the final value and verify
+    let heap_value = wip.build().unwrap();
+    let test_struct: TestStruct = heap_value.materialize().unwrap();
+
+    assert_eq!(
+        test_struct.number, 42,
+        "number field should have default value 42"
+    );
+    assert!(!test_struct.flag, "flag field should be false");
+}
+
+#[test]
+fn test_apply_field_defaults_with_custom_default() {
+    facet_testhelpers::setup();
+
+    fn get_custom_default() -> String {
+        "custom default".to_string()
+    }
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct TestStructWithCustomDefault {
+        #[facet(default = 100)]
+        number: u32,
+        #[facet(default = get_custom_default())]
+        text: String,
+        flag: bool, // No default, should be untouched
+    }
+
+    // Create a Wip instance
+    let wip = Wip::alloc::<TestStructWithCustomDefault>().unwrap();
+
+    // Apply the defaults
+    let wip = apply_field_defaults(wip).unwrap();
+
+    // Check if the defaults were applied to non-boolean fields
+    let Type::User(UserType::Struct(st)) = wip.shape().ty else {
+        panic!("Expected struct type");
+    };
+
+    // Find field indices
+    let number_index = st.fields.iter().position(|f| f.name == "number").unwrap();
+    let text_index = st.fields.iter().position(|f| f.name == "text").unwrap();
+    let flag_index = st.fields.iter().position(|f| f.name == "flag").unwrap();
+
+    // Verify fields were initialized correctly
+    assert!(
+        wip.is_field_set(number_index).unwrap(),
+        "number field should be initialized"
+    );
+    assert!(
+        wip.is_field_set(text_index).unwrap(),
+        "text field should be initialized"
+    );
+    assert!(
+        !wip.is_field_set(flag_index).unwrap(),
+        "flag field should not be initialized yet"
+    );
+
+    // Complete the boolean field initialization
+    let field = wip.field(flag_index).unwrap();
+    let wip = parse_field(field, "false").unwrap();
+
+    // Build the final value and verify
+    let heap_value = wip.build().unwrap();
+    let test_struct: TestStructWithCustomDefault = heap_value.materialize().unwrap();
+
+    assert_eq!(
+        test_struct.number, 100,
+        "number field should have default value 100"
+    );
+    assert_eq!(
+        test_struct.text, "custom default",
+        "text field should have custom default value"
+    );
+    assert!(!test_struct.flag, "flag field should be false");
+}

--- a/facet-args/tests/parse.rs
+++ b/facet-args/tests/parse.rs
@@ -1,0 +1,335 @@
+#![cfg(test)]
+
+use eyre::{Ok, Result};
+use facet::Facet;
+use facet_args::parse::{parse_named_arg, parse_positional_arg, parse_short_arg};
+use facet_reflect::Wip;
+
+#[test]
+fn test_parse_named_arg() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct TestStruct {
+        #[facet(named)]
+        text: String,
+        #[facet(named)]
+        flag: bool,
+        #[facet(named)]
+        count: u32,
+    }
+
+    // Test parsing a named string argument
+    let wip = Wip::alloc::<TestStruct>()?;
+    let mut args = &["value_for_text"][..];
+    let wip = parse_named_arg(wip, "text", &mut args)?;
+
+    // Test parsing a named boolean argument
+    let wip = parse_named_arg(wip, "flag", &mut args)?;
+
+    // Test parsing a named numeric argument
+    let mut args = &["42"][..];
+    let wip = parse_named_arg(wip, "count", &mut args)?;
+
+    // Build and verify
+    let heap_value = wip.build()?;
+    let test_struct: TestStruct = heap_value.materialize()?;
+
+    assert_eq!(test_struct.text, "value_for_text");
+    assert!(test_struct.flag);
+    assert_eq!(test_struct.count, 42);
+
+    Ok(())
+}
+
+#[test]
+fn test_parse_named_arg_errors() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug)]
+    struct TestStruct {
+        #[facet(named)]
+        value: String,
+    }
+
+    // Test unknown argument error
+    let wip = Wip::alloc::<TestStruct>()?;
+    let mut args = &["some_value"][..];
+    let result = parse_named_arg(wip, "unknown_field", &mut args);
+    assert!(result.is_err());
+
+    // Check the error message without using unwrap_err()
+    if let Err(err) = result {
+        assert_eq!(
+            err.message(),
+            "Args error: Unknown argument `unknown_field`"
+        );
+    } else {
+        panic!("Expected an error but got Ok");
+    }
+
+    // Test missing value error
+    let wip = Wip::alloc::<TestStruct>()?;
+    let mut args = &[][..]; // Empty args
+    let result = parse_named_arg(wip, "value", &mut args);
+    assert!(result.is_err());
+
+    if let Err(err) = result {
+        assert_eq!(
+            err.message(),
+            "Args error: expected value after argument `value`"
+        );
+    } else {
+        panic!("Expected an error but got Ok");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_parse_short_arg() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct TestStruct {
+        #[facet(named, short = 'v')]
+        verbose: bool,
+        #[facet(named, short = 'c')]
+        count: u32,
+    }
+
+    // Get the struct type for testing
+    let wip = Wip::alloc::<TestStruct>()?;
+    let facet_core::Type::User(facet_core::UserType::Struct(st)) = wip.shape().ty else {
+        panic!("Expected struct type");
+    };
+
+    // Test parsing a short boolean flag
+    let wip = parse_short_arg(wip, "v", &mut &[][..], &st)?;
+
+    // Test parsing a short numeric argument
+    let mut args = &["42"][..];
+    let wip = parse_short_arg(wip, "c", &mut args, &st)?;
+
+    // Build and verify
+    let heap_value = wip.build()?;
+    let test_struct: TestStruct = heap_value.materialize()?;
+
+    assert!(test_struct.verbose);
+    assert_eq!(test_struct.count, 42);
+
+    Ok(())
+}
+
+#[test]
+fn test_parse_short_arg_errors() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug)]
+    struct TestStruct {
+        #[facet(named, short = 'c')]
+        count: u32,
+    }
+
+    // Get the struct type for testing
+    let wip = Wip::alloc::<TestStruct>()?;
+    let facet_core::Type::User(facet_core::UserType::Struct(st)) = wip.shape().ty else {
+        panic!("Expected struct type");
+    };
+
+    // Test unknown short argument
+    let result = parse_short_arg(wip, "x", &mut &[][..], &st);
+    assert!(result.is_err());
+
+    if let Err(err) = result {
+        assert_eq!(err.message(), "Args error: Unknown short argument `-x`");
+    } else {
+        panic!("Expected an error but got Ok");
+    }
+
+    // Test missing value for short argument
+    let wip = Wip::alloc::<TestStruct>()?;
+    let mut args = &[][..]; // Empty args
+    let result = parse_short_arg(wip, "c", &mut args, &st);
+    assert!(result.is_err());
+
+    if let Err(err) = result {
+        assert_eq!(
+            err.message(),
+            "Args error: expected value after argument `c`"
+        );
+    } else {
+        panic!("Expected an error but got Ok");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_parse_positional_arg() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct TestStruct {
+        #[facet(positional)]
+        path: String,
+        #[facet(positional)]
+        count: u32,
+    }
+
+    // Get the struct type for testing
+    let wip = Wip::alloc::<TestStruct>()?;
+    let facet_core::Type::User(facet_core::UserType::Struct(st)) = wip.shape().ty else {
+        panic!("Expected struct type");
+    };
+
+    // Test parsing first positional argument
+    let wip = parse_positional_arg(wip, "test.rs", &st)?;
+
+    // Test parsing second positional argument
+    let wip = parse_positional_arg(wip, "42", &st)?;
+
+    // Build and verify
+    let heap_value = wip.build()?;
+    let test_struct: TestStruct = heap_value.materialize()?;
+
+    assert_eq!(test_struct.path, "test.rs");
+    assert_eq!(test_struct.count, 42);
+
+    Ok(())
+}
+
+#[test]
+fn test_parse_positional_arg_errors() -> Result<()> {
+    facet_testhelpers::setup();
+
+    // Struct without positional args
+    #[derive(Facet, Debug)]
+    struct TestStructNoPositional {
+        #[facet(named)]
+        value: String,
+    }
+
+    // Get the struct type for testing
+    let wip = Wip::alloc::<TestStructNoPositional>()?;
+    let facet_core::Type::User(facet_core::UserType::Struct(st)) = wip.shape().ty else {
+        panic!("Expected struct type");
+    };
+
+    // Test no positional argument available
+    let result = parse_positional_arg(wip, "test.rs", &st);
+    assert!(result.is_err());
+
+    if let Err(err) = result {
+        assert_eq!(
+            err.message(),
+            "Args error: No positional argument field available for token `test.rs`"
+        );
+    } else {
+        panic!("Expected an error but got Ok");
+    }
+
+    // Struct with one positional arg already set
+    #[derive(Facet, Debug)]
+    struct TestStructOnePositional {
+        #[facet(positional)]
+        path: String,
+    }
+
+    // Create and set the positional field
+    let wip = Wip::alloc::<TestStructOnePositional>()?;
+    let facet_core::Type::User(facet_core::UserType::Struct(st)) = wip.shape().ty else {
+        panic!("Expected struct type");
+    };
+
+    // Set the positional field
+    let wip = parse_positional_arg(wip, "first.rs", &st)?;
+
+    // Now try to add another positional argument which should fail
+    let result = parse_positional_arg(wip, "second.rs", &st);
+    assert!(result.is_err());
+
+    if let Err(err) = result {
+        assert_eq!(
+            err.message(),
+            "Args error: No positional argument field available for token `second.rs`"
+        );
+    } else {
+        panic!("Expected an error but got Ok");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_parse_multiple_positional_args() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct TestStruct<'a> {
+        #[facet(positional)]
+        path: String,
+        #[facet(positional)]
+        path_borrow: &'a str,
+    }
+
+    // Get the struct type for testing
+    let wip = Wip::alloc::<TestStruct>()?;
+    let facet_core::Type::User(facet_core::UserType::Struct(st)) = wip.shape().ty else {
+        panic!("Expected struct type");
+    };
+
+    // Parse first positional arg
+    let wip = parse_positional_arg(wip, "example.rs", &st)?;
+
+    // Parse second positional arg
+    let wip = parse_positional_arg(wip, "test.rs", &st)?;
+
+    // Build and verify
+    let heap_value = wip.build()?;
+    let test_struct: TestStruct = heap_value.materialize()?;
+
+    assert_eq!(test_struct.path, "example.rs");
+    assert_eq!(test_struct.path_borrow, "test.rs");
+
+    Ok(())
+}
+
+#[test]
+fn test_parse_different_arg_types() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct TestStruct {
+        #[facet(named)]
+        string: String,
+        #[facet(named)]
+        number: u32,
+        #[facet(named)]
+        flag: bool,
+    }
+
+    // Test with different argument types
+    let wip = Wip::alloc::<TestStruct>()?;
+
+    // Parse string arg
+    let mut args = &["hello"][..];
+    let wip = parse_named_arg(wip, "string", &mut args)?;
+
+    // Parse numeric arg
+    let mut args = &["42"][..];
+    let wip = parse_named_arg(wip, "number", &mut args)?;
+
+    // Parse boolean arg
+    let wip = parse_named_arg(wip, "flag", &mut &[][..])?;
+
+    // Build and verify
+    let heap_value = wip.build()?;
+    let test_struct: TestStruct = heap_value.materialize()?;
+
+    assert_eq!(test_struct.string, "hello");
+    assert_eq!(test_struct.number, 42);
+    assert!(test_struct.flag);
+
+    Ok(())
+}

--- a/facet-args/tests/simple.rs
+++ b/facet-args/tests/simple.rs
@@ -1,3 +1,5 @@
+#![cfg(test)]
+
 use facet::Facet;
 
 use eyre::{Ok, Result};

--- a/facet-deserialize/src/lib.rs
+++ b/facet-deserialize/src/lib.rs
@@ -357,7 +357,7 @@ where
 /// and remembers the span of the last processed token to provide accurate error reporting.
 pub struct StackRunner<'input> {
     /// A version of the input that doesn't advance as we parse.
-    original_input: &'input [u8],
+    pub original_input: &'input [u8],
     /// The raw input data being deserialized.
     pub input: &'input [u8],
 
@@ -379,7 +379,7 @@ impl<'input> StackRunner<'input> {
         DeserError::new_reflect(err, self.original_input, self.last_span)
     }
 
-    fn pop<'facet>(
+    pub fn pop<'facet>(
         &mut self,
         mut wip: Wip<'facet>,
         reason: PopReason,


### PR DESCRIPTION
- Refactor of facet-args to rely on facet-deserialize, with structured default field parsing (i.e. done on a StackRunner)
  - which was then extracted into a dedicated module `defaults.rs` (with tests)
  - default handling done in dedicated functions moved over to a proper module `parse.rs` (with tests)

- I am still not using a Format trait (I drafted it but it didn't take and I walked it back), but it _is_ using facet-deserialize where it wasn't before so I'd suggest going with this?

- Note: 2 small `pub` changes in facet-deserialize (`original_input` field and `pop` fn)

- :shipit: Squished into one commit, ship/review at will

- **stretch goal** - while this PR is ready, I wanted to try developing a format trait and sort of got it, but it's a bit involved and still unsure if it will take so split that off to a draft PR #575 (that one is WIP)