### PR TITLE
Fixes around Camino/UUID/ULID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,7 @@ dependencies = [
 name = "facet-json"
 version = "0.23.4"
 dependencies = [
+ "camino",
  "eyre",
  "facet",
  "facet-core",
@@ -465,6 +466,8 @@ dependencies = [
  "insta",
  "log",
  "time",
+ "ulid",
+ "uuid",
 ]
 
 [[package]]
@@ -523,7 +526,6 @@ name = "facet-reflect"
 version = "0.25.1"
 dependencies = [
  "bitflags",
- "camino",
  "eyre",
  "facet",
  "facet-core",
@@ -531,9 +533,6 @@ dependencies = [
  "log",
  "owo-colors",
  "tempfile",
- "time",
- "ulid",
- "uuid",
 ]
 
 [[package]]

--- a/facet-core/src/impls_camino.rs
+++ b/facet-core/src/impls_camino.rs
@@ -4,8 +4,8 @@ use alloc::string::String;
 use camino::{Utf8Path, Utf8PathBuf};
 
 use crate::{
-    Def, Facet, PtrConst, PtrMut, PtrUninit, ScalarAffinity, ScalarDef, Shape, TryBorrowInnerError,
-    TryFromError, TryIntoInnerError, Type, UserType, ValueVTable, value_vtable,
+    Def, Facet, PtrConst, PtrMut, PtrUninit, ScalarAffinity, ScalarDef, Shape, TryFromError,
+    TryIntoInnerError, Type, UserType, ValueVTable, value_vtable,
 };
 
 unsafe impl Facet<'_> for Utf8PathBuf {
@@ -34,18 +34,10 @@ unsafe impl Facet<'_> for Utf8PathBuf {
             Ok(unsafe { dst.put(path.as_str().to_owned()) })
         }
 
-        unsafe fn try_borrow_inner(
-            src_ptr: PtrConst<'_>,
-        ) -> Result<PtrConst<'_>, TryBorrowInnerError> {
-            let path = unsafe { src_ptr.get::<Utf8PathBuf>() };
-            Ok(PtrConst::new(path.as_str().as_ptr()))
-        }
-
         let mut vtable = value_vtable!(Utf8PathBuf, |f, _opts| write!(f, "Utf8PathBuf"));
         vtable.parse = Some(|s, target| Ok(unsafe { target.put(Utf8Path::new(s).to_owned()) }));
         vtable.try_from = Some(try_from);
         vtable.try_into_inner = Some(try_into_inner);
-        vtable.try_borrow_inner = Some(try_borrow_inner);
         vtable
     };
 

--- a/facet-core/src/impls_camino.rs
+++ b/facet-core/src/impls_camino.rs
@@ -22,16 +22,16 @@ unsafe impl Facet<'_> for Utf8PathBuf {
                     expected: &[<String as Facet>::SHAPE],
                 });
             }
-            let s = unsafe { src_ptr.get::<String>() };
-            Ok(unsafe { dst.put(Utf8PathBuf::from(s.clone())) })
+            let s = unsafe { src_ptr.read::<String>() };
+            Ok(unsafe { dst.put(Utf8PathBuf::from(s)) })
         }
 
         unsafe fn try_into_inner<'dst>(
             src_ptr: PtrConst<'_>,
             dst: PtrUninit<'dst>,
         ) -> Result<PtrMut<'dst>, TryIntoInnerError> {
-            let path = unsafe { src_ptr.get::<Utf8PathBuf>() };
-            Ok(unsafe { dst.put(path.as_str().to_owned()) })
+            let path = unsafe { src_ptr.read::<Utf8PathBuf>() };
+            Ok(unsafe { dst.put(path.into_string()) })
         }
 
         let mut vtable = value_vtable!(Utf8PathBuf, |f, _opts| write!(f, "Utf8PathBuf"));

--- a/facet-core/src/impls_ulid.rs
+++ b/facet-core/src/impls_ulid.rs
@@ -21,8 +21,8 @@ unsafe impl Facet<'_> for Ulid {
                     expected: &[<String as Facet>::SHAPE],
                 });
             }
