### PR TITLE
Allow nav to scroll on facet.rs website

### DIFF
--- a/docs/templates/main-style.css.jinja
+++ b/docs/templates/main-style.css.jinja
@@ -52,6 +52,8 @@ nav.table-of-contents {
     height: auto;
     max-height: 80vh;
 
+    overflow-y: scroll;
+
     font-size: 90%;
     top: 40px;
     position: sticky;


### PR DESCRIPTION
I noticed that the `<nav>`, on the right of the screen, was overflowed and the text was running vertically past the end of it's container. Letting the y axis scroll fixed this :)

wasn't sure how to organize the CSS, but after the height seemed like a smart place.