### PR TITLE
Add a new QOL function to parse std args.

### DIFF
--- a/facet-args/src/format.rs
+++ b/facet-args/src/format.rs
@@ -29,6 +29,21 @@ where
     facet_deserialize::deserialize(args, Cli)
 }
 
+/// Parse command line arguments provided by std::env::args() into a Facet-compatible type
+pub fn from_std_args<'input, 'facet, 'shape, T: Facet<'facet>>()
+-> Result<T, DeserError<'input, 'shape>>
+where
+    'input: 'facet + 'shape,
+{
+    let args = std::env::args().skip(1).collect::<Vec<String>>();
+    let args_str: Vec<&'static str> = args
+        .into_iter()
+        .map(|s| Box::leak(s.into_boxed_str()) as &str)
+        .collect();
+
+    from_slice(Box::leak(args_str.into_boxed_slice()))
+}
+
 impl Format for Cli {
     type Input<'input> = [&'input str];
     type SpanType = Raw;

--- a/facet-args/src/lib.rs
+++ b/facet-args/src/lib.rs
@@ -16,3 +16,6 @@ pub(crate) mod results;
 
 #[allow(unused)]
 pub use format::from_slice;
+
+#[allow(unused)]
+pub use format::from_std_args;


### PR DESCRIPTION
This PR just adds a function to make the ergonomics of parsing command line arguments provided directly from std::env::args a bit nicer.