### PR TITLE
Use std iterators for some collections

### DIFF
--- a/facet-core/src/impls_alloc/btreeset.rs
+++ b/facet-core/src/impls_alloc/btreeset.rs
@@ -134,6 +134,14 @@ where
                                                 .next()
                                                 .map(|value| PtrConst::new(value as *const T))
                                         })
+                                        .next_back(|iter_ptr| {
+                                            let state = unsafe {
+                                                iter_ptr.as_mut::<BTreeSetIterator<'_, T>>()
+                                            };
+                                            state
+                                                .next_back()
+                                                .map(|value| PtrConst::new(value as *const T))
+                                        })
                                         .dealloc(|iter_ptr| unsafe {
                                             drop(Box::from_raw(
                                                 iter_ptr.as_ptr::<BTreeSetIterator<'_, T>>()

--- a/facet-core/src/impls_std/hashmap.rs
+++ b/facet-core/src/impls_std/hashmap.rs
@@ -186,20 +186,6 @@ where
 
                                             None
                                         })
-                                        .next_back(|iter_ptr| unsafe {
-                                            let state = iter_ptr.as_mut::<HashMapIterator<'_, K>>();
-                                            let map = state.map.get::<HashMap<K, V>>();
-                                            while let Some(key) = state.keys.pop_back() {
-                                                if let Some(value) = map.get(key) {
-                                                    return Some((
-                                                        PtrConst::new(key as *const K),
-                                                        PtrConst::new(value as *const V),
-                                                    ));
-                                                }
-                                            }
-
-                                            None
-                                        })
                                         .dealloc(|iter_ptr| unsafe {
                                             drop(Box::from_raw(
                                                 iter_ptr.as_ptr::<HashMapIterator<'_, K>>()

--- a/facet-reflect/src/peek/map.rs
+++ b/facet-reflect/src/peek/map.rs
@@ -24,21 +24,6 @@ impl<'mem, 'facet, 'shape> Iterator for PeekMapIter<'mem, 'facet, 'shape> {
     }
 }
 
-impl<'mem, 'facet, 'shape> DoubleEndedIterator for PeekMapIter<'mem, 'facet, 'shape> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        let next_back_fn = self.map.def.vtable.iter_vtable.next_back.unwrap();
-        unsafe {
-            let next_back = next_back_fn(self.iter);
-            next_back.map(|(key_ptr, value_ptr)| {
-                (
-                    Peek::unchecked_new(key_ptr, self.map.def.k()),
-                    Peek::unchecked_new(value_ptr, self.map.def.v()),
-                )
-            })
-        }
-    }
-}
-
 impl<'mem, 'facet, 'shape> Drop for PeekMapIter<'mem, 'facet, 'shape> {
     fn drop(&mut self) {
         unsafe { (self.map.def.vtable.iter_vtable.dealloc)(self.iter) }


### PR DESCRIPTION
This PR replaces the custom iterators for various collection types, to instead use the built-in iterators from `std` (or `alloc`). This applies to `HashMap`, `HashSet`, `BTreeMap`, and `BTreeSet`. In addition to simplifying the implementation, this also means we no longer need to `.collect()` for `HashMap` or `HashSet` when creating the iterator!

This was unblocked by #641 (previously, `HashMap` needed a custom iterator that buffered the keys in order to implement `DoubleEndedIterator`)

As part of this change, the iter vtable for `HashMap` no longer provides an `next_back`, while the iter vtable for `BTreeSet` now _does_ provide it