### PR TITLE
Migrate push_ methods to begin_ convention in facet-reflect

### DIFF
--- a/facet-msgpack/src/deserialize.rs
+++ b/facet-msgpack/src/deserialize.rs
@@ -701,8 +701,8 @@ impl<'input, 'shape> Decoder<'input> {
             } else {
                 trace!("Option value is present, setting to Some");
                 // Value is present - initialize a Some option
-                wip.push_some()?;
-                trace!("After push_some, wip shape: {}", wip.shape());
+                wip.begin_some()?;
+                trace!("After begin_some, wip shape: {}", wip.shape());
                 self.deserialize_value(wip)?;
                 trace!("After deserialize_value, calling end");
                 wip.end()?;

--- a/facet-reflect/MIGRATION.md
+++ b/facet-reflect/MIGRATION.md
@@ -13,6 +13,11 @@
 | `wip.begin_map_insert()` | Just use `partial.begin_map()` | No separate insert method |
 | `wip.put_empty_list()` | Just use `partial.begin_list()` | Don't add items for empty |
 | `wip.put_empty_map()` | Just use `partial.begin_map()` | Don't add items for empty |
+| `wip.push_some()` | `partial.begin_some()` | For Option::Some variant |
+| `wip.push_inner()` | `partial.begin_inner()` | For wrapper types |
+| `wip.push_pointee()` | `partial.begin_smart_ptr()` | Removed alias |
+| `wip.push_map_key()` | `partial.begin_key()` | Removed alias |
+| `wip.push_map_value()` | `partial.begin_value()` | Removed alias |
 
 ## Major API Changes
 
@@ -43,13 +48,17 @@ The API uses descriptive method names for different operations:
 - `begin_list()` - Initialize a list/vector for adding elements
 - `begin_list_item()` - Add an item to a list
 - `begin_map()` - Initialize a map for adding key-value pairs
-- `begin_key()` / `push_map_key()` - Push a frame for setting the key of a map entry (push_map_key is an alias)
-- `begin_value()` / `push_map_value()` - Push a frame for setting the value of a map entry (push_map_value is an alias)
+- `begin_key()` - Push a frame for setting the key of a map entry
+- `begin_value()` - Push a frame for setting the value of a map entry
 
 Note: Methods like `put_empty_list()` and `put_empty_map()` no longer exist. To create empty collections, just call `begin_list()`/`begin_map()` without adding any items.
 
-#### Smart Pointers
+#### Option Types
+- `begin_some()` - Initialize the Some variant of an Option
+
+#### Smart Pointers and Wrapper Types
 - `begin_smart_ptr()` - Navigate into smart pointer contents (Box, Arc, etc.)
+- `begin_inner()` - Navigate into wrapper type contents (types with inner values)
 
 ### 4. Setting Values
 - `put()` → `set()` - Set a value at the current position
@@ -119,10 +128,10 @@ wip = wip.pop_map_entry()?;
 ```rust
 let mut partial = Partial::alloc::<HashMap<String, i32>>()?;
 partial.begin_map()?;
-partial.begin_key()?;   // or push_map_key()
+partial.begin_key()?;
 partial.set("key".to_string())?;
 partial.end()?;
-partial.begin_value()?; // or push_map_value()
+partial.begin_value()?;
 partial.set(42)?;
 partial.end()?;
 ```
@@ -162,9 +171,15 @@ partial.set(Some("hello".to_string()))?;  // Explicit Some
 
 // Or for None:
 partial.set(None)?;
+
+// Alternative: Use begin_some() to build Some variant
+let mut partial = Partial::alloc::<Option<String>>()?;
+partial.begin_some()?;
+partial.set("hello".to_string())?;
+partial.end()?;
 ```
 
-**Note**: The implicit conversion from inner value to `Some` has been removed for clarity and consistency. You must now explicitly provide `Some(value)` or `None`.
+**Note**: The implicit conversion from inner value to `Some` has been removed for clarity and consistency. You must now explicitly provide `Some(value)` or `None` when using `set()`, or use `begin_some()` to construct the Some variant.
 
 ## Key Differences
 

--- a/facet-reflect/src/error.rs
+++ b/facet-reflect/src/error.rs
@@ -84,7 +84,7 @@ pub enum ReflectError<'shape> {
     },
 
     /// Indicates that we try to access a field on an `Arc<T>`, for example, and the field might exist
-    /// on the T, but you need to do push_pointee first when using the WIP API.
+    /// on the T, but you need to do begin_smart_ptr first when using the WIP API.
     MissingPushPointee {
         /// The smart pointer (`Arc<T>`, `Box<T>` etc.) shape on which field was caleld
         shape: &'shape Shape<'shape>,
@@ -220,7 +220,7 @@ impl core::fmt::Display for ReflectError<'_> {
                     f,
                     "Tried to access a field on smart pointer '{}', but you need to call {} first to work with the value it points to (and pop it with {} later)",
                     shape.blue(),
-                    ".push_pointee()".yellow(),
+                    ".begin_smart_ptr()".yellow(),
                     ".pop()".yellow()
                 )
             }

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -2140,7 +2140,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     }
 
     /// Begin building the Some variant of an Option
-    pub fn push_some(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
+    pub fn begin_some(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
         self.require_active()?;
         let frame = self.frames.last_mut().unwrap();
 
@@ -2190,13 +2190,8 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
         Ok(self)
     }
 
-    /// Begin building the inner value of a smart pointer
-    pub fn push_pointee(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
-        self.begin_smart_ptr()
-    }
-
     /// Begin building the inner value of a wrapper type
-    pub fn push_inner(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
+    pub fn begin_inner(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
         self.require_active()?;
 
         // Get the inner shape and check for try_from
@@ -2240,7 +2235,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
                 // This allows setting values of the inner type which will be converted
                 // The automatic conversion detection in end() will handle the conversion
                 trace!(
-                    "push_inner: Creating frame for inner type {} (parent is {})",
+                    "begin_inner: Creating frame for inner type {} (parent is {})",
                     inner_shape, parent_shape
                 );
                 self.frames
@@ -2251,7 +2246,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
                 // For wrapper types without try_from, navigate to the first field
                 // This is a common pattern for newtype wrappers
                 trace!(
-                    "push_inner: No try_from for {}, using field navigation",
+                    "begin_inner: No try_from for {}, using field navigation",
                     parent_shape
                 );
                 self.begin_nth_field(0)
@@ -2262,16 +2257,6 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
                 operation: "type does not have an inner value",
             })
         }
-    }
-
-    /// Begin building a map key (for compatibility)
-    pub fn push_map_key(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
-        self.begin_key()
-    }
-
-    /// Begin building a map value (for compatibility)
-    pub fn push_map_value(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
-        self.begin_value()
     }
 
     /// Copy a value from a Peek into the current position (safe alternative to set_shape)
@@ -2695,21 +2680,15 @@ impl<'facet, 'shape, T> TypedPartial<'facet, 'shape, T> {
         Ok(self)
     }
 
-    /// Forwards push_some to the inner wip instance.
-    pub fn push_some(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
-        self.inner.push_some()?;
+    /// Forwards begin_some to the inner wip instance.
+    pub fn begin_some(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
+        self.inner.begin_some()?;
         Ok(self)
     }
 
-    /// Forwards push_pointee to the inner wip instance.
-    pub fn push_pointee(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
-        self.inner.push_pointee()?;
-        Ok(self)
-    }
-
-    /// Forwards push_inner to the inner wip instance.
-    pub fn push_inner(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
-        self.inner.push_inner()?;
+    /// Forwards begin_inner to the inner wip instance.
+    pub fn begin_inner(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
+        self.inner.begin_inner()?;
         Ok(self)
     }
 }

--- a/facet-reflect/tests/partial/option_building.rs
+++ b/facet-reflect/tests/partial/option_building.rs
@@ -45,17 +45,17 @@ fn test_option_building_none() {
 }
 
 #[test]
-fn test_option_building_with_push_some() {
+fn test_option_building_with_begin_some() {
     // This test will likely fail with the current implementation
     // but it shows what we WANT to be able to do
     let mut wip = Partial::alloc::<Option<String>>()?;
 
-    // Try the current push_some API
-    let result = wip.push_some();
+    // Try the current begin_some API
+    let result = wip.begin_some();
 
     match result {
         Ok(_) => {
-            // If push_some works, continue building
+            // If begin_some works, continue building
             wip.set("hello".to_string())?;
             wip.end()?;
 
@@ -64,8 +64,8 @@ fn test_option_building_with_push_some() {
             assert_eq!(option_value, Some("hello".to_string()));
         }
         Err(e) => {
-            println!("push_some failed as expected: {:?}", e);
-            // This shows that push_some is not properly implemented
+            println!("begin_some failed as expected: {:?}", e);
+            // This shows that begin_some is not properly implemented
         }
     }
 }

--- a/facet-toml/src/deserialize/mod.rs
+++ b/facet-toml/src/deserialize/mod.rs
@@ -532,8 +532,8 @@ fn deserialize_as_option<'input, 'a, 'shape>(
         "option".blue()
     );
 
-    // Use push_some to initialize the Option as Some
-    reflect!(wip, toml, item.span(), push_some());
+    // Use begin_some to initialize the Option as Some
+    reflect!(wip, toml, item.span(), begin_some());
 
     // Deserialize the inner value
     deserialize_item(toml, wip, item)?;

--- a/facet-yaml/src/deserialize/mod.rs
+++ b/facet-yaml/src/deserialize/mod.rs
@@ -94,7 +94,7 @@ fn deserialize_value<'facet, 'shape>(
         log::debug!("Handling facet(transparent) type");
 
         // For transparent types, push inner and deserialize as inner type
-        wip.push_inner().map_err(|e| AnyErr(e.to_string()))?;
+        wip.begin_inner().map_err(|e| AnyErr(e.to_string()))?;
         deserialize_value(wip, value)?;
         wip.end().map_err(|e| AnyErr(e.to_string()))?;
         return Ok(());
@@ -408,7 +408,7 @@ fn deserialize_value<'facet, 'shape>(
                 // Null maps to None - already handled by default
             } else {
                 // Non-null maps to Some(value)
-                wip.push_some().map_err(|e| AnyErr(e.to_string()))?;
+                wip.begin_some().map_err(|e| AnyErr(e.to_string()))?;
                 deserialize_value(wip, value)?;
                 wip.end().map_err(|e| AnyErr(e.to_string()))?;
             }


### PR DESCRIPTION
This completes the transition from push_*/pop naming to begin_*/end convention by:

- Renaming push_some() to begin_some() for Option::Some variant
- Renaming push_inner() to begin_inner() for wrapper types
- Removing compatibility aliases: push_map_key, push_map_value, push_pointee
- Updating all call sites across facet-deserialize, facet-msgpack, facet-yaml, and facet-toml
- Updating MIGRATION.md with the new method names

This change makes the API more consistent with the begin_* prefix for all navigation methods.

Fixes #715

🤖 Generated with [Claude Code](https://claude.ai/code)