### PR TITLE
Refactor serialization to avoid reversing or collecting iterators

### DIFF
--- a/facet-reflect/src/peek/enum_.rs
+++ b/facet-reflect/src/peek/enum_.rs
@@ -1,8 +1,8 @@
-use facet_core::{EnumRepr, EnumType, Field, Shape, UserType, Variant};
+use facet_core::{EnumRepr, EnumType, Shape, UserType, Variant};
 
 use crate::{Peek, trace};
 
-use super::HasFields;
+use super::{FieldIter, HasFields};
 
 /// Lets you read from an enum (implements read-only enum operations)
 #[derive(Clone, Copy)]
@@ -243,29 +243,8 @@ impl<'mem, 'facet, 'shape> PeekEnum<'mem, 'facet, 'shape> {
 }
 
 impl<'mem, 'facet, 'shape> HasFields<'mem, 'facet, 'shape> for PeekEnum<'mem, 'facet, 'shape> {
-    fn fields(
-        &self,
-    ) -> impl DoubleEndedIterator<Item = (Field<'shape>, Peek<'mem, 'facet, 'shape>)> {
-        // Get the active variant and its fields
-        let variant = match self.active_variant() {
-            Ok(v) => v,
-            Err(e) => panic!("Cannot get active variant: {:?}", e),
-        };
-        let fields = &variant.data.fields;
-
-        // Create an iterator that yields the field definition and field value
-        (0..fields.len()).filter_map(move |i| {
-            // Get the field definition
-            let field = fields[i];
-            // Get the field value
-            let field_value = match self.field(i) {
-                Ok(Some(v)) => v,
-                Ok(None) => return None,
-                Err(e) => panic!("Cannot get field: {:?}", e),
-            };
-            // Return the field definition and value
-            Some((field, field_value))
-        })
+    fn fields(&self) -> FieldIter<'mem, 'facet, 'shape> {
+        FieldIter::new_enum(*self)
     }
 }
 

--- a/facet-reflect/src/peek/fields.rs
+++ b/facet-reflect/src/peek/fields.rs
@@ -1,0 +1,61 @@
+use facet_core::{Field, FieldFlags};
+
+use crate::Peek;
+use alloc::{vec, vec::Vec};
+
+/// Trait for types that have field methods
+///
+/// This trait allows code to be written generically over both structs and enums
+/// that provide field access and iteration capabilities.
+pub trait HasFields<'mem, 'facet, 'shape> {
+    /// Iterates over all fields in this type, providing both field metadata and value
+    fn fields(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (Field<'shape>, Peek<'mem, 'facet, 'shape>)>;
+
+    /// Iterates over fields in this type that should be included when it is serialized
+    fn fields_for_serialize(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (Field<'shape>, Peek<'mem, 'facet, 'shape>)> {
+        // This is a default implementation that filters out fields with `skip_serializing`
+        // attribute and handles field flattening.
+        self.fields()
+            .filter(|(field, peek)| !unsafe { field.should_skip_serializing(peek.data()) })
+            .flat_map(move |(mut field, peek)| {
+                if field.flags.contains(FieldFlags::FLATTEN) {
+                    let mut flattened = Vec::new();
+                    if let Ok(struct_peek) = peek.into_struct() {
+                        struct_peek
+                            .fields_for_serialize()
+                            .for_each(|item| flattened.push(item));
+                    } else if let Ok(enum_peek) = peek.into_enum() {
+                        // normally we'd serialize to something like:
+                        //
+                        //   {
+                        //     "field_on_struct": {
+                        //       "VariantName": { "field_on_variant": "foo" }
+                        //     }
+                        //   }
+                        //
+                        // But since `field_on_struct` is flattened, instead we do:
+                        //
+                        //   {
+                        //     "VariantName": { "field_on_variant": "foo" }
+                        //   }
+                        field.name = enum_peek
+                            .active_variant()
+                            .expect("Failed to get active variant")
+                            .name;
+                        field.flattened = true;
+                        flattened.push((field, peek));
+                    } else {
+                        // TODO: fail more gracefully
+                        panic!("cannot flatten a {}", field.shape())
+                    }
+                    flattened
+                } else {
+                    vec![(field, peek)]
+                }
+            })
+    }
+}

--- a/facet-reflect/src/peek/fields.rs
+++ b/facet-reflect/src/peek/fields.rs
@@ -1,7 +1,11 @@
+use core::ops::Range;
+
 use facet_core::{Field, FieldFlags};
 
 use crate::Peek;
 use alloc::{vec, vec::Vec};
+
+use super::{PeekEnum, PeekStruct};
 
 /// Trait for types that have field methods
 ///
@@ -9,9 +13,7 @@ use alloc::{vec, vec::Vec};
 /// that provide field access and iteration capabilities.
 pub trait HasFields<'mem, 'facet, 'shape> {
     /// Iterates over all fields in this type, providing both field metadata and value
-    fn fields(
-        &self,
-    ) -> impl DoubleEndedIterator<Item = (Field<'shape>, Peek<'mem, 'facet, 'shape>)>;
+    fn fields(&self) -> FieldIter<'mem, 'facet, 'shape>;
 
     /// Iterates over fields in this type that should be included when it is serialized
     fn fields_for_serialize(
@@ -59,3 +61,104 @@ pub trait HasFields<'mem, 'facet, 'shape> {
             })
     }
 }
