### PR TITLE
refactor(args): `ArgType` enum, various field helpers

### DIFF
--- a/facet-args/src/arg.rs
+++ b/facet-args/src/arg.rs
@@ -1,0 +1,29 @@
+use alloc::borrow::Cow;
+
+pub(crate) enum ArgType<'a> {
+    LongFlag(Cow<'a, str>),
+    ShortFlag(&'a str),
+    Positional,
+    None,
+}
+
+impl<'a> ArgType<'a> {
+    pub(crate) fn parse(arg: &'a str) -> Self {
+        if let Some(key) = arg.strip_prefix("--") {
+            ArgType::LongFlag(Self::kebab_to_snake(key))
+        } else if let Some(key) = arg.strip_prefix('-') {
+            ArgType::ShortFlag(key)
+        } else if !arg.is_empty() {
+            ArgType::Positional
+        } else {
+            ArgType::None
+        }
+    }
+
+    pub(crate) fn kebab_to_snake(input: &str) -> Cow<str> {
+        if !input.contains('-') {
+            return Cow::Borrowed(input);
+        }
+        Cow::Owned(input.replace('-', "_"))
+    }
+}

--- a/facet-args/src/fields.rs
+++ b/facet-args/src/fields.rs
@@ -1,0 +1,162 @@
+use alloc::borrow::Cow;
+use alloc::string::ToString;
+use facet_core::{FieldAttribute, Shape, Type, UserType};
+use facet_deserialize::{DeserErrorKind, Outcome, Raw, Scalar, Span, Spanned};
+use facet_reflect::Wip;
+
+pub(crate) fn validate_field<'facet, 'shape>(
+    field_name: &str,
+    shape: &'shape Shape<'shape>,
+    wip: &Wip<'facet, 'shape>,
+) -> Result<(), DeserErrorKind<'shape>> {
+    if let Type::User(UserType::Struct(_)) = &shape.ty {
+        if wip.field_index(field_name).is_none() {
+            return Err(DeserErrorKind::UnknownField {
+                field_name: field_name.to_string(),
+                shape,
+            });
+        }
+    }
+    Ok(())
+}
+
+// Find a positional field
+pub(crate) fn find_positional_field<'facet, 'shape>(
+    shape: &'shape Shape<'shape>,
+    wip: &Wip<'facet, 'shape>,
+) -> Result<&'shape str, DeserErrorKind<'shape>> {
+    if let Type::User(UserType::Struct(st)) = &shape.ty {
+        for (idx, field) in st.fields.iter().enumerate() {
+            for attr in field.attributes.iter() {
+                if let FieldAttribute::Arbitrary(a) = attr {
+                    if a.contains("positional") {
+                        // Check if this field is already set
+                        let is_set = wip.is_field_set(idx).unwrap_or(false);
+                        if !is_set {
+                            return Ok(field.name);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Err(DeserErrorKind::UnknownField {
+        field_name: "positional argument".to_string(),
+        shape,
+    })
+}
+
+// Find an unset boolean field for implicit false handling
+pub(crate) fn find_unset_bool_field<'facet, 'shape>(
+    shape: &'shape Shape<'shape>,
+    wip: &Wip<'facet, 'shape>,
+) -> Option<&'shape str> {
+    if let Type::User(UserType::Struct(st)) = &shape.ty {
+        for (idx, field) in st.fields.iter().enumerate() {
+            if !wip.is_field_set(idx).unwrap_or(false) && field.shape().is_type::<bool>() {
+                return Some(field.name);
+            }
+        }
+    }
+    None
+}
+
+pub(crate) fn find_field_by_short_flag<'shape>(
+    key: &str,
+    shape: &'shape Shape<'shape>,
+) -> Result<&'shape str, DeserErrorKind<'shape>> {
+    match &shape.ty {
+        Type::User(UserType::Struct(st)) => st
+            .fields
+            .iter()
+            .find(|field| {
+                field.attributes.iter().any(|attr| {
+                    matches!(attr, FieldAttribute::Arbitrary(a) if a.contains("short") &&
+                            (a.contains(key) || (key.len() == 1 && field.name == key)))
+                })
+            })
+            .map(|field| field.name)
+            .ok_or_else(|| DeserErrorKind::UnknownField {
+                field_name: key.to_string(),
+                shape,
+            }),
+        _ => Err(DeserErrorKind::UnsupportedType {
+            got: shape,
+            wanted: "struct",
+        }),
+    }
+}
+
+// Create a missing value error
+pub(crate) fn create_missing_value_error<'shape>(field: &str) -> DeserErrorKind<'shape> {
+    DeserErrorKind::MissingValue {
+        expected: "argument value",
+        field: field.to_string(),
+    }
+}
+
+// Handle boolean value parsing
+pub(crate) fn handle_bool_value<'shape>(
+    args_available: bool,
+) -> Result<Scalar<'static>, DeserErrorKind<'shape>> {
+    Ok(Scalar::Bool(args_available))
+}
+
+// Check if a value is available and valid (not a flag)
+pub(crate) fn validate_value_available<'shape, 'input>(
+    arg_idx: usize,
+    args: &[&'input str],
+) -> Result<&'input str, DeserErrorKind<'shape>> {
+    if arg_idx >= args.len() {
+        return Err(create_missing_value_error(args[arg_idx.saturating_sub(1)]));
+    }
+
+    let arg = args[arg_idx];
+    if arg.starts_with('-') {
+        return Err(create_missing_value_error(args[arg_idx.saturating_sub(1)]));
+    }
+
+    Ok(arg)
+}
+
+// Check if a list has reached its end
+pub(crate) fn is_list_ended(arg_idx: usize, args: &[&str]) -> bool {
+    arg_idx >= args.len() || args[arg_idx].starts_with('-')
+}
+
+// Validate a struct type and return appropriate error if it's not a struct
+pub(crate) fn validate_struct_type<'shape>(
+    shape: &'shape Shape<'shape>,
+) -> Result<(), DeserErrorKind<'shape>> {
+    if !matches!(shape.ty, Type::User(UserType::Struct(_))) {
+        Err(DeserErrorKind::UnsupportedType {
+            got: shape,
+            wanted: "struct",
+        })
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn create_unknown_field_error<'shape>(
+    field_name: &str,
+    shape: &'shape Shape<'shape>,
+) -> DeserErrorKind<'shape> {
+    DeserErrorKind::UnknownField {
+        field_name: field_name.to_string(),
+        shape,
+    }
+}
+
+pub(crate) fn handle_unset_bool_field<'shape>(
+    field_name_opt: Option<&'shape str>,
+    span: Span<Raw>,
+) -> Result<Spanned<Outcome<'shape>, Raw>, Spanned<DeserErrorKind<'shape>, Raw>> {
+    Ok(Spanned {
+        node: match field_name_opt {
+            Some(field_name) => Outcome::Scalar(Scalar::String(Cow::Borrowed(field_name))),
+            None => Outcome::ObjectEnded,
+        },
+        span,
+    })
+}

--- a/facet-args/src/format.rs
+++ b/facet-args/src/format.rs
@@ -1,7 +1,10 @@
+use crate::arg::ArgType;
+use crate::fields::*;
+use crate::parse::parse_scalar;
+use crate::results::*;
 use alloc::borrow::Cow;
-use alloc::string::ToString;
 use core::fmt;
-use facet_core::{Facet, FieldAttribute, Type, UserType};
+use facet_core::Facet;
 use facet_deserialize::{
     DeserError, DeserErrorKind, Expectation, Format, NextData, NextResult, Outcome, Raw, Scalar,
     Span, Spanned,
@@ -13,16 +16,6 @@ pub struct Cli;
 impl fmt::Display for Cli {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Cli")
-    }
-}
-
-impl Cli {
-    /// Helper function to convert kebab-case to snake_case
-    fn kebab_to_snake(input: &str) -> Cow<str> {
-        if !input.contains('-') {
-            return Cow::Borrowed(input);
-        }
-        Cow::Owned(input.replace('-', "_"))
     }
 }
 
@@ -64,30 +57,13 @@ impl Format for Cli {
         let shape = nd.wip.shape();
         let args = nd.input();
 
-        match expectation {
+        let result = match expectation {
             // Top-level value
             Expectation::Value => {
+                let span = Span::new(arg_idx, 0);
+
                 // Check if it's a struct type
-                if !matches!(shape.ty, Type::User(UserType::Struct(_))) {
-                    return (
-                        nd,
-                        Err(Spanned {
-                            node: DeserErrorKind::UnsupportedType {
-                                got: shape,
-                                wanted: "struct",
-                            },
-                            span: Span::new(arg_idx, 0),
-                        }),
-                    );
-                }
-                // For CLI args, we always start with an object (struct)
-                (
-                    nd,
-                    Ok(Spanned {
-                        node: Outcome::ObjectStarted,
-                        span: Span::new(arg_idx, 0),
-                    }),
-                )
+                wrap_outcome_result(validate_struct_type(shape), Outcome::ObjectStarted, span)
             }
 
             // Object key (or finished)
@@ -96,263 +72,97 @@ impl Format for Cli {
                 if arg_idx < args.len() {
                     let arg = args[arg_idx];
                     let span = Span::new(arg_idx, 1);
+                    let error_span = Span::new(arg_idx, 0);
 
-                    // Named long argument?
-                    if let Some(key) = arg.strip_prefix("--") {
-                        let key = Self::kebab_to_snake(key);
-
-                        // Check if the field exists in the struct
-                        if let Type::User(UserType::Struct(_)) = shape.ty {
-                            if nd.wip.field_index(&key).is_none() {
-                                return (
-                                    nd,
-                                    Err(Spanned {
-                                        node: DeserErrorKind::UnknownField {
-                                            field_name: key.to_string(),
-                                            shape,
-                                        },
-                                        span: Span::new(arg_idx, 0),
-                                    }),
-                                );
-                            }
-                        }
-                        return (
-                            nd,
-                            Ok(Spanned {
-                                node: Outcome::Scalar(Scalar::String(key)),
+                    // Parse the argument type
+                    match ArgType::parse(arg) {
+                        ArgType::LongFlag(key) => {
+                            // Validate field exists
+                            wrap_string_result(
+                                validate_field(&key, shape, &nd.wip).map(|_| key),
                                 span,
-                            }),
-                        );
-                    }
-
-                    // Short flag?
-                    if let Some(key) = arg.strip_prefix('-') {
-                        // Convert short argument to field name via shape
-                        if let Type::User(UserType::Struct(st)) = shape.ty {
-                            for field in st.fields.iter() {
-                                for attr in field.attributes {
-                                    if let FieldAttribute::Arbitrary(a) = attr {
-                                        // Don't require specifying a short key for a single-char key
-                                        if a.contains("short")
-                                            && (a.contains(key)
-                                                || (key.len() == 1 && field.name == key))
-                                        {
-                                            return (
-                                                nd,
-                                                Ok(Spanned {
-                                                    node: Outcome::Scalar(Scalar::String(
-                                                        Cow::Borrowed(field.name),
-                                                    )),
-                                                    span,
-                                                }),
-                                            );
-                                        }
-                                    }
-                                }
-                            }
+                                error_span,
+                            )
                         }
-                        return (
-                            nd,
+                        ArgType::ShortFlag(key) => {
+                            // Convert short argument to field name via shape
+                            wrap_field_result(
+                                find_field_by_short_flag(key, shape),
+                                span,
+                                error_span,
+                            )
+                        }
+                        ArgType::Positional => {
+                            // Handle positional argument
+                            wrap_field_result(
+                                find_positional_field(shape, &nd.wip),
+                                Span::new(arg_idx, 0), // TODO: just pass as span?
+                                error_span,
+                            )
+                        }
+                        ArgType::None => {
+                            // Handle empty argument (shouldn't happen normally)
+                            let err = create_unknown_field_error("empty argument", shape);
                             Err(Spanned {
-                                node: DeserErrorKind::UnknownField {
-                                    field_name: key.to_string(),
-                                    shape,
-                                },
-                                span: Span::new(arg_idx, 0),
-                            }),
-                        );
-                    }
-
-                    // positional argument
-                    if let Type::User(UserType::Struct(st)) = &shape.ty {
-                        for (idx, field) in st.fields.iter().enumerate() {
-                            for attr in field.attributes.iter() {
-                                if let FieldAttribute::Arbitrary(a) = attr {
-                                    if a.contains("positional") {
-                                        // Check if this field is already set
-                                        let is_set = nd.wip.is_field_set(idx).unwrap_or(false);
-
-                                        if !is_set {
-                                            // Use this positional field
-                                            return (
-                                                nd,
-                                                Ok(Spanned {
-                                                    node: Outcome::Scalar(Scalar::String(
-                                                        Cow::Borrowed(field.name),
-                                                    )),
-                                                    span: Span::new(arg_idx, 0),
-                                                }),
-                                            );
-                                        }
-                                    }
-                                }
-                            }
+                                node: err,
+                                span: error_span,
+                            })
                         }
                     }
-
-                    // If no positional field was found
-                    return (
-                        nd,
-                        Err(Spanned {
-                            node: DeserErrorKind::UnknownField {
-                                field_name: "positional argument".to_string(),
-                                shape,
-                            },
-                            span: Span::new(arg_idx, 0),
-                        }),
-                    );
+                } else {
+                    // EOF: inject implicit-false-if-absent bool flags, if there are any
+                    let span = Span::new(arg_idx, 0);
+                    handle_unset_bool_field(find_unset_bool_field(shape, &nd.wip), span)
                 }
-
-                // EOF: inject implicit-false-if-absent bool flags, if there are any
-                if let Type::User(UserType::Struct(st)) = &shape.ty {
-                    for (idx, field) in st.fields.iter().enumerate() {
-                        if !nd.wip.is_field_set(idx).unwrap_or(false)
-                            && field.shape().is_type::<bool>()
-                        {
-                            return (
-                                nd,
-                                Ok(Spanned {
-                                    node: Outcome::Scalar(Scalar::String(Cow::Borrowed(
-                                        field.name,
-                                    ))),
-                                    span: Span::new(arg_idx, 0),
-                                }),
-                            );
-                        }
-                    }
-                }
-
-                // Real end of object
-                (
-                    nd,
-                    Ok(Spanned {
-                        node: Outcome::ObjectEnded,
-                        span: Span::new(arg_idx, 0),
-                    }),
-                )
             }
 
             // Value for the current key
             Expectation::ObjectVal => {
-                // Synthetic implicit-false
-                if arg_idx >= args.len() && shape.is_type::<bool>() {
-                    return (
-                        nd,
-                        Ok(Spanned {
-                            node: Outcome::Scalar(Scalar::Bool(false)),
-                            span: Span::new(arg_idx, 0),
-                        }),
-                    );
-                }
-
-                // Explicit boolean true
+                // Determine what to do based on the type and available arguments
                 if shape.is_type::<bool>() {
-                    // For boolean fields, we don't need an explicit value
-                    return (
-                        nd,
-                        Ok(Spanned {
-                            node: Outcome::Scalar(Scalar::Bool(true)),
-                            span: Span::new(arg_idx, 0),
-                        }),
-                    );
-                }
-
-                // For other types, get the next arg as the value.
-                // Need another CLI token:
-                if arg_idx >= args.len() {
-                    return (
-                        nd,
-                        Err(Spanned {
-                            node: DeserErrorKind::MissingValue {
-                                expected: "argument value",
-                                field: args[arg_idx.saturating_sub(1)].to_string(),
-                            },
+                    // Handle boolean values (true if we have an arg, false if EOF)
+                    let has_arg = arg_idx < args.len();
+                    wrap_result(
+                        handle_bool_value(has_arg),
+                        Outcome::Scalar,
+                        Span::new(arg_idx, 0),
+                        Span::new(arg_idx, 0),
+                    )
+                } else {
+                    // For non-boolean types, validate and parse the value
+                    match validate_value_available(arg_idx, args) {
+                        Ok(arg) => {
+                            let span = Span::new(arg_idx, 1);
+                            Ok(parse_scalar(arg, span))
+                        }
+                        Err(err) => Err(Spanned {
+                            node: err,
                             span: Span::new(arg_idx.saturating_sub(1), 0),
                         }),
-                    );
+                    }
                 }
-
-                let arg = args[arg_idx];
-                let span = Span::new(arg_idx, 1);
-
-                // Skip this value if it starts with - (it's probably another flag)
-                if arg.starts_with('-') {
-                    // This means we're missing a value for the previous argument
-                    return (
-                        nd,
-                        Err(Spanned {
-                            node: DeserErrorKind::MissingValue {
-                                expected: "argument value",
-                                field: args[arg_idx.saturating_sub(1)].to_string(),
-                            },
-                            span: Span::new(arg_idx.saturating_sub(1), 0),
-                        }),
-                    );
-                }
-
-                // Try to parse as appropriate type
-                // Handle numeric types
-                if let Ok(v) = arg.parse::<u64>() {
-                    return (
-                        nd,
-                        Ok(Spanned {
-                            node: Outcome::Scalar(Scalar::U64(v)),
-                            span,
-                        }),
-                    );
-                }
-                if let Ok(v) = arg.parse::<i64>() {
-                    return (
-                        nd,
-                        Ok(Spanned {
-                            node: Outcome::Scalar(Scalar::I64(v)),
-                            span,
-                        }),
-                    );
-                }
-                if let Ok(v) = arg.parse::<f64>() {
-                    return (
-                        nd,
-                        Ok(Spanned {
-                            node: Outcome::Scalar(Scalar::F64(v)),
-                            span,
-                        }),
-                    );
-                }
-
-                // Default to string type
-                (
-                    nd,
-                    Ok(Spanned {
-                        node: Outcome::Scalar(Scalar::String(Cow::Borrowed(arg))),
-                        span,
-                    }),
-                )
             }
 
             // List items
             Expectation::ListItemOrListClose => {
                 // End the list if we're out of arguments, or if it's a new flag
-                if arg_idx >= args.len() || args[arg_idx].starts_with('-') {
-                    return (
-                        nd,
-                        Ok(Spanned {
-                            node: Outcome::ListEnded,
-                            span: Span::new(arg_idx, 0),
-                        }),
-                    );
-                }
-
-                // Process the next item in the list
-                (
-                    nd,
+                if is_list_ended(arg_idx, args) {
+                    // End the list
+                    Ok(Spanned {
+                        node: Outcome::ListEnded,
+                        span: Span::new(arg_idx, 0),
+                    })
+                } else {
+                    // Process the next item
                     Ok(Spanned {
                         node: Outcome::Scalar(Scalar::String(Cow::Borrowed(args[arg_idx]))),
                         span: Span::new(arg_idx, 1),
-                    }),
-                )
+                    })
+                }
             }
-        }
+        };
+
+        (nd, result)
     }
 
     fn skip<'input, 'facet, 'shape>(

--- a/facet-args/src/lib.rs
+++ b/facet-args/src/lib.rs
@@ -9,5 +9,10 @@ extern crate alloc;
 /// CLI argument format implementation for facet-deserialize
 pub mod format;
 
+pub(crate) mod arg;
+pub(crate) mod fields;
+pub(crate) mod parse;
+pub(crate) mod results;
+
 #[allow(unused)]
 pub use format::from_slice;

--- a/facet-args/src/parse.rs
+++ b/facet-args/src/parse.rs
@@ -1,0 +1,30 @@
+use alloc::borrow::Cow;
+use facet_deserialize::{Outcome, Raw, Scalar, Span, Spanned};
+
+pub(crate) fn parse_scalar<'a>(arg: &'a str, span: Span<Raw>) -> Spanned<Outcome<'a>, Raw> {
+    // Try to parse numbers in order of specificity
+    if let Ok(v) = arg.parse::<u64>() {
+        return Spanned {
+            node: Outcome::Scalar(Scalar::U64(v)),
+            span,
+        };
+    }
+    if let Ok(v) = arg.parse::<i64>() {
+        return Spanned {
+            node: Outcome::Scalar(Scalar::I64(v)),
+            span,
+        };
+    }
+    if let Ok(v) = arg.parse::<f64>() {
+        return Spanned {
+            node: Outcome::Scalar(Scalar::F64(v)),
+            span,
+        };
+    }
+
+    // Default to string
+    Spanned {
+        node: Outcome::Scalar(Scalar::String(Cow::Borrowed(arg))),
+        span,
+    }
+}

