### PR TITLE
feat(deserialize): multi-input type support via generic `Format`

### DIFF
--- a/facet-args/src/defaults.rs
+++ b/facet-args/src/defaults.rs
@@ -24,8 +24,8 @@ pub(crate) fn apply_field_defaults(wip: Wip<'_>) -> Result<Wip<'_>, ArgsError> {
 
     // Set up StackRunner for default handling
     let mut runner = StackRunner {
-        original_input: &[],
-        input: &[],
+        original_input: &[] as &[u8],
+        input: &[] as &[u8],
         stack: vec![],
         last_span: Span::new(0, 0),
     };

--- a/facet-deserialize/src/debug.rs
+++ b/facet-deserialize/src/debug.rs
@@ -1,0 +1,52 @@
+//! Debug utilities for deserialization formats.
+
+use crate::span::Span;
+use alloc::borrow::Cow;
+
+/// Trait for handling input data in error reporting and debugging.
+/// Provides methods to convert input slices to human-readable strings
+/// and to create byte arrays for error storage.
+pub trait InputDebug {
+    /// Returns a string representation of the input at the given span.
+    /// Used for pretty error messages in diagnostics.
+    fn slice(&self, span: Span) -> &str;
+
+    /// Converts the input to a borrowed or owned byte array.
+    /// Used when constructing error objects that need to store input data.
+    fn as_cow(&self) -> Cow<'_, [u8]>;
+}
+
+impl InputDebug for [u8] {
+    fn slice(&self, span: Span) -> &str {
+        core::str::from_utf8(&self[span.start()..span.end()]).unwrap_or("<invalid utf8>")
+    }
+
+    fn as_cow(&self) -> Cow<'_, [u8]> {
+        alloc::borrow::Cow::Borrowed(self)
+    }
+}
+
+impl InputDebug for [&str] {
+    fn slice(&self, span: Span) -> &str {
+        // Simplified implementation - just return the argument at that position if it exists
+        if span.start() < self.len() {
+            self[span.start()]
+        } else {
+            "<out of bounds>"
+        }
+    }
+
+    fn as_cow(&self) -> Cow<'_, [u8]> {
+        // For CLI args, we join them for error reporting
+        let joined = self.join(" ");
+        Cow::Owned(joined.into_bytes())
+    }
+}
+
+/// Helper function for error creation
+pub fn input_to_cow<'input, I>(input: &'input I) -> Cow<'input, [u8]>
+where
+    I: ?Sized + 'input + InputDebug,
+{
+    input.as_cow()
+}

--- a/facet-deserialize/src/error.rs
+++ b/facet-deserialize/src/error.rs
@@ -7,6 +7,7 @@ use facet_core::{Shape, Type, UserType};
 use facet_reflect::{ReflectError, VariantError};
 use owo_colors::OwoColorize;
 
+use crate::debug::InputDebug;
 use crate::{Outcome, Span};
 
 /// A JSON parse error, with context. Never would've guessed huh.
