### PR TITLE
facet-macros-emit: output correct Repr for structs and enums

### DIFF
--- a/facet-macros-emit/src/process_enum.rs
+++ b/facet-macros-emit/src/process_enum.rs
@@ -68,6 +68,13 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
     // Determine enum repr (already resolved by PEnum::parse())
     let valid_repr = &pe.repr;
 
+    // Are these relevant for enums? Or is it always `repr(C)` if a `PrimitiveRepr` is present?
+    let repr = match &valid_repr {
+        PRepr::Transparent => unreachable!("this should be caught by PRepr::parse"),
+        PRepr::Rust(_) => quote! { ::facet::Repr::default() },
+        PRepr::C(_) => quote! { ::facet::Repr::c() },
+    };
+
     // Helper for EnumRepr TS (token stream) generation for primitives
     fn enum_repr_ts_from_primitive(primitive_repr: PrimitiveRepr) -> TokenStream {
         let type_name_str = primitive_repr.type_name().to_string();
@@ -590,7 +597,7 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                             // Use variant expressions that just reference the shadow structs
                             // which are now defined above
                             .variants(__facet_variants)
-                            .repr(::facet::Repr::c())
+                            .repr(#repr)
                             .enum_repr(#enum_repr_type_tokenstream)
                             .build())
                     ))

--- a/facet-macros-emit/src/process_struct.rs
+++ b/facet-macros-emit/src/process_struct.rs
@@ -197,6 +197,13 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
     let struct_name = &ps.container.name;
     let struct_name_str = struct_name.to_string();
 
