### PR TITLE
feat(deserialize,args): pop Subspan stack; `--key=val` CLI flags

### DIFF
--- a/facet-args/src/arg.rs
+++ b/facet-args/src/arg.rs
@@ -1,5 +1,7 @@
 use alloc::borrow::Cow;
+use facet_deserialize::{Subspan, SubspanMeta};
 
+#[derive(Debug)]
 pub(crate) enum ArgType<'a> {
     LongFlag(Cow<'a, str>),
     ShortFlag(&'a str),
@@ -26,4 +28,60 @@ impl<'a> ArgType<'a> {
         }
         Cow::Owned(input.replace('-', "_"))
     }
+}
+
+// This trait implementation allows for using a Subspan together with an arg string
+impl<'a> From<(&'a Subspan, &'a str)> for ArgType<'a> {
+    /// Converts a subspan and argument string into the appropriate ArgType.
+    ///
+    /// - For KeyValue metadata: key part (offset 0) is parsed normally (ShortFlag or LongFlag),
+    ///   value part (offset > 0) is treated as Positional
+    /// - For Delimiter metadata: treated as Positional
+    /// - For no metadata: parsed normally
+    fn from((subspan, arg): (&'a Subspan, &'a str)) -> Self {
+        if subspan.offset >= arg.len() {
+            return ArgType::None;
+        }
+
+        let end = core::cmp::min(subspan.offset + subspan.len, arg.len());
+        let part = &arg[subspan.offset..end];
+
+        // Check metadata for special handling
+        if let Some(meta) = &subspan.meta {
+            match meta {
+                SubspanMeta::KeyValue => {
+                    // For KeyValue, if it's the value part (offset > 0),
+                    // treat it as a positional argument regardless of content
+                    if subspan.offset > 0 {
+                        return if !part.is_empty() {
+                            ArgType::Positional
+                        } else {
+                            ArgType::None
+                        };
+                    }
+                    // Otherwise parse key part normally with parse()
+                }
+                SubspanMeta::Delimiter(_) => {
+                    // For delimited values, treat as positional
+                    return if !part.is_empty() {
+                        ArgType::Positional
+                    } else {
+                        ArgType::None
+                    };
+                }
+            }
+        }
+
+        // Default parsing for keys and non-special cases
+        ArgType::parse(part)
+    }
+}
+
+/// Extracts a substring from arg based on a subspan
+pub(crate) fn extract_subspan<'a>(subspan: &Subspan, arg: &'a str) -> &'a str {
+    if subspan.offset >= arg.len() {
+        return "";
+    }
+    let end = core::cmp::min(subspan.offset + subspan.len, arg.len());
+    &arg[subspan.offset..end]
 }

--- a/facet-args/src/results.rs
+++ b/facet-args/src/results.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use facet_deserialize::{DeserErrorKind, Outcome, Raw, Scalar, Span, Spanned};
+use facet_deserialize::{DeserErrorKind, Outcome, Raw, Scalar, Span, Spanned, Subspan};
 
 /// General purpose wrapper for results
 pub(crate) fn wrap_result<'input, 'shape, T>(
@@ -43,4 +43,15 @@ pub(crate) fn wrap_field_result<'shape>(
         |s| Outcome::Scalar(Scalar::String(s)),
         span,
     )
+}
+
+/// Convenience wrapper for creating a Resegmented outcome with subspans
+pub(crate) fn wrap_resegmented_result<'input, 'shape>(
+    subspans: Vec<Subspan>,
+    span: Span<Raw>,
+) -> Result<Spanned<Outcome<'input>, Raw>, Spanned<DeserErrorKind<'shape>, Raw>> {
+    Ok(Spanned {
+        node: Outcome::Resegmented(subspans),
+        span,
+    })
 }

--- a/facet-args/tests/simple.rs
+++ b/facet-args/tests/simple.rs
@@ -184,3 +184,78 @@ fn test_inf_float_parsing() {
     let args: Args = facet_args::from_slice(&["--rate", "infinity"])?;
     assert_eq!(args.rate, f64::INFINITY);
 }
