### PR TITLE
Add support for `url` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "divan-macros"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +378,7 @@ dependencies = [
  "impls",
  "ordered-float",
  "ulid",
+ "url",
  "uuid",
 ]
 
@@ -679,6 +691,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "impls"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +912,12 @@ name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
@@ -992,6 +1117,15 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1201,6 +1335,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1361,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1259,6 +1416,16 @@ dependencies = [
  "libredox",
  "numtoa",
  "redox_termios",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1341,6 +1508,23 @@ dependencies = [
  "proc-macro2",
  "shadow_counted",
 ]
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -1537,6 +1721,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1753,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,6 +1790,60 @@ name = "zerocopy-derive"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -17,6 +17,7 @@ camino = ["dep:camino", "alloc"]
 ordered-float = ["dep:ordered-float"]
 uuid = ["alloc", "dep:uuid"]
 ulid = ["alloc", "dep:ulid"]
+url = ["dep:url"]
 
 [dependencies]
 impls = "1.0.3"
@@ -25,6 +26,7 @@ camino = { version = "1", optional = true }
 ordered-float = { version = "5.0.0", optional = true, default-features = false }
 uuid = { version = "1.16.0", optional = true }
 ulid = { version = "1.2.1", optional = true }
+url = { version = "2.5.4", optional = true, default-features = false }
 
 [dev-dependencies]
 eyre = "0.6.12"

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -17,7 +17,7 @@ camino = ["dep:camino", "alloc"]
 ordered-float = ["dep:ordered-float"]
 uuid = ["alloc", "dep:uuid"]
 ulid = ["alloc", "dep:ulid"]
-url = ["dep:url"]
+url = ["alloc", "dep:url"]
 
 [dependencies]
 impls = "1.0.3"

--- a/facet-core/src/impls_url.rs
+++ b/facet-core/src/impls_url.rs
@@ -1,0 +1,79 @@
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+
+use url::Url;
+
+use crate::{
+    Def, Facet, ParseError, PtrConst, PtrMut, PtrUninit, ScalarAffinity, ScalarDef, Shape,
+    TryBorrowInnerError, TryIntoInnerError, Type, UserType, ValueVTable, value_vtable,
+};
+
+unsafe impl Facet<'_> for Url {
+    const VTABLE: &'static ValueVTable = &const {
+        // Custom parse impl with detailed errors
+        unsafe fn parse<'target>(
+            s: &str,
+            target: PtrUninit<'target>,
+        ) -> Result<PtrMut<'target>, ParseError> {
+            let url = Url::parse(s).map_err(|error| {
+                let message = match error {
+                    url::ParseError::EmptyHost => "empty host",
+                    url::ParseError::IdnaError => "invalid international domain name",
+                    url::ParseError::InvalidPort => "invalid port number",
+                    url::ParseError::InvalidIpv4Address => "invalid IPv4 address",
+                    url::ParseError::InvalidIpv6Address => "invalid IPv6 address",
+                    url::ParseError::InvalidDomainCharacter => "invalid domain character",
+                    url::ParseError::RelativeUrlWithoutBase => "relative URL without a base",
+                    url::ParseError::RelativeUrlWithCannotBeABaseBase => {
+                        "relative URL with a cannot-be-a-base base"
+                    }
+                    url::ParseError::SetHostOnCannotBeABaseUrl => {
+                        "a cannot-be-a-base URL doesn’t have a host to set"
+                    }
+                    url::ParseError::Overflow => "URLs more than 4 GB are not supported",
+                    _ => "failed to parse URL",
+                };
+                ParseError::Generic(message)
+            })?;
+            Ok(unsafe { target.put(url) })
+        }
+
+        unsafe fn try_into_inner<'dst>(
+            src_ptr: PtrConst<'_>,
+            dst: PtrUninit<'dst>,
+        ) -> Result<PtrMut<'dst>, TryIntoInnerError> {
+            let url = unsafe { src_ptr.get::<Url>() };
+            Ok(unsafe { dst.put(url.as_str().to_owned()) })
+        }
+
+        unsafe fn try_borrow_inner(
+            src_ptr: PtrConst<'_>,
+        ) -> Result<PtrConst<'_>, TryBorrowInnerError> {
+            let url = unsafe { src_ptr.get::<Url>() };
+            Ok(PtrConst::new(url.as_str().as_ptr()))
+        }
+
+        let mut vtable = value_vtable!(Url, |f, _opts| write!(f, "Url"));
+        vtable.parse = Some(parse);
+        vtable.try_into_inner = Some(try_into_inner);
+        vtable.try_borrow_inner = Some(try_borrow_inner);
+        vtable
+    };
+
+    const SHAPE: &'static Shape = &const {
+        // Function to return inner type's shape
+        fn inner_shape() -> &'static Shape {
+            <String as Facet>::SHAPE
+        }
+
+        Shape::builder_for_sized::<Self>()
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::Scalar(
+                ScalarDef::builder()
+                    .affinity(ScalarAffinity::url().build())
+                    .build(),
+            ))
+            .inner(inner_shape)
+            .build()
+    };
+}