-            let s = unsafe { src_ptr.get::<String>() };
-            match Ulid::from_string(s) {
+            let s = unsafe { src_ptr.read::<String>() };
+            match Ulid::from_string(&s) {
                 Ok(ulid) => Ok(unsafe { dst.put(ulid) }),
                 Err(_) => Err(TryFromError::UnsupportedSourceShape {
                     src_shape,
@@ -35,7 +35,7 @@ unsafe impl Facet<'_> for Ulid {
             src_ptr: PtrConst<'_>,
             dst: PtrUninit<'dst>,
         ) -> Result<PtrMut<'dst>, TryIntoInnerError> {
-            let ulid = unsafe { src_ptr.get::<Ulid>() };
+            let ulid = unsafe { src_ptr.read::<Ulid>() };
             Ok(unsafe { dst.put(ulid.to_string()) })
         }
 

--- a/facet-core/src/impls_ulid.rs
+++ b/facet-core/src/impls_ulid.rs
@@ -39,7 +39,7 @@ unsafe impl Facet<'_> for Ulid {
             Ok(unsafe { dst.put(ulid.to_string()) })
         }
 
-        let mut vtable = value_vtable!((), |f, _opts| write!(f, "Ulid"));
+        let mut vtable = value_vtable!(Ulid, |f, _opts| write!(f, "Ulid"));
         vtable.parse = Some(|s, target| match Ulid::from_string(s) {
             Ok(ulid) => Ok(unsafe { target.put(ulid) }),
             Err(_) => Err(ParseError::Generic("ULID parsing failed")),

--- a/facet-core/src/impls_uuid.rs
+++ b/facet-core/src/impls_uuid.rs
@@ -40,7 +40,7 @@ unsafe impl Facet<'_> for Uuid {
             Ok(unsafe { dst.put(uuid.to_string()) })
         }
 
-        let mut vtable = value_vtable!((), |f, _opts| write!(f, "Uuid"));
+        let mut vtable = value_vtable!(Uuid, |f, _opts| write!(f, "Uuid"));
         vtable.parse = Some(|s, target| match Uuid::parse_str(s) {
             Ok(uuid) => Ok(unsafe { target.put(uuid) }),
             Err(_) => Err(ParseError::Generic("UUID parsing failed")),

--- a/facet-core/src/impls_uuid.rs
+++ b/facet-core/src/impls_uuid.rs
@@ -22,8 +22,8 @@ unsafe impl Facet<'_> for Uuid {
                     expected: &[<String as Facet>::SHAPE],
                 });
             }
-            let s = unsafe { src_ptr.get::<String>() };
-            match Uuid::parse_str(s) {
+            let s = unsafe { src_ptr.read::<String>() };
+            match Uuid::parse_str(&s) {
                 Ok(uuid) => Ok(unsafe { dst.put(uuid) }),
                 Err(_) => Err(TryFromError::UnsupportedSourceShape {
                     src_shape,
@@ -36,7 +36,7 @@ unsafe impl Facet<'_> for Uuid {
             src_ptr: PtrConst<'_>,
             dst: PtrUninit<'dst>,
         ) -> Result<PtrMut<'dst>, TryIntoInnerError> {
-            let uuid = unsafe { src_ptr.get::<Uuid>() };
+            let uuid = unsafe { src_ptr.read::<Uuid>() };
             Ok(unsafe { dst.put(uuid.to_string()) })
         }
 

--- a/facet-core/src/impls_uuid.rs
+++ b/facet-core/src/impls_uuid.rs
@@ -5,8 +5,7 @@ use uuid::Uuid;
 
 use crate::{
     Def, Facet, ParseError, PtrConst, PtrMut, PtrUninit, ScalarAffinity, ScalarDef, Shape,
-    TryBorrowInnerError, TryFromError, TryIntoInnerError, Type, UserType, ValueVTable,
-    value_vtable,
+    TryFromError, TryIntoInnerError, Type, UserType, ValueVTable, value_vtable,
 };
 
 unsafe impl Facet<'_> for Uuid {
@@ -41,13 +40,6 @@ unsafe impl Facet<'_> for Uuid {
             Ok(unsafe { dst.put(uuid.to_string()) })
         }
 
-        unsafe fn try_borrow_inner(
-            src_ptr: PtrConst<'_>,
-        ) -> Result<PtrConst<'_>, TryBorrowInnerError> {
-            let uuid = unsafe { src_ptr.get::<Uuid>() };
-            Ok(PtrConst::new(uuid.as_bytes().as_ptr()))
-        }
-
         let mut vtable = value_vtable!((), |f, _opts| write!(f, "Uuid"));
         vtable.parse = Some(|s, target| match Uuid::parse_str(s) {
             Ok(uuid) => Ok(unsafe { target.put(uuid) }),
@@ -55,7 +47,6 @@ unsafe impl Facet<'_> for Uuid {
         });
         vtable.try_from = Some(try_from);
         vtable.try_into_inner = Some(try_into_inner);
-        vtable.try_borrow_inner = Some(try_borrow_inner);
         vtable
     };
 

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -27,9 +27,12 @@ facet-serialize = { version = "0.23.4", path = "../facet-serialize", default-fea
 log = "0.4.27"
 
 [dev-dependencies]
-facet-core = { version = "0.25.1", path = "../facet-core", features = ["time"] }
+camino = { version = "1" }
 eyre = "0.6.12"
 facet = { path = "../facet" }
+facet-core = { version = "0.25.1", path = "../facet-core", features = ["camino", "time", "ulid", "uuid"] }
 facet-testhelpers = { path = "../facet-testhelpers" }
 insta = "1.43.1"
 time = { version = "0.3.41", features = ["macros"] }
+ulid = { version = "1.2.1" }
+uuid = { version = "1.16.0" }

--- a/facet-json/tests/integration/read.rs
+++ b/facet-json/tests/integration/read.rs
@@ -1,4 +1,5 @@
 mod bool;
+mod camino;
 mod datetime;
 mod deny_unknown_and_default;
 mod diagnostics;
@@ -13,4 +14,6 @@ mod rename;
 mod skip_unknown_fields;
 mod structs;
 mod tuple;
+mod ulid;
+mod uuid;
 mod vec;

--- a/facet-json/tests/integration/read/camino.rs
+++ b/facet-json/tests/integration/read/camino.rs
@@ -1,0 +1,26 @@
+use camino::Utf8PathBuf;
+use eyre::Result;
+use facet::Facet;
+use facet_json::from_str;
+
+#[test]
+fn json_read_utf8pathbuf() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        path: Utf8PathBuf,
+    }
+
+    let json = r#"{"path":"foo/bar"}"#;
+
+    let s: FooBar = from_str(json)?;
+    assert_eq!(
+        s,
+        FooBar {
+            path: Utf8PathBuf::from("foo/bar"),
+        }
+    );
+
+    Ok(())
+}

