### PR TITLE
facet-core: rework impl Debug for Shape

### DIFF
--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -406,18 +406,33 @@ impl core::fmt::Debug for Shape<'_> {
         } else {
             let mut debug_struct = f.debug_struct("Shape");
 
-            // Always show the type name
-            debug_struct.field("type", &format_args!("{}", self));
-
-            // Show def if it's not Undefined
-            if !matches!(self.def, Def::Undefined) {
-                debug_struct.field("def", &format_args!("{:?}", self.def));
+            macro_rules! field {
+                ( $field:literal, $( $fmt_args:tt )* ) => {{
+                    debug_struct.field($field, &format_args!($($fmt_args)*));
+                }};
             }
 
-            // Show inner if present
-            if self.inner.is_some() {
-                debug_struct.field("inner", &format_args!("Some(..)"));
-            }
+            field!("id", "{:?}", self.id);
+
+            field!("layout", "{:?}", self.layout);
+
+            field!("vtable", "{:?}", self.vtable);
+
+            field!("ty", "{:?}", self.ty);
+
+            field!("def", "{:?}", self.def);
+
+            field!("type_identifier", "{:?}", self.type_identifier);
+
+            field!("type_params", "{:?}", self.type_params);
+
+            field!("doc", "{:?}", self.doc);
+
+            field!("attributes", "{:?}", self.attributes);
+
+            field!("type_tag", "{:?}", self.type_tag);
+
+            field!("inner", "{:?}", self.inner);
 
             debug_struct.finish()
         }

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -416,7 +416,10 @@ impl core::fmt::Debug for Shape<'_> {
 
             field!("ty", "{:?}", self.ty);
 
-            field!("def", "{:?}", self.def);
+            // If `def` is `Undefined`, the information in `ty` would be more useful.
+            if !matches!(self.def, Def::Undefined) {
+                field!("def", "{:?}", self.def);
+            }
 
             field!("type_identifier", "{:?}", self.type_identifier);
 

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -376,7 +376,7 @@ impl core::fmt::Debug for Shape<'_> {
         // developers will get a compiler error in this function, reminding them
         // to carefully consider whether it should be shown when debug formatting.
         let Self {
-            id: _,
+            id: _, // omit by default
             layout: _,
             vtable: _, // omit by default
             ty: _,
@@ -411,8 +411,6 @@ impl core::fmt::Debug for Shape<'_> {
                     debug_struct.field($field, &format_args!($($fmt_args)*));
                 }};
             }
-
-            field!("id", "{:?}", self.id);
 
             field!("layout", "{:?}", self.layout);
 

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -429,7 +429,9 @@ impl core::fmt::Debug for Shape<'_> {
 
             field!("attributes", "{:?}", self.attributes);
 
-            field!("type_tag", "{:?}", self.type_tag);
+            if let Some(type_tag) = self.type_tag {
+                field!("type_tag", "{:?}", type_tag);
+            }
 
             field!("inner", "{:?}", self.inner);
 

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -427,7 +427,9 @@ impl core::fmt::Debug for Shape<'_> {
                 field!("type_params", "{:?}", self.type_params);
             }
 
-            field!("doc", "{:?}", self.doc);
+            if !self.doc.is_empty() {
+                field!("doc", "{:?}", self.doc);
+            }
 
             if !self.attributes.is_empty() {
                 field!("attributes", "{:?}", self.attributes);

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -429,7 +429,9 @@ impl core::fmt::Debug for Shape<'_> {
 
             field!("doc", "{:?}", self.doc);
 
-            field!("attributes", "{:?}", self.attributes);
+            if !self.attributes.is_empty() {
+                field!("attributes", "{:?}", self.attributes);
+            }
 
             if let Some(type_tag) = self.type_tag {
                 field!("type_tag", "{:?}", type_tag);

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -392,7 +392,7 @@ impl core::fmt::Debug for Shape<'_> {
         if f.alternate() {
             f.debug_struct("Shape")
                 .field("id", &self.id)
-                .field("layout", &self.layout)
+                .field("layout", &format_args!("{:?}", self.layout))
                 .field("vtable", &format_args!("ValueVTable {{ .. }}"))
                 .field("ty", &self.ty)
                 .field("def", &self.def)

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -423,7 +423,9 @@ impl core::fmt::Debug for Shape<'_> {
 
             field!("type_identifier", "{:?}", self.type_identifier);
 
-            field!("type_params", "{:?}", self.type_params);
+            if !self.type_params.is_empty() {
+                field!("type_params", "{:?}", self.type_params);
+            }
 
             field!("doc", "{:?}", self.doc);
 

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -378,7 +378,7 @@ impl core::fmt::Debug for Shape<'_> {
         let Self {
             id: _,
             layout: _,
-            vtable: _,
+            vtable: _, // omit by default
             ty: _,
             def: _,
             type_identifier: _,
@@ -393,7 +393,7 @@ impl core::fmt::Debug for Shape<'_> {
             f.debug_struct("Shape")
                 .field("id", &self.id)
                 .field("layout", &self.layout)
-                .field("vtable", &self.vtable)
+                .field("vtable", &format_args!("ValueVTable {{ .. }}"))
                 .field("ty", &self.ty)
                 .field("def", &self.def)
                 .field("type_identifier", &self.type_identifier)
@@ -416,8 +416,6 @@ impl core::fmt::Debug for Shape<'_> {
 
             field!("layout", "{:?}", self.layout);
 
-            field!("vtable", "{:?}", self.vtable);
-
             field!("ty", "{:?}", self.ty);
 
             field!("def", "{:?}", self.def);
@@ -434,7 +432,7 @@ impl core::fmt::Debug for Shape<'_> {
 
             field!("inner", "{:?}", self.inner);
 
-            debug_struct.finish()
+            debug_struct.finish_non_exhaustive()
         }
     }
 }

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -437,7 +437,10 @@ impl core::fmt::Debug for Shape<'_> {
                 field!("type_tag", "{:?}", type_tag);
             }
 
