### PR TITLE
Port facet-xdr to facet-serialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "facet-csv"
-version = "0.23.5"
+version = "0.24.0"
 dependencies = [
  "eyre",
  "facet",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "facet-json"
-version = "0.23.6"
+version = "0.24.0"
 dependencies = [
  "camino",
  "eyre",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "facet-msgpack"
-version = "0.24.5"
+version = "0.25.0"
 dependencies = [
  "eyre",
  "facet",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "facet-serialize"
-version = "0.23.6"
+version = "0.24.0"
 dependencies = [
  "eyre",
  "facet",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "facet-toml"
-version = "0.24.5"
+version = "0.25.0"
 dependencies = [
  "ariadne",
  "codspeed-divan-compat",
@@ -622,11 +622,12 @@ dependencies = [
 
 [[package]]
 name = "facet-xdr"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "facet",
  "facet-core",
  "facet-reflect",
+ "facet-serialize",
  "facet-testhelpers 0.17.2",
 ]
 

--- a/facet-csv/Cargo.toml
+++ b/facet-csv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-csv"
-version = "0.23.5"
+version = "0.24.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -23,7 +23,7 @@ default = ["std", "rich-diagnostics"]
 facet-core = { version = "0.26.1", path = "../facet-core", default-features = false }
 facet-deserialize = { version = "0.24.5", path = "../facet-deserialize", default-features = false }
 facet-reflect = { version = "0.26.1", path = "../facet-reflect", default-features = false }
-facet-serialize = { version = "0.23.6", path = "../facet-serialize", default-features = false }
+facet-serialize = { version = "0.24.0", path = "../facet-serialize", default-features = false }
 log = "0.4.27"
 
 [dev-dependencies]

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-json"
-version = "0.23.6"
+version = "0.24.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -23,7 +23,7 @@ default = ["std", "rich-diagnostics"]
 facet-core = { version = "0.26.1", path = "../facet-core", default-features = false }
 facet-deserialize = { version = "0.24.5", path = "../facet-deserialize", default-features = false }
 facet-reflect = { version = "0.26.1", path = "../facet-reflect", default-features = false }
-facet-serialize = { version = "0.23.6", path = "../facet-serialize", default-features = false }
+facet-serialize = { version = "0.24.0", path = "../facet-serialize", default-features = false }
 log = "0.4.27"
 
 [dev-dependencies]

--- a/facet-msgpack/Cargo.toml
+++ b/facet-msgpack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-msgpack"
-version = "0.24.5"
+version = "0.25.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -19,7 +19,7 @@ categories = ["encoding", "parsing", "data-structures"]
 facet-core = { version = "0.26.1", path = "../facet-core" }
 facet-reflect = { version = "0.26.1", path = "../facet-reflect" }
 log = "0.4.27"
-facet-serialize = { version = "0.23.6", path = "../facet-serialize" }
+facet-serialize = { version = "0.24.0", path = "../facet-serialize" }
 
 [dev-dependencies]
 eyre = "0.6.12"

--- a/facet-msgpack/src/serialize.rs
+++ b/facet-msgpack/src/serialize.rs
@@ -515,7 +515,9 @@ mod tests {
     fn rmp_serialize<T: Serialize>(value: &T) -> Vec<u8> {
         // Configure rmp_serde to serialize structs as maps
         let mut buf = Vec::new();
-        let mut ser = rmp_serde::Serializer::new(&mut buf).with_struct_map();
+        let mut ser = rmp_serde::Serializer::new(&mut buf)
+            .with_bytes(rmp_serde::config::BytesMode::ForceIterables)
+            .with_struct_map();
         value.serialize(&mut ser).unwrap();
         buf
     }
@@ -575,7 +577,7 @@ mod tests {
                 c: true,
             },
             d: None,
-            e: vec![],
+            e: vec![0], // rmp can't serialize empty bin8 correctly
         };
 
         let facet_bytes = to_vec(&value);

--- a/facet-serialize/Cargo.toml
+++ b/facet-serialize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-serialize"
-version = "0.23.6"
+version = "0.24.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/facet-toml/Cargo.toml
+++ b/facet-toml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-toml"
-version = "0.24.5"
+version = "0.25.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -32,7 +32,7 @@ toml_edit = { version = "0.22.26", default-features = false, features = [
 ], optional = true }
 facet-core = { version = "0.26.1", path = "../facet-core", default-features = false }
 facet-reflect = { version = "0.26.1", path = "../facet-reflect", default-features = false }
-facet-serialize = { version = "0.23.6", path = "../facet-serialize", default-features = false, optional = true }
+facet-serialize = { version = "0.24.0", path = "../facet-serialize", default-features = false, optional = true }
 yansi = "1.0.1"
 
 [dev-dependencies]

--- a/facet-xdr/Cargo.toml
+++ b/facet-xdr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-xdr"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -10,13 +10,14 @@ keywords = ["xdr", "serialization", "deserialization", "reflection", "facet"]
 categories = ["encoding", "parsing", "data-structures"]
 
 [features]
-std = ["alloc", "facet-core/std", "facet-reflect/std"]
-alloc = ["facet-core/alloc", "facet-reflect/alloc"]
+std = ["alloc", "facet-core/std", "facet-reflect/std", "facet-serialize/std"]
+alloc = ["facet-core/alloc", "facet-reflect/alloc", "facet-serialize/alloc"]
 default = ["std"]
 
 [dependencies]
 facet-core = { version = "0.26.1", path = "../facet-core", default-features = false }
 facet-reflect = { version = "0.26.1", path = "../facet-reflect", default-features = false }
+facet-serialize = { version = "0.24.0", path = "../facet-serialize", default-features = false }
 
 [dev-dependencies]
 facet = { path = "../facet" }


### PR DESCRIPTION
Also fixes #582 

Additionally, facet-serialize will now properly use `Serializer::serialize_bytes` for all `T = u8; [T; N] | Vec<T> | &[T]`. This isn't backwards compatible, so I bumped the version for it and all dependants.