### PR TITLE
Add indirection to vtable fns to fix cyclic types

### DIFF
--- a/facet-core/src/impls_alloc/boxed.rs
+++ b/facet-core/src/impls_alloc/boxed.rs
@@ -49,9 +49,9 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::boxed::Box<T> {
             }
             Ok(())
         });
-        vtable.try_from = Some(try_from::<T>);
-        vtable.try_into_inner = Some(try_into_inner::<T>);
-        vtable.try_borrow_inner = Some(try_borrow_inner::<T>);
+        vtable.try_from = || Some(try_from::<T>);
+        vtable.try_into_inner = || Some(try_into_inner::<T>);
+        vtable.try_borrow_inner = || Some(try_borrow_inner::<T>);
         vtable
     };
 
@@ -148,10 +148,7 @@ mod tests {
         assert_eq!(unsafe { borrowed_ptr.get::<String>() }, "example");
 
         // Get the function pointer for dropping the Box
-        let drop_fn = box_shape
-            .vtable
-            .drop_in_place
-            .expect("Box<T> should have drop_in_place");
+        let drop_fn = (box_shape.vtable.drop_in_place)().expect("Box<T> should have drop_in_place");
 
         // Drop the Box in place
         // SAFETY: box_ptr points to a valid Box<String>

--- a/facet-core/src/impls_alloc/btreemap.rs
+++ b/facet-core/src/impls_alloc/btreemap.rs
@@ -16,13 +16,13 @@ where
 {
     const VTABLE: &'static ValueVTable = &const {
         let mut builder = ValueVTable::builder::<Self>()
-            .marker_traits({
+            .marker_traits(|| {
                 let arg_dependent_traits = MarkerTraits::SEND
                     .union(MarkerTraits::SYNC)
                     .union(MarkerTraits::EQ);
                 arg_dependent_traits
-                    .intersection(V::SHAPE.vtable.marker_traits)
-                    .intersection(K::SHAPE.vtable.marker_traits)
+                    .intersection(V::SHAPE.vtable.marker_traits())
+                    .intersection(K::SHAPE.vtable.marker_traits())
                     // only depends on `A` which we are not generic over (yet)
                     .union(MarkerTraits::UNPIN)
             })
@@ -38,77 +38,95 @@ where
                 }
             });
 
-        if K::SHAPE.vtable.debug.is_some() && V::SHAPE.vtable.debug.is_some() {
-            builder = builder.debug(|value, f| {
-                let k_debug = <VTableView<K>>::of().debug().unwrap();
-                let v_debug = <VTableView<V>>::of().debug().unwrap();
-                write!(f, "{{")?;
-                for (i, (key, val)) in value.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
+        builder = builder.debug(|| {
+            if (K::VTABLE.debug)().is_some() && (V::VTABLE.debug)().is_some() {
+                Some(|value, f| {
+                    let k_debug = <VTableView<K>>::of().debug().unwrap();
+                    let v_debug = <VTableView<V>>::of().debug().unwrap();
+                    write!(f, "{{")?;
+                    for (i, (key, val)) in value.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        (k_debug)(key, f)?;
+                        write!(f, ": ")?;
+                        (v_debug)(val, f)?;
                     }
-                    (k_debug)(key, f)?;
-                    write!(f, ": ")?;
-                    (v_debug)(val, f)?;
-                }
-                write!(f, "}}")
-            })
-        }
+                    write!(f, "}}")
+                })
+            } else {
+                None
+            }
+        });
 
-        builder = builder.default_in_place(|target| unsafe { target.put(Self::default()) });
+        builder =
+            builder.default_in_place(|| Some(|target| unsafe { target.put(Self::default()) }));
 
-        if V::SHAPE.vtable.clone_into.is_some() && K::SHAPE.vtable.clone_into.is_some() {
-            builder = builder.clone_into(|src, dst| unsafe {
-                let mut new_map = BTreeMap::new();
+        builder = builder.clone_into(|| {
+            if (K::SHAPE.vtable.clone_into)().is_some() && (V::SHAPE.vtable.clone_into)().is_some()
+            {
+                Some(|src, dst| unsafe {
+                    let mut new_map = BTreeMap::new();
 
-                let k_clone_into = <VTableView<K>>::of().clone_into().unwrap();
-                let v_clone_into = <VTableView<V>>::of().clone_into().unwrap();
+                    let k_clone_into = <VTableView<K>>::of().clone_into().unwrap();
+                    let v_clone_into = <VTableView<V>>::of().clone_into().unwrap();
 
-                for (k, v) in src {
-                    use crate::TypedPtrUninit;
-                    use core::mem::MaybeUninit;
+                    for (k, v) in src {
+                        use crate::TypedPtrUninit;
+                        use core::mem::MaybeUninit;
 
-                    let mut new_k = MaybeUninit::<K>::uninit();
-                    let mut new_v = MaybeUninit::<V>::uninit();
+                        let mut new_k = MaybeUninit::<K>::uninit();
+                        let mut new_v = MaybeUninit::<V>::uninit();
 
-                    let uninit_k = TypedPtrUninit::new(new_k.as_mut_ptr());
-                    let uninit_v = TypedPtrUninit::new(new_v.as_mut_ptr());
+                        let uninit_k = TypedPtrUninit::new(new_k.as_mut_ptr());
+                        let uninit_v = TypedPtrUninit::new(new_v.as_mut_ptr());
 
-                    (k_clone_into)(k, uninit_k);
-                    (v_clone_into)(v, uninit_v);
+                        (k_clone_into)(k, uninit_k);
+                        (v_clone_into)(v, uninit_v);
 
-                    new_map.insert(new_k.assume_init(), new_v.assume_init());
-                }
+                        new_map.insert(new_k.assume_init(), new_v.assume_init());
+                    }
 
-                dst.put(new_map)
-            });
-        }
+                    dst.put(new_map)
+                })
+            } else {
+                None
+            }
+        });
 
-        if V::SHAPE.vtable.eq.is_some() {
-            builder = builder.eq(|a, b| {
-                let v_eq = <VTableView<V>>::of().eq().unwrap();
-                a.len() == b.len()
-                    && a.iter().all(|(key_a, val_a)| {
-                        b.get(key_a).is_some_and(|val_b| (v_eq)(val_a, val_b))
-                    })
-            });
-        }
+        builder = builder.eq(|| {
+            if (V::SHAPE.vtable.eq)().is_some() {
+                Some(|a, b| {
+                    let v_eq = <VTableView<V>>::of().eq().unwrap();
+                    a.len() == b.len()
+                        && a.iter().all(|(key_a, val_a)| {
+                            b.get(key_a).is_some_and(|val_b| (v_eq)(val_a, val_b))
+                        })
+                })
+            } else {
+                None
+            }
+        });
 
-        if K::SHAPE.vtable.hash.is_some() && V::SHAPE.vtable.hash.is_some() {
-            builder = builder.hash(|map, hasher_this, hasher_write_fn| unsafe {
-                use crate::HasherProxy;
-                use core::hash::Hash;
+        builder = builder.hash(|| {
+            if (K::SHAPE.vtable.hash)().is_some() && (V::SHAPE.vtable.hash)().is_some() {
+                Some(|map, hasher_this, hasher_write_fn| unsafe {
+                    use crate::HasherProxy;
+                    use core::hash::Hash;
 
-                let k_hash = <VTableView<K>>::of().hash().unwrap();
-                let v_hash = <VTableView<V>>::of().hash().unwrap();
-                let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
-                map.len().hash(&mut hasher);
-                for (k, v) in map {
-                    (k_hash)(k, hasher_this, hasher_write_fn);
-                    (v_hash)(v, hasher_this, hasher_write_fn);
-                }
-            });
-        }
+                    let k_hash = <VTableView<K>>::of().hash().unwrap();
+                    let v_hash = <VTableView<V>>::of().hash().unwrap();
+                    let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
+                    map.len().hash(&mut hasher);
+                    for (k, v) in map {
+                        (k_hash)(k, hasher_this, hasher_write_fn);
+                        (v_hash)(v, hasher_this, hasher_write_fn);
+                    }
+                })
+            } else {
+                None
+            }
+        });
 
         builder.build()
     };

--- a/facet-core/src/impls_alloc/vec.rs
+++ b/facet-core/src/impls_alloc/vec.rs
@@ -21,75 +21,92 @@ where
                     write!(f, "Vec<⋯>")
                 }
             })
-            .default_in_place(|target| unsafe { target.put(Self::default()) });
+            .default_in_place(|| Some(|target| unsafe { target.put(Self::default()) }));
 
-        if T::SHAPE.vtable.clone_into.is_some() {
-            builder = builder.clone_into(|src, dst| unsafe {
-                let mut new_vec = Vec::with_capacity(src.len());
+        builder = builder.clone_into(|| {
+            if (T::SHAPE.vtable.clone_into)().is_some() {
+                Some(|src, dst| unsafe {
+                    let mut new_vec = Vec::with_capacity(src.len());
 
-                let t_clone_into = <VTableView<T>>::of().clone_into().unwrap();
+                    let t_clone_into = <VTableView<T>>::of().clone_into().unwrap();
 
-                for item in src {
-                    use crate::TypedPtrUninit;
-                    use core::mem::MaybeUninit;
+                    for item in src {
+                        use crate::TypedPtrUninit;
+                        use core::mem::MaybeUninit;
 
-                    let mut new_item = MaybeUninit::<T>::uninit();
-                    let uninit_item = TypedPtrUninit::new(new_item.as_mut_ptr());
+                        let mut new_item = MaybeUninit::<T>::uninit();
+                        let uninit_item = TypedPtrUninit::new(new_item.as_mut_ptr());
 
-                    (t_clone_into)(item, uninit_item);
+                        (t_clone_into)(item, uninit_item);
 
-                    new_vec.push(new_item.assume_init());
-                }
-
-                dst.put(new_vec)
-            });
-        }
-
-        if T::SHAPE.vtable.debug.is_some() {
-            builder = builder.debug(|value, f| {
-                write!(f, "[")?;
-                for (i, item) in value.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
+                        new_vec.push(new_item.assume_init());
                     }
-                    (<VTableView<T>>::of().debug().unwrap())(item, f)?;
-                }
-                write!(f, "]")
-            });
-        }
 
-        if T::SHAPE.vtable.eq.is_some() {
-            builder = builder.eq(|a, b| {
-                if a.len() != b.len() {
-                    return false;
-                }
-                for (item_a, item_b) in a.iter().zip(b.iter()) {
-                    if !(<VTableView<T>>::of().eq().unwrap())(item_a, item_b) {
+                    dst.put(new_vec)
+                })
+            } else {
+                None
+            }
+        });
+
+        builder = builder.debug(|| {
+            if (T::SHAPE.vtable.debug)().is_some() {
+                Some(|value, f| {
+                    write!(f, "[")?;
+                    for (i, item) in value.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        (<VTableView<T>>::of().debug().unwrap())(item, f)?;
+                    }
+                    write!(f, "]")
+                })
+            } else {
+                None
+            }
+        });
+
+        builder = builder.eq(|| {
+            if (T::SHAPE.vtable.eq)().is_some() {
+                Some(|a, b| {
+                    if a.len() != b.len() {
                         return false;
                     }
-                }
-                true
-            });
-        }
+                    for (item_a, item_b) in a.iter().zip(b.iter()) {
+                        if !(<VTableView<T>>::of().eq().unwrap())(item_a, item_b) {
+                            return false;
+                        }
+                    }
+                    true
+                })
+            } else {
+                None
+            }
+        });
 
-        if T::SHAPE.vtable.hash.is_some() {
-            builder = builder.hash(|vec, hasher_this, hasher_write_fn| unsafe {
-                use crate::HasherProxy;
-                let t_hash = <VTableView<T>>::of().hash().unwrap_unchecked();
-                let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
-                vec.len().hash(&mut hasher);
-                for item in vec {
-                    (t_hash)(item, hasher_this, hasher_write_fn);
-                }
-            });
-        }
+        builder = builder.hash(|| {
+            if (T::SHAPE.vtable.hash)().is_some() {
+                Some(|vec, hasher_this, hasher_write_fn| unsafe {
+                    use crate::HasherProxy;
+                    let t_hash = <VTableView<T>>::of().hash().unwrap_unchecked();
+                    let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
+                    vec.len().hash(&mut hasher);
+                    for item in vec {
+                        (t_hash)(item, hasher_this, hasher_write_fn);
+                    }
+                })
+            } else {
+                None
+            }
+        });
 
-        let traits = MarkerTraits::SEND
-            .union(MarkerTraits::SYNC)
-            .union(MarkerTraits::EQ)
-            .union(MarkerTraits::UNPIN)
-            .intersection(T::SHAPE.vtable.marker_traits);
-        builder = builder.marker_traits(traits);
+        builder = builder.marker_traits(|| {
+            MarkerTraits::SEND
+                .union(MarkerTraits::SYNC)
+                .union(MarkerTraits::EQ)
+                .union(MarkerTraits::UNPIN)
+                .intersection(T::SHAPE.vtable.marker_traits())
+        });
 
         builder.build()
     };

--- a/facet-core/src/impls_bytes.rs
+++ b/facet-core/src/impls_bytes.rs
@@ -12,20 +12,22 @@ type BytesIterator<'mem> = core::slice::Iter<'mem, u8>;
 unsafe impl Facet<'_> for Bytes {
     const VTABLE: &'static ValueVTable = &const {
         let mut vtable = value_vtable!(Bytes, |f, _opts| write!(f, "Bytes"));
-        vtable.try_from = Some(
-            |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
-                if source_shape.is_type::<BytesMut>() {
-                    let source = unsafe { source.read::<BytesMut>() };
-                    let bytes = source.freeze();
-                    Ok(unsafe { target.put(bytes) })
-                } else {
-                    Err(crate::TryFromError::UnsupportedSourceShape {
-                        src_shape: source_shape,
-                        expected: &[Bytes::SHAPE],
-                    })
-                }
-            },
-        );
+        vtable.try_from = || {
+            Some(
+                |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
+                    if source_shape.is_type::<BytesMut>() {
+                        let source = unsafe { source.read::<BytesMut>() };
+                        let bytes = source.freeze();
+                        Ok(unsafe { target.put(bytes) })
+                    } else {
+                        Err(crate::TryFromError::UnsupportedSourceShape {
+                            src_shape: source_shape,
+                            expected: &[Bytes::SHAPE],
+                        })
+                    }
+                },
+            )
+        };
 
         vtable
     };

--- a/facet-core/src/impls_camino.rs
+++ b/facet-core/src/impls_camino.rs
@@ -35,9 +35,9 @@ unsafe impl Facet<'_> for Utf8PathBuf {
         }
 
         let mut vtable = value_vtable!(Utf8PathBuf, |f, _opts| write!(f, "Utf8PathBuf"));
-        vtable.parse = Some(|s, target| Ok(unsafe { target.put(Utf8Path::new(s).to_owned()) }));
-        vtable.try_from = Some(try_from);
-        vtable.try_into_inner = Some(try_into_inner);
+        vtable.parse = || Some(|s, target| Ok(unsafe { target.put(Utf8Path::new(s).to_owned()) }));
+        vtable.try_from = || Some(try_from);
+        vtable.try_into_inner = || Some(try_into_inner);
         vtable
     };
 
@@ -79,7 +79,7 @@ unsafe impl Facet<'_> for Utf8Path {
         }
 
         let mut vtable = value_vtable_unsized!(Utf8Path, |f, _opts| write!(f, "Utf8Path"));
-        vtable.try_from = Some(try_from);
+        vtable.try_from = || Some(try_from);
         vtable
     };
 

--- a/facet-core/src/impls_core/array.rs
+++ b/facet-core/src/impls_core/array.rs
@@ -6,7 +6,7 @@ where
     T: Facet<'a>,
 {
     const VTABLE: &'static ValueVTable = &const {
-        let mut builder = ValueVTable::builder::<Self>()
+        ValueVTable::builder::<Self>()
             .marker_traits(T::SHAPE.vtable.marker_traits)
             .type_name(|f, opts| {
                 if let Some(opts) = opts.for_children() {
@@ -16,141 +16,141 @@ where
                 } else {
                     write!(f, "[⋯; {L}]")
                 }
-            });
-        builder = builder.display(|| {
-            if (T::SHAPE.vtable.display)().is_some() {
-                Some(|value, f| {
-                    write!(f, "[")?;
+            })
+            .display(|| {
+                if (T::SHAPE.vtable.display)().is_some() {
+                    Some(|value, f| {
+                        write!(f, "[")?;
 
-                    for (idx, value) in value.iter().enumerate() {
-                        (<VTableView<T>>::of().display().unwrap())(value, f)?;
-                        if idx != L - 1 {
-                            write!(f, ", ")?;
-                        }
-                    }
-                    write!(f, "]")
-                })
-            } else {
-                None
-            }
-        });
-        builder = builder.debug(|| {
-            if (T::SHAPE.vtable.debug)().is_some() {
-                Some(|value, f| {
-                    write!(f, "[")?;
-
-                    for (idx, value) in value.iter().enumerate() {
-                        (<VTableView<T>>::of().debug().unwrap())(value, f)?;
-                        if idx != L - 1 {
-                            write!(f, ", ")?;
-                        }
-                    }
-                    write!(f, "]")
-                })
-            } else {
-                None
-            }
-        });
-        builder = builder.eq(|| {
-            if (T::SHAPE.vtable.eq)().is_some() {
-                Some(|a, b| zip(a, b).all(|(a, b)| (<VTableView<T>>::of().eq().unwrap())(a, b)))
-            } else {
-                None
-            }
-        });
-        builder = builder.default_in_place(|| {
-            if L == 0 {
-                // Zero-length arrays implement `Default` irrespective of the element type
-                Some(|target| unsafe { target.assume_init() })
-            } else if L <= 32 && (T::SHAPE.vtable.default_in_place)().is_some() {
-                Some(|mut target| unsafe {
-                    let t_dip = <VTableView<T>>::of().default_in_place().unwrap();
-                    let stride = T::SHAPE
-                        .layout
-                        .sized_layout()
-                        .unwrap()
-                        .pad_to_align()
-                        .size();
-                    for idx in 0..L {
-                        t_dip(target.field_uninit_at(idx * stride));
-                    }
-                    target.assume_init()
-                })
-            } else {
-                // arrays do not yet implement `Default` for > 32 elements due
-                // to specializing the `0` len case
-                None
-            }
-        });
-        builder = builder.clone_into(|| {
-            if (T::SHAPE.vtable.clone_into)().is_some() {
-                Some(|src, mut dst| unsafe {
-                    let t_cip = <VTableView<T>>::of().clone_into().unwrap();
-                    let stride = T::SHAPE
-                        .layout
-                        .sized_layout()
-                        .unwrap()
-                        .pad_to_align()
-                        .size();
-                    for (idx, src) in src.iter().enumerate() {
-                        (t_cip)(src, dst.field_uninit_at(idx * stride));
-                    }
-                    dst.assume_init()
-                })
-            } else {
-                None
-            }
-        });
-        builder = builder.partial_ord(|| {
-            if (T::SHAPE.vtable.partial_ord)().is_some() {
-                Some(|a, b| {
-                    zip(a, b)
-                        .find_map(|(a, b)| {
-                            match (<VTableView<T>>::of().partial_ord().unwrap())(a, b) {
-                                Some(Ordering::Equal) => None,
-                                c => Some(c),
+                        for (idx, value) in value.iter().enumerate() {
+                            (<VTableView<T>>::of().display().unwrap())(value, f)?;
+                            if idx != L - 1 {
+                                write!(f, ", ")?;
                             }
-                        })
-                        .unwrap_or(Some(Ordering::Equal))
-                })
-            } else {
-                // arrays do not yet implement `Default` for > 32 elements due
-                // to specializing the `0` len case
-                None
-            }
-        });
-        builder = builder.ord(|| {
-            if (T::SHAPE.vtable.ord)().is_some() {
-                Some(|a, b| {
-                    zip(a, b)
-                        .find_map(
-                            |(a, b)| match (<VTableView<T>>::of().ord().unwrap())(a, b) {
-                                Ordering::Equal => None,
-                                c => Some(c),
-                            },
-                        )
-                        .unwrap_or(Ordering::Equal)
-                })
-            } else {
-                // arrays do not yet implement `Default` for > 32 elements due
-                // to specializing the `0` len case
-                None
-            }
-        });
-        builder = builder.hash(|| {
-            if (T::SHAPE.vtable.hash)().is_some() {
-                Some(|value, state, hasher| {
-                    for value in value {
-                        (<VTableView<T>>::of().hash().unwrap())(value, state, hasher)
-                    }
-                })
-            } else {
-                // arrays do not yet implement `Default` for > 32 elements due
-                // to specializing the `0` len case
-                None
-            }
-        });
-        builder.build()
+                        }
+                        write!(f, "]")
+                    })
+                } else {
+                    None
+                }
+            })
+            .debug(|| {
+                if (T::SHAPE.vtable.debug)().is_some() {
+                    Some(|value, f| {
+                        write!(f, "[")?;
+
+                        for (idx, value) in value.iter().enumerate() {
+                            (<VTableView<T>>::of().debug().unwrap())(value, f)?;
+                            if idx != L - 1 {
+                                write!(f, ", ")?;
+                            }
+                        }
+                        write!(f, "]")
+                    })
+                } else {
+                    None
+                }
+            })
+            .eq(|| {
+                if (T::SHAPE.vtable.eq)().is_some() {
+                    Some(|a, b| zip(a, b).all(|(a, b)| (<VTableView<T>>::of().eq().unwrap())(a, b)))
+                } else {
+                    None
+                }
+            })
+            .default_in_place(|| {
+                if L == 0 {
+                    // Zero-length arrays implement `Default` irrespective of the element type
+                    Some(|target| unsafe { target.assume_init() })
+                } else if L <= 32 && (T::SHAPE.vtable.default_in_place)().is_some() {
+                    Some(|mut target| unsafe {
+                        let t_dip = <VTableView<T>>::of().default_in_place().unwrap();
+                        let stride = T::SHAPE
+                            .layout
+                            .sized_layout()
+                            .unwrap()
+                            .pad_to_align()
+                            .size();
+                        for idx in 0..L {
+                            t_dip(target.field_uninit_at(idx * stride));
+                        }
+                        target.assume_init()
+                    })
+                } else {
+                    // arrays do not yet implement `Default` for > 32 elements due
+                    // to specializing the `0` len case
+                    None
+                }
+            })
+            .clone_into(|| {
+                if (T::SHAPE.vtable.clone_into)().is_some() {
+                    Some(|src, mut dst| unsafe {
+                        let t_cip = <VTableView<T>>::of().clone_into().unwrap();
+                        let stride = T::SHAPE
+                            .layout
+                            .sized_layout()
+                            .unwrap()
+                            .pad_to_align()
+                            .size();
+                        for (idx, src) in src.iter().enumerate() {
+                            (t_cip)(src, dst.field_uninit_at(idx * stride));
+                        }
+                        dst.assume_init()
+                    })
+                } else {
+                    None
+                }
+            })
+            .partial_ord(|| {
+                if (T::SHAPE.vtable.partial_ord)().is_some() {
+                    Some(|a, b| {
+                        zip(a, b)
+                            .find_map(|(a, b)| {
+                                match (<VTableView<T>>::of().partial_ord().unwrap())(a, b) {
+                                    Some(Ordering::Equal) => None,
+                                    c => Some(c),
+                                }
+                            })
+                            .unwrap_or(Some(Ordering::Equal))
+                    })
+                } else {
+                    // arrays do not yet implement `Default` for > 32 elements due
+                    // to specializing the `0` len case
+                    None
+                }
+            })
+            .ord(|| {
+                if (T::SHAPE.vtable.ord)().is_some() {
+                    Some(|a, b| {
+                        zip(a, b)
+                            .find_map(
+                                |(a, b)| match (<VTableView<T>>::of().ord().unwrap())(a, b) {
+                                    Ordering::Equal => None,
+                                    c => Some(c),
+                                },
+                            )
+                            .unwrap_or(Ordering::Equal)
+                    })
+                } else {
+                    // arrays do not yet implement `Default` for > 32 elements due
+                    // to specializing the `0` len case
+                    None
+                }
+            })
+            .hash(|| {
+                if (T::SHAPE.vtable.hash)().is_some() {
+                    Some(|value, state, hasher| {
+                        for value in value {
+                            (<VTableView<T>>::of().hash().unwrap())(value, state, hasher)
+                        }
+                    })
+                } else {
+                    // arrays do not yet implement `Default` for > 32 elements due
+                    // to specializing the `0` len case
+                    None
+                }
+            })
+            .build()
     };
 
     const SHAPE: &'static Shape<'static> = &const {

--- a/facet-core/src/impls_core/array.rs
+++ b/facet-core/src/impls_core/array.rs
@@ -17,103 +17,139 @@ where
                     write!(f, "[⋯; {L}]")
                 }
             });
