### PR TITLE
facet-dev: prepush: nextest: do not fail fast

### DIFF
--- a/facet-dev/src/main.rs
+++ b/facet-dev/src/main.rs
@@ -884,7 +884,12 @@ fn pre_push() {
         },
         CommandInfo {
             name: "test".to_string(),
-            command: vec!["cargo".into(), "nextest".into(), "run".into()],
+            command: vec![
+                "cargo".into(),
+                "nextest".into(),
+                "run".into(),
+                "--no-fail-fast".into(),
+            ],
         },
     ];
     let total_commands = commands.len();


### PR DESCRIPTION
I was being gaslit by `facet-dev`'s invocation of `nextest`, it was telling me that snapshots were changing at points in the history that made no sense. After chasing my tail for a while, I noticed it was because it skips any more jobs after a failure, but allows the current jobs to finish. I took its suggestion of using the `--no-fail-fast` flag. I still have no idea how `facet-dev` works, or why `nextest` changes the snapshots insead of `codegen`, why this is separate from `cargo insta test`, and so many other questions.