+
+/// An iterator over all the fields of a struct or enum. See [`HasFields::fields`]
+pub struct FieldIter<'mem, 'facet, 'shape> {
+    state: FieldIterState<'mem, 'facet, 'shape>,
+    range: Range<usize>,
+}
+
+enum FieldIterState<'mem, 'facet, 'shape> {
+    Struct(PeekStruct<'mem, 'facet, 'shape>),
+    Enum {
+        peek_enum: PeekEnum<'mem, 'facet, 'shape>,
+        fields: &'shape [Field<'shape>],
+    },
+}
+
+impl<'mem, 'facet, 'shape> FieldIter<'mem, 'facet, 'shape> {
+    pub(crate) fn new_struct(struct_: PeekStruct<'mem, 'facet, 'shape>) -> Self {
+        Self {
+            range: 0..struct_.ty.fields.len(),
+            state: FieldIterState::Struct(struct_),
+        }
+    }
+
+    pub(crate) fn new_enum(enum_: PeekEnum<'mem, 'facet, 'shape>) -> Self {
+        // Get the fields of the active variant
+        let variant = match enum_.active_variant() {
+            Ok(v) => v,
+            Err(e) => panic!("Cannot get active variant: {:?}", e),
+        };
+        let fields = &variant.data.fields;
+
+        Self {
+            range: 0..fields.len(),
+            state: FieldIterState::Enum {
+                peek_enum: enum_,
+                fields,
+            },
+        }
+    }
+
+    fn get_field_by_index(
+        &self,
+        index: usize,
+    ) -> Option<(Field<'shape>, Peek<'mem, 'facet, 'shape>)> {
+        match self.state {
+            FieldIterState::Struct(peek_struct) => {
+                let field = peek_struct.ty.fields.get(index).copied()?;
+                let value = peek_struct.field(index).ok()?;
+                Some((field, value))
+            }
+            FieldIterState::Enum { peek_enum, fields } => {
+                // Get the field definition
+                let field = fields[index];
+                // Get the field value
+                let field_value = match peek_enum.field(index) {
+                    Ok(Some(v)) => v,
+                    Ok(None) => return None,
+                    Err(e) => panic!("Cannot get field: {:?}", e),
+                };
+                // Return the field definition and value
+                Some((field, field_value))
+            }
+        }
+    }
+}
+
+impl<'mem, 'facet, 'shape> Iterator for FieldIter<'mem, 'facet, 'shape> {
+    type Item = (Field<'shape>, Peek<'mem, 'facet, 'shape>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let index = self.range.next()?;
+
+            let Some(field) = self.get_field_by_index(index) else {
+                continue;
+            };
+
+            return Some(field);
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
+}
+
+impl DoubleEndedIterator for FieldIter<'_, '_, '_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            let index = self.range.next_back()?;
+
+            let Some(field) = self.get_field_by_index(index) else {
+                continue;
+            };
+
+            return Some(field);
+        }
+    }
+}
+
+impl ExactSizeIterator for FieldIter<'_, '_, '_> {}

--- a/facet-reflect/src/peek/mod.rs
+++ b/facet-reflect/src/peek/mod.rs
@@ -9,6 +9,9 @@ pub use struct_::*;
 mod enum_;
 pub use enum_::*;
 
+mod fields;
+pub use fields::*;
+
 mod list;
 pub use list::*;
 

