### PR TITLE
Fix marker traits for references and also test marker traits in facts

### DIFF
--- a/facet-core/src/types/value.rs
+++ b/facet-core/src/types/value.rs
@@ -424,7 +424,7 @@ impl core::hash::Hasher for HasherProxy<'_> {
 
 bitflags! {
     /// Bitflags for common marker traits that a type may implement
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct MarkerTraits: u8 {
         /// Indicates that the type implements the [`Eq`] marker trait
         const EQ = 1 << 0;


### PR DESCRIPTION
I don't know why the last test in `test_mut_ref` doesn't work when checking its `PartialEq` and `Ord` implementations. Seems like a bug in `Facet` somewhere...