-        if T::SHAPE.vtable.display.is_some() {
-            builder = builder.display(|value, f| {
-                write!(f, "[")?;
+        builder = builder.display(|| {
+            if (T::SHAPE.vtable.display)().is_some() {
+                Some(|value, f| {
+                    write!(f, "[")?;
 
-                for (idx, value) in value.iter().enumerate() {
-                    (<VTableView<T>>::of().display().unwrap())(value, f)?;
-                    if idx != L - 1 {
-                        write!(f, ", ")?;
+                    for (idx, value) in value.iter().enumerate() {
+                        (<VTableView<T>>::of().display().unwrap())(value, f)?;
+                        if idx != L - 1 {
+                            write!(f, ", ")?;
+                        }
                     }
-                }
-                write!(f, "]")
-            });
-        }
-        if T::SHAPE.vtable.debug.is_some() {
-            builder = builder.debug(|value, f| {
-                write!(f, "[")?;
+                    write!(f, "]")
+                })
+            } else {
+                None
+            }
+        });
+        builder = builder.debug(|| {
+            if (T::SHAPE.vtable.debug)().is_some() {
+                Some(|value, f| {
+                    write!(f, "[")?;
 
-                for (idx, value) in value.iter().enumerate() {
-                    (<VTableView<T>>::of().debug().unwrap())(value, f)?;
-                    if idx != L - 1 {
-                        write!(f, ", ")?;
+                    for (idx, value) in value.iter().enumerate() {
+                        (<VTableView<T>>::of().debug().unwrap())(value, f)?;
+                        if idx != L - 1 {
+                            write!(f, ", ")?;
+                        }
                     }
-                }
-                write!(f, "]")
-            });
-        }
-        if T::SHAPE.vtable.eq.is_some() {
-            builder = builder
-                .eq(|a, b| zip(a, b).all(|(a, b)| (<VTableView<T>>::of().eq().unwrap())(a, b)));
-        }
-        if L == 0 {
-            // Zero-length arrays implement `Default` irrespective of the element type
-            builder = builder.default_in_place(|target| unsafe { target.assume_init() });
-        } else if L <= 32 && T::SHAPE.vtable.default_in_place.is_some() {
-            builder = builder.default_in_place(|mut target| unsafe {
-                let t_dip = <VTableView<T>>::of().default_in_place().unwrap();
-                let stride = T::SHAPE
-                    .layout
-                    .sized_layout()
-                    .unwrap()
-                    .pad_to_align()
-                    .size();
-                for idx in 0..L {
-                    t_dip(target.field_uninit_at(idx * stride));
-                }
-                target.assume_init()
-            });
-        } else {
-            // arrays do not yet implement `Default` for > 32 elements due to
-            // specializing the `0` len case
-        }
-        if T::SHAPE.vtable.clone_into.is_some() {
-            builder = builder.clone_into(|src, mut dst| unsafe {
-                let t_cip = <VTableView<T>>::of().clone_into().unwrap();
-                let stride = T::SHAPE
-                    .layout
-                    .sized_layout()
-                    .unwrap()
-                    .pad_to_align()
-                    .size();
-                for (idx, src) in src.iter().enumerate() {
-                    (t_cip)(src, dst.field_uninit_at(idx * stride));
-                }
-                dst.assume_init()
-            });
-        }
-        if T::SHAPE.vtable.partial_ord.is_some() {
-            builder = builder.partial_ord(|a, b| {
-                zip(a, b)
-                    .find_map(
-                        |(a, b)| match (<VTableView<T>>::of().partial_ord().unwrap())(a, b) {
-                            Some(Ordering::Equal) => None,
-                            c => Some(c),
-                        },
-                    )
-                    .unwrap_or(Some(Ordering::Equal))
-            });
-        }
-        if T::SHAPE.vtable.ord.is_some() {
-            builder = builder.ord(|a, b| {
-                zip(a, b)
-                    .find_map(
-                        |(a, b)| match (<VTableView<T>>::of().ord().unwrap())(a, b) {
-                            Ordering::Equal => None,
-                            c => Some(c),
-                        },
-                    )
-                    .unwrap_or(Ordering::Equal)
-            });
-        }
-        if T::SHAPE.vtable.hash.is_some() {
-            builder = builder.hash(|value, state, hasher| {
-                for value in value {
-                    (<VTableView<T>>::of().hash().unwrap())(value, state, hasher)
-                }
-            });
-        }
+                    write!(f, "]")
+                })
+            } else {
+                None
+            }
+        });
+        builder = builder.eq(|| {
+            if (T::SHAPE.vtable.eq)().is_some() {
+                Some(|a, b| zip(a, b).all(|(a, b)| (<VTableView<T>>::of().eq().unwrap())(a, b)))
+            } else {
+                None
+            }
+        });
+        builder = builder.default_in_place(|| {
+            if L == 0 {
+                // Zero-length arrays implement `Default` irrespective of the element type
+                Some(|target| unsafe { target.assume_init() })
+            } else if L <= 32 && (T::SHAPE.vtable.default_in_place)().is_some() {
+                Some(|mut target| unsafe {
+                    let t_dip = <VTableView<T>>::of().default_in_place().unwrap();
+                    let stride = T::SHAPE
+                        .layout
+                        .sized_layout()
+                        .unwrap()
+                        .pad_to_align()
+                        .size();
+                    for idx in 0..L {
+                        t_dip(target.field_uninit_at(idx * stride));
+                    }
+                    target.assume_init()
+                })
+            } else {
+                // arrays do not yet implement `Default` for > 32 elements due
+                // to specializing the `0` len case
+                None
+            }
+        });
+        builder = builder.clone_into(|| {
+            if (T::SHAPE.vtable.clone_into)().is_some() {
+                Some(|src, mut dst| unsafe {
+                    let t_cip = <VTableView<T>>::of().clone_into().unwrap();
+                    let stride = T::SHAPE
+                        .layout
+                        .sized_layout()
+                        .unwrap()
+                        .pad_to_align()
+                        .size();
+                    for (idx, src) in src.iter().enumerate() {
+                        (t_cip)(src, dst.field_uninit_at(idx * stride));
+                    }
+                    dst.assume_init()
+                })
+            } else {
+                None
+            }
+        });
+        builder = builder.partial_ord(|| {
+            if (T::SHAPE.vtable.partial_ord)().is_some() {
+                Some(|a, b| {
+                    zip(a, b)
+                        .find_map(|(a, b)| {
+                            match (<VTableView<T>>::of().partial_ord().unwrap())(a, b) {
+                                Some(Ordering::Equal) => None,
+                                c => Some(c),
+                            }
+                        })
+                        .unwrap_or(Some(Ordering::Equal))
+                })
+            } else {
+                // arrays do not yet implement `Default` for > 32 elements due
+                // to specializing the `0` len case
+                None
+            }
+        });
+        builder = builder.ord(|| {
+            if (T::SHAPE.vtable.ord)().is_some() {
+                Some(|a, b| {
+                    zip(a, b)
+                        .find_map(
+                            |(a, b)| match (<VTableView<T>>::of().ord().unwrap())(a, b) {
+                                Ordering::Equal => None,
+                                c => Some(c),
+                            },
+                        )
+                        .unwrap_or(Ordering::Equal)
+                })
+            } else {
+                // arrays do not yet implement `Default` for > 32 elements due
+                // to specializing the `0` len case
+                None
+            }
+        });
+        builder = builder.hash(|| {
+            if (T::SHAPE.vtable.hash)().is_some() {
+                Some(|value, state, hasher| {
+                    for value in value {
+                        (<VTableView<T>>::of().hash().unwrap())(value, state, hasher)
+                    }
+                })
+            } else {
+                // arrays do not yet implement `Default` for > 32 elements due
+                // to specializing the `0` len case
+                None
+            }
+        });
         builder.build()
     };
 

--- a/facet-core/src/impls_core/fn_ptr.rs
+++ b/facet-core/src/impls_core/fn_ptr.rs
@@ -68,31 +68,31 @@ macro_rules! impl_facet_for_fn_ptr {
                     .type_name(|f, opts| {
                         write_type_name_list(f, opts, $abi, &[$($args::SHAPE),*], R::SHAPE)
                     })
-                    .debug(|data, f| fmt::Debug::fmt(data, f))
-                    .clone_into(|src, dst| unsafe { dst.put(src.clone()) })
-                    .marker_traits(
+                    .debug(|| Some(|data, f| fmt::Debug::fmt(data, f)))
+                    .clone_into(|| Some(|src, dst| unsafe { dst.put(src.clone()) }))
+                    .marker_traits(||
                         MarkerTraits::EQ
                             .union(MarkerTraits::SEND)
                             .union(MarkerTraits::SYNC)
                             .union(MarkerTraits::COPY)
                             .union(MarkerTraits::UNPIN)
                     )
-                    .eq(|&left, &right| {
+                    .eq(|| Some(|&left, &right| {
                         fn_addr_eq(left, right)
-                    })
-                    .partial_ord(|left, right| {
+                    }))
+                    .partial_ord(|| Some(|left, right| {
                         #[allow(unpredictable_function_pointer_comparisons)]
                         left.partial_cmp(right)
-                    })
-                    .ord(|left, right| {
+                    }))
+                    .ord(|| Some(|left, right| {
                         #[allow(unpredictable_function_pointer_comparisons)]
                         left.cmp(right)
-                    })
-                    .hash(|value, hasher_this, hasher_write_fn| {
+                    }))
+                    .hash(|| Some(|value, hasher_this, hasher_write_fn| {
                         value.hash(&mut unsafe {
                                 HasherProxy::new(hasher_this, hasher_write_fn)
                             })
-                    })
+                    }))
                     .build()
             };
 

--- a/facet-core/src/impls_core/ops.rs
+++ b/facet-core/src/impls_core/ops.rs
@@ -48,14 +48,18 @@ unsafe impl<'a, Idx: Facet<'a>> Facet<'a> for core::ops::Range<Idx> {
             Ok(())
         });
 
-        if Idx::SHAPE.is_debug() {
-            builder = builder.debug(|this, f| {
-                (<VTableView<Idx>>::of().debug().unwrap())(&this.start, f)?;
-                write!(f, "..")?;
-                (<VTableView<Idx>>::of().debug().unwrap())(&this.end, f)?;
-                Ok(())
-            });
-        }
+        builder = builder.debug(|| {
+            if Idx::SHAPE.is_debug() {
+                Some(|this, f| {
+                    (<VTableView<Idx>>::of().debug().unwrap())(&this.start, f)?;
+                    write!(f, "..")?;
+                    (<VTableView<Idx>>::of().debug().unwrap())(&this.end, f)?;
+                    Ok(())
+                })
+            } else {
+                None
+            }
+        });
 
         builder.build()
     };

--- a/facet-core/src/impls_core/ops.rs
+++ b/facet-core/src/impls_core/ops.rs
@@ -36,31 +36,30 @@ unsafe impl<'a, Idx: Facet<'a>> Facet<'a> for core::ops::Range<Idx> {
     };
 
     const VTABLE: &'static ValueVTable = &const {
-        let mut builder = ValueVTable::builder::<Self>().type_name(|f, opts| {
-            write!(f, "Range")?;
-            if let Some(opts) = opts.for_children() {
-                write!(f, "<")?;
-                (Idx::SHAPE.vtable.type_name)(f, opts)?;
-                write!(f, ">")?;
-            } else {
-                write!(f, "<…>")?;
-            }
-            Ok(())
-        });
-
-        builder = builder.debug(|| {
-            if Idx::SHAPE.is_debug() {
-                Some(|this, f| {
-                    (<VTableView<Idx>>::of().debug().unwrap())(&this.start, f)?;
-                    write!(f, "..")?;
-                    (<VTableView<Idx>>::of().debug().unwrap())(&this.end, f)?;
-                    Ok(())
-                })
-            } else {
-                None
-            }
-        });
-
-        builder.build()
+        ValueVTable::builder::<Self>()
+            .type_name(|f, opts| {
+                write!(f, "Range")?;
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "<")?;
+                    (Idx::SHAPE.vtable.type_name)(f, opts)?;
+                    write!(f, ">")?;
+                } else {
+                    write!(f, "<…>")?;
+                }
+                Ok(())
+            })
+            .debug(|| {
+                if Idx::SHAPE.is_debug() {
+                    Some(|this, f| {
+                        (<VTableView<Idx>>::of().debug().unwrap())(&this.start, f)?;
+                        write!(f, "..")?;
+                        (<VTableView<Idx>>::of().debug().unwrap())(&this.end, f)?;
+                        Ok(())
+                    })
+                } else {
+                    None
+                }
+            })
+            .build()
     };
 }

