### PR TITLE
Add new `SetDef` and impls for `HashSet` and `BTreeSet`

### DIFF
--- a/facet-core/src/impls_alloc/btreeset.rs
+++ b/facet-core/src/impls_alloc/btreeset.rs
@@ -1,5 +1,6 @@
 use core::hash::Hash;
 
+use alloc::boxed::Box;
 use alloc::collections::BTreeSet;
 
 use crate::ptr::{PtrConst, PtrMut};

--- a/facet-core/src/impls_alloc/btreeset.rs
+++ b/facet-core/src/impls_alloc/btreeset.rs
@@ -1,0 +1,307 @@
+use core::hash::Hash;
+
+use alloc::collections::BTreeSet;
+
+use crate::ptr::{PtrConst, PtrMut};
+
+use crate::{
+    Def, Facet, MarkerTraits, SetDef, SetIterVTable, SetVTable, Shape, Type, TypeParam, UserType,
+    VTableView, ValueVTable,
+};
+
+struct BTreeSetIterator<'mem, T> {
+    set: &'mem BTreeSet<T>,
+    next_bound: core::ops::Bound<&'mem T>,
+}
+
+impl<'mem, T> BTreeSetIterator<'mem, T>
+where
+    T: Ord,
+{
+    fn next(&mut self) -> Option<&'mem T> {
+        let mut range = self
+            .set
+            .range((self.next_bound, core::ops::Bound::Unbounded));
+        let next = range.next();
+
+        if let Some(next) = next {
+            self.next_bound = core::ops::Bound::Excluded(next);
+        }
+
+        next
+    }
+}
+
+unsafe impl<'a, T> Facet<'a> for BTreeSet<T>
+where
+    T: Facet<'a> + core::cmp::Eq + core::cmp::Ord,
+{
+    const VTABLE: &'static ValueVTable = &const {
+        let mut builder = ValueVTable::builder::<Self>()
+            .marker_traits(
+                MarkerTraits::SEND
+                    .union(MarkerTraits::SYNC)
+                    .union(MarkerTraits::EQ)
+                    .union(MarkerTraits::UNPIN)
+                    .intersection(T::SHAPE.vtable.marker_traits),
+            )
+            .type_name(|f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "BTreeSet<")?;
+                    (T::SHAPE.vtable.type_name)(f, opts)?;
+                    write!(f, ">")
+                } else {
+                    write!(f, "BTreeSet<⋯>")
+                }
+            })
+            .default_in_place(|target| unsafe { target.put(Self::default()) })
+            .eq(|a, b| a == b);
+
+        if T::SHAPE.vtable.debug.is_some() {
+            builder = builder.debug(|value, f| {
+                let t_debug = <VTableView<T>>::of().debug().unwrap();
+                write!(f, "{{")?;
+                for (i, item) in value.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    (t_debug)(item, f)?;
+                }
+                write!(f, "}}")
+            });
+        }
+
+        if T::SHAPE.vtable.clone_into.is_some() {
+            builder = builder.clone_into(|src, dst| unsafe {
+                let set = src;
+                let mut new_set = BTreeSet::new();
+
+                let t_clone_into = <VTableView<T>>::of().clone_into().unwrap();
+
+                for item in set {
+                    use crate::TypedPtrUninit;
+                    use core::mem::MaybeUninit;
+
+                    let mut new_item = MaybeUninit::<T>::uninit();
+                    let uninit_item = TypedPtrUninit::new(new_item.as_mut_ptr());
+
+                    (t_clone_into)(item, uninit_item);
+
+                    new_set.insert(new_item.assume_init());
+                }
+
+                dst.put(new_set)
+            });
+        }
+
+        if T::SHAPE.vtable.hash.is_some() {
+            builder = builder.hash(|set, hasher_this, hasher_write_fn| unsafe {
+                use crate::HasherProxy;
+                let t_hash = <VTableView<T>>::of().hash().unwrap();
+                let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
+                set.len().hash(&mut hasher);
+                for item in set {
+                    (t_hash)(item, hasher_this, hasher_write_fn);
+                }
+            });
+        }
+
+        builder.build()
+    };
+
+    const SHAPE: &'static Shape = &const {
+        Shape::builder_for_sized::<Self>()
+            .type_params(&[TypeParam {
+                name: "T",
+                shape: || T::SHAPE,
+            }])
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::Set(
+                SetDef::builder()
+                    .t(|| T::SHAPE)
+                    .vtable(
+                        &const {
+                            SetVTable::builder()
+                                .init_in_place_with_capacity(|uninit, _capacity| unsafe {
+                                    uninit.put(Self::new())
+                                })
+                                .insert(|ptr, item| unsafe {
+                                    let set = ptr.as_mut::<BTreeSet<T>>();
+                                    let item = item.read::<T>();
+                                    set.insert(item)
+                                })
+                                .len(|ptr| unsafe {
+                                    let set = ptr.get::<BTreeSet<T>>();
+                                    set.len()
+                                })
+                                .contains(|ptr, item| unsafe {
+                                    let set = ptr.get::<BTreeSet<T>>();
+                                    set.contains(item.get())
+                                })
+                                .iter(|ptr| {
+                                    let set = unsafe { ptr.get::<BTreeSet<T>>() };
+                                    let iter_state = Box::new(BTreeSetIterator {
+                                        set,
+                                        next_bound: core::ops::Bound::Unbounded,
+                                    });
+                                    PtrMut::new(Box::into_raw(iter_state) as *mut u8)
+                                })
+                                .iter_vtable(
+                                    SetIterVTable::builder()
+                                        .next(|iter_ptr| {
+                                            let state = unsafe {
+                                                iter_ptr.as_mut::<BTreeSetIterator<'_, T>>()
+                                            };
+                                            state
+                                                .next()
+                                                .map(|value| PtrConst::new(value as *const T))
+                                        })
+                                        .dealloc(|iter_ptr| unsafe {
+                                            drop(Box::from_raw(
+                                                iter_ptr.as_ptr::<BTreeSetIterator<'_, T>>()
+                                                    as *mut BTreeSetIterator<'_, T>,
+                                            ));
+                                        })
+                                        .build(),
+                                )
+                                .build()
+                        },
+                    )
+                    .build(),
+            ))
+            .build()
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeSet;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    use super::*;
+
+    #[test]
+    fn test_btreesetset_type_params() {
+        let [type_param_1] = <BTreeSet<i32>>::SHAPE.type_params else {
+            panic!("BTreeSet<T> should have 1 type param")
+        };
+        assert_eq!(type_param_1.shape(), i32::SHAPE);
+    }
+
+    #[test]
+    fn test_btreeset_vtable_1_new_insert_iter_drop() -> eyre::Result<()> {
+        facet_testhelpers::setup();
+
+        let btreeset_shape = <BTreeSet<String>>::SHAPE;
+        let btreeset_def = btreeset_shape
+            .def
+            .into_set()
+            .expect("BTreeSet<T> should have a set definition");
+
+        // Allocate memory for the BTreeSet
+        let btreeset_uninit_ptr = btreeset_shape.allocate()?;
+
+        // Create the BTreeSet
+        let btreeset_ptr =
+            unsafe { (btreeset_def.vtable.init_in_place_with_capacity_fn)(btreeset_uninit_ptr, 0) };
+
+        // The BTreeSet is empty, so ensure its length is 0
+        let btreeset_actual_length =
+            unsafe { (btreeset_def.vtable.len_fn)(btreeset_ptr.as_const()) };
+        assert_eq!(btreeset_actual_length, 0);
+
+        // 5 sample values to insert
+        let strings = ["foo", "bar", "bazz", "fizzbuzz", "fifth thing"];
+
+        // Insert the 5 values into the BTreeSet
+        let mut btreeset_length = 0;
+        for string in strings {
+            // Create the value
+            let mut new_value = string.to_string();
+
+            // Insert the value
+            let did_insert = unsafe {
+                (btreeset_def.vtable.insert_fn)(btreeset_ptr, PtrMut::new(&raw mut new_value))
+            };
+
+            // The value now belongs to the BTreeSet, so forget it
+            core::mem::forget(new_value);
+
+            assert!(did_insert, "expected value to be inserted in the BTreeSet");
+
+            // Ensure the BTreeSet's length increased by 1
+            btreeset_length += 1;
+            let btreeset_actual_length =
+                unsafe { (btreeset_def.vtable.len_fn)(btreeset_ptr.as_const()) };
+            assert_eq!(btreeset_actual_length, btreeset_length);
+        }
+
+        // Insert the same 5 values again, ensuring they are deduplicated
+        for string in strings {
+            // Create the value
+            let mut new_value = string.to_string();
+
+            // Try to insert the value
+            let did_insert = unsafe {
+                (btreeset_def.vtable.insert_fn)(btreeset_ptr, PtrMut::new(&raw mut new_value))
+            };
+
+            // The value now belongs to the BTreeSet, so forget it
+            core::mem::forget(new_value);
+
+            assert!(
+                !did_insert,
+                "expected value to not be inserted in the BTreeSet"
+            );
+
+            // Ensure the BTreeSet's length did not increase
+            let btreeset_actual_length =
+                unsafe { (btreeset_def.vtable.len_fn)(btreeset_ptr.as_const()) };
+            assert_eq!(btreeset_actual_length, btreeset_length);
+        }
+
+        // Create a new iterator over the BTreeSet
+        let btreeset_iter_ptr = unsafe { (btreeset_def.vtable.iter_fn)(btreeset_ptr.as_const()) };
+
+        // Collect all the items from the BTreeSet's iterator
+        let mut iter_items = Vec::<&str>::new();
+        loop {
+            // Get the next item from the iterator
+            let item_ptr = unsafe { (btreeset_def.vtable.iter_vtable.next)(btreeset_iter_ptr) };
+            let Some(item_ptr) = item_ptr else {
+                break;
+            };
+
+            let item = unsafe { item_ptr.get::<String>() };
+
+            // Add the item into the list of items returned from the iterator
+            iter_items.push(&**item);
+        }
+
+        // Deallocate the iterator
+        unsafe {
+            (btreeset_def.vtable.iter_vtable.dealloc)(btreeset_iter_ptr);
+        }
+
+        // BTrees iterate in sorted order, so ensure the iterator returned
+        // each item in order
+        let mut strings_sorted = strings.to_vec();
+        strings_sorted.sort();
+        assert_eq!(iter_items, strings_sorted);
+
+        // Get the function pointer for dropping the BTreeSet
+        let drop_fn = btreeset_shape
+            .vtable
+            .drop_in_place
+            .expect("BTreeSet<T> should have drop_in_place");
+
+        // Drop the BTreeSet in place
+        unsafe { drop_fn(btreeset_ptr) };
+
+        // Deallocate the memory
+        unsafe { btreeset_shape.deallocate_mut(btreeset_ptr)? };
+
+        Ok(())
+    }
+}

