### PR TITLE
Allowing to inspect facet objects (get field by path + object diff)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-inspect"
+version = "0.1.0"
+dependencies = [
+ "facet",
+ "facet-reflect",
+]
+
+[[package]]
 name = "facet-json"
 version = "0.24.15"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "facet-deserialize",
     "facet-bench",
     "facet-testhelpers-macros",
+    "facet-inspect",
 ]
 exclude = ["outside-workspace"]
 resolver = "3"

--- a/facet-inspect/Cargo.toml
+++ b/facet-inspect/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "facet-inspect"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+facet = { path = "../facet" }
+facet-reflect = { path = "../facet-reflect" }

--- a/facet-inspect/README.md
+++ b/facet-inspect/README.md
@@ -1,0 +1,56 @@
+<h1>
+<picture>
+    <source type="image/webp" media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/logo-v2/facet-b-dark.webp">
+    <source type="image/png" media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/logo-v2/facet-b-dark.png">
+    <source type="image/webp" srcset="https://github.com/facet-rs/facet/raw/main/static/logo-v2/facet-b-light.webp">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/logo-v2/facet-b-light.png" height="35" alt="Facet logo - a reflection library for Rust">
+</picture>
+</h1>
+
+[![Coverage Status](https://coveralls.io/repos/github/facet-rs/facet/badge.svg?branch=main)](https://coveralls.io/github/facet-rs/facet?branch=main)
+[![free of syn](https://img.shields.io/badge/free%20of-syn-hotpink)](https://github.com/fasterthanlime/free-of-syn)
+[![crates.io](https://img.shields.io/crates/v/facet-inspect.svg)](https://crates.io/crates/facet-inspect)
+[![documentation](https://docs.rs/facet-inspect/badge.svg)](https://docs.rs/facet-inspect)
+[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/facet-inspect.svg)](./LICENSE)
+[![Discord](https://img.shields.io/discord/1379550208551026748?logo=discord&label=discord)](https://discord.gg/JhD7CwCJ8F)
+
+_Logo by [Misiasart](https://misiasart.com/)_
+
+Thanks to all individual and corporate sponsors, without whom this work could not exist:
+
+<p> <a href="https://ko-fi.com/fasterthanlime">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/kofi-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/kofi-light.svg" height="40" alt="Ko-fi">
+</picture>
+</a> <a href="https://github.com/sponsors/fasterthanlime">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-light.svg" height="40" alt="GitHub Sponsors">
+</picture>
+</a> <a href="https://patreon.com/fasterthanlime">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-light.svg" height="40" alt="Patreon">
+</picture>
+</a> <a href="https://zed.dev">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-light.svg" height="40" alt="Zed">
+</picture>
+</a> <a href="https://depot.dev?utm_source=facet">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-light.svg" height="40" alt="Depot">
+</picture>
+</a> </p>
+
+Provide utilities to inspect the content of a Facet object.
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/facet-rs/facet/blob/main/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/facet-rs/facet/blob/main/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/facet-inspect/README.md.in
+++ b/facet-inspect/README.md.in
@@ -1,0 +1,1 @@
+Provide utilities to inspect the content of a Facet object.

--- a/facet-inspect/src/diff.rs
+++ b/facet-inspect/src/diff.rs
@@ -1,0 +1,227 @@
+use std::collections::HashMap;
+
+use facet::{Def, Facet};
+use facet_reflect::Peek;
+
+use crate::{FacetInspect, FacetPath};
+
+#[derive(Debug)]
+pub struct ModificationPeek<'mem, 'facet, 'shape> {
+    pub old_value: Peek<'mem, 'facet, 'shape>,
+    pub new_value: Peek<'mem, 'facet, 'shape>,
+}
+
+#[derive(Debug, Facet, PartialEq)]
+#[repr(C)]
+pub enum Modification {
+    U32 { before: u32, after: u32 },
+    String { before: String, after: String },
+}
+
+impl<'a> From<ModificationPeek<'a, 'a, 'a>> for Modification {
+    fn from(peek: ModificationPeek<'a, 'a, 'a>) -> Self {
+        let old_value = peek.old_value;
+        let new_value = peek.new_value;
+
+        match old_value.shape().type_identifier {
+            "u32" => {
+                let before = *old_value.get::<u32>().expect("old_value should be u32");
+                let after = *new_value.get::<u32>().expect("new_value should be u32");
+                Modification::U32 { before, after }
+            }
+            "String" => {
+                let before = old_value
+                    .get::<String>()
+                    .expect("old_value should be String")
+                    .clone();
+                let after = new_value
+                    .get::<String>()
+                    .expect("new_value should be String")
+                    .clone();
+                Modification::String { before, after }
+            }
+            _ => {
+                // Handle other types as needed
+                // For now, we will just panic if the type is not recognized
+                panic!(
+                    "Unsupported type for modification: {}",
+                    old_value.shape().type_identifier
+                );
+            }
+        }
+    }
+}
+
+#[derive(Debug, Facet)]
+pub struct Diff {
+    pub changes: HashMap<FacetPath, Modification>,
+}
+
+impl Diff {
+    pub fn compare<'a, T: Facet<'a>>(facet1: &'a T, facet2: &'a T) -> Self {
+        let mut changes = HashMap::new();
+
+        for ((path, peek1), (_, peek2)) in facet1.inspect().zip(facet2.inspect()) {
+            if peek1 == peek2 {
+                continue; // No change
+            }
+
+            if peek1.shape() == peek2.shape() && !matches!(peek1.shape().def, Def::Scalar) {
+                // There is change, deeper in the shape
+                // TODO: find a way to do the same without using Def::Scalar
+                continue;
+            }
+
+            let modif = ModificationPeek {
+                old_value: peek1,
+                new_value: peek2,
+            };
+
+            changes.insert(path, Modification::from(modif));
+        }
+
+        Diff { changes }
+    }
+}
+
+#[derive(Debug)]
+pub struct ShapeDiff<'a> {
+    pub changes: HashMap<FacetPath, DiffType<'a>>,
+}
+
+#[derive(Debug)]
+pub enum DiffType<'a> {
+    Added(Peek<'a, 'a, 'a>),
+    Removed(Peek<'a, 'a, 'a>),
+    Modified(ModificationPeek<'a, 'a, 'a>),
+}
+
+impl<'a> ShapeDiff<'a> {
+    pub fn compare<A: Facet<'a>, B: Facet<'a>>(facet1: &'a A, facet2: &'a B) -> Self {
+        let facet1_elements = facet1.inspect().collect::<HashMap<_, _>>();
+        let facet2_elements = facet2.inspect().collect::<HashMap<_, _>>();
+
+        let mut changes = HashMap::new();
+
+        for path in facet1_elements.keys().chain(facet2_elements.keys()) {
+            let peek1 = facet1_elements.get(path);
+            let peek2 = facet2_elements.get(path);
+
+            match (peek1, peek2) {
+                (Some(p1), Some(p2)) if p1 == p2 => continue, // No change
+                (Some(p1), Some(p2))
+                    if p1.shape() == p2.shape() && !matches!(p1.shape().def, Def::Scalar) =>
+                {
+                    // There is change, deeper in the shape
+                    // TODO: find a way to do the same without using Def::Scalar
+                    continue;
+                }
+                (Some(p1), None) => {
+                    changes.insert(path.clone(), DiffType::Removed(*p1));
+                }
+                (None, Some(p2)) => {
+                    changes.insert(path.clone(), DiffType::Added(*p2));
+                }
+                (Some(p1), Some(p2)) => {
+                    changes.insert(
+                        path.clone(),
+                        DiffType::Modified(ModificationPeek {
+                            old_value: *p1,
+                            new_value: *p2,
+                        }),
+                    );
+                }
+                (None, None) => unreachable!(), // This case should not happen
+            }
+        }
+
+        ShapeDiff { changes }
+    }
+}
+
+pub trait FacetDiff<'facet>: Facet<'facet> + Sized {
+    fn diff(&'facet self, other: &'facet Self) -> Diff {
+        Diff::compare(self, other)
+    }
+
+    fn shape_diff<T: Facet<'facet>>(&'facet self, other: &'facet T) -> ShapeDiff<'facet> {
+        ShapeDiff::compare(self, other)
+    }
+}
+
+impl<'facet, T: Facet<'facet>> FacetDiff<'facet> for T {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use facet::Facet;
+
+    #[derive(Facet, Clone)]
+    struct TestFacet {
+        field1: u32,
+        field2: String,
+    }
+
+    #[derive(Facet)]
+    struct NestedFacet {
+        nested_field: TestFacet,
+    }
+
+    #[derive(Facet)]
+    struct AnotherNestedFacet {
+        nested_field: TestFacet,
+        another_field: u32,
+    }
+
+    #[test]
+    fn test_facet_diff() {
+        let sub_facet1 = TestFacet {
+            field1: 42,
+            field2: "Hello".to_string(),
+        };
+
+        let facet1 = NestedFacet {
+            nested_field: sub_facet1.clone(),
+        };
+
+        let facet2 = NestedFacet {
+            nested_field: TestFacet {
+                field1: 43,
+                field2: "World".to_string(),
+            },
+        };
+
+        let diff = facet1.diff(&facet2);
+
+        assert_eq!(
+            diff.changes.get(&"$.nested_field.field1".into()).unwrap(),
+            &Modification::U32 {
+                before: 42,
+                after: 43
+            }
+        );
+    }
+
+    #[test]
+    fn test_shape_diff() {
+        let sub_facet1 = TestFacet {
+            field1: 42,
+            field2: "Hello".to_string(),
+        };
+
+        let facet1 = NestedFacet {
+            nested_field: sub_facet1.clone(),
+        };
+
+        let facet2 = AnotherNestedFacet {
+            nested_field: TestFacet {
+                field1: 43,
+                field2: "World".to_string(),
+            },
+            another_field: 100,
+        };
+
+        let shape_diff = facet1.shape_diff(&facet2);
+        dbg!(shape_diff);
+    }
+}

--- a/facet-inspect/src/inspect.rs
+++ b/facet-inspect/src/inspect.rs
@@ -1,0 +1,418 @@
+use facet::{Def, Facet, PointerType, Type, UserType};
+use facet_reflect::{HasFields, Peek};
+
+// TODO: Discuss if we should use a indexes as path to reduce the size of the path, this would make it more efficient to
+// send through the network, but less readable.
+/// A structure representing the path to a sub-object in a [`Facet`] object.
+#[derive(Facet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FacetPath {
+    pub segments: Vec<String>,
+}
+
+impl FacetPath {
+    pub fn root() -> Self {
+        FacetPath {
+            segments: vec!["$".to_string()],
+        }
+    }
+
+    pub fn push(&mut self, path: &FacetPath) {
+        self.segments.extend(path.segments.iter().cloned());
+    }
+
+    pub fn join(&self, path: &FacetPath) -> Self {
+        let mut new_path = self.clone();
+        new_path.push(path);
+        new_path
+    }
+}
+
+impl From<&str> for FacetPath {
+    fn from(path: &str) -> Self {
+        FacetPath {
+            segments: path.split('.').map(|s| s.to_string()).collect(),
+        }
+    }
+}
+
+/// A structure allowing to iterate over the shape of a [`Facet`] object.
+/// This iterator will yield the [`Peek`]s of the [`Facet`] sub-objects composing the inspected object.
+/// Each [`Peek`] will be associated to the path leading to it, allowing to reconstruct the structure of the object.
+#[derive(Clone)]
+pub struct FacetIterator<'mem, 'facet, 'shape> {
+    stack: Vec<(FacetPath, Peek<'mem, 'facet, 'shape>)>,
+}
+
+impl<'mem, 'facet, 'shape> Iterator for FacetIterator<'mem, 'facet, 'shape> {
+    type Item = (FacetPath, Peek<'mem, 'facet, 'shape>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some((path, peek)) = self.stack.pop() else {
+            return None; // If the stack is empty, we are done
+        };
+
+        let def = peek.shape().def;
+        let ty = peek.shape().ty;
+
+        match (def, ty) {
+            (Def::Scalar, _) => {} // Scalars do not have sub-objects, so we skip them
+            (Def::Array(_), _) | (Def::List(_), _) | (Def::Slice(_), _) => {
+                self.push_list_items_to_stack(
+                    &path,
+                    peek.into_list_like().expect("Expected a list").iter(),
+                );
+            }
+            (Def::Map(_), _) => {
+                self.push_map_items_to_stack(
+                    &path,
+                    peek.into_map().expect("Expected a map").iter(),
+                );
+            }
+            (_, Type::User(UserType::Struct(_))) => {
+                self.push_fields_to_stack(&path, peek.into_struct().expect("Expected a struct"));
+            }
+            (_, Type::User(UserType::Enum(_))) => {
+                self.push_fields_to_stack(&path, peek.into_enum().expect("Expected an enum"));
+            }
+            (_, Type::Sequence(_)) => {
+                // Sequences are treated like lists, so we push their items to the stack
+                self.push_list_items_to_stack(
+                    &path,
+                    peek.into_list_like().expect("Expected a sequence").iter(),
+                );
+            }
+            (_, Type::Pointer(PointerType::Reference(r))) => {
+                let target = (r.target)();
+                if let Type::Sequence(_) = target.ty {
+                    self.push_list_items_to_stack(
+                        &path,
+                        peek.into_list_like().expect("Expected a sequence").iter(),
+                    );
+                }
+            }
+            (_, _) => {
+                // TODO: discuss behavior here as I don't think runtime crash is the best option
+                todo!(
+                    "this type is not yet supported for inspection\ndef:{:?}\nty:{:?}",
+                    def,
+                    ty
+                );
+            }
+        }
+
+        Some((path, peek))
+    }
+}
+
+impl<'mem, 'facet, 'shape> FacetIterator<'mem, 'facet, 'shape> {
+    fn push_fields_to_stack(
+        &mut self,
+        parent_path: &FacetPath,
+        object: impl HasFields<'mem, 'facet, 'shape>,
+    ) {
+        // TODO: discuss if the performance trade-off of having the fields in reverse order is worth it
+        // We reverse the fields to maintain the order of fields as they are defined in the struct
+        for (field, peek) in object.fields().rev() {
+            let new_path = parent_path.join(&field.name.into());
+            self.stack.push((new_path, peek));
+        }
+    }
+
+    fn push_list_items_to_stack(
+        &mut self,
+        parent_path: &FacetPath,
+        list: impl Iterator<Item = Peek<'mem, 'facet, 'shape>>,
+    ) {
+        for (index, item) in list.enumerate() {
+            let new_path = parent_path.join(&FacetPath::from(index.to_string().as_str()));
+            self.stack.push((new_path, item));
+        }
+    }
+
+    fn push_map_items_to_stack(
+        &mut self,
+        parent_path: &FacetPath,
+        map: impl Iterator<Item = (Peek<'mem, 'facet, 'shape>, Peek<'mem, 'facet, 'shape>)>,
+    ) {
+        for (key, value_peek) in map {
+            let new_path = parent_path.join(&FacetPath::from(format!("{}", key).as_str()));
+            self.stack.push((new_path, value_peek));
+        }
+    }
+}
+
+pub trait FacetInspect<'a>: Facet<'a> {
+    /// Returns an iterator over the shape of the [`Facet`] object.
+    ///
+    /// The iterator will yield tuples containing the path to the sub-object and its corresponding [`Peek`].
+    fn inspect(&'a self) -> FacetIterator<'a, 'a, 'a> {
+        FacetIterator {
+            stack: vec![(FacetPath::root(), Peek::new(self))], // Start with the root path and a Peek of self
+        }
+    }
+
+    /// Returns a [`Peek`] for the sub-object at the specified path.
+    ///
+    /// If the path does not lead to a valid sub-object, `None` is returned.
+    fn get(&'a self, path: &FacetPath) -> Option<Peek<'a, 'a, 'a>> {
+        self.inspect()
+            .find(|(p, _)| p == path)
+            .map(|(_, peek)| peek)
+    }
+}
+
+impl<'a, T: Facet<'a>> FacetInspect<'a> for T {}
+
+#[cfg(test)]
+mod tests {
+    use super::FacetInspect;
+    use super::*;
+    use std::collections::HashMap;
+
+    #[derive(Facet)]
+    struct TestFacet {
+        field1: u32,
+        field2: String,
+    }
+
+    #[derive(Facet)]
+    struct NestedFacet {
+        nested_field: TestFacet,
+    }
+
+    #[derive(Facet, Debug, PartialEq)]
+    #[repr(u8)]
+    enum MyEnum {
+        Unit,
+        Tuple(u32, String),
+        Struct { x: u32, y: String },
+    }
+
+    #[test]
+    fn test_facet_iterator_struct() {
+        let facet = NestedFacet {
+            nested_field: TestFacet {
+                field1: 42,
+                field2: "Hello".to_string(),
+            },
+        };
+
+        let mut iter = facet.inspect();
+
+        let iterator_contains_field1 = iter.any(|(path, peek)| {
+            path == FacetPath::from("$.nested_field.field1")
+                && matches!(
+                    peek.partial_eq(&Peek::new(&facet.nested_field.field1)),
+                    Some(true)
+                )
+        });
+
+        let iterator_contains_field2 = iter.any(|(path, peek)| {
+            path == FacetPath::from("$.nested_field.field2")
+                && matches!(
+                    peek.partial_eq(&Peek::new(&facet.nested_field.field2)),
+                    Some(true)
+                )
+        });
+
+        assert!(iterator_contains_field1);
+        assert!(iterator_contains_field2);
+    }
+
+    #[test]
+    fn test_get_peek_by_path_struct() {
+        let facet = TestFacet {
+            field1: 42,
+            field2: "Hello".to_string(),
+        };
+
+        let peek1 = facet.get(&FacetPath::from("$.field1")).unwrap();
+        let peek2 = facet.get(&FacetPath::from("$.field2")).unwrap();
+
+        assert_eq!(peek1.partial_eq(&Peek::new(&facet.field1)), Some(true));
+        assert_eq!(peek2.partial_eq(&Peek::new(&facet.field2)), Some(true));
+    }
+
+    #[test]
+    fn test_facet_iterator_enum_unit() {
+        let facet = MyEnum::Unit;
+        let mut iter = facet.inspect();
+        // Should contain only the root path
+        assert!(iter.any(|(p, _)| p == FacetPath::from("$")));
+    }
+
+    #[test]
+    fn test_facet_iterator_enum_tuple() {
+        let facet = MyEnum::Tuple(42, "hello".to_string());
+        let mut iter = facet.inspect();
+        // Should contain root, and tuple fields
+        assert!(iter.any(|(p, peek)| p == FacetPath::from("$.0")
+            && peek.partial_eq(&Peek::new(&42)).unwrap_or(false)));
+        assert!(iter.any(|(p, peek)| {
+            p == FacetPath::from("$.1")
+                && peek
+                    .partial_eq(&Peek::new(&"hello".to_string()))
+                    .unwrap_or(false)
+        }));
+    }
+
+    #[test]
+    fn test_facet_iterator_enum_struct() {
+        let facet = MyEnum::Struct {
+            x: 7,
+            y: "abc".to_string(),
+        };
+        let mut iter = facet.inspect();
+
+        assert!(iter.any(|(p, peek)| p == FacetPath::from("$.x")
+            && peek.partial_eq(&Peek::new(&7)).unwrap_or(false)));
+        assert!(iter.any(|(p, peek)| {
+            p == FacetPath::from("$.y")
+                && peek
+                    .partial_eq(&Peek::new(&"abc".to_string()))
+                    .unwrap_or(false)
+        }));
+    }
+
+    #[test]
+    fn test_get_peek_by_path_enum_variants() {
+        // Struct variant
+        let facet = MyEnum::Struct {
+            x: 99,
+            y: "zzz".to_string(),
+        };
+        let peek_x = facet.get(&FacetPath::from("$.x")).unwrap();
+        let peek_y = facet.get(&FacetPath::from("$.y")).unwrap();
+        assert_eq!(peek_x.partial_eq(&Peek::new(&99)), Some(true));
+        assert_eq!(
+            peek_y.partial_eq(&Peek::new(&"zzz".to_string())),
+            Some(true)
+        );
+
+        // Tuple variant
+        let facet = MyEnum::Tuple(123, "tupleval".to_string());
+        let peek_0 = facet.get(&FacetPath::from("$.0")).unwrap();
+        let peek_1 = facet.get(&FacetPath::from("$.1")).unwrap();
+        assert_eq!(peek_0.partial_eq(&Peek::new(&123)), Some(true));
+        assert_eq!(
+            peek_1.partial_eq(&Peek::new(&"tupleval".to_string())),
+            Some(true)
+        );
+
+        // Unit variant (should only have root path)
+        let facet = MyEnum::Unit;
+        let peek_root = facet.get(&FacetPath::from("$")).unwrap();
+        // For unit, just check that we get a Peek and it matches itself
+        assert!(peek_root.partial_eq(&Peek::new(&facet)).unwrap_or(false));
+    }
+
+    #[test]
+    fn test_facet_iterator_array() {
+        let arr = [10, 20, 30];
+        let iter = arr.inspect();
+
+        let items: Vec<_> = iter.clone().collect();
+        dbg!(items);
+
+        assert!(iter.clone().any(|(p, peek)| p == FacetPath::from("$.0")
+            && peek.partial_eq(&Peek::new(&10)).unwrap_or(false)));
+        assert!(iter.clone().any(|(p, peek)| p == FacetPath::from("$.1")
+            && peek.partial_eq(&Peek::new(&20)).unwrap_or(false)));
+        assert!(iter.clone().any(|(p, peek)| p == FacetPath::from("$.2")
+            && peek.partial_eq(&Peek::new(&30)).unwrap_or(false)));
+    }
+
+    #[test]
+    fn test_facet_iterator_vec() {
+        let vec = vec!["a".to_string(), "b".to_string()];
+        let iter = vec.inspect();
+        assert!(iter.clone().any(|(p, peek)| {
+            p == FacetPath::from("$.0")
+                && peek
+                    .partial_eq(&Peek::new(&"a".to_string()))
+                    .unwrap_or(false)
+        }));
+        assert!(iter.clone().any(|(p, peek)| {
+            p == FacetPath::from("$.1")
+                && peek
+                    .partial_eq(&Peek::new(&"b".to_string()))
+                    .unwrap_or(false)
+        }));
+    }
+
+    #[test]
+    fn test_facet_iterator_slice() {
+        let slice: &[u32] = &[5, 6, 7];
+        let iter = slice.inspect();
+
+        dbg!(iter.clone().collect::<Vec<_>>());
+
+        assert!(iter.clone().any(|(p, peek)| p == FacetPath::from("$.0")
+            && peek.partial_eq(&Peek::new(&5)).unwrap_or(false)));
+        assert!(iter.clone().any(|(p, peek)| p == FacetPath::from("$.1")
+            && peek.partial_eq(&Peek::new(&6)).unwrap_or(false)));
+        assert!(iter.clone().any(|(p, peek)| p == FacetPath::from("$.2")
+            && peek.partial_eq(&Peek::new(&7)).unwrap_or(false)));
+    }
+
+    #[test]
+    fn test_facet_iterator_map() {
+        let mut map = HashMap::new();
+        map.insert("foo".to_string(), 123);
+        map.insert("bar".to_string(), 456);
+        let iter = map.inspect();
+        assert!(iter.clone().any(|(p, peek)| p == FacetPath::from("$.foo")
+            && peek.partial_eq(&Peek::new(&123)).unwrap_or(false)));
+        assert!(iter.clone().any(|(p, peek)| p == FacetPath::from("$.bar")
+            && peek.partial_eq(&Peek::new(&456)).unwrap_or(false)));
+    }
+
+    #[test]
+    fn test_get_peek_by_path_array_vec_slice_map() {
+        let arr = [1, 2, 3];
+        assert_eq!(
+            arr.get(&FacetPath::from("$.0"))
+                .unwrap()
+                .partial_eq(&Peek::new(&1)),
+            Some(true)
+        );
+        assert_eq!(
+            arr.get(&FacetPath::from("$.2"))
+                .unwrap()
+                .partial_eq(&Peek::new(&3)),
+            Some(true)
+        );
+
+        let vec = vec![9, 8, 7];
+        assert_eq!(
+            vec.get(&FacetPath::from("$.1"))
+                .unwrap()
+                .partial_eq(&Peek::new(&8)),
+            Some(true)
+        );
+
+        let slice: &[u32] = &[4, 5];
+        assert_eq!(
+            FacetInspect::get(&slice, &FacetPath::from("$.0"))
+                .unwrap()
+                .partial_eq(&Peek::new(&4)),
+            Some(true)
+        );
+
+        let mut map = HashMap::new();
+        map.insert("k1".to_string(), 11);
+        map.insert("k2".to_string(), 22);
+        assert_eq!(
+            FacetInspect::get(&map, &FacetPath::from("$.k1"))
+                .unwrap()
+                .partial_eq(&Peek::new(&11)),
+            Some(true)
+        );
+        assert_eq!(
+            FacetInspect::get(&map, &FacetPath::from("$.k2"))
+                .unwrap()
+                .partial_eq(&Peek::new(&22)),
+            Some(true)
+        );
+    }
+}

--- a/facet-inspect/src/lib.rs
+++ b/facet-inspect/src/lib.rs
@@ -1,0 +1,5 @@
+mod diff;
+pub use diff::*;
+
+mod inspect;
+pub use inspect::*;


### PR DESCRIPTION
Hi !

This is an experimentation on allowing facet objects to be diffed.

I make this PR early to gather feedback and make sure that I go the right way.

The key elements of this PR are:
- Introducing Paths allowing to navigate a facet object
- Creating an iterator that will traverse a given facet object and yield a (path, peek) tuple
- using this iterator to create a diff between two facet objects

I have two things in mind with this addition, allowing facet_assert (https://github.com/facet-rs/facet/issues/339) and allowing sending diffs over the network and apply them like patches to existing objects.
 