### PR TITLE
feat: expose ordered-float feature through facet crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ dependencies = [
  "facet-core",
  "facet-derive",
  "facet-reflect",
+ "ordered-float",
  "static_assertions",
 ]
 

--- a/facet-core/src/impls_ordered_float.rs
+++ b/facet-core/src/impls_ordered_float.rs
@@ -63,6 +63,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for OrderedFloat<T> {
                 StructType::builder()
                     .repr(Repr::transparent())
                     .fields(&const { [field_in_type!(Self, 0)] })
+                    .kind(crate::StructKind::Tuple)
                     .build(),
             )))
             .def(Def::Scalar(
@@ -139,6 +140,7 @@ unsafe impl<'a, T: Facet<'a> + ordered_float::FloatCore + Clone + core::str::Fro
         }
 
         Shape::builder_for_sized::<Self>()
+            .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(ScalarAffinity::opaque().build())

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["facet", "introspection", "reflection"]
 categories = ["development-tools"]
 
 [package.metadata.docs.rs]
-features = ["std", "reflect", "camino"]
+features = ["std", "reflect", "camino", "ordered-float"]
 
 [features]
 default = ["std"]
@@ -22,6 +22,7 @@ camino = [
     "facet-core/camino",
 ] # Implements Facet for camino types (Utf8PathBuf, Utf8Path)
 uuid = ["facet-core/uuid"] # Implements Facet for Uuid
+ordered-float = ["facet-core/ordered-float"] # Implements Facet for OrderedFloat
 
 [dependencies]
 facet-core = { path = "../facet-core", version = "0.25.0", default-features = false }
@@ -35,3 +36,4 @@ cargo-husky = { version = "1.5.0", default-features = false, features = [
 ] }
 eyre = { version = "0.6.12", default-features = false }
 facet-reflect = { path = "../facet-reflect" }
+ordered-float = { version = "5.0.0", default-features = false }

--- a/facet/tests/ordered_float.rs
+++ b/facet/tests/ordered_float.rs
@@ -1,0 +1,22 @@
+#![cfg(feature = "ordered-float")]
+
+use facet::Facet;
+use ordered_float::{NotNan, OrderedFloat};
+
+#[test]
+fn test_ordered_float() {
+    let shape = <OrderedFloat<f64> as Facet>::SHAPE;
+    assert!(shape.inner.is_some());
+
+    let inner_shape = (shape.inner.unwrap())();
+    assert_eq!(inner_shape.id, <f64 as Facet>::SHAPE.id);
+}
+
+#[test]
+fn test_not_nan() {
+    let shape = <NotNan<f64> as Facet>::SHAPE;
+    assert!(shape.inner.is_some());
+
+    let inner_shape = (shape.inner.unwrap())();
+    assert_eq!(inner_shape.id, <f64 as Facet>::SHAPE.id);
+}


### PR DESCRIPTION
- Add ordered-float feature to facet/Cargo.toml that enables facet-core/ordered-float
- Add to docs.rs metadata to include the feature in documentation
- Fix implementation of OrderedFloat and NotNan with proper Type constructors
- Make NotNan opaque to handle its private fields
- Add tests to verify the implementation works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)