### PR TITLE
facet-toml: ser: init newtype KeyStack with Display impl

### DIFF
--- a/facet-toml/src/serialize/mod.rs
+++ b/facet-toml/src/serialize/mod.rs
@@ -286,7 +286,7 @@ impl core::fmt::Display for KeyStack<'_> {
             }
             write!(f, "]")?;
         } else {
-            write!(f, "{}", "root".red())?;
+            write!(f, "«{}»", "root".red())?;
         }
         Ok(())
     }


### PR DESCRIPTION
This introduces a wrapper type `KeyStack` in order to provide a `Display` implementation, avoiding allocating multiple `String`s while tracing.

This falls into the territory of a micro-optimization.