--- a/facet-core/src/impls_alloc/mod.rs
+++ b/facet-core/src/impls_alloc/mod.rs
@@ -1,6 +1,7 @@
 mod arc;
 mod boxed;
 mod btreemap;
+mod btreeset;
 mod rc;
 mod string;
 mod vec;

--- a/facet-core/src/impls_std/hashset.rs
+++ b/facet-core/src/impls_std/hashset.rs
@@ -1,0 +1,294 @@
+use alloc::collections::VecDeque;
+use core::hash::{BuildHasher, Hash};
+use std::collections::HashSet;
+
+use crate::ptr::{PtrConst, PtrMut};
+
+use crate::{
+    Def, Facet, MarkerTraits, SetDef, SetIterVTable, SetVTable, Shape, Type, TypeParam, UserType,
+    VTableView, ValueVTable,
+};
+
+struct HashSetIterator<'mem, T> {
+    items: VecDeque<&'mem T>,
+}
+
+unsafe impl<'a, T, S> Facet<'a> for HashSet<T, S>
+where
+    T: Facet<'a> + core::cmp::Eq + core::hash::Hash,
+    S: Facet<'a> + Default + BuildHasher,
+{
+    const VTABLE: &'static ValueVTable = &const {
+        let mut builder = ValueVTable::builder::<Self>()
+            .marker_traits(
+                MarkerTraits::SEND
+                    .union(MarkerTraits::SYNC)
+                    .union(MarkerTraits::EQ)
+                    .union(MarkerTraits::UNPIN)
+                    .intersection(T::SHAPE.vtable.marker_traits),
+            )
+            .type_name(|f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "HashSet<")?;
+                    (T::SHAPE.vtable.type_name)(f, opts)?;
+                    write!(f, ">")
+                } else {
+                    write!(f, "HashSet<⋯>")
+                }
+            })
+            .default_in_place(|target| unsafe { target.put(Self::default()) })
+            .eq(|a, b| a == b);
+
+        if T::SHAPE.vtable.debug.is_some() {
+            builder = builder.debug(|value, f| {
+                let t_debug = <VTableView<T>>::of().debug().unwrap();
+                write!(f, "{{")?;
+                for (i, item) in value.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    (t_debug)(item, f)?;
+                }
+                write!(f, "}}")
+            });
+        }
+
+        if T::SHAPE.vtable.clone_into.is_some() {
+            builder = builder.clone_into(|src, dst| unsafe {
+                let set = src;
+                let mut new_set = HashSet::with_capacity_and_hasher(set.len(), S::default());
+
+                let t_clone_into = <VTableView<T>>::of().clone_into().unwrap();
+
+                for item in set {
+                    use crate::TypedPtrUninit;
+                    use core::mem::MaybeUninit;
+
+                    let mut new_item = MaybeUninit::<T>::uninit();
+                    let uninit_item = TypedPtrUninit::new(new_item.as_mut_ptr());
+
+                    (t_clone_into)(item, uninit_item);
+
+                    new_set.insert(new_item.assume_init());
+                }
+
+                dst.put(new_set)
+            });
+        }
+
+        if T::SHAPE.vtable.hash.is_some() {
+            builder = builder.hash(|set, hasher_this, hasher_write_fn| unsafe {
+                use crate::HasherProxy;
+                let t_hash = <VTableView<T>>::of().hash().unwrap();
+                let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
+                set.len().hash(&mut hasher);
+                for item in set {
+                    (t_hash)(item, hasher_this, hasher_write_fn);
+                }
+            });
+        }
+
+        builder.build()
+    };
+
+    const SHAPE: &'static Shape = &const {
+        Shape::builder_for_sized::<Self>()
+            .type_params(&[
+                TypeParam {
+                    name: "T",
+                    shape: || T::SHAPE,
+                },
+                TypeParam {
+                    name: "S",
+                    shape: || S::SHAPE,
+                },
+            ])
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::Set(
+                SetDef::builder()
+                    .t(|| T::SHAPE)
+                    .vtable(
+                        &const {
+                            SetVTable::builder()
+                                .init_in_place_with_capacity(|uninit, capacity| unsafe {
+                                    uninit
+                                        .put(Self::with_capacity_and_hasher(capacity, S::default()))
+                                })
+                                .insert(|ptr, item| unsafe {
+                                    let set = ptr.as_mut::<HashSet<T>>();
+                                    let item = item.read::<T>();
+                                    set.insert(item)
+                                })
+                                .len(|ptr| unsafe {
+                                    let set = ptr.get::<HashSet<T>>();
+                                    set.len()
+                                })
+                                .contains(|ptr, item| unsafe {
+                                    let set = ptr.get::<HashSet<T>>();
+                                    set.contains(item.get())
+                                })
+                                .iter(|ptr| unsafe {
+                                    let set = ptr.get::<HashSet<T>>();
+                                    let items: VecDeque<&T> = set.iter().collect();
+                                    let iter_state = Box::new(HashSetIterator { items });
+                                    PtrMut::new(Box::into_raw(iter_state) as *mut u8)
+                                })
+                                .iter_vtable(
+                                    SetIterVTable::builder()
+                                        .next(|iter_ptr| unsafe {
+                                            let state = iter_ptr.as_mut::<HashSetIterator<'_, T>>();
+                                            state
+                                                .items
+                                                .pop_front()
+                                                .map(|item| PtrConst::new(item as *const T))
+                                        })
+                                        .dealloc(|iter_ptr| unsafe {
+                                            drop(Box::from_raw(
+                                                iter_ptr.as_ptr::<HashSetIterator<'_, T>>()
+                                                    as *mut HashSetIterator<'_, T>,
+                                            ));
+                                        })
+                                        .build(),
+                                )
+                                .build()
+                        },
+                    )
+                    .build(),
+            ))
+            .build()
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+    use std::collections::HashSet;
+    use std::hash::RandomState;
+
+    use super::*;
+
+    #[test]
+    fn test_hashset_type_params() {
+        // HashSet should have a type param for both its value type
+        // and its hasher state
+        let [type_param_1, type_param_2] = <HashSet<i32>>::SHAPE.type_params else {
+            panic!("HashSet<T> should have 2 type params")
+        };
+        assert_eq!(type_param_1.shape(), i32::SHAPE);
+        assert_eq!(type_param_2.shape(), RandomState::SHAPE);
+    }
+
+    #[test]
+    fn test_hashset_vtable_1_new_insert_iter_drop() -> eyre::Result<()> {
+        facet_testhelpers::setup();
+
+        let hashset_shape = <HashSet<String>>::SHAPE;
+        let hashset_def = hashset_shape
+            .def
+            .into_set()
+            .expect("HashSet<T> should have a set definition");
+
+        // Allocate memory for the HashSet
+        let hashset_uninit_ptr = hashset_shape.allocate()?;
+
+        // Create the HashSet with a capacity of 3
+        let hashset_ptr =
+            unsafe { (hashset_def.vtable.init_in_place_with_capacity_fn)(hashset_uninit_ptr, 3) };
+
+        // The HashSet is empty, so ensure its length is 0
+        let hashset_actual_length = unsafe { (hashset_def.vtable.len_fn)(hashset_ptr.as_const()) };
+        assert_eq!(hashset_actual_length, 0);
+
+        // 5 sample values to insert
+        let strings = ["foo", "bar", "bazz", "fizzbuzz", "fifth thing"];
+
+        // Insert the 5 values into the HashSet
+        let mut hashset_length = 0;
+        for string in strings {
+            // Create the value
+            let mut new_value = string.to_string();
+
+            // Insert the value
+            let did_insert = unsafe {
+                (hashset_def.vtable.insert_fn)(hashset_ptr, PtrMut::new(&raw mut new_value))
+            };
+
+            // The value now belongs to the HashSet, so forget it
+            core::mem::forget(new_value);
+
+            assert!(did_insert, "expected value to be inserted in the HashSet");
+
+            // Ensure the HashSet's length increased by 1
+            hashset_length += 1;
+            let hashset_actual_length =
+                unsafe { (hashset_def.vtable.len_fn)(hashset_ptr.as_const()) };
+            assert_eq!(hashset_actual_length, hashset_length);
+        }
+
+        // Insert the same 5 values again, ensuring they are deduplicated
+        for string in strings {
+            // Create the value
+            let mut new_value = string.to_string();
+
+            // Try to insert the value
+            let did_insert = unsafe {
+                (hashset_def.vtable.insert_fn)(hashset_ptr, PtrMut::new(&raw mut new_value))
+            };
+
+            // The value now belongs to the HashSet, so forget it
+            core::mem::forget(new_value);
+
+            assert!(
+                !did_insert,
+                "expected value to not be inserted in the HashSet"
+            );
+
+            // Ensure the HashSet's length did not increase
+            let hashset_actual_length =
+                unsafe { (hashset_def.vtable.len_fn)(hashset_ptr.as_const()) };
+            assert_eq!(hashset_actual_length, hashset_length);
+        }
+
+        // Create a new iterator over the HashSet
+        let hashset_iter_ptr = unsafe { (hashset_def.vtable.iter_fn)(hashset_ptr.as_const()) };
+
+        // Collect all the items from the HashSet's iterator
+        let mut iter_items = HashSet::<&str>::new();
+        loop {
+            // Get the next item from the iterator
+            let item_ptr = unsafe { (hashset_def.vtable.iter_vtable.next)(hashset_iter_ptr) };
+            let Some(item_ptr) = item_ptr else {
+                break;
+            };
+
+            let item = unsafe { item_ptr.get::<String>() };
+
+            // Insert the item into the set of items returned from the iterator
+            let did_insert = iter_items.insert(&**item);
+
+            assert!(did_insert, "HashSet iterator returned duplicate item");
+        }
+
+        // Deallocate the iterator
+        unsafe {
+            (hashset_def.vtable.iter_vtable.dealloc)(hashset_iter_ptr);
+        }
+
+        // Ensure the iterator returned all of the strings
+        assert_eq!(iter_items, strings.iter().copied().collect::<HashSet<_>>());
+
+        // Get the function pointer for dropping the HashSet
+        let drop_fn = hashset_shape
+            .vtable
+            .drop_in_place
+            .expect("HashSet<T> should have drop_in_place");
+
+        // Drop the HashSet in place
+        unsafe { drop_fn(hashset_ptr) };
+
+        // Deallocate the memory
+        unsafe { hashset_shape.deallocate_mut(hashset_ptr)? };
+
+        Ok(())
+    }
+}

