### PR TITLE
Add UnwindSafe and RefUnwindSafe to marker traits

### DIFF
--- a/facet-core/src/impls_alloc/vec.rs
+++ b/facet-core/src/impls_alloc/vec.rs
@@ -100,6 +100,8 @@ where
                     .union(MarkerTraits::SYNC)
                     .union(MarkerTraits::EQ)
                     .union(MarkerTraits::UNPIN)
+                    .union(MarkerTraits::UNWIND_SAFE)
+                    .union(MarkerTraits::REF_UNWIND_SAFE)
                     .intersection(T::SHAPE.vtable.marker_traits())
             })
             .build()

--- a/facet-core/src/impls_core/fn_ptr.rs
+++ b/facet-core/src/impls_core/fn_ptr.rs
@@ -76,6 +76,8 @@ macro_rules! impl_facet_for_fn_ptr {
                             .union(MarkerTraits::SYNC)
                             .union(MarkerTraits::COPY)
                             .union(MarkerTraits::UNPIN)
+                            .union(MarkerTraits::UNWIND_SAFE)
+                            .union(MarkerTraits::REF_UNWIND_SAFE)
                     )
                     .eq(|| Some(|&left, &right| {
                         fn_addr_eq(left, right)

--- a/facet-core/src/impls_core/tuple.rs
+++ b/facet-core/src/impls_core/tuple.rs
@@ -214,9 +214,7 @@ macro_rules! impl_facet_for_tuple {
                         let fields = [
                             $(field_in_type!(Self, $idx),)+
                         ];
-                        if fields.len() == 0 {
-                            "()"
-                        } else if fields.len() == 1 {
+                        if fields.len() == 1 {
                             "(_)"
                         } else {
                             "(⋯)"

--- a/facet-core/src/impls_std/hashmap.rs
+++ b/facet-core/src/impls_std/hashmap.rs
@@ -23,7 +23,9 @@ where
                 let arg_dependent_traits = MarkerTraits::SEND
                     .union(MarkerTraits::SYNC)
                     .union(MarkerTraits::EQ)
-                    .union(MarkerTraits::UNPIN);
+                    .union(MarkerTraits::UNPIN)
+                    .union(MarkerTraits::UNWIND_SAFE)
+                    .union(MarkerTraits::REF_UNWIND_SAFE);
                 arg_dependent_traits
                     .intersection(V::SHAPE.vtable.marker_traits())
                     .intersection(K::SHAPE.vtable.marker_traits())

--- a/facet-core/src/macros.rs
+++ b/facet-core/src/macros.rs
@@ -103,6 +103,12 @@ macro_rules! value_vtable {
                     if $crate::spez::impls!($type_name: core::marker::Unpin) {
                         traits = traits.union($crate::MarkerTraits::UNPIN);
                     }
+                    if $crate::spez::impls!($type_name: core::panic::UnwindSafe) {
+                        traits = traits.union($crate::MarkerTraits::UNWIND_SAFE);
+                    }
+                    if $crate::spez::impls!($type_name: core::panic::RefUnwindSafe) {
+                        traits = traits.union($crate::MarkerTraits::REF_UNWIND_SAFE);
+                    }
 
                     traits
                 })
@@ -210,6 +216,12 @@ macro_rules! value_vtable_unsized {
                     }
                     if $crate::spez::impls!($type_name: core::marker::Unpin) {
                         traits = traits.union($crate::MarkerTraits::UNPIN);
+                    }
+                    if $crate::spez::impls!($type_name: core::panic::UnwindSafe) {
+                        traits = traits.union($crate::MarkerTraits::UNWIND_SAFE);
+                    }
+                    if $crate::spez::impls!($type_name: core::panic::RefUnwindSafe) {
+                        traits = traits.union($crate::MarkerTraits::REF_UNWIND_SAFE);
                     }
 
                     traits

--- a/facet-core/src/types/value.rs
+++ b/facet-core/src/types/value.rs
@@ -436,9 +436,9 @@ bitflags! {
         const COPY = 1 << 3;
         /// Indicates that the type implements the [`Unpin`] marker trait
         const UNPIN = 1 << 4;
-        /// Indicates that the type implements the [`UnwindSafe`] marker trait
+        /// Indicates that the type implements the [`UnwindSafe`](core::panic::UnwindSafe) marker trait
         const UNWIND_SAFE = 1 << 5;
-        /// Indicates that the type implements the [`RefUnwindSafe`] marker trait
+        /// Indicates that the type implements the [`RefUnwindSafe`](core::panic::RefUnwindSafe) marker trait
         const REF_UNWIND_SAFE = 1 << 6;
     }
 }
@@ -568,12 +568,12 @@ impl ValueVTable {
         self.marker_traits().contains(MarkerTraits::UNPIN)
     }
 
-    /// Check if the type implements the [`UnwindSafe`] marker trait
+    /// Check if the type implements the [`UnwindSafe`](core::panic::UnwindSafe) marker trait
     pub fn is_unwind_safe(&self) -> bool {
         self.marker_traits().contains(MarkerTraits::UNWIND_SAFE)
     }
 
-    /// Check if the type implements the [`RefUnwindSafe`] marker trait
+    /// Check if the type implements the [`RefUnwindSafe`](core::panic::RefUnwindSafe) marker trait
     pub fn is_ref_unwind_safe(&self) -> bool {
         self.marker_traits().contains(MarkerTraits::REF_UNWIND_SAFE)
     }

--- a/facet-core/src/types/value.rs
+++ b/facet-core/src/types/value.rs
@@ -424,7 +424,7 @@ impl core::hash::Hasher for HasherProxy<'_> {
 
 bitflags! {
     /// Bitflags for common marker traits that a type may implement
-    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct MarkerTraits: u8 {
         /// Indicates that the type implements the [`Eq`] marker trait
         const EQ = 1 << 0;
@@ -436,6 +436,10 @@ bitflags! {
         const COPY = 1 << 3;
         /// Indicates that the type implements the [`Unpin`] marker trait
         const UNPIN = 1 << 4;
+        /// Indicates that the type implements the [`UnwindSafe`] marker trait
+        const UNWIND_SAFE = 1 << 5;
+        /// Indicates that the type implements the [`RefUnwindSafe`] marker trait
+        const REF_UNWIND_SAFE = 1 << 6;
     }
 }
 
@@ -562,6 +566,16 @@ impl ValueVTable {
     /// Check if the type implements the [`Unpin`] marker trait
     pub fn is_unpin(&self) -> bool {
         self.marker_traits().contains(MarkerTraits::UNPIN)
+    }
+
+    /// Check if the type implements the [`UnwindSafe`] marker trait
+    pub fn is_unwind_safe(&self) -> bool {
+        self.marker_traits().contains(MarkerTraits::UNWIND_SAFE)
+    }
+
+    /// Check if the type implements the [`RefUnwindSafe`] marker trait
+    pub fn is_ref_unwind_safe(&self) -> bool {
+        self.marker_traits().contains(MarkerTraits::REF_UNWIND_SAFE)
     }
 
     /// Creates a new [`ValueVTableBuilder`]

--- a/facet/src/sample_generated_code.rs
+++ b/facet/src/sample_generated_code.rs
@@ -226,6 +226,42 @@ unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkStruct {
                     } {
                         traits = traits.union(::facet_core::MarkerTraits::UNPIN);
                     }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::panic::UnwindSafe> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::UNWIND_SAFE);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::panic::RefUnwindSafe> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::REF_UNWIND_SAFE);
+                    }
                     traits
                 })
                 .eq(|| {
@@ -664,6 +700,42 @@ unsafe impl<'__facet> crate::Facet<'__facet> for Point {
                     } {
                         traits = traits.union(::facet_core::MarkerTraits::UNPIN);
                     }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::panic::UnwindSafe> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::UNWIND_SAFE);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::panic::RefUnwindSafe> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::REF_UNWIND_SAFE);
+                    }
                     traits
                 })
                 .eq(|| {
@@ -1095,6 +1167,42 @@ unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkEnum {
                         <Wrapper<Self>>::IMPLS
                     } {
                         traits = traits.union(::facet_core::MarkerTraits::UNPIN);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::panic::UnwindSafe> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::UNWIND_SAFE);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::panic::RefUnwindSafe> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::REF_UNWIND_SAFE);
                     }
                     traits
                 })
