### PR TITLE
Switch JSON floats to lexical-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,9 +536,9 @@ dependencies = [
  "insta",
  "itoa",
  "jiff",
+ "lexical-core",
  "log",
  "ordered-float",
- "ryu",
  "time",
  "ulid",
  "uuid",
@@ -1072,6 +1072,68 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lexical-core"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b765c31809609075565a70b4b71402281283aeda7ecaf4818ac14a7b2ade8958"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-util",
+ "lexical-write-float",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de6f9cb01fb0b08060209a057c048fcbab8717b4c1ecd2eac66ebfe39a65b0f2"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72207aae22fc0a121ba7b6d479e42cbfea549af1479c3f3a4f12c70dd66df12e"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a82e24bf537fd24c177ffbbdc6ebcc8d54732c35b50a3f28cc3f4e4c949a0b3"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afc668a27f460fb45a81a757b6bf2f43c2d7e30cb5a2dcd3abf294c78d62bd"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629ddff1a914a836fb245616a7888b62903aae58fa771e1d83943035efa0f978"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"

--- a/facet-json/CHANGELOG.md
+++ b/facet-json/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - move to self-owned write trait
 - Use a Vec instead of a Writer for the json serialializer
 - Allow transparent key types
-- switch to ryu for float formatting
+- switch to lexical-core for float formatting and parsing
 - add tokenizer test, fix tokenizer using said test
 - cow tokens
 - expand flamegraph using inline never

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -20,7 +20,7 @@ facet-reflect = { version = "0.27.11", path = "../facet-reflect", default-featur
 facet-serialize = { version = "0.24.12", path = "../facet-serialize", default-features = false }
 itoa = "1.0.15"
 log = "0.4.27"
-ryu = "1"
+lexical-core = { version = "1", default-features = false, features = ["write-floats", "parse-floats"] }
 
 [dev-dependencies]
 bytes = { version = "1.10.1" }

--- a/facet-json/src/serialize.rs
+++ b/facet-json/src/serialize.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 use facet_core::Facet;
 use facet_reflect::Peek;
 use facet_serialize::{Serializer, serialize_iterative};
+use lexical_core::{BUFFER_SIZE, write};
 use log::debug;
 
 /// Serializes a value implementing `Facet` to a JSON string.
@@ -195,17 +196,17 @@ impl<'shape, W: crate::JsonWrite> Serializer<'shape> for JsonSerializer<W> {
 
     fn serialize_f32(&mut self, value: f32) -> Result<(), Self::Error> {
         self.start_value()?;
-        // self.writer.write(value.to_string().as_bytes());
-        self.writer
-            .write(ryu::Buffer::new().format(value).as_bytes());
+        let mut buf = [0u8; BUFFER_SIZE];
+        let bytes = write(value, &mut buf);
+        self.writer.write(bytes);
         self.end_value()
     }
 
     fn serialize_f64(&mut self, value: f64) -> Result<(), Self::Error> {
         self.start_value()?;
-        // self.writer.write(value.to_string().as_bytes());
-        self.writer
-            .write(ryu::Buffer::new().format(value).as_bytes());
+        let mut buf = [0u8; BUFFER_SIZE];
+        let bytes = write(value, &mut buf);
+        self.writer.write(bytes);
         self.end_value()
     }
 

--- a/facet-json/src/tokenizer.rs
+++ b/facet-json/src/tokenizer.rs
@@ -414,7 +414,7 @@ impl<'input> Tokenizer<'input> {
 
         let token = if text.contains('.') || text.contains('e') || text.contains('E') {
             // If the number contains a decimal point or exponent, parse as f64
-            match text.parse::<f64>() {
+            match lexical_core::parse::<f64>(slice) {
                 Ok(n) => Token::F64(n),
                 Err(_) => {
                     return Err(TokenError {
@@ -429,7 +429,7 @@ impl<'input> Tokenizer<'input> {
                 Ok(n) => Token::I64(n),
                 Err(_) => {
                     // If i64 parsing fails, try to parse as f64 for error reporting
-                    let num = text.parse::<f64>().unwrap_or(0.0);
+                    let num = lexical_core::parse::<f64>(slice).unwrap_or(0.0);
                     return Err(TokenError {
                         kind: TokenErrorKind::NumberOutOfRange(num),
                         span,
@@ -442,7 +442,7 @@ impl<'input> Tokenizer<'input> {
                 Ok(n) => Token::U64(n),
                 Err(_) => {
                     // If u64 parsing fails, try to parse as f64 for error reporting
-                    let num = text.parse::<f64>().unwrap_or(0.0);
+                    let num = lexical_core::parse::<f64>(slice).unwrap_or(0.0);
                     return Err(TokenError {
                         kind: TokenErrorKind::NumberOutOfRange(num),
                         span,


### PR DESCRIPTION
## Summary
- swap in lexical-core for floating point formatting/parsing
- document change in changelog
- use cargo-nextest for tests
- address review comments about imports

## Testing
- `cargo nextest run -p facet-json --lib --test-threads=1`
- `cargo nextest run -p facet-json --tests --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_b_683ff63d33a483329f82d69507ea5db8