--- a/facet-core/src/impls_std/mod.rs
+++ b/facet-core/src/impls_std/mod.rs
@@ -1,2 +1,3 @@
 mod hashmap;
+mod hashset;
 mod path;

--- a/facet-core/src/types/def/list.rs
+++ b/facet-core/src/types/def/list.rs
@@ -102,8 +102,7 @@ pub type ListAsPtrFn = unsafe fn(list: PtrConst) -> PtrConst;
 /// The `list` parameter must point to aligned, initialized memory of the correct type.
 pub type ListAsMutPtrFn = unsafe fn(list: PtrMut) -> PtrMut;
 
-/// Virtual table for a list-like type (like `Vec<T>`,
-/// but also `HashSet<T>`, etc.)
+/// Virtual table for a list-like type (like `Vec<T>`)
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 #[repr(C)]
 #[non_exhaustive]

--- a/facet-core/src/types/def/mod.rs
+++ b/facet-core/src/types/def/mod.rs
@@ -12,6 +12,9 @@ pub use list::*;
 mod map;
 pub use map::*;
 
+mod set;
+pub use set::*;
+
 mod option;
 pub use option::*;
 
@@ -45,6 +48,11 @@ pub enum Def {
     ///
     /// e.g. `Map<String, T>`
     Map(MapDef),
+
+    /// Unique set of homogenous values
+    ///
+    /// e.g. `HashSet<T>`
+    Set(SetDef),
 
     /// Ordered list of heterogenous values, variable size
     ///
@@ -83,6 +91,13 @@ impl Def {
     pub fn into_map(self) -> Result<MapDef, Self> {
         match self {
             Self::Map(def) => Ok(def),
+            _ => Err(self),
+        }
+    }
+    /// Returns the `SetDef` wrapped in an `Ok` if this is a [`Def::Set`].
+    pub fn into_set(self) -> Result<SetDef, Self> {
+        match self {
+            Self::Set(def) => Ok(def),
             _ => Err(self),
         }
     }

--- a/facet-core/src/types/def/mod.rs
+++ b/facet-core/src/types/def/mod.rs
@@ -46,7 +46,7 @@ pub enum Def {
 
     /// Map — keys are dynamic (and strings, sorry), values are homogeneous
     ///
-    /// e.g. `Map<String, T>`
+    /// e.g. `HashMap<String, T>`
     Map(MapDef),
 
     /// Unique set of homogenous values

--- a/facet-core/src/types/def/set.rs
+++ b/facet-core/src/types/def/set.rs
@@ -1,0 +1,286 @@
+use crate::ptr::{PtrConst, PtrMut, PtrUninit};
+
+use super::Shape;
+
+/// Fields for set types
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[repr(C)]
+#[non_exhaustive]
+pub struct SetDef {
+    /// vtable for interacting with the set
+    pub vtable: &'static SetVTable,
+    /// shape of the values in the set
+    pub t: fn() -> &'static Shape,
+}
+
+impl SetDef {
+    /// Returns a builder for SetDef
+    pub const fn builder() -> SetDefBuilder {
+        SetDefBuilder::new()
+    }
+
+    /// Returns the shape of the items in the set
+    pub fn t(&self) -> &'static Shape {
+        (self.t)()
+    }
+}
+
+/// Builder for SetDef
+pub struct SetDefBuilder {
+    vtable: Option<&'static SetVTable>,
+    t: Option<fn() -> &'static Shape>,
+}
+
+impl SetDefBuilder {
+    /// Creates a new SetDefBuilder
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self {
+            vtable: None,
+            t: None,
+        }
+    }
+
+    /// Sets the vtable for the SetDef
+    pub const fn vtable(mut self, vtable: &'static SetVTable) -> Self {
+        self.vtable = Some(vtable);
+        self
+    }
+
+    /// Sets the value shape for the SetDef
+    pub const fn t(mut self, t: fn() -> &'static Shape) -> Self {
+        self.t = Some(t);
+        self
+    }
+
+    /// Builds the SetDef
+    pub const fn build(self) -> SetDef {
+        SetDef {
+            vtable: self.vtable.unwrap(),
+            t: self.t.unwrap(),
+        }
+    }
+}
+
+/// Initialize a set in place with a given capacity
+///
+/// # Safety
+///
+/// The `set` parameter must point to uninitialized memory of sufficient size.
+/// The function must properly initialize the memory.
+pub type SetInitInPlaceWithCapacityFn =
+    for<'mem> unsafe fn(set: PtrUninit<'mem>, capacity: usize) -> PtrMut<'mem>;
+
+/// Insert a value in the set if not already contained, returning true
+/// if the value wasn't present before
+///
+/// # Safety
+///
+/// The `set` parameter must point to aligned, initialized memory of the correct type.
+/// `value` is moved out of (with [`core::ptr::read`]) — it should be deallocated afterwards (e.g.
+/// with [`core::mem::forget`]) but NOT dropped.
+pub type SetInsertFn =
+    for<'set, 'value> unsafe fn(set: PtrMut<'set>, value: PtrMut<'value>) -> bool;
+
+/// Get the number of values in the set
+///
+/// # Safety
+///
+/// The `set` parameter must point to aligned, initialized memory of the correct type.
+pub type SetLenFn = for<'set> unsafe fn(set: PtrConst<'set>) -> usize;
+
+/// Check if the set contains a value
+///
+/// # Safety
+///
+/// The `set` parameter must point to aligned, initialized memory of the correct type.
+pub type SetContainsFn =
+    for<'set, 'value> unsafe fn(set: PtrConst<'set>, value: PtrConst<'value>) -> bool;
+
+/// Get an iterator over the set
+///
+/// # Safety
+///
+/// The `set` parameter must point to aligned, initialized memory of the correct type.
+pub type SetIterFn = for<'set> unsafe fn(set: PtrConst<'set>) -> PtrMut<'set>;
+
+/// Get the next value from the iterator
+///
+/// # Safety
+///
+/// The `iter` parameter must point to aligned, initialized memory of the correct type.
+pub type SetIterNextFn = for<'iter> unsafe fn(iter: PtrMut<'iter>) -> Option<PtrConst<'iter>>;
+
+/// Deallocate the iterator
+///
+/// # Safety
+///
+/// The `iter` parameter must point to aligned, initialized memory of the correct type.
+pub type SetIterDeallocFn = for<'iter> unsafe fn(iter: PtrMut<'iter>);
+
+/// VTable for an iterator over a set
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[repr(C)]
+#[non_exhaustive]
+pub struct SetIterVTable {
+    /// cf. [`SetIterNextFn`]
+    pub next: SetIterNextFn,
+
+    /// cf. [`SetIterDeallocFn`]
+    pub dealloc: SetIterDeallocFn,
+}
+
+impl SetIterVTable {
+    /// Returns a builder for SetIterVTable
+    pub const fn builder() -> SetIterVTableBuilder {
+        SetIterVTableBuilder::new()
+    }
+}
+
+/// Builds a [`SetIterVTable`]
+pub struct SetIterVTableBuilder {
+    next: Option<SetIterNextFn>,
+    dealloc: Option<SetIterDeallocFn>,
+}
+
+impl SetIterVTableBuilder {
+    /// Creates a new [`SetIterVTableBuilder`] with all fields set to `None`.
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self {
+            next: None,
+            dealloc: None,
+        }
+    }
+
+    /// Sets the next field
+    pub const fn next(mut self, f: SetIterNextFn) -> Self {
+        self.next = Some(f);
+        self
+    }
+
+    /// Sets the dealloc field
+    pub const fn dealloc(mut self, f: SetIterDeallocFn) -> Self {
+        self.dealloc = Some(f);
+        self
+    }
+
+    /// Builds the [`SetIterVTable`] from the current state of the builder.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if any of the required fields are `None`.
+    pub const fn build(self) -> SetIterVTable {
+        SetIterVTable {
+            next: self.next.unwrap(),
+            dealloc: self.dealloc.unwrap(),
+        }
+    }
+}
+
+/// Virtual table for a Set<T>
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[repr(C)]
+pub struct SetVTable {
+    /// cf. [`SetInitInPlaceWithCapacityFn`]
+    pub init_in_place_with_capacity_fn: SetInitInPlaceWithCapacityFn,
+
+    /// cf. [`SetInsertFn`]
+    pub insert_fn: SetInsertFn,
+
+    /// cf. [`SetLenFn`]
+    pub len_fn: SetLenFn,
+
+    /// cf. [`SetContainsFn`]
+    pub contains_fn: SetContainsFn,
+
+    /// cf. [`SetIterFn`]
+    pub iter_fn: SetIterFn,
+
+    /// Virtual table for set iterator operations
+    pub iter_vtable: SetIterVTable,
+}
+
+impl SetVTable {
+    /// Returns a builder for SetVTable
+    pub const fn builder() -> SetVTableBuilder {
+        SetVTableBuilder::new()
+    }
+}
+
+/// Builds a [`SetVTable`]
+pub struct SetVTableBuilder {
+    init_in_place_with_capacity_fn: Option<SetInitInPlaceWithCapacityFn>,
+    insert_fn: Option<SetInsertFn>,
+    len_fn: Option<SetLenFn>,
+    contains_fn: Option<SetContainsFn>,
+    iter_fn: Option<SetIterFn>,
+    iter_vtable: Option<SetIterVTable>,
+}
+
+impl SetVTableBuilder {
+    /// Creates a new [`SetVTableBuilder`] with all fields set to `None`.
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self {
+            init_in_place_with_capacity_fn: None,
+            insert_fn: None,
+            len_fn: None,
+            contains_fn: None,
+            iter_fn: None,
+            iter_vtable: None,
+        }
+    }
+
+    /// Sets the init_in_place_with_capacity_fn field
+    pub const fn init_in_place_with_capacity(mut self, f: SetInitInPlaceWithCapacityFn) -> Self {
+        self.init_in_place_with_capacity_fn = Some(f);
+        self
+    }
+
+    /// Sets the insert_fn field
+    pub const fn insert(mut self, f: SetInsertFn) -> Self {
+        self.insert_fn = Some(f);
+        self
+    }
+
+    /// Sets the len_fn field
+    pub const fn len(mut self, f: SetLenFn) -> Self {
+        self.len_fn = Some(f);
+        self
+    }
+
+    /// Sets the contains_fn field
+    pub const fn contains(mut self, f: SetContainsFn) -> Self {
+        self.contains_fn = Some(f);
+        self
+    }
+
+    /// Sets the iter_fn field
+    pub const fn iter(mut self, f: SetIterFn) -> Self {
+        self.iter_fn = Some(f);
+        self
+    }
+
+    /// Sets the iter_vtable field
+    pub const fn iter_vtable(mut self, vtable: SetIterVTable) -> Self {
+        self.iter_vtable = Some(vtable);
+        self
+    }
+
+    /// Builds the [`SetVTable`] from the current state of the builder.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if any of the required fields are `None`.
+    pub const fn build(self) -> SetVTable {
+        SetVTable {
+            init_in_place_with_capacity_fn: self.init_in_place_with_capacity_fn.unwrap(),
+            insert_fn: self.insert_fn.unwrap(),
+            len_fn: self.len_fn.unwrap(),
+            contains_fn: self.contains_fn.unwrap(),
+            iter_fn: self.iter_fn.unwrap(),
+            iter_vtable: self.iter_vtable.unwrap(),
+        }
+    }
+}