+
+#[test]
+fn test_short_rename() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(named, short, rename = "j")]
+        concurrency: i64,
+    }
+    let args: Args = facet_args::from_slice(&["-j", "4"])?;
+    assert_eq!(args.concurrency, 4);
+}
+
+#[test]
+fn test_bool_str_before() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(named)]
+        foo: bool,
+        #[facet(named)]
+        hello: String,
+    }
+    let args: Args = facet_args::from_slice(&["--foo", "--hello", "world"])?;
+    assert!(args.foo);
+    assert_eq!(args.hello, "world".to_string());
+}
+
+// Weird failures (known bugs: TODO fix)
+
+#[test]
+#[ignore]
+fn test_bool_str_mix_middle() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(named)]
+        foo: bool,
+        #[facet(named)]
+        hello: String,
+        #[facet(named)]
+        bar: bool,
+    }
+    let args: Args = facet_args::from_slice(&["--foo", "--hello", "world", "--bar"])?;
+    assert!(args.foo);
+    assert_eq!(args.hello, "world".to_string());
+    assert!(args.bar);
+}
+
+#[test]
+#[ignore]
+fn test_bool_str_after() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(named)]
+        hello: String,
+        #[facet(named)]
+        bar: bool,
+    }
+    let args: Args = facet_args::from_slice(&["--hello", "world", "--bar"])?;
+    assert_eq!(args.hello, "world".to_string());
+    assert!(args.bar);
+}
+
+// The bug is unique to bools
+#[test]
+fn test_int_str_after() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(named)]
+        hello: String,
+        #[facet(named)]
+        baz: i64,
+    }
+    let args: Args = facet_args::from_slice(&["--hello", "world", "--baz", "2"])?;
+    assert_eq!(args.hello, "world".to_string());
+    assert_eq!(args.baz, 2);
+}

--- a/facet-args/tests/subspans.rs
+++ b/facet-args/tests/subspans.rs
@@ -1,0 +1,136 @@
+use facet::Facet;
+use facet_testhelpers::test;
+
+#[test]
+fn test_eq_long_solo() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(named)]
+        hello: String,
+    }
+    let args: Args = facet_args::from_slice(&["--hello=world"])?;
+    assert_eq!(args.hello, "world".to_string());
+}
+
+#[test]
+fn test_eq_short_solo() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(short)]
+        k: i64,
+    }
+    let args: Args = facet_args::from_slice(&["-k=3"])?;
+    assert_eq!(args.k, 3);
+}
+
+#[test]
+fn test_eq_long_rename_solo() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(named, rename = "cores")]
+        concurrency: i64,
+    }
+    let args: Args = facet_args::from_slice(&["--cores=4"])?;
+    assert_eq!(args.concurrency, 4);
+}
+
+#[test]
+fn test_eq_short_rename_solo() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(short, rename = "j")]
+        concurrency: i64,
+    }
+    let args: Args = facet_args::from_slice(&["-j=4"])?;
+    assert_eq!(args.concurrency, 4);
+}
+
+#[test]
+fn test_eq_long_followed() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(named)]
+        hello: String,
+        #[facet(named)]
+        two: i64,
+    }
+    let args: Args = facet_args::from_slice(&["--hello=world", "--two", "2"])?;
+    assert_eq!(args.hello, "world".to_string());
+    assert_eq!(args.two, 2);
+}
+
+#[test]
+fn test_eq_short_followed() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(short)]
+        y: String,
+        #[facet(named)]
+        two: i64,
+    }
+    let args: Args = facet_args::from_slice(&["-y=yes", "--two", "2"])?;
+    assert_eq!(args.y, "yes".to_string());
+    assert_eq!(args.two, 2);
+}
+
+#[test]
+fn test_eq_long_preceded() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(named)]
+        one: i64,
+        #[facet(named)]
+        hello: String,
+    }
+    let args: Args = facet_args::from_slice(&["--one", "1", "--hello=world"])?;
+    assert_eq!(args.one, 1);
+    assert_eq!(args.hello, "world".to_string());
+}
+
+#[test]
+fn test_eq_short_preceded() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(named)]
+        one: i64,
+        #[facet(short)]
+        y: String,
+    }
+    let args: Args = facet_args::from_slice(&["--one", "1", "-y=yes"])?;
+    assert_eq!(args.one, 1);
+    assert_eq!(args.y, "yes".to_string());
+}
+
+#[test]
+fn test_eq_long_in_the_middle() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(named)]
+        one: i64,
+        #[facet(named)]
+        hello: String,
+        #[facet(named)]
+        two: i64,
+    }
+    let args: Args = facet_args::from_slice(&["--one", "1", "--hello=world", "--two", "2"])?;
+    assert_eq!(args.one, 1);
+    assert_eq!(args.hello, "world".to_string());
+    assert_eq!(args.two, 2);
+}
+
+#[test]
+fn test_eq_short_in_the_middle() {
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(named)]
+        one: i64,
+        #[facet(short)]
+        y: String,
+        #[facet(named)]
+        two: i64,
+    }
+    let args: Args = facet_args::from_slice(&["--one", "1", "-y=yes", "--two", "2"])?;
+    assert_eq!(args.one, 1);
+    assert_eq!(args.y, "yes".to_string());
+    assert_eq!(args.two, 2);
+}