--- a/facet-core/src/impls_core/pointer.rs
+++ b/facet-core/src/impls_core/pointer.rs
@@ -75,23 +75,23 @@ impl_facet_for_pointer!(
         => Shape::builder_for_sized::<Self>()
             .inner(|| T::SHAPE)
         => ValueVTable::builder::<Self>()
-            .marker_traits(
+            .marker_traits(||
                 MarkerTraits::EQ
                     .union(MarkerTraits::COPY)
                     .union(MarkerTraits::UNPIN),
             )
-            .debug(fmt::Debug::fmt)
-            .clone_into(|src, dst| unsafe { dst.put(*src) })
-            .eq(|left, right| left.cast::<()>().eq(&right.cast::<()>()))
-            .partial_ord(|&left, &right| {
+            .debug(|| Some(fmt::Debug::fmt))
+            .clone_into(|| Some(|src, dst| unsafe { dst.put(*src) }))
+            .eq(|| Some(|left, right| left.cast::<()>().eq(&right.cast::<()>())))
+            .partial_ord(|| Some(|&left, &right| {
                 left.cast::<()>().partial_cmp(&right.cast::<()>())
-            })
-            .ord(|&left, &right| left.cast::<()>().cmp(&right.cast::<()>()))
-            .hash(|value, hasher_this, hasher_write_fn| {
+            }))
+            .ord(|| Some(|&left, &right| left.cast::<()>().cmp(&right.cast::<()>())))
+            .hash(|| Some(|value, hasher_this, hasher_write_fn| {
                 value.hash(&mut unsafe {
                     HasherProxy::new(hasher_this, hasher_write_fn)
                 })
-            })
+            }))
         => Raw, false
 );
 
@@ -101,23 +101,23 @@ impl_facet_for_pointer!(
         => Shape::builder_for_sized::<Self>()
             .inner(|| T::SHAPE)
         => ValueVTable::builder::<Self>()
-            .marker_traits(
+            .marker_traits(||
                 MarkerTraits::EQ
                     .union(MarkerTraits::COPY)
                     .union(MarkerTraits::UNPIN),
             )
-            .debug(fmt::Debug::fmt)
-            .clone_into(|src, dst| unsafe { dst.put(*src) })
-            .eq(|left, right| left.cast::<()>().eq(&right.cast::<()>()))
-            .partial_ord(|&left, &right| {
+            .debug(|| Some(fmt::Debug::fmt))
+            .clone_into(|| Some(|src, dst| unsafe { dst.put(*src) }))
+            .eq(|| Some(|left, right| left.cast::<()>().eq(&right.cast::<()>())))
+            .partial_ord(|| Some(|&left, &right| {
                 left.cast::<()>().partial_cmp(&right.cast::<()>())
-            })
-            .ord(|&left, &right| left.cast::<()>().cmp(&right.cast::<()>()))
-            .hash(|value, hasher_this, hasher_write_fn| {
+            }))
+            .ord(|| Some(|&left, &right| left.cast::<()>().cmp(&right.cast::<()>())))
+            .hash(|| Some(|value, hasher_this, hasher_write_fn| {
                 value.hash(&mut unsafe {
                     HasherProxy::new(hasher_this, hasher_write_fn)
                 })
-            })
+            }))
         => Raw, true
 );
 
@@ -126,60 +126,81 @@ impl_facet_for_pointer!(
     Reference: &'a T
         => Shape::builder_for_sized::<Self>()
         => {
-            let mut marker_traits = MarkerTraits::COPY.union(MarkerTraits::UNPIN);
-            if T::SHAPE.vtable.marker_traits.contains(MarkerTraits::EQ) {
-                marker_traits = marker_traits.union(MarkerTraits::EQ);
-            }
-            if T::SHAPE.vtable.marker_traits.contains(MarkerTraits::SYNC) {
-                marker_traits = marker_traits.union(MarkerTraits::SEND).union(MarkerTraits::SYNC);
-            }
-
             let mut builder = ValueVTable::builder::<Self>()
-                .marker_traits(marker_traits)
-                .clone_into(|src, dst| unsafe { dst.put(core::ptr::read(src)) });
+                .marker_traits(|| {
+                    let mut marker_traits = MarkerTraits::COPY.union(MarkerTraits::UNPIN);
+                    if T::SHAPE.vtable.marker_traits().contains(MarkerTraits::EQ) {
+                        marker_traits = marker_traits.union(MarkerTraits::EQ);
+                    }
+                    if T::SHAPE.vtable.marker_traits().contains(MarkerTraits::SYNC) {
+                        marker_traits = marker_traits.union(MarkerTraits::SEND).union(MarkerTraits::SYNC);
+                    }
+
+                    marker_traits
+                })
+                .clone_into(|| Some(|src, dst| unsafe { dst.put(core::ptr::read(src)) }));
 
             // Forward trait methods to the underlying type if it implements them
-            if T::VTABLE.debug.is_some() {
-                builder = builder.debug(|value, f| {
-                    let debug_fn = unsafe { transmute::<DebugFn, DebugFnTyped<T>>(T::VTABLE.debug.unwrap()) };
-                    debug_fn(*value, f)
-                });
-            }
-
-            if T::VTABLE.display.is_some() {
-                builder = builder.display(|value, f| {
-                    let display_fn = unsafe { transmute::<DisplayFn, DisplayFnTyped<T>>(T::VTABLE.display.unwrap()) };
-                    display_fn(*value, f)
-                });
-            }
-
-            if T::VTABLE.eq.is_some() {
-                builder = builder.eq(|a, b| {
-                    let eq_fn = unsafe { transmute::<PartialEqFn, PartialEqFnTyped<T>>(T::VTABLE.eq.unwrap()) };
-                    eq_fn(*a, *b)
-                });
-            }
-
-            if T::VTABLE.partial_ord.is_some() {
-                builder = builder.partial_ord(|a, b| {
-                    let partial_ord_fn = unsafe { transmute::<PartialOrdFn, PartialOrdFnTyped<T>>(T::VTABLE.partial_ord.unwrap()) };
-                    partial_ord_fn(*a, *b)
-                });
-            }
-
-            if T::VTABLE.ord.is_some() {
-                builder = builder.ord(|a, b| {
-                    let ord_fn = unsafe { transmute::<CmpFn, CmpFnTyped<T>>(T::VTABLE.ord.unwrap()) };
-                    ord_fn(*a, *b)
-                });
-            }
-
-            if T::VTABLE.hash.is_some() {
-                builder = builder.hash(|value, hasher_this, hasher_write_fn| {
-                    let hash_fn = unsafe { transmute::<HashFn, HashFnTyped<T>>(T::VTABLE.hash.unwrap()) };
-                    hash_fn(*value, hasher_this, hasher_write_fn)
-                });
-            }
+            builder = builder.debug(|| {
+                if (T::VTABLE.debug)().is_some() {
+                    Some(|value, f| {
+                        let debug_fn = unsafe { transmute::<DebugFn, DebugFnTyped<T>>((T::VTABLE.debug)().unwrap()) };
+                        debug_fn(*value, f)
+                    })
+                } else {
+                    None
+                }
+            });
+            builder = builder.display(|| {
+                if (T::VTABLE.display)().is_some() {
+                    Some(|value, f| {
+                        let display_fn = unsafe { transmute::<DisplayFn, DisplayFnTyped<T>>((T::VTABLE.display)().unwrap()) };
+                        display_fn(*value, f)
+                    })
+                } else {
+                    None
+                }
+            });
+            builder = builder.eq(|| {
+                if (T::VTABLE.eq)().is_some() {
+                    Some(|a, b| {
+                        let eq_fn = unsafe { transmute::<PartialEqFn, PartialEqFnTyped<T>>((T::VTABLE.eq)().unwrap()) };
+                        eq_fn(*a, *b)
+                    })
+                } else {
+                    None
+                }
+            });
+            builder = builder.partial_ord(|| {
+                if (T::VTABLE.partial_ord)().is_some() {
+                    Some(|a, b| {
+                        let partial_ord_fn = unsafe { transmute::<PartialOrdFn, PartialOrdFnTyped<T>>((T::VTABLE.partial_ord)().unwrap()) };
+                        partial_ord_fn(*a, *b)
+                    })
+                } else {
+                    None
+                }
+            });
+            builder = builder.ord(|| {
+                if (T::VTABLE.ord)().is_some() {
+                    Some(|a, b| {
+                        let ord_fn = unsafe { transmute::<CmpFn, CmpFnTyped<T>>((T::VTABLE.ord)().unwrap()) };
+                        ord_fn(*a, *b)
+                    })
+                } else {
+                    None
+                }
+            });
+            builder = builder.hash(|| {
+                if (T::VTABLE.hash)().is_some() {
+                    Some(|value, hasher_this, hasher_write_fn| {
+                        let hash_fn = unsafe { transmute::<HashFn, HashFnTyped<T>>((T::VTABLE.hash)().unwrap()) };
+                        hash_fn(*value, hasher_this, hasher_write_fn)
+                    })
+                } else {
+                    None
+                }
+            });
 
             builder
         }
@@ -191,62 +212,83 @@ impl_facet_for_pointer!(
     Reference: &'a mut T
         => Shape::builder_for_sized::<Self>()
         => {
-            let mut marker_traits = MarkerTraits::UNPIN;
-            if T::SHAPE.vtable.marker_traits.contains(MarkerTraits::EQ) {
-                marker_traits = marker_traits.union(MarkerTraits::EQ);
-            }
-            if T::SHAPE.vtable.marker_traits.contains(MarkerTraits::SEND) {
-                marker_traits = marker_traits.union(MarkerTraits::SEND);
-            }
-            if T::SHAPE.vtable.marker_traits.contains(MarkerTraits::SYNC) {
-                marker_traits = marker_traits.union(MarkerTraits::SYNC);
-            }
-
             let mut builder = ValueVTable::builder::<Self>()
-                .marker_traits(marker_traits);
+                .marker_traits(|| {
+                    let mut marker_traits = MarkerTraits::UNPIN;
+                    if T::SHAPE.vtable.marker_traits().contains(MarkerTraits::EQ) {
+                        marker_traits = marker_traits.union(MarkerTraits::EQ);
+                    }
+                    if T::SHAPE.vtable.marker_traits().contains(MarkerTraits::SEND) {
+                        marker_traits = marker_traits.union(MarkerTraits::SEND);
+                    }
+                    if T::SHAPE.vtable.marker_traits().contains(MarkerTraits::SYNC) {
+                        marker_traits = marker_traits.union(MarkerTraits::SYNC);
+                    }
+
+                    marker_traits
+                });
 
             // Forward trait methods to the underlying type if it implements them
-            if T::VTABLE.debug.is_some() {
-                builder = builder.debug(|value, f| {
-                    let debug_fn = unsafe { transmute::<DebugFn, DebugFnTyped<T>>(T::VTABLE.debug.unwrap()) };
-                    debug_fn(*value, f)
-                });
-            }
-
-            if T::VTABLE.display.is_some() {
-                builder = builder.display(|value, f| {
-                    let display_fn = unsafe { transmute::<DisplayFn, DisplayFnTyped<T>>(T::VTABLE.display.unwrap()) };
-                    display_fn(*value, f)
-                });
-            }
-
-            if T::VTABLE.eq.is_some() {
-                builder = builder.eq(|a, b| {
-                    let eq_fn = unsafe { transmute::<PartialEqFn, PartialEqFnTyped<T>>(T::VTABLE.eq.unwrap()) };
-                    eq_fn(*a, *b)
-                });
-            }
-
-            if T::VTABLE.partial_ord.is_some() {
-                builder = builder.partial_ord(|a, b| {
-                    let partial_ord_fn = unsafe { transmute::<PartialOrdFn, PartialOrdFnTyped<T>>(T::VTABLE.partial_ord.unwrap()) };
-                    partial_ord_fn(*a, *b)
-                });
-            }
-
-            if T::VTABLE.ord.is_some() {
-                builder = builder.ord(|a, b| {
-                    let ord_fn = unsafe { transmute::<CmpFn, CmpFnTyped<T>>(T::VTABLE.ord.unwrap()) };
-                    ord_fn(*a, *b)
-                });
-            }
-
-            if T::VTABLE.hash.is_some() {
-                builder = builder.hash(|value, hasher_this, hasher_write_fn| {
-                    let hash_fn = unsafe { transmute::<HashFn, HashFnTyped<T>>(T::VTABLE.hash.unwrap()) };
-                    hash_fn(*value, hasher_this, hasher_write_fn)
-                });
-            }
+            builder = builder.debug(|| {
+                if (T::VTABLE.debug)().is_some() {
+                    Some(|value, f| {
+                        let debug_fn = unsafe { transmute::<DebugFn, DebugFnTyped<T>>((T::VTABLE.debug)().unwrap()) };
+                        debug_fn(*value, f)
+                    })
+                } else {
+                    None
+                }
+            });
+            builder = builder.display(|| {
+                if (T::VTABLE.display)().is_some() {
+                    Some(|value, f| {
+                        let display_fn = unsafe { transmute::<DisplayFn, DisplayFnTyped<T>>((T::VTABLE.display)().unwrap()) };
+                        display_fn(*value, f)
+                    })
+                } else {
+                    None
+                }
+            });
+            builder = builder.eq(|| {
+                if (T::VTABLE.eq)().is_some() {
+                    Some(|a, b| {
+                        let eq_fn = unsafe { transmute::<PartialEqFn, PartialEqFnTyped<T>>((T::VTABLE.eq)().unwrap()) };
+                        eq_fn(*a, *b)
+                    })
+                } else {
+                    None
+                }
+            });
+            builder = builder.partial_ord(|| {
+                if (T::VTABLE.partial_ord)().is_some() {
+                    Some(|a, b| {
+                        let partial_ord_fn = unsafe { transmute::<PartialOrdFn, PartialOrdFnTyped<T>>((T::VTABLE.partial_ord)().unwrap()) };
+                        partial_ord_fn(*a, *b)
+                    })
+                } else {
+                    None
+                }
+            });
+            builder = builder.ord(|| {
+                if (T::VTABLE.ord)().is_some() {
+                    Some(|a, b| {
+                        let ord_fn = unsafe { transmute::<CmpFn, CmpFnTyped<T>>((T::VTABLE.ord)().unwrap()) };
+                        ord_fn(*a, *b)
+                    })
+                } else {
+                    None
+                }
+            });
+            builder = builder.hash(|| {
+                if (T::VTABLE.hash)().is_some() {
+                    Some(|value, hasher_this, hasher_write_fn| {
+                        let hash_fn = unsafe { transmute::<HashFn, HashFnTyped<T>>((T::VTABLE.hash)().unwrap()) };
+                        hash_fn(*value, hasher_this, hasher_write_fn)
+                    })
+                } else {
+                    None
+                }
+            });
 
             builder
         }

--- a/facet-core/src/impls_core/pointer.rs
+++ b/facet-core/src/impls_core/pointer.rs
@@ -126,7 +126,7 @@ impl_facet_for_pointer!(
     Reference: &'a T
         => Shape::builder_for_sized::<Self>()
         => {
-            let mut builder = ValueVTable::builder::<Self>()
+            ValueVTable::builder::<Self>()
                 .marker_traits(|| {
                     let mut marker_traits = MarkerTraits::COPY.union(MarkerTraits::UNPIN);
                     if T::SHAPE.vtable.marker_traits().contains(MarkerTraits::EQ) {
@@ -138,71 +138,67 @@ impl_facet_for_pointer!(
 
                     marker_traits
                 })
-                .clone_into(|| Some(|src, dst| unsafe { dst.put(core::ptr::read(src)) }));
-
-            // Forward trait methods to the underlying type if it implements them
-            builder = builder.debug(|| {
-                if (T::VTABLE.debug)().is_some() {
-                    Some(|value, f| {
-                        let debug_fn = unsafe { transmute::<DebugFn, DebugFnTyped<T>>((T::VTABLE.debug)().unwrap()) };
-                        debug_fn(*value, f)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.display(|| {
-                if (T::VTABLE.display)().is_some() {
-                    Some(|value, f| {
-                        let display_fn = unsafe { transmute::<DisplayFn, DisplayFnTyped<T>>((T::VTABLE.display)().unwrap()) };
-                        display_fn(*value, f)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.eq(|| {
-                if (T::VTABLE.eq)().is_some() {
-                    Some(|a, b| {
-                        let eq_fn = unsafe { transmute::<PartialEqFn, PartialEqFnTyped<T>>((T::VTABLE.eq)().unwrap()) };
-                        eq_fn(*a, *b)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.partial_ord(|| {
-                if (T::VTABLE.partial_ord)().is_some() {
-                    Some(|a, b| {
-                        let partial_ord_fn = unsafe { transmute::<PartialOrdFn, PartialOrdFnTyped<T>>((T::VTABLE.partial_ord)().unwrap()) };
-                        partial_ord_fn(*a, *b)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.ord(|| {
-                if (T::VTABLE.ord)().is_some() {
-                    Some(|a, b| {
-                        let ord_fn = unsafe { transmute::<CmpFn, CmpFnTyped<T>>((T::VTABLE.ord)().unwrap()) };
-                        ord_fn(*a, *b)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.hash(|| {
-                if (T::VTABLE.hash)().is_some() {
-                    Some(|value, hasher_this, hasher_write_fn| {
-                        let hash_fn = unsafe { transmute::<HashFn, HashFnTyped<T>>((T::VTABLE.hash)().unwrap()) };
-                        hash_fn(*value, hasher_this, hasher_write_fn)
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder
+                .clone_into(|| Some(|src, dst| unsafe { dst.put(core::ptr::read(src)) }))
+                .debug(|| {
+                    if (T::VTABLE.debug)().is_some() {
+                        Some(|value, f| {
+                            let debug_fn = unsafe { transmute::<DebugFn, DebugFnTyped<T>>((T::VTABLE.debug)().unwrap()) };
+                            debug_fn(*value, f)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .display(|| {
+                    if (T::VTABLE.display)().is_some() {
+                        Some(|value, f| {
+                            let display_fn = unsafe { transmute::<DisplayFn, DisplayFnTyped<T>>((T::VTABLE.display)().unwrap()) };
+                            display_fn(*value, f)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .eq(|| {
+                    if (T::VTABLE.eq)().is_some() {
+                        Some(|a, b| {
+                            let eq_fn = unsafe { transmute::<PartialEqFn, PartialEqFnTyped<T>>((T::VTABLE.eq)().unwrap()) };
+                            eq_fn(*a, *b)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .partial_ord(|| {
+                    if (T::VTABLE.partial_ord)().is_some() {
+                        Some(|a, b| {
+                            let partial_ord_fn = unsafe { transmute::<PartialOrdFn, PartialOrdFnTyped<T>>((T::VTABLE.partial_ord)().unwrap()) };
+                            partial_ord_fn(*a, *b)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .ord(|| {
+                    if (T::VTABLE.ord)().is_some() {
+                        Some(|a, b| {
+                            let ord_fn = unsafe { transmute::<CmpFn, CmpFnTyped<T>>((T::VTABLE.ord)().unwrap()) };
+                            ord_fn(*a, *b)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .hash(|| {
+                    if (T::VTABLE.hash)().is_some() {
+                        Some(|value, hasher_this, hasher_write_fn| {
+                            let hash_fn = unsafe { transmute::<HashFn, HashFnTyped<T>>((T::VTABLE.hash)().unwrap()) };
+                            hash_fn(*value, hasher_this, hasher_write_fn)
+                        })
+                    } else {
+                        None
+                    }
+                })
         }
         => Reference, false
 );
@@ -212,7 +208,7 @@ impl_facet_for_pointer!(
     Reference: &'a mut T
         => Shape::builder_for_sized::<Self>()
         => {
-            let mut builder = ValueVTable::builder::<Self>()
+            ValueVTable::builder::<Self>()
                 .marker_traits(|| {
                     let mut marker_traits = MarkerTraits::UNPIN;
                     if T::SHAPE.vtable.marker_traits().contains(MarkerTraits::EQ) {
@@ -226,71 +222,67 @@ impl_facet_for_pointer!(
                     }
 
                     marker_traits
-                });
-
-            // Forward trait methods to the underlying type if it implements them
-            builder = builder.debug(|| {
-                if (T::VTABLE.debug)().is_some() {
-                    Some(|value, f| {
-                        let debug_fn = unsafe { transmute::<DebugFn, DebugFnTyped<T>>((T::VTABLE.debug)().unwrap()) };
-                        debug_fn(*value, f)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.display(|| {
-                if (T::VTABLE.display)().is_some() {
-                    Some(|value, f| {
-                        let display_fn = unsafe { transmute::<DisplayFn, DisplayFnTyped<T>>((T::VTABLE.display)().unwrap()) };
-                        display_fn(*value, f)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.eq(|| {
-                if (T::VTABLE.eq)().is_some() {
-                    Some(|a, b| {
-                        let eq_fn = unsafe { transmute::<PartialEqFn, PartialEqFnTyped<T>>((T::VTABLE.eq)().unwrap()) };
-                        eq_fn(*a, *b)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.partial_ord(|| {
-                if (T::VTABLE.partial_ord)().is_some() {
-                    Some(|a, b| {
-                        let partial_ord_fn = unsafe { transmute::<PartialOrdFn, PartialOrdFnTyped<T>>((T::VTABLE.partial_ord)().unwrap()) };
-                        partial_ord_fn(*a, *b)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.ord(|| {
-                if (T::VTABLE.ord)().is_some() {
-                    Some(|a, b| {
-                        let ord_fn = unsafe { transmute::<CmpFn, CmpFnTyped<T>>((T::VTABLE.ord)().unwrap()) };
-                        ord_fn(*a, *b)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.hash(|| {
-                if (T::VTABLE.hash)().is_some() {
-                    Some(|value, hasher_this, hasher_write_fn| {
-                        let hash_fn = unsafe { transmute::<HashFn, HashFnTyped<T>>((T::VTABLE.hash)().unwrap()) };
-                        hash_fn(*value, hasher_this, hasher_write_fn)
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder
+                })
+                .debug(|| {
+                    if (T::VTABLE.debug)().is_some() {
+                        Some(|value, f| {
+                            let debug_fn = unsafe { transmute::<DebugFn, DebugFnTyped<T>>((T::VTABLE.debug)().unwrap()) };
+                            debug_fn(*value, f)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .display(|| {
+                    if (T::VTABLE.display)().is_some() {
+                        Some(|value, f| {
+                            let display_fn = unsafe { transmute::<DisplayFn, DisplayFnTyped<T>>((T::VTABLE.display)().unwrap()) };
+                            display_fn(*value, f)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .eq(|| {
+                    if (T::VTABLE.eq)().is_some() {
+                        Some(|a, b| {
+                            let eq_fn = unsafe { transmute::<PartialEqFn, PartialEqFnTyped<T>>((T::VTABLE.eq)().unwrap()) };
+                            eq_fn(*a, *b)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .partial_ord(|| {
+                    if (T::VTABLE.partial_ord)().is_some() {
+                        Some(|a, b| {
+                            let partial_ord_fn = unsafe { transmute::<PartialOrdFn, PartialOrdFnTyped<T>>((T::VTABLE.partial_ord)().unwrap()) };
+                            partial_ord_fn(*a, *b)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .ord(|| {
+                    if (T::VTABLE.ord)().is_some() {
+                        Some(|a, b| {
+                            let ord_fn = unsafe { transmute::<CmpFn, CmpFnTyped<T>>((T::VTABLE.ord)().unwrap()) };
+                            ord_fn(*a, *b)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .hash(|| {
+                    if (T::VTABLE.hash)().is_some() {
+                        Some(|value, hasher_this, hasher_write_fn| {
+                            let hash_fn = unsafe { transmute::<HashFn, HashFnTyped<T>>((T::VTABLE.hash)().unwrap()) };
+                            hash_fn(*value, hasher_this, hasher_write_fn)
+                        })
+                    } else {
+                        None
+                    }
+                })
         }
         => Reference, true
 );

--- a/facet-core/src/impls_core/scalar.rs
+++ b/facet-core/src/impls_core/scalar.rs
@@ -132,133 +132,151 @@ macro_rules! impl_facet_for_integer {
                 let mut vtable =
                     value_vtable!($type, |f, _opts| write!(f, "{}", stringify!($type)));
 
-                vtable.try_from = Some(|source, source_shape, dest| {
-                    if source_shape == Self::SHAPE {
-                        return Ok(unsafe { dest.copy_from(source, source_shape)? });
-                    }
-                    if source_shape == u64::SHAPE {
-                        let value: u64 = *unsafe { source.get::<u64>() };
-                        match <$type>::try_from(value) {
-                            Ok(converted) => {
-                                return Ok(unsafe { dest.put::<$type>(converted) });
-                            }
-                            Err(_) => {
-                                return Err(TryFromError::Generic("conversion from u64 failed"));
+                vtable.try_from = || {
+                    Some(|source, source_shape, dest| {
+                        if source_shape == Self::SHAPE {
+                            return Ok(unsafe { dest.copy_from(source, source_shape)? });
+                        }
+                        if source_shape == u64::SHAPE {
+                            let value: u64 = *unsafe { source.get::<u64>() };
+                            match <$type>::try_from(value) {
+                                Ok(converted) => {
+                                    return Ok(unsafe { dest.put::<$type>(converted) });
+                                }
+                                Err(_) => {
+                                    return Err(TryFromError::Generic(
+                                        "conversion from u64 failed",
+                                    ));
+                                }
                             }
                         }
-                    }
-                    if source_shape == u32::SHAPE {
-                        let value: u32 = *unsafe { source.get::<u32>() };
-                        let value: u64 = value as u64;
-                        match <$type>::try_from(value) {
-                            Ok(converted) => {
-                                return Ok(unsafe { dest.put::<$type>(converted) });
-                            }
-                            Err(_) => {
-                                return Err(TryFromError::Generic("conversion from u32 failed"));
-                            }
-                        }
-                    }
-                    if source_shape == u16::SHAPE {
-                        let value: u16 = *unsafe { source.get::<u16>() };
-                        let value: u64 = value as u64;
-                        match <$type>::try_from(value) {
-                            Ok(converted) => {
-                                return Ok(unsafe { dest.put::<$type>(converted) });
-                            }
-                            Err(_) => {
-                                return Err(TryFromError::Generic("conversion from u16 failed"));
+                        if source_shape == u32::SHAPE {
+                            let value: u32 = *unsafe { source.get::<u32>() };
+                            let value: u64 = value as u64;
+                            match <$type>::try_from(value) {
+                                Ok(converted) => {
+                                    return Ok(unsafe { dest.put::<$type>(converted) });
+                                }
+                                Err(_) => {
+                                    return Err(TryFromError::Generic(
+                                        "conversion from u32 failed",
+                                    ));
+                                }
                             }
                         }
-                    }
-                    if source_shape == u8::SHAPE {
-                        let value: u8 = *unsafe { source.get::<u8>() };
-                        let value: u64 = value as u64;
-                        match <$type>::try_from(value) {
-                            Ok(converted) => {
-                                return Ok(unsafe { dest.put::<$type>(converted) });
-                            }
-                            Err(_) => {
-                                return Err(TryFromError::Generic("conversion from u8 failed"));
-                            }
-                        }
-                    }
-                    if source_shape == i64::SHAPE {
-                        let value: i64 = *unsafe { source.get::<i64>() };
-                        match <$type>::try_from(value) {
-                            Ok(converted) => {
-                                return Ok(unsafe { dest.put::<$type>(converted) });
-                            }
-                            Err(_) => {
-                                return Err(TryFromError::Generic("conversion from i64 failed"));
+                        if source_shape == u16::SHAPE {
+                            let value: u16 = *unsafe { source.get::<u16>() };
+                            let value: u64 = value as u64;
+                            match <$type>::try_from(value) {
+                                Ok(converted) => {
+                                    return Ok(unsafe { dest.put::<$type>(converted) });
+                                }
+                                Err(_) => {
+                                    return Err(TryFromError::Generic(
+                                        "conversion from u16 failed",
+                                    ));
+                                }
                             }
                         }
-                    }
-                    if source_shape == i32::SHAPE {
-                        let value: i32 = *unsafe { source.get::<i32>() };
-                        let value: i64 = value as i64;
-                        match <$type>::try_from(value) {
-                            Ok(converted) => {
-                                return Ok(unsafe { dest.put::<$type>(converted) });
-                            }
-                            Err(_) => {
-                                return Err(TryFromError::Generic("conversion from i32 failed"));
-                            }
-                        }
-                    }
-                    if source_shape == i16::SHAPE {
-                        let value: i16 = *unsafe { source.get::<i16>() };
-                        let value: i64 = value as i64;
-                        match <$type>::try_from(value) {
-                            Ok(converted) => {
-                                return Ok(unsafe { dest.put::<$type>(converted) });
-                            }
-                            Err(_) => {
-                                return Err(TryFromError::Generic("conversion from i16 failed"));
+                        if source_shape == u8::SHAPE {
+                            let value: u8 = *unsafe { source.get::<u8>() };
+                            let value: u64 = value as u64;
+                            match <$type>::try_from(value) {
+                                Ok(converted) => {
+                                    return Ok(unsafe { dest.put::<$type>(converted) });
+                                }
+                                Err(_) => {
+                                    return Err(TryFromError::Generic("conversion from u8 failed"));
+                                }
                             }
                         }
-                    }
-                    if source_shape == i8::SHAPE {
-                        let value: i8 = *unsafe { source.get::<i8>() };
-                        let value: i64 = value as i64;
-                        match <$type>::try_from(value) {
-                            Ok(converted) => {
-                                return Ok(unsafe { dest.put::<$type>(converted) });
-                            }
-                            Err(_) => {
-                                return Err(TryFromError::Generic("conversion from i8 failed"));
-                            }
-                        }
-                    }
-                    if source_shape == f64::SHAPE {
-                        let value: f64 = *unsafe { source.get::<f64>() };
-                        let value = value as i64;
-                        match <$type>::try_from(value) {
-                            Ok(converted) => {
-                                return Ok(unsafe { dest.put::<$type>(converted) });
-                            }
-                            Err(_) => {
-                                return Err(TryFromError::Generic("conversion from f64 failed"));
+                        if source_shape == i64::SHAPE {
+                            let value: i64 = *unsafe { source.get::<i64>() };
+                            match <$type>::try_from(value) {
+                                Ok(converted) => {
+                                    return Ok(unsafe { dest.put::<$type>(converted) });
+                                }
+                                Err(_) => {
+                                    return Err(TryFromError::Generic(
+                                        "conversion from i64 failed",
+                                    ));
+                                }
                             }
                         }
-                    }
-                    if source_shape == f32::SHAPE {
-                        let value: f32 = *unsafe { source.get::<f32>() };
-                        let value = value as i64;
-                        match <$type>::try_from(value) {
-                            Ok(converted) => {
-                                return Ok(unsafe { dest.put::<$type>(converted) });
-                            }
-                            Err(_) => {
-                                return Err(TryFromError::Generic("conversion from f32 failed"));
+                        if source_shape == i32::SHAPE {
+                            let value: i32 = *unsafe { source.get::<i32>() };
+                            let value: i64 = value as i64;
+                            match <$type>::try_from(value) {
+                                Ok(converted) => {
+                                    return Ok(unsafe { dest.put::<$type>(converted) });
+                                }
+                                Err(_) => {
+                                    return Err(TryFromError::Generic(
+                                        "conversion from i32 failed",
+                                    ));
+                                }
                             }
                         }
-                    }
-                    Err(TryFromError::UnsupportedSourceShape {
-                        src_shape: source_shape,
-                        expected: &[Self::SHAPE, u64::SHAPE, i64::SHAPE, f64::SHAPE],
+                        if source_shape == i16::SHAPE {
+                            let value: i16 = *unsafe { source.get::<i16>() };
+                            let value: i64 = value as i64;
+                            match <$type>::try_from(value) {
+                                Ok(converted) => {
+                                    return Ok(unsafe { dest.put::<$type>(converted) });
+                                }
+                                Err(_) => {
+                                    return Err(TryFromError::Generic(
+                                        "conversion from i16 failed",
+                                    ));
+                                }
+                            }
+                        }
+                        if source_shape == i8::SHAPE {
+                            let value: i8 = *unsafe { source.get::<i8>() };
+                            let value: i64 = value as i64;
+                            match <$type>::try_from(value) {
+                                Ok(converted) => {
+                                    return Ok(unsafe { dest.put::<$type>(converted) });
+                                }
+                                Err(_) => {
+                                    return Err(TryFromError::Generic("conversion from i8 failed"));
+                                }
+                            }
+                        }
+                        if source_shape == f64::SHAPE {
+                            let value: f64 = *unsafe { source.get::<f64>() };
+                            let value = value as i64;
+                            match <$type>::try_from(value) {
+                                Ok(converted) => {
+                                    return Ok(unsafe { dest.put::<$type>(converted) });
+                                }
+                                Err(_) => {
+                                    return Err(TryFromError::Generic(
+                                        "conversion from f64 failed",
+                                    ));
+                                }
+                            }
+                        }
+                        if source_shape == f32::SHAPE {
+                            let value: f32 = *unsafe { source.get::<f32>() };
+                            let value = value as i64;
+                            match <$type>::try_from(value) {
+                                Ok(converted) => {
+                                    return Ok(unsafe { dest.put::<$type>(converted) });
+                                }
+                                Err(_) => {
+                                    return Err(TryFromError::Generic(
+                                        "conversion from f32 failed",
+                                    ));
+                                }
+                            }
+                        }
+                        Err(TryFromError::UnsupportedSourceShape {
+                            src_shape: source_shape,
+                            expected: &[Self::SHAPE, u64::SHAPE, i64::SHAPE, f64::SHAPE],
+                        })
                     })
-                });
+                };
 
                 vtable
             };
@@ -294,7 +312,7 @@ macro_rules! impl_facet_for_integer {
                         // Put the NonZero value into the destination
                         Ok(unsafe { dst.put(nz) })
                     } else {
-                        let inner_try_from = <$type as Facet>::SHAPE.vtable.try_from.ok_or(
+                        let inner_try_from = (<$type as Facet>::SHAPE.vtable.try_from)().ok_or(
                             TryFromError::UnsupportedSourceShape {
                                 src_shape,
                                 expected: &[<$type as Facet>::SHAPE],
@@ -343,9 +361,9 @@ macro_rules! impl_facet_for_integer {
                 ));
 
                 // Add our new transparency functions
-                vtable.try_from = Some(try_from);
-                vtable.try_into_inner = Some(try_into_inner);
-                vtable.try_borrow_inner = Some(try_borrow_inner);
+                vtable.try_from = || Some(try_from);
+                vtable.try_into_inner = || Some(try_into_inner);
+                vtable.try_borrow_inner = || Some(try_borrow_inner);
 
                 vtable
             };
@@ -680,30 +698,32 @@ unsafe impl Facet<'_> for f32 {
     const VTABLE: &'static ValueVTable = &const {
         let mut vtable = value_vtable!(f32, |f, _opts| write!(f, "f32"));
 
-        vtable.try_from = Some(|source, source_shape, dest| {
-            if source_shape == Self::SHAPE {
-                return Ok(unsafe { dest.copy_from(source, source_shape)? });
-            }
-            if source_shape == u64::SHAPE {
-                let value: u64 = *unsafe { source.get::<u64>() };
-                let converted: f32 = value as f32;
-                return Ok(unsafe { dest.put::<f32>(converted) });
-            }
-            if source_shape == i64::SHAPE {
-                let value: i64 = *unsafe { source.get::<i64>() };
-                let converted: f32 = value as f32;
-                return Ok(unsafe { dest.put::<f32>(converted) });
-            }
-            if source_shape == f64::SHAPE {
-                let value: f64 = *unsafe { source.get::<f64>() };
-                let converted: f32 = value as f32;
-                return Ok(unsafe { dest.put::<f32>(converted) });
-            }
-            Err(TryFromError::UnsupportedSourceShape {
-                src_shape: source_shape,
-                expected: &[Self::SHAPE, u64::SHAPE, i64::SHAPE, f64::SHAPE],
+        vtable.try_from = || {
+            Some(|source, source_shape, dest| {
+                if source_shape == Self::SHAPE {
+                    return Ok(unsafe { dest.copy_from(source, source_shape)? });
+                }
+                if source_shape == u64::SHAPE {
+                    let value: u64 = *unsafe { source.get::<u64>() };
+                    let converted: f32 = value as f32;
+                    return Ok(unsafe { dest.put::<f32>(converted) });
+                }
+                if source_shape == i64::SHAPE {
+                    let value: i64 = *unsafe { source.get::<i64>() };
+                    let converted: f32 = value as f32;
+                    return Ok(unsafe { dest.put::<f32>(converted) });
+                }
+                if source_shape == f64::SHAPE {
+                    let value: f64 = *unsafe { source.get::<f64>() };
+                    let converted: f32 = value as f32;
+                    return Ok(unsafe { dest.put::<f32>(converted) });
+                }
+                Err(TryFromError::UnsupportedSourceShape {
+                    src_shape: source_shape,
+                    expected: &[Self::SHAPE, u64::SHAPE, i64::SHAPE, f64::SHAPE],
+                })
             })
-        });
+        };
 
         vtable
     };
@@ -738,30 +758,32 @@ unsafe impl Facet<'_> for f64 {
     const VTABLE: &'static ValueVTable = &const {
         let mut vtable = value_vtable!(f64, |f, _opts| write!(f, "f64"));
 
-        vtable.try_from = Some(|source, source_shape, dest| {
-            if source_shape == Self::SHAPE {
-                return Ok(unsafe { dest.copy_from(source, source_shape)? });
-            }
-            if source_shape == u64::SHAPE {
-                let value: u64 = *unsafe { source.get::<u64>() };
-                let converted: f64 = value as f64;
-                return Ok(unsafe { dest.put::<f64>(converted) });
-            }
-            if source_shape == i64::SHAPE {
-                let value: i64 = *unsafe { source.get::<i64>() };
-                let converted: f64 = value as f64;
-                return Ok(unsafe { dest.put::<f64>(converted) });
-            }
-            if source_shape == f32::SHAPE {
-                let value: f32 = *unsafe { source.get::<f32>() };
-                let converted: f64 = value as f64;
-                return Ok(unsafe { dest.put::<f64>(converted) });
-            }
-            Err(TryFromError::UnsupportedSourceShape {
-                src_shape: source_shape,
-                expected: &[Self::SHAPE, u64::SHAPE, i64::SHAPE, f32::SHAPE],
+        vtable.try_from = || {
+            Some(|source, source_shape, dest| {
+                if source_shape == Self::SHAPE {
+                    return Ok(unsafe { dest.copy_from(source, source_shape)? });
+                }
+                if source_shape == u64::SHAPE {
+                    let value: u64 = *unsafe { source.get::<u64>() };
+                    let converted: f64 = value as f64;
+                    return Ok(unsafe { dest.put::<f64>(converted) });
+                }
+                if source_shape == i64::SHAPE {
+                    let value: i64 = *unsafe { source.get::<i64>() };
+                    let converted: f64 = value as f64;
+                    return Ok(unsafe { dest.put::<f64>(converted) });
+                }
+                if source_shape == f32::SHAPE {
+                    let value: f32 = *unsafe { source.get::<f32>() };
+                    let converted: f64 = value as f64;
+                    return Ok(unsafe { dest.put::<f64>(converted) });
+                }
+                Err(TryFromError::UnsupportedSourceShape {
+                    src_shape: source_shape,
+                    expected: &[Self::SHAPE, u64::SHAPE, i64::SHAPE, f32::SHAPE],
+                })
             })
-        });
+        };
 
         vtable
     };

--- a/facet-core/src/impls_core/slice.rs
+++ b/facet-core/src/impls_core/slice.rs
@@ -5,7 +5,7 @@ where
     T: Facet<'a>,
 {
     const VTABLE: &'static ValueVTable = &const {
-        let mut builder = ValueVTable::builder_unsized::<Self>()
+        ValueVTable::builder_unsized::<Self>()
             .type_name(|f, opts| {
                 if let Some(opts) = opts.for_children() {
                     write!(f, "[")?;
@@ -20,86 +20,84 @@ where
                     .vtable
                     .marker_traits()
                     .difference(MarkerTraits::COPY)
-            });
-
-        builder = builder.debug(|| {
-            if (T::SHAPE.vtable.debug)().is_some() {
-                Some(|value, f| {
-                    write!(f, "[")?;
-                    for (i, item) in value.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+            })
+            .debug(|| {
+                if (T::SHAPE.vtable.debug)().is_some() {
+                    Some(|value, f| {
+                        write!(f, "[")?;
+                        for (i, item) in value.iter().enumerate() {
+                            if i > 0 {
+                                write!(f, ", ")?;
+                            }
+                            (<VTableView<T>>::of().debug().unwrap())(item, f)?;
                         }
-                        (<VTableView<T>>::of().debug().unwrap())(item, f)?;
-                    }
-                    write!(f, "]")
-                })
-            } else {
-                None
-            }
-        });
-        builder = builder.eq(|| {
-            if (T::SHAPE.vtable.eq)().is_some() {
-                Some(|a, b| {
-                    if a.len() != b.len() {
-                        return false;
-                    }
-                    for (x, y) in a.iter().zip(b.iter()) {
-                        if !(<VTableView<T>>::of().eq().unwrap())(x, y) {
+                        write!(f, "]")
+                    })
+                } else {
+                    None
+                }
+            })
+            .eq(|| {
+                if (T::SHAPE.vtable.eq)().is_some() {
+                    Some(|a, b| {
+                        if a.len() != b.len() {
                             return false;
                         }
-                    }
-                    true
-                })
-            } else {
-                None
-            }
-        });
-        builder = builder.partial_ord(|| {
-            if (T::SHAPE.vtable.partial_ord)().is_some() {
-                Some(|a, b| {
-                    for (x, y) in a.iter().zip(b.iter()) {
-                        let ord = (<VTableView<T>>::of().partial_ord().unwrap())(x, y);
-                        match ord {
-                            Some(core::cmp::Ordering::Equal) => continue,
-                            Some(order) => return Some(order),
-                            None => return None,
+                        for (x, y) in a.iter().zip(b.iter()) {
+                            if !(<VTableView<T>>::of().eq().unwrap())(x, y) {
+                                return false;
+                            }
                         }
-                    }
-                    a.len().partial_cmp(&b.len())
-                })
-            } else {
-                None
-            }
-        });
-        builder = builder.ord(|| {
-            if (T::SHAPE.vtable.ord)().is_some() {
-                Some(|a, b| {
-                    for (x, y) in a.iter().zip(b.iter()) {
-                        let ord = (<VTableView<T>>::of().ord().unwrap())(x, y);
-                        if ord != core::cmp::Ordering::Equal {
-                            return ord;
+                        true
+                    })
+                } else {
+                    None
+                }
+            })
+            .partial_ord(|| {
+                if (T::SHAPE.vtable.partial_ord)().is_some() {
+                    Some(|a, b| {
+                        for (x, y) in a.iter().zip(b.iter()) {
+                            let ord = (<VTableView<T>>::of().partial_ord().unwrap())(x, y);
+                            match ord {
+                                Some(core::cmp::Ordering::Equal) => continue,
+                                Some(order) => return Some(order),
+                                None => return None,
+                            }
                         }
-                    }
-                    a.len().cmp(&b.len())
-                })
-            } else {
-                None
-            }
-        });
-        builder = builder.hash(|| {
-            if (T::SHAPE.vtable.hash)().is_some() {
-                Some(|value, state, hasher| {
-                    for item in value.iter() {
-                        (<VTableView<T>>::of().hash().unwrap())(item, state, hasher);
-                    }
-                })
-            } else {
-                None
-            }
-        });
-
-        builder.build()
+                        a.len().partial_cmp(&b.len())
+                    })
+                } else {
+                    None
+                }
+            })
+            .ord(|| {
+                if (T::SHAPE.vtable.ord)().is_some() {
+                    Some(|a, b| {
+                        for (x, y) in a.iter().zip(b.iter()) {
+                            let ord = (<VTableView<T>>::of().ord().unwrap())(x, y);
+                            if ord != core::cmp::Ordering::Equal {
+                                return ord;
+                            }
+                        }
+                        a.len().cmp(&b.len())
+                    })
+                } else {
+                    None
+                }
+            })
+            .hash(|| {
+                if (T::SHAPE.vtable.hash)().is_some() {
+                    Some(|value, state, hasher| {
+                        for item in value.iter() {
+                            (<VTableView<T>>::of().hash().unwrap())(item, state, hasher);
+                        }
+                    })
+                } else {
+                    None
+                }
+            })
+            .build()
     };
 
     const SHAPE: &'static Shape<'static> = &const {

--- a/facet-core/src/impls_core/tuple.rs
+++ b/facet-core/src/impls_core/tuple.rs
@@ -87,7 +87,7 @@ macro_rules! impl_facet_for_tuple {
             $($elems: Facet<'a>,)+
         {
             const VTABLE: &'static ValueVTable = &const {
-                let mut builder = ValueVTable::builder::<Self>()
+                ValueVTable::builder::<Self>()
                     .type_name(|f, opts| {
                         write_type_name_list(f, opts, "(", ", ", ")", &[$($elems::SHAPE),+])
                     })
@@ -95,126 +95,117 @@ macro_rules! impl_facet_for_tuple {
                     .marker_traits(||
                         MarkerTraits::all()
                             $(.intersection($elems::SHAPE.vtable.marker_traits()))+
-                    );
-
-                builder = builder.debug(|| {
-                    let elem_shapes = const { &[$($elems::SHAPE),+] };
-                    if Characteristic::Debug.all(elem_shapes) {
-                        Some(|value, f| {
-                            impl_facet_for_tuple! {
-                                debug on f {
-                                    $(
-                                        (<VTableView<$elems>>::of().debug().unwrap())(
-                                            &value.$idx,
-                                            f,
-                                        )?;
-                                    )+
+                    )
+                    .debug(|| {
+                        let elem_shapes = const { &[$($elems::SHAPE),+] };
+                        if Characteristic::Debug.all(elem_shapes) {
+                            Some(|value, f| {
+                                impl_facet_for_tuple! {
+                                    debug on f {
+                                        $(
+                                            (<VTableView<$elems>>::of().debug().unwrap())(
+                                                &value.$idx,
+                                                f,
+                                            )?;
+                                        )+
+                                    }
                                 }
-                            }
-                        })
-                    } else {
-                        None
-                    }
-                });
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .default_in_place(|| {
+                        let elem_shapes = const { &[$($elems::SHAPE),+] };
+                        if Characteristic::all_default(elem_shapes) {
+                            Some(|mut dst| {
+                                $(
+                                    unsafe {
+                                        (<VTableView<$elems>>::of().default_in_place().unwrap())(
+                                            dst.field_uninit_at(mem::offset_of!(Self, $idx))
+                                        );
+                                    }
+                                )+
 
-                builder = builder.default_in_place(|| {
-                    let elem_shapes = const { &[$($elems::SHAPE),+] };
-                    if Characteristic::all_default(elem_shapes) {
-                        Some(|mut dst| {
-                            $(
-                                unsafe {
-                                    (<VTableView<$elems>>::of().default_in_place().unwrap())(
-                                        dst.field_uninit_at(mem::offset_of!(Self, $idx))
+                                unsafe { dst.assume_init() }
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    // .clone_into(|| {
+                    //     let elem_shapes = const { &[$($elems::SHAPE),+] };
+                    //     if Characteristic::Clone.all(elem_shapes) {
+                    //         Some(|src, dst| {
+                    //             $({
+                    //                 let offset = mem::offset_of!(Self, $idx);
+                    //                 unsafe {
+                    //                     (<VTableView<$elems>>::of().clone_into().unwrap())(
+                    //                         src.field(offset),
+                    //                         dst.field_uninit_at(offset),
+                    //                     );
+                    //                 }
+                    //             })+
+
+                    //             unsafe { dst.assume_init() }
+                    //         })
+                    //     } else {
+                    //         None
+                    //     }
+                    // })
+                    .eq(|| {
+                        let elem_shapes = const { &[$($elems::SHAPE),+] };
+                        if Characteristic::all_partial_eq(elem_shapes) {
+                            Some(|a, b| impl_facet_for_tuple! {
+                                ord on ($($elems.$idx,)+),
+                                eq(a, b),
+                                eq = true
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .partial_ord(|| {
+                        let elem_shapes = const { &[$($elems::SHAPE),+] };
+                        if Characteristic::all_partial_ord(elem_shapes) {
+                            Some(|a, b| impl_facet_for_tuple! {
+                                ord on ($($elems.$idx,)+),
+                                partial_ord(a, b),
+                                eq = Some(Ordering::Equal)
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .ord(|| {
+                        let elem_shapes = const { &[$($elems::SHAPE),+] };
+                        if Characteristic::all_ord(elem_shapes) {
+                            Some(|a, b| impl_facet_for_tuple! {
+                                ord on ($($elems.$idx,)+),
+                                ord(a, b),
+                                eq = Ordering::Equal
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .hash(|| {
+                        let elem_shapes = const { &[$($elems::SHAPE),+] };
+                        if Characteristic::all_hash(elem_shapes) {
+                            Some(|value, hasher_this, hasher_write_fn| {
+                                $(
+                                    (<VTableView<$elems>>::of().hash().unwrap())(
+                                        &value.$idx,
+                                        hasher_this,
+                                        hasher_write_fn,
                                     );
-                                }
-                            )+
-
-                            unsafe { dst.assume_init() }
-                        })
-                    } else {
-                        None
-                    }
-                });
-
-                // builder = builder.clone_into(|| {
-                //     let elem_shapes = const { &[$($elems::SHAPE),+] };
-                //     if Characteristic::Clone.all(elem_shapes) {
-                //         Some(|src, dst| {
-                //             $({
-                //                 let offset = mem::offset_of!(Self, $idx);
-                //                 unsafe {
-                //                     (<VTableView<$elems>>::of().clone_into().unwrap())(
-                //                         src.field(offset),
-                //                         dst.field_uninit_at(offset),
-                //                     );
-                //                 }
-                //             })+
-
-                //             unsafe { dst.assume_init() }
-                //         })
-                //     } else {
-                //         None
-                //     }
-                // });
-
-
-                builder = builder.eq(|| {
-                    let elem_shapes = const { &[$($elems::SHAPE),+] };
-                    if Characteristic::all_partial_eq(elem_shapes) {
-                        Some(|a, b| impl_facet_for_tuple! {
-                            ord on ($($elems.$idx,)+),
-                            eq(a, b),
-                            eq = true
-                        })
-                    } else {
-                        None
-                    }
-                });
-
-                builder = builder.partial_ord(|| {
-                    let elem_shapes = const { &[$($elems::SHAPE),+] };
-                    if Characteristic::all_partial_ord(elem_shapes) {
-                        Some(|a, b| impl_facet_for_tuple! {
-                            ord on ($($elems.$idx,)+),
-                            partial_ord(a, b),
-                            eq = Some(Ordering::Equal)
-                        })
-                    } else {
-                        None
-                    }
-                });
-
-                builder = builder.ord(|| {
-                    let elem_shapes = const { &[$($elems::SHAPE),+] };
-                    if Characteristic::all_ord(elem_shapes) {
-                        Some(|a, b| impl_facet_for_tuple! {
-                            ord on ($($elems.$idx,)+),
-                            ord(a, b),
-                            eq = Ordering::Equal
-                        })
-                    } else {
-                        None
-                    }
-                });
-
-                builder = builder.hash(|| {
-                    let elem_shapes = const { &[$($elems::SHAPE),+] };
-                    if Characteristic::all_hash(elem_shapes) {
-                        Some(|value, hasher_this, hasher_write_fn| {
-                            $(
-                                (<VTableView<$elems>>::of().hash().unwrap())(
-                                    &value.$idx,
-                                    hasher_this,
-                                    hasher_write_fn,
-                                );
-                            )+
-                        })
-                    } else {
-                        None
-                    }
-                });
-
-                builder.build()
+                                )+
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .build()
             };
 
             const SHAPE: &'static Shape<'static> = &const {

--- a/facet-core/src/impls_jiff.rs
+++ b/facet-core/src/impls_jiff.rs
@@ -11,30 +11,34 @@ const ZONED_ERROR: &str = "could not parse time-zone aware instant of time";
 unsafe impl Facet<'_> for Zoned {
     const VTABLE: &'static ValueVTable = &const {
         let mut vtable = value_vtable!(Zoned, |f, _opts| write!(f, "Zoned"));
-        vtable.try_from = Some(
-            |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
-                if source_shape.is_type::<String>() {
-                    let source = unsafe { source.read::<String>() };
-                    let parsed = source
-                        .parse::<Zoned>()
-                        .map_err(|_| ParseError::Generic(ZONED_ERROR));
-                    match parsed {
-                        Ok(val) => Ok(unsafe { target.put(val) }),
-                        Err(_e) => Err(crate::TryFromError::Generic(ZONED_ERROR)),
+        vtable.try_from = || {
+            Some(
+                |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
+                    if source_shape.is_type::<String>() {
+                        let source = unsafe { source.read::<String>() };
+                        let parsed = source
+                            .parse::<Zoned>()
+                            .map_err(|_| ParseError::Generic(ZONED_ERROR));
+                        match parsed {
+                            Ok(val) => Ok(unsafe { target.put(val) }),
+                            Err(_e) => Err(crate::TryFromError::Generic(ZONED_ERROR)),
+                        }
+                    } else {
+                        Err(crate::TryFromError::UnsupportedSourceShape {
+                            src_shape: source_shape,
+                            expected: &[String::SHAPE],
+                        })
                     }
-                } else {
-                    Err(crate::TryFromError::UnsupportedSourceShape {
-                        src_shape: source_shape,
-                        expected: &[String::SHAPE],
-                    })
-                }
-            },
-        );
-        vtable.parse = Some(|s: &str, target: PtrUninit| {
-            let parsed: Zoned = s.parse().map_err(|_| ParseError::Generic(ZONED_ERROR))?;
-            Ok(unsafe { target.put(parsed) })
-        });
-        vtable.display = Some(|value, f| unsafe { write!(f, "{}", value.get::<Zoned>()) });
+                },
+            )
+        };
+        vtable.parse = || {
+            Some(|s: &str, target: PtrUninit| {
+                let parsed: Zoned = s.parse().map_err(|_| ParseError::Generic(ZONED_ERROR))?;
+                Ok(unsafe { target.put(parsed) })
+            })
+        };
+        vtable.display = || Some(|value, f| unsafe { write!(f, "{}", value.get::<Zoned>()) });
         vtable
     };
 
@@ -55,32 +59,36 @@ const TIMESTAMP_ERROR: &str = "could not parse timestamp";
 unsafe impl Facet<'_> for Timestamp {
     const VTABLE: &'static ValueVTable = &const {
         let mut vtable = value_vtable!(Timestamp, |f, _opts| write!(f, "Timestamp"));
-        vtable.try_from = Some(
-            |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
-                if source_shape.is_type::<String>() {
-                    let source = unsafe { source.read::<String>() };
-                    let parsed = source
-                        .parse::<Timestamp>()
-                        .map_err(|_| ParseError::Generic(TIMESTAMP_ERROR));
-                    match parsed {
-                        Ok(val) => Ok(unsafe { target.put(val) }),
-                        Err(_e) => Err(crate::TryFromError::Generic(TIMESTAMP_ERROR)),
+        vtable.try_from = || {
+            Some(
+                |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
+                    if source_shape.is_type::<String>() {
+                        let source = unsafe { source.read::<String>() };
+                        let parsed = source
+                            .parse::<Timestamp>()
+                            .map_err(|_| ParseError::Generic(TIMESTAMP_ERROR));
+                        match parsed {
+                            Ok(val) => Ok(unsafe { target.put(val) }),
+                            Err(_e) => Err(crate::TryFromError::Generic(TIMESTAMP_ERROR)),
+                        }
+                    } else {
+                        Err(crate::TryFromError::UnsupportedSourceShape {
+                            src_shape: source_shape,
+                            expected: &[String::SHAPE],
+                        })
                     }
-                } else {
-                    Err(crate::TryFromError::UnsupportedSourceShape {
-                        src_shape: source_shape,
-                        expected: &[String::SHAPE],
-                    })
-                }
-            },
-        );
-        vtable.parse = Some(|s: &str, target: PtrUninit| {
-            let parsed: Timestamp = s
-                .parse()
-                .map_err(|_| ParseError::Generic(TIMESTAMP_ERROR))?;
-            Ok(unsafe { target.put(parsed) })
-        });
-        vtable.display = Some(|value, f| unsafe { write!(f, "{}", value.get::<Timestamp>()) });
+                },
+            )
+        };
+        vtable.parse = || {
+            Some(|s: &str, target: PtrUninit| {
+                let parsed: Timestamp = s
+                    .parse()
+                    .map_err(|_| ParseError::Generic(TIMESTAMP_ERROR))?;
+                Ok(unsafe { target.put(parsed) })
+            })
+        };
+        vtable.display = || Some(|value, f| unsafe { write!(f, "{}", value.get::<Timestamp>()) });
         vtable
     };
 
@@ -101,30 +109,35 @@ const DATETIME_ERROR: &str = "could not parse civil datetime";
 unsafe impl Facet<'_> for DateTime {
     const VTABLE: &'static ValueVTable = &const {
         let mut vtable = value_vtable!(DateTime, |f, _opts| write!(f, "DateTime"));
-        vtable.try_from = Some(
-            |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
-                if source_shape.is_type::<String>() {
-                    let source = unsafe { source.read::<String>() };
-                    let parsed = source
-                        .parse::<DateTime>()
-                        .map_err(|_| ParseError::Generic(DATETIME_ERROR));
-                    match parsed {
-                        Ok(val) => Ok(unsafe { target.put(val) }),
-                        Err(_e) => Err(crate::TryFromError::Generic(DATETIME_ERROR)),
+        vtable.try_from = || {
+            Some(
+                |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
+                    if source_shape.is_type::<String>() {
+                        let source = unsafe { source.read::<String>() };
+                        let parsed = source
+                            .parse::<DateTime>()
+                            .map_err(|_| ParseError::Generic(DATETIME_ERROR));
+                        match parsed {
+                            Ok(val) => Ok(unsafe { target.put(val) }),
+                            Err(_e) => Err(crate::TryFromError::Generic(DATETIME_ERROR)),
+                        }
+                    } else {
+                        Err(crate::TryFromError::UnsupportedSourceShape {
+                            src_shape: source_shape,
+                            expected: &[String::SHAPE],
+                        })
                     }
-                } else {
-                    Err(crate::TryFromError::UnsupportedSourceShape {
-                        src_shape: source_shape,
-                        expected: &[String::SHAPE],
-                    })
-                }
-            },
-        );
-        vtable.parse = Some(|s: &str, target: PtrUninit| {
-            let parsed: DateTime = s.parse().map_err(|_| ParseError::Generic(DATETIME_ERROR))?;
-            Ok(unsafe { target.put(parsed) })
-        });
-        vtable.display = Some(|value, f| unsafe { write!(f, "{}", value.get::<DateTime>()) });
+                },
+            )
+        };
+        vtable.parse = || {
+            Some(|s: &str, target: PtrUninit| {
+                let parsed: DateTime =
+                    s.parse().map_err(|_| ParseError::Generic(DATETIME_ERROR))?;
+                Ok(unsafe { target.put(parsed) })
+            })
+        };
+        vtable.display = || Some(|value, f| unsafe { write!(f, "{}", value.get::<DateTime>()) });
         vtable
     };
 
@@ -157,7 +170,10 @@ mod tests {
 
         let target = Zoned::SHAPE.allocate()?;
         unsafe {
-            (Zoned::VTABLE.parse.unwrap())("2023-12-31T18:30:00+07:00[Asia/Ho_Chi_Minh]", target)?;
+            ((Zoned::VTABLE.parse)().unwrap())(
+                "2023-12-31T18:30:00+07:00[Asia/Ho_Chi_Minh]",
+                target,
+            )?;
         }
         let odt: Zoned = unsafe { target.assume_init().read() };
         assert_eq!(odt, "2023-12-31T18:30:00+07:00[Asia/Ho_Chi_Minh]".parse()?);
@@ -166,7 +182,7 @@ mod tests {
 
         impl fmt::Display for DisplayWrapper<'_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                unsafe { (Zoned::VTABLE.display.unwrap())(self.0, f) }
+                unsafe { ((Zoned::VTABLE.display)().unwrap())(self.0, f) }
             }
         }
 
@@ -187,7 +203,7 @@ mod tests {
 
         let target = Timestamp::SHAPE.allocate()?;
         unsafe {
-            (Timestamp::VTABLE.parse.unwrap())("2024-06-19T15:22:45Z", target)?;
+            ((Timestamp::VTABLE.parse)().unwrap())("2024-06-19T15:22:45Z", target)?;
         }
         let odt: Timestamp = unsafe { target.assume_init().read() };
         assert_eq!(odt, "2024-06-19T15:22:45Z".parse()?);
@@ -196,7 +212,7 @@ mod tests {
 
         impl fmt::Display for DisplayWrapper<'_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                unsafe { (Timestamp::VTABLE.display.unwrap())(self.0, f) }
+                unsafe { ((Timestamp::VTABLE.display)().unwrap())(self.0, f) }
             }
         }
 
@@ -217,7 +233,7 @@ mod tests {
 
         let target = DateTime::SHAPE.allocate()?;
         unsafe {
-            (DateTime::VTABLE.parse.unwrap())("2024-06-19T15:22:45", target)?;
+            ((DateTime::VTABLE.parse)().unwrap())("2024-06-19T15:22:45", target)?;
         }
         let odt: DateTime = unsafe { target.assume_init().read() };
         assert_eq!(odt, "2024-06-19T15:22:45".parse()?);
@@ -226,7 +242,7 @@ mod tests {
 
         impl fmt::Display for DisplayWrapper<'_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                unsafe { (DateTime::VTABLE.display.unwrap())(self.0, f) }
+                unsafe { ((DateTime::VTABLE.display)().unwrap())(self.0, f) }
             }
         }
 

--- a/facet-core/src/impls_std/hashmap.rs
+++ b/facet-core/src/impls_std/hashmap.rs
@@ -18,7 +18,7 @@ where
     S: Facet<'a> + Default + BuildHasher,
 {
     const VTABLE: &'static ValueVTable = &const {
-        let mut builder = ValueVTable::builder::<Self>()
+        ValueVTable::builder::<Self>()
             .marker_traits(|| {
                 let arg_dependent_traits = MarkerTraits::SEND
                     .union(MarkerTraits::SYNC)
@@ -38,97 +38,92 @@ where
                 } else {
                     write!(f, "HashMap<⋯>")
                 }
-            });
-
-        builder = builder.debug(|| {
-            if (K::SHAPE.vtable.debug)().is_some() && (V::SHAPE.vtable.debug)().is_some() {
-                Some(|value, f| {
-                    let k_debug = <VTableView<K>>::of().debug().unwrap();
-                    let v_debug = <VTableView<V>>::of().debug().unwrap();
-                    write!(f, "{{")?;
-                    for (i, (key, val)) in value.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+            })
+            .debug(|| {
+                if (K::SHAPE.vtable.debug)().is_some() && (V::SHAPE.vtable.debug)().is_some() {
+                    Some(|value, f| {
+                        let k_debug = <VTableView<K>>::of().debug().unwrap();
+                        let v_debug = <VTableView<V>>::of().debug().unwrap();
+                        write!(f, "{{")?;
+                        for (i, (key, val)) in value.iter().enumerate() {
+                            if i > 0 {
+                                write!(f, ", ")?;
+                            }
+                            (k_debug)(key, f)?;
+                            write!(f, ": ")?;
+                            (v_debug)(val, f)?;
                         }
-                        (k_debug)(key, f)?;
-                        write!(f, ": ")?;
-                        (v_debug)(val, f)?;
-                    }
-                    write!(f, "}}")
-                })
-            } else {
-                None
-            }
-        });
+                        write!(f, "}}")
+                    })
+                } else {
+                    None
+                }
+            })
+            .default_in_place(|| Some(|target| unsafe { target.put(Self::default()) }))
+            .clone_into(|| {
+                if (K::SHAPE.vtable.clone_into)().is_some()
+                    && (V::SHAPE.vtable.clone_into)().is_some()
+                {
+                    Some(|src, dst| unsafe {
+                        let map = src;
+                        let mut new_map =
+                            HashMap::with_capacity_and_hasher(map.len(), S::default());
 
-        builder =
-            builder.default_in_place(|| Some(|target| unsafe { target.put(Self::default()) }));
+                        let k_clone_into = <VTableView<K>>::of().clone_into().unwrap();
+                        let v_clone_into = <VTableView<V>>::of().clone_into().unwrap();
 
-        builder = builder.clone_into(|| {
-            if (K::SHAPE.vtable.clone_into)().is_some() && (V::SHAPE.vtable.clone_into)().is_some()
-            {
-                Some(|src, dst| unsafe {
-                    let map = src;
-                    let mut new_map = HashMap::with_capacity_and_hasher(map.len(), S::default());
+                        for (k, v) in map {
+                            use crate::TypedPtrUninit;
+                            use core::mem::MaybeUninit;
 
-                    let k_clone_into = <VTableView<K>>::of().clone_into().unwrap();
-                    let v_clone_into = <VTableView<V>>::of().clone_into().unwrap();
+                            let mut new_k = MaybeUninit::<K>::uninit();
+                            let mut new_v = MaybeUninit::<V>::uninit();
 
-                    for (k, v) in map {
-                        use crate::TypedPtrUninit;
-                        use core::mem::MaybeUninit;
+                            let uninit_k = TypedPtrUninit::new(new_k.as_mut_ptr());
+                            let uninit_v = TypedPtrUninit::new(new_v.as_mut_ptr());
 
-                        let mut new_k = MaybeUninit::<K>::uninit();
-                        let mut new_v = MaybeUninit::<V>::uninit();
+                            (k_clone_into)(k, uninit_k);
+                            (v_clone_into)(v, uninit_v);
 
-                        let uninit_k = TypedPtrUninit::new(new_k.as_mut_ptr());
-                        let uninit_v = TypedPtrUninit::new(new_v.as_mut_ptr());
+                            new_map.insert(new_k.assume_init(), new_v.assume_init());
+                        }
 
-                        (k_clone_into)(k, uninit_k);
-                        (v_clone_into)(v, uninit_v);
-
-                        new_map.insert(new_k.assume_init(), new_v.assume_init());
-                    }
-
-                    dst.put(new_map)
-                })
-            } else {
-                None
-            }
-        });
-
-        builder = builder.eq(|| {
-            if (V::SHAPE.vtable.eq)().is_some() {
-                Some(|a, b| {
-                    let v_eq = <VTableView<V>>::of().eq().unwrap();
-                    a.len() == b.len()
-                        && a.iter().all(|(key_a, val_a)| {
-                            b.get(key_a).is_some_and(|val_b| (v_eq)(val_a, val_b))
-                        })
-                })
-            } else {
-                None
-            }
-        });
-
-        builder = builder.hash(|| {
-            if (V::SHAPE.vtable.hash)().is_some() {
-                Some(|map, hasher_this, hasher_write_fn| unsafe {
-                    use crate::HasherProxy;
-                    let v_hash = <VTableView<V>>::of().hash().unwrap();
-                    let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
-                    map.len().hash(&mut hasher);
-                    for (k, v) in map {
-                        k.hash(&mut hasher);
-                        (v_hash)(v, hasher_this, hasher_write_fn);
-                    }
-                })
-            } else {
-                None
-            }
-        });
-
-        builder.build()
+                        dst.put(new_map)
+                    })
+                } else {
+                    None
+                }
+            })
+            .eq(|| {
+                if (V::SHAPE.vtable.eq)().is_some() {
+                    Some(|a, b| {
+                        let v_eq = <VTableView<V>>::of().eq().unwrap();
+                        a.len() == b.len()
+                            && a.iter().all(|(key_a, val_a)| {
+                                b.get(key_a).is_some_and(|val_b| (v_eq)(val_a, val_b))
+                            })
+                    })
+                } else {
+                    None
+                }
+            })
+            .hash(|| {
+                if (V::SHAPE.vtable.hash)().is_some() {
+                    Some(|map, hasher_this, hasher_write_fn| unsafe {
+                        use crate::HasherProxy;
+                        let v_hash = <VTableView<V>>::of().hash().unwrap();
+                        let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
+                        map.len().hash(&mut hasher);
+                        for (k, v) in map {
+                            k.hash(&mut hasher);
+                            (v_hash)(v, hasher_this, hasher_write_fn);
+                        }
+                    })
+                } else {
+                    None
+                }
+            })
+            .build()
     };
 
     const SHAPE: &'static Shape<'static> = &const {

--- a/facet-core/src/impls_std/hashset.rs
+++ b/facet-core/src/impls_std/hashset.rs
@@ -16,7 +16,7 @@ where
     S: Facet<'a> + Default + BuildHasher,
 {
     const VTABLE: &'static ValueVTable = &const {
-        let mut builder = ValueVTable::builder::<Self>()
+        ValueVTable::builder::<Self>()
             .marker_traits(|| {
                 MarkerTraits::SEND
                     .union(MarkerTraits::SYNC)
@@ -34,70 +34,67 @@ where
                 }
             })
             .default_in_place(|| Some(|target| unsafe { target.put(Self::default()) }))
-            .eq(|| Some(|a, b| a == b));
-
-        builder = builder.debug(|| {
-            if (T::SHAPE.vtable.debug)().is_some() {
-                Some(|value, f| {
-                    let t_debug = <VTableView<T>>::of().debug().unwrap();
-                    write!(f, "{{")?;
-                    for (i, item) in value.iter().enumerate() {
-                        if i > 0 {
-                            write!(f, ", ")?;
+            .eq(|| Some(|a, b| a == b))
+            .debug(|| {
+                if (T::SHAPE.vtable.debug)().is_some() {
+                    Some(|value, f| {
+                        let t_debug = <VTableView<T>>::of().debug().unwrap();
+                        write!(f, "{{")?;
+                        for (i, item) in value.iter().enumerate() {
+                            if i > 0 {
+                                write!(f, ", ")?;
+                            }
+                            (t_debug)(item, f)?;
                         }
-                        (t_debug)(item, f)?;
-                    }
-                    write!(f, "}}")
-                })
-            } else {
-                None
-            }
-        });
+                        write!(f, "}}")
+                    })
+                } else {
+                    None
+                }
+            })
+            .clone_into(|| {
+                if (T::SHAPE.vtable.clone_into)().is_some() {
+                    Some(|src, dst| unsafe {
+                        let set = src;
+                        let mut new_set =
+                            HashSet::with_capacity_and_hasher(set.len(), S::default());
 
-        builder = builder.clone_into(|| {
-            if (T::SHAPE.vtable.clone_into)().is_some() {
-                Some(|src, dst| unsafe {
-                    let set = src;
-                    let mut new_set = HashSet::with_capacity_and_hasher(set.len(), S::default());
+                        let t_clone_into = <VTableView<T>>::of().clone_into().unwrap();
 
-                    let t_clone_into = <VTableView<T>>::of().clone_into().unwrap();
+                        for item in set {
+                            use crate::TypedPtrUninit;
+                            use core::mem::MaybeUninit;
 
-                    for item in set {
-                        use crate::TypedPtrUninit;
-                        use core::mem::MaybeUninit;
+                            let mut new_item = MaybeUninit::<T>::uninit();
+                            let uninit_item = TypedPtrUninit::new(new_item.as_mut_ptr());
 
-                        let mut new_item = MaybeUninit::<T>::uninit();
-                        let uninit_item = TypedPtrUninit::new(new_item.as_mut_ptr());
+                            (t_clone_into)(item, uninit_item);
 
-                        (t_clone_into)(item, uninit_item);
+                            new_set.insert(new_item.assume_init());
+                        }
 
-                        new_set.insert(new_item.assume_init());
-                    }
-
-                    dst.put(new_set)
-                })
-            } else {
-                None
-            }
-        });
-
-        builder = builder.hash(|| {
-            if (T::SHAPE.vtable.hash)().is_some() {
-                Some(|set, hasher_this, hasher_write_fn| unsafe {
-                    use crate::HasherProxy;
-                    let t_hash = <VTableView<T>>::of().hash().unwrap();
-                    let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
-                    set.len().hash(&mut hasher);
-                    for item in set {
-                        (t_hash)(item, hasher_this, hasher_write_fn);
-                    }
-                })
-            } else {
-                None
-            }
-        });
-
-        builder.build()
+                        dst.put(new_set)
+                    })
+                } else {
+                    None
+                }
+            })
+            .hash(|| {
+                if (T::SHAPE.vtable.hash)().is_some() {
+                    Some(|set, hasher_this, hasher_write_fn| unsafe {
+                        use crate::HasherProxy;
+                        let t_hash = <VTableView<T>>::of().hash().unwrap();
+                        let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
+                        set.len().hash(&mut hasher);
+                        for item in set {
+                            (t_hash)(item, hasher_this, hasher_write_fn);
+                        }
+                    })
+                } else {
+                    None
+                }
+            })
+            .build()
     };
 
     const SHAPE: &'static Shape<'static> = &const {

--- a/facet-core/src/impls_std/hashset.rs
+++ b/facet-core/src/impls_std/hashset.rs
@@ -17,13 +17,13 @@ where
 {
     const VTABLE: &'static ValueVTable = &const {
         let mut builder = ValueVTable::builder::<Self>()
-            .marker_traits(
+            .marker_traits(|| {
                 MarkerTraits::SEND
                     .union(MarkerTraits::SYNC)
                     .union(MarkerTraits::EQ)
                     .union(MarkerTraits::UNPIN)
-                    .intersection(T::SHAPE.vtable.marker_traits),
-            )
+                    .intersection(T::SHAPE.vtable.marker_traits())
+            })
             .type_name(|f, opts| {
                 if let Some(opts) = opts.for_children() {
                     write!(f, "HashSet<")?;
@@ -33,57 +33,69 @@ where
                     write!(f, "HashSet<⋯>")
                 }
             })
-            .default_in_place(|target| unsafe { target.put(Self::default()) })
-            .eq(|a, b| a == b);
+            .default_in_place(|| Some(|target| unsafe { target.put(Self::default()) }))
+            .eq(|| Some(|a, b| a == b));
 
-        if T::SHAPE.vtable.debug.is_some() {
-            builder = builder.debug(|value, f| {
-                let t_debug = <VTableView<T>>::of().debug().unwrap();
-                write!(f, "{{")?;
-                for (i, item) in value.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
+        builder = builder.debug(|| {
+            if (T::SHAPE.vtable.debug)().is_some() {
+                Some(|value, f| {
+                    let t_debug = <VTableView<T>>::of().debug().unwrap();
+                    write!(f, "{{")?;
+                    for (i, item) in value.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        (t_debug)(item, f)?;
                     }
-                    (t_debug)(item, f)?;
-                }
-                write!(f, "}}")
-            });
-        }
+                    write!(f, "}}")
+                })
+            } else {
+                None
+            }
+        });
 
-        if T::SHAPE.vtable.clone_into.is_some() {
-            builder = builder.clone_into(|src, dst| unsafe {
-                let set = src;
-                let mut new_set = HashSet::with_capacity_and_hasher(set.len(), S::default());
+        builder = builder.clone_into(|| {
+            if (T::SHAPE.vtable.clone_into)().is_some() {
+                Some(|src, dst| unsafe {
+                    let set = src;
+                    let mut new_set = HashSet::with_capacity_and_hasher(set.len(), S::default());
 
-                let t_clone_into = <VTableView<T>>::of().clone_into().unwrap();
+                    let t_clone_into = <VTableView<T>>::of().clone_into().unwrap();
 
-                for item in set {
-                    use crate::TypedPtrUninit;
-                    use core::mem::MaybeUninit;
+                    for item in set {
+                        use crate::TypedPtrUninit;
+                        use core::mem::MaybeUninit;
 
-                    let mut new_item = MaybeUninit::<T>::uninit();
-                    let uninit_item = TypedPtrUninit::new(new_item.as_mut_ptr());
+                        let mut new_item = MaybeUninit::<T>::uninit();
+                        let uninit_item = TypedPtrUninit::new(new_item.as_mut_ptr());
 
-                    (t_clone_into)(item, uninit_item);
+                        (t_clone_into)(item, uninit_item);
 
-                    new_set.insert(new_item.assume_init());
-                }
+                        new_set.insert(new_item.assume_init());
+                    }
 
-                dst.put(new_set)
-            });
-        }
+                    dst.put(new_set)
+                })
+            } else {
+                None
+            }
+        });
 
-        if T::SHAPE.vtable.hash.is_some() {
-            builder = builder.hash(|set, hasher_this, hasher_write_fn| unsafe {
-                use crate::HasherProxy;
-                let t_hash = <VTableView<T>>::of().hash().unwrap();
-                let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
-                set.len().hash(&mut hasher);
-                for item in set {
-                    (t_hash)(item, hasher_this, hasher_write_fn);
-                }
-            });
-        }
+        builder = builder.hash(|| {
+            if (T::SHAPE.vtable.hash)().is_some() {
+                Some(|set, hasher_this, hasher_write_fn| unsafe {
+                    use crate::HasherProxy;
+                    let t_hash = <VTableView<T>>::of().hash().unwrap();
+                    let mut hasher = HasherProxy::new(hasher_this, hasher_write_fn);
+                    set.len().hash(&mut hasher);
+                    for item in set {
+                        (t_hash)(item, hasher_this, hasher_write_fn);
+                    }
+                })
+            } else {
+                None
+            }
+        });
 
         builder.build()
     };
@@ -273,10 +285,8 @@ mod tests {
         assert_eq!(iter_items, strings.iter().copied().collect::<HashSet<_>>());
 
         // Get the function pointer for dropping the HashSet
-        let drop_fn = hashset_shape
-            .vtable
-            .drop_in_place
-            .expect("HashSet<T> should have drop_in_place");
+        let drop_fn =
+            (hashset_shape.vtable.drop_in_place)().expect("HashSet<T> should have drop_in_place");
 
         // Drop the HashSet in place
         unsafe { drop_fn(hashset_ptr) };

--- a/facet-core/src/impls_time.rs
+++ b/facet-core/src/impls_time.rs
@@ -9,37 +9,45 @@ use crate::{
 unsafe impl Facet<'_> for UtcDateTime {
     const VTABLE: &'static ValueVTable = &const {
         let mut vtable = value_vtable!(UtcDateTime, |f, _opts| write!(f, "UtcDateTime"));
-        vtable.try_from = Some(
-            |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
-                if source_shape.is_type::<String>() {
-                    let source = unsafe { source.read::<String>() };
-                    let parsed =
-                        UtcDateTime::parse(&source, &time::format_description::well_known::Rfc3339)
-                            .map_err(|_| ParseError::Generic("could not parse date"));
-                    match parsed {
-                        Ok(val) => Ok(unsafe { target.put(val) }),
-                        Err(_e) => Err(crate::TryFromError::Generic("could not parse date")),
+        vtable.try_from = || {
+            Some(
+                |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
+                    if source_shape.is_type::<String>() {
+                        let source = unsafe { source.read::<String>() };
+                        let parsed = UtcDateTime::parse(
+                            &source,
+                            &time::format_description::well_known::Rfc3339,
+                        )
+                        .map_err(|_| ParseError::Generic("could not parse date"));
+                        match parsed {
+                            Ok(val) => Ok(unsafe { target.put(val) }),
+                            Err(_e) => Err(crate::TryFromError::Generic("could not parse date")),
+                        }
+                    } else {
+                        Err(crate::TryFromError::UnsupportedSourceShape {
+                            src_shape: source_shape,
+                            expected: &[String::SHAPE],
+                        })
                     }
-                } else {
-                    Err(crate::TryFromError::UnsupportedSourceShape {
-                        src_shape: source_shape,
-                        expected: &[String::SHAPE],
-                    })
+                },
+            )
+        };
+        vtable.parse = || {
+            Some(|s: &str, target: PtrUninit| {
+                let parsed = UtcDateTime::parse(s, &time::format_description::well_known::Rfc3339)
+                    .map_err(|_| ParseError::Generic("could not parse date"))?;
+                Ok(unsafe { target.put(parsed) })
+            })
+        };
+        vtable.display = || {
+            Some(|value, f| unsafe {
+                let udt = value.get::<UtcDateTime>();
+                match udt.format(&time::format_description::well_known::Rfc3339) {
+                    Ok(s) => write!(f, "{s}"),
+                    Err(_) => write!(f, "<invalid UtcDateTime>"),
                 }
-            },
-        );
-        vtable.parse = Some(|s: &str, target: PtrUninit| {
-            let parsed = UtcDateTime::parse(s, &time::format_description::well_known::Rfc3339)
-                .map_err(|_| ParseError::Generic("could not parse date"))?;
-            Ok(unsafe { target.put(parsed) })
-        });
-        vtable.display = Some(|value, f| unsafe {
-            let udt = value.get::<UtcDateTime>();
-            match udt.format(&time::format_description::well_known::Rfc3339) {
-                Ok(s) => write!(f, "{s}"),
-                Err(_) => write!(f, "<invalid UtcDateTime>"),
-            }
-        });
+            })
+        };
         vtable
     };
 
@@ -58,39 +66,46 @@ unsafe impl Facet<'_> for UtcDateTime {
 unsafe impl Facet<'_> for OffsetDateTime {
     const VTABLE: &'static ValueVTable = &const {
         let mut vtable = value_vtable!(OffsetDateTime, |f, _opts| write!(f, "OffsetDateTime"));
-        vtable.try_from = Some(
-            |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
-                if source_shape.is_type::<String>() {
-                    let source = unsafe { source.read::<String>() };
-                    let parsed = OffsetDateTime::parse(
-                        &source,
-                        &time::format_description::well_known::Rfc3339,
-                    )
-                    .map_err(|_| ParseError::Generic("could not parse date"));
-                    match parsed {
-                        Ok(val) => Ok(unsafe { target.put(val) }),
-                        Err(_e) => Err(crate::TryFromError::Generic("could not parse date")),
+        vtable.try_from = || {
+            Some(
+                |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
+                    if source_shape.is_type::<String>() {
+                        let source = unsafe { source.read::<String>() };
+                        let parsed = OffsetDateTime::parse(
+                            &source,
+                            &time::format_description::well_known::Rfc3339,
+                        )
+                        .map_err(|_| ParseError::Generic("could not parse date"));
+                        match parsed {
+                            Ok(val) => Ok(unsafe { target.put(val) }),
+                            Err(_e) => Err(crate::TryFromError::Generic("could not parse date")),
+                        }
+                    } else {
+                        Err(crate::TryFromError::UnsupportedSourceShape {
+                            src_shape: source_shape,
+                            expected: &[String::SHAPE],
+                        })
                     }
-                } else {
-                    Err(crate::TryFromError::UnsupportedSourceShape {
-                        src_shape: source_shape,
-                        expected: &[String::SHAPE],
-                    })
+                },
+            )
+        };
+        vtable.parse = || {
+            Some(|s: &str, target: PtrUninit| {
+                let parsed =
+                    OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339)
+                        .map_err(|_| ParseError::Generic("could not parse date"))?;
+                Ok(unsafe { target.put(parsed) })
+            })
+        };
+        vtable.display = || {
+            Some(|value, f| unsafe {
+                let odt = value.get::<OffsetDateTime>();
+                match odt.format(&time::format_description::well_known::Rfc3339) {
+                    Ok(s) => write!(f, "{s}"),
+                    Err(_) => write!(f, "<invalid OffsetDateTime>"),
                 }
-            },
-        );
-        vtable.parse = Some(|s: &str, target: PtrUninit| {
-            let parsed = OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339)
-                .map_err(|_| ParseError::Generic("could not parse date"))?;
-            Ok(unsafe { target.put(parsed) })
-        });
-        vtable.display = Some(|value, f| unsafe {
-            let odt = value.get::<OffsetDateTime>();
-            match odt.format(&time::format_description::well_known::Rfc3339) {
-                Ok(s) => write!(f, "{s}"),
-                Err(_) => write!(f, "<invalid OffsetDateTime>"),
-            }
-        });
+            })
+        };
         vtable
     };
 
@@ -120,7 +135,7 @@ mod tests {
 
         let target = OffsetDateTime::SHAPE.allocate()?;
         unsafe {
-            (OffsetDateTime::VTABLE.parse.unwrap())("2023-03-14T15:09:26Z", target)?;
+            ((OffsetDateTime::VTABLE.parse)().unwrap())("2023-03-14T15:09:26Z", target)?;
         }
         let odt: OffsetDateTime = unsafe { target.assume_init().read() };
         assert_eq!(
@@ -136,7 +151,7 @@ mod tests {
 
         impl fmt::Display for DisplayWrapper<'_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                unsafe { (OffsetDateTime::VTABLE.display.unwrap())(self.0, f) }
+                unsafe { ((OffsetDateTime::VTABLE.display)().unwrap())(self.0, f) }
             }
         }
 

--- a/facet-core/src/impls_ulid.rs
+++ b/facet-core/src/impls_ulid.rs
@@ -40,12 +40,14 @@ unsafe impl Facet<'_> for Ulid {
         }
 
         let mut vtable = value_vtable!(Ulid, |f, _opts| write!(f, "Ulid"));
-        vtable.parse = Some(|s, target| match Ulid::from_string(s) {
-            Ok(ulid) => Ok(unsafe { target.put(ulid) }),
-            Err(_) => Err(ParseError::Generic("ULID parsing failed")),
-        });
-        vtable.try_from = Some(try_from);
-        vtable.try_into_inner = Some(try_into_inner);
+        vtable.parse = || {
+            Some(|s, target| match Ulid::from_string(s) {
+                Ok(ulid) => Ok(unsafe { target.put(ulid) }),
+                Err(_) => Err(ParseError::Generic("ULID parsing failed")),
+            })
+        };
+        vtable.try_from = || Some(try_from);
+        vtable.try_into_inner = || Some(try_into_inner);
         vtable
     };
 

--- a/facet-core/src/impls_url.rs
+++ b/facet-core/src/impls_url.rs
@@ -54,9 +54,9 @@ unsafe impl Facet<'_> for Url {
         }
 
         let mut vtable = value_vtable!(Url, |f, _opts| write!(f, "Url"));
-        vtable.parse = Some(parse);
-        vtable.try_into_inner = Some(try_into_inner);
-        vtable.try_borrow_inner = Some(try_borrow_inner);
+        vtable.parse = || Some(parse);
+        vtable.try_into_inner = || Some(try_into_inner);
+        vtable.try_borrow_inner = || Some(try_borrow_inner);
         vtable
     };
 

--- a/facet-core/src/impls_uuid.rs
+++ b/facet-core/src/impls_uuid.rs
@@ -41,12 +41,14 @@ unsafe impl Facet<'_> for Uuid {
         }
 
         let mut vtable = value_vtable!(Uuid, |f, _opts| write!(f, "Uuid"));
-        vtable.parse = Some(|s, target| match Uuid::parse_str(s) {
-            Ok(uuid) => Ok(unsafe { target.put(uuid) }),
-            Err(_) => Err(ParseError::Generic("UUID parsing failed")),
-        });
-        vtable.try_from = Some(try_from);
-        vtable.try_into_inner = Some(try_into_inner);
+        vtable.parse = || {
+            Some(|s, target| match Uuid::parse_str(s) {
+                Ok(uuid) => Ok(unsafe { target.put(uuid) }),
+                Err(_) => Err(ParseError::Generic("UUID parsing failed")),
+            })
+        };
+        vtable.try_from = || Some(try_from);
+        vtable.try_into_inner = || Some(try_into_inner);
         vtable
     };
 

--- a/facet-core/src/macros.rs
+++ b/facet-core/src/macros.rs
@@ -44,136 +44,125 @@ where
 macro_rules! value_vtable {
     ($type_name:ty, $type_name_fn:expr) => {
         const {
-            let mut builder = $crate::ValueVTable::builder::<$type_name>()
-                .type_name($type_name_fn);
+            $crate::ValueVTable::builder::<$type_name>()
+                .type_name($type_name_fn)
+                .display(|| {
+                    if $crate::spez::impls!($type_name: core::fmt::Display) {
+                        Some(|data, f| {
+                            use $crate::spez::*;
+                            (&&Spez(data)).spez_display(f)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .debug(|| {
+                    if $crate::spez::impls!($type_name: core::fmt::Debug) {
+                        Some(|data, f| {
+                            use $crate::spez::*;
+                            (&&Spez(data)).spez_debug(f)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .default_in_place(|| {
+                    if $crate::spez::impls!($type_name: core::default::Default) {
+                        Some(|target| unsafe {
+                            use $crate::spez::*;
+                            (&&SpezEmpty::<$type_name>::SPEZ).spez_default_in_place(target.into()).as_mut()
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .clone_into(|| {
+                    if $crate::spez::impls!($type_name: core::clone::Clone) {
+                        Some(|src, dst| unsafe {
+                            use $crate::spez::*;
+                            (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .marker_traits(|| {
+                    let mut traits = $crate::MarkerTraits::empty();
+                    if $crate::spez::impls!($type_name: core::cmp::Eq) {
+                        traits = traits.union($crate::MarkerTraits::EQ);
+                    }
+                    if $crate::spez::impls!($type_name: core::marker::Send) {
+                        traits = traits.union($crate::MarkerTraits::SEND);
+                    }
+                    if $crate::spez::impls!($type_name: core::marker::Sync) {
+                        traits = traits.union($crate::MarkerTraits::SYNC);
+                    }
+                    if $crate::spez::impls!($type_name: core::marker::Copy) {
+                        traits = traits.union($crate::MarkerTraits::COPY);
+                    }
+                    if $crate::spez::impls!($type_name: core::marker::Unpin) {
+                        traits = traits.union($crate::MarkerTraits::UNPIN);
+                    }
 
-            builder = builder.display(|| {
-                if $crate::spez::impls!($type_name: core::fmt::Display) {
-                    Some(|data, f| {
-                        use $crate::spez::*;
-                        (&&Spez(data)).spez_display(f)
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.debug(|| {
-                if $crate::spez::impls!($type_name: core::fmt::Debug) {
-                    Some(|data, f| {
-                        use $crate::spez::*;
-                        (&&Spez(data)).spez_debug(f)
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.default_in_place(|| {
-                if $crate::spez::impls!($type_name: core::default::Default) {
-                    Some(|target| unsafe {
-                        use $crate::spez::*;
-                        (&&SpezEmpty::<$type_name>::SPEZ).spez_default_in_place(target.into()).as_mut()
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.clone_into(|| {
-                if $crate::spez::impls!($type_name: core::clone::Clone) {
-                    Some(|src, dst| unsafe {
-                        use $crate::spez::*;
-                        (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.marker_traits(|| {
-                let mut traits = $crate::MarkerTraits::empty();
-                if $crate::spez::impls!($type_name: core::cmp::Eq) {
-                    traits = traits.union($crate::MarkerTraits::EQ);
-                }
-                if $crate::spez::impls!($type_name: core::marker::Send) {
-                    traits = traits.union($crate::MarkerTraits::SEND);
-                }
-                if $crate::spez::impls!($type_name: core::marker::Sync) {
-                    traits = traits.union($crate::MarkerTraits::SYNC);
-                }
-                if $crate::spez::impls!($type_name: core::marker::Copy) {
-                    traits = traits.union($crate::MarkerTraits::COPY);
-                }
-                if $crate::spez::impls!($type_name: core::marker::Unpin) {
-                    traits = traits.union($crate::MarkerTraits::UNPIN);
-                }
-
-                traits
-            });
-
-            builder = builder.eq(|| {
-                if $crate::spez::impls!($type_name: core::cmp::PartialEq) {
-                    Some(|left, right| {
-                        use $crate::spez::*;
-                        (&&Spez(left))
-                            .spez_eq(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.partial_ord(|| {
-                if $crate::spez::impls!($type_name: core::cmp::PartialOrd) {
-                    Some(|left, right| {
-                        use $crate::spez::*;
-                        (&&Spez(left))
-                            .spez_partial_cmp(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.ord(|| {
-                if $crate::spez::impls!($type_name: core::cmp::Ord) {
-                    Some(|left, right| {
-                        use $crate::spez::*;
-                        (&&Spez(left))
-                            .spez_cmp(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.hash(|| {
-                if $crate::spez::impls!($type_name: core::hash::Hash) {
-                    Some(|value, hasher_this, hasher_write_fn| {
-                        use $crate::spez::*;
-                        use $crate::HasherProxy;
-                        (&&Spez(value))
-                            .spez_hash(&mut unsafe { HasherProxy::new(hasher_this, hasher_write_fn) })
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.parse(|| {
-                if $crate::spez::impls!($type_name: core::str::FromStr) {
-                    Some(|s, target| {
-                        use $crate::spez::*;
-                        let res = unsafe { (&&SpezEmpty::<$type_name>::SPEZ).spez_parse(s, target.into()) };
-                        res.map(|res| unsafe { res.as_mut() })
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder.build()
+                    traits
+                })
+                .eq(|| {
+                    if $crate::spez::impls!($type_name: core::cmp::PartialEq) {
+                        Some(|left, right| {
+                            use $crate::spez::*;
+                            (&&Spez(left))
+                                .spez_eq(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .partial_ord(|| {
+                    if $crate::spez::impls!($type_name: core::cmp::PartialOrd) {
+                        Some(|left, right| {
+                            use $crate::spez::*;
+                            (&&Spez(left))
+                                .spez_partial_cmp(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .ord(|| {
+                    if $crate::spez::impls!($type_name: core::cmp::Ord) {
+                        Some(|left, right| {
+                            use $crate::spez::*;
+                            (&&Spez(left))
+                                .spez_cmp(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .hash(|| {
+                    if $crate::spez::impls!($type_name: core::hash::Hash) {
+                        Some(|value, hasher_this, hasher_write_fn| {
+                            use $crate::spez::*;
+                            use $crate::HasherProxy;
+                            (&&Spez(value))
+                                .spez_hash(&mut unsafe { HasherProxy::new(hasher_this, hasher_write_fn) })
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .parse(|| {
+                    if $crate::spez::impls!($type_name: core::str::FromStr) {
+                        Some(|s, target| {
+                            use $crate::spez::*;
+                            let res = unsafe { (&&SpezEmpty::<$type_name>::SPEZ).spez_parse(s, target.into()) };
+                            res.map(|res| unsafe { res.as_mut() })
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .build()
         }
     };
 }
@@ -183,102 +172,94 @@ macro_rules! value_vtable {
 macro_rules! value_vtable_unsized {
     ($type_name:ty, $type_name_fn:expr) => {
         const {
-            let mut builder = $crate::ValueVTable::builder_unsized::<$type_name>()
-                .type_name($type_name_fn);
+            $crate::ValueVTable::builder_unsized::<$type_name>()
+                .type_name($type_name_fn)
+                .display(|| {
+                    if $crate::spez::impls!($type_name: core::fmt::Display) {
+                        Some(|data, f| {
+                            use $crate::spez::*;
+                            (&&Spez(data)).spez_display(f)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .debug(|| {
+                    if $crate::spez::impls!($type_name: core::fmt::Debug) {
+                        Some(|data, f| {
+                            use $crate::spez::*;
+                            (&&Spez(data)).spez_debug(f)
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .marker_traits(|| {
+                    let mut traits = $crate::MarkerTraits::empty();
+                    if $crate::spez::impls!($type_name: core::cmp::Eq) {
+                        traits = traits.union($crate::MarkerTraits::EQ);
+                    }
+                    if $crate::spez::impls!($type_name: core::marker::Send) {
+                        traits = traits.union($crate::MarkerTraits::SEND);
+                    }
+                    if $crate::spez::impls!($type_name: core::marker::Sync) {
+                        traits = traits.union($crate::MarkerTraits::SYNC);
+                    }
+                    if $crate::spez::impls!($type_name: core::marker::Copy) {
+                        traits = traits.union($crate::MarkerTraits::COPY);
+                    }
+                    if $crate::spez::impls!($type_name: core::marker::Unpin) {
+                        traits = traits.union($crate::MarkerTraits::UNPIN);
+                    }
 
-            builder = builder.display(|| {
-                if $crate::spez::impls!($type_name: core::fmt::Display) {
-                    Some(|data, f| {
-                        use $crate::spez::*;
-                        (&&Spez(data)).spez_display(f)
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.debug(|| {
-                if $crate::spez::impls!($type_name: core::fmt::Debug) {
-                    Some(|data, f| {
-                        use $crate::spez::*;
-                        (&&Spez(data)).spez_debug(f)
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.marker_traits(|| {
-                let mut traits = $crate::MarkerTraits::empty();
-                if $crate::spez::impls!($type_name: core::cmp::Eq) {
-                    traits = traits.union($crate::MarkerTraits::EQ);
-                }
-                if $crate::spez::impls!($type_name: core::marker::Send) {
-                    traits = traits.union($crate::MarkerTraits::SEND);
-                }
-                if $crate::spez::impls!($type_name: core::marker::Sync) {
-                    traits = traits.union($crate::MarkerTraits::SYNC);
-                }
-                if $crate::spez::impls!($type_name: core::marker::Copy) {
-                    traits = traits.union($crate::MarkerTraits::COPY);
-                }
-                if $crate::spez::impls!($type_name: core::marker::Unpin) {
-                    traits = traits.union($crate::MarkerTraits::UNPIN);
-                }
-
-                traits
-            });
-
-            builder = builder.eq(|| {
-                if $crate::spez::impls!($type_name: core::cmp::PartialEq) {
-                    Some(|left, right| {
-                        use $crate::spez::*;
-                        (&&Spez(left))
-                            .spez_eq(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.partial_ord(|| {
-                if $crate::spez::impls!($type_name: core::cmp::PartialOrd) {
-                    Some(|left, right| {
-                        use $crate::spez::*;
-                        (&&Spez(left))
-                            .spez_partial_cmp(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.ord(|| {
-                if $crate::spez::impls!($type_name: core::cmp::Ord) {
-                    Some(|left, right| {
-                        use $crate::spez::*;
-                        (&&Spez(left))
-                            .spez_cmp(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder = builder.hash(|| {
-                if $crate::spez::impls!($type_name: core::hash::Hash) {
-                    Some(|value, hasher_this, hasher_write_fn| {
-                        use $crate::spez::*;
-                        use $crate::HasherProxy;
-                        (&&Spez(value))
-                            .spez_hash(&mut unsafe { HasherProxy::new(hasher_this, hasher_write_fn) })
-                    })
-                } else {
-                    None
-                }
-            });
-
-            builder.build()
+                    traits
+                })
+                .eq(|| {
+                    if $crate::spez::impls!($type_name: core::cmp::PartialEq) {
+                        Some(|left, right| {
+                            use $crate::spez::*;
+                            (&&Spez(left))
+                                .spez_eq(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .partial_ord(|| {
+                    if $crate::spez::impls!($type_name: core::cmp::PartialOrd) {
+                        Some(|left, right| {
+                            use $crate::spez::*;
+                            (&&Spez(left))
+                                .spez_partial_cmp(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .ord(|| {
+                    if $crate::spez::impls!($type_name: core::cmp::Ord) {
+                        Some(|left, right| {
+                            use $crate::spez::*;
+                            (&&Spez(left))
+                                .spez_cmp(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .hash(|| {
+                    if $crate::spez::impls!($type_name: core::hash::Hash) {
+                        Some(|value, hasher_this, hasher_write_fn| {
+                            use $crate::spez::*;
+                            use $crate::HasherProxy;
+                            (&&Spez(value))
+                                .spez_hash(&mut unsafe { HasherProxy::new(hasher_this, hasher_write_fn) })
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .build()
         }
     };
 }

--- a/facet-core/src/types/characteristic.rs
+++ b/facet-core/src/types/characteristic.rs
@@ -54,7 +54,7 @@ pub enum Characteristic {
 
 impl Characteristic {
     /// Checks if all shapes have the given characteristic.
-    pub const fn all(self, shapes: &[&Shape]) -> bool {
+    pub fn all(self, shapes: &[&Shape]) -> bool {
         let mut i = 0;
         while i < shapes.len() {
             if !shapes[i].is(self) {
@@ -66,7 +66,7 @@ impl Characteristic {
     }
 
     /// Checks if any shape has the given characteristic.
-    pub const fn any(self, shapes: &[&Shape]) -> bool {
+    pub fn any(self, shapes: &[&Shape]) -> bool {
         let mut i = 0;
         while i < shapes.len() {
             if shapes[i].is(self) {
@@ -78,10 +78,70 @@ impl Characteristic {
     }
 
     /// Checks if none of the shapes have the given characteristic.
-    pub const fn none(self, shapes: &[&Shape]) -> bool {
+    pub fn none(self, shapes: &[&Shape]) -> bool {
         let mut i = 0;
         while i < shapes.len() {
             if shapes[i].is(self) {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// Checks if all shapes have the `Default` characteristic
+    pub fn all_default(shapes: &[&Shape]) -> bool {
+        let mut i = 0;
+        while i < shapes.len() {
+            if !shapes[i].is_default() {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// Checks if all shapes have the `PartialEq` characteristic
+    pub fn all_partial_eq(shapes: &[&Shape]) -> bool {
+        let mut i = 0;
+        while i < shapes.len() {
+            if !shapes[i].is_partial_eq() {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// Checks if all shapes have the `PartialOrd` characteristic
+    pub fn all_partial_ord(shapes: &[&Shape]) -> bool {
+        let mut i = 0;
+        while i < shapes.len() {
+            if !shapes[i].is_partial_ord() {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// Checks if all shapes have the `Ord` characteristic
+    pub fn all_ord(shapes: &[&Shape]) -> bool {
+        let mut i = 0;
+        while i < shapes.len() {
+            if !shapes[i].is_ord() {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// Checks if all shapes have the `Hash` characteristic
+    pub fn all_hash(shapes: &[&Shape]) -> bool {
+        let mut i = 0;
+        while i < shapes.len() {
+            if !shapes[i].is_hash() {
                 return false;
             }
             i += 1;
@@ -92,90 +152,90 @@ impl Characteristic {
 
 impl<'shape> Shape<'shape> {
     /// Checks if a shape has the given characteristic.
-    pub const fn is(&self, characteristic: Characteristic) -> bool {
+    pub fn is(&self, characteristic: Characteristic) -> bool {
         match characteristic {
             // Marker traits
-            Characteristic::Send => self.vtable.marker_traits.contains(MarkerTraits::SEND),
-            Characteristic::Sync => self.vtable.marker_traits.contains(MarkerTraits::SYNC),
-            Characteristic::Copy => self.vtable.marker_traits.contains(MarkerTraits::COPY),
-            Characteristic::Eq => self.vtable.marker_traits.contains(MarkerTraits::EQ),
-            Characteristic::Unpin => self.vtable.marker_traits.contains(MarkerTraits::UNPIN),
+            Characteristic::Send => self.vtable.marker_traits().contains(MarkerTraits::SEND),
+            Characteristic::Sync => self.vtable.marker_traits().contains(MarkerTraits::SYNC),
+            Characteristic::Copy => self.vtable.marker_traits().contains(MarkerTraits::COPY),
+            Characteristic::Eq => self.vtable.marker_traits().contains(MarkerTraits::EQ),
+            Characteristic::Unpin => self.vtable.marker_traits().contains(MarkerTraits::UNPIN),
 
             // Functionality traits
-            Characteristic::Clone => self.vtable.clone_into.is_some(),
-            Characteristic::Display => self.vtable.display.is_some(),
-            Characteristic::Debug => self.vtable.debug.is_some(),
-            Characteristic::PartialEq => self.vtable.eq.is_some(),
-            Characteristic::PartialOrd => self.vtable.partial_ord.is_some(),
-            Characteristic::Ord => self.vtable.ord.is_some(),
-            Characteristic::Hash => self.vtable.hash.is_some(),
-            Characteristic::Default => self.vtable.default_in_place.is_some(),
-            Characteristic::FromStr => self.vtable.parse.is_some(),
+            Characteristic::Clone => (self.vtable.clone_into)().is_some(),
+            Characteristic::Display => (self.vtable.display)().is_some(),
+            Characteristic::Debug => (self.vtable.debug)().is_some(),
+            Characteristic::PartialEq => (self.vtable.eq)().is_some(),
+            Characteristic::PartialOrd => (self.vtable.partial_ord)().is_some(),
+            Characteristic::Ord => (self.vtable.ord)().is_some(),
+            Characteristic::Hash => (self.vtable.hash)().is_some(),
+            Characteristic::Default => (self.vtable.default_in_place)().is_some(),
+            Characteristic::FromStr => (self.vtable.parse)().is_some(),
         }
     }
 
     /// Check if this shape implements the Send trait
-    pub const fn is_send(&self) -> bool {
+    pub fn is_send(&self) -> bool {
         self.is(Characteristic::Send)
     }
 
     /// Check if this shape implements the Sync trait
-    pub const fn is_sync(&self) -> bool {
+    pub fn is_sync(&self) -> bool {
         self.is(Characteristic::Sync)
     }
 
     /// Check if this shape implements the Copy trait
-    pub const fn is_copy(&self) -> bool {
+    pub fn is_copy(&self) -> bool {
         self.is(Characteristic::Copy)
     }
 
     /// Check if this shape implements the Eq trait
-    pub const fn is_eq(&self) -> bool {
+    pub fn is_eq(&self) -> bool {
         self.is(Characteristic::Eq)
     }
 
     /// Check if this shape implements the Clone trait
-    pub const fn is_clone(&self) -> bool {
+    pub fn is_clone(&self) -> bool {
         self.is(Characteristic::Clone)
     }
 
     /// Check if this shape implements the Display trait
-    pub const fn is_display(&self) -> bool {
-        self.vtable.display.is_some()
+    pub fn is_display(&self) -> bool {
+        (self.vtable.display)().is_some()
     }
 
     /// Check if this shape implements the Debug trait
-    pub const fn is_debug(&self) -> bool {
+    pub fn is_debug(&self) -> bool {
         self.is(Characteristic::Debug)
     }
 
     /// Check if this shape implements the PartialEq trait
-    pub const fn is_partial_eq(&self) -> bool {
+    pub fn is_partial_eq(&self) -> bool {
         self.is(Characteristic::PartialEq)
     }
 
     /// Check if this shape implements the PartialOrd trait
-    pub const fn is_partial_ord(&self) -> bool {
+    pub fn is_partial_ord(&self) -> bool {
         self.is(Characteristic::PartialOrd)
     }
 
     /// Check if this shape implements the Ord trait
-    pub const fn is_ord(&self) -> bool {
+    pub fn is_ord(&self) -> bool {
         self.is(Characteristic::Ord)
     }
 
     /// Check if this shape implements the Hash trait
-    pub const fn is_hash(&self) -> bool {
+    pub fn is_hash(&self) -> bool {
         self.is(Characteristic::Hash)
     }
 
     /// Check if this shape implements the Default trait
-    pub const fn is_default(&self) -> bool {
+    pub fn is_default(&self) -> bool {
         self.is(Characteristic::Default)
     }
 
     /// Check if this shape implements the FromStr trait
-    pub const fn is_from_str(&self) -> bool {
+    pub fn is_from_str(&self) -> bool {
         self.is(Characteristic::FromStr)
     }
 

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_facet_transparent.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_facet_transparent.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 1072
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(transparent)]\n        struct Wrapper(u32);\n        \"#)"
 ---
 #[used]
@@ -14,7 +15,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Wrapper {
             src_shape: &'shape ::facet::Shape<'shape>,
             dst: ::facet::PtrUninit<'dst>,
         ) -> Result<::facet::PtrMut<'dst>, ::facet::TryFromError<'shape>> {
-            match <u32 as ::facet::Facet>::SHAPE.vtable.try_from {
+            match (<u32 as ::facet::Facet>::SHAPE.vtable.try_from)() {
                 Some(inner_try) => unsafe { (inner_try)(src_ptr, src_shape, dst) },
                 None => {
                     if src_shape != <u32 as ::facet::Facet>::SHAPE {
@@ -28,7 +29,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Wrapper {
                 }
             }
         }
-        vtable.try_from = Some(try_from);
+        vtable.try_from = || Some(try_from);
         unsafe fn try_into_inner<'src, 'dst>(
             src_ptr: ::facet::PtrMut<'src>,
             dst: ::facet::PtrUninit<'dst>,
@@ -36,14 +37,14 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Wrapper {
             let wrapper = unsafe { src_ptr.get::<Wrapper>() };
             Ok(unsafe { dst.put(wrapper.0.clone()) })
         }
-        vtable.try_into_inner = Some(try_into_inner);
+        vtable.try_into_inner = || Some(try_into_inner);
         unsafe fn try_borrow_inner<'src>(
             src_ptr: ::facet::PtrConst<'src>,
         ) -> Result<::facet::PtrConst<'src>, ::facet::TryBorrowInnerError> {
             let wrapper = unsafe { src_ptr.get::<Wrapper>() };
             Ok(::facet::PtrConst::new(&wrapper.0 as *const _ as *const u8))
         }
-        vtable.try_borrow_inner = Some(try_borrow_inner);
+        vtable.try_borrow_inner = || Some(try_borrow_inner);
         vtable
     };
     const SHAPE: &'static ::facet::Shape<'static> = &const {

--- a/facet-json/src/recursive/serialize.rs
+++ b/facet-json/src/recursive/serialize.rs
@@ -123,7 +123,7 @@ pub(crate) fn peek_to_writer<'mem, 'facet, 'shape, W: Write>(
                         | ScalarAffinity::Path(_)
                         | ScalarAffinity::ULID(_)
                         | ScalarAffinity::UUID(_) => {
-                            if let Some(_display) = scalar_peek.shape().vtable.display {
+                            if let Some(_display) = (scalar_peek.shape().vtable.display)() {
                                 // Use display formatting if available
                                 crate::write_json_string(output, &scalar_peek.to_string())
                             } else {

--- a/facet-reflect/src/peek/enum_.rs
+++ b/facet-reflect/src/peek/enum_.rs
@@ -19,7 +19,7 @@ pub struct PeekEnum<'mem, 'facet, 'shape> {
 
 impl core::fmt::Debug for PeekEnum<'_, '_, '_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if let Some(debug_fn) = self.vtable().debug {
+        if let Some(debug_fn) = (self.vtable().debug)() {
             unsafe { debug_fn(self.data, f) }
         } else {
             write!(f, "⟨{}⟩", self.shape)

--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -96,12 +96,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     /// `false` if equality comparison is not supported for this scalar type
     #[inline]
     pub fn eq(&self, other: &Peek<'_, '_, '_>) -> Option<bool> {
-        unsafe {
-            self.shape
-                .vtable
-                .eq
-                .map(|eq_fn| eq_fn(self.data, other.data))
-        }
+        unsafe { (self.shape.vtable.eq)().map(|eq_fn| eq_fn(self.data, other.data)) }
     }
 
     /// Compares this scalar with another and returns their ordering
@@ -112,9 +107,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     #[inline]
     pub fn partial_cmp(&self, other: &Peek<'_, '_, '_>) -> Option<Ordering> {
         unsafe {
-            self.shape
-                .vtable
-                .partial_ord
+            (self.shape.vtable.partial_ord)()
                 .and_then(|partial_ord_fn| partial_ord_fn(self.data, other.data))
         }
     }
@@ -127,7 +120,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     #[inline(always)]
     pub fn hash<H: core::hash::Hasher>(&self, hasher: &mut H) -> bool {
         unsafe {
-            if let Some(hash_fn) = self.shape.vtable.hash {
+            if let Some(hash_fn) = (self.shape.vtable.hash)() {
                 let hasher_opaque = PtrMut::new(hasher);
                 hash_fn(self.data, hasher_opaque, |opaque, bytes| {
                     opaque.as_mut::<H>().write(bytes)
@@ -346,7 +339,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     pub fn innermost_peek(self) -> Self {
         let mut current_peek = self;
         while let (Some(try_borrow_inner_fn), Some(inner_shape)) = (
-            current_peek.shape.vtable.try_borrow_inner,
+            (current_peek.shape.vtable.try_borrow_inner)(),
             current_peek.shape.inner,
         ) {
             unsafe {
@@ -368,7 +361,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
 
 impl<'mem, 'facet, 'shape> core::fmt::Display for Peek<'mem, 'facet, 'shape> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if let Some(display_fn) = self.vtable().display {
+        if let Some(display_fn) = (self.vtable().display)() {
             unsafe { display_fn(self.data, f) }
         } else {
             write!(f, "⟨{}⟩", self.shape)
@@ -378,7 +371,7 @@ impl<'mem, 'facet, 'shape> core::fmt::Display for Peek<'mem, 'facet, 'shape> {
 
 impl<'mem, 'facet, 'shape> core::fmt::Debug for Peek<'mem, 'facet, 'shape> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if let Some(debug_fn) = self.vtable().debug {
+        if let Some(debug_fn) = (self.vtable().debug)() {
             unsafe { debug_fn(self.data, f) }
         } else {
             write!(f, "⟨{}⟩", self.shape)
@@ -391,7 +384,7 @@ impl<'mem, 'facet, 'shape> core::cmp::PartialEq for Peek<'mem, 'facet, 'shape> {
         if self.shape != other.shape {
             return false;
         }
-        let eq_fn = match self.shape.vtable.eq {
+        let eq_fn = match (self.shape.vtable.eq)() {
             Some(eq_fn) => eq_fn,
             None => return false,
         };
@@ -404,14 +397,14 @@ impl<'mem, 'facet, 'shape> core::cmp::PartialOrd for Peek<'mem, 'facet, 'shape> 
         if self.shape != other.shape {
             return None;
         }
-        let partial_ord_fn = self.shape.vtable.partial_ord?;
+        let partial_ord_fn = (self.shape.vtable.partial_ord)()?;
         unsafe { partial_ord_fn(self.data, other.data) }
     }
 }
 
 impl<'mem, 'facet, 'shape> core::hash::Hash for Peek<'mem, 'facet, 'shape> {
     fn hash<H: core::hash::Hasher>(&self, hasher: &mut H) {
-        if let Some(hash_fn) = self.shape.vtable.hash {
+        if let Some(hash_fn) = (self.shape.vtable.hash)() {
             let hasher_opaque = PtrMut::new(hasher);
             unsafe {
                 hash_fn(self.data, hasher_opaque, |opaque, bytes| {

--- a/facet-reflect/src/wip/drop.rs
+++ b/facet-reflect/src/wip/drop.rs
@@ -148,7 +148,7 @@ impl<'facet, 'shape> Drop for Wip<'facet, 'shape> {
                                     // that means it's fully initialized and we need to drop it
                                     unsafe {
                                         if let Some(drop_in_place) =
-                                            field_shape.vtable.drop_in_place
+                                            (field_shape.vtable.drop_in_place)()
                                         {
                                             drop_in_place(field_ptr);
                                         }

--- a/facet-reflect/src/wip/frame.rs
+++ b/facet-reflect/src/wip/frame.rs
@@ -143,7 +143,7 @@ impl<'shape> Frame<'shape> {
 
     // Safety: only call if is fully initialized
     pub(crate) unsafe fn drop_and_dealloc_if_needed(mut self) {
-        if let Some(drop_in_place) = self.shape.vtable.drop_in_place {
+        if let Some(drop_in_place) = (self.shape.vtable.drop_in_place)() {
             unsafe {
                 trace!(
                     "Invoking drop_in_place for shape {} at {:p}",

--- a/facet-reflect/src/wip/heap_value.rs
+++ b/facet-reflect/src/wip/heap_value.rs
@@ -16,7 +16,7 @@ pub struct HeapValue<'facet, 'shape> {
 impl<'facet, 'shape> Drop for HeapValue<'facet, 'shape> {
     fn drop(&mut self) {
         if let Some(guard) = self.guard.take() {
-            if let Some(drop_fn) = self.shape.vtable.drop_in_place {
+            if let Some(drop_fn) = (self.shape.vtable.drop_in_place)() {
                 unsafe { drop_fn(PtrMut::new(guard.ptr)) };
             }
             drop(guard);
@@ -50,7 +50,7 @@ impl<'facet, 'shape> HeapValue<'facet, 'shape> {
 impl<'facet, 'shape> HeapValue<'facet, 'shape> {
     /// Formats the value using its Display implementation, if available
     pub fn fmt_display(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if let Some(display_fn) = self.shape.vtable.display {
+        if let Some(display_fn) = (self.shape.vtable.display)() {
             unsafe { display_fn(PtrConst::new(self.guard.as_ref().unwrap().ptr), f) }
         } else {
             write!(f, "⟨{}⟩", self.shape)
@@ -59,7 +59,7 @@ impl<'facet, 'shape> HeapValue<'facet, 'shape> {
 
     /// Formats the value using its Debug implementation, if available
     pub fn fmt_debug(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if let Some(debug_fn) = self.shape.vtable.debug {
+        if let Some(debug_fn) = (self.shape.vtable.debug)() {
             unsafe { debug_fn(PtrConst::new(self.guard.as_ref().unwrap().ptr), f) }
         } else {
             write!(f, "⟨{}⟩", self.shape)
@@ -84,7 +84,7 @@ impl<'facet, 'shape> PartialEq for HeapValue<'facet, 'shape> {
         if self.shape != other.shape {
             return false;
         }
-        if let Some(eq_fn) = self.shape.vtable.eq {
+        if let Some(eq_fn) = (self.shape.vtable.eq)() {
             unsafe {
                 eq_fn(
                     PtrConst::new(self.guard.as_ref().unwrap().ptr),
@@ -102,7 +102,7 @@ impl<'facet, 'shape> PartialOrd for HeapValue<'facet, 'shape> {
         if self.shape != other.shape {
             return None;
         }
-        if let Some(partial_ord_fn) = self.shape.vtable.partial_ord {
+        if let Some(partial_ord_fn) = (self.shape.vtable.partial_ord)() {
             unsafe {
                 partial_ord_fn(
                     PtrConst::new(self.guard.as_ref().unwrap().ptr),

--- a/facet-reflect/src/wip/mod.rs
+++ b/facet-reflect/src/wip/mod.rs
@@ -544,7 +544,7 @@ impl<'facet, 'shape> Wip<'facet, 'shape> {
         // We have already checked root is fully initialized above, so we only need to check its invariants.
         let root_shape = root_frame.shape;
         let root_data = unsafe { root_frame.data.assume_init() };
-        if let Some(invariant_fn) = root_shape.vtable.invariants {
+        if let Some(invariant_fn) = (root_shape.vtable.invariants)() {
             debug!(
                 "Checking invariants for root shape {} at {:p}",
                 root_shape.green(),
@@ -791,7 +791,7 @@ impl<'facet, 'shape> Wip<'facet, 'shape> {
         let shape = frame.shape;
         let index = frame.field_index_in_parent;
 
-        let Some(parse_fn) = frame.shape.vtable.parse else {
+        let Some(parse_fn) = (frame.shape.vtable.parse)() else {
             return Err(ReflectError::OperationFailed {
                 shape: frame.shape,
                 operation: "type does not implement Parse",
@@ -862,7 +862,7 @@ impl<'facet, 'shape> Wip<'facet, 'shape> {
         };
 
         let vtable = frame.shape.vtable;
-        let Some(default_in_place) = vtable.default_in_place else {
+        let Some(default_in_place) = (vtable.default_in_place)() else {
             return Err(ReflectError::OperationFailed {
                 shape: frame.shape,
                 operation: "type does not implement Default",
@@ -966,7 +966,7 @@ impl<'facet, 'shape> Wip<'facet, 'shape> {
         let vtable = frame.shape.vtable;
 
         // Initialize an empty list
-        let Some(default_in_place) = vtable.default_in_place else {
+        let Some(default_in_place) = (vtable.default_in_place)() else {
             return Err(ReflectError::OperationFailed {
                 shape: frame.shape,
                 operation: "list type does not implement Default",
@@ -1006,7 +1006,7 @@ impl<'facet, 'shape> Wip<'facet, 'shape> {
         let vtable = frame.shape.vtable;
 
         // Initialize an empty map
-        let Some(default_in_place) = vtable.default_in_place else {
+        let Some(default_in_place) = (vtable.default_in_place)() else {
             return Err(ReflectError::OperationFailed {
                 shape: frame.shape,
                 operation: "map type does not implement Default",
@@ -1077,7 +1077,7 @@ impl<'facet, 'shape> Wip<'facet, 'shape> {
             let vtable = frame.shape.vtable;
             // Initialize an empty list if it's not already marked as initialized (field 0)
             if !frame.istate.fields.has(0) {
-                let Some(default_in_place) = vtable.default_in_place else {
+                let Some(default_in_place) = (vtable.default_in_place)() else {
                     return Err(ReflectError::OperationFailed {
                         shape: frame.shape,
                         operation: "list type does not implement Default, cannot begin pushback",
@@ -1121,7 +1121,7 @@ impl<'facet, 'shape> Wip<'facet, 'shape> {
 
         // Initialize an empty map if it's not already initialized
         if !frame.istate.fields.has(0) {
-            let Some(default_in_place) = vtable.default_in_place else {
+            let Some(default_in_place) = (vtable.default_in_place)() else {
                 return Err(ReflectError::OperationFailed {
                     shape: frame.shape,
                     operation: "map type does not implement Default",
@@ -1505,7 +1505,7 @@ impl<'facet, 'shape> Wip<'facet, 'shape> {
 
         // Safety: option frames are correctly sized, and data is valid
         unsafe {
-            if let Some(default_fn) = parent_frame.shape.vtable.default_in_place {
+            if let Some(default_fn) = (parent_frame.shape.vtable.default_in_place)() {
                 default_fn(parent_frame.data);
             } else {
                 return Err(ReflectError::OperationFailed {

--- a/facet-reflect/tests/peek/facts.rs
+++ b/facet-reflect/tests/peek/facts.rs
@@ -14,12 +14,12 @@ where
     let mut facts: HashSet<Fact> = HashSet::new();
     let value_vtable = T::SHAPE.vtable;
     let traits = [
-        ("Debug", value_vtable.debug.is_some()),
-        ("Display", value_vtable.display.is_some()),
-        ("Default", value_vtable.default_in_place.is_some()),
-        ("Eq", value_vtable.eq.is_some()),
-        ("Ord", value_vtable.ord.is_some()),
-        ("Clone", value_vtable.clone_into.is_some()),
+        ("Debug", (value_vtable.debug)().is_some()),
+        ("Display", (value_vtable.display)().is_some()),
+        ("Default", (value_vtable.default_in_place)().is_some()),
+        ("Eq", (value_vtable.eq)().is_some()),
+        ("Ord", (value_vtable.ord)().is_some()),
+        ("Clone", (value_vtable.clone_into)().is_some()),
     ];
     let trait_str = traits
         .iter()
@@ -38,7 +38,7 @@ where
     let r = Peek::new(val2);
 
     // Format display representation
-    if l.shape().vtable.display.is_some() {
+    if (l.shape().vtable.display)().is_some() {
         facts.insert(Fact::Display);
         eprintln!(
             "Display:   {}",
@@ -47,7 +47,7 @@ where
     }
 
     // Format debug representation
-    if l.shape().vtable.debug.is_some() {
+    if (l.shape().vtable.debug)().is_some() {
         facts.insert(Fact::Debug);
         eprintln!(
             "Debug:     {}",
@@ -94,13 +94,19 @@ where
     }
 
     // Test clone
-    if l.shape().vtable.clone_into.is_some() {
+    if (l.shape().vtable.clone_into)().is_some() {
         facts.insert(Fact::Clone);
         eprintln!("Clone:     Implemented");
     }
 
     // Marker traits
-    facts.extend(l.shape().vtable.marker_traits.iter().map(Fact::MarkerTrait));
+    facts.extend(
+        l.shape()
+            .vtable
+            .marker_traits()
+            .iter()
+            .map(Fact::MarkerTrait),
+    );
 
     facts
 }

--- a/facet-reflect/tests/wip/misc.rs
+++ b/facet-reflect/tests/wip/misc.rs
@@ -767,7 +767,7 @@ fn clone_into() {
     assert_eq!(CLONES.load(Ordering::SeqCst), 1);
 
     let mut f3: MaybeUninit<Foo> = MaybeUninit::uninit();
-    let clone_into = <Foo as Facet>::SHAPE.vtable.clone_into.unwrap();
+    let clone_into = (<Foo as Facet>::SHAPE.vtable.clone_into)().unwrap();
     unsafe {
         clone_into(PtrConst::new(&f), PtrUninit::from_maybe_uninit(&mut f3));
     }
@@ -779,7 +779,7 @@ fn clone_into_vec() {
     type Type = Vec<String>;
     let mut vec: Type = vec!["hello".to_owned()];
     let mut vec_clone: MaybeUninit<Type> = MaybeUninit::uninit();
-    let clone_into = <Type as Facet>::SHAPE.vtable.clone_into.unwrap();
+    let clone_into = (<Type as Facet>::SHAPE.vtable.clone_into)().unwrap();
     let clone_vec = unsafe {
         clone_into(
             PtrConst::new(&vec),
@@ -800,7 +800,7 @@ fn clone_into_hash_map() {
     map.insert("key".to_owned(), 42);
 
     let mut map_clone: MaybeUninit<Type> = MaybeUninit::uninit();
-    let clone_into = <Type as Facet>::SHAPE.vtable.clone_into.unwrap();
+    let clone_into = (<Type as Facet>::SHAPE.vtable.clone_into)().unwrap();
     let clone_map = unsafe {
         clone_into(
             PtrConst::new(&map),
@@ -825,7 +825,7 @@ fn clone_into_btree_map() {
     map.insert("key".to_owned(), 42);
 
     let mut map_clone: MaybeUninit<Type> = MaybeUninit::uninit();
-    let clone_into = <Type as Facet>::SHAPE.vtable.clone_into.unwrap();
+    let clone_into = (<Type as Facet>::SHAPE.vtable.clone_into)().unwrap();
     let clone_map = unsafe {
         clone_into(
             PtrConst::new(&map),

--- a/facet-serialize/src/lib.rs
+++ b/facet-serialize/src/lib.rs
@@ -376,7 +376,7 @@ where
                                     | ScalarAffinity::Path(_)
                                     | ScalarAffinity::ULID(_)
                                     | ScalarAffinity::UUID(_) => {
-                                        if let Some(_display) = cpeek.shape().vtable.display {
+                                        if let Some(_display) = (cpeek.shape().vtable.display)() {
                                             // Use display formatting if available
                                             serializer
                                                 .serialize_str(&alloc::format!("{}", cpeek))?

--- a/facet/src/sample_generated_code.rs
+++ b/facet/src/sample_generated_code.rs
@@ -30,335 +30,335 @@ static KITCHEN_SINK_STRUCT_SHAPE: &'static crate::Shape =
 unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkStruct {
     const VTABLE: &'static crate::ValueVTable = &const {
         let mut vtable = const {
-            let mut builder = ::facet_core::ValueVTable::builder::<Self>()
-                .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "KitchenSinkStruct"));
-            builder = builder.display(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|data, f| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(data)).spez_display(f)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.debug(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|data, f| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(data)).spez_debug(f)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.default_in_place(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::default::Default> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|target| unsafe {
-                        use ::facet_core::spez::*;
-                        (&&SpezEmpty::<Self>::SPEZ)
-                            .spez_default_in_place(target.into())
-                            .as_mut()
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.clone_into(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|src, dst| unsafe {
-                        use ::facet_core::spez::*;
-                        (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.marker_traits(|| {
-                let mut traits = ::facet_core::MarkerTraits::empty();
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::Eq> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::EQ);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Send> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::SEND);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Sync> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::SYNC);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Copy> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::COPY);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Unpin> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::UNPIN);
-                }
-                traits
-            });
-            builder = builder.eq(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|left, right| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(left)).spez_eq(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.partial_ord(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|left, right| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(left)).spez_partial_cmp(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.ord(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|left, right| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(left)).spez_cmp(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.hash(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|value, hasher_this, hasher_write_fn| {
-                        use ::facet_core::HasherProxy;
-                        use ::facet_core::spez::*;
-                        (&&Spez(value)).spez_hash(&mut unsafe {
-                            HasherProxy::new(hasher_this, hasher_write_fn)
+            ::facet_core::ValueVTable::builder::<Self>()
+                .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "KitchenSinkStruct"))
+                .display(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|data, f| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(data)).spez_display(f)
                         })
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.parse(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
+                    } else {
+                        None
                     }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
-                        const IMPLS: bool = true;
+                })
+                .debug(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|data, f| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(data)).spez_debug(f)
+                        })
+                    } else {
+                        None
                     }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|s, target| {
-                        use ::facet_core::spez::*;
-                        let res =
-                            unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
-                        res.map(|res| unsafe { res.as_mut() })
-                    })
-                } else {
-                    None
-                }
-            });
-            builder.build()
+                })
+                .default_in_place(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::default::Default> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|target| unsafe {
+                            use ::facet_core::spez::*;
+                            (&&SpezEmpty::<Self>::SPEZ)
+                                .spez_default_in_place(target.into())
+                                .as_mut()
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .clone_into(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|src, dst| unsafe {
+                            use ::facet_core::spez::*;
+                            (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .marker_traits(|| {
+                    let mut traits = ::facet_core::MarkerTraits::empty();
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::Eq> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::EQ);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Send> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::SEND);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Sync> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::SYNC);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Copy> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::COPY);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Unpin> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::UNPIN);
+                    }
+                    traits
+                })
+                .eq(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|left, right| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(left)).spez_eq(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .partial_ord(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|left, right| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(left)).spez_partial_cmp(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .ord(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|left, right| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(left)).spez_cmp(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .hash(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|value, hasher_this, hasher_write_fn| {
+                            use ::facet_core::HasherProxy;
+                            use ::facet_core::spez::*;
+                            (&&Spez(value)).spez_hash(&mut unsafe {
+                                HasherProxy::new(hasher_this, hasher_write_fn)
+                            })
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .parse(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|s, target| {
+                            use ::facet_core::spez::*;
+                            let res =
+                                unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
+                            res.map(|res| unsafe { res.as_mut() })
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .build()
         };
         vtable
     };
@@ -467,335 +467,335 @@ static POINT_SHAPE: &'static crate::Shape = <Point as crate::Facet>::SHAPE;
 unsafe impl<'__facet> crate::Facet<'__facet> for Point {
     const VTABLE: &'static crate::ValueVTable = &const {
         let mut vtable = const {
-            let mut builder = ::facet_core::ValueVTable::builder::<Self>()
-                .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "Point"));
-            builder = builder.display(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|data, f| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(data)).spez_display(f)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.debug(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|data, f| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(data)).spez_debug(f)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.default_in_place(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::default::Default> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|target| unsafe {
-                        use ::facet_core::spez::*;
-                        (&&SpezEmpty::<Self>::SPEZ)
-                            .spez_default_in_place(target.into())
-                            .as_mut()
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.clone_into(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|src, dst| unsafe {
-                        use ::facet_core::spez::*;
-                        (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.marker_traits(|| {
-                let mut traits = ::facet_core::MarkerTraits::empty();
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::Eq> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::EQ);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Send> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::SEND);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Sync> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::SYNC);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Copy> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::COPY);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Unpin> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::UNPIN);
-                }
-                traits
-            });
-            builder = builder.eq(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|left, right| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(left)).spez_eq(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.partial_ord(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|left, right| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(left)).spez_partial_cmp(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.ord(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|left, right| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(left)).spez_cmp(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.hash(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|value, hasher_this, hasher_write_fn| {
-                        use ::facet_core::HasherProxy;
-                        use ::facet_core::spez::*;
-                        (&&Spez(value)).spez_hash(&mut unsafe {
-                            HasherProxy::new(hasher_this, hasher_write_fn)
+            ::facet_core::ValueVTable::builder::<Self>()
+                .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "Point"))
+                .display(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|data, f| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(data)).spez_display(f)
                         })
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.parse(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
+                    } else {
+                        None
                     }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
-                        const IMPLS: bool = true;
+                })
+                .debug(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|data, f| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(data)).spez_debug(f)
+                        })
+                    } else {
+                        None
                     }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|s, target| {
-                        use ::facet_core::spez::*;
-                        let res =
-                            unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
-                        res.map(|res| unsafe { res.as_mut() })
-                    })
-                } else {
-                    None
-                }
-            });
-            builder.build()
+                })
+                .default_in_place(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::default::Default> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|target| unsafe {
+                            use ::facet_core::spez::*;
+                            (&&SpezEmpty::<Self>::SPEZ)
+                                .spez_default_in_place(target.into())
+                                .as_mut()
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .clone_into(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|src, dst| unsafe {
+                            use ::facet_core::spez::*;
+                            (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .marker_traits(|| {
+                    let mut traits = ::facet_core::MarkerTraits::empty();
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::Eq> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::EQ);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Send> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::SEND);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Sync> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::SYNC);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Copy> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::COPY);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Unpin> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::UNPIN);
+                    }
+                    traits
+                })
+                .eq(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|left, right| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(left)).spez_eq(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .partial_ord(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|left, right| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(left)).spez_partial_cmp(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .ord(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|left, right| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(left)).spez_cmp(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .hash(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|value, hasher_this, hasher_write_fn| {
+                            use ::facet_core::HasherProxy;
+                            use ::facet_core::spez::*;
+                            (&&Spez(value)).spez_hash(&mut unsafe {
+                                HasherProxy::new(hasher_this, hasher_write_fn)
+                            })
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .parse(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|s, target| {
+                            use ::facet_core::spez::*;
+                            let res =
+                                unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
+                            res.map(|res| unsafe { res.as_mut() })
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .build()
         };
         vtable
     };
@@ -898,335 +898,335 @@ static KITCHEN_SINK_ENUM_SHAPE: &'static crate::Shape = <KitchenSinkEnum as crat
 unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkEnum {
     const VTABLE: &'static crate::ValueVTable = &const {
         const {
-            let mut builder = ::facet_core::ValueVTable::builder::<Self>()
-                .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "KitchenSinkEnum"));
-            builder = builder.display(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|data, f| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(data)).spez_display(f)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.debug(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|data, f| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(data)).spez_debug(f)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.default_in_place(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::default::Default> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|target| unsafe {
-                        use ::facet_core::spez::*;
-                        (&&SpezEmpty::<Self>::SPEZ)
-                            .spez_default_in_place(target.into())
-                            .as_mut()
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.clone_into(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|src, dst| unsafe {
-                        use ::facet_core::spez::*;
-                        (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.marker_traits(|| {
-                let mut traits = ::facet_core::MarkerTraits::empty();
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::Eq> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::EQ);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Send> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::SEND);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Sync> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::SYNC);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Copy> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::COPY);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Unpin> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::UNPIN);
-                }
-                traits
-            });
-            builder = builder.eq(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|left, right| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(left)).spez_eq(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.partial_ord(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|left, right| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(left)).spez_partial_cmp(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.ord(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|left, right| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(left)).spez_cmp(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.hash(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|value, hasher_this, hasher_write_fn| {
-                        use ::facet_core::HasherProxy;
-                        use ::facet_core::spez::*;
-                        (&&Spez(value)).spez_hash(&mut unsafe {
-                            HasherProxy::new(hasher_this, hasher_write_fn)
+            ::facet_core::ValueVTable::builder::<Self>()
+                .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "KitchenSinkEnum"))
+                .display(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|data, f| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(data)).spez_display(f)
                         })
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.parse(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
+                    } else {
+                        None
                     }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
-                        const IMPLS: bool = true;
+                })
+                .debug(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|data, f| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(data)).spez_debug(f)
+                        })
+                    } else {
+                        None
                     }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|s, target| {
-                        use ::facet_core::spez::*;
-                        let res =
-                            unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
-                        res.map(|res| unsafe { res.as_mut() })
-                    })
-                } else {
-                    None
-                }
-            });
-            builder.build()
+                })
+                .default_in_place(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::default::Default> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|target| unsafe {
+                            use ::facet_core::spez::*;
+                            (&&SpezEmpty::<Self>::SPEZ)
+                                .spez_default_in_place(target.into())
+                                .as_mut()
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .clone_into(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|src, dst| unsafe {
+                            use ::facet_core::spez::*;
+                            (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .marker_traits(|| {
+                    let mut traits = ::facet_core::MarkerTraits::empty();
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::Eq> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::EQ);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Send> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::SEND);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Sync> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::SYNC);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Copy> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::COPY);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Unpin> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::UNPIN);
+                    }
+                    traits
+                })
+                .eq(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|left, right| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(left)).spez_eq(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .partial_ord(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|left, right| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(left)).spez_partial_cmp(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .ord(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|left, right| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(left)).spez_cmp(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .hash(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|value, hasher_this, hasher_write_fn| {
+                            use ::facet_core::HasherProxy;
+                            use ::facet_core::spez::*;
+                            (&&Spez(value)).spez_hash(&mut unsafe {
+                                HasherProxy::new(hasher_this, hasher_write_fn)
+                            })
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .parse(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|s, target| {
+                            use ::facet_core::spez::*;
+                            let res =
+                                unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
+                            res.map(|res| unsafe { res.as_mut() })
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .build()
         }
     };
     const SHAPE: &'static crate::Shape<'static> = &const {
@@ -1544,335 +1544,335 @@ static SUB_ENUM_SHAPE: &'static crate::Shape = <SubEnum as crate::Facet>::SHAPE;
 unsafe impl<'__facet> crate::Facet<'__facet> for SubEnum {
     const VTABLE: &'static crate::ValueVTable = &const {
         const {
-            let mut builder = ::facet_core::ValueVTable::builder::<Self>()
-                .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "SubEnum"));
-            builder = builder.display(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|data, f| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(data)).spez_display(f)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.debug(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|data, f| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(data)).spez_debug(f)
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.default_in_place(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::default::Default> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|target| unsafe {
-                        use ::facet_core::spez::*;
-                        (&&SpezEmpty::<Self>::SPEZ)
-                            .spez_default_in_place(target.into())
-                            .as_mut()
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.clone_into(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|src, dst| unsafe {
-                        use ::facet_core::spez::*;
-                        (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.marker_traits(|| {
-                let mut traits = ::facet_core::MarkerTraits::empty();
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::Eq> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::EQ);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Send> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::SEND);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Sync> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::SYNC);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Copy> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::COPY);
-                }
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::marker::Unpin> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    traits = traits.union(::facet_core::MarkerTraits::UNPIN);
-                }
-                traits
-            });
-            builder = builder.eq(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|left, right| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(left)).spez_eq(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.partial_ord(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|left, right| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(left)).spez_partial_cmp(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.ord(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|left, right| {
-                        use ::facet_core::spez::*;
-                        (&&Spez(left)).spez_cmp(&&Spez(right))
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.hash(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
-                    }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
-                        const IMPLS: bool = true;
-                    }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|value, hasher_this, hasher_write_fn| {
-                        use ::facet_core::HasherProxy;
-                        use ::facet_core::spez::*;
-                        (&&Spez(value)).spez_hash(&mut unsafe {
-                            HasherProxy::new(hasher_this, hasher_write_fn)
+            ::facet_core::ValueVTable::builder::<Self>()
+                .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "SubEnum"))
+                .display(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|data, f| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(data)).spez_display(f)
                         })
-                    })
-                } else {
-                    None
-                }
-            });
-            builder = builder.parse(|| {
-                if {
-                    /// Fallback trait with `False` for `IMPLS` if the type does not
-                    /// implement the given trait.
-                    trait DoesNotImpl {
-                        const IMPLS: bool = false;
+                    } else {
+                        None
                     }
-                    impl<T: ?Sized> DoesNotImpl for T {}
-                    /// Concrete type with `True` for `IMPLS` if the type implements the
-                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                    #[allow(dead_code)]
-                    impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
-                        const IMPLS: bool = true;
+                })
+                .debug(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|data, f| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(data)).spez_debug(f)
+                        })
+                    } else {
+                        None
                     }
-                    <Wrapper<Self>>::IMPLS
-                } {
-                    Some(|s, target| {
-                        use ::facet_core::spez::*;
-                        let res =
-                            unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
-                        res.map(|res| unsafe { res.as_mut() })
-                    })
-                } else {
-                    None
-                }
-            });
-            builder.build()
+                })
+                .default_in_place(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::default::Default> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|target| unsafe {
+                            use ::facet_core::spez::*;
+                            (&&SpezEmpty::<Self>::SPEZ)
+                                .spez_default_in_place(target.into())
+                                .as_mut()
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .clone_into(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|src, dst| unsafe {
+                            use ::facet_core::spez::*;
+                            (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .marker_traits(|| {
+                    let mut traits = ::facet_core::MarkerTraits::empty();
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::Eq> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::EQ);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Send> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::SEND);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Sync> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::SYNC);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Copy> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::COPY);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::marker::Unpin> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::UNPIN);
+                    }
+                    traits
+                })
+                .eq(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|left, right| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(left)).spez_eq(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .partial_ord(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|left, right| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(left)).spez_partial_cmp(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .ord(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|left, right| {
+                            use ::facet_core::spez::*;
+                            (&&Spez(left)).spez_cmp(&&Spez(right))
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .hash(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|value, hasher_this, hasher_write_fn| {
+                            use ::facet_core::HasherProxy;
+                            use ::facet_core::spez::*;
+                            (&&Spez(value)).spez_hash(&mut unsafe {
+                                HasherProxy::new(hasher_this, hasher_write_fn)
+                            })
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .parse(|| {
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        Some(|s, target| {
+                            use ::facet_core::spez::*;
+                            let res =
+                                unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
+                            res.map(|res| unsafe { res.as_mut() })
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .build()
         }
     };
     const SHAPE: &'static crate::Shape<'static> = &const {

--- a/facet/src/sample_generated_code.rs
+++ b/facet/src/sample_generated_code.rs
@@ -32,93 +32,109 @@ unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkStruct {
         let mut vtable = const {
             let mut builder = ::facet_core::ValueVTable::builder::<Self>()
                 .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "KitchenSinkStruct"));
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            builder = builder.display(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|data, f| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(data)).spez_display(f)
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.debug(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|data, f| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(data)).spez_debug(f)
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.display(|data, f| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(data)).spez_display(f)
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            });
+            builder = builder.default_in_place(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::default::Default> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|target| unsafe {
+                        use ::facet_core::spez::*;
+                        (&&SpezEmpty::<Self>::SPEZ)
+                            .spez_default_in_place(target.into())
+                            .as_mut()
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.clone_into(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|src, dst| unsafe {
+                        use ::facet_core::spez::*;
+                        (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.debug(|data, f| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(data)).spez_debug(f)
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::default::Default> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.default_in_place(|target| unsafe {
-                    use ::facet_core::spez::*;
-                    (&&SpezEmpty::<Self>::SPEZ)
-                        .spez_default_in_place(target.into())
-                        .as_mut()
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.clone_into(|src, dst| unsafe {
-                    use ::facet_core::spez::*;
-                    (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
-                });
-            }
-            {
+            });
+            builder = builder.marker_traits(|| {
                 let mut traits = ::facet_core::MarkerTraits::empty();
                 if {
                     /// Fallback trait with `False` for `IMPLS` if the type does not
@@ -210,116 +226,138 @@ unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkStruct {
                 } {
                     traits = traits.union(::facet_core::MarkerTraits::UNPIN);
                 }
-                builder = builder.marker_traits(traits);
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+                traits
+            });
+            builder = builder.eq(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|left, right| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(left)).spez_eq(&&Spez(right))
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.partial_ord(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|left, right| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(left)).spez_partial_cmp(&&Spez(right))
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.eq(|left, right| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(left)).spez_eq(&&Spez(right))
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            });
+            builder = builder.ord(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|left, right| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(left)).spez_cmp(&&Spez(right))
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.hash(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|value, hasher_this, hasher_write_fn| {
+                        use ::facet_core::HasherProxy;
+                        use ::facet_core::spez::*;
+                        (&&Spez(value)).spez_hash(&mut unsafe {
+                            HasherProxy::new(hasher_this, hasher_write_fn)
+                        })
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.partial_ord(|left, right| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(left)).spez_partial_cmp(&&Spez(right))
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            });
+            builder = builder.parse(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|s, target| {
+                        use ::facet_core::spez::*;
+                        let res =
+                            unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
+                        res.map(|res| unsafe { res.as_mut() })
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.ord(|left, right| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(left)).spez_cmp(&&Spez(right))
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.hash(|value, hasher_this, hasher_write_fn| {
-                    use ::facet_core::HasherProxy;
-                    use ::facet_core::spez::*;
-                    (&&Spez(value))
-                        .spez_hash(&mut unsafe { HasherProxy::new(hasher_this, hasher_write_fn) })
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.parse(|s, target| {
-                    use ::facet_core::spez::*;
-                    let res = unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
-                    res.map(|res| unsafe { res.as_mut() })
-                });
-            }
+            });
             builder.build()
         };
         vtable
@@ -431,93 +469,109 @@ unsafe impl<'__facet> crate::Facet<'__facet> for Point {
         let mut vtable = const {
             let mut builder = ::facet_core::ValueVTable::builder::<Self>()
                 .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "Point"));
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            builder = builder.display(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|data, f| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(data)).spez_display(f)
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.debug(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|data, f| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(data)).spez_debug(f)
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.display(|data, f| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(data)).spez_display(f)
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            });
+            builder = builder.default_in_place(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::default::Default> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|target| unsafe {
+                        use ::facet_core::spez::*;
+                        (&&SpezEmpty::<Self>::SPEZ)
+                            .spez_default_in_place(target.into())
+                            .as_mut()
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.clone_into(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|src, dst| unsafe {
+                        use ::facet_core::spez::*;
+                        (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.debug(|data, f| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(data)).spez_debug(f)
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::default::Default> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.default_in_place(|target| unsafe {
-                    use ::facet_core::spez::*;
-                    (&&SpezEmpty::<Self>::SPEZ)
-                        .spez_default_in_place(target.into())
-                        .as_mut()
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.clone_into(|src, dst| unsafe {
-                    use ::facet_core::spez::*;
-                    (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
-                });
-            }
-            {
+            });
+            builder = builder.marker_traits(|| {
                 let mut traits = ::facet_core::MarkerTraits::empty();
                 if {
                     /// Fallback trait with `False` for `IMPLS` if the type does not
@@ -609,116 +663,138 @@ unsafe impl<'__facet> crate::Facet<'__facet> for Point {
                 } {
                     traits = traits.union(::facet_core::MarkerTraits::UNPIN);
                 }
-                builder = builder.marker_traits(traits);
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+                traits
+            });
+            builder = builder.eq(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|left, right| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(left)).spez_eq(&&Spez(right))
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.partial_ord(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|left, right| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(left)).spez_partial_cmp(&&Spez(right))
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.eq(|left, right| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(left)).spez_eq(&&Spez(right))
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            });
+            builder = builder.ord(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|left, right| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(left)).spez_cmp(&&Spez(right))
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.hash(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|value, hasher_this, hasher_write_fn| {
+                        use ::facet_core::HasherProxy;
+                        use ::facet_core::spez::*;
+                        (&&Spez(value)).spez_hash(&mut unsafe {
+                            HasherProxy::new(hasher_this, hasher_write_fn)
+                        })
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.partial_ord(|left, right| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(left)).spez_partial_cmp(&&Spez(right))
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            });
+            builder = builder.parse(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|s, target| {
+                        use ::facet_core::spez::*;
+                        let res =
+                            unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
+                        res.map(|res| unsafe { res.as_mut() })
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.ord(|left, right| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(left)).spez_cmp(&&Spez(right))
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.hash(|value, hasher_this, hasher_write_fn| {
-                    use ::facet_core::HasherProxy;
-                    use ::facet_core::spez::*;
-                    (&&Spez(value))
-                        .spez_hash(&mut unsafe { HasherProxy::new(hasher_this, hasher_write_fn) })
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.parse(|s, target| {
-                    use ::facet_core::spez::*;
-                    let res = unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
-                    res.map(|res| unsafe { res.as_mut() })
-                });
-            }
+            });
             builder.build()
         };
         vtable
@@ -824,93 +900,109 @@ unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkEnum {
         const {
             let mut builder = ::facet_core::ValueVTable::builder::<Self>()
                 .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "KitchenSinkEnum"));
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            builder = builder.display(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|data, f| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(data)).spez_display(f)
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.debug(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|data, f| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(data)).spez_debug(f)
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.display(|data, f| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(data)).spez_display(f)
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            });
+            builder = builder.default_in_place(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::default::Default> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|target| unsafe {
+                        use ::facet_core::spez::*;
+                        (&&SpezEmpty::<Self>::SPEZ)
+                            .spez_default_in_place(target.into())
+                            .as_mut()
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.clone_into(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|src, dst| unsafe {
+                        use ::facet_core::spez::*;
+                        (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.debug(|data, f| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(data)).spez_debug(f)
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::default::Default> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.default_in_place(|target| unsafe {
-                    use ::facet_core::spez::*;
-                    (&&SpezEmpty::<Self>::SPEZ)
-                        .spez_default_in_place(target.into())
-                        .as_mut()
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.clone_into(|src, dst| unsafe {
-                    use ::facet_core::spez::*;
-                    (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
-                });
-            }
-            {
+            });
+            builder = builder.marker_traits(|| {
                 let mut traits = ::facet_core::MarkerTraits::empty();
                 if {
                     /// Fallback trait with `False` for `IMPLS` if the type does not
@@ -1002,116 +1094,138 @@ unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkEnum {
                 } {
                     traits = traits.union(::facet_core::MarkerTraits::UNPIN);
                 }
-                builder = builder.marker_traits(traits);
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+                traits
+            });
+            builder = builder.eq(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|left, right| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(left)).spez_eq(&&Spez(right))
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.partial_ord(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|left, right| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(left)).spez_partial_cmp(&&Spez(right))
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.eq(|left, right| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(left)).spez_eq(&&Spez(right))
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            });
+            builder = builder.ord(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|left, right| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(left)).spez_cmp(&&Spez(right))
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.hash(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|value, hasher_this, hasher_write_fn| {
+                        use ::facet_core::HasherProxy;
+                        use ::facet_core::spez::*;
+                        (&&Spez(value)).spez_hash(&mut unsafe {
+                            HasherProxy::new(hasher_this, hasher_write_fn)
+                        })
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.partial_ord(|left, right| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(left)).spez_partial_cmp(&&Spez(right))
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            });
+            builder = builder.parse(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|s, target| {
+                        use ::facet_core::spez::*;
+                        let res =
+                            unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
+                        res.map(|res| unsafe { res.as_mut() })
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.ord(|left, right| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(left)).spez_cmp(&&Spez(right))
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.hash(|value, hasher_this, hasher_write_fn| {
-                    use ::facet_core::HasherProxy;
-                    use ::facet_core::spez::*;
-                    (&&Spez(value))
-                        .spez_hash(&mut unsafe { HasherProxy::new(hasher_this, hasher_write_fn) })
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.parse(|s, target| {
-                    use ::facet_core::spez::*;
-                    let res = unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
-                    res.map(|res| unsafe { res.as_mut() })
-                });
-            }
+            });
             builder.build()
         }
     };
@@ -1432,93 +1546,109 @@ unsafe impl<'__facet> crate::Facet<'__facet> for SubEnum {
         const {
             let mut builder = ::facet_core::ValueVTable::builder::<Self>()
                 .type_name(|f, _opts| ::core::fmt::Write::write_str(f, "SubEnum"));
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            builder = builder.display(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|data, f| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(data)).spez_display(f)
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::fmt::Display> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.debug(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|data, f| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(data)).spez_debug(f)
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.display(|data, f| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(data)).spez_display(f)
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            });
+            builder = builder.default_in_place(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::default::Default> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|target| unsafe {
+                        use ::facet_core::spez::*;
+                        (&&SpezEmpty::<Self>::SPEZ)
+                            .spez_default_in_place(target.into())
+                            .as_mut()
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::fmt::Debug> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.clone_into(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|src, dst| unsafe {
+                        use ::facet_core::spez::*;
+                        (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.debug(|data, f| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(data)).spez_debug(f)
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::default::Default> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.default_in_place(|target| unsafe {
-                    use ::facet_core::spez::*;
-                    (&&SpezEmpty::<Self>::SPEZ)
-                        .spez_default_in_place(target.into())
-                        .as_mut()
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::clone::Clone> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.clone_into(|src, dst| unsafe {
-                    use ::facet_core::spez::*;
-                    (&&Spez(src)).spez_clone_into(dst.into()).as_mut()
-                });
-            }
-            {
+            });
+            builder = builder.marker_traits(|| {
                 let mut traits = ::facet_core::MarkerTraits::empty();
                 if {
                     /// Fallback trait with `False` for `IMPLS` if the type does not
@@ -1610,116 +1740,138 @@ unsafe impl<'__facet> crate::Facet<'__facet> for SubEnum {
                 } {
                     traits = traits.union(::facet_core::MarkerTraits::UNPIN);
                 }
-                builder = builder.marker_traits(traits);
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+                traits
+            });
+            builder = builder.eq(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|left, right| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(left)).spez_eq(&&Spez(right))
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::cmp::PartialEq> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.partial_ord(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|left, right| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(left)).spez_partial_cmp(&&Spez(right))
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.eq(|left, right| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(left)).spez_eq(&&Spez(right))
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            });
+            builder = builder.ord(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|left, right| {
+                        use ::facet_core::spez::*;
+                        (&&Spez(left)).spez_cmp(&&Spez(right))
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::cmp::PartialOrd> Wrapper<T> {
-                    const IMPLS: bool = true;
+            });
+            builder = builder.hash(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|value, hasher_this, hasher_write_fn| {
+                        use ::facet_core::HasherProxy;
+                        use ::facet_core::spez::*;
+                        (&&Spez(value)).spez_hash(&mut unsafe {
+                            HasherProxy::new(hasher_this, hasher_write_fn)
+                        })
+                    })
+                } else {
+                    None
                 }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.partial_ord(|left, right| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(left)).spez_partial_cmp(&&Spez(right))
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
+            });
+            builder = builder.parse(|| {
+                if {
+                    /// Fallback trait with `False` for `IMPLS` if the type does not
+                    /// implement the given trait.
+                    trait DoesNotImpl {
+                        const IMPLS: bool = false;
+                    }
+                    impl<T: ?Sized> DoesNotImpl for T {}
+                    /// Concrete type with `True` for `IMPLS` if the type implements the
+                    /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                    struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                    #[allow(dead_code)]
+                    impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
+                        const IMPLS: bool = true;
+                    }
+                    <Wrapper<Self>>::IMPLS
+                } {
+                    Some(|s, target| {
+                        use ::facet_core::spez::*;
+                        let res =
+                            unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
+                        res.map(|res| unsafe { res.as_mut() })
+                    })
+                } else {
+                    None
                 }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::cmp::Ord> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.ord(|left, right| {
-                    use ::facet_core::spez::*;
-                    (&&Spez(left)).spez_cmp(&&Spez(right))
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::hash::Hash> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.hash(|value, hasher_this, hasher_write_fn| {
-                    use ::facet_core::HasherProxy;
-                    use ::facet_core::spez::*;
-                    (&&Spez(value))
-                        .spez_hash(&mut unsafe { HasherProxy::new(hasher_this, hasher_write_fn) })
-                });
-            }
-            if {
-                /// Fallback trait with `False` for `IMPLS` if the type does not
-                /// implement the given trait.
-                trait DoesNotImpl {
-                    const IMPLS: bool = false;
-                }
-                impl<T: ?Sized> DoesNotImpl for T {}
-                /// Concrete type with `True` for `IMPLS` if the type implements the
-                /// given trait. Otherwise, it falls back to `DoesNotImpl`.
-                struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
-                #[allow(dead_code)]
-                impl<T: ?Sized + core::str::FromStr> Wrapper<T> {
-                    const IMPLS: bool = true;
-                }
-                <Wrapper<Self>>::IMPLS
-            } {
-                builder = builder.parse(|s, target| {
-                    use ::facet_core::spez::*;
-                    let res = unsafe { (&&SpezEmpty::<Self>::SPEZ).spez_parse(s, target.into()) };
-                    res.map(|res| unsafe { res.as_mut() })
-                });
-            }
+            });
             builder.build()
         }
     };

--- a/facet/tests/cycle.rs
+++ b/facet/tests/cycle.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 #[derive(Facet)]
 struct Recursive {
     next: Option<Arc<Recursive>>,
+    others: Vec<Recursive>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Closes #644

This PR updates all of the optional functions in `VTableValue` to use an extra layer of indirection (e.g. replacing `debug: Option<DebugFn>` with `debug: fn() -> Option<DebugFn>`). Also, the marker traits were given the same treatment: the vtable now stores `marker_traits: fn() -> MarkerTraits`

This extra layer of indirection is required to support cyclic types. There are a lot of types that opt-in to optional functions or marker traits depending on if its generic parameter(s) implement the function/trait

This does give up some const-ness. It's no longer possible to determine which traits a shape implements within a `const` context, even marker traits...