### PR TITLE
Update list vtables to allow for more types of lists

### DIFF
--- a/facet-core/src/impls_alloc/vec.rs
+++ b/facet-core/src/impls_alloc/vec.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use core::hash::Hash as _;
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 type VecIterator<'mem, T> = core::slice::Iter<'mem, T>;

--- a/facet-core/src/impls_alloc/vec.rs
+++ b/facet-core/src/impls_alloc/vec.rs
@@ -117,6 +117,16 @@ where
                                     let vec = ptr.get::<Self>();
                                     vec.len()
                                 })
+                                .get(|ptr, index| unsafe {
+                                    let vec = ptr.get::<Self>();
+                                    let item = vec.get(index)?;
+                                    Some(PtrConst::new(item))
+                                })
+                                .get_mut(|ptr, index| unsafe {
+                                    let vec = ptr.as_mut::<Self>();
+                                    let item = vec.get_mut(index)?;
+                                    Some(PtrMut::new(item))
+                                })
                                 .as_ptr(|ptr| unsafe {
                                     let vec = ptr.get::<Self>();
                                     PtrConst::new(vec.as_ptr())

--- a/facet-core/src/types/def/list.rs
+++ b/facet-core/src/types/def/list.rs
@@ -88,6 +88,22 @@ pub type ListPushFn = unsafe fn(list: PtrMut, item: PtrMut);
 /// The `list` parameter must point to aligned, initialized memory of the correct type.
 pub type ListLenFn = unsafe fn(list: PtrConst) -> usize;
 
+/// Get pointer to the element at `index` in the list, or `None` if the
+/// index is out of bounds.
+///
+/// # Safety
+///
+/// The `list` parameter must point to aligned, initialized memory of the correct type.
+pub type ListGetFn = unsafe fn(list: PtrConst, index: usize) -> Option<PtrConst>;
+
+/// Get mutable pointer to the element at `index` in the list, or `None` if the
+/// index is out of bounds.
+///
+/// # Safety
+///
+/// The `list` parameter must point to aligned, initialized memory of the correct type.
+pub type ListGetMutFn = unsafe fn(list: PtrMut, index: usize) -> Option<PtrMut>;
+
 /// Get pointer to the data buffer of the list.
 ///
 /// # Safety
@@ -117,6 +133,12 @@ pub struct ListVTable {
     /// cf. [`ListLenFn`]
     pub len: ListLenFn,
 
+    /// cf. [`ListGetFn`]
+    pub get: ListGetFn,
+
+    /// cf. [`ListGetMutFn`]
+    pub get_mut: ListGetMutFn,
+
     /// cf. [`ListAsPtrFn`]
     /// Only available for types that can be accessed as a contiguous array
     pub as_ptr: Option<ListAsPtrFn>,
@@ -141,6 +163,8 @@ pub struct ListVTableBuilder {
     init_in_place_with_capacity: Option<ListInitInPlaceWithCapacityFn>,
     push: Option<ListPushFn>,
     len: Option<ListLenFn>,
+    get: Option<ListGetFn>,
+    get_mut: Option<ListGetMutFn>,
     as_ptr: Option<ListAsPtrFn>,
     as_mut_ptr: Option<ListAsMutPtrFn>,
     iter_vtable: Option<IterVTable<PtrConst<'static>>>,
@@ -154,6 +178,8 @@ impl ListVTableBuilder {
             init_in_place_with_capacity: None,
             push: None,
             len: None,
+            get: None,
+            get_mut: None,
             as_ptr: None,
             as_mut_ptr: None,
             iter_vtable: None,
@@ -175,6 +201,18 @@ impl ListVTableBuilder {
     /// Sets the len field
     pub const fn len(mut self, f: ListLenFn) -> Self {
         self.len = Some(f);
+        self
+    }
+
+    /// Sets the get field
+    pub const fn get(mut self, f: ListGetFn) -> Self {
+        self.get = Some(f);
+        self
+    }
+
+    /// Sets the get_mut field
+    pub const fn get_mut(mut self, f: ListGetMutFn) -> Self {
+        self.get_mut = Some(f);
         self
     }
 
@@ -206,6 +244,8 @@ impl ListVTableBuilder {
             init_in_place_with_capacity: self.init_in_place_with_capacity,
             push: self.push.unwrap(),
             len: self.len.unwrap(),
+            get: self.get.unwrap(),
+            get_mut: self.get_mut.unwrap(),
             as_ptr: self.as_ptr,
             as_mut_ptr: self.as_mut_ptr,
             iter_vtable: self.iter_vtable.unwrap(),

--- a/facet-core/src/types/def/list.rs
+++ b/facet-core/src/types/def/list.rs
@@ -1,6 +1,6 @@
 use crate::ptr::{PtrConst, PtrMut, PtrUninit};
 
-use super::Shape;
+use super::{IterVTable, Shape};
 
 /// Fields for list types
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -122,6 +122,9 @@ pub struct ListVTable {
 
     /// cf. [`ListAsMutPtrFn`]
     pub as_mut_ptr: ListAsMutPtrFn,
+
+    /// Virtual table for list iterator operations
+    pub iter_vtable: IterVTable<PtrConst<'static>>,
 }
 
 impl ListVTable {
@@ -138,6 +141,7 @@ pub struct ListVTableBuilder {
     len: Option<ListLenFn>,
     as_ptr: Option<ListAsPtrFn>,
     as_mut_ptr: Option<ListAsMutPtrFn>,
+    iter_vtable: Option<IterVTable<PtrConst<'static>>>,
 }
 
 impl ListVTableBuilder {
@@ -150,6 +154,7 @@ impl ListVTableBuilder {
             len: None,
             as_ptr: None,
             as_mut_ptr: None,
+            iter_vtable: None,
         }
     }
 
@@ -183,6 +188,12 @@ impl ListVTableBuilder {
         self
     }
 
+    /// Sets the iter_vtable field
+    pub const fn iter_vtable(mut self, vtable: IterVTable<PtrConst<'static>>) -> Self {
+        self.iter_vtable = Some(vtable);
+        self
+    }
+
     /// Builds the [`ListVTable`] from the current state of the builder.
     ///
     /// # Panics
@@ -195,6 +206,7 @@ impl ListVTableBuilder {
             len: self.len.unwrap(),
             as_ptr: self.as_ptr.unwrap(),
             as_mut_ptr: self.as_mut_ptr.unwrap(),
+            iter_vtable: self.iter_vtable.unwrap(),
         }
     }
 }

--- a/facet-core/src/types/def/list.rs
+++ b/facet-core/src/types/def/list.rs
@@ -118,10 +118,12 @@ pub struct ListVTable {
     pub len: ListLenFn,
 
     /// cf. [`ListAsPtrFn`]
-    pub as_ptr: ListAsPtrFn,
+    /// Only available for types that can be accessed as a contiguous array
+    pub as_ptr: Option<ListAsPtrFn>,
 
     /// cf. [`ListAsMutPtrFn`]
-    pub as_mut_ptr: ListAsMutPtrFn,
+    /// Only available for types that can be accessed as a contiguous array
+    pub as_mut_ptr: Option<ListAsMutPtrFn>,
 
     /// Virtual table for list iterator operations
     pub iter_vtable: IterVTable<PtrConst<'static>>,
@@ -204,8 +206,8 @@ impl ListVTableBuilder {
             init_in_place_with_capacity: self.init_in_place_with_capacity,
             push: self.push.unwrap(),
             len: self.len.unwrap(),
-            as_ptr: self.as_ptr.unwrap(),
-            as_mut_ptr: self.as_mut_ptr.unwrap(),
+            as_ptr: self.as_ptr,
+            as_mut_ptr: self.as_mut_ptr,
             iter_vtable: self.iter_vtable.unwrap(),
         }
     }

--- a/facet-reflect/src/peek/list.rs
+++ b/facet-reflect/src/peek/list.rs
@@ -1,24 +1,38 @@
 use super::Peek;
-use core::fmt::Debug;
-use facet_core::ListDef;
+use core::{fmt::Debug, marker::PhantomData};
+use facet_core::{ListDef, PtrConst, PtrMut};
 
 /// Iterator over a `PeekList`
 pub struct PeekListIter<'mem, 'facet_lifetime> {
-    list: PeekList<'mem, 'facet_lifetime>,
+    state: PeekListIterState<'mem>,
     index: usize,
     len: usize,
+    def: ListDef,
+    _list: PhantomData<Peek<'mem, 'facet_lifetime>>,
 }
 
 impl<'mem, 'facet_lifetime> Iterator for PeekListIter<'mem, 'facet_lifetime> {
     type Item = Peek<'mem, 'facet_lifetime>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.index >= self.len {
-            return None;
-        }
-        let item = self.list.get(self.index);
+        let item_ptr = match self.state {
+            PeekListIterState::Ptr { data, stride } => {
+                if self.index >= self.len {
+                    return None;
+                }
+
+                unsafe { data.field(stride * self.index) }
+            }
+            PeekListIterState::Iter { iter } => unsafe {
+                (self.def.vtable.iter_vtable.next)(iter)?
+            },
+        };
+
+        // Update the index. This is used pointer iteration and for
+        // calculating the iterator's size
         self.index += 1;
-        item
+
+        Some(unsafe { Peek::unchecked_new(item_ptr, self.def.t()) })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -36,6 +50,11 @@ impl<'mem, 'facet_lifetime> IntoIterator for &'mem PeekList<'mem, 'facet_lifetim
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
+}
+
+enum PeekListIterState<'mem> {
+    Ptr { data: PtrConst<'mem>, stride: usize },
+    Iter { iter: PtrMut<'mem> },
 }
 
 /// Lets you read from a list (implements read-only [`facet_core::ListVTable`] proxies)
@@ -66,30 +85,40 @@ impl<'mem, 'facet_lifetime> PeekList<'mem, 'facet_lifetime> {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
     /// Get an item from the list at the specified index
     pub fn get(&self, index: usize) -> Option<Peek<'mem, 'facet_lifetime>> {
-        if index >= self.len() {
-            return None;
-        }
+        let item = unsafe { (self.def.vtable.get)(self.value.data(), index)? };
 
-        let Ok(layout) = self.def.t().layout.sized_layout() else {
-            return None;
-        };
-
-        let data = unsafe { (self.def.vtable.as_ptr.unwrap())(self.value.data()) };
-
-        // SAFETY: we verify index bounds at the start of the function
-        let item_ptr = unsafe { data.field(layout.size() * index) };
-
-        Some(unsafe { Peek::unchecked_new(item_ptr, self.def.t()) })
+        Some(unsafe { Peek::unchecked_new(item, self.def.t()) })
     }
 
     /// Returns an iterator over the list
     pub fn iter(self) -> PeekListIter<'mem, 'facet_lifetime> {
+        let state = if let Some(as_ptr_fn) = self.def.vtable.as_ptr {
+            let data = unsafe { as_ptr_fn(self.value.data()) };
+            let layout = self
+                .def
+                .t()
+                .layout
+                .sized_layout()
+                .expect("can only iterate over sized list elements");
+            let stride = layout.size();
+
+            PeekListIterState::Ptr { data, stride }
+        } else {
+            let iter = unsafe {
+                (self.def.vtable.iter_vtable.init_with_value.unwrap())(self.value.data())
+            };
+            PeekListIterState::Iter { iter }
+        };
+
         PeekListIter {
-            list: self,
+            state,
             index: 0,
             len: self.len(),
+            def: self.def(),
+            _list: PhantomData,
         }
     }
 

--- a/facet-reflect/src/peek/list.rs
+++ b/facet-reflect/src/peek/list.rs
@@ -43,6 +43,19 @@ impl<'mem, 'facet_lifetime> Iterator for PeekListIter<'mem, 'facet_lifetime> {
 
 impl ExactSizeIterator for PeekListIter<'_, '_> {}
 
+impl Drop for PeekListIter<'_, '_> {
+    fn drop(&mut self) {
+        match self.state {
+            PeekListIterState::Iter { iter } => unsafe {
+                (self.def.vtable.iter_vtable.dealloc)(iter)
+            },
+            PeekListIterState::Ptr { .. } => {
+                // Nothing to do
+            }
+        }
+    }
+}
+
 impl<'mem, 'facet_lifetime> IntoIterator for &'mem PeekList<'mem, 'facet_lifetime> {
     type Item = Peek<'mem, 'facet_lifetime>;
     type IntoIter = PeekListIter<'mem, 'facet_lifetime>;

--- a/facet-reflect/src/peek/list.rs
+++ b/facet-reflect/src/peek/list.rs
@@ -76,7 +76,7 @@ impl<'mem, 'facet_lifetime> PeekList<'mem, 'facet_lifetime> {
             return None;
         };
 
-        let data = unsafe { (self.def.vtable.as_ptr)(self.value.data()) };
+        let data = unsafe { (self.def.vtable.as_ptr.unwrap())(self.value.data()) };
 
         // SAFETY: we verify index bounds at the start of the function
         let item_ptr = unsafe { data.field(layout.size() * index) };

--- a/facet-reflect/src/peek/list_like.rs
+++ b/facet-reflect/src/peek/list_like.rs
@@ -92,6 +92,17 @@ enum PeekListLikeIterState<'mem> {
     },
 }
 
+impl Drop for PeekListLikeIterState<'_> {
+    fn drop(&mut self) {
+        match self {
+            Self::Iter { iter, vtable } => unsafe { (vtable.dealloc)(*iter) },
+            Self::Ptr { .. } => {
+                // Nothing to do
+            }
+        }
+    }
+}
+
 /// Lets you read from a list, array or slice
 #[derive(Clone, Copy)]
 pub struct PeekListLike<'mem, 'facet_lifetime> {

--- a/facet-reflect/src/peek/list_like.rs
+++ b/facet-reflect/src/peek/list_like.rs
@@ -88,7 +88,10 @@ impl<'mem, 'facet_lifetime> PeekListLike<'mem, 'facet_lifetime> {
     /// Creates a new peek list
     pub fn new(value: Peek<'mem, 'facet_lifetime>, def: ListLikeDef) -> Self {
         let (len, as_ptr_fn) = match def {
-            ListLikeDef::List(v) => (unsafe { (v.vtable.len)(value.data()) }, v.vtable.as_ptr),
+            ListLikeDef::List(v) => (
+                unsafe { (v.vtable.len)(value.data()) },
+                v.vtable.as_ptr.unwrap(),
+            ),
             ListLikeDef::Slice(v) => (unsafe { (v.vtable.len)(value.data()) }, v.vtable.as_ptr),
             ListLikeDef::Array(v) => (v.n, v.vtable.as_ptr),
         };

--- a/facet-reflect/src/peek/list_like.rs
+++ b/facet-reflect/src/peek/list_like.rs
@@ -1,7 +1,7 @@
-use facet_core::{PtrConst, Shape, ShapeLayout};
+use facet_core::{IterVTable, PtrConst, PtrMut, Shape, ShapeLayout};
 
 use super::Peek;
-use core::fmt::Debug;
+use core::{fmt::Debug, marker::PhantomData};
 
 /// Fields for types which act like lists
 #[derive(Clone, Copy)]
@@ -35,21 +35,33 @@ impl ListLikeDef {
 
 /// Iterator over a `PeekListLike`
 pub struct PeekListLikeIter<'mem, 'facet_lifetime> {
-    list: PeekListLike<'mem, 'facet_lifetime>,
+    state: PeekListLikeIterState<'mem>,
     index: usize,
     len: usize,
+    def: ListLikeDef,
+    _list: PhantomData<Peek<'mem, 'facet_lifetime>>,
 }
 
 impl<'mem, 'facet_lifetime> Iterator for PeekListLikeIter<'mem, 'facet_lifetime> {
     type Item = Peek<'mem, 'facet_lifetime>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.index >= self.len {
-            return None;
-        }
-        let item = self.list.get(self.index);
+        let item_ptr = match self.state {
+            PeekListLikeIterState::Ptr { data, stride } => {
+                if self.index >= self.len {
+                    return None;
+                }
+
+                unsafe { data.field(stride * self.index) }
+            }
+            PeekListLikeIterState::Iter { iter, vtable } => unsafe { (vtable.next)(iter)? },
+        };
+
+        // Update the index. This is used pointer iteration and for
+        // calculating the iterator's size
         self.index += 1;
-        item
+
+        Some(unsafe { Peek::unchecked_new(item_ptr, self.def.t()) })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -69,13 +81,23 @@ impl<'mem, 'facet_lifetime> IntoIterator for &'mem PeekListLike<'mem, 'facet_lif
     }
 }
 
+enum PeekListLikeIterState<'mem> {
+    Ptr {
+        data: PtrConst<'mem>,
+        stride: usize,
+    },
+    Iter {
+        iter: PtrMut<'mem>,
+        vtable: IterVTable<PtrConst<'static>>,
+    },
+}
+
 /// Lets you read from a list, array or slice
 #[derive(Clone, Copy)]
 pub struct PeekListLike<'mem, 'facet_lifetime> {
     pub(crate) value: Peek<'mem, 'facet_lifetime>,
     pub(crate) def: ListLikeDef,
     len: usize,
-    as_ptr: unsafe fn(this: PtrConst) -> PtrConst,
 }
 
 impl Debug for PeekListLike<'_, '_> {
@@ -87,20 +109,12 @@ impl Debug for PeekListLike<'_, '_> {
 impl<'mem, 'facet_lifetime> PeekListLike<'mem, 'facet_lifetime> {
     /// Creates a new peek list
     pub fn new(value: Peek<'mem, 'facet_lifetime>, def: ListLikeDef) -> Self {
-        let (len, as_ptr_fn) = match def {
-            ListLikeDef::List(v) => (
-                unsafe { (v.vtable.len)(value.data()) },
-                v.vtable.as_ptr.unwrap(),
-            ),
-            ListLikeDef::Slice(v) => (unsafe { (v.vtable.len)(value.data()) }, v.vtable.as_ptr),
-            ListLikeDef::Array(v) => (v.n, v.vtable.as_ptr),
+        let len = match def {
+            ListLikeDef::List(v) => unsafe { (v.vtable.len)(value.data()) },
+            ListLikeDef::Slice(v) => unsafe { (v.vtable.len)(value.data()) },
+            ListLikeDef::Array(v) => v.n,
         };
-        Self {
-            value,
-            def,
-            len,
-            as_ptr: as_ptr_fn,
-        }
+        Self { value, def, len }
     }
 
     /// Get the length of the list
@@ -119,12 +133,22 @@ impl<'mem, 'facet_lifetime> PeekListLike<'mem, 'facet_lifetime> {
     ///
     /// Panics if the index is out of bounds
     pub fn get(&self, index: usize) -> Option<Peek<'mem, 'facet_lifetime>> {
+        let as_ptr = match self.def {
+            ListLikeDef::List(def) => {
+                // Call get from the list's vtable directly if available
+                let item = unsafe { (def.vtable.get)(self.value.data(), index)? };
+                return Some(unsafe { Peek::unchecked_new(item, self.def.t()) });
+            }
+            ListLikeDef::Array(def) => def.vtable.as_ptr,
+            ListLikeDef::Slice(def) => def.vtable.as_ptr,
+        };
+
         if index >= self.len() {
             return None;
         }
 
         // Get the base pointer of the array
-        let base_ptr = unsafe { (self.as_ptr)(self.value.data()) };
+        let base_ptr = unsafe { as_ptr(self.value.data()) };
 
         // Get the layout of the element type
         let elem_layout = match self.def.t().layout {
@@ -143,10 +167,38 @@ impl<'mem, 'facet_lifetime> PeekListLike<'mem, 'facet_lifetime> {
 
     /// Returns an iterator over the list
     pub fn iter(self) -> PeekListLikeIter<'mem, 'facet_lifetime> {
+        let (as_ptr_fn, iter_vtable) = match self.def {
+            ListLikeDef::List(def) => (def.vtable.as_ptr, Some(def.vtable.iter_vtable)),
+            ListLikeDef::Array(def) => (Some(def.vtable.as_ptr), None),
+            ListLikeDef::Slice(def) => (Some(def.vtable.as_ptr), None),
+        };
+
+        let state = match (as_ptr_fn, iter_vtable) {
+            (Some(as_ptr_fn), _) => {
+                let data = unsafe { as_ptr_fn(self.value.data()) };
+                let layout = self
+                    .def
+                    .t()
+                    .layout
+                    .sized_layout()
+                    .expect("can only iterate over sized list elements");
+                let stride = layout.size();
+
+                PeekListLikeIterState::Ptr { data, stride }
+            }
+            (None, Some(vtable)) => {
+                let iter = unsafe { (vtable.init_with_value.unwrap())(self.value.data()) };
+                PeekListLikeIterState::Iter { iter, vtable }
+            }
+            (None, None) => unreachable!(),
+        };
+
         PeekListLikeIter {
-            list: self,
+            state,
             index: 0,
             len: self.len(),
+            def: self.def(),
+            _list: PhantomData,
         }
     }
 


### PR DESCRIPTION
Closes #578, should unblock #597 (I think)

This PR updates `ListVTable` with the following changes:

- Make `as_ptr` / `as_mut_ptr` fields optional
- Add new `get` / `get_mut` fields to get an element by index in the list
- Add new `iter_vtable` field: a vtable for creating/using/destroying an iterator for the list
  - See these PRs for more context: #617, #618
  - The iterators aren't all that useful when the `get` method is O(1), but that also means that more unusual collections can fit into `ListDef` more naturally (e.g. `LinkedList`, which can't efficiently implement `get` but can still iterate efficiently... relatively speaking)

I also updated `PeekList` and `PeekListLike` to account for lists that have / don't have `as_ptr`. Basically, it tries to use `as_ptr` as a fast path if available, but falls back to using `iter_vtable` to create an iterator if needed.

Also note that, the code paths where `as_ptr` is _not_ set are never hit, since `Vec` provides `as_ptr`. For validation, I commented out the `as_ptr` and `as_mut_ptr` methods on `Vec`, and tests still passed both normally and under Miri.