--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -44,6 +44,9 @@ mod impls_uuid;
 #[cfg(feature = "ulid")]
 mod impls_ulid;
 
+#[cfg(feature = "url")]
+mod impls_url;
+
 // Const type Id
 mod typeid;
 pub use typeid::*;

--- a/facet-core/src/types/def/scalar.rs
+++ b/facet-core/src/types/def/scalar.rs
@@ -62,8 +62,10 @@ pub enum ScalarAffinity {
     Empty(EmptyAffinity),
     /// Socket address scalar affinity
     SocketAddr(SocketAddrAffinity),
-    /// Ip Address scalar affinity
+    /// IP Address scalar affinity
     IpAddr(IpAddrAffinity),
+    /// URL scalar affinity
+    Url(UrlAffinity),
     /// UUID or UUID-like identifier, containing 16 bytes of information
     UUID(UuidAffinity),
     /// ULID or ULID-like identifier, containing 16 bytes of information
@@ -114,6 +116,11 @@ impl ScalarAffinity {
     /// Returns an IpAddrAffinityBuilder
     pub const fn ip_addr() -> IpAddrAffinityBuilder {
         IpAddrAffinityBuilder::new()
+    }
+
+    /// Returns a UrlAffinityBuilder
+    pub const fn url() -> UrlAffinityBuilder {
+        UrlAffinityBuilder::new()
     }
 
     /// Returns an UuidAffinityBuilder
@@ -650,6 +657,36 @@ impl IpAddrAffinityBuilder {
     /// Builds the ScalarAffinity
     pub const fn build(self) -> ScalarAffinity {
         ScalarAffinity::IpAddr(IpAddrAffinity {})
+    }
+}
+
+/// Definition for URL scalar affinities
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[repr(C)]
+#[non_exhaustive]
+pub struct UrlAffinity {}
+
+impl UrlAffinity {
+    /// Returns a builder for UrlAffinity
+    pub const fn builder() -> UrlAffinityBuilder {
+        UrlAffinityBuilder::new()
+    }
+}
+
+/// Builder for UrlAffinity
+#[repr(C)]
+pub struct UrlAffinityBuilder {}
+
+impl UrlAffinityBuilder {
+    /// Creates a new UrlAffinityBuilder
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self {}
+    }
+
+    /// Builds the ScalarAffinity
+    pub const fn build(self) -> ScalarAffinity {
+        ScalarAffinity::Url(UrlAffinity {})
     }
 }
 


### PR DESCRIPTION
This PR implements support for [`Url`](https://docs.rs/url/2.5.4/url/struct.Url.html) type from the `url` crate. I added a new `ScalarAffinity::Url` variant, which seemed in-line with other types (I saw the conversation about the terminology around "URL" vs "URI" [in #162](https://github.com/facet-rs/facet/pull/162#issuecomment-2799029989)... personally, my opinion is :shrug:)