--- a/facet-json/tests/integration/read/camino.rs
+++ b/facet-json/tests/integration/read/camino.rs
@@ -24,3 +24,21 @@ fn json_read_utf8pathbuf() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn json_write_utf8pathbuf() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        path: Utf8PathBuf,
+    }
+
+    let original = FooBar {
+        path: Utf8PathBuf::from("foo/bar/baz"),
+    };
+
+    let _json = facet_json::to_string(&original);
+
+    Ok(())
+}

--- a/facet-json/tests/integration/read/ulid.rs
+++ b/facet-json/tests/integration/read/ulid.rs
@@ -1,0 +1,26 @@
+use eyre::Result;
+use facet::Facet;
+use facet_json::from_str;
+use uuid::Uuid;
+
+#[test]
+fn json_read_ulid() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        id: Uuid,
+    }
+
+    let json = r#"{"id":"f49e1d6c-7e95-4654-a861-8b66f94a623a"}"#;
+
+    let s: FooBar = from_str(json)?;
+    assert_eq!(
+        s,
+        FooBar {
+            id: "f49e1d6c-7e95-4654-a861-8b66f94a623a".parse().unwrap(),
+        }
+    );
+
+    Ok(())
+}

--- a/facet-json/tests/integration/read/ulid.rs
+++ b/facet-json/tests/integration/read/ulid.rs
@@ -1,7 +1,7 @@
 use eyre::Result;
 use facet::Facet;
 use facet_json::from_str;
