### PR TITLE
Refactor `MapVTable` and `SetVTable` to share a common `IterVTable`

### DIFF
--- a/facet-core/src/types/def/iter.rs
+++ b/facet-core/src/types/def/iter.rs
@@ -1,0 +1,83 @@
+use crate::{PtrConst, PtrMut};
+
+/// Create a new iterator that iterates over the provided value
+///
+/// # Safety
+///
+/// The `value` parameter must point to aligned, initialized memory of the correct type.
+pub type IterNewFn = for<'value> unsafe fn(value: PtrConst<'value>) -> PtrMut<'value>;
+
+/// Advance the iterator, returning the next value from the iterator
+///
+/// # Safety
+///
+/// The `iter` parameter must point to aligned, initialized memory of the correct type.
+pub type IterNextFn = for<'iter> unsafe fn(iter: PtrMut<'iter>) -> Option<PtrConst<'iter>>;
+
+/// Advance the iterator, returning the next value pair from the iterator.
+/// For example, this would return the next key/value pair from a map.
+///
+/// # Safety
+///
+/// The `iter` parameter must point to aligned, initialized memory of the correct type.
+pub type IterNextPairFn =
+    for<'iter> unsafe fn(iter: PtrMut<'iter>) -> Option<(PtrConst<'iter>, PtrConst<'iter>)>;
+
+/// Advance the iterator in reverse, returning the next value from the end
+/// of the iterator.
+///
+/// # Safety
+///
+/// The `iter` parameter must point to aligned, initialized memory of the correct type.
+pub type IterNextBackFn = for<'iter> unsafe fn(iter: PtrMut<'iter>) -> Option<PtrConst<'iter>>;
+
+/// Advance the iterator in reverse, returning the next value pair from the
+/// end of the iterator. For example, this would return the end key/value
+/// pair from a map.
+///
+/// # Safety
+///
+/// The `iter` parameter must point to aligned, initialized memory of the correct type.
+pub type IterNextPairBackFn =
+    for<'iter> unsafe fn(iter: PtrMut<'iter>) -> Option<(PtrConst<'iter>, PtrConst<'iter>)>;
+
+/// Return the lower and upper bounds of the iterator, if known.
+///
+/// # Safety
+///
+/// The `iter` parameter must point to aligned, initialized memory of the correct type.
+pub type IterSizeHintFn =
+    for<'iter> unsafe fn(iter: PtrMut<'iter>) -> Option<(usize, Option<usize>)>;
+
+/// Deallocate the iterator
+///
+/// # Safety
+///
+/// The `iter` parameter must point to aligned, initialized memory of the correct type.
+pub type IterDeallocFn = for<'iter> unsafe fn(iter: PtrMut<'iter>);
+
+/// VTable for an iterator
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[repr(C)]
+#[non_exhaustive]
+pub struct IterVTable {
+    pub new: Option<IterNewFn>,
+
+    /// cf. [`IterNextFn`]
+    pub next: IterNextFn,
+
+    /// cf. [`IterNextPairFn`]
+    pub next_pair: Option<IterNextPairFn>,
+
+    /// cf. [`IterNextBackFn`]
+    pub next_back: Option<IterNextBackFn>,
+
+    /// cf. [`IterNextPairBackFn`]
+    pub next_pair_back: Option<IterNextPairBackFn>,
+
+    /// cf. [`IterSizeHintFn`]
+    pub size_hint: Option<IterSizeHintFn>,
+
+    /// cf. [`IterDeallocFn`]
+    pub dealloc: IterDeallocFn,
+}

--- a/facet-core/src/types/def/iter.rs
+++ b/facet-core/src/types/def/iter.rs
@@ -5,7 +5,7 @@ use crate::{PtrConst, PtrMut};
 /// # Safety
 ///
 /// The `value` parameter must point to aligned, initialized memory of the correct type.
-pub type IterNewFn = for<'value> unsafe fn(value: PtrConst<'value>) -> PtrMut<'value>;
+pub type IterInitWithValueFn = for<'value> unsafe fn(value: PtrConst<'value>) -> PtrMut<'value>;
 
 /// Advance the iterator, returning the next value from the iterator
 ///
