### PR TITLE
Add support for the `bytes` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +398,7 @@ name = "facet-core"
 version = "0.27.4"
 dependencies = [
  "bitflags",
+ "bytes",
  "camino",
  "eyre",
  "facet-testhelpers 0.17.4",
@@ -478,6 +485,7 @@ dependencies = [
 name = "facet-json"
 version = "0.24.5"
 dependencies = [
+ "bytes",
  "camino",
  "eyre",
  "facet",

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -20,6 +20,7 @@ ulid = ["alloc", "dep:ulid"]
 time = ["alloc", "dep:time"]
 url = ["alloc", "dep:url"]
 jiff02 = ["alloc", "dep:jiff"]
+bytes = ["alloc", "dep:bytes"]
 
 [dependencies]
 url = { version = "2.5.4", optional = true, default-features = false }
@@ -34,6 +35,7 @@ time = { version = "0.3.41", optional = true, features = [
     "formatting",
 ] }
 jiff = { version = "0.2.13", optional = true }
+bytes = { version = "1.10.1", optional = true, default-features = false }
 
 [dev-dependencies]
 eyre = "0.6.12"

--- a/facet-core/src/impls_bytes.rs
+++ b/facet-core/src/impls_bytes.rs
@@ -1,0 +1,145 @@
+use alloc::boxed::Box;
+
+use bytes::{BufMut as _, Bytes, BytesMut};
+
+use crate::{
+    Def, Facet, IterVTable, ListDef, ListVTable, PtrConst, PtrMut, Shape, Type, UserType,
+    ValueVTable, value_vtable,
+};
+
+type BytesIterator<'mem> = core::slice::Iter<'mem, u8>;
+
+unsafe impl Facet<'_> for Bytes {
+    const VTABLE: &'static ValueVTable =
+        &const { value_vtable!(Bytes, |f, _opts| write!(f, "Bytes")) };
+
+    const SHAPE: &'static Shape<'static> = &const {
+        Shape::builder_for_sized::<Self>()
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::List(
+                ListDef::builder()
+                    .vtable(
+                        &const {
+                            ListVTable::builder()
+                                .len(|ptr| unsafe {
+                                    let bytes = ptr.get::<Self>();
+                                    bytes.len()
+                                })
+                                .get(|ptr, index| unsafe {
+                                    let bytes = ptr.get::<Self>();
+                                    let item = bytes.get(index)?;
+                                    Some(PtrConst::new(item))
+                                })
+                                .as_ptr(|ptr| unsafe {
+                                    let bytes = ptr.get::<Self>();
+                                    PtrConst::new(bytes.as_ptr())
+                                })
+                                .iter_vtable(
+                                    IterVTable::builder()
+                                        .init_with_value(|ptr| unsafe {
+                                            let bytes = ptr.get::<Self>();
+                                            let iter: BytesIterator = bytes.iter();
+                                            let iter_state = Box::new(iter);
+                                            PtrMut::new(Box::into_raw(iter_state) as *mut u8)
+                                        })
+                                        .next(|iter_ptr| unsafe {
+                                            let state = iter_ptr.as_mut::<BytesIterator<'_>>();
+                                            state.next().map(|value| PtrConst::new(value))
+                                        })
+                                        .next_back(|iter_ptr| unsafe {
+                                            let state = iter_ptr.as_mut::<BytesIterator<'_>>();
+                                            state.next_back().map(|value| PtrConst::new(value))
+                                        })
+                                        .dealloc(|iter_ptr| unsafe {
+                                            drop(Box::from_raw(
+                                                iter_ptr.as_ptr::<BytesIterator<'_>>()
+                                                    as *mut BytesIterator<'_>,
+                                            ));
+                                        })
+                                        .build(),
+                                )
+                                .build()
+                        },
+                    )
+                    .t(|| u8::SHAPE)
+                    .build(),
+            ))
+            .build()
+    };
+}
+
+unsafe impl Facet<'_> for BytesMut {
+    const VTABLE: &'static ValueVTable =
+        &const { value_vtable!(BytesMut, |f, _opts| write!(f, "BytesMut")) };
+
+    const SHAPE: &'static Shape<'static> = &const {
+        Shape::builder_for_sized::<Self>()
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::List(
+                ListDef::builder()
+                    .vtable(
+                        &const {
+                            ListVTable::builder()
+                                .init_in_place_with_capacity(|data, capacity| unsafe {
+                                    data.put(Self::with_capacity(capacity))
+                                })
+                                .push(|ptr, item| unsafe {
+                                    let bytes = ptr.as_mut::<Self>();
+                                    let item = item.read::<u8>();
+                                    (*bytes).put_u8(item);
+                                })
+                                .len(|ptr| unsafe {
+                                    let bytes = ptr.get::<Self>();
+                                    bytes.len()
+                                })
+                                .get(|ptr, index| unsafe {
+                                    let bytes = ptr.get::<Self>();
+                                    let item = bytes.get(index)?;
+                                    Some(PtrConst::new(item))
+                                })
+                                .get_mut(|ptr, index| unsafe {
+                                    let bytes = ptr.as_mut::<Self>();
+                                    let item = bytes.get_mut(index)?;
+                                    Some(PtrMut::new(item))
+                                })
+                                .as_ptr(|ptr| unsafe {
+                                    let bytes = ptr.get::<Self>();
+                                    PtrConst::new(bytes.as_ptr())
+                                })
+                                .as_mut_ptr(|ptr| unsafe {
+                                    let bytes = ptr.as_mut::<Self>();
+                                    PtrMut::new(bytes.as_mut_ptr())
+                                })
+                                .iter_vtable(
+                                    IterVTable::builder()
+                                        .init_with_value(|ptr| unsafe {
+                                            let bytes = ptr.get::<Self>();
+                                            let iter: BytesIterator = bytes.iter();
+                                            let iter_state = Box::new(iter);
+                                            PtrMut::new(Box::into_raw(iter_state) as *mut u8)
+                                        })
+                                        .next(|iter_ptr| unsafe {
+                                            let state = iter_ptr.as_mut::<BytesIterator<'_>>();
+                                            state.next().map(|value| PtrConst::new(value))
+                                        })
+                                        .next_back(|iter_ptr| unsafe {
+                                            let state = iter_ptr.as_mut::<BytesIterator<'_>>();
+                                            state.next_back().map(|value| PtrConst::new(value))
+                                        })
+                                        .dealloc(|iter_ptr| unsafe {
+                                            drop(Box::from_raw(
+                                                iter_ptr.as_ptr::<BytesIterator<'_>>()
+                                                    as *mut BytesIterator<'_>,
+                                            ));
+                                        })
+                                        .build(),
+                                )
+                                .build()
+                        },
+                    )
+                    .t(|| u8::SHAPE)
+                    .build(),
+            ))
+            .build()
+    };
+}

