### PR TITLE
Make `IterVTable` generic over the iteratee

### DIFF
--- a/facet-core/src/impls_alloc/btreemap.rs
+++ b/facet-core/src/impls_alloc/btreemap.rs
@@ -169,43 +169,16 @@ where
                                                 Box::new(BTreeMapIterator { map: ptr, keys });
                                             PtrMut::new(Box::into_raw(iter_state) as *mut u8)
                                         })
-                                        .next_pair(|iter_ptr| unsafe {
-                                            let state =
-                                                iter_ptr.as_mut::<BTreeMapIterator<'_, K>>();
-                                            let map = state.map.get::<Self>();
-                                            while let Some(key) = state.keys.pop_front() {
-                                                if let Some(value) = map.get(key) {
-                                                    return Some((
-                                                        PtrConst::new(key as *const K),
-                                                        PtrConst::new(value as *const V),
-                                                    ));
-                                                }
-                                            }
-
-                                            None
-                                        })
-                                        .next_pair_back(|iter_ptr| unsafe {
-                                            let state =
-                                                iter_ptr.as_mut::<BTreeMapIterator<'_, K>>();
-                                            let map = state.map.get::<Self>();
-                                            while let Some(key) = state.keys.pop_back() {
-                                                if let Some(value) = map.get(key) {
-                                                    return Some((
-                                                        PtrConst::new(key as *const K),
-                                                        PtrConst::new(value as *const V),
-                                                    ));
-                                                }
-                                            }
-
-                                            None
-                                        })
                                         .next(|iter_ptr| unsafe {
                                             let state =
                                                 iter_ptr.as_mut::<BTreeMapIterator<'_, K>>();
                                             let map = state.map.get::<Self>();
                                             while let Some(key) = state.keys.pop_front() {
                                                 if let Some(value) = map.get(key) {
-                                                    return Some(PtrConst::new(value as *const V));
+                                                    return Some((
+                                                        PtrConst::new(key as *const K),
+                                                        PtrConst::new(value as *const V),
+                                                    ));
                                                 }
                                             }
 
@@ -217,7 +190,10 @@ where
                                             let map = state.map.get::<Self>();
                                             while let Some(key) = state.keys.pop_back() {
                                                 if let Some(value) = map.get(key) {
-                                                    return Some(PtrConst::new(value as *const V));
+                                                    return Some((
+                                                        PtrConst::new(key as *const K),
+                                                        PtrConst::new(value as *const V),
+                                                    ));
                                                 }
                                             }
 

--- a/facet-core/src/impls_std/hashmap.rs
+++ b/facet-core/src/impls_std/hashmap.rs
@@ -172,40 +172,15 @@ where
                                                 Box::new(HashMapIterator { map: ptr, keys });
                                             PtrMut::new(Box::into_raw(iter_state) as *mut u8)
                                         })