--- a/facet-core/src/types/def/set.rs
+++ b/facet-core/src/types/def/set.rs
@@ -178,7 +178,7 @@ impl SetIterVTableBuilder {
     }
 }
 
-/// Virtual table for a Set<T>
+/// Virtual table for a `Set<T>`
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 #[repr(C)]
 pub struct SetVTable {


### PR DESCRIPTION
Closes #247

This PR adds initial support for sets with a new `Def::Set(SetDef)` variant-- plus a new `SetVTable` to go along with it. It also adds impls of `Facet` for both `HashSet<T, S>` and `BTreeSet<T>`

`SetVTable` has the following methods:

- `init_in_place_with_capacity(PtrUninit, usize) -> PtrMut`
- `insert(PtrMut, T) -> bool`
- `len(PtrConst) -> usize`
- `contains(PtrConst, T) -> bool`
- `iter(PtrConst) -> PtrMut`

From a high level, I was split between adding set as its own def, or if I should try to build on map (or possibly list). Personally, I feel it's right in between map and a list, but different enough from either to warrant its own category. I learned about JSON Structure after spotting #471, and was ultimately swayed because [a set is one of the core types in JSON Structure](https://json-structure.org/json-structure-primer.html#21-differences-to-json-schema-drafts). But, I'm not married to this design and would be happy to iterate on this PR!