--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -32,6 +32,9 @@ mod impls_alloc;
 #[cfg(feature = "std")]
 mod impls_std;
 
+#[cfg(feature = "bytes")]
+mod impls_bytes;
+
 #[cfg(feature = "camino")]
 mod impls_camino;
 

--- a/facet-core/src/types/def/list.rs
+++ b/facet-core/src/types/def/list.rs
@@ -128,7 +128,8 @@ pub struct ListVTable {
     pub init_in_place_with_capacity: Option<ListInitInPlaceWithCapacityFn>,
 
     /// cf. [`ListPushFn`]
-    pub push: ListPushFn,
+    /// Only available for mutable lists
+    pub push: Option<ListPushFn>,
 
     /// cf. [`ListLenFn`]
     pub len: ListLenFn,
@@ -137,7 +138,8 @@ pub struct ListVTable {
     pub get: ListGetFn,
 
     /// cf. [`ListGetMutFn`]
-    pub get_mut: ListGetMutFn,
+    /// Only available for mutable lists
+    pub get_mut: Option<ListGetMutFn>,
 
     /// cf. [`ListAsPtrFn`]
     /// Only available for types that can be accessed as a contiguous array
@@ -242,10 +244,10 @@ impl ListVTableBuilder {
     pub const fn build(self) -> ListVTable {
         ListVTable {
             init_in_place_with_capacity: self.init_in_place_with_capacity,
-            push: self.push.unwrap(),
+            push: self.push,
             len: self.len.unwrap(),
             get: self.get.unwrap(),
-            get_mut: self.get_mut.unwrap(),
+            get_mut: self.get_mut,
             as_ptr: self.as_ptr,
             as_mut_ptr: self.as_mut_ptr,
             iter_vtable: self.iter_vtable.unwrap(),

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -27,10 +27,12 @@ facet-serialize = { version = "0.24.5", path = "../facet-serialize", default-fea
 log = "0.4.27"
 
 [dev-dependencies]
+bytes = { version = "1.10.1" }
 camino = { version = "1" }
 eyre = "0.6.12"
 facet = { path = "../facet" }
 facet-core = { version = "0.27.4", path = "../facet-core", features = [
+    "bytes",
     "camino",
     "time",
     "ulid",

--- a/facet-json/tests/bytes.rs
+++ b/facet-json/tests/bytes.rs
@@ -6,6 +6,24 @@ use facet_json::to_string;
 use facet_testhelpers::test;
 
 #[test]
+fn json_read_bytes() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        data: Bytes,
+    }
+
+    let json = r#"{"data":[1, 2, 3, 4, 255]}"#;
+
+    let s: FooBar = from_str(json)?;
+    assert_eq!(
+        s,
+        FooBar {
+            data: Bytes::from_iter([1, 2, 3, 4, 255]),
+        }
+    );
+}
+
+#[test]
 fn json_read_bytes_mut() {
     #[derive(Facet, Debug, PartialEq)]
     struct FooBar {

--- a/facet-json/tests/bytes.rs
+++ b/facet-json/tests/bytes.rs
@@ -1,0 +1,54 @@
+use bytes::Bytes;
+use bytes::BytesMut;
+use facet::Facet;
+use facet_json::from_str;
+use facet_json::to_string;
+use facet_testhelpers::test;
+
+#[test]
+fn json_read_bytes_mut() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        data: BytesMut,
+    }
+
+    let json = r#"{"data":[1, 2, 3, 4, 255]}"#;
+
+    let s: FooBar = from_str(json)?;
+    assert_eq!(
+        s,
+        FooBar {
+            data: BytesMut::from_iter([1, 2, 3, 4, 255]),
+        }
+    );
+}
+
+#[test]
+fn json_write_bytes() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        data: Bytes,
+    }
+
+    let value = FooBar {
+        data: Bytes::from_iter([1, 2, 3, 4, 255]),
+    };
+
+    let json = to_string(&value);
+    assert_eq!(json, r#"{"data":[1,2,3,4,255]}"#);
+}
+
+#[test]
+fn json_write_bytes_mut() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        data: BytesMut,
+    }
+
+    let value = FooBar {
+        data: BytesMut::from_iter([1, 2, 3, 4, 255]),
+    };
+
+    let json = to_string(&value);
+    assert_eq!(json, r#"{"data":[1,2,3,4,255]}"#);
+}

--- a/facet-json/tests/option.rs
+++ b/facet-json/tests/option.rs
@@ -17,15 +17,48 @@ fn test_from_json_with_option() {
     }
 
     let json = r#"{
-    "name": "Alice",
-    "age": null,
-    "inner": {
-        "foo": 42
-    }
-}"#;
+        "name": "Alice",
+        "age": null,
+        "inner": {
+            "foo": 42
+        }
+    }"#;
 
     let test_struct: Options = from_str(json)?;
     assert_eq!(test_struct.name.as_deref(), Some("Alice"));
     assert_eq!(test_struct.age, None);
     assert_eq!(test_struct.inner.as_ref().map(|i| i.foo), Some(42));
+}
+
+#[test]
+fn test_from_json_with_nested_options() {
+    #[derive(Facet)]
+    struct Options {
+        name: Option<Option<String>>,
+        age: Option<Box<u32>>,
+        inner: Option<Box<Option<Inner>>>,
+    }
+
+    #[derive(Facet)]
+    struct Inner {
+        foo: i32,
+    }
+
+    let json = r#"{
+        "name": "Alice",
+        "age": 5,
+        "inner": {
+            "foo": 42
+        }
+    }"#;
+
+    let test_struct: Options = from_str(json)?;
+    assert_eq!(test_struct.name.flatten().as_deref(), Some("Alice"));
+    assert_eq!(test_struct.age, Some(Box::new(5)));
+    assert_eq!(
+        test_struct
+            .inner
+            .and_then(|inner| inner.map(|inner| inner.foo)),
+        Some(42)
+    );
 }