--- a/facet-args/src/results.rs
+++ b/facet-args/src/results.rs
@@ -1,0 +1,58 @@
+use alloc::borrow::Cow;
+use facet_deserialize::{DeserErrorKind, Outcome, Raw, Scalar, Span, Spanned};
+
+/// General purpose wrapper for results
+pub(crate) fn wrap_result<'input, 'shape, T>(
+    result: Result<T, DeserErrorKind<'shape>>,
+    success_fn: impl FnOnce(T) -> Outcome<'input>,
+    success_span: Span<Raw>,
+    error_span: Span<Raw>,
+) -> Result<Spanned<Outcome<'input>, Raw>, Spanned<DeserErrorKind<'shape>, Raw>> {
+    match result {
+        Ok(value) => Ok(Spanned {
+            node: success_fn(value),
+            span: success_span,
+        }),
+        Err(err) => Err(Spanned {
+            node: err,
+            span: error_span,
+        }),
+    }
+}
+
+/// Convenience wrapper for string results that become scalars
+pub(crate) fn wrap_string_result<'input, 'shape>(
+    result: Result<Cow<'input, str>, DeserErrorKind<'shape>>,
+    success_span: Span<Raw>,
+    error_span: Span<Raw>,
+) -> Result<Spanned<Outcome<'input>, Raw>, Spanned<DeserErrorKind<'shape>, Raw>> {
+    wrap_result(
+        result,
+        |s| Outcome::Scalar(Scalar::String(s)),
+        success_span,
+        error_span,
+    )
+}
+
+/// Convenience wrapper for field name results that become scalars
+pub(crate) fn wrap_field_result<'shape>(
+    result: Result<&'shape str, DeserErrorKind<'shape>>,
+    success_span: Span<Raw>,
+    error_span: Span<Raw>,
+) -> Result<Spanned<Outcome<'shape>, Raw>, Spanned<DeserErrorKind<'shape>, Raw>> {
+    wrap_result(
+        result.map(Cow::Borrowed),
+        |s| Outcome::Scalar(Scalar::String(s)),
+        success_span,
+        error_span,
+    )
+}
+
+/// Convenience wrapper for validation results that map to a single outcome
+pub(crate) fn wrap_outcome_result<'input, 'shape>(
+    result: Result<(), DeserErrorKind<'shape>>,
+    success_outcome: Outcome<'input>,
+    span: Span<Raw>,
+) -> Result<Spanned<Outcome<'input>, Raw>, Spanned<DeserErrorKind<'shape>, Raw>> {
+    wrap_result(result, |_| success_outcome, span, span)
+}


### PR DESCRIPTION
- **refactor(args):**
  - extract parse module for simpler format
  - enum of ArgType
  - short flag lookup
  - various field helpers
  - result wrappers (avoid `map`/`map_err` boilerplate bloat)

**Summary** Uses combinators in facet-args rather than early returns, tuck `DeserErrorKind` creation away in field helpers so span handling becomes relatively more visible

- The `DeserErrorKind` can be abstracted away, it's just bloating the main business logic (and making it very indented and hard to read!), the important thing is to keep the span handling inline (as this will be central to control when doing subspan logic, and to abstract it away would make that require arg passing which'd lose visibility)

- For instance using a helper to do the short field name lookup allows us to keep visibility of the important Cow borrow state rather than the detail of how short keys are matched from single chars