--- a/facet-reflect/src/peek/struct_.rs
+++ b/facet-reflect/src/peek/struct_.rs
@@ -1,8 +1,8 @@
-use facet_core::{Field, FieldError, StructType};
+use facet_core::{FieldError, StructType};
 
 use crate::Peek;
 
-use super::HasFields;
+use super::{FieldIter, HasFields};
 
 /// Lets you read from a struct (implements read-only struct operations)
 #[derive(Clone, Copy)]
@@ -64,13 +64,7 @@ impl<'mem, 'facet, 'shape> PeekStruct<'mem, 'facet, 'shape> {
 impl<'mem, 'facet, 'shape> HasFields<'mem, 'facet, 'shape> for PeekStruct<'mem, 'facet, 'shape> {
     /// Iterates over all fields in this struct, providing both name and value
     #[inline]
-    fn fields(
-        &self,
-    ) -> impl DoubleEndedIterator<Item = (Field<'shape>, Peek<'mem, 'facet, 'shape>)> {
-        (0..self.field_count()).filter_map(|i| {
-            let field = self.ty.fields.get(i).copied()?;
-            let value = self.field(i).ok()?;
-            Some((field, value))
-        })
+    fn fields(&self) -> FieldIter<'mem, 'facet, 'shape> {
+        FieldIter::new_struct(*self)
     }
 }

--- a/facet-reflect/src/peek/struct_.rs
+++ b/facet-reflect/src/peek/struct_.rs
@@ -1,7 +1,8 @@
-use facet_core::{Field, FieldError, FieldFlags, StructType};
+use facet_core::{Field, FieldError, StructType};
 
 use crate::Peek;
-use alloc::{vec, vec::Vec};
+
+use super::HasFields;
 
 /// Lets you read from a struct (implements read-only struct operations)
 #[derive(Clone, Copy)]
@@ -71,62 +72,5 @@ impl<'mem, 'facet, 'shape> HasFields<'mem, 'facet, 'shape> for PeekStruct<'mem, 
             let value = self.field(i).ok()?;
             Some((field, value))
         })
-    }
-}
-
-/// Trait for types that have field methods
-///
-/// This trait allows code to be written generically over both structs and enums
-/// that provide field access and iteration capabilities.
-pub trait HasFields<'mem, 'facet, 'shape> {
-    /// Iterates over all fields in this type, providing both field metadata and value
-    fn fields(
-        &self,
-    ) -> impl DoubleEndedIterator<Item = (Field<'shape>, Peek<'mem, 'facet, 'shape>)>;
-
-    /// Iterates over fields in this type that should be included when it is serialized
-    fn fields_for_serialize(
-        &self,
-    ) -> impl DoubleEndedIterator<Item = (Field<'shape>, Peek<'mem, 'facet, 'shape>)> {
-        // This is a default implementation that filters out fields with `skip_serializing`
-        // attribute and handles field flattening.
-        self.fields()
-            .filter(|(field, peek)| !unsafe { field.should_skip_serializing(peek.data()) })
-            .flat_map(move |(mut field, peek)| {
-                if field.flags.contains(FieldFlags::FLATTEN) {
-                    let mut flattened = Vec::new();
-                    if let Ok(struct_peek) = peek.into_struct() {
-                        struct_peek
-                            .fields_for_serialize()
-                            .for_each(|item| flattened.push(item));
-                    } else if let Ok(enum_peek) = peek.into_enum() {
-                        // normally we'd serialize to something like:
-                        //
-                        //   {
-                        //     "field_on_struct": {
-                        //       "VariantName": { "field_on_variant": "foo" }
-                        //     }
-                        //   }
-                        //
-                        // But since `field_on_struct` is flattened, instead we do:
-                        //
-                        //   {
-                        //     "VariantName": { "field_on_variant": "foo" }
-                        //   }
-                        field.name = enum_peek
-                            .active_variant()
-                            .expect("Failed to get active variant")
-                            .name;
-                        field.flattened = true;
-                        flattened.push((field, peek));
-                    } else {
-                        // TODO: fail more gracefully
-                        panic!("cannot flatten a {}", field.shape())
-                    }
-                    flattened
-                } else {
-                    vec![(field, peek)]
-                }
-            })
     }
 }

--- a/facet-reflect/src/peek/tuple.rs
+++ b/facet-reflect/src/peek/tuple.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use facet_core::TupleType;
 
-use super::Peek;
+use super::{FieldIter, Peek};
 
 /// Field index and associated peek value
 pub type TupleField<'mem, 'facet, 'shape> = (usize, Peek<'mem, 'facet, 'shape>);