@@ -61,7 +61,8 @@ pub type IterDeallocFn = for<'iter> unsafe fn(iter: PtrMut<'iter>);
 #[repr(C)]
 #[non_exhaustive]
 pub struct IterVTable {
-    pub new: Option<IterNewFn>,
+    /// cf. [`IterInitWithValueFn`]
+    pub init_with_value: Option<IterInitWithValueFn>,
 
     /// cf. [`IterNextFn`]
     pub next: IterNextFn,
@@ -80,4 +81,91 @@ pub struct IterVTable {
 
     /// cf. [`IterDeallocFn`]
     pub dealloc: IterDeallocFn,
+}
+
+impl IterVTable {
+    /// Returns a builder for [`IterVTable`]
+    pub const fn builder() -> IterVTableBuilder {
+        IterVTableBuilder::new()
+    }
+}
+
+/// Builds an [`IterVTable`]
+pub struct IterVTableBuilder {
+    init_with_value: Option<IterInitWithValueFn>,
+    next: Option<IterNextFn>,
+    next_pair: Option<IterNextPairFn>,
+    next_back: Option<IterNextBackFn>,
+    next_pair_back: Option<IterNextPairBackFn>,
+    size_hint: Option<IterSizeHintFn>,
+    dealloc: Option<IterDeallocFn>,
+}
+
+impl IterVTableBuilder {
+    /// Creates a new [`IterVTableBuilder`] with all fields set to `None`.
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self {
+            init_with_value: None,
+            next: None,
+            next_pair: None,
+            next_back: None,
+            next_pair_back: None,
+            size_hint: None,
+            dealloc: None,
+        }
+    }
+
+    /// Sets the `init_with_value` function
+    pub const fn init_with_value(mut self, f: IterInitWithValueFn) -> Self {
+        self.init_with_value = Some(f);
+        self
+    }
+
+    /// Sets the `next` function
+    pub const fn next(mut self, f: IterNextFn) -> Self {
+        self.next = Some(f);
+        self
+    }
+
+    /// Sets the `next_pair` function
+    pub const fn next_pair(mut self, f: IterNextPairFn) -> Self {
+        self.next_pair = Some(f);
+        self
+    }
+
+    /// Sets the `next_back` function
+    pub const fn next_back(mut self, f: IterNextBackFn) -> Self {
+        self.next_back = Some(f);
+        self
+    }
+
+    /// Sets the `next_pair_back` function
+    pub const fn next_pair_back(mut self, f: IterNextPairBackFn) -> Self {
+        self.next_pair_back = Some(f);
+        self
+    }
+
+    /// Sets the `dealloc` function
+    pub const fn dealloc(mut self, f: IterDeallocFn) -> Self {
+        self.dealloc = Some(f);
+        self
+    }
+
+    /// Builds the [`IterVTable`] from the current state of the builder.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if any of the required fields are `None`.
+    pub const fn build(self) -> IterVTable {
+        IterVTable {
+            init_with_value: self.init_with_value,
+            next: self.next.unwrap(),
+            next_pair: self.next_pair,
+            next_back: self.next_back,
+            next_pair_back: self.next_pair_back,
+            size_hint: self.size_hint,
+            dealloc: self.dealloc.unwrap(),
+        }
+    }
 }

--- a/facet-core/src/types/def/mod.rs
+++ b/facet-core/src/types/def/mod.rs
@@ -6,6 +6,9 @@ pub use array::*;
 mod slice;
 pub use slice::*;
 
+mod iter;
+pub use iter::*;
+
 mod list;
 pub use list::*;
 

--- a/facet-reflect/src/peek/map.rs
+++ b/facet-reflect/src/peek/map.rs
@@ -12,8 +12,9 @@ impl<'mem, 'facet_lifetime> Iterator for PeekMapIter<'mem, 'facet_lifetime> {
     type Item = (Peek<'mem, 'facet_lifetime>, Peek<'mem, 'facet_lifetime>);
 
     fn next(&mut self) -> Option<Self::Item> {
+        let next_pair_fn = self.map.def.vtable.iter_vtable.next_pair.unwrap();
         unsafe {
-            let next = (self.map.def.vtable.iter_vtable.next)(self.iter);
+            let next = next_pair_fn(self.iter);
             next.map(|(key_ptr, value_ptr)| {
                 (
                     Peek::unchecked_new(key_ptr, self.map.def.k()),
@@ -26,8 +27,9 @@ impl<'mem, 'facet_lifetime> Iterator for PeekMapIter<'mem, 'facet_lifetime> {
 
 impl DoubleEndedIterator for PeekMapIter<'_, '_> {
     fn next_back(&mut self) -> Option<Self::Item> {
+        let next_pair_back_fn = self.map.def.vtable.iter_vtable.next_pair_back.unwrap();
         unsafe {
-            let next_back = (self.map.def.vtable.iter_vtable.next_back)(self.iter);
+            let next_back = next_pair_back_fn(self.iter);
             next_back.map(|(key_ptr, value_ptr)| {
                 (
                     Peek::unchecked_new(key_ptr, self.map.def.k()),
@@ -105,7 +107,8 @@ impl<'mem, 'facet_lifetime> PeekMap<'mem, 'facet_lifetime> {
 
     /// Returns an iterator over the key-value pairs in the map
     pub fn iter(self) -> PeekMapIter<'mem, 'facet_lifetime> {
-        let iter = unsafe { (self.def.vtable.iter_fn)(self.value.data()) };
+        let iter_init_with_value_fn = self.def.vtable.iter_vtable.init_with_value.unwrap();
+        let iter = unsafe { iter_init_with_value_fn(self.value.data()) };
         PeekMapIter { map: self, iter }
     }
 


### PR DESCRIPTION
Relates to #578

This PR adds a new `IterVTable`, which covers the functionality of both the prior `MapVTable` and `SetVTable`. The new vtable also has an `init_with_value` function, which also replaces both previous `iter` functions (this was so the iter vtable could have both the `init` and `dealloc` functions for symmetry)

To account for maps returning key/value pairs and sets returning just values, `IterVTable` includes both `next`/`next_back` functions (required, yields a single value) plus `next_pair`/`next_pair_back` functions (optional, yields two values). This feels a little gross, but my thought was that you can view a map like an iterator over its values, so it kinda makes sense?[^iter-keys] (I also have an alternative idea for implementing this but it's also a little gross, so I'll open it as a follow-up PR for discussion)

This change is on the road to #578, where I see the final step as giving `ListVTable` its own iterator. It seemed silly to have another separate iter vtable just for lists, so I wanted to generalize first.

[^iter-keys]: I think it would also be valid to see a map as an iterator over its _keys_ instead of its _values_, I don't have a strong opinion on which is better honestly...