### PR TITLE
Rename `Wip` → `Partial` in docs and comments

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -58,7 +58,7 @@ However, vtables are low-level and unsafe, and you would normally invoke stuff t
 [facet-reflect](https://docs.rs/facet-reflect) types like:
 
   * [Peek](https://docs.rs/facet-reflect/latest/facet_reflect/struct.Peek.html) when reading from a value
-  * [Wip](https://docs.rs/facet-reflect/latest/facet_reflect/struct.Wip.html) when building values from scratch
+  * [Partial](https://docs.rs/facet-reflect/latest/facet_reflect/struct.Partial.html) when building values from scratch
 
 These two abstractions are used by serializers and deserializers respectively,
 and are fully safe, despite dealing with partially-initialized values under the hood.

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -85,7 +85,7 @@ pub struct Shape<'shape> {
     ///
     /// Same for `Utf8PathBuf`, which is parsed from and serialized to "just a string".
     ///
-    /// See Wip's `innermost_shape` function (and its support in `put`).
+    /// See Partial's `innermost_shape` function (and its support in `put`).
     pub inner: Option<fn() -> &'shape Shape<'shape>>,
 }
 

--- a/facet-kdl/src/lib.rs
+++ b/facet-kdl/src/lib.rs
@@ -96,7 +96,7 @@ impl<'input, 'facet: 'shape, 'shape> KdlDeserializer<'input> {
 
         // PERF: This definitely isn't zero-copy, so it might be worth seeing if that's something that can be added to
         // `kdl-rs` at some point in the future?
-        // PERF: Would be be better / quicker if I did this parsing incrementally? Using information from the `Wip` to
+        // PERF: Would be be better / quicker if I did this parsing incrementally? Using information from the `Partial` to
         // decide when to call `KdlNode::parse` and `KdlEntry::parse`? Probably would be if I'm only trying to parse
         // some of the KDL text, but I'm not so sure otherwise? Will need benchmarking...
         let document: KdlDocument = dbg!(kdl.parse()?);
@@ -129,7 +129,7 @@ impl<'input, 'facet: 'shape, 'shape> KdlDeserializer<'input> {
 
         // First check the type system (Type)
         if let Type::User(UserType::Struct(struct_def)) = &wip.shape().ty {
-            log::trace!("Document `Wip` is a struct: {struct_def:#?}");
+            log::trace!("Document `Partial` is a struct: {struct_def:#?}");
             // QUESTION: Would be be possible, once we allow custom types, to make all attributes arbitrary? With
             // the sort of general tool that `facet` is, I think it might actually be best if we didn't try to
             // "bake-in" anything like sensitive, default, skip, etc...
@@ -180,7 +180,7 @@ impl<'input, 'facet: 'shape, 'shape> KdlDeserializer<'input> {
 
         // TODO: Planning to step through those entries one at a time then dispatch a method like
         // `deserialize_argument()` or `deserialize_property()` depending on which it is. Then I need a way to keep
-        // track of which `Wip` fields have already been filled? I think that shouldn't be too bad, then I can just
+        // track of which `Partial` fields have already been filled? I think that shouldn't be too bad, then I can just
         // grab the next "unfilled" argument field if it's an argument, or search all of the (filled or unfilled) fields
         // if it's a parameter?
         for entry in node.entries() {

--- a/facet-macros-emit/src/parsed.rs
+++ b/facet-macros-emit/src/parsed.rs
@@ -52,7 +52,7 @@ pub enum PFacetAttr {
 
     /// Valid in container
     /// `#[facet(invariants = "Self::invariants_func")]` — returns a bool, is called
-    /// when doing `Wip::build`
+    /// when doing `Partial::build`
     Invariants { expr: TokenStream },
 
     /// Valid in container

--- a/facet-msgpack/src/deserialize.rs
+++ b/facet-msgpack/src/deserialize.rs
@@ -44,7 +44,7 @@ pub fn from_slice<T: Facet<'static>>(msgpack: &[u8]) -> Result<T, DecodeError<'s
 
 /// Deserializes MessagePack-encoded data into a Facet value.
 ///
-/// This function takes a MessagePack byte array and populates a Wip object
+/// This function takes a MessagePack byte array and populates a Partial object
 /// according to the shape description, returning an Opaque value.
 ///
 /// # Example
@@ -71,7 +71,7 @@ pub fn from_slice<T: Facet<'static>>(msgpack: &[u8]) -> Result<T, DecodeError<'s
 /// ```
 ///
 /// # Parameters
-/// * `wip` - A Wip object that will be filled with deserialized data
+/// * `wip` - A Partial object that will be filled with deserialized data
 /// * `msgpack` - A byte slice containing MessagePack-encoded data
 ///
 /// # Returns

--- a/facet-reflect/README.md
+++ b/facet-reflect/README.md
@@ -46,7 +46,7 @@ Thanks to all individual and corporate sponsors, without whom this work could no
 </a> </p>
 
 
-Allows building values, via `Wip`, and inspecting existing values, via `PeekValue`.
+Allows building values, via `Partial`, and inspecting existing values, via `PeekValue`.
 
 ## License
 

--- a/facet-reflect/README.md.in
+++ b/facet-reflect/README.md.in
@@ -1,2 +1,2 @@
 
-Allows building values, via `Wip`, and inspecting existing values, via `PeekValue`.
+Allows building values, via `Partial`, and inspecting existing values, via `PeekValue`.

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -427,7 +427,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
         })
     }
 
-    /// Creates a Wip from an existing pointer and shape (used for nested initialization)
+    /// Creates a Partial from an existing pointer and shape (used for nested initialization)
     pub fn from_ptr(data: PtrUninit<'_>, shape: &'shape Shape<'shape>) -> Self {
         // We need to convert the lifetime, which is safe because we're storing it in a frame
         // that will manage the lifetime correctly
@@ -1562,7 +1562,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
         if self.frames.len() <= 1 {
             // Never pop the last/root frame.
             return Err(ReflectError::InvariantViolation {
-                invariant: "Wip::end() called with only one frame on the stack",
+                invariant: "Partial::end() called with only one frame on the stack",
             });
         }
 
@@ -1882,7 +1882,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
         if self.frames.len() != 1 {
             self.state = PartialState::BuildFailed;
             return Err(ReflectError::InvariantViolation {
-                invariant: "Wip::build() expects a single frame — pop until that's the case",
+                invariant: "Partial::build() expects a single frame — pop until that's the case",
             });
         }
 
@@ -2428,7 +2428,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     }
 }
 
-/// A typed wrapper around `Wip`, for when you want to statically
+/// A typed wrapper around `Partial`, for when you want to statically
 /// ensure that `build` gives you the proper type.
 pub struct TypedPartial<'facet, 'shape, T> {
     inner: Partial<'facet, 'shape>,
@@ -2695,7 +2695,7 @@ impl<'facet, 'shape, T> TypedPartial<'facet, 'shape, T> {
 
 impl<'facet, 'shape, T> core::fmt::Debug for TypedPartial<'facet, 'shape, T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TypedWip")
+        f.debug_struct("TypedPartial")
             .field("shape", &self.inner.frames.last().map(|frame| frame.shape))
             .finish()
     }
@@ -2703,7 +2703,7 @@ impl<'facet, 'shape, T> core::fmt::Debug for TypedPartial<'facet, 'shape, T> {
 
 impl<'facet, 'shape> Drop for Partial<'facet, 'shape> {
     fn drop(&mut self) {
-        trace!("🧹 Wip is being dropped");
+        trace!("🧹 Partial is being dropped");
 
         // We need to properly drop all initialized fields
         while let Some(frame) = self.frames.pop() {

--- a/facet-toml/src/deserialize/error.rs
+++ b/facet-toml/src/deserialize/error.rs
@@ -22,7 +22,7 @@ pub struct TomlDeError<'input, 'shape> {
     /// Which part of the TOML this error applies to.
     #[cfg_attr(not(feature = "rich-diagnostics"), allow(dead_code))]
     span: Option<Range<usize>>,
-    /// Full Wip path.
+    /// Full Partial path.
     path: String,
 }
 

--- a/facet-urlencoded/src/lib.rs
+++ b/facet-urlencoded/src/lib.rs
@@ -82,7 +82,7 @@ pub fn from_str<'input: 'facet, 'facet, T: Facet<'facet>>(
 
 /// Deserializes a URL encoded form data string into an heap-allocated value.
 ///
-/// This is the lower-level function that works with `Wip` directly.
+/// This is the lower-level function that works with `Partial` directly.
 fn from_str_value<'mem, 'shape>(
     wip: &mut Partial<'mem, 'shape>,
     urlencoded: &str,

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -49,7 +49,7 @@ pub use facet_core::*;
 ///
 /// * `skip_serializing_if = ".."` Don't allow this type to be serialized if the function returns `true`.
 ///
-/// * `invariants = ".."` Called when doing `Wip::build`. **TODO**
+/// * `invariants = ".."` Called when doing `Partial::build`. **TODO**
 ///
 /// # Field Attributes
 ///


### PR DESCRIPTION
I noticed that the `Wip` link on https://facet.rs/ was broken (since it was renamed to `Partial`); this PR fixes that and other obvious cases.