-            field!("inner", "{:?}", self.inner);
+            // Omit the `inner` field if this shape is not a transparent wrapper.
+            if let Some(inner) = self.inner {
+                field!("inner", "{:?}", inner);
+            }
 
             debug_struct.finish_non_exhaustive()
         }

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -452,7 +452,18 @@ impl core::fmt::Debug for Shape<'_> {
             // Uses `Display` to potentially format with shorthand syntax.
             field!("ty", "{}", self.ty);
 
-            field!("layout", "{:?}", self.layout);
+            // For sized layouts, display size and alignment in shorthand.
+            // NOTE: If you wish to display the bitshift for alignment, please open an issue.
+            if let ShapeLayout::Sized(layout) = self.layout {
+                field!(
+                    "layout",
+                    "Sized(«{} align {}»)",
+                    layout.size(),
+                    layout.align()
+                );
+            } else {
+                field!("layout", "{:?}", self.layout);
+            }
 
             // If `def` is `Undefined`, the information in `ty` would be more useful.
             if !matches!(self.def, Def::Undefined) {

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -449,7 +449,8 @@ impl core::fmt::Debug for Shape<'_> {
                 field!("inner", "{:?}", (inner)());
             }
 
-            field!("ty", "{:?}", self.ty);
+            // Uses `Display` to potentially format with shorthand syntax.
+            field!("ty", "{}", self.ty);
 
             field!("layout", "{:?}", self.layout);
 

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -415,17 +415,20 @@ impl core::fmt::Debug for Shape<'_> {
             field!("type_identifier", "{:?}", self.type_identifier);
 
             if !self.type_params.is_empty() {
+                // Use `[]` to indicate empty `type_params` (a real empty slice),
+                // and `«(...)»` to show custom-formatted parameter sets when present.
+                // Avoids visual conflict with array types like `[T; N]` in other fields.
                 field!("type_params", "{}", {
                     struct TypeParams<'shape>(&'shape [TypeParam<'shape>]);
                     impl core::fmt::Display for TypeParams<'_> {
                         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                             let mut iter = self.0.iter();
                             if let Some(first) = iter.next() {
-                                write!(f, "<{}: {}", first.name, (first.shape)())?;
+                                write!(f, "«({}: {}", first.name, (first.shape)())?;
                                 for next in iter {
                                     write!(f, ", {}: {}", next.name, (next.shape)())?;
                                 }
-                                write!(f, ">")?;
+                                write!(f, ")»")?;
                             } else {
                                 write!(f, "[]")?;
                             }

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -460,7 +460,8 @@ impl core::fmt::Debug for Shape<'_> {
             }
 
             if !self.doc.is_empty() {
-                field!("doc", "{:?}", self.doc);
+                // TODO: Should these be called "strings"? Because `#[doc]` can contain newlines.
+                field!("doc", "«{} lines»", self.doc.len());
             }
 
             debug_struct.finish_non_exhaustive()

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -412,36 +412,36 @@ impl core::fmt::Debug for Shape<'_> {
                 }};
             }
 
-            field!("layout", "{:?}", self.layout);
-
-            field!("ty", "{:?}", self.ty);
-
-            // If `def` is `Undefined`, the information in `ty` would be more useful.
-            if !matches!(self.def, Def::Undefined) {
-                field!("def", "{:?}", self.def);
-            }
-
             field!("type_identifier", "{:?}", self.type_identifier);
 
             if !self.type_params.is_empty() {
                 field!("type_params", "{:?}", self.type_params);
             }
 