@@ -109,16 +110,22 @@ pub enum DeserErrorKind {
 
 impl<'input> DeserError<'input> {
     /// Creates a new deser error, preserving input and location context for accurate reporting.
-    pub fn new(kind: DeserErrorKind, input: &'input [u8], span: Span) -> Self {
+    pub fn new<I>(kind: DeserErrorKind, input: &'input I, span: Span) -> Self
+    where
+        I: ?Sized + 'input + InputDebug,
+    {
         Self {
-            input: alloc::borrow::Cow::Borrowed(input),
+            input: input.as_cow(),
             span,
             kind,
         }
     }
 
     /// Constructs a reflection-related deser error, keeping contextual information intact.
-    pub(crate) fn new_reflect(e: ReflectError, input: &'input [u8], span: Span) -> Self {
+    pub(crate) fn new_reflect<I>(e: ReflectError, input: &'input I, span: Span) -> Self
+    where
+        I: ?Sized + 'input + InputDebug,
+    {
         DeserError::new(DeserErrorKind::ReflectError(e), input, span)
     }
 

--- a/facet-deserialize/tests/input_types.rs
+++ b/facet-deserialize/tests/input_types.rs
@@ -1,0 +1,320 @@
+// Integration tests for the Format trait's ability to handle different input types.
+// Verify that the deserialization engine correctly processes various input types
+// (e.g. `u8` bytes for JSON or `&str` for CLI args) with the same reflection machinery.
+
+#[cfg(test)]
+mod tests {
+    use facet::Facet;
+    use facet_deserialize::*;
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct TestConfig {
+        nom: String,
+    }
+
+    /// Mock formatter that processes byte slices ([u8]).
+    ///
+    /// This implementation provides a minimal verification that the deserialization
+    /// system correctly handles the traditional byte-slice input format.
+    struct MockByteFormat;
+
+    impl Format for MockByteFormat {
+        type Input<'input> = [u8];
+
+        /// Generate tokens for deserialization in a predetermined sequence.
+        ///
+        /// Rather than actually parsing input bytes, this implementation simulates
+        /// a parsing process by returning a fixed sequence of tokens based on the
+        /// current position in the input.
+        fn next<'input, 'facet>(
+            &mut self,
+            nd: NextData<'input, 'facet, Self::Input<'input>>,
+            _exp: Expectation,
+        ) -> NextResult<
+            'input,
+            'facet,
+            Spanned<Outcome<'input>>,
+            Spanned<DeserErrorKind>,
+            Self::Input<'input>,
+        > {
+            // Use the start position to determine which token to return
+            let position = nd.start();
+            let input = nd.input();
+            eprintln!("POSITION: {:?}", &position);
+            eprintln!("INPUT: {:?}", &input);
+            // Try to get the current byte
+            let rel_pos = (position + 1) % 2; // pos. 1 -> 0, pos. 4 -> 2 -> 1
+            if position == 0 {
+                eprintln!("CURRENT BYTE: None (object start)");
+            } else if rel_pos < input.len() && position < 8 {
+                eprintln!(
+                    "CURRENT BYTE: {:?} (ASCII: '{}')",
+                    input[rel_pos],
+                    char::from(input[rel_pos])
+                );
+            } else {
+                eprintln!("CURRENT BYTE: None (object end)");
+            }
+
+            // Very rudimentary deserialisation routine: if we get 2 bytes we read the first as
+            // "nom" (span=3) and the second as "test" (span=4). When the 2nd byte's span is put
+            // on the runner we reach position 8 and the object ends. Anything unexpected errors.
+            match position {
+                0 => {
+                    // Object start
+                    let span = Span::new(position, 1);
+                    (
+                        nd,
+                        Ok(Spanned {
+                            node: Outcome::ObjectStarted,
+                            span,
+                        }),
+                    )
+                }
+                1 => {
+                    // Field name "nom"
+                    let span = Span::new(position, 3);
+                    (
+                        nd,
+                        Ok(Spanned {
+                            node: Outcome::Scalar(Scalar::String("nom".into())),
+                            span,
+                        }),
+                    )
+                }
+                4 => {
+                    // Field value "test"
+                    let span = Span::new(position, 4);
+                    (
+                        nd,
+                        Ok(Spanned {
+                            node: Outcome::Scalar(Scalar::String("test".into())),
+                            span,
+                        }),
+                    )
+                }
+                8 => {
+                    // Object end
+                    let span = Span::new(position, 1);
+                    (
+                        nd,
+                        Ok(Spanned {
+                            node: Outcome::ObjectEnded,
+                            span,
+                        }),
+                    )
+                }
+                _ => {
+                    // Unexpected position
+                    (
+                        nd,
+                        Err(Spanned {
+                            node: DeserErrorKind::UnexpectedEof {
+                                wanted: "no more input expected",
+                            },
+                            span: Span::new(position, 0),
+                        }),
+                    )
+                }
+            }
+        }
+
+        /// Minimal implementation of the skip method required by the Format trait.
+        fn skip<'input, 'facet>(
+            &mut self,
+            nd: NextData<'input, 'facet, Self::Input<'input>>,
+        ) -> NextResult<'input, 'facet, Span, Spanned<DeserErrorKind>, Self::Input<'input>>
+        {
+            // Simply advance the position by 1
+            let position = nd.start();
+            let span = Span::new(position, 1);
+            (nd, Ok(span))
+        }
+    }
+
+    #[test]
+    fn test_byte_slice_input() {
+        // Explicit slice type annotation to avoid array type inference
+        let dummy_bytes: &[u8] = b"xy";
+
+        // Deserialize using the byte-based format
+        let result: TestConfig = deserialize(dummy_bytes, MockByteFormat)
+            .expect("Failed to deserialize from byte slice");
+
+        // Verify expected field value
+        assert_eq!(
+            result,
+            TestConfig {
+                nom: "test".to_string()
+            }
+        );
+    }
+
+    /// Mock formatter that processes string slices ([&str]).
+    ///
+    /// This implementation verifies that the deserialization system
+    /// can process string-based inputs like CLI arguments.
+    struct MockCliFormat;
+
+    impl Format for MockCliFormat {
+        type Input<'input> = [&'input str];
+
+        /// Generate tokens for processing CLI-like arguments.
+        ///
+        /// Simulates parsing of arguments in the pattern:
+        /// ["--nom", "test"]
+        fn next<'input, 'facet>(
+            &mut self,
+            nd: NextData<'input, 'facet, Self::Input<'input>>,
+            exp: Expectation,
+        ) -> NextResult<
+            'input,
+            'facet,
+            Spanned<Outcome<'input>>,
+            Spanned<DeserErrorKind>,
+            Self::Input<'input>,
+        > {
+            // Use the start position and expectation to determine which token to return
+            let position = nd.start();
+            let input = nd.input();
+            eprintln!("POSITION: {:?}", &position);
+            eprintln!("INPUT: {:?}", &input);
+
+            if position == 0 {
+                eprintln!("CURRENT ARG: None (object start)");
+            } else if position <= input.len() {
+                eprintln!("CURRENT ARG: {:?}", input[position - 1]);
+            } else {
+                eprintln!("CURRENT ARG: None (object end)");
+            }
+
+            match exp {
+                Expectation::Value => {
+                    if position == 0 {
+                        // Start with object
+                        let span = Span::new(position, 1); // Length 1 to advance position
+                        (
+                            nd,
+                            Ok(Spanned {
+                                node: Outcome::ObjectStarted,
+                                span,
+                            }),
+                        )
+                    } else {
+                        // Unexpected value request
+                        (
+                            nd,
+                            Err(Spanned {
+                                node: DeserErrorKind::UnexpectedEof {
+                                    wanted: "value at unexpected position",
+                                },
+                                span: Span::new(position, 0),
+                            }),
+                        )
+                    }
+                }
+                Expectation::ObjectKeyOrObjectClose => {
+                    if position == 1 {
+                        // Field name "nom"
+                        let field_name = input[position - 1].strip_prefix("--").unwrap();
+                        let span = Span::new(position, 1); // Length 1 to advance position
+                        (
+                            nd,
+                            Ok(Spanned {
+                                node: Outcome::Scalar(Scalar::String(field_name.into())),
+                                span,
+                            }),
+                        )
+                    } else if position == 3 {
+                        // End object
+                        let span = Span::new(position, 1); // Length 1 to advance position
+                        (
+                            nd,
+                            Ok(Spanned {
+                                node: Outcome::ObjectEnded,
+                                span,
+                            }),
+                        )
+                    } else {
+                        // Unexpected position
+                        (
+                            nd,
+                            Err(Spanned {
+                                node: DeserErrorKind::UnexpectedEof {
+                                    wanted: "field or object end",
+                                },
+                                span: Span::new(position, 0),
+                            }),
+                        )
+                    }
+                }
+                Expectation::ObjectVal => {
+                    if position == 2 {
+                        // Field value "test"
+                        let field_value = input[position - 1];
+                        let span = Span::new(position, 1); // Length 1 to advance position
+                        (
+                            nd,
+                            Ok(Spanned {
+                                node: Outcome::Scalar(Scalar::String(field_value.into())),
+                                span,
+                            }),
+                        )
+                    } else {
+                        // Unexpected position
+                        (
+                            nd,
+                            Err(Spanned {
+                                node: DeserErrorKind::UnexpectedEof {
+                                    wanted: "object value",
+                                },
+                                span: Span::new(position, 0),
+                            }),
+                        )
+                    }
+                }
+                _ => {
+                    // Unexpected expectation
+                    (
+                        nd,
+                        Err(Spanned {
+                            node: DeserErrorKind::UnexpectedEof {
+                                wanted: "unsupported expectation",
+                            },
+                            span: Span::new(position, 0),
+                        }),
+                    )
+                }
+            }
+        }
+
+        fn skip<'input, 'facet>(
+            &mut self,
+            nd: NextData<'input, 'facet, Self::Input<'input>>,
+        ) -> NextResult<'input, 'facet, Span, Spanned<DeserErrorKind>, Self::Input<'input>>
+        {
+            // Simply return a span that advances the position
+            let position = nd.start();
+            let span = Span::new(position, 1); // Length 1 to advance position
+            (nd, Ok(span))
+        }
+    }
+
+    #[test]
+    fn test_string_slice_input() {
+        // Sample CLI args (content doesn't matter for this mock)
+        let args: &[&str] = &["--nom", "test"];
+
+        // Deserialize using the string-based format
+        let result: TestConfig =
+            deserialize(args, MockCliFormat).expect("Failed to deserialize from string slices");
+
+        // Verify expected field value
+        assert_eq!(
+            result,
+            TestConfig {
+                nom: "test".to_string()
+            }
+        );
+    }
+}

--- a/facet-json/src/iterative/deserialize.rs
+++ b/facet-json/src/iterative/deserialize.rs
@@ -23,6 +23,8 @@ pub(crate) fn from_str_static_error<'input: 'facet, 'facet, T: Facet<'facet>>(
 }
 
 impl Format for crate::Json {
+    type Input<'input> = [u8];
+
     fn next<'input, 'facet>(
         &mut self,
         nd: NextData<'input, 'facet>,


### PR DESCRIPTION
- **feat(deserialize): support multiple input types via generic `Format`**

**Summary**: refactor with no change to behaviour, allows us to support `&str` arguments in a Format needed for facet-args
**Motivation**: JSON is a sequence of bytes, but the OS splits up the CLI args for us when making `std::env::args` so we need a way to iterate over those strings, this allows us to do that

This PR keeps the currently hardcoded `Format` input type as `u8` as the default while adding the ability to take `&str`

It demonstrates usage of this in the 2 tests included, both deserializing the same Facet struct with one field `nom: String` (note the change in string type in this PR refers to the deserialisation data _input_ type not the Facet field type)

- `u8` test (which we already know works thanks to facet-json), here implements a trivial mock bytes format that reads 2 bytes `b"xy"` and always produces the same output
  - imaginary scenario where `b"x"` is always interpreted as the field name "nom" and `b"y"` is always code for the field value "test"
- `&str` test (which gives a simple proof of concept for a facet-args rewrite), here implements a trivial mock CLI arguments format
   - more realistic scenario where `"--nom"` is always stripped of "--" prefix and interpreted as the field name ("nom") and the other value "test" is not interfered with

![image](https://github.com/user-attachments/assets/249dc227-c1c2-4f21-b7e0-5803eae7fdb7)