-                                        .next_pair(|iter_ptr| unsafe {
-                                            let state = iter_ptr.as_mut::<HashMapIterator<'_, K>>();
-                                            let map = state.map.get::<HashMap<K, V>>();
-                                            while let Some(key) = state.keys.pop_front() {
-                                                if let Some(value) = map.get(key) {
-                                                    return Some((
-                                                        PtrConst::new(key as *const K),
-                                                        PtrConst::new(value as *const V),
-                                                    ));
-                                                }
-                                            }
-
-                                            None
-                                        })
-                                        .next_pair_back(|iter_ptr| unsafe {
-                                            let state = iter_ptr.as_mut::<HashMapIterator<'_, K>>();
-                                            let map = state.map.get::<HashMap<K, V>>();
-                                            while let Some(key) = state.keys.pop_back() {
-                                                if let Some(value) = map.get(key) {
-                                                    return Some((
-                                                        PtrConst::new(key as *const K),
-                                                        PtrConst::new(value as *const V),
-                                                    ));
-                                                }
-                                            }
-
-                                            None
-                                        })
                                         .next(|iter_ptr| unsafe {
                                             let state = iter_ptr.as_mut::<HashMapIterator<'_, K>>();
                                             let map = state.map.get::<HashMap<K, V>>();
                                             while let Some(key) = state.keys.pop_front() {
                                                 if let Some(value) = map.get(key) {
-                                                    return Some(PtrConst::new(value as *const V));
+                                                    return Some((
+                                                        PtrConst::new(key as *const K),
+                                                        PtrConst::new(value as *const V),
+                                                    ));
                                                 }
                                             }
 
@@ -216,7 +191,10 @@ where
                                             let map = state.map.get::<HashMap<K, V>>();
                                             while let Some(key) = state.keys.pop_back() {
                                                 if let Some(value) = map.get(key) {
-                                                    return Some(PtrConst::new(value as *const V));
+                                                    return Some((
+                                                        PtrConst::new(key as *const K),
+                                                        PtrConst::new(value as *const V),
+                                                    ));
                                                 }
                                             }
 

--- a/facet-core/src/types/def/map.rs
+++ b/facet-core/src/types/def/map.rs
@@ -140,7 +140,7 @@ pub struct MapVTable {
     pub get_value_ptr_fn: MapGetValuePtrFn,
 
     /// Virtual table for map iterator operations
-    pub iter_vtable: IterVTable,
+    pub iter_vtable: IterVTable<(PtrConst<'static>, PtrConst<'static>)>,
 }
 
 impl MapVTable {
@@ -157,7 +157,7 @@ pub struct MapVTableBuilder {
     len_fn: Option<MapLenFn>,
     contains_key_fn: Option<MapContainsKeyFn>,
     get_value_ptr_fn: Option<MapGetValuePtrFn>,
-    iter_vtable: Option<IterVTable>,
+    iter_vtable: Option<IterVTable<(PtrConst<'static>, PtrConst<'static>)>>,
 }
 
 impl MapVTableBuilder {
@@ -205,7 +205,10 @@ impl MapVTableBuilder {
     }
 
     /// Sets the iter_vtable field
-    pub const fn iter_vtable(mut self, vtable: IterVTable) -> Self {
+    pub const fn iter_vtable(
+        mut self,
+        vtable: IterVTable<(PtrConst<'static>, PtrConst<'static>)>,
+    ) -> Self {
         self.iter_vtable = Some(vtable);
         self
     }

--- a/facet-core/src/types/def/set.rs
+++ b/facet-core/src/types/def/set.rs
@@ -114,7 +114,7 @@ pub struct SetVTable {
     pub contains_fn: SetContainsFn,
 
     /// Virtual table for set iterator operations
-    pub iter_vtable: IterVTable,
+    pub iter_vtable: IterVTable<PtrConst<'static>>,
 }
 
 impl SetVTable {
@@ -130,7 +130,7 @@ pub struct SetVTableBuilder {
     insert_fn: Option<SetInsertFn>,
     len_fn: Option<SetLenFn>,
     contains_fn: Option<SetContainsFn>,
-    iter_vtable: Option<IterVTable>,
+    iter_vtable: Option<IterVTable<PtrConst<'static>>>,
 }
 
 impl SetVTableBuilder {
@@ -171,7 +171,7 @@ impl SetVTableBuilder {
     }
 
     /// Sets the iter_vtable field
-    pub const fn iter_vtable(mut self, vtable: IterVTable) -> Self {
+    pub const fn iter_vtable(mut self, vtable: IterVTable<PtrConst<'static>>) -> Self {
         self.iter_vtable = Some(vtable);
         self
     }

--- a/facet-reflect/src/peek/map.rs
+++ b/facet-reflect/src/peek/map.rs
@@ -12,9 +12,8 @@ impl<'mem, 'facet_lifetime> Iterator for PeekMapIter<'mem, 'facet_lifetime> {
     type Item = (Peek<'mem, 'facet_lifetime>, Peek<'mem, 'facet_lifetime>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let next_pair_fn = self.map.def.vtable.iter_vtable.next_pair.unwrap();
         unsafe {
-            let next = next_pair_fn(self.iter);
+            let next = (self.map.def.vtable.iter_vtable.next)(self.iter);
             next.map(|(key_ptr, value_ptr)| {
                 (
                     Peek::unchecked_new(key_ptr, self.map.def.k()),
@@ -27,9 +26,9 @@ impl<'mem, 'facet_lifetime> Iterator for PeekMapIter<'mem, 'facet_lifetime> {
 
 impl DoubleEndedIterator for PeekMapIter<'_, '_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let next_pair_back_fn = self.map.def.vtable.iter_vtable.next_pair_back.unwrap();
+        let next_back_fn = self.map.def.vtable.iter_vtable.next_back.unwrap();
         unsafe {
-            let next_back = next_pair_back_fn(self.iter);
+            let next_back = next_back_fn(self.iter);
             next_back.map(|(key_ptr, value_ptr)| {
                 (
                     Peek::unchecked_new(key_ptr, self.map.def.k()),


### PR DESCRIPTION
Follow-up to #617

This PR builds on #617, with a different way to handle the "map vs. set" iteration problem. The original way was to basically offer two different ways to iterate: `next` which returnes a single `PtrConst`, and `next_pair` which returns a pair of `PtrConst` values (i.e. the key and value of a map)

This PR tweaks the new `IterVTable` type to be generic over what `next` should return-- the iteratee. Sounds easy enough... except `NextFn` (like all vtable methods) uses [Higher-Ranked Trait Bounds](https://doc.rust-lang.org/nomicon/hrtb.html) so it can be generic over lifetimes. To properly type this, we need to "apply" this higher-ranked lifetime to the generic type.

The tool we need for that is a Higher-Kinded Type. Luckily, [GATs](https://blog.rust-lang.org/2022/10/28/gats-stabilization/) are isomorphic to Higher-Kinded Types, but it's a little clunky. That's what the new `ItemIter` trait is-- it lets us fill in a lifetime for either `PtrConst` or `(PtrConst, PtrConst)`, letting us treat it like a Higher-Kinded Type.