### PR TITLE
Add support for `Shape::type_tag`

### DIFF
--- a/facet-core/CHANGELOG.md
+++ b/facet-core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for `Shape::type_tag`
+
 ## [0.27.6](https://github.com/facet-rs/facet/compare/facet-core-v0.27.5...facet-core-v0.27.6) - 2025-05-26
 
 ### Other

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -64,6 +64,12 @@ pub struct Shape<'shape> {
     /// Attributes that can be applied to a shape
     pub attributes: &'shape [ShapeAttribute<'shape>],
 
+    /// Shape type tag, used to identify the type in self describing formats.
+    ///
+    /// For some formats, this is a fully or partially qualified name.
+    /// For other formats, this is a simple string or integer type.
+    pub type_tag: Option<&'shape str>,
+
     /// As far as serialization and deserialization goes, we consider that this shape is a wrapper
     /// for that shape This is true for "newtypes" like `NonZero`, wrappers like `Utf8PathBuf`,
     /// smart pointers like `Arc<T>`, etc.
@@ -197,6 +203,7 @@ pub struct ShapeBuilder<'shape> {
     type_params: &'shape [TypeParam<'shape>],
     doc: &'shape [&'shape str],
     attributes: &'shape [ShapeAttribute<'shape>],
+    type_tag: Option<&'shape str>,
     inner: Option<fn() -> &'shape Shape<'shape>>,
 }
 
@@ -214,6 +221,7 @@ impl<'shape> ShapeBuilder<'shape> {
             type_params: &[],
             doc: &[],
             attributes: &[],
+            type_tag: None,
             inner: None,
         }
     }
@@ -281,6 +289,13 @@ impl<'shape> ShapeBuilder<'shape> {
         self
     }
 
+    /// Sets the `type_tag` field of the `ShapeBuilder`.
+    #[inline]
+    pub const fn type_tag(mut self, type_tag: &'shape str) -> Self {
+        self.type_tag = Some(type_tag);
+        self
+    }
+
     /// Sets the `inner` field of the `ShapeBuilder`.
     ///
     /// This indicates that this shape is a transparent wrapper for another shape,
@@ -311,6 +326,7 @@ impl<'shape> ShapeBuilder<'shape> {
             ty: self.ty.unwrap(),
             doc: self.doc,
             attributes: self.attributes,
+            type_tag: self.type_tag,
             inner: self.inner,
         }
     }

--- a/facet-derive-emit/CHANGELOG.md
+++ b/facet-derive-emit/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for `Shape::type_tag`
+
 ## [0.27.7](https://github.com/facet-rs/facet/compare/facet-derive-emit-v0.27.6...facet-derive-emit-v0.27.7) - 2025-05-27
 
 ### Other

--- a/facet-derive-emit/src/parsed.rs
+++ b/facet-derive-emit/src/parsed.rs
@@ -84,6 +84,10 @@ pub enum PFacetAttr {
     /// Valid in field, enum variant, or container
     /// `#[facet(skip_serializing_if = "func")]` — skip serializing if the function returns true.
     SkipSerializingIf { expr: TokenStream },
+
+    /// Valid in container
+    /// `#[facet(type_tag = "com.example.MyType")]` — identify type by tag and serialize with this tag
+    TypeTag { content: String },
 }
 
 impl PFacetAttr {
@@ -135,6 +139,11 @@ impl PFacetAttr {
                 FacetInner::SkipSerializingIf(skip_if) => {
                     dest.push(PFacetAttr::SkipSerializingIf {
                         expr: skip_if.expr.to_token_stream(),
+                    });
+                }
+                FacetInner::TypeTag(type_tag) => {
+                    dest.push(PFacetAttr::TypeTag {
+                        content: type_tag.expr.as_str().to_string(),
                     });
                 }
             }
@@ -439,6 +448,15 @@ impl PAttrs {
         self.facet
             .iter()
             .any(|attr| matches!(attr, PFacetAttr::Transparent))
+    }
+
+    pub(crate) fn type_tag(&self) -> Option<&str> {
+        for attr in &self.facet {
+            if let PFacetAttr::TypeTag { content } = attr {
+                return Some(content);
+            }
+        }
+        None
     }
 }
 

