### PR TITLE
facet-toml: tests: deser: add missing vec_struct test

### DIFF
--- a/facet-toml/tests/deserialize/mod.rs
+++ b/facet-toml/tests/deserialize/mod.rs
@@ -6,3 +6,4 @@ mod map;
 mod option;
 mod scalar;
 mod struct_;
+mod vec_struct;

--- a/facet-toml/tests/deserialize/vec_struct.rs
+++ b/facet-toml/tests/deserialize/vec_struct.rs
@@ -1,0 +1,44 @@
+//! Test for Vec<Struct> deserialization
+
+use facet::Facet;
+use facet_testhelpers::test;
+
+#[derive(Debug, Facet, PartialEq)]
+struct Person {
+    name: String,
+    age: u64,
+}
+
+#[derive(Debug, Facet, PartialEq)]
+struct Root {
+    people: Vec<Person>,
+}
+
+#[test]
+fn test_deserialize_vec_struct() {
+    assert_eq!(
+        facet_toml::from_str::<Root>(
+            r#"
+            [[people]]
+            name = "Alice"
+            age = 30
+
+            [[people]]
+            name = "Bob"
+            age = 25
+            "#
+        )?,
+        Root {
+            people: vec![
+                Person {
+                    name: "Alice".to_string(),
+                    age: 30,
+                },
+                Person {
+                    name: "Bob".to_string(),
+                    age: 25,
+                },
+            ],
+        }
+    );
+}


### PR DESCRIPTION
Somebody seems to have dropped this.