### PR TITLE
Fix JSON serialization of &[u8] slices

### DIFF
--- a/facet-json/src/serialize.rs
+++ b/facet-json/src/serialize.rs
@@ -230,8 +230,12 @@ impl<'shape, W: crate::JsonWrite> Serializer<'shape> for JsonSerializer<W> {
         self.end_value()
     }
 
-    fn serialize_bytes(&mut self, _value: &[u8]) -> Result<(), Self::Error> {
-        panic!("JSON does not support byte arrays")
+    fn serialize_bytes(&mut self, value: &[u8]) -> Result<(), Self::Error> {
+        self.start_array(Some(value.len()))?;
+        for &byte in value {
+            self.serialize_u8(byte)?;
+        }
+        self.end_array()
     }
 
     fn serialize_none(&mut self) -> Result<(), Self::Error> {

--- a/facet-json/tests/bytes.rs
+++ b/facet-json/tests/bytes.rs
@@ -70,3 +70,103 @@ fn json_write_bytes_mut() {
     let json = to_string(&value);
     assert_eq!(json, r#"{"data":[1,2,3,4,255]}"#);
 }
+
+#[test]
+fn json_write_vec_u8() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        data: Vec<u8>,
+    }
+
+    let value = FooBar {
+        data: vec![0, 128, 255, 42],
+    };
+
+    let json = to_string(&value);
+    assert_eq!(json, r#"{"data":[0,128,255,42]}"#);
+}
+
+#[test]
+fn json_read_vec_u8() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        data: Vec<u8>,
+    }
+
+    let json = r#"{"data":[0, 128, 255, 42]}"#;
+
+    let s: FooBar = from_str(json)?;
+    assert_eq!(
+        s,
+        FooBar {
+            data: vec![0, 128, 255, 42],
+        }
+    );
+}
+
+#[test]
+fn json_write_slice_u8() {
+    let bytes: [u8; 5] = [10, 20, 30, 40, 250];
+    let json = to_string(&bytes);
+    assert_eq!(json, r#"[10,20,30,40,250]"#);
+}
+
+#[test]
+fn json_write_slice_u8_in_struct() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Container<'a> {
+        data: &'a [u8],
+    }
+
+    let bytes: [u8; 5] = [10, 20, 30, 40, 250];
+    let container = Container { data: &bytes };
+    let json = to_string(&container);
+    assert_eq!(json, r#"{"data":[10,20,30,40,250]}"#);
+}
+
+#[test]
+fn json_roundtrip_empty_bytes() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        data: Vec<u8>,
+    }
+
+    let value = FooBar { data: vec![] };
+    let json = to_string(&value);
+    assert_eq!(json, r#"{"data":[]}"#);
+
+    let parsed: FooBar = from_str(&json).unwrap();
+    assert_eq!(parsed, value);
+}
+
+#[test]
+fn json_roundtrip_single_byte() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        data: Vec<u8>,
+    }
+
+    let value = FooBar { data: vec![123] };
+    let json = to_string(&value);
+    assert_eq!(json, r#"{"data":[123]}"#);
+
+    let parsed: FooBar = from_str(&json).unwrap();
+    assert_eq!(parsed, value);
+}
+
+#[test]
+fn json_roundtrip_bytes_full_range() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct FooBar {
+        data: Vec<u8>,
+    }
+
+    // Test all possible byte values
+    let value = FooBar {
+        data: (0..=255).collect(),
+    };
+    let json = to_string(&value);
+
+    let parsed: FooBar = from_str(&json).unwrap();
+    assert_eq!(parsed, value);
+}

--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -205,6 +205,21 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
         }
     }
 
+    /// Try to get the value as a byte slice if it's a &[u8] type
+    /// Returns None if the value is not a byte slice or couldn't be extracted
+    pub fn as_bytes(&self) -> Option<&'mem [u8]> {
+        // Check if it's a direct &[u8]
+        if let Type::Pointer(PointerType::Reference(vpt)) = self.shape.ty {
+            let target_shape = (vpt.target)();
+            if let Def::Slice(sd) = target_shape.def {
+                if sd.t().is_type::<u8>() {
+                    unsafe { return Some(self.data.get::<&[u8]>()) }
+                }
+            }
+        }
+        None
+    }
+
     /// Tries to identify this value as a struct
     pub fn into_struct(self) -> Result<PeekStruct<'mem, 'facet, 'shape>, ReflectError<'shape>> {
         if let Type::User(UserType::Struct(ty)) = self.shape.ty {

--- a/facet-serialize/src/lib.rs
+++ b/facet-serialize/src/lib.rs
@@ -296,6 +296,12 @@ where
                     );
                 }
 
+                debug!(
+                    "Matching def={:?}, ty={:?} for shape={}",
+                    cpeek.shape().def,
+                    cpeek.shape().ty,
+                    cpeek.shape()
+                );
                 match (cpeek.shape().def, cpeek.shape().ty) {
                     (Def::Scalar(sd), _) => {
                         let cpeek = cpeek.innermost_peek();
@@ -619,6 +625,9 @@ where
                         if let Some(str_value) = cpeek.as_str() {
                             // We have a string value, serialize it
                             serializer.serialize_str(str_value)?;
+                        } else if let Some(bytes) = cpeek.as_bytes() {
+                            // We have a byte slice, serialize it as bytes
+                            serializer.serialize_bytes(bytes)?;
                         } else if let PointerType::Function(_) = pointer_type {
                             // Serialize function pointers as units
                             serializer.serialize_unit()?;


### PR DESCRIPTION
Previously, &[u8] references were serialized as null in JSON. This adds proper support for serializing them as arrays of numbers, matching the behavior of Vec<u8> and other byte containers.

- Add as_bytes() method to Peek for detecting &[u8] references
- Update serializer to check for byte slices and use serialize_bytes()
- Add comprehensive tests for various byte slice scenarios