--- a/facet-deserialize/src/lib.rs
+++ b/facet-deserialize/src/lib.rs
@@ -75,6 +75,8 @@ pub enum Outcome<'input> {
     ObjectStarted,
     /// Ending an object/map.
     ObjectEnded,
+    /// Resegmenting input into subspans.
+    Resegmented(Vec<Subspan>),
 }
 
 impl<'input> From<Scalar<'input>> for Outcome<'input> {
@@ -94,6 +96,7 @@ impl fmt::Display for Outcome<'_> {
             Outcome::ListEnded => write!(f, "list end"),
             Outcome::ObjectStarted => write!(f, "object start"),
             Outcome::ObjectEnded => write!(f, "object end"),
+            Outcome::Resegmented(_) => write!(f, "resegment"),
         }
     }
 }
@@ -130,6 +133,17 @@ impl Outcome<'_> {
             Outcome::ListEnded => Outcome::ListEnded,
             Outcome::ObjectStarted => Outcome::ObjectStarted,
             Outcome::ObjectEnded => Outcome::ObjectEnded,
+            Outcome::Resegmented(subspans) => {
+                let owned_subspans = subspans
+                    .into_iter()
+                    .map(|s| Subspan {
+                        offset: s.offset,
+                        len: s.len,
+                        meta: s.meta,
+                    })
+                    .collect();
+                Outcome::Resegmented(owned_subspans)
+            }
         }
     }
 }
@@ -165,6 +179,11 @@ where
     pub fn start(&self) -> usize {
         self.start
     }
+
+    /// Access the substack
+    pub fn substack(&self) -> &Substack<C> {
+        &self.runner.substack
+    }
 }
 
 /// The result of advancing the parser: updated state and parse outcome or error.
@@ -181,7 +200,7 @@ pub trait Format {
     type Input<'input>: ?Sized;
 
     /// The type of span used by this format (Raw or Cooked)
-    type SpanType: Debug + 'static;
+    type SpanType: Debug + SubstackBehavior + 'static;
 
     /// The lowercase source ID of the format, used for error reporting.
     fn source(&self) -> &'static str;
@@ -266,6 +285,8 @@ pub enum Instruction {
     ObjectKeyOrObjectClose,
     /// Expect a list item or the end of a list.
     ListItemOrListClose,
+    /// Triggers clearing a substack.
+    SubstackClose,
 }
 
 /// Reasons for expecting a value, reflecting the current parse context.
@@ -407,6 +428,7 @@ pub fn deserialize_wip<'input, 'facet, 'shape, F>(
 ) -> Result<HeapValue<'facet, 'shape>, DeserError<'input, 'shape, Cooked>>
 where
     F: Format + 'shape,
+    F::SpanType: SubstackBehavior,
     F::Input<'input>: InputDebug,
     Span<F::SpanType>: ToCooked<'input, F>,
     'input: 'facet,
@@ -446,7 +468,19 @@ where
                     source_id: error.source_id,
                 }
             })?;
+            if F::SpanType::USES_SUBSTACK {
+                if !$runner.substack.get().is_empty() {
+                    trace!("Substack: {}", "carried".cyan());
+                } else {
+                    trace!("Substack: {}", "-".red());
+                }
+            }
             $runner.last_span = outcome.span;
