### PR TITLE
refactor args standardise erorr spans

### DIFF
--- a/facet-args/src/fields.rs
+++ b/facet-args/src/fields.rs
@@ -148,7 +148,7 @@ pub(crate) fn create_unknown_field_error<'shape>(
     }
 }
 
-pub(crate) fn handle_unset_bool_field<'shape>(
+pub(crate) fn handle_unset_bool_field_error<'shape>(
     field_name_opt: Option<&'shape str>,
     span: Span<Raw>,
 ) -> Result<Spanned<Outcome<'shape>, Raw>, Spanned<DeserErrorKind<'shape>, Raw>> {


### PR DESCRIPTION
- **refactor(args): standardise spans in runner and errors**

**Summary**: Raw error spans don't actually use the raw span length when converting to byte-index over the input (`to_cooked` method), i.e. an error is always for a single arg. This means we can use 0-length spans (used by the stack runner to mean "do not advance to the next arg") and 1-length spans (to mean "step forward") for our errors too, without modification, except for the one odd case where we subtract 1 from the arg index.

- This lets us discard error span length handling entirely.
- This further simplifies the facet-args central `next` routine to the point it's now less than 100 lines, and easy to read.

![Screenshot from 2025-05-20 22-38-25](https://github.com/user-attachments/assets/9ce64d1c-2fed-4331-ae48-2bc3f939ad75)