--- a/facet-reflect/src/wip/pop.rs
+++ b/facet-reflect/src/wip/pop.rs
@@ -159,8 +159,13 @@ impl<'facet, 'shape> Wip<'facet, 'shape> {
                                 frame_len,
                                 parent_shape.blue()
                             );
+
+                            let Some(push) = list_vtable.push else {
+                                panic!("Tried to push into list {parent_shape} but it's immutable");
+                            };
+
                             unsafe {
-                                (list_vtable.push)(
+                                push(
                                     PtrMut::new(parent_frame.data.as_mut_byte_ptr()),
                                     PtrMut::new(frame.data.as_mut_byte_ptr()),
                                 );

--- a/facet-reflect/src/wip/pop.rs
+++ b/facet-reflect/src/wip/pop.rs
@@ -22,16 +22,19 @@ impl<'facet, 'shape> Wip<'facet, 'shape> {
             }
         };
 
-        if let FrameMode::SmartPointee = frame.istate.mode {
+        if matches!(
+            frame.istate.mode,
+            FrameMode::SmartPointee | FrameMode::Inner
+        ) {
             let parent_frame = match self.frames.last_mut() {
                 Some(parent_frame) => parent_frame,
                 None => {
                     return Err(ReflectError::InvariantViolation {
-                        invariant: "popping a smart pointee frame without a parent frame to put it in.",
+                        invariant: "popping a wrapper frame without a parent frame to put it in.",
                     });
                 }
             };
-            trace!("Popping smart pointee frame!",);
+            trace!("Popping wrapper frame with mode {:?}!", frame.istate.mode);
             trace!(
                 "This frame shape = {}, fully_initialized = {}",
                 frame.shape.cyan(),

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -18,6 +18,7 @@ reflect = ["dep:facet-reflect"] # Enables reflection via Peek and Poke types
 testfeat = [] # Does nothing, only used for tests
 std = ["facet-core/std", "alloc"] # Uses libstd and alloc
 alloc = ["facet-core/alloc"] # Enables alloc support
+bytes = ["facet-core/bytes"] # Implements Facet for bytes types (Bytes, BytesMut)
 camino = [
     "facet-core/camino",
 ] # Implements Facet for camino types (Utf8PathBuf, Utf8Path)


### PR DESCRIPTION
Closes #597

This PR adds `bytes` as an optional dependency / feature-- when enabled, it impls `Facet` for the [`Bytes`](https://docs.rs/bytes/latest/bytes/struct.Bytes.html) and [`BytesMut`](https://docs.rs/bytes/latest/bytes/struct.BytesMut.html) types.

Turns out [I was wrong before](https://github.com/facet-rs/facet/issues/578#issue-3055805317): both `Bytes` and `BytesMut` are backed by a single contiguous slice. That means they both provide an `as_ptr` function for faster iteration

Dealing with `Bytes` still ended up being a little tricky because it's immutable. I felt the most direct option for now was to make mutating functions from `ListVTable` optional, making it effectively immutable. That means you can't e.g. deserialize `Bytes` (unless it's empty), since `Wip` can't insert any elements.

(I wonder if there would be a way to make it so `Wip<Bytes>` could be backed by a `BytesMut` behind the scenes, converting to `Bytes` at zero-cost via [`BytesMut::freeze`](https://docs.rs/bytes/latest/bytes/struct.BytesMut.html#method.freeze) only once the type is finished...?)