### PR TITLE
Add support for the time crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "divan-macros"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +375,7 @@ dependencies = [
  "facet-testhelpers 0.17.2",
  "impls",
  "ordered-float",
+ "time",
  "ulid",
  "uuid",
 ]
@@ -888,6 +898,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1008,12 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1259,6 +1281,37 @@ dependencies = [
  "libredox",
  "numtoa",
  "redox_termios",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,7 @@ dependencies = [
  "facet-testhelpers 0.17.2",
  "insta",
  "log",
+ "time",
 ]
 
 [[package]]
@@ -529,6 +530,7 @@ dependencies = [
  "log",
  "owo-colors",
  "tempfile",
+ "time",
  "ulid",
  "uuid",
 ]

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -17,7 +17,7 @@ camino = ["dep:camino", "alloc"]
 ordered-float = ["dep:ordered-float"]
 uuid = ["alloc", "dep:uuid"]
 ulid = ["alloc", "dep:ulid"]
-time = ["dep:time"]
+time = ["alloc", "dep:time"]
 
 [dependencies]
 impls = "1.0.3"

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -17,6 +17,7 @@ camino = ["dep:camino", "alloc"]
 ordered-float = ["dep:ordered-float"]
 uuid = ["alloc", "dep:uuid"]
 ulid = ["alloc", "dep:ulid"]
+time = ["dep:time"]
 
 [dependencies]
 impls = "1.0.3"
@@ -25,6 +26,10 @@ camino = { version = "1", optional = true }
 ordered-float = { version = "5.0.0", optional = true, default-features = false }
 uuid = { version = "1.16.0", optional = true }
 ulid = { version = "1.2.1", optional = true }
+time = { version = "0.3.41", optional = true, features = [
+    "parsing",
+    "formatting",
+] }
 
 [dev-dependencies]
 eyre = "0.6.12"

--- a/facet-core/src/impls_time.rs
+++ b/facet-core/src/impls_time.rs
@@ -1,0 +1,75 @@
+use time::{OffsetDateTime, UtcDateTime};
+
+use crate::{
+    Def, Facet, ParseError, PtrUninit, ScalarAffinity, ScalarDef, Shape, Type, UserType,
+    ValueVTable, value_vtable,
+};
+
+unsafe impl Facet<'_> for UtcDateTime {
+    const VTABLE: &'static ValueVTable =
+        &const { value_vtable!(UtcDateTime, |f, _opts| write!(f, "UtcDateTime")) };
+
+    const SHAPE: &'static Shape = &const {
+        Shape::builder_for_sized::<Self>()
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::Scalar(
+                ScalarDef::builder()
+                    .affinity(ScalarAffinity::time().build())
+                    .build(),
+            ))
+            .build()
+    };
+}
+
+unsafe impl Facet<'_> for OffsetDateTime {
+    const VTABLE: &'static ValueVTable = &const {
+        let mut vtable = value_vtable!(OffsetDateTime, |f, _opts| write!(f, "OffsetDateTime"));
+        vtable.parse = Some(|s: &str, target: PtrUninit| {
+            // Use the correct pattern for the `time` crate.
+            // RFC 3339 is the format of "2023-03-14T15:09:26Z"
+            let parsed = OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339)
+                .map_err(|_| ParseError::Generic("could not parse date"))?;
+            Ok(unsafe { target.put(parsed) })
+        });
+        vtable
+    };
+
+    const SHAPE: &'static Shape = &const {
+        Shape::builder_for_sized::<Self>()
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::Scalar(
+                ScalarDef::builder()
+                    .affinity(ScalarAffinity::time().build())
+                    .build(),
+            ))
+            .build()
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use time::OffsetDateTime;
+
+    use crate::Facet;
+
+    #[test]
+    fn parse_offset_date_time() -> eyre::Result<()> {
+        facet_testhelpers::setup();
+
+        let target = OffsetDateTime::SHAPE.allocate()?;
+        unsafe {
+            (OffsetDateTime::VTABLE.parse.unwrap())("2023-03-14T15:09:26Z", target)?;
+        }
+        let odt: OffsetDateTime = unsafe { target.assume_init().read() };
+        assert_eq!(
+            odt,
+            OffsetDateTime::parse(
+                "2023-03-14T15:09:26Z",
+                &time::format_description::well_known::Rfc3339
+            )
+            .unwrap()
+        );
+
+        Ok(())
+    }
+}

