### PR TITLE
Add `Shape.type_identifier` to access type name in const contexts

### DIFF
--- a/facet-core/src/impls_alloc/arc.rs
+++ b/facet-core/src/impls_alloc/arc.rs
@@ -137,7 +137,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::sync::Arc<T> {
         }
 
         let mut vtable = value_vtable!(alloc::sync::Arc<T>, |f, opts| {
-            write!(f, "Arc")?;
+            write!(f, "{}", Self::SHAPE.type_identifier)?;
             if let Some(opts) = opts.for_children() {
                 write!(f, "<")?;
                 (T::SHAPE.vtable.type_name)(f, opts)?;
@@ -161,6 +161,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::sync::Arc<T> {
         }
 
         crate::Shape::builder_for_sized::<Self>()
+            .type_identifier("Arc")
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,
@@ -243,7 +244,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::sync::Arc<T> {
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::sync::Weak<T> {
     const VTABLE: &'static ValueVTable = &const {
         value_vtable!(alloc::sync::Weak<T>, |f, opts| {
-            write!(f, "Weak")?;
+            write!(f, "{}", Self::SHAPE.type_identifier)?;
             if let Some(opts) = opts.for_children() {
                 write!(f, "<")?;
                 (T::SHAPE.vtable.type_name)(f, opts)?;
@@ -262,6 +263,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::sync::Weak<T> {
         }
 
         crate::Shape::builder_for_sized::<Self>()
+            .type_identifier("Weak")
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_alloc/boxed.rs
+++ b/facet-core/src/impls_alloc/boxed.rs
@@ -39,7 +39,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::boxed::Box<T> {
         }
 
         let mut vtable = value_vtable!(alloc::boxed::Box<T>, |f, opts| {
-            write!(f, "Box")?;
+            write!(f, "{}", Self::SHAPE.type_identifier)?;
             if let Some(opts) = opts.for_children() {
                 write!(f, "<")?;
                 (T::SHAPE.vtable.type_name)(f, opts)?;
@@ -62,6 +62,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::boxed::Box<T> {
         }
 
         crate::Shape::builder_for_sized::<Self>()
+            .type_identifier("Box")
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_alloc/btreemap.rs
+++ b/facet-core/src/impls_alloc/btreemap.rs
@@ -28,7 +28,7 @@ where
             })
             .type_name(|f, opts| {
                 if let Some(opts) = opts.for_children() {
-                    write!(f, "BTreeMap<")?;
+                    write!(f, "{}<", Self::SHAPE.type_identifier)?;
                     (K::SHAPE.vtable.type_name)(f, opts)?;
                     write!(f, ", ")?;
                     (V::SHAPE.vtable.type_name)(f, opts)?;
@@ -127,6 +127,7 @@ where
 
     const SHAPE: &'static crate::Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("BTreeMap")
             .type_params(&[
                 crate::TypeParam {
                     name: "K",

--- a/facet-core/src/impls_alloc/btreeset.rs
+++ b/facet-core/src/impls_alloc/btreeset.rs
@@ -27,11 +27,11 @@ where
             })
             .type_name(|f, opts| {
                 if let Some(opts) = opts.for_children() {
-                    write!(f, "BTreeSet<")?;
+                    write!(f, "{}<", Self::SHAPE.type_identifier)?;
                     (T::SHAPE.vtable.type_name)(f, opts)?;
                     write!(f, ">")
                 } else {
-                    write!(f, "BTreeSet<⋯>")
+                    write!(f, "{}<⋯>", Self::SHAPE.type_identifier)
                 }
             })
             .default_in_place(|| Some(|target| unsafe { target.put(Self::default()) }))
@@ -99,6 +99,7 @@ where
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("BTreeSet")
             .type_params(&[TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_alloc/rc.rs
+++ b/facet-core/src/impls_alloc/rc.rs
@@ -42,7 +42,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::rc::Rc<T> {
         }
 
         let mut vtable = value_vtable!(alloc::rc::Rc<T>, |f, opts| {
-            write!(f, "Rc")?;
+            write!(f, "{}", Self::SHAPE.type_identifier)?;
             if let Some(opts) = opts.for_children() {
                 write!(f, "<")?;
                 (T::SHAPE.vtable.type_name)(f, opts)?;
@@ -65,6 +65,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::rc::Rc<T> {
         }
 
         crate::Shape::builder_for_sized::<Self>()
+            .type_identifier("Rc")
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,
@@ -104,7 +105,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::rc::Rc<T> {
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::rc::Weak<T> {
     const VTABLE: &'static ValueVTable = &const {
         value_vtable!(alloc::rc::Weak<T>, |f, opts| {
-            write!(f, "Weak")?;
+            write!(f, "{}", Self::SHAPE.type_identifier)?;
             if let Some(opts) = opts.for_children() {
                 write!(f, "<")?;
                 (T::SHAPE.vtable.type_name)(f, opts)?;
@@ -123,6 +124,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for alloc::rc::Weak<T> {
         }
 
         crate::Shape::builder_for_sized::<Self>()
+            .type_identifier("Weak")
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_alloc/string.rs
+++ b/facet-core/src/impls_alloc/string.rs
@@ -4,8 +4,13 @@ use crate::{
 
 #[cfg(feature = "alloc")]
 unsafe impl Facet<'_> for alloc::string::String {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable!(alloc::string::String, |f, _opts| write!(f, "String")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable!(alloc::string::String, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
@@ -15,6 +20,7 @@ unsafe impl Facet<'_> for alloc::string::String {
                     .affinity(&const { ScalarAffinity::string().max_inline_length(0).build() })
                     .build(),
             ))
+            .type_identifier("String")
             .ty(Type::User(UserType::Opaque))
             .build()
     };
@@ -35,6 +41,7 @@ unsafe impl<'a> Facet<'a> for alloc::borrow::Cow<'a, str> {
                     .affinity(&const { ScalarAffinity::string().build() })
                     .build(),
             ))
+            .type_identifier("Cow")
             .ty(Type::User(UserType::Opaque))
             .build()
     };

--- a/facet-core/src/impls_alloc/vec.rs
+++ b/facet-core/src/impls_alloc/vec.rs
@@ -14,11 +14,11 @@ where
         ValueVTable::builder::<Self>()
             .type_name(|f, opts| {
                 if let Some(opts) = opts.for_children() {
-                    write!(f, "Vec<")?;
+                    write!(f, "{}<", Self::SHAPE.type_identifier)?;
                     (T::SHAPE.vtable.type_name)(f, opts)?;
                     write!(f, ">")
                 } else {
-                    write!(f, "Vec<⋯>")
+                    write!(f, "{}<⋯>", Self::SHAPE.type_identifier)
                 }
             })
             .default_in_place(|| Some(|target| unsafe { target.put(Self::default()) }))
@@ -107,6 +107,7 @@ where
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("Vec")
             .type_params(&[TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_bytes.rs
+++ b/facet-core/src/impls_bytes.rs
@@ -11,7 +11,11 @@ type BytesIterator<'mem> = core::slice::Iter<'mem, u8>;
 
 unsafe impl Facet<'_> for Bytes {
     const VTABLE: &'static ValueVTable = &const {
-        let mut vtable = value_vtable!(Bytes, |f, _opts| write!(f, "Bytes"));
+        let mut vtable = value_vtable!(Bytes, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ));
         vtable.try_from = || {
             Some(
                 |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
@@ -35,6 +39,7 @@ unsafe impl Facet<'_> for Bytes {
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
             .ty(Type::User(UserType::Opaque))
+            .type_identifier("Bytes")
             .inner(|| BytesMut::SHAPE)
             .def(Def::List(
                 ListDef::builder()
@@ -89,11 +94,17 @@ unsafe impl Facet<'_> for Bytes {
 }
 
 unsafe impl Facet<'_> for BytesMut {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable!(BytesMut, |f, _opts| write!(f, "BytesMut")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable!(BytesMut, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("BytesMut")
             .ty(Type::User(UserType::Opaque))
             .def(Def::List(
                 ListDef::builder()

--- a/facet-core/src/impls_camino.rs
+++ b/facet-core/src/impls_camino.rs
@@ -34,7 +34,11 @@ unsafe impl Facet<'_> for Utf8PathBuf {
             Ok(unsafe { dst.put(path.into_string()) })
         }
 
-        let mut vtable = value_vtable!(Utf8PathBuf, |f, _opts| write!(f, "Utf8PathBuf"));
+        let mut vtable = value_vtable!(Utf8PathBuf, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ));
         vtable.parse = || Some(|s, target| Ok(unsafe { target.put(Utf8Path::new(s).to_owned()) }));
         vtable.try_from = || Some(try_from);
         vtable.try_into_inner = || Some(try_into_inner);
@@ -48,6 +52,7 @@ unsafe impl Facet<'_> for Utf8PathBuf {
         }
 
         Shape::builder_for_sized::<Self>()
+            .type_identifier("Utf8PathBuf")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()
@@ -78,13 +83,18 @@ unsafe impl Facet<'_> for Utf8Path {
             Ok(unsafe { dst.put(path) })
         }
 
-        let mut vtable = value_vtable_unsized!(Utf8Path, |f, _opts| write!(f, "Utf8Path"));
+        let mut vtable = value_vtable_unsized!(Utf8Path, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ));
         vtable.try_from = || Some(try_from);
         vtable
     };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_unsized::<Self>()
+            .type_identifier("Utf8Path")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()

--- a/facet-core/src/impls_core/array.rs
+++ b/facet-core/src/impls_core/array.rs
@@ -155,6 +155,7 @@ where
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("&[_; _]")
             .type_params(&[TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_core/fn_ptr.rs
+++ b/facet-core/src/impls_core/fn_ptr.rs
@@ -98,6 +98,7 @@ macro_rules! impl_facet_for_fn_ptr {
 
             const SHAPE: &'static Shape<'static> = &const {
                 Shape::builder_for_sized::<Self>()
+                    .type_identifier("fn")
                     .type_params(&[
                         $(TypeParam { name: stringify!($args), shape: || $args::SHAPE },)*
                     ])

--- a/facet-core/src/impls_core/ops.rs
+++ b/facet-core/src/impls_core/ops.rs
@@ -4,6 +4,7 @@ use core::{alloc::Layout, mem};
 unsafe impl<'a, Idx: Facet<'a>> Facet<'a> for core::ops::Range<Idx> {
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("Range")
             .type_params(&[crate::TypeParam {
                 name: "Idx",
                 shape: || Idx::SHAPE,
@@ -38,7 +39,7 @@ unsafe impl<'a, Idx: Facet<'a>> Facet<'a> for core::ops::Range<Idx> {
     const VTABLE: &'static ValueVTable = &const {
         ValueVTable::builder::<Self>()
             .type_name(|f, opts| {
-                write!(f, "Range")?;
+                write!(f, "{}", Self::SHAPE.type_identifier)?;
                 if let Some(opts) = opts.for_children() {
                     write!(f, "<")?;
                     (Idx::SHAPE.vtable.type_name)(f, opts)?;

--- a/facet-core/src/impls_core/option.rs
+++ b/facet-core/src/impls_core/option.rs
@@ -47,7 +47,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Option<T> {
         }
 
         let mut vtable = value_vtable!(core::option::Option<T>, |f, opts| {
-            write!(f, "Option")?;
+            write!(f, "{}", Self::SHAPE.type_identifier)?;
             if let Some(opts) = opts.for_children() {
                 write!(f, "<")?;
                 (T::SHAPE.vtable.type_name)(f, opts)?;
@@ -107,6 +107,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Option<T> {
         }
 
         Shape::builder_for_sized::<Self>()
+            .type_identifier("Option")
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_core/pointer.rs
+++ b/facet-core/src/impls_core/pointer.rs
@@ -48,6 +48,20 @@ macro_rules! impl_facet_for_pointer {
 
             const SHAPE: &'static Shape<'static> = &const {
                 $shape
+                    .type_identifier(
+                        const {
+                            let ptr_type = stringify!($ptr_type);
+                            let is_raw = ptr_type.len() == 3
+                                && ptr_type.as_bytes()[0] == b'R'
+                                && ptr_type.as_bytes()[1] == b'a'
+                                && ptr_type.as_bytes()[2] == b'w';
+                            if is_raw {
+                                if $mutable { "*mut _" } else { "*const _" }
+                            } else {
+                                if $mutable { "&mut _" } else { "&_" }
+                            }
+                        },
+                    )
                     .type_params(&[TypeParam {
                         name: "T",
                         shape: || T::SHAPE,

--- a/facet-core/src/impls_core/scalar.rs
+++ b/facet-core/src/impls_core/scalar.rs
@@ -4,11 +4,17 @@ use core::num::NonZero;
 use typeid::ConstTypeId;
 
 unsafe impl Facet<'_> for ConstTypeId {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable!(ConstTypeId, |f, _opts| write!(f, "ConstTypeId")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable!(ConstTypeId, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("ConstTypeId")
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(&const { ScalarAffinity::opaque().build() })
@@ -24,11 +30,17 @@ unsafe impl Facet<'_> for ConstTypeId {
 }
 
 unsafe impl Facet<'_> for core::any::TypeId {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable!(core::any::TypeId, |f, _opts| write!(f, "TypeId")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable!(core::any::TypeId, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("TypeId")
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(&const { ScalarAffinity::opaque().build() })
@@ -44,6 +56,7 @@ unsafe impl Facet<'_> for () {
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("()")
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(&const { ScalarAffinity::empty().build() })
@@ -59,10 +72,11 @@ unsafe impl Facet<'_> for () {
 unsafe impl<'a, T: ?Sized + 'a> Facet<'a> for core::marker::PhantomData<T> {
     // TODO: we might be able to do something with specialization re: the shape of T?
     const VTABLE: &'static ValueVTable =
-        &const { value_vtable!((), |f, _opts| write!(f, "PhantomData")) };
+        &const { value_vtable!((), |f, _opts| write!(f, "{}", Self::SHAPE.type_identifier)) };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("PhantomData")
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(&const { ScalarAffinity::empty().build() })
@@ -78,11 +92,17 @@ unsafe impl<'a, T: ?Sized + 'a> Facet<'a> for core::marker::PhantomData<T> {
 }
 
 unsafe impl Facet<'_> for char {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable!(char, |f, _opts| write!(f, "char")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable!(char, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("char")
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(&const { ScalarAffinity::char().build() })
@@ -94,11 +114,13 @@ unsafe impl Facet<'_> for char {
 }
 
 unsafe impl Facet<'_> for str {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable_unsized!(str, |f, _opts| write!(f, "str")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable_unsized!(str, |f, _opts| write!(f, "{}", Self::SHAPE.type_identifier))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_unsized::<Self>()
+            .type_identifier("str")
             .ty(Type::Primitive(PrimitiveType::Textual(TextualType::Str)))
             .def(Def::Scalar(
                 ScalarDef::builder()
@@ -110,11 +132,17 @@ unsafe impl Facet<'_> for str {
 }
 
 unsafe impl Facet<'_> for bool {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable!(bool, |f, _opts| write!(f, "bool")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable!(bool, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("bool")
             .def(Def::Scalar(
                 ScalarDef::builder()
                     .affinity(&const { ScalarAffinity::boolean().build() })
@@ -129,8 +157,11 @@ macro_rules! impl_facet_for_integer {
     ($type:ty, $affinity:expr, $nz_affinity:expr) => {
         unsafe impl<'a> Facet<'a> for $type {
             const VTABLE: &'static ValueVTable = &const {
-                let mut vtable =
-                    value_vtable!($type, |f, _opts| write!(f, "{}", stringify!($type)));
+                let mut vtable = value_vtable!($type, |f, _opts| write!(
+                    f,
+                    "{}",
+                    Self::SHAPE.type_identifier
+                ));
 
                 vtable.try_from = || {
                     Some(|source, source_shape, dest| {
@@ -283,6 +314,7 @@ macro_rules! impl_facet_for_integer {
 
             const SHAPE: &'static Shape<'static> = &const {
                 Shape::builder_for_sized::<Self>()
+                    .type_identifier(stringify!($type))
                     .ty(Type::Primitive(PrimitiveType::Numeric(
                         NumericType::Integer {
                             signed: (1 as $type).checked_neg().is_some(),
@@ -356,7 +388,8 @@ macro_rules! impl_facet_for_integer {
 
                 let mut vtable = value_vtable!($type, |f, _opts| write!(
                     f,
-                    "NonZero<{}>",
+                    "{}<{}>",
+                    Self::SHAPE.type_identifier,
                     stringify!($type)
                 ));
 
@@ -375,6 +408,7 @@ macro_rules! impl_facet_for_integer {
                 }
 
                 Shape::builder_for_sized::<Self>()
+                    .type_identifier("NonZero")
                     .def(Def::Scalar(
                         ScalarDef::builder().affinity($nz_affinity).build(),
                     ))
@@ -696,7 +730,8 @@ static EPSILON_F64: f64 = f64::EPSILON;
 
 unsafe impl Facet<'_> for f32 {
     const VTABLE: &'static ValueVTable = &const {
-        let mut vtable = value_vtable!(f32, |f, _opts| write!(f, "f32"));
+        let mut vtable =
+            value_vtable!(f32, |f, _opts| write!(f, "{}", Self::SHAPE.type_identifier));
 
         vtable.try_from = || {
             Some(|source, source_shape, dest| {
@@ -730,6 +765,7 @@ unsafe impl Facet<'_> for f32 {
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("f32")
             .ty(Type::Primitive(PrimitiveType::Numeric(NumericType::Float)))
             .def(Def::Scalar(
                 ScalarDef::builder()
@@ -756,7 +792,8 @@ unsafe impl Facet<'_> for f32 {
 
 unsafe impl Facet<'_> for f64 {
     const VTABLE: &'static ValueVTable = &const {
-        let mut vtable = value_vtable!(f64, |f, _opts| write!(f, "f64"));
+        let mut vtable =
+            value_vtable!(f64, |f, _opts| write!(f, "{}", Self::SHAPE.type_identifier));
 
         vtable.try_from = || {
             Some(|source, source_shape, dest| {
@@ -790,6 +827,7 @@ unsafe impl Facet<'_> for f64 {
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("f64")
             .ty(Type::Primitive(PrimitiveType::Numeric(NumericType::Float)))
             .def(Def::Scalar(
                 ScalarDef::builder()
@@ -815,11 +853,17 @@ unsafe impl Facet<'_> for f64 {
 }
 
 unsafe impl Facet<'_> for core::net::SocketAddr {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable!(core::net::SocketAddr, |f, _opts| write!(f, "SocketAddr")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable!(core::net::SocketAddr, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("SocketAddr")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()
@@ -831,11 +875,17 @@ unsafe impl Facet<'_> for core::net::SocketAddr {
 }
 
 unsafe impl Facet<'_> for core::net::IpAddr {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable!(core::net::IpAddr, |f, _opts| write!(f, "IpAddr")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable!(core::net::IpAddr, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("IpAddr")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()
@@ -847,11 +897,17 @@ unsafe impl Facet<'_> for core::net::IpAddr {
 }
 
 unsafe impl Facet<'_> for core::net::Ipv4Addr {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable!(core::net::Ipv4Addr, |f, _opts| write!(f, "Ipv4Addr")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable!(core::net::Ipv4Addr, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("Ipv4Addr")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()
@@ -863,11 +919,17 @@ unsafe impl Facet<'_> for core::net::Ipv4Addr {
 }
 
 unsafe impl Facet<'_> for core::net::Ipv6Addr {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable!(core::net::Ipv6Addr, |f, _opts| write!(f, "Ipv6Addr")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable!(core::net::Ipv6Addr, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("Ipv6Addr")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()

--- a/facet-core/src/impls_core/slice.rs
+++ b/facet-core/src/impls_core/slice.rs
@@ -102,6 +102,7 @@ where
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_unsized::<Self>()
+            .type_identifier("[_]")
             .type_params(&[TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_core/smartptr.rs
+++ b/facet-core/src/impls_core/smartptr.rs
@@ -5,11 +5,17 @@ use crate::{
 };
 
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for core::ptr::NonNull<T> {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable!(core::ptr::NonNull<T>, |f, _opts| write!(f, "NonNull")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable!(core::ptr::NonNull<T>, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static crate::Shape<'static> = &const {
         crate::Shape::builder_for_sized::<Self>()
+            .type_identifier("NonNull")
             .type_params(&[crate::TypeParam {
                 name: "T",
                 shape: || T::SHAPE,

--- a/facet-core/src/impls_core/tuple.rs
+++ b/facet-core/src/impls_core/tuple.rs
@@ -210,6 +210,18 @@ macro_rules! impl_facet_for_tuple {
 
             const SHAPE: &'static Shape<'static> = &const {
                 Shape::builder_for_sized::<Self>()
+                    .type_identifier(const {
+                        let fields = [
+                            $(field_in_type!(Self, $idx),)+
+                        ];
+                        if fields.len() == 0 {
+                            "()"
+                        } else if fields.len() == 1 {
+                            "(_)"
+                        } else {
+                            "(⋯)"
+                        }
+                    })
                     .ty(Type::Sequence(SequenceType::Tuple(TupleType {
                         fields: &const {[
                             $(field_in_type!(Self, $idx),)+

--- a/facet-core/src/impls_jiff.rs
+++ b/facet-core/src/impls_jiff.rs
@@ -10,7 +10,11 @@ const ZONED_ERROR: &str = "could not parse time-zone aware instant of time";
 
 unsafe impl Facet<'_> for Zoned {
     const VTABLE: &'static ValueVTable = &const {
-        let mut vtable = value_vtable!(Zoned, |f, _opts| write!(f, "Zoned"));
+        let mut vtable = value_vtable!(Zoned, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ));
         vtable.try_from = || {
             Some(
                 |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
@@ -44,6 +48,7 @@ unsafe impl Facet<'_> for Zoned {
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("Zoned")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()
@@ -58,7 +63,11 @@ const TIMESTAMP_ERROR: &str = "could not parse timestamp";
 
 unsafe impl Facet<'_> for Timestamp {
     const VTABLE: &'static ValueVTable = &const {
-        let mut vtable = value_vtable!(Timestamp, |f, _opts| write!(f, "Timestamp"));
+        let mut vtable = value_vtable!(Timestamp, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ));
         vtable.try_from = || {
             Some(
                 |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
@@ -94,6 +103,7 @@ unsafe impl Facet<'_> for Timestamp {
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("Timestamp")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()
@@ -108,7 +118,11 @@ const DATETIME_ERROR: &str = "could not parse civil datetime";
 
 unsafe impl Facet<'_> for DateTime {
     const VTABLE: &'static ValueVTable = &const {
-        let mut vtable = value_vtable!(DateTime, |f, _opts| write!(f, "DateTime"));
+        let mut vtable = value_vtable!(DateTime, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ));
         vtable.try_from = || {
             Some(
                 |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
@@ -143,6 +157,7 @@ unsafe impl Facet<'_> for DateTime {
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("DateTime")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()

--- a/facet-core/src/impls_ordered_float.rs
+++ b/facet-core/src/impls_ordered_float.rs
@@ -60,7 +60,8 @@ macro_rules! impl_facet_for_ordered_float_and_notnan {
                     Ok(PtrConst::new((&v.0) as *const $float as *const u8))
                 }
 
-                let mut vtable = value_vtable!((), |f, _opts| write!(f, "OrderedFloat"));
+                let mut vtable =
+                    value_vtable!((), |f, _opts| write!(f, "{}", Self::SHAPE.type_identifier));
                 vtable.parse = || {
                     // `OrderedFloat` is `repr(transparent)`
                     (<$float as Facet>::SHAPE.vtable.parse)()
@@ -77,6 +78,7 @@ macro_rules! impl_facet_for_ordered_float_and_notnan {
                 }
 
                 Shape::builder_for_sized::<Self>()
+                    .type_identifier("OrderedFloat")
                     .ty(Type::User(UserType::Struct(
                         StructType::builder()
                             .repr(Repr::transparent())
@@ -153,7 +155,8 @@ macro_rules! impl_facet_for_ordered_float_and_notnan {
                     ))
                 }
 
-                let mut vtable = value_vtable!((), |f, _opts| write!(f, "NotNan"));
+                let mut vtable =
+                    value_vtable!((), |f, _opts| write!(f, "{}", Self::SHAPE.type_identifier));
                 // Accept parsing as inner T, but enforce NotNan invariant
                 vtable.parse = || {
                     Some(|s, target| match s.parse::<$float>() {
@@ -180,6 +183,7 @@ macro_rules! impl_facet_for_ordered_float_and_notnan {
                 }
 
                 Shape::builder_for_sized::<Self>()
+                    .type_identifier("NotNan")
                     .ty(Type::User(UserType::Opaque))
                     .def(Def::Scalar(
                         ScalarDef::builder()

--- a/facet-core/src/impls_std/hashmap.rs
+++ b/facet-core/src/impls_std/hashmap.rs
@@ -30,13 +30,13 @@ where
             })
             .type_name(|f, opts| {
                 if let Some(opts) = opts.for_children() {
-                    write!(f, "HashMap<")?;
+                    write!(f, "{}<", Self::SHAPE.type_identifier)?;
                     (K::SHAPE.vtable.type_name)(f, opts)?;
                     write!(f, ", ")?;
                     (V::SHAPE.vtable.type_name)(f, opts)?;
                     write!(f, ">")
                 } else {
-                    write!(f, "HashMap<⋯>")
+                    write!(f, "{}<⋯>", Self::SHAPE.type_identifier)
                 }
             })
             .debug(|| {
@@ -128,6 +128,7 @@ where
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("HashMap")
             .type_params(&[
                 TypeParam {
                     name: "K",
@@ -209,10 +210,11 @@ where
 
 unsafe impl Facet<'_> for RandomState {
     const VTABLE: &'static ValueVTable =
-        &const { value_vtable!((), |f, _opts| write!(f, "RandomState")) };
+        &const { value_vtable!((), |f, _opts| write!(f, "{}", Self::SHAPE.type_identifier)) };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("RandomState")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()

--- a/facet-core/src/impls_std/hashset.rs
+++ b/facet-core/src/impls_std/hashset.rs
@@ -26,7 +26,7 @@ where
             })
             .type_name(|f, opts| {
                 if let Some(opts) = opts.for_children() {
-                    write!(f, "HashSet<")?;
+                    write!(f, "{}<", Self::SHAPE.type_identifier)?;
                     (T::SHAPE.vtable.type_name)(f, opts)?;
                     write!(f, ">")
                 } else {
@@ -99,6 +99,7 @@ where
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("HashSet")
             .type_params(&[
                 TypeParam {
                     name: "T",

--- a/facet-core/src/impls_std/path.rs
+++ b/facet-core/src/impls_std/path.rs
@@ -1,11 +1,17 @@
 use crate::*;
 
 unsafe impl Facet<'_> for std::path::PathBuf {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable!(std::path::PathBuf, |f, _opts| write!(f, "PathBuf")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable!(std::path::PathBuf, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("PathBuf")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()
@@ -17,11 +23,17 @@ unsafe impl Facet<'_> for std::path::PathBuf {
 }
 
 unsafe impl Facet<'_> for std::path::Path {
-    const VTABLE: &'static ValueVTable =
-        &const { value_vtable_unsized!(std::path::Path, |f, _opts| write!(f, "Path")) };
+    const VTABLE: &'static ValueVTable = &const {
+        value_vtable_unsized!(std::path::Path, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ))
+    };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_unsized::<Self>()
+            .type_identifier("Path")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()

--- a/facet-core/src/impls_time.rs
+++ b/facet-core/src/impls_time.rs
@@ -8,7 +8,11 @@ use crate::{
 
 unsafe impl Facet<'_> for UtcDateTime {
     const VTABLE: &'static ValueVTable = &const {
-        let mut vtable = value_vtable!(UtcDateTime, |f, _opts| write!(f, "UtcDateTime"));
+        let mut vtable = value_vtable!(UtcDateTime, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ));
         vtable.try_from = || {
             Some(
                 |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
@@ -53,6 +57,7 @@ unsafe impl Facet<'_> for UtcDateTime {
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("UtcDateTime")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()
@@ -65,7 +70,11 @@ unsafe impl Facet<'_> for UtcDateTime {
 
 unsafe impl Facet<'_> for OffsetDateTime {
     const VTABLE: &'static ValueVTable = &const {
-        let mut vtable = value_vtable!(OffsetDateTime, |f, _opts| write!(f, "OffsetDateTime"));
+        let mut vtable = value_vtable!(OffsetDateTime, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ));
         vtable.try_from = || {
             Some(
                 |source: PtrConst, source_shape: &Shape, target: PtrUninit| {
@@ -111,6 +120,7 @@ unsafe impl Facet<'_> for OffsetDateTime {
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("OffsetDateTime")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()

--- a/facet-core/src/impls_ulid.rs
+++ b/facet-core/src/impls_ulid.rs
@@ -39,7 +39,11 @@ unsafe impl Facet<'_> for Ulid {
             Ok(unsafe { dst.put(ulid.to_string()) })
         }
 
-        let mut vtable = value_vtable!(Ulid, |f, _opts| write!(f, "Ulid"));
+        let mut vtable = value_vtable!(Ulid, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ));
         vtable.parse = || {
             Some(|s, target| match Ulid::from_string(s) {
                 Ok(ulid) => Ok(unsafe { target.put(ulid) }),
@@ -58,6 +62,7 @@ unsafe impl Facet<'_> for Ulid {
         }
 
         Shape::builder_for_sized::<Self>()
+            .type_identifier("Ulid")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()

--- a/facet-core/src/impls_url.rs
+++ b/facet-core/src/impls_url.rs
@@ -53,7 +53,8 @@ unsafe impl Facet<'_> for Url {
             Ok(PtrConst::new(url.as_str().as_ptr()))
         }
 
-        let mut vtable = value_vtable!(Url, |f, _opts| write!(f, "Url"));
+        let mut vtable =
+            value_vtable!(Url, |f, _opts| write!(f, "{}", Self::SHAPE.type_identifier));
         vtable.parse = || Some(parse);
         vtable.try_into_inner = || Some(try_into_inner);
         vtable.try_borrow_inner = || Some(try_borrow_inner);
@@ -67,6 +68,7 @@ unsafe impl Facet<'_> for Url {
         }
 
         Shape::builder_for_sized::<Self>()
+            .type_identifier("Url")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()

--- a/facet-core/src/impls_uuid.rs
+++ b/facet-core/src/impls_uuid.rs
@@ -40,7 +40,11 @@ unsafe impl Facet<'_> for Uuid {
             Ok(unsafe { dst.put(uuid.to_string()) })
         }
 
-        let mut vtable = value_vtable!(Uuid, |f, _opts| write!(f, "Uuid"));
+        let mut vtable = value_vtable!(Uuid, |f, _opts| write!(
+            f,
+            "{}",
+            Self::SHAPE.type_identifier
+        ));
         vtable.parse = || {
             Some(|s, target| match Uuid::parse_str(s) {
                 Ok(uuid) => Ok(unsafe { target.put(uuid) }),
@@ -59,6 +63,7 @@ unsafe impl Facet<'_> for Uuid {
         }
 
         Shape::builder_for_sized::<Self>()
+            .type_identifier("Uuid")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()

--- a/facet-core/src/opaque.rs
+++ b/facet-core/src/opaque.rs
@@ -9,10 +9,11 @@ unsafe impl<'a, T: 'a> Facet<'a> for Opaque<T> {
     // Since T is opaque and could be anything, we can't provide much functionality.
     // Using `()` for the vtable like PhantomData.
     const VTABLE: &'static ValueVTable =
-        &const { value_vtable!((), |f, _opts| write!(f, "Opaque")) };
+        &const { value_vtable!((), |f, _opts| write!(f, "{}", Self::SHAPE.type_identifier)) };
 
     const SHAPE: &'static Shape<'static> = &const {
         Shape::builder_for_sized::<Self>()
+            .type_identifier("Opaque")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Scalar(
                 ScalarDef::builder()

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -50,6 +50,10 @@ pub struct Shape<'shape> {
     /// a map, or fetching a value from a list.
     pub def: Def<'shape>,
 
+    /// Identifier for a type: the type's name without generic parameters. To get the type's full
+    /// name with generic parameters, see [`ValueVTable::type_name`].
+    pub type_identifier: &'shape str,
+
     /// Generic parameters for the shape
     pub type_params: &'shape [TypeParam<'shape>],
 
@@ -189,6 +193,7 @@ pub struct ShapeBuilder<'shape> {
     vtable: &'shape ValueVTable,
     def: Def<'shape>,
     ty: Option<Type<'shape>>,
+    type_identifier: Option<&'shape str>,
     type_params: &'shape [TypeParam<'shape>],
     doc: &'shape [&'shape str],
     attributes: &'shape [ShapeAttribute<'shape>],
@@ -205,6 +210,7 @@ impl<'shape> ShapeBuilder<'shape> {
             vtable,
             def: Def::Undefined,
             ty: None,
+            type_identifier: None,
             type_params: &[],
             doc: &[],
             attributes: &[],
@@ -244,6 +250,13 @@ impl<'shape> ShapeBuilder<'shape> {
     #[inline]
     pub const fn ty(mut self, ty: Type<'shape>) -> Self {
         self.ty = Some(ty);
+        self
+    }
+
+    /// Sets the `type_identifier` field of the `ShapeBuilder`.
+    #[inline]
+    pub const fn type_identifier(mut self, type_identifier: &'shape str) -> Self {
+        self.type_identifier = Some(type_identifier);
         self
     }
 
@@ -292,6 +305,7 @@ impl<'shape> ShapeBuilder<'shape> {
             id: self.id.unwrap(),
             layout: self.layout.unwrap(),
             vtable: self.vtable,
+            type_identifier: self.type_identifier.unwrap(),
             type_params: self.type_params,
             def: self.def,
             ty: self.ty.unwrap(),

--- a/facet-derive-emit/src/process_enum.rs
+++ b/facet-derive-emit/src/process_enum.rs
@@ -576,6 +576,7 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                 ]};
 
                 ::facet::Shape::builder_for_sized::<Self>()
+                    .type_identifier(#enum_name_str)
                     #type_params
                     .ty(::facet::Type::User(::facet::UserType::Enum(::facet::EnumType::builder()
                             // Use variant expressions that just reference the shadow structs

--- a/facet-derive-emit/src/process_struct.rs
+++ b/facet-derive-emit/src/process_struct.rs
@@ -468,6 +468,7 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
                 #inner_shape_fn // Include inner_shape function if needed
 
                 ::facet::Shape::builder_for_sized::<Self>()
+                    .type_identifier(#struct_name_str)
                     #type_params // Still from parsed.generics
                     .ty(::facet::Type::User(::facet::UserType::Struct(::facet::StructType::builder()
                         .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__array_field_in_enum.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__array_field_in_enum.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 569
 expression: "expand(r#\"\n        /// Network packet types\n        #[derive(Facet)]\n        #[repr(u8)]\n        pub enum Packet {\n            /// Array of bytes representing the header\n            Header([u8; 4]),\n            Payload(Vec<u8>), // Add another variant for completeness\n        }\n        \"#)"
 ---
 #[used]
@@ -89,6 +90,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Packet {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Packet")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__array_field_in_struct.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__array_field_in_struct.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 585
 expression: "expand(r#\"\n        #[derive(Facet)]\n        pub struct DataPacket {\n            header: [u8; 16],\n            payload: Vec<u8>,\n            metadata: [MetadataTag; 4],\n        }\n        \"#)"
 ---
 #[used]
@@ -40,6 +41,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for DataPacket {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("DataPacket")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__cfg_attrs.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__cfg_attrs.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 473
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[cfg_attr(feature = \"testfeat\", derive(Debug))]\n        #[cfg_attr(feature = \"testfeat\", facet(deny_unknown_fields))]\n        pub struct CubConfig {}\n        \"#)"
 ---
 #[used]
@@ -16,6 +17,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for CubConfig {
     const SHAPE: &'static ::facet::Shape<'static> = &const {
         let fields: &'static [::facet::Field] = &const { [] };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("CubConfig")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__cfg_attrs_on_field.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__cfg_attrs_on_field.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 486
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[cfg_attr(feature = \"testfeat\", derive(Debug))]\n        #[cfg_attr(feature = \"testfeat\", facet(deny_unknown_fields))]\n        pub struct CubConfig {\n            /// size the disk cache is allowed to use\n            #[cfg_attr(feature = \"testfeat\", facet(skip_serializing))]\n            #[cfg_attr(\n                feature = \"testfeat\",\n                facet(default = \"serde_defaults::default_disk_cache_size\")\n            )]\n            pub disk_cache_size: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -25,6 +26,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for CubConfig {
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("CubConfig")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__derive_real_life_cub_config.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__derive_real_life_cub_config.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 520
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[cfg_attr(feature = \"testfeat\", facet(deny_unknown_fields))]\n        pub struct CubConfig {\n            /// size the disk cache is allowed to use\n            #[cfg_attr(feature = \"testfeat\", facet(skip_serializing))]\n            #[cfg_attr(\n                feature = \"testfeat\",\n                facet(default = \"serde_defaults::default_disk_cache_size\")\n            )]\n            pub disk_cache_size: String,\n\n            /// Listen address without http, something like \"127.0.0.1:1111\"\n            #[cfg_attr(feature = \"testfeat\", facet(default = \"serde_defaults::address\"))]\n            pub address: std::string::String,\n\n            /// Something like `http://localhost:1118`\n            /// or `http://mom.svc.cluster.local:1118`, never\n            /// a trailing slash.\n            #[cfg_attr(feature = \"testfeat\", facet(default = \"serde_defaults::mom_base_url\"))]\n            pub mom_base_url: String,\n\n            /// API key used to talk to mom\n            #[cfg_attr(feature = \"testfeat\", facet(default = \"serde_defaults::mom_api_key\"))]\n            #[cfg_attr(feature = \"testfeat\", facet(sensitive))] // Example addition\n            pub mom_api_key: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -55,6 +56,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for CubConfig {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("CubConfig")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_doc_comment.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_doc_comment.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 263
 expression: "expand(r#\"\n        /// This is an enum\n        #[derive(Facet)]\n        #[repr(u8)]\n        enum MyEnum {\n            #[allow(dead_code)]\n            A,\n            #[allow(dead_code)]\n            B,\n        }\n        \"#)"
 ---
 #[used]
@@ -36,6 +37,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for MyEnum {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("MyEnum")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_generic.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_generic.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 430
 expression: "expand(r#\"\n        #[allow(dead_code)]\n        #[derive(Facet)]\n        #[repr(u8)]\n        enum E<'a, T: Facet<'a> + core::hash::Hash, const C: usize = 3>\n        where\n            T: Debug, // Added Debug bound\n             [u8; C]: Debug, // Added Debug bound\n        {\n            Unit,\n            Tuple(T, core::marker::PhantomData<&'a [u8; C]>),\n            Record {\n                field: T,\n                phantom: core::marker::PhantomData<&'a ()>,\n                constant_val: [u8; C],\n            },\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -191,6 +192,7 @@ where
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("E")
             .type_params(&[::facet::TypeParam {
                 name: "T",
                 shape: || <T as ::facet::Facet>::SHAPE,

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_variants_with_comments.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_variants_with_comments.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 308
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(u8)]\n        enum CommentedEnum {\n            /// This is variant A\n            #[allow(dead_code)]\n            A,\n            /// This is variant B\n            /// with multiple lines\n            #[allow(dead_code)]\n            B(u32),\n            /// This is variant C\n            /// which has named fields\n            #[allow(dead_code)]\n            C {\n                /// This is field x\n                x: u32,\n                /// This is field y\n                y: String,\n            },\n        }\n        \"#)"
 ---
 #[used]
@@ -123,6 +124,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for CommentedEnum {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("CommentedEnum")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_binary.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_binary.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 100
 expression: "expand(r#\"\n        #[repr(u8)]\n        #[derive(Facet)]\n        enum BitFlags {\n          None = 0b0000_0000,\n          Read = 0b0000_0001,\n          Write = 0b0000_0010,\n          Execute = 0b0000_0100,\n          All = 0b0000_0111,\n        }\n        \"#)"
 ---
 #[used]
@@ -68,6 +69,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for BitFlags {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("BitFlags")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_decimal.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_decimal.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 66
 expression: "expand(r#\"\n        #[repr(u8)]\n        #[derive(Facet)]\n        enum Test {\n          Red,\n          Blue = 7,\n          Green,\n          Yellow = 10,\n        }\n        \"#)"
 ---
 #[used]
@@ -56,6 +57,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Test {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Test")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_hexadecimal.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_hexadecimal.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 82
 expression: "expand(r#\"\n        #[repr(u16)]\n        #[derive(Facet)]\n        enum Color {\n          Red      = 0x01,\n          Blue     = 0x7F,\n          Green    = 0x80,\n          Yellow   = 0x10,\n          Magenta  = 0xfeed,\n          Cyan     = 0xBEEF,\n        }\n        \"#)"
 ---
 #[used]
@@ -76,6 +77,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Color {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Color")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_mixed_notations.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_mixed_notations.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 117
 expression: "expand(r#\"\n        #[repr(u32)]\n        #[derive(Facet)]\n        enum Status {\n            Ok = 1,\n            Warn = 0xA,\n            Error = 0b1111,\n            Timeout = 0o77,\n        }\n        \"#)"
 ---
 #[used]
@@ -56,6 +57,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Status {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Status")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_facet_attributes.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_facet_attributes.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 648
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(name = \"MyCoolEnum\", repr = \"u16\")]\n        #[repr(u16)] // Ensure repr matches if specified in facet attribute\n        enum EnumWithAttributes {\n            #[facet(name = \"FirstVariant\", discriminant = 10)]\n            VariantA,\n\n            #[facet(skip)]\n            InternalVariant(i32),\n\n            #[facet(deprecated = \"Use VariantD instead\")]\n            VariantC {\n                #[facet(sensitive)]\n                secret: String\n            },\n\n            VariantD {\n                 #[facet(default = forty_two())]\n                 value: i32\n            },\n        }\n        \"#)"
 ---
 #[used]
@@ -113,6 +114,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for EnumWithAttributes {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("EnumWithAttributes")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_macro_discriminants.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_macro_discriminants.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 1083
 expression: "expand(r#\"\n        #[repr(u16)]\n        #[derive(Facet)]\n        enum TestEnum {\n            Value1 = test_macro!(1, 2),\n            Value2 = test_macro!(3, 4),\n        }\n        \"#)"
 ---
 #[used]
@@ -38,6 +39,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for TestEnum {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("TestEnum")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_multiple_attributes_per_variant.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_multiple_attributes_per_variant.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 1037
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(u8)]\n        enum ConfigValue {\n            #[facet(rename = \"TextValue\")]\n            Text(String),\n            #[facet(rename = \"NumberValue\")]\n            Number {\n                #[facet(rename = \"numValue\")]\n                value: f64,\n                #[facet(rename = \"unitName\", sensitive)]\n                unit: String,\n            },\n            #[facet(rename = \"BoolValue\")]\n            Boolean(bool),\n        }\n        \"#)"
 ---
 #[used]
@@ -145,6 +146,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ConfigValue {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("ConfigValue")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_nested_generic_in_variant_one_level.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_nested_generic_in_variant_one_level.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 742
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(u8)]\n        enum OneLevelNested<T> {\n            VariantA(Result<T, String>),\n            VariantB(Option<T>),\n            // Also include a unit variant to check un-nested\n            Plain,\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -116,6 +117,7 @@ where
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("OneLevelNested")
             .type_params(&[::facet::TypeParam {
                 name: "T",
                 shape: || <T as ::facet::Facet>::SHAPE,

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_nested_generic_in_variant_two_levels.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_nested_generic_in_variant_two_levels.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 759
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(u8)]\n        enum DeeplyNested<T> {\n            LevelOne(\n                Option<\n                    Result<\n                        Vec<T>,\n                        String\n                    >\n                >\n            ),\n            // Another variant to prove non-nested still works.\n            Simple(T),\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -100,6 +101,7 @@ where
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("DeeplyNested")
             .type_params(&[::facet::TypeParam {
                 name: "T",
                 shape: || <T as ::facet::Facet>::SHAPE,

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_rename_all.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_rename_all.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 816
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(u8)]\n        #[facet(rename_all = \"snake_case\")]\n        enum ApiResponse {\n            OkResponse {\n                #[facet(rename = \"responseData\")]\n                data: String,\n            },\n            ErrorResponse {\n                code: u32,\n                message: String,\n            },\n        }\n        \"#)"
 ---
 #[used]
@@ -86,6 +87,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ApiResponse {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("ApiResponse")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_renamed_variants_and_fields.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_renamed_variants_and_fields.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 994
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(u8)]\n        enum ApiResponse {\n            #[facet(rename = \"Success\")]\n            Ok {\n                #[facet(rename = \"responseData\")]\n                data: String,\n            },\n            #[facet(rename = \"Error\")]\n            Err {\n                #[facet(rename = \"errorCode\")]\n                code: u32,\n                #[facet(rename = \"errorMessage\")]\n                message: String,\n            },\n        }\n        \"#)"
 ---
 #[used]
@@ -108,6 +109,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ApiResponse {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("ApiResponse")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_variants.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_variants.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 51
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(u8)]\n        enum EnumWithVariants {\n            Variant1,\n            Variant2(i32),\n            Variant3 { field1: i32, field2: String },\n        }\n        \"#)"
 ---
 #[used]
@@ -97,6 +98,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for EnumWithVariants {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("EnumWithVariants")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__generic_bounds_k_v.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__generic_bounds_k_v.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 721
 expression: "expand(r#\"\n        struct Foo<K, V> where K: Eq + Hash {\n            inner: HashMap<K, V>,\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -25,6 +26,7 @@ where
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Foo")
             .type_params(&[
                 ::facet::TypeParam {
                     name: "K",

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__generic_bounds_t.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__generic_bounds_t.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 710
 expression: "expand(r#\"\n        struct Foo<T> where T: Copy {\n            inner: Vec<T>,\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -24,6 +25,7 @@ where
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Foo")
             .type_params(&[::facet::TypeParam {
                 name: "T",
                 shape: || <T as ::facet::Facet>::SHAPE,

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__generic_bounds_tuple_t.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__generic_bounds_tuple_t.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 732
 expression: "expand(r#\"\n        struct Foo<T>(Vec<T>);\n        \"#)"
 ---
 #[automatically_derived]
@@ -23,6 +24,7 @@ where
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Foo")
             .type_params(&[::facet::TypeParam {
                 name: "T",
                 shape: || <T as ::facet::Facet>::SHAPE,

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__macroed_type.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__macroed_type.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 556
 expression: "expand(r#\"\n        #[derive(Debug, Facet, PartialEq)]\n        struct Macroed {\n            // NOTICE type is variable here\n            value: u32,\n        }\n        \"#)"
 ---
 #[used]
@@ -22,6 +23,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Macroed {
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Macroed")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__mixed_rename_and_sensitive_attributes.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__mixed_rename_and_sensitive_attributes.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 1019
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct User {\n            #[facet(rename = \"userName\")]\n            name: String,\n            #[facet(rename = \"userEmail\", sensitive)]\n            email: String,\n            #[facet(sensitive)]\n            password: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -40,6 +41,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for User {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("User")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__opaque_arc.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__opaque_arc.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 617
 expression: "expand(r#\"\n        #[derive(Facet)]\n        pub struct Handle(#[facet(opaque)] std::sync::Arc<NotDerivingFacet>);\n        \"#)"
 ---
 #[used]
@@ -22,6 +23,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Handle {
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Handle")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__pub_crate_enum.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__pub_crate_enum.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 1110
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(u8)]\n        pub(crate) enum LogLevel {\n            Debug,\n            Info,\n            Warn,\n            Error,\n        }\n        \"#)"
 ---
 #[used]
@@ -58,6 +59,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for LogLevel {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("LogLevel")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__record_struct_generic.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__record_struct_generic.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 388
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Blah<'a, T: Facet + core::hash::Hash, const C: usize = 3>\n        where\n            T: Debug, // Added a Debug bound for demonstration if needed, adjust as per Facet constraints\n        {\n            field: core::marker::PhantomData<&'a T>,\n            another: T,\n            constant_val: [u8; C],\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -43,6 +44,7 @@ where
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Blah")
             .type_params(&[::facet::TypeParam {
                 name: "T",
                 shape: || <T as ::facet::Facet>::SHAPE,

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_camelcase.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_camelcase.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 901
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"camelCase\")]\n        struct CamelCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -34,6 +35,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for CamelCaseExample {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("CamelCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_kebabcase.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_kebabcase.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 946
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"kebab-case\")]\n        struct KebabCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -34,6 +35,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for KebabCaseExample {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("KebabCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_pascalcase.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_pascalcase.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 886
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"PascalCase\")]\n        struct PascalCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -34,6 +35,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for PascalCaseExample {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("PascalCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_screaming_kebabcase.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_screaming_kebabcase.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 961
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"SCREAMING-KEBAB-CASE\")]\n        struct ScreamingKebabCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -44,6 +45,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ScreamingKebabCaseExample {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("ScreamingKebabCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_screaming_snake_case.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_screaming_snake_case.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 871
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"SCREAMING_SNAKE_CASE\")]\n        struct UpperCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -34,6 +35,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for UpperCaseExample {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("UpperCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_screaming_snakecase.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_screaming_snakecase.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 931
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"SCREAMING_SNAKE_CASE\")]\n        struct ScreamingSnakeCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -44,6 +45,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ScreamingSnakeCaseExample {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("ScreamingSnakeCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_snake_case.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_snake_case.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 856
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"snake_case\")]\n        struct SnakeCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -34,6 +35,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for SnakeCaseExample {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("SnakeCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_snakecase.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_snakecase.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 916
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"snake_case\")]\n        struct SnakeCaseExample {\n            fieldOne: String, // Note the camelCase input field name\n            fieldTwo: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -34,6 +35,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for SnakeCaseExample {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("SnakeCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__repr_c_enum.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__repr_c_enum.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 133
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(C)]\n        enum EnumWithVariants {\n            /// Comment A\n            Variant1,\n            /// Comment B\n            Variant2(i32),\n            Variant3 { field1: i32, field2: String },\n        }\n        \"#)"
 ---
 #[used]
@@ -164,6 +165,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for EnumWithVariants {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("EnumWithVariants")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__repr_c_enum_empty_struct_variant.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__repr_c_enum_empty_struct_variant.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 150
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(C)]\n        enum EnumWithEmptyStructVariant {\n            Variant1 { },\n        }\n        \"#)"
 ---
 #[used]
@@ -57,6 +58,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for EnumWithEmptyStructVariant {
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("EnumWithEmptyStructVariant")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__repr_c_enum_lifetime_field.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__repr_c_enum_lifetime_field.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 163
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(C)]\n        enum EnumWithLifetimeField {\n            Variant1 { field1: &'static str },\n        }\n        \"#)"
 ---
 #[used]
@@ -78,6 +79,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for EnumWithLifetimeField {
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("EnumWithLifetimeField")
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__simple_struct.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__simple_struct.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 38
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Blah {\n            foo: u32,\n            bar: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -31,6 +32,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 217
 expression: "expand(r#\"\n        /// yes\n        #[derive(Facet)]\n        struct Foo {}\n        \"#)"
 ---
 #[used]
@@ -14,6 +15,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Foo {
     const SHAPE: &'static ::facet::Shape<'static> = &const {
         let fields: &'static [::facet::Field] = &const { [] };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment_multi_line.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment_multi_line.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 228
 expression: "expand(r#\"\n        /// yes\n        /// no\n        #[derive(Facet)]\n        struct Foo {}\n        \"#)"
 ---
 #[used]
@@ -14,6 +15,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Foo {
     const SHAPE: &'static ::facet::Shape<'static> = &const {
         let fields: &'static [::facet::Field] = &const { [] };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment_quotes.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment_quotes.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 252
 expression: "expand(r#\"\n        /// what about \"quotes\"\n        #[derive(Facet)]\n        struct Foo {}\n        \"#)"
 ---
 #[used]
@@ -14,6 +15,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Foo {
     const SHAPE: &'static ::facet::Shape<'static> = &const {
         let fields: &'static [::facet::Field] = &const { [] };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment_unicode.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment_unicode.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 240
 expression: "expand(r#\"\n        /// yes 😄\n        /// no\n        #[derive(Facet)]\n        struct Foo {}\n        \"#)"
 ---
 #[used]
@@ -14,6 +15,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Foo {
     const SHAPE: &'static ::facet::Shape<'static> = &const {
         let fields: &'static [::facet::Field] = &const { [] };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_facet_transparent.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_facet_transparent.snap
@@ -61,6 +61,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Wrapper {
             <u32 as ::facet::Facet>::SHAPE
         }
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Wrapper")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_field_doc_comment.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_field_doc_comment.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 280
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Foo {\n            /// This field has a doc comment\n            bar: u32,\n        }\n        \"#)"
 ---
 #[used]
@@ -23,6 +24,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Foo {
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_impls_drop.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_impls_drop.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 601
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct BarFoo {\n            bar: u32,\n            foo: String,\n        }\n        // The Drop impl doesn't affect the derive macro input:\n        // impl Drop for BarFoo { fn drop(&mut self) {} }\n        \"#)"
 ---
 #[used]
@@ -31,6 +32,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for BarFoo {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("BarFoo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_repr_c.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_repr_c.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 203
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(C)]\n        struct Blah {\n            foo: u32,\n            bar: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -31,6 +32,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_equal_defaults.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_equal_defaults.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 680
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct StructWithDefaults {\n            field1: i32 = 42,\n            field2: String = \"default\".to_string(),\n        }\n        \"#)"
 ---
 #[used]
@@ -34,6 +35,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for StructWithDefaults {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("StructWithDefaults")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_facet_attributes.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_facet_attributes.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 628
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(name = \"MyCoolStruct\", deny_unknown_fields, version = 2)]\n        struct StructWithAttributes {\n            #[facet(name = \"identifier\", default = generate_id, sensitive)]\n            id: String,\n            #[facet(skip, version = 3)]\n            internal_data: Vec<u8>,\n            #[facet(deprecated = \"Use 'new_value' instead\")]\n            old_value: i32,\n            new_value: i32,\n        }\n        \"#)"
 ---
 #[used]
@@ -61,6 +62,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for StructWithAttributes {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("StructWithAttributes")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_field_default_facets.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_field_default_facets.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 693
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(default)]\n        struct ForFacetDefaultDemo {\n            #[facet(default)]\n            field1: u32,\n            #[facet(default = my_field_default_fn())]\n            field2: String,\n            field3: bool,\n        }\n        \"#)"
 ---
 #[used]
@@ -53,6 +54,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ForFacetDefaultDemo {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("ForFacetDefaultDemo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_generics_simple.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_generics_simple.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 176
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct StructWithGenericsSimple<T, U> {\n            field1: T,\n            field2: U,\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -27,6 +28,7 @@ where
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("StructWithGenericsSimple")
             .type_params(&[
                 ::facet::TypeParam {
                     name: "T",

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_mixed_rename_attributes.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_mixed_rename_attributes.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 838
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"snake_case\")]\n        struct ConfigSettings {\n            server_url: String,\n            #[facet(rename = \"apiKey\")]\n            api_key: String,\n            timeout_secs: u32,\n            max_retry_count: u8,\n        }\n        \"#)"
 ---
 #[used]
@@ -47,6 +48,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ConfigSettings {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("ConfigSettings")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_option_cow_str.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_option_cow_str.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 1097
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Foo<'a> {\n            #[facet(default)]\n            name: Option<Cow<'a, str>>,\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -26,6 +27,7 @@ where
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_pub_field.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_pub_field.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 336
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Foo {\n            /// This is a public field\n            pub bar: u32,\n        }\n        \"#)"
 ---
 #[used]
@@ -23,6 +24,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Foo {
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_rename_all.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_rename_all.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 799
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"camelCase\")]\n        struct PersonInfo {\n            first_name: String,\n            last_name: String,\n            home_address: String,\n            phone_number: u32,\n        }\n        \"#)"
 ---
 #[used]
@@ -47,6 +48,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for PersonInfo {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("PersonInfo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_renamed_field.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_renamed_field.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 782
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Person {\n            #[facet(rename = \"firstName\")]\n            first_name: String,\n            #[facet(rename = \"lastName\")]\n            last_name: String,\n            age: u32,\n        }\n        \"#)"
 ---
 #[used]
@@ -38,6 +39,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Person {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Person")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_sensitive_field.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_sensitive_field.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 189
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Blah {\n            foo: u32,\n            #[facet(sensitive)]\n            bar: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -32,6 +33,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_std_string.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_std_string.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 506
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct FileInfo {\n            path: std::string::String, // Explicitly use std::string::String\n            size: u64,\n        }\n        \"#)"
 ---
 #[used]
@@ -32,6 +33,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for FileInfo {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("FileInfo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 28
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct TupleStruct(i32, String);\n        \"#)"
 ---
 #[used]
@@ -33,6 +34,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for TupleStruct {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("TupleStruct")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_doc_comment.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_doc_comment.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 360
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(transparent)]\n        /// This is a struct for sure\n        struct Blah(u32);\n        \"#)"
 ---
 #[used]
@@ -22,6 +23,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_field_doc_comment.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_field_doc_comment.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 293
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct MyTupleStruct(\n            /// This is a documented field\n            u32,\n            /// This is another documented field\n            String,\n        );\n        \"#)"
 ---
 #[used]
@@ -35,6 +36,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for MyTupleStruct {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("MyTupleStruct")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_field_doc_comment_repr_transparent.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_field_doc_comment_repr_transparent.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 373
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(transparent)]\n        /// This is a struct for sure\n        struct Blah(\n            /// and this is a field\n            u32,\n        );\n        \"#)"
 ---
 #[used]
@@ -23,6 +24,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_generic.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_generic.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 405
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(transparent)]\n        struct Blah<'a, T: Facet + core::hash::Hash, const C: usize = 3>(T, core::marker::PhantomData<&'a [u8; C]>)\n        where\n            T: Debug; // Added a Debug bound for demonstration\n        \"#)"
 ---
 #[automatically_derived]
@@ -36,6 +37,7 @@ where
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Blah")
             .type_params(&[::facet::TypeParam {
                 name: "T",
                 shape: || <T as ::facet::Facet>::SHAPE,

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_repr_transparent.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_repr_transparent.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 349
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(transparent)]\n        struct Blah(u32);\n        \"#)"
 ---
 #[used]
@@ -22,6 +23,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_with_pub_fields.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_with_pub_fields.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 454
 expression: "expand(r#\"\n        #[derive(Facet)]\n        /// This is a struct for sure\n        struct Blah(\n            /// and this is a public field\n            pub u32,\n            /// and this is a crate public field\n            pub(crate) u32,\n        );\n        \"#)"
 ---
 #[used]
@@ -33,6 +34,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_with_renamed_field.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_with_renamed_field.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 976
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Point(\n            #[facet(rename = \"x_coordinate\")]\n            f32,\n            #[facet(rename = \"y_coordinate\")]\n            f32,\n            #[facet(rename = \"z_coordinate\")]\n            f32,\n        );\n        \"#)"
 ---
 #[used]
@@ -38,6 +39,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Point {
             ]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Point")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__unit_struct.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__unit_struct.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 18
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct UnitStruct;\n        \"#)"
 ---
 #[used]
@@ -16,6 +17,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for UnitStruct {
     const SHAPE: &'static ::facet::Shape<'static> = &const {
         let fields: &'static [::facet::Field] = &const { [] };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("UnitStruct")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__unit_struct_generic.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__unit_struct_generic.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 418
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Blah<const C: usize = 3>\n        where\n             [u8; C]: Debug; // Example bound using the const generic\n        \"#)"
 ---
 #[automatically_derived]
@@ -15,6 +16,7 @@ where
     const SHAPE: &'static ::facet::Shape<'static> = &const {
         let fields: &'static [::facet::Field] = &const { [] };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
                     .repr(::facet::Repr::c())

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__visibility.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__visibility.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
+assertion_line: 1060
 expression: "expand(r#\"\n        #[derive(Facet)]\n        pub struct Test<T> {\n            pub(crate) a: T,\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -23,6 +24,7 @@ where
             }]
         };
         ::facet::Shape::builder_for_sized::<Self>()
+            .type_identifier("Test")
             .type_params(&[::facet::TypeParam {
                 name: "T",
                 shape: || <T as ::facet::Facet>::SHAPE,

--- a/facet/src/sample_generated_code.rs
+++ b/facet/src/sample_generated_code.rs
@@ -443,6 +443,7 @@ unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkStruct {
             ]
         };
         crate::Shape::builder_for_sized::<Self>()
+            .type_identifier("KitchenSinkStruct")
             .ty(crate::Type::User(crate::UserType::Struct(
                 crate::StructType::builder()
                     .repr(crate::Repr::c())
@@ -834,6 +835,7 @@ unsafe impl<'__facet> crate::Facet<'__facet> for Point {
             ]
         };
         crate::Shape::builder_for_sized::<Self>()
+            .type_identifier("Point")
             .ty(crate::Type::User(crate::UserType::Struct(
                 crate::StructType::builder()
                     .repr(crate::Repr::c())
@@ -1511,6 +1513,7 @@ unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkEnum {
             ]
         };
         crate::Shape::builder_for_sized::<Self>()
+            .type_identifier("KitchenSinkEnum")
             .ty(crate::Type::User(crate::UserType::Enum(
                 crate::EnumType::builder()
                     .variants(__facet_variants)
@@ -1986,6 +1989,7 @@ unsafe impl<'__facet> crate::Facet<'__facet> for SubEnum {
             ]
         };
         crate::Shape::builder_for_sized::<Self>()
+            .type_identifier("SubEnum")
             .ty(crate::Type::User(crate::UserType::Enum(
                 crate::EnumType::builder()
                     .variants(__facet_variants)


### PR DESCRIPTION
Resolves #639 

This PR adds a `type_identifier: &str` field to `Shape`, which allows for getting a type's name in const contexts.

Since the `format!` machinery isn't available in const contexts, the best we could do today is to provide a type's name without any generic parameters. I felt that this was probably useful enough to add on its own.

I went with the name `type_identifier` to help distinguish it from `ValueVTable.type_name`, which can handle generics but can't be used in const contexts. For user types, the thing before the generic parameter list is the [identifier](https://doc.rust-lang.org/stable/reference/items/structs.html#r-items.struct.syntax), so that seemed to be the most accurate name I could think of. It's a misnomer for types like `()` and `&T` which still set `type_identifier` but don't have an "identifier" per se

(also, feel free to bikeshed a new name for `Shape.type_identifier` or maybe a new name for `ValueVTable.type_name`? or maybe we should keep it literal and set `type_identifier` to `None` for identifier-less types like `&T`?)