### PR TITLE
Hashset serializes to null

### DIFF
--- a/facet-json/tests/set.rs
+++ b/facet-json/tests/set.rs
@@ -1,0 +1,23 @@
+use facet_json::to_string;
+use facet_testhelpers::test;
+
+#[test]
+fn test_set() {
+    let mut set = std::collections::HashSet::new();
+    set.insert(3);
+
+    let json = to_string(&set);
+
+    assert_eq!(json, "[3]");
+}
+
+#[test]
+fn test_set_with_multiple_entries() {
+    let mut set = std::collections::HashSet::new();
+    set.insert(3);
+    set.insert(4);
+
+    let json = to_string(&set);
+
+    assert!(json == "[3,4]" || json == "[4,3]");
+}

--- a/facet-reflect/src/peek/mod.rs
+++ b/facet-reflect/src/peek/mod.rs
@@ -21,6 +21,9 @@ pub use list_like::*;
 mod map;
 pub use map::*;
 
+mod set;
+pub use set::*;
+
 mod option;
 pub use option::*;
 

--- a/facet-reflect/src/peek/set.rs
+++ b/facet-reflect/src/peek/set.rs
@@ -53,6 +53,11 @@ impl<'mem, 'facet, 'shape> PeekSet<'mem, 'facet, 'shape> {
         Self { value, def }
     }
 
+    /// Returns true if the set is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Get the number of entries in the set
     pub fn len(&self) -> usize {
         unsafe { (self.def.vtable.len_fn)(self.value.data().thin().unwrap()) }

--- a/facet-reflect/src/peek/set.rs
+++ b/facet-reflect/src/peek/set.rs
@@ -1,0 +1,72 @@
+use super::Peek;
+use facet_core::{PtrMut, SetDef};
+
+/// Iterator over values in a `PeekSet`
+pub struct PeekSetIter<'mem, 'facet, 'shape> {
+    set: PeekSet<'mem, 'facet, 'shape>,
+    iter: PtrMut<'mem>,
+}
+
+impl<'mem, 'facet, 'shape> Iterator for PeekSetIter<'mem, 'facet, 'shape> {
+    type Item = Peek<'mem, 'facet, 'shape>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            let next = (self.set.def.vtable.iter_vtable.next)(self.iter)?;
+            Some(Peek::unchecked_new(next, self.set.def.t()))
+        }
+    }
+}
+
+impl<'mem, 'facet, 'shape> Drop for PeekSetIter<'mem, 'facet, 'shape> {
+    fn drop(&mut self) {
+        unsafe { (self.set.def.vtable.iter_vtable.dealloc)(self.iter) }
+    }
+}
+
+impl<'mem, 'facet, 'shape> IntoIterator for &'mem PeekSet<'mem, 'facet, 'shape> {
+    type Item = Peek<'mem, 'facet, 'shape>;
+    type IntoIter = PeekSetIter<'mem, 'facet, 'shape>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Lets you read from a set
+#[derive(Clone, Copy)]
+pub struct PeekSet<'mem, 'facet, 'shape> {
+    pub(crate) value: Peek<'mem, 'facet, 'shape>,
+
+    pub(crate) def: SetDef<'shape>,
+}
+
+impl<'mem, 'facet, 'shape> core::fmt::Debug for PeekSet<'mem, 'facet, 'shape> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PeekSet").finish_non_exhaustive()
+    }
+}
+
+impl<'mem, 'facet, 'shape> PeekSet<'mem, 'facet, 'shape> {
+    /// Constructor
+    pub fn new(value: Peek<'mem, 'facet, 'shape>, def: SetDef<'shape>) -> Self {
+        Self { value, def }
+    }
+
+    /// Get the number of entries in the set
+    pub fn len(&self) -> usize {
+        unsafe { (self.def.vtable.len_fn)(self.value.data().thin().unwrap()) }
+    }
+
+    /// Returns an iterator over the values in the set
+    pub fn iter(self) -> PeekSetIter<'mem, 'facet, 'shape> {
+        let iter_init_with_value_fn = self.def.vtable.iter_vtable.init_with_value.unwrap();
+        let iter = unsafe { iter_init_with_value_fn(self.value.data().thin().unwrap()) };
+        PeekSetIter { set: self, iter }
+    }
+
+    /// Def getter
+    pub fn def(&self) -> SetDef<'shape> {
+        self.def
+    }
+}

