### PR TITLE
Feature unsynn quote

### DIFF
--- a/facet-macros-parse/Cargo.toml
+++ b/facet-macros-parse/Cargo.toml
@@ -16,8 +16,7 @@ keywords = [
 categories = ["development-tools", "encoding"]
 
 [dependencies]
-unsynn = "0.1.0"
-quote = "1.0.40"
+unsynn = "0.2"
 
 [features]
 function = []

--- a/facet-macros-parse/src/function/fn_shape_input.rs
+++ b/facet-macros-parse/src/function/fn_shape_input.rs
@@ -41,7 +41,6 @@ pub fn parse_fn_shape_input(input: TokenStream) -> ParsedFnShapeInput {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quote::quote;
 
     #[test]
     fn test_simple_function_name() {

--- a/facet-macros-parse/src/function/func_body.rs
+++ b/facet-macros-parse/src/function/func_body.rs
@@ -27,7 +27,7 @@ pub fn parse_function_body(tokens: &[TokenTree]) -> TokenStream {
         Ok(func_with_body) => func_with_body.body.to_token_stream(),
         Err(_) => {
             // No function body found, return empty braces
-            quote::quote! { {} }
+            quote! { {} }
         }
     }
 }
@@ -35,7 +35,6 @@ pub fn parse_function_body(tokens: &[TokenTree]) -> TokenStream {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quote::quote;
 
     #[test]
     fn test_simple_function_body() {

--- a/facet-macros-parse/src/function/func_params.rs
+++ b/facet-macros-parse/src/function/func_params.rs
@@ -35,7 +35,6 @@ pub fn parse_fn_parameters(params_ts: TokenStream) -> Vec<Parameter> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quote::quote;
 
     #[test]
     fn test_empty_parameters() {

--- a/facet-macros-parse/src/function/func_sig.rs
+++ b/facet-macros-parse/src/function/func_sig.rs
@@ -99,7 +99,7 @@ pub fn parse_function_signature(input: TokenStream) -> FunctionSignature {
             let return_type = sig
                 .return_type
                 .map(|rt| rt.return_type.to_token_stream())
-                .unwrap_or_else(|| quote::quote! { () });
+                .unwrap_or_else(|| quote! { () });
 
             // Extract body
             let body = sig.body.to_token_stream();
@@ -125,7 +125,6 @@ pub fn parse_function_signature(input: TokenStream) -> FunctionSignature {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quote::quote;
 
     #[test]
     fn test_simple_function() {

--- a/facet-macros-parse/src/function/generics.rs
+++ b/facet-macros-parse/src/function/generics.rs
@@ -39,7 +39,6 @@ pub fn parse_generics_for_test(input: TokenStream) -> Option<GenericParams> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quote::quote;
 
     #[test]
     fn test_no_generics() {

--- a/facet-macros-parse/src/function/ret_type.rs
+++ b/facet-macros-parse/src/function/ret_type.rs
@@ -26,7 +26,7 @@ pub fn parse_return_type(tokens: Vec<TokenTree>) -> TokenStream {
         Ok(ret_type) => ret_type.return_type.to_token_stream(),
         Err(_) => {
             // No return type found, default to unit type
-            quote::quote! { () }
+            quote! { () }
         }
     }
 }
@@ -34,7 +34,6 @@ pub fn parse_return_type(tokens: Vec<TokenTree>) -> TokenStream {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quote::quote;
 
     #[test]
     fn test_no_return_type() {

--- a/facet-macros-parse/src/function/type_params.rs
+++ b/facet-macros-parse/src/function/type_params.rs
@@ -10,7 +10,7 @@ pub fn extract_type_params(generics_ts: TokenStream) -> TokenStream {
 
     match it.parse::<GenericParams>() {
         Ok(generics) => {
-            let type_param_names: Vec<_> = generics
+            let type_param_names: CommaDelimitedVec<_> = generics
                 .params
                 .0
                 .into_iter()
@@ -18,17 +18,16 @@ pub fn extract_type_params(generics_ts: TokenStream) -> TokenStream {
                 .collect();
 
             if type_param_names.is_empty() {
-                quote::quote! { () }
+                quote! { () }
             } else if type_param_names.len() == 1 {
-                let param = &type_param_names[0];
-                quote::quote! { #param }
+                quote! { #type_param_names }
             } else {
-                quote::quote! { ( #( #type_param_names ),* ) }
+                quote! { ( #type_param_names ) }
             }
         }
         Err(_) => {
             // Fallback to unit type if parsing fails
-            quote::quote! { () }
+            quote! { () }
         }
     }
 }
@@ -36,7 +35,6 @@ pub fn extract_type_params(generics_ts: TokenStream) -> TokenStream {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quote::quote;
 
     #[test]
     fn test_single_type_param() {

--- a/facet-macros-parse/src/lib.rs
+++ b/facet-macros-parse/src/lib.rs
@@ -600,7 +600,6 @@ impl Struct {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quote::quote;
 
     #[test]
     fn test_struct_with_field_doc_comments() {


### PR DESCRIPTION
Yo Amos!

I see you like quote!, so I removed quote from facet and put quote in unsynn, now you can quote without depending or quote! (also the proc_macro2 dependency is gone)

Short story, long:
This is WIP/anticipatory of a not yet released unsynn 0.2 which will include its own quote! macro. for $reasons it will be slightly different (simpler) to the quote crate. there are no `#()` repetitions yet. But this can be easily handled see the patch.

Initially i was thinking i could just `impl quote::ToTokens for dyn unsynn::ToTokens ..` but unfortunally this didnt worked out, either because the `quote::quote!()` macro can't handle that or because the trait solver isn't smart enough. Anyway, i just got my "Hold my beer" moment yesterday: How complicated can a `quote!{}` in unsynn be? .. turns out its pretty trivial to do the basics. So unsynn has its own lean `quote!{}` macro now.

This is yet just a Draft PR (don't merge!) up for comment. For now I only touched `facet-macros-parse` I'll see to remove proc_macro2 deps (its reexported from unsynn) and quote from the rest of facet while going over it. Its a nice test case to me to see where unsynn lacks features.