-use uuid::Uuid;
+use ulid::Ulid;
 
 #[test]
 fn json_read_ulid() -> Result<()> {
@@ -9,18 +9,36 @@ fn json_read_ulid() -> Result<()> {
 
     #[derive(Facet, Debug, PartialEq)]
     struct FooBar {
-        id: Uuid,
+        id: Ulid,
     }
 
-    let json = r#"{"id":"f49e1d6c-7e95-4654-a861-8b66f94a623a"}"#;
+    let json = r#"{"id":"01ARZ3NDEKTSV4RRFFQ69G5FAV"}"#;
 
     let s: FooBar = from_str(json)?;
     assert_eq!(
         s,
         FooBar {
-            id: "f49e1d6c-7e95-4654-a861-8b66f94a623a".parse().unwrap(),
+            id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".parse().unwrap(),
         }
     );
+
+    Ok(())
+}
+
+#[test]
+fn json_write_ulid() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        id: Ulid,
+    }
+
+    let original = FooBar {
+        id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".parse().unwrap(),
+    };
+
+    let _json = facet_json::to_string(&original);
 
     Ok(())
 }

--- a/facet-json/tests/integration/read/uuid.rs
+++ b/facet-json/tests/integration/read/uuid.rs
@@ -4,6 +4,24 @@ use facet_json::from_str;
 use uuid::Uuid;
 
 #[test]
+fn json_write_uuid() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        id: Uuid,
+    }
+
+    let original = FooBar {
+        id: "f49e1d6c-7e95-4654-a861-8b66f94a623a".parse().unwrap(),
+    };
+
+    let _json = facet_json::to_string(&original);
+
+    Ok(())
+}
+
+#[test]
 fn json_read_uuid() -> Result<()> {
     facet_testhelpers::setup();
 

--- a/facet-json/tests/integration/read/uuid.rs
+++ b/facet-json/tests/integration/read/uuid.rs
@@ -1,0 +1,26 @@
+use eyre::Result;
+use facet::Facet;
+use facet_json::from_str;
+use uuid::Uuid;
+
+#[test]
+fn json_read_uuid() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        id: Uuid,
+    }
+
+    let json = r#"{"id":"f49e1d6c-7e95-4654-a861-8b66f94a623a"}"#;
+
+    let s: FooBar = from_str(json)?;
+    assert_eq!(
+        s,
+        FooBar {
+            id: "f49e1d6c-7e95-4654-a861-8b66f94a623a".parse().unwrap(),
+        }
+    );
+
+    Ok(())
+}

--- a/facet-json/tests/integration/write.rs
+++ b/facet-json/tests/integration/write.rs
@@ -1,3 +1,4 @@
+mod camino;
 mod datetime;
 mod enums;
 mod json;
@@ -8,3 +9,5 @@ mod skip_serializing;
 mod string;
 mod structs;
 mod tuple;
+mod ulid;
+mod uuid;

--- a/facet-json/tests/integration/write/camino.rs
+++ b/facet-json/tests/integration/write/camino.rs
@@ -1,0 +1,23 @@
+use camino::Utf8PathBuf;
+use eyre::Result;
+use facet::Facet;
+use facet_json::to_string;
+
+#[test]
+fn json_write_utf8pathbuf() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        path: Utf8PathBuf,
+    }
+
+    let value = FooBar {
+        path: Utf8PathBuf::from("foo/bar"),
+    };
+
+    let json = to_string(&value);
+    assert_eq!(json, r#"{"path":"foo/bar"}"#);
+
+    Ok(())
+}