+    // TODO: I assume the `PrimitiveRepr` is only relevant for enums, and does not need to be preserved?
+    let repr = match &ps.container.attrs.repr {
+        PRepr::Transparent => quote! { ::facet::Repr::transparent() },
+        PRepr::Rust(_) => quote! { ::facet::Repr::default() },
+        PRepr::C(_) => quote! { ::facet::Repr::c() },
+    };
+
     // Use PStruct for kind and fields
     let (kind, fields_vec) = match &ps.kind {
         PStructKind::Struct { fields } => {
@@ -506,7 +513,7 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
                     .type_identifier(#struct_name_str)
                     #type_params // Still from parsed.generics
                     .ty(::facet::Type::User(::facet::UserType::Struct(::facet::StructType::builder()
-                        .repr(::facet::Repr::c())
+                        .repr(#repr)
                         .kind(#kind)
                         .fields(fields)
                         .build()

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__array_field_in_enum.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__array_field_in_enum.snap
@@ -93,7 +93,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Packet {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__array_field_in_struct.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__array_field_in_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 585
 expression: "expand(r#\"\n        #[derive(Facet)]\n        pub struct DataPacket {\n            header: [u8; 16],\n            payload: Vec<u8>,\n            metadata: [MetadataTag; 4],\n        }\n        \"#)"
 ---
 #[used]
@@ -44,7 +43,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for DataPacket {
             .type_identifier("DataPacket")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__cfg_attrs.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__cfg_attrs.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 473
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[cfg_attr(feature = \"testfeat\", derive(Debug))]\n        #[cfg_attr(feature = \"testfeat\", facet(deny_unknown_fields))]\n        pub struct CubConfig {}\n        \"#)"
 ---
 #[used]
@@ -20,7 +19,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for CubConfig {
             .type_identifier("CubConfig")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__cfg_attrs_on_field.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__cfg_attrs_on_field.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 486
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[cfg_attr(feature = \"testfeat\", derive(Debug))]\n        #[cfg_attr(feature = \"testfeat\", facet(deny_unknown_fields))]\n        pub struct CubConfig {\n            /// size the disk cache is allowed to use\n            #[cfg_attr(feature = \"testfeat\", facet(skip_serializing))]\n            #[cfg_attr(\n                feature = \"testfeat\",\n                facet(default = \"serde_defaults::default_disk_cache_size\")\n            )]\n            pub disk_cache_size: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -29,7 +28,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for CubConfig {
             .type_identifier("CubConfig")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__derive_real_life_cub_config.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__derive_real_life_cub_config.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 520
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[cfg_attr(feature = \"testfeat\", facet(deny_unknown_fields))]\n        pub struct CubConfig {\n            /// size the disk cache is allowed to use\n            #[cfg_attr(feature = \"testfeat\", facet(skip_serializing))]\n            #[cfg_attr(\n                feature = \"testfeat\",\n                facet(default = \"serde_defaults::default_disk_cache_size\")\n            )]\n            pub disk_cache_size: String,\n\n            /// Listen address without http, something like \"127.0.0.1:1111\"\n            #[cfg_attr(feature = \"testfeat\", facet(default = \"serde_defaults::address\"))]\n            pub address: std::string::String,\n\n            /// Something like `http://localhost:1118`\n            /// or `http://mom.svc.cluster.local:1118`, never\n            /// a trailing slash.\n            #[cfg_attr(feature = \"testfeat\", facet(default = \"serde_defaults::mom_base_url\"))]\n            pub mom_base_url: String,\n\n            /// API key used to talk to mom\n            #[cfg_attr(feature = \"testfeat\", facet(default = \"serde_defaults::mom_api_key\"))]\n            #[cfg_attr(feature = \"testfeat\", facet(sensitive))] // Example addition\n            pub mom_api_key: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -59,7 +58,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for CubConfig {
             .type_identifier("CubConfig")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_doc_comment.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_doc_comment.snap
@@ -40,7 +40,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for MyEnum {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_generic.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_generic.snap
@@ -199,7 +199,7 @@ where
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_variants_with_comments.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_variants_with_comments.snap
@@ -127,7 +127,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for CommentedEnum {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_binary.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_binary.snap
@@ -72,7 +72,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for BitFlags {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_decimal.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_decimal.snap
@@ -60,7 +60,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Test {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_hexadecimal.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_hexadecimal.snap
@@ -80,7 +80,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Color {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U16)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_mixed_notations.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_discriminants_mixed_notations.snap
@@ -60,7 +60,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Status {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U32)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_facet_attributes.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_facet_attributes.snap
@@ -117,7 +117,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for EnumWithAttributes {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U16)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_macro_discriminants.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_macro_discriminants.snap
@@ -42,7 +42,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for TestEnum {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U16)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_multiple_attributes_per_variant.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_multiple_attributes_per_variant.snap
@@ -149,7 +149,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ConfigValue {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_nested_generic_in_variant_one_level.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_nested_generic_in_variant_one_level.snap
@@ -124,7 +124,7 @@ where
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_nested_generic_in_variant_two_levels.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_nested_generic_in_variant_two_levels.snap
@@ -108,7 +108,7 @@ where
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_rename_all.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_rename_all.snap
@@ -90,7 +90,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ApiResponse {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_renamed_variants_and_fields.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_renamed_variants_and_fields.snap
@@ -112,7 +112,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ApiResponse {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_variants.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__enum_with_variants.snap
@@ -101,7 +101,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for EnumWithVariants {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__generic_bounds_k_v.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__generic_bounds_k_v.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 721
 expression: "expand(r#\"\n        struct Foo<K, V> where K: Eq + Hash {\n            inner: HashMap<K, V>,\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -39,7 +38,7 @@ where
             ])
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__generic_bounds_t.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__generic_bounds_t.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 710
 expression: "expand(r#\"\n        struct Foo<T> where T: Copy {\n            inner: Vec<T>,\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -32,7 +31,7 @@ where
             }])
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__generic_bounds_tuple_t.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__generic_bounds_tuple_t.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 732
 expression: "expand(r#\"\n        struct Foo<T>(Vec<T>);\n        \"#)"
 ---
 #[automatically_derived]
@@ -31,7 +30,7 @@ where
             }])
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::TupleStruct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__macroed_type.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__macroed_type.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 556
 expression: "expand(r#\"\n        #[derive(Debug, Facet, PartialEq)]\n        struct Macroed {\n            // NOTICE type is variable here\n            value: u32,\n        }\n        \"#)"
 ---
 #[used]
@@ -26,7 +25,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Macroed {
             .type_identifier("Macroed")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__mixed_rename_and_sensitive_attributes.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__mixed_rename_and_sensitive_attributes.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 1019
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct User {\n            #[facet(rename = \"userName\")]\n            name: String,\n            #[facet(rename = \"userEmail\", sensitive)]\n            email: String,\n            #[facet(sensitive)]\n            password: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -44,7 +43,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for User {
             .type_identifier("User")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__opaque_arc.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__opaque_arc.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 617
 expression: "expand(r#\"\n        #[derive(Facet)]\n        pub struct Handle(#[facet(opaque)] std::sync::Arc<NotDerivingFacet>);\n        \"#)"
 ---
 #[used]
@@ -26,7 +25,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Handle {
             .type_identifier("Handle")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::TupleStruct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__pub_crate_enum.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__pub_crate_enum.snap
@@ -62,7 +62,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for LogLevel {
             .ty(::facet::Type::User(::facet::UserType::Enum(
                 ::facet::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .enum_repr(::facet::EnumRepr::U8)
                     .build(),
             )))

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__record_struct_generic.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__record_struct_generic.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 388
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Blah<'a, T: Facet + core::hash::Hash, const C: usize = 3>\n        where\n            T: Debug, // Added a Debug bound for demonstration if needed, adjust as per Facet constraints\n        {\n            field: core::marker::PhantomData<&'a T>,\n            another: T,\n            constant_val: [u8; C],\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -51,7 +50,7 @@ where
             }])
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_camelcase.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_camelcase.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 901
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"camelCase\")]\n        struct CamelCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -38,7 +37,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for CamelCaseExample {
             .type_identifier("CamelCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_kebabcase.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_kebabcase.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 946
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"kebab-case\")]\n        struct KebabCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -38,7 +37,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for KebabCaseExample {
             .type_identifier("KebabCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_pascalcase.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_pascalcase.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 886
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"PascalCase\")]\n        struct PascalCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -38,7 +37,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for PascalCaseExample {
             .type_identifier("PascalCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_screaming_kebabcase.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_screaming_kebabcase.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 961
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"SCREAMING-KEBAB-CASE\")]\n        struct ScreamingKebabCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -48,7 +47,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ScreamingKebabCaseExample {
             .type_identifier("ScreamingKebabCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_screaming_snake_case.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_screaming_snake_case.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 871
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"SCREAMING_SNAKE_CASE\")]\n        struct UpperCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -38,7 +37,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for UpperCaseExample {
             .type_identifier("UpperCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_screaming_snakecase.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_screaming_snakecase.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 931
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"SCREAMING_SNAKE_CASE\")]\n        struct ScreamingSnakeCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -48,7 +47,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ScreamingSnakeCaseExample {
             .type_identifier("ScreamingSnakeCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_snake_case.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_snake_case.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 856
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"snake_case\")]\n        struct SnakeCaseExample {\n            field_one: String,\n            field_two: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -38,7 +37,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for SnakeCaseExample {
             .type_identifier("SnakeCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_snakecase.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__rename_all_snakecase.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 916
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"snake_case\")]\n        struct SnakeCaseExample {\n            fieldOne: String, // Note the camelCase input field name\n            fieldTwo: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -38,7 +37,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for SnakeCaseExample {
             .type_identifier("SnakeCaseExample")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__simple_struct.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__simple_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 38
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Blah {\n            foo: u32,\n            bar: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -35,7 +34,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 217
 expression: "expand(r#\"\n        /// yes\n        #[derive(Facet)]\n        struct Foo {}\n        \"#)"
 ---
 #[used]
@@ -18,7 +17,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Foo {
             .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment_multi_line.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment_multi_line.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 228
 expression: "expand(r#\"\n        /// yes\n        /// no\n        #[derive(Facet)]\n        struct Foo {}\n        \"#)"
 ---
 #[used]
@@ -18,7 +17,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Foo {
             .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment_quotes.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment_quotes.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 252
 expression: "expand(r#\"\n        /// what about \"quotes\"\n        #[derive(Facet)]\n        struct Foo {}\n        \"#)"
 ---
 #[used]
@@ -18,7 +17,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Foo {
             .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment_unicode.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_doc_comment_unicode.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 240
 expression: "expand(r#\"\n        /// yes 😄\n        /// no\n        #[derive(Facet)]\n        struct Foo {}\n        \"#)"
 ---
 #[used]
@@ -18,7 +17,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Foo {
             .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_facet_transparent.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_facet_transparent.snap
@@ -77,7 +77,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Wrapper {
             .type_identifier("Wrapper")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::TupleStruct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_field_doc_comment.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_field_doc_comment.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 280
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Foo {\n            /// This field has a doc comment\n            bar: u32,\n        }\n        \"#)"
 ---
 #[used]
@@ -27,7 +26,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Foo {
             .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_impls_drop.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_impls_drop.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 601
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct BarFoo {\n            bar: u32,\n            foo: String,\n        }\n        // The Drop impl doesn't affect the derive macro input:\n        // impl Drop for BarFoo { fn drop(&mut self) {} }\n        \"#)"
 ---
 #[used]
@@ -35,7 +34,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for BarFoo {
             .type_identifier("BarFoo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_equal_defaults.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_equal_defaults.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 680
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct StructWithDefaults {\n            field1: i32 = 42,\n            field2: String = \"default\".to_string(),\n        }\n        \"#)"
 ---
 #[used]
@@ -38,7 +37,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for StructWithDefaults {
             .type_identifier("StructWithDefaults")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_facet_attributes.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_facet_attributes.snap
@@ -64,7 +64,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for StructWithAttributes {
             .type_identifier("StructWithAttributes")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_field_default_facets.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_field_default_facets.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 693
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(default)]\n        struct ForFacetDefaultDemo {\n            #[facet(default)]\n            field1: u32,\n            #[facet(default = my_field_default_fn())]\n            field2: String,\n            field3: bool,\n        }\n        \"#)"
 ---
 #[used]
@@ -57,7 +56,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ForFacetDefaultDemo {
             .type_identifier("ForFacetDefaultDemo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_generics_simple.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_generics_simple.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 176
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct StructWithGenericsSimple<T, U> {\n            field1: T,\n            field2: U,\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -41,7 +40,7 @@ where
             ])
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_mixed_rename_attributes.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_mixed_rename_attributes.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 838
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"snake_case\")]\n        struct ConfigSettings {\n            server_url: String,\n            #[facet(rename = \"apiKey\")]\n            api_key: String,\n            timeout_secs: u32,\n            max_retry_count: u8,\n        }\n        \"#)"
 ---
 #[used]
@@ -51,7 +50,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for ConfigSettings {
             .type_identifier("ConfigSettings")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_option_cow_str.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_option_cow_str.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 1097
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Foo<'a> {\n            #[facet(default)]\n            name: Option<Cow<'a, str>>,\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -30,7 +29,7 @@ where
             .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_pub_field.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_pub_field.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 336
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Foo {\n            /// This is a public field\n            pub bar: u32,\n        }\n        \"#)"
 ---
 #[used]
@@ -27,7 +26,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Foo {
             .type_identifier("Foo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_rename_all.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_rename_all.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 799
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[facet(rename_all = \"camelCase\")]\n        struct PersonInfo {\n            first_name: String,\n            last_name: String,\n            home_address: String,\n            phone_number: u32,\n        }\n        \"#)"
 ---
 #[used]
@@ -51,7 +50,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for PersonInfo {
             .type_identifier("PersonInfo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_renamed_field.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_renamed_field.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 782
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Person {\n            #[facet(rename = \"firstName\")]\n            first_name: String,\n            #[facet(rename = \"lastName\")]\n            last_name: String,\n            age: u32,\n        }\n        \"#)"
 ---
 #[used]
@@ -42,7 +41,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Person {
             .type_identifier("Person")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_sensitive_field.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_sensitive_field.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 189
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Blah {\n            foo: u32,\n            #[facet(sensitive)]\n            bar: String,\n        }\n        \"#)"
 ---
 #[used]
@@ -36,7 +35,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_std_string.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__struct_with_std_string.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 506
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct FileInfo {\n            path: std::string::String, // Explicitly use std::string::String\n            size: u64,\n        }\n        \"#)"
 ---
 #[used]
@@ -36,7 +35,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for FileInfo {
             .type_identifier("FileInfo")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 28
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct TupleStruct(i32, String);\n        \"#)"
 ---
 #[used]
@@ -37,7 +36,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for TupleStruct {
             .type_identifier("TupleStruct")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::TupleStruct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_doc_comment.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_doc_comment.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 360
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(transparent)]\n        /// This is a struct for sure\n        struct Blah(u32);\n        \"#)"
 ---
 #[used]
@@ -26,7 +25,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::transparent())
                     .kind(::facet::StructKind::TupleStruct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_field_doc_comment.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_field_doc_comment.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 293
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct MyTupleStruct(\n            /// This is a documented field\n            u32,\n            /// This is another documented field\n            String,\n        );\n        \"#)"
 ---
 #[used]
@@ -39,7 +38,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for MyTupleStruct {
             .type_identifier("MyTupleStruct")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::TupleStruct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_field_doc_comment_repr_transparent.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_field_doc_comment_repr_transparent.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 373
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(transparent)]\n        /// This is a struct for sure\n        struct Blah(\n            /// and this is a field\n            u32,\n        );\n        \"#)"
 ---
 #[used]
@@ -27,7 +26,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::transparent())
                     .kind(::facet::StructKind::TupleStruct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_generic.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_generic.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 405
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(transparent)]\n        struct Blah<'a, T: Facet + core::hash::Hash, const C: usize = 3>(T, core::marker::PhantomData<&'a [u8; C]>)\n        where\n            T: Debug; // Added a Debug bound for demonstration\n        \"#)"
 ---
 #[automatically_derived]
@@ -44,7 +43,7 @@ where
             }])
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::transparent())
                     .kind(::facet::StructKind::TupleStruct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_repr_transparent.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_repr_transparent.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 349
 expression: "expand(r#\"\n        #[derive(Facet)]\n        #[repr(transparent)]\n        struct Blah(u32);\n        \"#)"
 ---
 #[used]
@@ -26,7 +25,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::transparent())
                     .kind(::facet::StructKind::TupleStruct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_with_pub_fields.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_with_pub_fields.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 454
 expression: "expand(r#\"\n        #[derive(Facet)]\n        /// This is a struct for sure\n        struct Blah(\n            /// and this is a public field\n            pub u32,\n            /// and this is a crate public field\n            pub(crate) u32,\n        );\n        \"#)"
 ---
 #[used]
@@ -37,7 +36,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Blah {
             .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::TupleStruct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_with_renamed_field.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__tuple_struct_with_renamed_field.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 976
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Point(\n            #[facet(rename = \"x_coordinate\")]\n            f32,\n            #[facet(rename = \"y_coordinate\")]\n            f32,\n            #[facet(rename = \"z_coordinate\")]\n            f32,\n        );\n        \"#)"
 ---
 #[used]
@@ -42,7 +41,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for Point {
             .type_identifier("Point")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::TupleStruct)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__unit_struct.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__unit_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 18
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct UnitStruct;\n        \"#)"
 ---
 #[used]
@@ -20,7 +19,7 @@ unsafe impl<'__facet> ::facet::Facet<'__facet> for UnitStruct {
             .type_identifier("UnitStruct")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Unit)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__unit_struct_generic.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__unit_struct_generic.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 418
 expression: "expand(r#\"\n        #[derive(Facet)]\n        struct Blah<const C: usize = 3>\n        where\n             [u8; C]: Debug; // Example bound using the const generic\n        \"#)"
 ---
 #[automatically_derived]
@@ -19,7 +18,7 @@ where
             .type_identifier("Blah")
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Unit)
                     .fields(fields)
                     .build(),

--- a/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__visibility.snap
+++ b/facet-macros-emit/tests/codegen/snapshots/r#mod__codegen__visibility.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-macros-emit/tests/codegen/mod.rs
-assertion_line: 1060
 expression: "expand(r#\"\n        #[derive(Facet)]\n        pub struct Test<T> {\n            pub(crate) a: T,\n        }\n        \"#)"
 ---
 #[automatically_derived]
@@ -31,7 +30,7 @@ where
             }])
             .ty(::facet::Type::User(::facet::UserType::Struct(
                 ::facet::StructType::builder()
-                    .repr(::facet::Repr::c())
+                    .repr(::facet::Repr::default())
                     .kind(::facet::StructKind::Struct)
                     .fields(fields)
                     .build(),

--- a/facet/src/sample_generated_code.rs
+++ b/facet/src/sample_generated_code.rs
@@ -1627,7 +1627,7 @@ unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkEnum {
             .ty(crate::Type::User(crate::UserType::Enum(
                 crate::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(crate::Repr::c())
+                    .repr(crate::Repr::default())
                     .enum_repr(crate::EnumRepr::U8)
                     .build(),
             )))
@@ -2139,7 +2139,7 @@ unsafe impl<'__facet> crate::Facet<'__facet> for SubEnum {
             .ty(crate::Type::User(crate::UserType::Enum(
                 crate::EnumType::builder()
                     .variants(__facet_variants)
-                    .repr(crate::Repr::c())
+                    .repr(crate::Repr::default())
                     .enum_repr(crate::EnumRepr::U8)
                     .build(),
             )))

--- a/facet/src/sample_generated_code.rs
+++ b/facet/src/sample_generated_code.rs
@@ -482,7 +482,7 @@ unsafe impl<'__facet> crate::Facet<'__facet> for KitchenSinkStruct {
             .type_identifier("KitchenSinkStruct")
             .ty(crate::Type::User(crate::UserType::Struct(
                 crate::StructType::builder()
-                    .repr(crate::Repr::c())
+                    .repr(crate::Repr::default())
                     .kind(crate::StructKind::Struct)
                     .fields(fields)
                     .build(),
@@ -910,7 +910,7 @@ unsafe impl<'__facet> crate::Facet<'__facet> for Point {
             .type_identifier("Point")
             .ty(crate::Type::User(crate::UserType::Struct(
                 crate::StructType::builder()
-                    .repr(crate::Repr::c())
+                    .repr(crate::Repr::default())
                     .kind(crate::StructKind::Struct)
                     .fields(fields)
                     .build(),


### PR DESCRIPTION
I don't think this change is accurate. Maybe for `struct`s, but I have no confidence in `enum`s, because I don't really understand how the `repr(transparent/Rust/C)` works for them in combination with the `PrimitiveRepr` passed around as `EnumRepr`.

If you could provide some guidance to help me understand why the code involving `repr` is so complex, and why `Rust` isn't supported for `enum`s, I can work more to ensure this PR is accurate.

Some specific questions:
- Why does `PRepr` parse a `PrimitiveRepr` for `C` and `Rust`, and what is the syntax for this?
- If `PRepr` always parses the `Option<PrimitiveRepr>`, why isn't that retained for `EnumType.repr` instead of constructing a second `EnumRepr`?