--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -378,7 +378,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
             Ok(PeekSet { value: self, def })
         } else {
             Err(ReflectError::WasNotA {
-                expected: "map",
+                expected: "set",
                 actual: self.shape,
             })
         }

--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -4,7 +4,7 @@ use facet_core::{
     UserType, ValueVTable,
 };
 
-use crate::{ReflectError, ScalarType};
+use crate::{PeekSet, ReflectError, ScalarType};
 
 use super::{
     ListLikeDef, PeekEnum, PeekList, PeekListLike, PeekMap, PeekSmartPointer, PeekStruct,
@@ -364,6 +364,18 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     pub fn into_map(self) -> Result<PeekMap<'mem, 'facet, 'shape>, ReflectError<'shape>> {
         if let Def::Map(def) = self.shape.def {
             Ok(PeekMap { value: self, def })
+        } else {
+            Err(ReflectError::WasNotA {
+                expected: "map",
+                actual: self.shape,
+            })
+        }
+    }
+
+    /// Tries to identify this value as a set
+    pub fn into_set(self) -> Result<PeekSet<'mem, 'facet, 'shape>, ReflectError<'shape>> {
+        if let Def::Set(def) = self.shape.def {
+            Ok(PeekSet { value: self, def })
         } else {
             Err(ReflectError::WasNotA {
                 expected: "map",

--- a/facet-reflect/tests/peek/mod.rs
+++ b/facet-reflect/tests/peek/mod.rs
@@ -5,6 +5,7 @@ mod list_like;
 mod map;
 mod option;
 mod reference;
+mod set;
 mod smartptr;
 mod struct_;
 mod value;

--- a/facet-reflect/tests/peek/set.rs
+++ b/facet-reflect/tests/peek/set.rs
@@ -9,8 +9,10 @@ fn test_peek_set_basics() {
     source.insert("b");
 
     let peek_value = Peek::new(&source);
-    let peek_map = peek_value.into_set()?;
-    assert_eq!(peek_map.len(), 2);
+    let peek_set = peek_value.into_set()?;
+
+    assert_eq!(peek_set.len(), 2);
+    assert!(!peek_set.is_empty());
 }
 
 #[test]
@@ -20,9 +22,9 @@ fn test_peek_set_iteration() {
     source.insert("b");
 
     let peek_value = Peek::new(&source);
-    let peek_map = peek_value.into_set()?;
-    let mut entries: Vec<_> = peek_map.iter().map(|v| *v.get::<&str>().unwrap()).collect();
-    entries.sort_by(|a, b| a.cmp(&b));
+    let peek_set = peek_value.into_set()?;
+    let mut entries: Vec<_> = peek_set.iter().map(|v| *v.get::<&str>().unwrap()).collect();
+    entries.sort();
 
     assert_eq!(entries, vec!["a", "b"]);
 }

--- a/facet-reflect/tests/peek/set.rs
+++ b/facet-reflect/tests/peek/set.rs
@@ -1,0 +1,28 @@
+use facet_reflect::Peek;
+use facet_testhelpers::test;
+use std::collections::HashSet;
+
+#[test]
+fn test_peek_set_basics() {
+    let mut source = HashSet::new();
+    source.insert("a");
+    source.insert("b");
+
+    let peek_value = Peek::new(&source);
+    let peek_map = peek_value.into_set()?;
+    assert_eq!(peek_map.len(), 2);
+}
+
+#[test]
+fn test_peek_set_iteration() {
+    let mut source = HashSet::new();
+    source.insert("a");
+    source.insert("b");
+
+    let peek_value = Peek::new(&source);
+    let peek_map = peek_value.into_set()?;
+    let mut entries: Vec<_> = peek_map.iter().map(|v| *v.get::<&str>().unwrap()).collect();
+    entries.sort_by(|a, b| a.cmp(&b));
+
+    assert_eq!(entries, vec!["a", "b"]);
+}


### PR DESCRIPTION
This PR tries to fix https://github.com/facet-rs/facet/issues/783 (`HashSet` being serialized to `null`) by adding set handling to `facet-serialize`. 

Before it was unhandled, ending up in the default unit serialization, hence the translation into `null`.