--- a/facet-core/src/impls_time.rs
+++ b/facet-core/src/impls_time.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use time::{OffsetDateTime, UtcDateTime};
 
 use crate::{

--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -44,6 +44,9 @@ mod impls_uuid;
 #[cfg(feature = "ulid")]
 mod impls_ulid;
 
+#[cfg(feature = "time")]
+mod impls_time;
+
 // Const type Id
 mod typeid;
 pub use typeid::*;

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -27,7 +27,9 @@ facet-serialize = { version = "0.23.4", path = "../facet-serialize", default-fea
 log = "0.4.27"
 
 [dev-dependencies]
+facet-core = { version = "0.25.1", path = "../facet-core", features = ["time"] }
 eyre = "0.6.12"
 facet = { path = "../facet" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 insta = "1.43.1"
+time = { version = "0.3.41", features = ["macros"] }

--- a/facet-json/tests/integration/read.rs
+++ b/facet-json/tests/integration/read.rs
@@ -1,4 +1,5 @@
 mod bool;
+mod datetime;
 mod deny_unknown_and_default;
 mod diagnostics;
 mod enums;

--- a/facet-json/tests/integration/read/datetime.rs
+++ b/facet-json/tests/integration/read/datetime.rs
@@ -1,0 +1,28 @@
+use eyre::Result;
+use facet::Facet;
+use facet_json::from_str;
+use time::OffsetDateTime;
+
+#[test]
+fn json_read_datetime() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        created_at: OffsetDateTime,
+    }
+
+    use time::macros::datetime;
+
+    let json = r#"{"created_at":"2023-01-15T12:34:56Z"}"#;
+
+    let s: FooBar = from_str(json)?;
+    assert_eq!(
+        s,
+        FooBar {
+            created_at: datetime!(2023-01-15 12:34:56 UTC),
+        }
+    );
+
+    Ok(())
+}

--- a/facet-json/tests/integration/write.rs
+++ b/facet-json/tests/integration/write.rs
@@ -1,3 +1,4 @@
+mod datetime;
 mod enums;
 mod json;
 mod map;

--- a/facet-json/tests/integration/write/datetime.rs
+++ b/facet-json/tests/integration/write/datetime.rs
@@ -1,0 +1,25 @@
+use eyre::Result;
+use facet::Facet;
+use facet_json::to_string;
+use time::OffsetDateTime;
+
+#[test]
+fn write_datetime() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        created_at: OffsetDateTime,
+    }
+
+    use time::macros::datetime;
+
+    let value = FooBar {
+        created_at: datetime!(2023-01-15 12:34:56 UTC),
+    };
+
+    let json = to_string(&value);
+    assert_eq!(json, r#"{"created_at":"2023-01-15T12:34:56Z"}"#);
+
+    Ok(())
+}

--- a/facet-reflect/Cargo.toml
+++ b/facet-reflect/Cargo.toml
@@ -23,6 +23,7 @@ slow-tests = [] # Enable slow tests (compile tests)
 camino = ["alloc", "dep:camino", "facet-core/camino"]
 uuid = ["alloc", "dep:uuid", "facet-core/uuid"]
 ulid = ["alloc", "dep:ulid", "facet-core/ulid"]
+time = ["dep:time"]
 
 [dependencies]
 bitflags = "2.9.0"
@@ -32,6 +33,10 @@ owo-colors = { version = "4.2.0" }
 camino = { version = "1", optional = true }
 uuid = { version = "1.16.0", optional = true }
 ulid = { version = "1.2.1", optional = true }
+time = { version = "0.3.41", optional = true, features = [
+    "formatting",
+    "parsing",
+] }
 
 [dev-dependencies]
 eyre = "0.6.12"


### PR DESCRIPTION
While doing this it reminded me that I think `ScalarType` is kinda duplicated with ScalarAffinity.

And also that I think DateTime affinities should have vtables.