-            if !self.doc.is_empty() {
-                field!("doc", "{:?}", self.doc);
+            if let Some(type_tag) = self.type_tag {
+                field!("type_tag", "{:?}", type_tag);
             }
 
             if !self.attributes.is_empty() {
                 field!("attributes", "{:?}", self.attributes);
             }
 
-            if let Some(type_tag) = self.type_tag {
-                field!("type_tag", "{:?}", type_tag);
-            }
-
             // Omit the `inner` field if this shape is not a transparent wrapper.
             if let Some(inner) = self.inner {
                 field!("inner", "{:?}", inner);
+            }
+
+            field!("ty", "{:?}", self.ty);
+
+            field!("layout", "{:?}", self.layout);
+
+            // If `def` is `Undefined`, the information in `ty` would be more useful.
+            if !matches!(self.def, Def::Undefined) {
+                field!("def", "{:?}", self.def);
+            }
+
+            if !self.doc.is_empty() {
+                field!("doc", "{:?}", self.doc);
             }
 
             debug_struct.finish_non_exhaustive()

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -415,7 +415,25 @@ impl core::fmt::Debug for Shape<'_> {
             field!("type_identifier", "{:?}", self.type_identifier);
 
             if !self.type_params.is_empty() {
-                field!("type_params", "{:?}", self.type_params);
+                field!("type_params", "{}", {
+                    struct TypeParams<'shape>(&'shape [TypeParam<'shape>]);
+                    impl core::fmt::Display for TypeParams<'_> {
+                        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                            let mut iter = self.0.iter();
+                            if let Some(first) = iter.next() {
+                                write!(f, "<{}: {}", first.name, (first.shape)())?;
+                                for next in iter {
+                                    write!(f, ", {}: {}", next.name, (next.shape)())?;
+                                }
+                                write!(f, ">")?;
+                            } else {
+                                write!(f, "[]")?;
+                            }
+                            Ok(())
+                        }
+                    }
+                    TypeParams(self.type_params)
+                });
             }
 
             if let Some(type_tag) = self.type_tag {

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -428,7 +428,7 @@ impl core::fmt::Debug for Shape<'_> {
 
             // Omit the `inner` field if this shape is not a transparent wrapper.
             if let Some(inner) = self.inner {
-                field!("inner", "{:?}", inner);
+                field!("inner", "{:?}", (inner)());
             }
 
             field!("ty", "{:?}", self.ty);


### PR DESCRIPTION
Something that I'm not sure about is: there are some fields which are optionally shown, but `Some(...)` does not appear in the output to indicate that they are indeed `Option`. For the time-being, I have decided it's okay to be XXX, because if the developer needs the field they will quickly notice the `Option`-ality from the LSP's feedback or the compiler yelling at them. Still, I'm not a fan of lying in the `Debug` formatting.

There are more comments in the code and descriptions on certain commits, but here's an overview:

- `type_identifier` - First, because it tells you what type the `Shape` is for.
  - This position orients the reader immediately.
- `type_params` - Second, because it forms a complete path to the monomorphized type.
  - Distinguishes between `Shape`s with the same `type_identifier`.
  - Only shown if there are generic parameters present, otherwise omitted.
- `type_tag` - Third, as it provides optional information relevant to self-describing or introspective formats.
  - Omitted if it is `None`, shown without `Some(...)`.
- `attributes` - Fourth, because it determines how de/serialization should behave, and is that is high-value in most applications.
  - Only shown if there are attributes, otherwise omitted.
- `inner` - Fifth, because if the type is a wrapper, knowing the type that is wrapped is structurally relevant.
  - However, it's deferred slightly since it can be long, and because it builds upon the context provided by `ty` (adjacent).
  - Omitted if it is `None`, shown without `Some(...)`.
- `ty` - Sixth, even though it's arguably the most important field, it can be quite verbose.
  - Shown after metadata to avoid disrupting visual flow.
- `layout` - Seventh, because memory layout is rarely needed unless debugging ABI or alignment issues.
  - Positioning this directly after `ty` helps link them logically.
- `def` - Eighth, since it's often redundant with `ty`.
  - May want to consider selectively showing this field, depending on `inner` and `ty`.
- `doc` - Last, because it's either irrelevant noise for a summary, or the only thing you care about.
  - In the latter case, it's easy to spot at the bottom.
  - Omitted if there is no documentation.
- `id` - Omitted because it's not very useful.
- `vtable` - Omitted because raw function pointers probably aren't helpful outside of a low-level debugging context.