@@ -50,8 +50,8 @@ impl<'mem, 'facet, 'shape> PeekTuple<'mem, 'facet, 'shape> {
     }
 
     /// Iterate over all fields
-    pub fn fields(&self) -> impl DoubleEndedIterator<Item = TupleField<'mem, 'facet, 'shape>> + '_ {
-        (0..self.len()).filter_map(|i| self.field(i).map(|p| (i, p)))
+    pub fn fields(&self) -> FieldIter<'mem, 'facet, 'shape> {
+        FieldIter::new_tuple(*self)
     }
 
     /// Type information

--- a/facet-serialize/src/lib.rs
+++ b/facet-serialize/src/lib.rs
@@ -493,10 +493,6 @@ where
                                 let fields = peek_struct.fields_for_serialize().count();
                                 debug!("  Serializing {} fields as object", fields);
 
-                                // FIXME
-                                // serializer.start_object(Some(fields))?;
-                                // stack.push(SerializeTask::EndObject);
-                                // stack.push(SerializeTask::ObjectFields(peek_struct));
                                 stack.push(SerializeTask::Object {
                                     entries: peek_struct.fields_for_serialize(),
                                     first: true,

--- a/facet-serialize/src/lib.rs
+++ b/facet-serialize/src/lib.rs
@@ -571,7 +571,9 @@ where
                                 stack.push(SerializeTask::EndArray);
 
                                 // Push fields in reverse order for tuple variant
-                                for (field, field_peek) in peek_enum.fields_for_serialize().rev() {
+                                let fields_for_serialize =
+                                    peek_enum.fields_for_serialize().collect::<Vec<_>>();
+                                for (field, field_peek) in fields_for_serialize.into_iter().rev() {
                                     stack.push(SerializeTask::Value(field_peek, Some(field)));
                                 }
                             } else {
@@ -581,7 +583,9 @@ where
                                 stack.push(SerializeTask::EndObject);
 
                                 // Push fields in reverse order for struct variant
-                                for (field, field_peek) in peek_enum.fields_for_serialize().rev() {
+                                let fields_for_serialize =
+                                    peek_enum.fields_for_serialize().collect::<Vec<_>>();
+                                for (field, field_peek) in fields_for_serialize.into_iter().rev() {
                                     stack.push(SerializeTask::EndField);
                                     stack.push(SerializeTask::Value(field_peek, Some(field)));
                                     stack.push(SerializeTask::SerializeFieldName(field.name));
@@ -623,7 +627,8 @@ where
             // --- Pushing sub-elements onto the stack ---
             SerializeTask::ObjectFields(peek_struct) => {
                 // Push fields in reverse order for stack processing
-                for (field, field_peek) in peek_struct.fields_for_serialize().rev() {
+                let fields_for_serialize = peek_struct.fields_for_serialize().collect::<Vec<_>>();
+                for (field, field_peek) in fields_for_serialize.into_iter().rev() {
                     stack.push(SerializeTask::EndField);
                     stack.push(SerializeTask::Value(field_peek, Some(field)));
                     stack.push(SerializeTask::SerializeFieldName(field.name));
@@ -631,7 +636,8 @@ where
             }
             SerializeTask::TupleStructFields(peek_struct) => {
                 // Push fields in reverse order
-                for (field, field_peek) in peek_struct.fields_for_serialize().rev() {
+                let fields_for_serialize = peek_struct.fields_for_serialize().collect::<Vec<_>>();
+                for (field, field_peek) in fields_for_serialize.into_iter().rev() {
                     stack.push(SerializeTask::Value(field_peek, Some(field)));
                 }
             }


### PR DESCRIPTION
This PR makes it so `facet-serialize` no longer requires [`DoubleEndedIterator`](https://doc.rust-lang.org/stable/std/iter/trait.DoubleEndedIterator.html) when iterating over values. In turn, this also means that serialization can use plain iterator values in more places, without resorting to collecting e.g. into a `Vec`.

The "trick" is in `SerialzeTask`, which now holds iterators wherever possible. When popped from the stack, it gets the next value from the iterator then pushes it back onto the stack (until the iterator is empty).

I was hoping this would lead to perf improvements, but locally, I wasn't seeing a noticeable difference... I still felt like this change had other minor benefits (e.g. less memory use during iteration, `iter_vtable` for `HashMap` no longer needs to collect its keys into a vec, etc.)