### PR TITLE
flake: formatter: set to alejandra

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,36 +7,38 @@
   # shell.nix compatibility
   inputs.flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
 
-  outputs = { self, nixpkgs, ... }:
-    let
-      # System types to support.
-      targetSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  }: let
+    # System types to support.
+    targetSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
 
-      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
-      forAllSystems = nixpkgs.lib.genAttrs targetSystems;
-    in {
-      devShells = forAllSystems (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-        in
-        {
-          default = pkgs.mkShell {
-            strictDeps = true;
-            RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
-            nativeBuildInputs = with pkgs; [
-              cargo
-              rustc
+    # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+    forAllSystems = nixpkgs.lib.genAttrs targetSystems;
+  in {
+    devShells = forAllSystems (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        default = pkgs.mkShell {
+          strictDeps = true;
+          RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+          nativeBuildInputs = with pkgs; [
+            cargo
+            rustc
 
-              rustfmt
-              clippy
-              rust-analyzer
+            rustfmt
+            clippy
+            rust-analyzer
 
-              cargo-nextest
-            ];
-          };
-        }
-      );
+            cargo-nextest
+          ];
+        };
+      }
+    );
 
-      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
-    };
+    formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
+  };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,13 +1,14 @@
-(import
+(
+  import
   (
     let
       lock = builtins.fromJSON (builtins.readFile ./flake.lock);
       nodeName = lock.nodes.root.inputs.flake-compat;
     in
-    fetchTarball {
-      url = lock.nodes.${nodeName}.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
-      sha256 = lock.nodes.${nodeName}.locked.narHash;
-    }
+      fetchTarball {
+        url = lock.nodes.${nodeName}.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+        sha256 = lock.nodes.${nodeName}.locked.narHash;
+      }
   )
-  { src = ./.; }
+  {src = ./.;}
 ).shellNix


### PR DESCRIPTION
This chooses Alejandra as the flake's formatter. For VS Code, this plays well with:
```json
"nix.serverSettings": {
  "nixd": {
    "formatting": {
      "command": [
        "nix",
        "fmt",
        "--",
        "--"
      ]
    }
  }
},
```

To format treewide on the command line, use `nix fmt -- .`.

I chose Alejandra for the formatter because despite all of the nixpkgs team's effort to force people to use `nixfmt-rfc-style`, many people still choose Alejandra because of the familiar style that closely resembles hand-written code. The original `nixfmt`, before the takeover (still available as `nixfmt-classic`) probably makes the most people happy, but doesn't get updates anymore. `nixfmt-classic` is the most diff-friendly one, but Alejandra is more common.