+            if F::SpanType::USES_SUBSTACK {
+                if let Outcome::Resegmented(subspans) = &outcome.node {
+                    $runner.substack = subspans.clone().into();
+                }
+            }
             $wip = $runner.$method($wip, outcome).map_err(|error| {
                 DeserError {
                     input:  error.input,
@@ -474,7 +508,7 @@ where
             None => unreachable!("Instruction stack is empty"),
         };
 
-        trace!("[{frame_count}] Instruction {:?}", insn.yellow());
+        trace!("[{frame_count}] Instruction {:?}", insn.bright_red());
 
         match insn {
             Instruction::Pop(reason) => {
@@ -534,6 +568,9 @@ where
                     Expectation::ListItemOrListClose,
                     list_item_or_list_close
                 );
+            }
+            Instruction::SubstackClose => {
+                runner.substack.clear();
             }
             Instruction::SkipValue => {
                 // Call F::skip to skip over the next value in the input
@@ -614,6 +651,11 @@ where
         mut wip: Wip<'facet, 'shape>,
         reason: PopReason,
     ) -> Result<Wip<'facet, 'shape>, DeserError<'input, 'shape, C>> {
+        trace!(
+            "--- STACK has {:?} {}",
+            self.stack.green(),
+            "(POP)".bright_yellow()
+        );
         trace!("Popping because {:?}", reason.yellow());
 
         let container_shape = wip.shape();
@@ -897,6 +939,11 @@ where
         'input: 'facet, // 'input must outlive 'facet
     {
         trace!(
+            "--- STACK has {:?} {}",
+            self.stack.green(),
+            "(VALUE)".bright_yellow()
+        );
+        trace!(
             "Handling value of type {} (innermost {})",
             wip.shape().blue(),
             wip.innermost_shape().yellow()
@@ -926,6 +973,7 @@ where
 
         match outcome.node {
             Outcome::Scalar(s) => {
+                trace!("Parsed scalar value: {}", s.cyan());
                 wip = self.handle_scalar(wip, s)?;
             }
             Outcome::ListStarted => {
@@ -1045,6 +1093,15 @@ where
 
                 self.stack.push(Instruction::ObjectKeyOrObjectClose);
             }
+            Outcome::Resegmented(subspans) => {
+                trace!("Resegmented with {} subspans (value)", subspans.len());
+                // Push an instruction to process the current argument again
+                // (but this time it will use the subspan from the substack)
+                // self.stack.push(Instruction::ObjectKeyOrObjectClose);
+                // 1) Go back to expecting another value
+                // self.stack.push(Instruction::Pop(PopReason::ObjectVal));
+                // self.stack.push(Instruction::Value(ValueReason::ObjectVal));
+            }
             Outcome::ObjectEnded => todo!(),
         }
         Ok(wip)
@@ -1058,6 +1115,12 @@ where
     where
         'input: 'facet,
     {
+        trace!(
+            "STACK: {:?} {}",
+            self.stack.green(),
+            "(OK/OC)".bright_yellow()
+        );
+        trace!("SUBSTACK: {:?}", self.substack.get().bright_green());
         match outcome.node {
             Outcome::Scalar(Scalar::String(key)) => {
                 trace!("Parsed object key: {}", key.cyan());
@@ -1065,6 +1128,7 @@ where
                 let mut ignore = false;
                 let mut needs_pop = true;
                 let mut handled_by_flatten = false;
+                let has_substack = !self.substack.get().is_empty();
 
                 let shape = wip.innermost_shape();
                 match shape.ty {
@@ -1210,11 +1274,21 @@ where
                     if needs_pop && !handled_by_flatten {
                         trace!("Pushing Pop insn to stack (ObjectVal)");
                         self.stack.push(Instruction::Pop(PopReason::ObjectVal));
+                        if has_substack {
+                            trace!("Pushing SubstackClose insn to stack");
+                            self.stack.push(Instruction::SubstackClose);
+                        }
                     } else if handled_by_flatten {
                         // We need two pops for flattened fields - one for the field itself,
                         // one for the containing struct
                         trace!("Pushing Pop insn to stack (ObjectVal) for flattened field");
                         self.stack.push(Instruction::Pop(PopReason::ObjectVal));
+                        // Can't tell yet if this is needed, not required for tests (yet),
+                        // but if we did need it I think it would go in the middle, for the field:
+                        // if has_substack {
+                        //     trace!("Pushing SubstackClose insn to stack");
+                        //     self.stack.push(Instruction::SubstackClose);
+                        // }
                         self.stack.push(Instruction::Pop(PopReason::ObjectVal));
                     }
                     self.stack.push(Instruction::Value(ValueReason::ObjectVal));
@@ -1223,6 +1297,16 @@ where
             }
             Outcome::ObjectEnded => {
                 trace!("Object closing");
+                Ok(wip)
+            }
+            Outcome::Resegmented(subspans) => {
+                trace!(
+                    "Resegmented into {} subspans ({:?}) - obj. key/close",
+                    subspans.len(),
+                    subspans
+                );
+                // stay in the same state: parse another 'object key'
+                self.stack.push(Instruction::ObjectKeyOrObjectClose);
                 Ok(wip)
             }
             _ => Err(self.err(DeserErrorKind::UnexpectedOutcome {
@@ -1240,6 +1324,11 @@ where
     where
         'input: 'facet,
     {
+        trace!(
+            "--- STACK has {:?} {}",
+            self.stack.green(),
+            "(LI/LC)".bright_yellow()
+        );
         match outcome.node {
             Outcome::ListEnded => {
                 trace!("List close");


### PR DESCRIPTION
**Summary**: populate the Substack in the state machine lender iterator data-passing style via NextData

- Adds a new `Outcome::Resegment` enum variant intended for use with `Format::SpanType = Raw` (e.g. facet-args)
  - In these formats, a `Span` is a meaningful unit, but in some cases may not actually be a good unit on first pass
  - For example, it is equivalent in a CLI to pass `["--key", "value"]` or `["--key=value"]` and we would want to be able to 'resegment' the latter to appear like the former at deserialisation

- The Format's `next()` method is allowed (opt-in) to find more meaningful units, put them on a 'substack' that lives on the runner alongside the regular stack, where they live for the duration of the individual arg's processing (hence "subspan")

- The format's `next()` method must pass spans of length 0, aliased as `stay_put`, until the last Subspan on the `nd.runner.substack` (made public via `substack()`) is processed and then move on by passing a Span of length 1, aliased as `step_forth`)
  - The `Substack` checking in the `next!` macro in `deserialize_wip` is compiled out via a const generic bool set via trait bound on the `Format::SpanType` (Raw/Cooked), i.e. will never be checked and will never be set
    - NB: it can only be set in this part of the code, the runner is non-mutable from the format's `next()` method itself (courtesy of a lending iterator ownership transfer)

- Adds a new `Instruction::SubstackClose` enum variant to trigger stack-based clearing, so the runner stack controls how long the substack persists (it should only persist for the duration of a Span, but we don't need to introduce any counter/index state to monitor when we're about to leave this, the existing stack suffices)

## Demo

```rust
#[test]
fn test_eq() {
    #[derive(Facet, Debug)]
    struct Args {
        #[facet(named)]
        hello: String,
    }
    let args: Args = facet_args::from_slice(&["--hello=world"])?;
    assert_eq!(args.hello, "world".to_string());
}
```

## Key parts

- `Substack` is created in `deserialize_wip`

https://github.com/facet-rs/facet/blob/858c8ceb2487b1e8ef955561b624011947c2cb34/facet-deserialize/src/lib.rs#L445

- It lives on the `StackRunner`

https://github.com/facet-rs/facet/blob/858c8ceb2487b1e8ef955561b624011947c2cb34/facet-deserialize/src/lib.rs#L619-L620

- A `Substack` is a struct with `Option<Vec<Subspan>>` in its `spans`

https://github.com/facet-rs/facet/blob/858c8ceb2487b1e8ef955561b624011947c2cb34/facet-deserialize/src/span.rs#L134-L137

https://github.com/facet-rs/facet/blob/858c8ceb2487b1e8ef955561b624011947c2cb34/facet-deserialize/src/span.rs#L108-L131

- For formats whose `SpanType` (generic type param `C`) is Cooked (the default), it is impossible to add to the substack (i.e. the substack is opt-in by the format).

https://github.com/facet-rs/facet/blob/858c8ceb2487b1e8ef955561b624011947c2cb34/facet-deserialize/src/span.rs#L188-L214

- ...so formats with SpanType = Cooked like facet-json etc. will only ever be able to have a `None` in the `substack` field, never a `Vec`

https://github.com/facet-rs/facet/blob/858c8ceb2487b1e8ef955561b624011947c2cb34/facet-deserialize/src/span.rs#L216-L228

- Specifically the access gets compiled out of the `next!` macro for non-`Formats::SpanType = Raw` formats like facet-json which don't use `Subspan`s :checkered_flag: here:

https://github.com/facet-rs/facet/blob/858c8ceb2487b1e8ef955561b624011947c2cb34/facet-deserialize/src/lib.rs#L471-L477

- and the clone gets compiled out here:

https://github.com/facet-rs/facet/blob/858c8ceb2487b1e8ef955561b624011947c2cb34/facet-deserialize/src/lib.rs#L479-L483