@@ -1742,6 +1850,42 @@ unsafe impl<'__facet> crate::Facet<'__facet> for SubEnum {
                         <Wrapper<Self>>::IMPLS
                     } {
                         traits = traits.union(::facet_core::MarkerTraits::UNPIN);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::panic::UnwindSafe> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::UNWIND_SAFE);
+                    }
+                    if {
+                        /// Fallback trait with `False` for `IMPLS` if the type does not
+                        /// implement the given trait.
+                        trait DoesNotImpl {
+                            const IMPLS: bool = false;
+                        }
+                        impl<T: ?Sized> DoesNotImpl for T {}
+                        /// Concrete type with `True` for `IMPLS` if the type implements the
+                        /// given trait. Otherwise, it falls back to `DoesNotImpl`.
+                        struct Wrapper<T: ?Sized>(::core::marker::PhantomData<T>);
+                        #[allow(dead_code)]
+                        impl<T: ?Sized + core::panic::RefUnwindSafe> Wrapper<T> {
+                            const IMPLS: bool = true;
+                        }
+                        <Wrapper<Self>>::IMPLS
+                    } {
+                        traits = traits.union(::facet_core::MarkerTraits::REF_UNWIND_SAFE);
                     }
                     traits
                 })


### PR DESCRIPTION
I don't know if `Sized` should be added to `MarkerTraits`. It is definitely a marker trait, however we already store whether a type is `Sized` elsewhere.