### PR TITLE
More lenient try_from_inner

### DIFF
--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_facet_transparent.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_facet_transparent.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
-assertion_line: 1072
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(transparent)]\n        struct Wrapper(u32);\n        \"#)"
 ---
 #[used]
@@ -15,9 +14,16 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Wrapper {
             src_shape: &'shape ::facet::Shape<'shape>,
             dst: ::facet::PtrUninit<'dst>,
         ) -> Result<::facet::PtrMut<'dst>, ::facet::TryFromError<'shape>> {
-            match (<u32 as ::facet::Facet>::SHAPE.vtable.try_from)() {
+            let inner_result = match (<u32 as ::facet::Facet>::SHAPE.vtable.try_from)() {
                 Some(inner_try) => unsafe { (inner_try)(src_ptr, src_shape, dst) },
-                None => {
+                None => Err(::facet::TryFromError::UnsupportedSourceShape {
+                    src_shape,
+                    expected: const { &[&<u32 as ::facet::Facet>::SHAPE] },
+                }),
+            };
+            match inner_result {
+                Ok(result) => Ok(result),
+                Err(_) => {
                     if src_shape != <u32 as ::facet::Facet>::SHAPE {
                         return Err(::facet::TryFromError::UnsupportedSourceShape {
                             src_shape,

--- a/facet-json/tests/ordered-float.rs
+++ b/facet-json/tests/ordered-float.rs
@@ -24,3 +24,13 @@ fn transparent_ordered_float_2() {
     let deser: PixelDensity = facet_json::from_str(r#"1.4"#).map_err(|e| eyre::eyre!("{e}"))?;
     assert_eq!(deser.0, 1.4);
 }
+
+#[test]
+fn transparent_ordered_float_3() {
+    #[derive(Facet)]
+    #[facet(transparent)]
+    struct PixelDensity(OrderedFloat<f32>);
+
+    let deser: PixelDensity = facet_json::from_str(r#"1.4"#).map_err(|e| eyre::eyre!("{e}"))?;
+    assert_eq!(deser.0, OrderedFloat(1.4));
+}


### PR DESCRIPTION
For the case `Density(OrderedFloat<f32>)` for example: don't fail if we're trying to put an OrderedFloat — even if OrderedFloat itself has a try_from_inner, we should still see if it's the exact same type.