--- a/facet-json/tests/integration/write/ulid.rs
+++ b/facet-json/tests/integration/write/ulid.rs
@@ -1,0 +1,23 @@
+use eyre::Result;
+use facet::Facet;
+use facet_json::to_string;
+use ulid::Ulid;
+
+#[test]
+fn json_write_ulid() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        better_id: Ulid,
+    }
+
+    let value = FooBar {
+        better_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".parse().unwrap(),
+    };
+
+    let json = to_string(&value);
+    assert_eq!(json, r#"{"better_id":"01ARZ3NDEKTSV4RRFFQ69G5FAV"}"#);
+
+    Ok(())
+}

--- a/facet-json/tests/integration/write/uuid.rs
+++ b/facet-json/tests/integration/write/uuid.rs
@@ -1,0 +1,23 @@
+use eyre::Result;
+use facet::Facet;
+use facet_json::to_string;
+use uuid::Uuid;
+
+#[test]
+fn json_write_uuid() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        id: Uuid,
+    }
+
+    let value = FooBar {
+        id: "f49e1d6c-7e95-4654-a861-8b66f94a623a".parse().unwrap(),
+    };
+
+    let json = to_string(&value);
+    assert_eq!(json, r#"{"id":"f49e1d6c-7e95-4654-a861-8b66f94a623a"}"#);
+
+    Ok(())
+}

--- a/facet-jsonschema/src/snapshots/facet_jsonschema__tests__pointers.snap
+++ b/facet-jsonschema/src/snapshots/facet_jsonschema__tests__pointers.snap
@@ -1,0 +1,5 @@
+---
+source: facet-jsonschema/src/lib.rs
+expression: schema
+---
+{"$schema": "https://json-schema.org/draft/2020-12/schema","$id": "http://example.com/schema","description": "Test documentation","type": "object","required": ["normal_pointer","box_pointer","arc","rc","nested"],"properties": {"normal_pointer": {"type": "string"},"box_pointer": {"type": "integer", "format": "uint32", "minimum": 0},"arc": {"type": "integer", "format": "uint32", "minimum": 0},"rc": {"type": "integer", "format": "uint32", "minimum": 0},"nested": {"type": "integer", "format": "uint32", "minimum": 0}}}

--- a/facet-reflect/Cargo.toml
+++ b/facet-reflect/Cargo.toml
@@ -20,23 +20,12 @@ log = [
     "dep:log",
 ] # Enable logging of reflection operations (mostly for internal development)
 slow-tests = [] # Enable slow tests (compile tests)
-camino = ["alloc", "dep:camino", "facet-core/camino"]
-uuid = ["alloc", "dep:uuid", "facet-core/uuid"]
-ulid = ["alloc", "dep:ulid", "facet-core/ulid"]
-time = ["dep:time"]
 
 [dependencies]
 bitflags = "2.9.0"
 facet-core = { path = "../facet-core", version = "0.25.1", default-features = false }
 log = { version = "0.4.27", optional = true }
 owo-colors = { version = "4.2.0" }
-camino = { version = "1", optional = true }
-uuid = { version = "1.16.0", optional = true }
-ulid = { version = "1.2.1", optional = true }
-time = { version = "0.3.41", optional = true, features = [
-    "formatting",
-    "parsing",
-] }
 
 [dev-dependencies]
 eyre = "0.6.12"

