### PR TITLE
feat(fn): capture function docstring in shape

### DIFF
--- a/facet-macros-emit/src/function/emit.rs
+++ b/facet-macros-emit/src/function/emit.rs
@@ -68,12 +68,19 @@ pub fn generate_function_shape(parsed: FunctionSignature) -> TokenStream {
         quote! { () }
     };
 
+    let documentation_lines: Vec<_> = parsed
+        .documentation
+        .iter()
+        .map(|doc| quote! { #doc })
+        .collect();
+
     let shape_definition = quote! {
         pub fn shape #generics () -> FunctionShape<( #( #types ),* ), #return_type, #generics_type> {
             FunctionShape::new(
                 #fn_name_str,
                 #arity,
-                &[ #( #names ),* ]
+                &[ #( #names ),* ],
+                &[ #( #documentation_lines ),* ]
             )
         }
     };
@@ -90,6 +97,7 @@ pub fn generate_function_shape(parsed: FunctionSignature) -> TokenStream {
                 pub name: &'static str,
                 pub param_count: usize,
                 pub param_names: &'static [&'static str],
+                pub documentation: &'static [&'static str],
                 _args: core::marker::PhantomData<Args>,
                 _ret: core::marker::PhantomData<Ret>,
                 _generics: core::marker::PhantomData<Generics>,
@@ -100,11 +108,13 @@ pub fn generate_function_shape(parsed: FunctionSignature) -> TokenStream {
                     name: &'static str,
                     param_count: usize,
                     param_names: &'static [&'static str],
+                    documentation: &'static [&'static str],
                 ) -> Self {
                     Self {
                         name,
                         param_count,
                         param_names,
+                        documentation,
                         _args: core::marker::PhantomData,
                         _ret: core::marker::PhantomData,
                         _generics: core::marker::PhantomData,

--- a/facet-macros-emit/tests/codegen/function.rs
+++ b/facet-macros-emit/tests/codegen/function.rs
@@ -238,3 +238,78 @@ fn function_with_mutable_references() {
         "#
     ));
 }
+
+#[test]
+fn function_with_single_doc_comment() {
+    insta::assert_snapshot!(expand_function(
+        r#"
+        /// Single line documentation
+        fn greet(name: String) -> String {
+            format!("Hello, {}!", name)
+        }
+        "#
+    ));
+}
+
+#[test]
+fn function_with_multiple_doc_comments() {
+    insta::assert_snapshot!(expand_function(
+        r#"
+        /// This is a test function
+        /// that does addition of two numbers
+        fn add(x: i32, y: i32) -> i32 {
+            x + y
+        }
+        "#
+    ));
+}
+
+#[test]
+fn function_with_doc_comments_and_quotes() {
+    insta::assert_snapshot!(expand_function(
+        r#"
+        /// Hello "world", if that is your real name
+        fn greet(name: String) -> String {
+            format!("Hello, {}...?", name)
+        }
+        "#
+    ));
+}
+
+#[test]
+fn function_with_complex_doc_comments() {
+    insta::assert_snapshot!(expand_function(
+        r###"
+        /// This uses r#"raw strings"# and r##"nested"## syntax
+        fn complex_doc() {
+            println!("test");
+        }
+        "###
+    ));
+}
+
+#[test]
+fn function_with_mixed_attributes() {
+    insta::assert_snapshot!(expand_function(
+        r#"
+        /// Documentation comment
+        #[derive(Debug)]
+        /// More documentation
+        fn mixed_attrs() {
+            println!("test");
+        }
+        "#
+    ));
+}
+
+#[test]
+fn generic_function_with_docs() {
+    insta::assert_snapshot!(expand_function(
+        r#"
+        /// Generic function that adds two values
+        fn generic_add<T: Add<Output = T>>(x: T, y: T) -> T {
+            x + y
+        }
+        "#
+    ));
+}

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_complex_doc_comments.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_complex_doc_comments.snap
@@ -1,12 +1,12 @@
 ---
 source: facet-macros-emit/tests/codegen/function.rs
-expression: "expand_function(r#\"\n        fn bounded_fn<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {\n            data.collect()\n        }\n        \"#)"
+expression: "expand_function(r###\"\n        /// This uses r#\"raw strings\"# and r##\"nested\"## syntax\n        fn complex_doc() {\n            println!(\"test\");\n        }\n        \"###)"
 ---
 #[allow(non_snake_case)]
-mod __fn_shape_bounded_fn {
+mod __fn_shape_complex_doc {
     use super::*;
-    pub(super) fn inner<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {
-        data.collect()
+    pub(super) fn inner() -> () {
+        println!("test");
     }
     #[derive(Debug, Clone)]
     pub struct FunctionShape<Args, Ret, Generics = ()> {
@@ -36,11 +36,16 @@ mod __fn_shape_bounded_fn {
             }
         }
     }
-    pub fn shape<T: Clone + Send, U: Iterator<Item = T>>() -> FunctionShape<(U), Vec<T>, (T, U)> {
-        FunctionShape::new("bounded_fn", 1usize, &["data"], &[])
+    pub fn shape() -> FunctionShape<(), (), ()> {
+        FunctionShape::new(
+            "complex_doc",
+            0usize,
+            &[],
+            &[" This uses r#\"raw strings\"# and r##\"nested\"## syntax"],
+        )
     }
 }
-pub fn bounded_fn<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {
-    __fn_shape_bounded_fn::inner(data)
+pub fn complex_doc() -> () {
+    __fn_shape_complex_doc::inner()
 }
-pub use __fn_shape_bounded_fn::shape as BOUNDED_FN_SHAPE;
+pub use __fn_shape_complex_doc::shape as COMPLEX_DOC_SHAPE;

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_doc_comments_and_quotes.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_doc_comments_and_quotes.snap
@@ -1,12 +1,12 @@
 ---
 source: facet-macros-emit/tests/codegen/function.rs
-expression: "expand_function(r#\"\n        fn bounded_fn<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {\n            data.collect()\n        }\n        \"#)"
+expression: "expand_function(r#\"\n        /// Hello \"world\", if that is your real name\n        fn greet(name: String) -> String {\n            format!(\"Hello, {}...?\", name)\n        }\n        \"#)"
 ---
 #[allow(non_snake_case)]
-mod __fn_shape_bounded_fn {
+mod __fn_shape_greet {
     use super::*;
-    pub(super) fn inner<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {
-        data.collect()
+    pub(super) fn inner(name: String) -> String {
+        format!("Hello, {}...?", name)
     }
     #[derive(Debug, Clone)]
     pub struct FunctionShape<Args, Ret, Generics = ()> {
@@ -36,11 +36,16 @@ mod __fn_shape_bounded_fn {
             }
         }
     }
-    pub fn shape<T: Clone + Send, U: Iterator<Item = T>>() -> FunctionShape<(U), Vec<T>, (T, U)> {
-        FunctionShape::new("bounded_fn", 1usize, &["data"], &[])
+    pub fn shape() -> FunctionShape<(String), String, ()> {
+        FunctionShape::new(
+            "greet",
+            1usize,
+            &["name"],
+            &[" Hello \"world\", if that is your real name"],
+        )
     }
 }
-pub fn bounded_fn<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {
-    __fn_shape_bounded_fn::inner(data)
+pub fn greet(name: String) -> String {
+    __fn_shape_greet::inner(name)
 }
-pub use __fn_shape_bounded_fn::shape as BOUNDED_FN_SHAPE;
+pub use __fn_shape_greet::shape as GREET_SHAPE;

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_mixed_attributes.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_mixed_attributes.snap
@@ -1,12 +1,12 @@
 ---
 source: facet-macros-emit/tests/codegen/function.rs
-expression: "expand_function(r#\"\n        fn bounded_fn<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {\n            data.collect()\n        }\n        \"#)"
+expression: "expand_function(r#\"\n        /// Documentation comment\n        #[derive(Debug)]\n        /// More documentation\n        fn mixed_attrs() {\n            println!(\"test\");\n        }\n        \"#)"
 ---
 #[allow(non_snake_case)]
-mod __fn_shape_bounded_fn {
+mod __fn_shape_mixed_attrs {
     use super::*;
-    pub(super) fn inner<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {
-        data.collect()
+    pub(super) fn inner() -> () {
+        println!("test");
     }
     #[derive(Debug, Clone)]
     pub struct FunctionShape<Args, Ret, Generics = ()> {
@@ -36,11 +36,16 @@ mod __fn_shape_bounded_fn {
             }
         }
     }
-    pub fn shape<T: Clone + Send, U: Iterator<Item = T>>() -> FunctionShape<(U), Vec<T>, (T, U)> {
-        FunctionShape::new("bounded_fn", 1usize, &["data"], &[])
+    pub fn shape() -> FunctionShape<(), (), ()> {
+        FunctionShape::new(
+            "mixed_attrs",
+            0usize,
+            &[],
+            &[" Documentation comment", " More documentation"],
+        )
     }
 }
-pub fn bounded_fn<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {
-    __fn_shape_bounded_fn::inner(data)
+pub fn mixed_attrs() -> () {
+    __fn_shape_mixed_attrs::inner()
 }
-pub use __fn_shape_bounded_fn::shape as BOUNDED_FN_SHAPE;
+pub use __fn_shape_mixed_attrs::shape as MIXED_ATTRS_SHAPE;

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_multiple_doc_comments.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_multiple_doc_comments.snap
@@ -1,12 +1,12 @@
 ---
 source: facet-macros-emit/tests/codegen/function.rs
-expression: "expand_function(r#\"\n        fn bounded_fn<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {\n            data.collect()\n        }\n        \"#)"
+expression: "expand_function(r#\"\n        /// This is a test function\n        /// that does addition of two numbers\n        fn add(x: i32, y: i32) -> i32 {\n            x + y\n        }\n        \"#)"
 ---
 #[allow(non_snake_case)]
-mod __fn_shape_bounded_fn {
+mod __fn_shape_add {
     use super::*;
-    pub(super) fn inner<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {
-        data.collect()
+    pub(super) fn inner(x: i32, y: i32) -> i32 {
+        x + y
     }
     #[derive(Debug, Clone)]
     pub struct FunctionShape<Args, Ret, Generics = ()> {
@@ -36,11 +36,19 @@ mod __fn_shape_bounded_fn {
             }
         }
     }
-    pub fn shape<T: Clone + Send, U: Iterator<Item = T>>() -> FunctionShape<(U), Vec<T>, (T, U)> {
-        FunctionShape::new("bounded_fn", 1usize, &["data"], &[])
+    pub fn shape() -> FunctionShape<(i32, i32), i32, ()> {
+        FunctionShape::new(
+            "add",
+            2usize,
+            &["x", "y"],
+            &[
+                " This is a test function",
+                " that does addition of two numbers",
+            ],
+        )
     }
 }
-pub fn bounded_fn<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {
-    __fn_shape_bounded_fn::inner(data)
+pub fn add(x: i32, y: i32) -> i32 {
+    __fn_shape_add::inner(x, y)
 }
-pub use __fn_shape_bounded_fn::shape as BOUNDED_FN_SHAPE;
+pub use __fn_shape_add::shape as ADD_SHAPE;

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_mutable_references.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_mutable_references.snap
@@ -14,6 +14,7 @@ mod __fn_shape_with_mut_refs {
         pub name: &'static str,
         pub param_count: usize,
         pub param_names: &'static [&'static str],
+        pub documentation: &'static [&'static str],
         _args: core::marker::PhantomData<Args>,
         _ret: core::marker::PhantomData<Ret>,
         _generics: core::marker::PhantomData<Generics>,
@@ -23,11 +24,13 @@ mod __fn_shape_with_mut_refs {
             name: &'static str,
             param_count: usize,
             param_names: &'static [&'static str],
+            documentation: &'static [&'static str],
         ) -> Self {
             Self {
                 name,
                 param_count,
                 param_names,
+                documentation,
                 _args: core::marker::PhantomData,
                 _ret: core::marker::PhantomData,
                 _generics: core::marker::PhantomData,
@@ -35,7 +38,7 @@ mod __fn_shape_with_mut_refs {
         }
     }
     pub fn shape() -> FunctionShape<(&mut i32, &mut Vec<String>), usize, ()> {
-        FunctionShape::new("with_mut_refs", 2usize, &["x", "y"])
+        FunctionShape::new("with_mut_refs", 2usize, &["x", "y"], &[])
     }
 }
 pub fn with_mut_refs(x: &mut i32, y: &mut Vec<String>) -> usize {

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_no_parameters.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_no_parameters.snap
@@ -13,6 +13,7 @@ mod __fn_shape_no_params {
         pub name: &'static str,
         pub param_count: usize,
         pub param_names: &'static [&'static str],
+        pub documentation: &'static [&'static str],
         _args: core::marker::PhantomData<Args>,
         _ret: core::marker::PhantomData<Ret>,
         _generics: core::marker::PhantomData<Generics>,
@@ -22,11 +23,13 @@ mod __fn_shape_no_params {
             name: &'static str,
             param_count: usize,
             param_names: &'static [&'static str],
+            documentation: &'static [&'static str],
         ) -> Self {
             Self {
                 name,
                 param_count,
                 param_names,
+                documentation,
                 _args: core::marker::PhantomData,
                 _ret: core::marker::PhantomData,
                 _generics: core::marker::PhantomData,
@@ -34,7 +37,7 @@ mod __fn_shape_no_params {
         }
     }
     pub fn shape() -> FunctionShape<(), &'static str, ()> {
-        FunctionShape::new("no_params", 0usize, &[])
+        FunctionShape::new("no_params", 0usize, &[], &[])
     }
 }
 pub fn no_params() -> &'static str {

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_no_return_type.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_no_return_type.snap
@@ -13,6 +13,7 @@ mod __fn_shape_no_return {
         pub name: &'static str,
         pub param_count: usize,
         pub param_names: &'static [&'static str],
+        pub documentation: &'static [&'static str],
         _args: core::marker::PhantomData<Args>,
         _ret: core::marker::PhantomData<Ret>,
         _generics: core::marker::PhantomData<Generics>,
@@ -22,11 +23,13 @@ mod __fn_shape_no_return {
             name: &'static str,
             param_count: usize,
             param_names: &'static [&'static str],
+            documentation: &'static [&'static str],
         ) -> Self {
             Self {
                 name,
                 param_count,
                 param_names,
+                documentation,
                 _args: core::marker::PhantomData,
                 _ret: core::marker::PhantomData,
                 _generics: core::marker::PhantomData,
@@ -34,7 +37,7 @@ mod __fn_shape_no_return {
         }
     }
     pub fn shape() -> FunctionShape<(i32), (), ()> {
-        FunctionShape::new("no_return", 1usize, &["x"])
+        FunctionShape::new("no_return", 1usize, &["x"], &[])
     }
 }
 pub fn no_return(x: i32) -> () {

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_single_doc_comment.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_single_doc_comment.snap
@@ -1,12 +1,12 @@
 ---
 source: facet-macros-emit/tests/codegen/function.rs
-expression: "expand_function(r#\"\n        fn bounded_fn<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {\n            data.collect()\n        }\n        \"#)"
+expression: "expand_function(r#\"\n        /// Single line documentation\n        fn greet(name: String) -> String {\n            format!(\"Hello, {}!\", name)\n        }\n        \"#)"
 ---
 #[allow(non_snake_case)]
-mod __fn_shape_bounded_fn {
+mod __fn_shape_greet {
     use super::*;
-    pub(super) fn inner<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {
-        data.collect()
+    pub(super) fn inner(name: String) -> String {
+        format!("Hello, {}!", name)
     }
     #[derive(Debug, Clone)]
     pub struct FunctionShape<Args, Ret, Generics = ()> {
@@ -36,11 +36,11 @@ mod __fn_shape_bounded_fn {
             }
         }
     }
-    pub fn shape<T: Clone + Send, U: Iterator<Item = T>>() -> FunctionShape<(U), Vec<T>, (T, U)> {
-        FunctionShape::new("bounded_fn", 1usize, &["data"], &[])
+    pub fn shape() -> FunctionShape<(String), String, ()> {
+        FunctionShape::new("greet", 1usize, &["name"], &[" Single line documentation"])
     }
 }
-pub fn bounded_fn<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {
-    __fn_shape_bounded_fn::inner(data)
+pub fn greet(name: String) -> String {
+    __fn_shape_greet::inner(name)
 }
-pub use __fn_shape_bounded_fn::shape as BOUNDED_FN_SHAPE;
+pub use __fn_shape_greet::shape as GREET_SHAPE;

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_string_parameter.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__function_with_string_parameter.snap
@@ -13,6 +13,7 @@ mod __fn_shape_greet {
         pub name: &'static str,
         pub param_count: usize,
         pub param_names: &'static [&'static str],
+        pub documentation: &'static [&'static str],
         _args: core::marker::PhantomData<Args>,
         _ret: core::marker::PhantomData<Ret>,
         _generics: core::marker::PhantomData<Generics>,
@@ -22,11 +23,13 @@ mod __fn_shape_greet {
             name: &'static str,
             param_count: usize,
             param_names: &'static [&'static str],
+            documentation: &'static [&'static str],
         ) -> Self {
             Self {
                 name,
                 param_count,
                 param_names,
+                documentation,
                 _args: core::marker::PhantomData,
                 _ret: core::marker::PhantomData,
                 _generics: core::marker::PhantomData,
@@ -34,7 +37,7 @@ mod __fn_shape_greet {
         }
     }
     pub fn shape() -> FunctionShape<(String), String, ()> {
-        FunctionShape::new("greet", 1usize, &["name"])
+        FunctionShape::new("greet", 1usize, &["name"], &[])
     }
 }
 pub fn greet(name: String) -> String {

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__generic_function_multiple_params.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__generic_function_multiple_params.snap
@@ -13,6 +13,7 @@ mod __fn_shape_complex_fn {
         pub name: &'static str,
         pub param_count: usize,
         pub param_names: &'static [&'static str],
+        pub documentation: &'static [&'static str],
         _args: core::marker::PhantomData<Args>,
         _ret: core::marker::PhantomData<Ret>,
         _generics: core::marker::PhantomData<Generics>,
@@ -22,11 +23,13 @@ mod __fn_shape_complex_fn {
             name: &'static str,
             param_count: usize,
             param_names: &'static [&'static str],
+            documentation: &'static [&'static str],
         ) -> Self {
             Self {
                 name,
                 param_count,
                 param_names,
+                documentation,
                 _args: core::marker::PhantomData,
                 _ret: core::marker::PhantomData,
                 _generics: core::marker::PhantomData,
@@ -34,7 +37,7 @@ mod __fn_shape_complex_fn {
         }
     }
     pub fn shape<T, U>() -> FunctionShape<(Vec<T>, Option<U>), Result<T, U>, (T, U)> {
-        FunctionShape::new("complex_fn", 2usize, &["x", "y"])
+        FunctionShape::new("complex_fn", 2usize, &["x", "y"], &[])
     }
 }
 pub fn complex_fn<T, U>(x: Vec<T>, y: Option<U>) -> Result<T, U> {

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__generic_function_simple.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__generic_function_simple.snap
@@ -13,6 +13,7 @@ mod __fn_shape_generic_add {
         pub name: &'static str,
         pub param_count: usize,
         pub param_names: &'static [&'static str],
+        pub documentation: &'static [&'static str],
         _args: core::marker::PhantomData<Args>,
         _ret: core::marker::PhantomData<Ret>,
         _generics: core::marker::PhantomData<Generics>,
@@ -22,11 +23,13 @@ mod __fn_shape_generic_add {
             name: &'static str,
             param_count: usize,
             param_names: &'static [&'static str],
+            documentation: &'static [&'static str],
         ) -> Self {
             Self {
                 name,
                 param_count,
                 param_names,
+                documentation,
                 _args: core::marker::PhantomData,
                 _ret: core::marker::PhantomData,
                 _generics: core::marker::PhantomData,
@@ -34,7 +37,7 @@ mod __fn_shape_generic_add {
         }
     }
     pub fn shape<T: Add<Output = T>>() -> FunctionShape<(T, T), T, T> {
-        FunctionShape::new("generic_add", 2usize, &["x", "y"])
+        FunctionShape::new("generic_add", 2usize, &["x", "y"], &[])
     }
 }
 pub fn generic_add<T: Add<Output = T>>(x: T, y: T) -> T {

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__generic_function_with_docs.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__generic_function_with_docs.snap
@@ -1,12 +1,12 @@
 ---
 source: facet-macros-emit/tests/codegen/function.rs
-expression: "expand_function(r#\"\n        fn bounded_fn<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {\n            data.collect()\n        }\n        \"#)"
+expression: "expand_function(r#\"\n        /// Generic function that adds two values\n        fn generic_add<T: Add<Output = T>>(x: T, y: T) -> T {\n            x + y\n        }\n        \"#)"
 ---
 #[allow(non_snake_case)]
-mod __fn_shape_bounded_fn {
+mod __fn_shape_generic_add {
     use super::*;
-    pub(super) fn inner<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {
-        data.collect()
+    pub(super) fn inner<T: Add<Output = T>>(x: T, y: T) -> T {
+        x + y
     }
     #[derive(Debug, Clone)]
     pub struct FunctionShape<Args, Ret, Generics = ()> {
@@ -36,11 +36,16 @@ mod __fn_shape_bounded_fn {
             }
         }
     }
-    pub fn shape<T: Clone + Send, U: Iterator<Item = T>>() -> FunctionShape<(U), Vec<T>, (T, U)> {
-        FunctionShape::new("bounded_fn", 1usize, &["data"], &[])
+    pub fn shape<T: Add<Output = T>>() -> FunctionShape<(T, T), T, T> {
+        FunctionShape::new(
+            "generic_add",
+            2usize,
+            &["x", "y"],
+            &[" Generic function that adds two values"],
+        )
     }
 }
-pub fn bounded_fn<T: Clone + Send, U: Iterator<Item = T>>(data: U) -> Vec<T> {
-    __fn_shape_bounded_fn::inner(data)
+pub fn generic_add<T: Add<Output = T>>(x: T, y: T) -> T {
+    __fn_shape_generic_add::inner(x, y)
 }
-pub use __fn_shape_bounded_fn::shape as BOUNDED_FN_SHAPE;
+pub use __fn_shape_generic_add::shape as GENERIC_ADD_SHAPE;

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__simple_function.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__function__simple_function.snap
@@ -13,6 +13,7 @@ mod __fn_shape_add {
         pub name: &'static str,
         pub param_count: usize,
         pub param_names: &'static [&'static str],
+        pub documentation: &'static [&'static str],
         _args: core::marker::PhantomData<Args>,
         _ret: core::marker::PhantomData<Ret>,
         _generics: core::marker::PhantomData<Generics>,
@@ -22,11 +23,13 @@ mod __fn_shape_add {
             name: &'static str,
             param_count: usize,
             param_names: &'static [&'static str],
+            documentation: &'static [&'static str],
         ) -> Self {
             Self {
                 name,
                 param_count,
                 param_names,
+                documentation,
                 _args: core::marker::PhantomData,
                 _ret: core::marker::PhantomData,
                 _generics: core::marker::PhantomData,
@@ -34,7 +37,7 @@ mod __fn_shape_add {
         }
     }
     pub fn shape() -> FunctionShape<(i32, i32), i32, ()> {
-        FunctionShape::new("add", 2usize, &["x", "y"])
+        FunctionShape::new("add", 2usize, &["x", "y"], &[])
     }
 }
 pub fn add(x: i32, y: i32) -> i32 {

--- a/facet-macros-parse/src/function/func_sig.rs
+++ b/facet-macros-parse/src/function/func_sig.rs
@@ -11,9 +11,38 @@ keyword! {
     pub KFn = "fn";
 }
 
+// We need to define how to parse different types of attributes
 unsynn! {
-    /// A complete function signature
+    /// A doc attribute: #[doc = "content"]
+    pub struct DocAttribute {
+        /// The "doc" identifier
+        pub _doc: Ident, // Should be "doc"
+        /// The equals sign
+        pub _equals: PunctAny<'='>,
+        /// The documentation string
+        pub lit_content: TokenStream,
+    }
+
+    /// Different types of attribute content
+    pub enum AttributeContent {
+        /// A doc comment attribute
+        Doc(DocAttribute),
+        /// Any other attribute (we don't parse these)
+        Other(TokenStream),
+    }
+
+    /// An attribute like #[doc = "content"] or #[derive(Debug)]
+    pub struct Attribute {
+        /// The # symbol
+        pub _hash: PunctAny<'#'>,
+        /// The attribute content in brackets, parsed
+        pub content: BracketGroupContaining<AttributeContent>,
+    }
+
+    /// A complete function signature with optional attributes
     pub struct FnSignature {
+        /// Zero or more attributes (including doc comments)
+        pub attributes: Option<Many<Attribute>>,
         /// The "fn" keyword
         pub _fn_keyword: KFn,
         /// Function name
@@ -29,7 +58,7 @@ unsynn! {
     }
 }
 
-/// Parsed function signature with extracted components
+/// Parsed function signature with extracted components including documentation
 pub struct FunctionSignature {
     /// Function name
     pub name: Ident,
@@ -41,6 +70,83 @@ pub struct FunctionSignature {
     pub return_type: TokenStream,
     /// Function body
     pub body: TokenStream,
+    /// Extracted documentation from doc comments as separate lines
+    pub documentation: Vec<String>,
+}
+
+/// Extract documentation from attributes
+pub fn extract_documentation(attributes: &Option<Many<Attribute>>) -> Vec<String> {
+    let attrs = match attributes {
+        Some(many_attrs) => &many_attrs.0,
+        None => return Vec::new(),
+    };
+
+    let mut doc_lines = Vec::new();
+
+    for attr in attrs.iter() {
+        // Pattern match on the AttributeContent enum (this was working!)
+        match &attr.value.content.content {
+            AttributeContent::Doc(doc_attr) => {
+                // Extract content from the Literal using the robust parsing function
+                let literal_str = &doc_attr.lit_content.to_string();
+                if let Some(content) = parse_string_literal(literal_str) {
+                    doc_lines.push(content);
+                }
+            }
+            AttributeContent::Other(_) => {
+                // Not a doc attribute, skipping
+            }
+        }
+    }
+
+    doc_lines
+}
+
+/// Parse the `proc_macro2::Literal` that we had to send `to_string()` to access
+fn parse_string_literal(literal_str: &str) -> Option<String> {
+    enum StringLiteralType {
+        Raw { hash_count: usize },
+        Regular,
+    }
+
+    let literal_type = if let Some(after_r) = literal_str.strip_prefix('r') {
+        let hash_count = after_r.chars().take_while(|&c| c == '#').count();
+        StringLiteralType::Raw { hash_count }
+    } else if literal_str.starts_with('"') {
+        StringLiteralType::Regular
+    } else {
+        return None;
+    };
+
+    match literal_type {
+        StringLiteralType::Raw { hash_count } => {
+            let quote_start = 1 + hash_count; // After 'r' and hashes
+            let quote_char = literal_str.chars().nth(quote_start)?;
+
+            if quote_char != '"' {
+                return None;
+            }
+
+            let content_start = quote_start + 1; // After opening quote
+            let content_end = literal_str.len().checked_sub(1 + hash_count)?; // Before closing quote and hashes
+
+            if content_start <= content_end {
+                Some(literal_str[content_start..content_end].to_string())
+            } else {
+                None
+            }
+        }
+
+        StringLiteralType::Regular => {
+            if literal_str.ends_with('"') && literal_str.len() >= 2 {
+                let content = &literal_str[1..literal_str.len() - 1];
+                let unescaped = content.replace("\\\"", "\"").replace("\\\\", "\\");
+                Some(unescaped)
+            } else {
+                None
+            }
+        }
+    }
 }
 
 /// Parse a complete function signature from TokenStream
@@ -50,15 +156,13 @@ pub fn parse_function_signature(input: TokenStream) -> FunctionSignature {
     match it.parse::<FnSignature>() {
         Ok(sig) => {
             // Extract parameters from the parenthesis group
-            // ParenthesisGroup contains the content, we need to get its stream
             let params_content = {
                 let params_tokens = sig.params.to_token_stream();
-                // Remove the outer parentheses by parsing as a group and getting its stream
                 let mut it = params_tokens.to_token_iter();
                 if let Ok(TokenTree::Group(group)) = it.parse::<TokenTree>() {
                     group.stream()
                 } else {
-                    TokenStream::new() // Empty if can't parse
+                    TokenStream::new()
                 }
             };
             let parameters = crate::func_params::parse_fn_parameters(params_content);
@@ -75,12 +179,16 @@ pub fn parse_function_signature(input: TokenStream) -> FunctionSignature {
             // Extract body
             let body = sig.body.to_token_stream();
 
+            // Extract documentation from attributes
+            let documentation = extract_documentation(&sig.attributes);
+
             FunctionSignature {
                 name: sig.name,
                 generics,
                 parameters,
                 return_type,
                 body,
+                documentation,
             }
         }
         Err(err) => {
@@ -152,5 +260,139 @@ mod tests {
         assert_eq!(parsed.name.to_string(), "no_return");
         assert_eq!(parsed.parameters.len(), 1);
         assert_eq!(parsed.return_type.to_string().trim(), "()");
+    }
+
+    #[test]
+    fn test_function_with_doc_comments() {
+        let input = quote! {
+            /// This is a test function
+            /// that does addition of two numbers
+            fn add(x: i32, y: i32) -> i32 {
+                x + y
+            }
+        };
+
+        let parsed = parse_function_signature(input);
+        assert_eq!(parsed.name.to_string(), "add");
+        assert!(parsed.generics.is_none());
+        assert_eq!(parsed.parameters.len(), 2);
+        assert_eq!(parsed.parameters[0].name.to_string(), "x");
+        assert_eq!(parsed.parameters[1].name.to_string(), "y");
+        assert_eq!(parsed.return_type.to_string().trim(), "i32");
+
+        // Check documentation
+        assert!(!parsed.documentation.is_empty());
+        assert_eq!(parsed.documentation.len(), 2); // Two doc lines
+        assert_eq!(parsed.documentation[0], " This is a test function");
+        assert_eq!(
+            parsed.documentation[1],
+            " that does addition of two numbers"
+        );
+    }
+
+    #[test]
+    fn test_function_with_single_doc_comment() {
+        let input = quote! {
+            /// Single line documentation
+            fn greet(name: String) -> String {
+                format!("Hello, {}!", name)
+            }
+        };
+
+        let parsed = parse_function_signature(input);
+        assert!(!parsed.documentation.is_empty());
+        assert_eq!(parsed.documentation.len(), 1);
+        assert_eq!(parsed.documentation[0], " Single line documentation");
+    }
+
+    #[test]
+    fn test_function_without_doc_comments() {
+        let input = quote! {
+            fn no_docs(x: i32) -> i32 {
+                x * 2
+            }
+        };
+
+        let parsed = parse_function_signature(input);
+        assert_eq!(parsed.name.to_string(), "no_docs");
+        assert!(parsed.documentation.is_empty());
+    }
+
+    #[test]
+    fn test_function_with_double_quote_in_doc_comment() {
+        let input = quote! {
+            /// Hello "world", if that is your real name
+            fn greet(name: String) -> String {
+                format!("Hello, {}...?", name)
+            }
+        };
+
+        let parsed = parse_function_signature(input);
+        assert!(!parsed.documentation.is_empty());
+        assert_eq!(parsed.documentation.len(), 1);
+        assert_eq!(
+            parsed.documentation[0],
+            " Hello \"world\", if that is your real name"
+        );
+    }
+
+    #[test]
+    fn test_function_with_multiple_hashes_in_doc_comment() {
+        let input = quote! {
+            /// This uses r#"raw strings"# and r##"nested"## syntax
+            fn complex_doc() {
+                println!("test");
+            }
+        };
+
+        let parsed = parse_function_signature(input);
+        assert!(!parsed.documentation.is_empty());
+        assert_eq!(parsed.documentation.len(), 1);
+        assert_eq!(
+            parsed.documentation[0],
+            " This uses r#\"raw strings\"# and r##\"nested\"## syntax"
+        );
+    }
+
+    #[test]
+    fn test_function_with_mixed_attributes() {
+        let input = quote! {
+            /// Documentation comment
+            #[derive(Debug)]
+            /// More documentation
+            fn mixed_attrs() {
+                println!("test");
+            }
+        };
+
+        let parsed = parse_function_signature(input);
+        assert_eq!(parsed.name.to_string(), "mixed_attrs");
+        assert!(!parsed.documentation.is_empty());
+        assert_eq!(parsed.documentation.len(), 2); // Two doc lines
+
+        assert_eq!(parsed.documentation[0], " Documentation comment");
+        assert_eq!(parsed.documentation[1], " More documentation");
+    }
+
+    #[test]
+    fn test_generic_function_with_docs() {
+        let input = quote! {
+            /// Generic function that adds two values
+            fn generic_add<T: Add<Output = T>>(x: T, y: T) -> T {
+                x + y
+            }
+        };
+
+        let parsed = parse_function_signature(input);
+        assert_eq!(parsed.name.to_string(), "generic_add");
+        assert!(parsed.generics.is_some());
+        assert!(!parsed.documentation.is_empty());
+        assert_eq!(parsed.documentation.len(), 1);
+
+        // Check the content
+        assert_eq!(
+            parsed.documentation[0],
+            " Generic function that adds two values"
+        );
     }
 }

--- a/facet/tests/functions.rs
+++ b/facet/tests/functions.rs
@@ -224,3 +224,98 @@ fn function_shape_clone() {
 //     assert_eq!(shape.param_count, 1);
 //     assert_eq!(shape.param_names, &["data"]);
 // }
+
+#[cfg(feature = "function")]
+#[test]
+fn function_with_single_doc_comment() {
+    /// Single line documentation
+    #[facet_fn]
+    fn greet(name: String) -> String {
+        format!("Hello, {}!", name)
+    }
+
+    // Test function works normally
+    assert_eq!(greet("World".to_string()), "Hello, World!");
+
+    // Test shape metadata
+    let shape = fn_shape!(greet);
+    assert_eq!(shape.name, "greet");
+    assert_eq!(shape.param_count, 1);
+    assert_eq!(shape.param_names, &["name"]);
+
+    // Test documentation is captured
+    assert_eq!(shape.documentation.len(), 1);
+    assert_eq!(shape.documentation[0], " Single line documentation");
+}
+
+#[cfg(feature = "function")]
+#[test]
+fn function_with_multiple_doc_comments() {
+    /// This is a test function
+    /// that does addition of two numbers
+    #[facet_fn]
+    fn add(x: i32, y: i32) -> i32 {
+        x + y
+    }
+
+    // Test function works normally
+    assert_eq!(add(2, 3), 5);
+
+    // Test shape metadata
+    let shape = fn_shape!(add);
+    assert_eq!(shape.name, "add");
+    assert_eq!(shape.param_count, 2);
+    assert_eq!(shape.param_names, &["x", "y"]);
+
+    // Test documentation is captured
+    assert_eq!(shape.documentation.len(), 2);
+    assert_eq!(shape.documentation[0], " This is a test function");
+    assert_eq!(shape.documentation[1], " that does addition of two numbers");
+}
+
+#[cfg(feature = "function")]
+#[test]
+fn function_with_doc_comments_and_quotes() {
+    /// Hello "world", if that is your real name
+    #[facet_fn]
+    fn greet_suspicious(name: String) -> String {
+        format!("Hello, {}...?", name)
+    }
+
+    // Test function works normally
+    assert_eq!(greet_suspicious("Alice".to_string()), "Hello, Alice...?");
+
+    // Test shape metadata
+    let shape = fn_shape!(greet_suspicious);
+    assert_eq!(shape.name, "greet_suspicious");
+    assert_eq!(shape.param_count, 1);
+    assert_eq!(shape.param_names, &["name"]);
+
+    // Test documentation with quotes is captured correctly
+    assert_eq!(shape.documentation.len(), 1);
+    assert_eq!(
+        shape.documentation[0],
+        " Hello \"world\", if that is your real name"
+    );
+}
+
+#[cfg(feature = "function")]
+#[test]
+fn function_without_doc_comments() {
+    #[facet_fn]
+    fn no_docs(x: i32) -> i32 {
+        x * 2
+    }
+
+    // Test function works normally
+    assert_eq!(no_docs(5), 10);
+
+    // Test shape metadata
+    let shape = fn_shape!(no_docs);
+    assert_eq!(shape.name, "no_docs");
+    assert_eq!(shape.param_count, 1);
+    assert_eq!(shape.param_names, &["x"]);
+
+    // Test no documentation is captured
+    assert!(shape.documentation.is_empty());
+}


### PR DESCRIPTION
- **feat(fn): capture function docstring in shape**

I added some debug logging initially, which showed what is going through here:

```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.03s
────────────
 Nextest run ID caab8be2-8433-41c7-b96d-ab162522fcc2 with nextest profile: default
    Starting 4 tests across 1 binary (33 tests skipped)
        PASS [   0.002s] facet-macros-parse function::func_sig::tests::test_function_without_doc_comments
──── STDOUT:             facet-macros-parse function::func_sig::tests::test_function_without_doc_comments

running 1 test
DEBUG: parse_function_signature called with input: fn no_docs (x : i32) -> i32 { x * 2 }
DEBUG: Successfully parsed FnSignature
DEBUG: Found 0 attributes
DEBUG: Final documentation: None
test function::func_sig::tests::test_function_without_doc_comments ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 36 filtered out; finished in 0.00s


        PASS [   0.002s] facet-macros-parse function::func_sig::tests::test_function_with_doc_comments
──── STDOUT:             facet-macros-parse function::func_sig::tests::test_function_with_doc_comments

running 1 test
DEBUG: parse_function_signature called with input: # [doc = r" This is a test function"] # [doc = r" that does addition of two numbers"] fn add (x : i32 , y : i32) -> i32 { x + y }
DEBUG: Successfully parsed FnSignature
DEBUG: Found 2 attributes
DEBUG: extract_documentation called with 2 attributes
DEBUG: Processing attribute 0
DEBUG: Found doc attribute
DEBUG: Found literal: r" This is a test function"
DEBUG: Extracted content: " This is a test function"
DEBUG: Processing attribute 1
DEBUG: Found doc attribute
DEBUG: Found literal: r" that does addition of two numbers"
DEBUG: Extracted content: " that does addition of two numbers"
DEBUG: Final documentation: Some(" This is a test function\n that does addition of two numbers")
test function::func_sig::tests::test_function_with_doc_comments ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 36 filtered out; finished in 0.00s


        PASS [   0.002s] facet-macros-parse function::func_sig::tests::test_function_with_single_doc_comment
──── STDOUT:             facet-macros-parse function::func_sig::tests::test_function_with_single_doc_comment

running 1 test
DEBUG: parse_function_signature called with input: # [doc = r" Single line documentation"] fn greet (name : String) -> String { format ! ("Hello, {}!" , name) }
DEBUG: Successfully parsed FnSignature
DEBUG: Found 1 attributes
DEBUG: extract_documentation called with 1 attributes
DEBUG: Processing attribute 0
DEBUG: Found doc attribute
DEBUG: Found literal: r" Single line documentation"
DEBUG: Extracted content: " Single line documentation"
DEBUG: Final documentation: Some(" Single line documentation")
test function::func_sig::tests::test_function_with_single_doc_comment ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 36 filtered out; finished in 0.00s


        PASS [   0.003s] facet-macros-parse function::func_sig::tests::test_generic_function_with_docs
──── STDOUT:             facet-macros-parse function::func_sig::tests::test_generic_function_with_docs

running 1 test
DEBUG: parse_function_signature called with input: # [doc = r" Generic function that adds two values"] fn generic_add < T : Add < Output = T >> (x : T , y : T) -> T { x + y }
DEBUG: Successfully parsed FnSignature
DEBUG: Found 1 attributes
DEBUG: extract_documentation called with 1 attributes
DEBUG: Processing attribute 0
DEBUG: Found doc attribute
DEBUG: Found literal: r" Generic function that adds two values"
DEBUG: Extracted content: " Generic function that adds two values"
DEBUG: Final documentation: Some(" Generic function that adds two values")
test function::func_sig::tests::test_generic_function_with_docs ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 36 filtered out; finished in 0.00s


────────────
     Summary [   0.003s] 4 tests run: 4 passed, 33 skipped
```

I tried out an approach that matched the existing `doc_lines` style as `Vec<TokenStream>` but realised that it's better to actually process those (the token is always just a `Literal` which you cannot access, but you can call `to_string()` on)

https://github.com/facet-rs/facet/blob/736fb2201b69d884f9defea27b17d6f3c832bde1/facet-macros-emit/src/parsed.rs#L391

This approach then unescapes (including both `"` and `r#` syntax!) the string that that produced, it seemingly can't be helped. We should probably propose to `cehteh` to get the `LiteralString` class to work with `r"..."` strings as they could not be parsed in this case (the `Literal` type comes from proc-macro2).

- [x] incorporated into the facet crate integration tests of the macro as `#[facet_fn]` and working nicely!
- [x] `facet-macros-emit` snapshot tests updated