### PR TITLE
Add missing `ulid` and `url` features to root crate

### DIFF
--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -22,6 +22,7 @@ camino = [
     "facet-core/camino",
 ] # Implements Facet for camino types (Utf8PathBuf, Utf8Path)
 uuid = ["facet-core/uuid"] # Implements Facet for Uuid
+ulid = ["facet-core/ulid"] # Implements Facet for Ulid
 ordered-float = ["facet-core/ordered-float"] # Implements Facet for OrderedFloat
 jiff02 = [
     "facet-core/jiff02",
@@ -29,6 +30,7 @@ jiff02 = [
 time = [
     "facet-core/time",
 ] # Implements Facet for time types (OffsetDateTime, PrimitiveDateTime, etc.)
+url = ["facet-core/url"] # Implements Facet for Url
 
 [dependencies]
 facet-core = { path = "../facet-core", version = "0.27.2", default-features = false }


### PR DESCRIPTION
I noticed that the root `facet` crate didn't have features for `ulid` or `url`