--- a/facet-reflect/src/scalar.rs
+++ b/facet-reflect/src/scalar.rs
@@ -57,18 +57,6 @@ pub enum ScalarType {
     Ipv6Addr,
     /// `facet_core::typeid::ConstTypeId`.
     ConstTypeId,
-    /// `&camino::Utf8Path`.
-    #[cfg(feature = "camino")]
-    Utf8Path,
-    /// `camino::Utf8PathBuf`.
-    #[cfg(feature = "camino")]
-    Utf8PathBuf,
-    /// `uuid::Uuid`.
-    #[cfg(feature = "uuid")]
-    Uuid,
-    /// `ulid::Ulid`.
-    #[cfg(feature = "ulid")]
-    Ulid,
 }
 
 impl ScalarType {
@@ -81,23 +69,6 @@ impl ScalarType {
             return Some(ScalarType::CowStr);
         } else if shape.id == ConstTypeId::of::<core::net::SocketAddr>() {
             return Some(ScalarType::SocketAddr);
-        }
-
-        #[cfg(feature = "camino")]
-        if shape.id == ConstTypeId::of::<&camino::Utf8Path>() {
-            return Some(ScalarType::Utf8Path);
-        } else if shape.id == ConstTypeId::of::<camino::Utf8PathBuf>() {
-            return Some(ScalarType::Utf8PathBuf);
-        }
-
-        #[cfg(feature = "uuid")]
-        if shape.id == ConstTypeId::of::<uuid::Uuid>() {
-            return Some(ScalarType::Uuid);
-        }
-
-        #[cfg(feature = "ulid")]
-        if shape.id == ConstTypeId::of::<ulid::Ulid>() {
-            return Some(ScalarType::Ulid);
         }
 
         if shape.id == ConstTypeId::of::<()>() {
@@ -259,26 +230,6 @@ mod tests {
         assert_eq!(
             ScalarType::ConstTypeId,
             ScalarType::try_from_shape(ConstTypeId::SHAPE).unwrap()
-        );
-        #[cfg(feature = "camino")]
-        assert_eq!(
-            ScalarType::Utf8Path,
-            ScalarType::try_from_shape(<&camino::Utf8Path>::SHAPE).unwrap()
-        );
-        #[cfg(feature = "camino")]
-        assert_eq!(
-            ScalarType::Utf8PathBuf,
-            ScalarType::try_from_shape(camino::Utf8PathBuf::SHAPE).unwrap()
-        );
-        #[cfg(feature = "uuid")]
-        assert_eq!(
-            ScalarType::Uuid,
-            ScalarType::try_from_shape(uuid::Uuid::SHAPE).unwrap()
-        );
-        #[cfg(feature = "ulid")]
-        assert_eq!(
-            ScalarType::Ulid,
-            ScalarType::try_from_shape(ulid::Ulid::SHAPE).unwrap()
         );
     }
 }

--- a/facet-serialize/src/lib.rs
+++ b/facet-serialize/src/lib.rs
@@ -344,7 +344,10 @@ where
                             Some(unsupported) => panic!("Unsupported scalar type: {unsupported:?}"),
                             None => {
                                 match sd.affinity {
-                                    ScalarAffinity::Time(_) => {
+                                    ScalarAffinity::Time(_)
+                                    | ScalarAffinity::Path(_)
+                                    | ScalarAffinity::ULID(_)
+                                    | ScalarAffinity::UUID(_) => {
                                         if let Some(_display) = cpeek.shape().vtable.display {
                                             // Use display formatting if available
                                             serializer


### PR DESCRIPTION
I started work on adding support for another crate (`bstr`), and had to do a gut check as I was referencing the impl from `camino`. I noticed that the `try_borrow_inner` method seemed to be returning a value of type `&str`, instead of `String` like it should've.

...anyway, I fell down a bit of a rabbit hole, and ended up with a few changes impacting Camino, UUID, and ULID integrations:

- Remove invalid `try_borrow_inner` impls across Camino/UUID/ULID (I'm not even really sure any of the 3 should have inner shapes at all...? but that's a bigger question)
- Fix `value_vtable!()` invocations for UUID/ULID. I think the prior version was valid, but this change gives us some more traits (namely `Display`, which was the important one)
- Remove `ScalarType` variants that were specific to Camino/UUID/ULID. It feels weird having the scalar types be feature-gated in general, and these particular ones were causing pain around serialization. It feels like `ScalarAffinity` is a cleaner fit
- Remove `camino` / `ulid` / `uuid` features/optional deps from `facet-reflect`. Without the `ScalarType` variants, these features had no effect
- Support serializing Camino/UUID/ULID types as strings. This defers to the `Display` impl based on the shape's affinity, basically piggy-backing off of #573
- Add some JSON (de)serialization tests for Camino/UUID/ULID