--- a/facet-derive-emit/src/process_enum.rs
+++ b/facet-derive-emit/src/process_enum.rs
@@ -57,6 +57,14 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
         }
     };
 
+    let type_tag_maybe = {
+        if let Some(type_tag) = pe.container.attrs.type_tag() {
+            quote! { .type_tag(#type_tag) }
+        } else {
+            quote! {}
+        }
+    };
+
     // Determine enum repr (already resolved by PEnum::parse())
     let valid_repr = &pe.repr;
 
@@ -588,6 +596,7 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                     ))
                     #maybe_container_doc
                     #container_attributes_tokens
+                    #type_tag_maybe
                     .build()
             };
         }

--- a/facet-derive-emit/tests/codegen/mod.rs
+++ b/facet-derive-emit/tests/codegen/mod.rs
@@ -628,7 +628,7 @@ fn struct_with_facet_attributes() {
     insta::assert_snapshot!(expand(
         r#"
         #[derive(Facet)]
-        #[facet(name = "MyCoolStruct", deny_unknown_fields, version = 2)]
+        #[facet(name = "MyCoolStruct", deny_unknown_fields, version = 2, type_tag = "rs.facet.MyCoolStruct")]
         struct StructWithAttributes {
             #[facet(name = "identifier", default = generate_id, sensitive)]
             id: String,
@@ -648,7 +648,7 @@ fn enum_with_facet_attributes() {
     insta::assert_snapshot!(expand(
         r#"
         #[derive(Facet)]
-        #[facet(name = "MyCoolEnum", repr = "u16")]
+        #[facet(name = "MyCoolEnum", repr = "u16", type_tag = "rs.facet.MyCoolEnum")]
         #[repr(u16)] // Ensure repr matches if specified in facet attribute
         enum EnumWithAttributes {
             #[facet(name = "FirstVariant", discriminant = 10)]

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_facet_attributes.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_facet_attributes.snap
@@ -1,7 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
-assertion_line: 648
-expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(name = \"MyCoolEnum\", repr = \"u16\")]\n        #[repr(u16)] // Ensure repr matches if specified in facet attribute\n        enum EnumWithAttributes {\n            #[facet(name = \"FirstVariant\", discriminant = 10)]\n            VariantA,\n\n            #[facet(skip)]\n            InternalVariant(i32),\n\n            #[facet(deprecated = \"Use VariantD instead\")]\n            VariantC {\n                #[facet(sensitive)]\n                secret: String\n            },\n\n            VariantD {\n                 #[facet(default = forty_two())]\n                 value: i32\n            },\n        }\n        \"#)"
+expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(name = \"MyCoolEnum\", repr = \"u16\", type_tag = \"rs.facet.MyCoolEnum\")]\n        #[repr(u16)] // Ensure repr matches if specified in facet attribute\n        enum EnumWithAttributes {\n            #[facet(name = \"FirstVariant\", discriminant = 10)]\n            VariantA,\n\n            #[facet(skip)]\n            InternalVariant(i32),\n\n            #[facet(deprecated = \"Use VariantD instead\")]\n            VariantC {\n                #[facet(sensitive)]\n                secret: String\n            },\n\n            VariantD {\n                 #[facet(default = forty_two())]\n                 value: i32\n            },\n        }\n        \"#)"
 ---
 #[used]
 static ENUM_WITH_ATTRIBUTES_SHAPE: &'static ::facet::Shape =
@@ -130,6 +129,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for EnumWithAttributes {
                     ]
                 },
             )
+            .type_tag("rs.facet.MyCoolEnum")
             .build()
     };
 }

--- a/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_facet_attributes.snap
+++ b/facet-derive-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_facet_attributes.snap
@@ -1,7 +1,6 @@
 ---
 source: facet-derive-emit/tests/codegen/mod.rs
-assertion_line: 628
-expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(name = \"MyCoolStruct\", deny_unknown_fields, version = 2)]\n        struct StructWithAttributes {\n            #[facet(name = \"identifier\", default = generate_id, sensitive)]\n            id: String,\n            #[facet(skip, version = 3)]\n            internal_data: Vec<u8>,\n            #[facet(deprecated = \"Use 'new_value' instead\")]\n            old_value: i32,\n            new_value: i32,\n        }\n        \"#)"
+expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(name = \"MyCoolStruct\", deny_unknown_fields, version = 2, type_tag = \"rs.facet.MyCoolStruct\")]\n        struct StructWithAttributes {\n            #[facet(name = \"identifier\", default = generate_id, sensitive)]\n            id: String,\n            #[facet(skip, version = 3)]\n            internal_data: Vec<u8>,\n            #[facet(deprecated = \"Use 'new_value' instead\")]\n            old_value: i32,\n            new_value: i32,\n        }\n        \"#)"
 ---
 #[used]
 static STRUCT_WITH_ATTRIBUTES_SHAPE: &'static ::facet::Shape =
@@ -75,6 +74,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for StructWithAttributes {
                 ::facet::ShapeAttribute::DenyUnknownFields,
                 ::facet::ShapeAttribute::Arbitrary("version = 2"),
             ])
+            .type_tag("rs.facet.MyCoolStruct")
             .build()
     };
 }

--- a/facet-derive-parse/CHANGELOG.md
+++ b/facet-derive-parse/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for `Shape::type_tag`
+
 ## [0.27.0](https://github.com/facet-rs/facet/compare/facet-derive-parse-v0.26.1...facet-derive-parse-v0.27.0) - 2025-05-13
 
 ### Other

--- a/facet-derive-parse/src/lib.rs
+++ b/facet-derive-parse/src/lib.rs
@@ -50,6 +50,8 @@ keyword! {
     pub KSkipSerializing = "skip_serializing";
     /// The "skip_serializing_if" keyword.
     pub KSkipSerializingIf = "skip_serializing_if";
+    /// The "type_tag" keyword.
+    pub KTypeTag = "type_tag";
 }
 
 operator! {
@@ -155,6 +157,8 @@ unsynn! {
         SkipSerializing(SkipSerializingInner),
         /// A skip_serializing_if attribute that specifies a condition for skipping serialization.
         SkipSerializingIf(SkipSerializingIfInner),
+        /// A type_tag attribute that specifies the identifying tag for self describing formats
+        TypeTag(TypeTagInner),
         /// Any other attribute represented as a sequence of token trees.
         Arbitrary(VerbatimUntil<Comma>),
     }
@@ -187,13 +191,23 @@ unsynn! {
         pub expr: VerbatimUntil<Comma>,
     }
 
+    /// Inner value for #[facet(type_tag = ...)]
+    pub struct TypeTagInner {
+        /// The "type_tag" keyword.
+        pub _kw_type_tag: KTypeTag,
+        /// The equals sign '='.
+        pub _eq: Eq,
+        /// The value assigned, as a literal string.
+        pub expr: LiteralString,
+    }
+
     /// Inner value for #[facet(default = ...)]
     pub struct DefaultEqualsInner {
         /// The "default" keyword.
         pub _kw_default: KDefault,
         /// The equals sign '='.
         pub _eq: Eq,
-        /// The value assigned, as a literal string.
+        /// The value assigned, as verbatim until comma.
         pub expr: VerbatimUntil<Comma>,
     }
 


### PR DESCRIPTION
Fixes #634 

I opted to name this `type_tag` to prevent future conflicts, as was raised in the linked issue.