### PR TITLE
Reflection perf tinkering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,7 @@ edition = "2024"
 rust-version = "1.87.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/facet-rs/facet"
+
+[profile.release]
+lto = true
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,3 @@ edition = "2024"
 rust-version = "1.87.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/facet-rs/facet"
-
-[profile.release]
-lto = true
-debug = true

--- a/facet-bench/Cargo.toml
+++ b/facet-bench/Cargo.toml
@@ -26,3 +26,7 @@ harness = false
 [[bench]]
 name = "canada"
 harness = false
+
+[[bench]]
+name = "reflect"
+harness = false

--- a/facet-bench/benches/reflect.rs
+++ b/facet-bench/benches/reflect.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::approx_constant)]
+
 use divan::{Bencher, black_box};
 use facet::Facet;
 use facet_reflect::{Partial, ReflectError};

--- a/facet-bench/benches/reflect.rs
+++ b/facet-bench/benches/reflect.rs
@@ -1,0 +1,50 @@
+use divan::{Bencher, black_box};
+use facet::Facet;
+use facet_reflect::{Partial, ReflectError};
+
+#[derive(Facet)]
+struct SimpleStruct {
+    a: u32,
+    b: i32,
+    c: f32,
+}
+
+#[divan::bench(name = "Populate small struct by field names")]
+fn populate_simple_struct(bencher: Bencher) {
+    fn populate_by_field_name<'shape>(
+        partial: &mut Partial<'_, 'shape>,
+    ) -> Result<(), ReflectError<'shape>> {
+        partial.set_field("a", 42u32)?;
+        partial.set_field("b", -42i32)?;
+        partial.set_field("c", 3.14f32)?;
+        Ok(())
+    }
+
+    bencher.bench(|| {
+        let mut partial = Partial::alloc::<SimpleStruct>().unwrap();
+        populate_by_field_name(black_box(partial.inner_mut())).unwrap();
+        // Don't materialize it - we just want to measure the population time.
+    })
+}
+
+#[divan::bench(name = "Populate small struct by field index")]
+fn populate_simple_struct_by_field_index(bencher: Bencher) {
+    fn populate_by_field_index<'shape>(
+        partial: &mut Partial<'_, 'shape>,
+    ) -> Result<(), ReflectError<'shape>> {
+        partial.set_nth_field(0, 42u32)?;
+        partial.set_nth_field(1, -42i32)?;
+        partial.set_nth_field(2, 3.14f32)?;
+        Ok(())
+    }
+
+    bencher.bench(|| {
+        let mut partial = Partial::alloc::<SimpleStruct>().unwrap();
+        populate_by_field_index(black_box(partial.inner_mut())).unwrap();
+        // Don't materialize it - we just want to measure the population time.
+    })
+}
+
+fn main() {
+    divan::main();
+}

--- a/facet-core/src/typeid.rs
+++ b/facet-core/src/typeid.rs
@@ -38,6 +38,7 @@ impl ConstTypeId {
 }
 
 impl Debug for ConstTypeId {
+    #[inline]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         Debug::fmt(&self.get(), formatter)
     }

--- a/facet-core/src/typeid.rs
+++ b/facet-core/src/typeid.rs
@@ -30,8 +30,9 @@ impl ConstTypeId {
         }
     }
 
+    /// Get the underlying [`TypeId`] for this `ConstTypeId`.
     #[inline]
-    fn get(self) -> TypeId {
+    pub fn get(self) -> TypeId {
         (self.type_id_fn)()
     }
 }
@@ -50,6 +51,7 @@ impl PartialEq for ConstTypeId {
 }
 
 impl PartialEq<TypeId> for ConstTypeId {
+    #[inline]
     fn eq(&self, other: &TypeId) -> bool {
         self.get() == *other
     }

--- a/facet-core/src/types/characteristic.rs
+++ b/facet-core/src/types/characteristic.rs
@@ -53,6 +53,7 @@ pub enum Characteristic {
 
 impl Characteristic {
     /// Checks if all shapes have the given characteristic.
+    #[inline]
     pub fn all(self, shapes: &[&Shape]) -> bool {
         let mut i = 0;
         while i < shapes.len() {
@@ -65,6 +66,7 @@ impl Characteristic {
     }
 
     /// Checks if any shape has the given characteristic.
+    #[inline]
     pub fn any(self, shapes: &[&Shape]) -> bool {
         let mut i = 0;
         while i < shapes.len() {
@@ -77,6 +79,7 @@ impl Characteristic {
     }
 
     /// Checks if none of the shapes have the given characteristic.
+    #[inline]
     pub fn none(self, shapes: &[&Shape]) -> bool {
         let mut i = 0;
         while i < shapes.len() {
@@ -89,6 +92,7 @@ impl Characteristic {
     }
 
     /// Checks if all shapes have the `Default` characteristic
+    #[inline]
     pub fn all_default(shapes: &[&Shape]) -> bool {
         let mut i = 0;
         while i < shapes.len() {
@@ -101,6 +105,7 @@ impl Characteristic {
     }
 
     /// Checks if all shapes have the `PartialEq` characteristic
+    #[inline]
     pub fn all_partial_eq(shapes: &[&Shape]) -> bool {
         let mut i = 0;
         while i < shapes.len() {
@@ -113,6 +118,7 @@ impl Characteristic {
     }
 
     /// Checks if all shapes have the `PartialOrd` characteristic
+    #[inline]
     pub fn all_partial_ord(shapes: &[&Shape]) -> bool {
         let mut i = 0;
         while i < shapes.len() {
@@ -125,6 +131,7 @@ impl Characteristic {
     }
 
     /// Checks if all shapes have the `Ord` characteristic
+    #[inline]
     pub fn all_ord(shapes: &[&Shape]) -> bool {
         let mut i = 0;
         while i < shapes.len() {
@@ -137,6 +144,7 @@ impl Characteristic {
     }
 
     /// Checks if all shapes have the `Hash` characteristic
+    #[inline]
     pub fn all_hash(shapes: &[&Shape]) -> bool {
         let mut i = 0;
         while i < shapes.len() {
@@ -151,6 +159,7 @@ impl Characteristic {
 
 impl<'shape> Shape<'shape> {
     /// Checks if a shape has the given characteristic.
+    #[inline]
     pub fn is(&self, characteristic: Characteristic) -> bool {
         match characteristic {
             // Marker traits
@@ -174,71 +183,85 @@ impl<'shape> Shape<'shape> {
     }
 
     /// Check if this shape implements the Send trait
+    #[inline]
     pub fn is_send(&self) -> bool {
         self.is(Characteristic::Send)
     }
 
     /// Check if this shape implements the Sync trait
+    #[inline]
     pub fn is_sync(&self) -> bool {
         self.is(Characteristic::Sync)
     }
 
     /// Check if this shape implements the Copy trait
+    #[inline]
     pub fn is_copy(&self) -> bool {
         self.is(Characteristic::Copy)
     }
 
     /// Check if this shape implements the Eq trait
+    #[inline]
     pub fn is_eq(&self) -> bool {
         self.is(Characteristic::Eq)
     }
 
     /// Check if this shape implements the Clone trait
+    #[inline]
     pub fn is_clone(&self) -> bool {
         self.is(Characteristic::Clone)
     }
 
     /// Check if this shape implements the Display trait
+    #[inline]
     pub fn is_display(&self) -> bool {
         self.is(Characteristic::Display)
     }
 
     /// Check if this shape implements the Debug trait
+    #[inline]
     pub fn is_debug(&self) -> bool {
         self.is(Characteristic::Debug)
     }
 
     /// Check if this shape implements the PartialEq trait
+    #[inline]
     pub fn is_partial_eq(&self) -> bool {
         self.is(Characteristic::PartialEq)
     }
 
     /// Check if this shape implements the PartialOrd trait
+    #[inline]
     pub fn is_partial_ord(&self) -> bool {
         self.is(Characteristic::PartialOrd)
     }
 
     /// Check if this shape implements the Ord trait
+    #[inline]
     pub fn is_ord(&self) -> bool {
         self.is(Characteristic::Ord)
     }
 
     /// Check if this shape implements the Hash trait
+    #[inline]
     pub fn is_hash(&self) -> bool {
         self.is(Characteristic::Hash)
     }
 
     /// Check if this shape implements the Default trait
+    #[inline]
     pub fn is_default(&self) -> bool {
         self.is(Characteristic::Default)
     }
 
     /// Check if this shape implements the FromStr trait
+    #[inline]
     pub fn is_from_str(&self) -> bool {
         self.is(Characteristic::FromStr)
     }
 
     /// Writes the name of this type to the given formatter
+    #[inline]
     pub fn write_type_name(&self, f: &mut fmt::Formatter<'_>, opts: TypeNameOpts) -> fmt::Result {
         (self.vtable.type_name())(f, opts)
     }

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -332,6 +332,7 @@ impl<'shape> ShapeBuilder<'shape> {
 }
 
 impl PartialEq for Shape<'_> {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
     }
@@ -348,6 +349,7 @@ impl core::hash::Hash for Shape<'_> {
 
 impl Shape<'_> {
     /// Check if this shape is of the given type
+    #[inline]
     pub fn is_shape(&self, other: &Shape<'_>) -> bool {
         self == other
     }

--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -99,6 +99,7 @@ pub enum ShapeLayout {
 
 impl ShapeLayout {
     /// `Layout` if this type is `Sized`
+    #[inline]
     pub fn sized_layout(self) -> Result<Layout, UnsizedError> {
         match self {
             ShapeLayout::Sized(layout) => Ok(layout),
@@ -170,16 +171,19 @@ impl<'shape> Shape<'shape> {
     }
 
     /// See [`ShapeAttribute::DenyUnknownFields`]
+    #[inline]
     pub fn has_deny_unknown_fields_attr(&self) -> bool {
         self.attributes.contains(&ShapeAttribute::DenyUnknownFields)
     }
 
     /// See [`ShapeAttribute::Default`]
+    #[inline]
     pub fn has_default_attr(&self) -> bool {
         self.attributes.contains(&ShapeAttribute::Default)
     }
 
     /// See [`ShapeAttribute::RenameAll`]
+    #[inline]
     pub fn get_rename_all_attr(&self) -> Option<&str> {
         self.attributes.iter().find_map(|attr| {
             if let ShapeAttribute::RenameAll(rule) = attr {
@@ -506,6 +510,7 @@ impl Shape<'_> {
     /// - `ptr` must have been allocated using [`Self::allocate`] and be aligned for this shape.
     /// - `ptr` must point to a region that is not already deallocated.
     #[cfg(feature = "alloc")]
+    #[inline]
     pub unsafe fn deallocate_mut(&self, ptr: PtrMut) -> Result<(), UnsizedError> {
         use alloc::alloc::dealloc;
 
@@ -529,6 +534,7 @@ impl Shape<'_> {
     /// - `ptr` must not have been already deallocated.
     /// - `ptr` must be properly aligned for this shape.
     #[cfg(feature = "alloc")]
+    #[inline]
     pub unsafe fn deallocate_uninit(
         &self,
         ptr: crate::ptr::PtrUninit<'static>,
@@ -562,6 +568,7 @@ pub struct TypeParam<'shape> {
 
 impl<'shape> TypeParam<'shape> {
     /// Returns the shape of the type parameter.
+    #[inline]
     pub fn shape(&self) -> &'shape Shape<'shape> {
         (self.shape)()
     }

--- a/facet-core/src/types/ty/enum_.rs
+++ b/facet-core/src/types/ty/enum_.rs
@@ -97,6 +97,7 @@ impl<'shape> Variant<'shape> {
 
     /// Checks whether the `Variant` has an attribute of form `VariantAttribute::Arbitrary` with the
     /// given content.
+    #[inline]
     pub fn has_arbitrary_attr(&self, content: &'static str) -> bool {
         self.attributes
             .contains(&VariantAttribute::Arbitrary(content))

--- a/facet-core/src/types/ty/pointer.rs
+++ b/facet-core/src/types/ty/pointer.rs
@@ -42,6 +42,7 @@ pub struct ValuePointerType<'shape> {
 
 impl<'shape> ValuePointerType<'shape> {
     /// Returns the shape of the pointer's pointee.
+    #[inline]
     pub fn target(&self) -> &'shape Shape<'shape> {
         (self.target)()
     }

--- a/facet-core/src/types/ty/user.rs
+++ b/facet-core/src/types/ty/user.rs
@@ -16,6 +16,7 @@ pub enum UserType<'shape> {
 
 impl<'shape> UserType<'shape> {
     /// Retrieves underlying representation of the type
+    #[inline]
     pub const fn repr(&self) -> Option<Repr> {
         match self {
             Self::Struct(s) => Some(s.repr),
@@ -46,6 +47,7 @@ impl Repr {
     /// Create default representation for a user type
     ///
     /// This will be Rust representation with no packing
+    #[inline]
     pub const fn default() -> Self {
         Self {
             base: BaseRepr::Rust,
@@ -54,6 +56,7 @@ impl Repr {
     }
 
     /// Build unpacked C representation
+    #[inline]
     pub const fn c() -> Self {
         Self {
             base: BaseRepr::C,
@@ -62,6 +65,7 @@ impl Repr {
     }
 
     /// Builds transparent representation
+    #[inline]
     pub const fn transparent() -> Self {
         Self {
             base: BaseRepr::Transparent,

--- a/facet-core/src/types/value.rs
+++ b/facet-core/src/types/value.rs
@@ -26,6 +26,7 @@ pub struct TypeNameOpts {
 }
 
 impl Default for TypeNameOpts {
+    #[inline]
     fn default() -> Self {
         Self { recurse_ttl: -1 }
     }
@@ -33,16 +34,19 @@ impl Default for TypeNameOpts {
 
 impl TypeNameOpts {
     /// Create a new `NameOpts` for which none of the type parameters are formatted
+    #[inline]
     pub fn none() -> Self {
         Self { recurse_ttl: 0 }
     }
 
     /// Create a new `NameOpts` for which only the direct children are formatted
+    #[inline]
     pub fn one() -> Self {
         Self { recurse_ttl: 1 }
     }
 
     /// Create a new `NameOpts` for which all type parameters are formatted
+    #[inline]
     pub fn infinite() -> Self {
         Self { recurse_ttl: -1 }
     }
@@ -54,6 +58,7 @@ impl TypeNameOpts {
     /// `…` (unicode ellipsis) character instead of your list of types.
     ///
     /// See the implementation for `Vec` for examples.
+    #[inline]
     pub fn for_children(&self) -> Option<Self> {
         match self.recurse_ttl.cmp(&0) {
             Ordering::Greater => Some(Self {
@@ -240,6 +245,7 @@ impl<'shape> core::fmt::Display for TryFromError<'shape> {
 impl<'shape> core::error::Error for TryFromError<'shape> {}
 
 impl<'shape> From<UnsizedError> for TryFromError<'shape> {
+    #[inline]
     fn from(_value: UnsizedError) -> Self {
         Self::Unsized
     }
@@ -459,6 +465,7 @@ impl<'a> HasherProxy<'a> {
     ///
     /// The `hasher_this` parameter must be a valid pointer to a Hasher trait object.
     /// The `hasher_write_fn` parameter must be a valid function pointer.
+    #[inline]
     pub unsafe fn new(hasher_this: PtrMut<'a>, hasher_write_fn: HasherWriteFn) -> Self {
         Self {
             hasher_this,
@@ -471,6 +478,7 @@ impl core::hash::Hasher for HasherProxy<'_> {
     fn finish(&self) -> u64 {
         unimplemented!("finish is not needed for this implementation")
     }
+    #[inline]
     fn write(&mut self, bytes: &[u8]) {
         unsafe { (self.hasher_write_fn)(self.hasher_this, bytes) }
     }
@@ -728,6 +736,7 @@ impl ValueVTable {
     }
 
     /// Get the marker traits implemented for the type
+    #[inline]
     pub fn marker_traits(&self) -> MarkerTraits {
         match self {
             ValueVTable::Sized(inner) => (inner.marker_traits)(),
@@ -736,6 +745,7 @@ impl ValueVTable {
     }
 
     /// Get the type name fn of the type
+    #[inline]
     pub const fn type_name(&self) -> TypeNameFn {
         match self {
             ValueVTable::Sized(inner) => inner.type_name,
@@ -744,81 +754,97 @@ impl ValueVTable {
     }
 
     /// Check if the type implements the [`Eq`] marker trait
+    #[inline]
     pub fn is_eq(&self) -> bool {
         self.marker_traits().contains(MarkerTraits::EQ)
     }
 
     /// Check if the type implements the [`Send`] marker trait
+    #[inline]
     pub fn is_send(&self) -> bool {
         self.marker_traits().contains(MarkerTraits::SEND)
     }
 
     /// Check if the type implements the [`Sync`] marker trait
+    #[inline]
     pub fn is_sync(&self) -> bool {
         self.marker_traits().contains(MarkerTraits::SYNC)
     }
 
     /// Check if the type implements the [`Copy`] marker trait
+    #[inline]
     pub fn is_copy(&self) -> bool {
         self.marker_traits().contains(MarkerTraits::COPY)
     }
 
     /// Check if the type implements the [`Unpin`] marker trait
+    #[inline]
     pub fn is_unpin(&self) -> bool {
         self.marker_traits().contains(MarkerTraits::UNPIN)
     }
 
     /// Check if the type implements the [`UnwindSafe`](core::panic::UnwindSafe) marker trait
+    #[inline]
     pub fn is_unwind_safe(&self) -> bool {
         self.marker_traits().contains(MarkerTraits::UNWIND_SAFE)
     }
 
     /// Check if the type implements the [`RefUnwindSafe`](core::panic::RefUnwindSafe) marker trait
+    #[inline]
     pub fn is_ref_unwind_safe(&self) -> bool {
         self.marker_traits().contains(MarkerTraits::REF_UNWIND_SAFE)
     }
 
     /// Returns `true` if the type implements the [`Display`](core::fmt::Display) trait and the `display` function is available in the vtable.
+    #[inline]
     pub fn has_display(&self) -> bool {
         has_fn!(self, display)
     }
 
     /// Returns `true` if the type implements the [`Debug`] trait and the `debug` function is available in the vtable.
+    #[inline]
     pub fn has_debug(&self) -> bool {
         has_fn!(self, debug)
     }
 
     /// Returns `true` if the type implements the [`PartialEq`] trait and the `partial_eq` function is available in the vtable.
+    #[inline]
     pub fn has_partial_eq(&self) -> bool {
         has_fn!(self, partial_eq)
     }
 
     /// Returns `true` if the type implements the [`PartialOrd`] trait and the `partial_ord` function is available in the vtable.
+    #[inline]
     pub fn has_partial_ord(&self) -> bool {
         has_fn!(self, partial_ord)
     }
 
     /// Returns `true` if the type implements the [`Ord`] trait and the `ord` function is available in the vtable.
+    #[inline]
     pub fn has_ord(&self) -> bool {
         has_fn!(self, ord)
     }
 
     /// Returns `true` if the type implements the [`Hash`] trait and the `hash` function is available in the vtable.
+    #[inline]
     pub fn has_hash(&self) -> bool {
         has_fn!(self, hash)
     }
 
     /// Returns `true` if the type supports default-in-place construction via the vtable.
+    #[inline]
     pub fn has_default_in_place(&self) -> bool {
         has_fn_sized!(self, default_in_place)
     }
 
     /// Returns `true` if the type supports in-place cloning via the vtable.
+    #[inline]
     pub fn has_clone_into(&self) -> bool {
         has_fn_sized!(self, clone_into)
     }
 
     /// Returns `true` if the type supports parsing from a string via the vtable.
+    #[inline]
     pub fn has_parse(&self) -> bool {
         has_fn_sized!(self, parse)
     }

--- a/facet-reflect/src/partial/iset.rs
+++ b/facet-reflect/src/partial/iset.rs
@@ -13,6 +13,7 @@ impl ISet {
     /// # Panics
     ///
     /// Panics if `count` > 64.
+    #[inline]
     pub fn new(count: usize) -> Self {
         if count > 64 {
             panic!("ISet can only track up to 64 fields. Count {count} is out of bounds.");
@@ -22,6 +23,7 @@ impl ISet {
     }
 
     /// Sets the bit at the given index.
+    #[inline]
     pub fn set(&mut self, index: usize) {
         if index >= 64 {
             panic!("ISet can only track up to 64 fields. Index {index} is out of bounds.");
@@ -30,6 +32,7 @@ impl ISet {
     }
 
     /// Checks if the bit at the given index is set.
+    #[inline]
     pub fn get(&self, index: usize) -> bool {
         if index >= 64 {
             panic!("ISet can only track up to 64 fields. Index {index} is out of bounds.");
@@ -38,6 +41,7 @@ impl ISet {
     }
 
     /// Unsets the bit at the given index.
+    #[inline]
     pub fn unset(&mut self, index: usize) {
         if index >= 64 {
             panic!("ISet can only track up to 64 fields. Index {index} is out of bounds.");
@@ -46,6 +50,7 @@ impl ISet {
     }
 
     /// Returns true if all bits up to MAX_INDEX are set.
+    #[inline]
     pub fn all_set(&self) -> bool {
         self.flags == u64::MAX >> (63 - Self::MAX_INDEX)
     }

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -249,7 +249,7 @@ enum Tracker<'shape> {
 
     /// Partially initialized enum (but we picked a variant)
     Enum {
-        variant: Variant<'shape>,
+        variant: &'shape Variant<'shape>,
         data: ISet,
         /// If we're pushing another frame, this is set to the field index
         current_child: Option<usize>,
@@ -814,7 +814,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
 
         // Update tracker to track the variant
         fr.tracker = Tracker::Enum {
-            variant: *variant,
+            variant,
             data: ISet::new(variant.data.fields.len()),
             current_child: None,
         };
@@ -2136,7 +2136,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
         let frame = self.frames.last()?;
 
         match &frame.tracker {
-            Tracker::Enum { variant, .. } => Some(*variant),
+            Tracker::Enum { variant, .. } => Some(**variant),
             _ => None,
         }
     }

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -490,6 +490,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     /// into the Partial (i.e., the destination), and the original value should not be used
     /// or dropped by the caller; consider using `core::mem::forget` on the passed value.
     /// If an error is returned, the destination remains unmodified and safe for future operations.
+    #[inline]
     pub unsafe fn set_shape(
         &mut self,
         src_value: PtrConst<'_>,
@@ -816,6 +817,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     }
 
     /// Selects a field of a struct with a given name
+    #[inline]
     pub fn begin_field(&mut self, field_name: &str) -> Result<&mut Self, ReflectError<'shape>> {
         self.require_active()?;
 
@@ -1554,7 +1556,8 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
         Ok(self)
     }
 
-    /// Pops the current frame off the stack, indicating we're done initializing the current field.
+    /// Pops the current frame off the stack, indicating we're done initializing the current field
+    #[inline]
     pub fn end(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
         self.require_active()?;
         if self.frames.len() <= 1 {
@@ -2393,6 +2396,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     }
 
     /// Convenience shortcut: sets the named field to value, popping after.
+    #[inline]
     pub fn set_field<U>(
         &mut self,
         field_name: &str,

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -457,6 +457,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     }
 
     /// Returns the current frame count (depth of nesting)
+    #[inline]
     pub fn frame_count(&self) -> usize {
         self.frames.len()
     }
@@ -525,6 +526,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     }
 
     /// Sets the current frame to its default value
+    #[inline]
     pub fn set_default(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
         let frame = self.frames.last().unwrap(); // Get frame to access vtable
 
@@ -554,6 +556,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     }
 
     /// Sets the current frame using a field-level default function
+    #[inline]
     pub fn set_field_default(
         &mut self,
         field_default_fn: DefaultInPlaceFn,
@@ -823,7 +826,6 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     }
 
     /// Selects a field of a struct with a given name
-    #[inline]
     pub fn begin_field(&mut self, field_name: &str) -> Result<&mut Self, ReflectError<'shape>> {
         self.require_active()?;
 
@@ -1563,7 +1565,6 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     }
 
     /// Pops the current frame off the stack, indicating we're done initializing the current field
-    #[inline]
     pub fn end(&mut self) -> Result<&mut Self, ReflectError<'shape>> {
         self.require_active()?;
         if self.frames.len() <= 1 {
@@ -2050,6 +2051,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     }
 
     /// Returns the shape of the current frame.
+    #[inline]
     pub fn shape(&self) -> &'shape Shape<'shape> {
         self.frames
             .last()
@@ -2058,6 +2060,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     }
 
     /// Returns the innermost shape (alias for shape(), for compatibility)
+    #[inline]
     pub fn innermost_shape(&self) -> &'shape Shape<'shape> {
         self.shape()
     }
@@ -2402,7 +2405,6 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
     }
 
     /// Convenience shortcut: sets the named field to value, popping after.
-    #[inline]
     pub fn set_field<U>(
         &mut self,
         field_name: &str,

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -409,8 +409,14 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
             .allocate()
             .map_err(|_| ReflectError::Unsized { shape })?;
 
+        // Preallocate a couple of frames. The cost of allocating 4 frames is
+        // basically identical to allocating 1 frame, so for every type that
+        // has at least 1 level of nesting, this saves at least one guaranteed reallocation.
+        let mut frames = Vec::with_capacity(4);
+        frames.push(Frame::new(data, shape, FrameOwnership::Owned));
+
         Ok(Self {
-            frames: vec![Frame::new(data, shape, FrameOwnership::Owned)],
+            frames,
             state: PartialState::Active,
             invariant: PhantomData,
         })

--- a/facet-reflect/src/peek/enum_.rs
+++ b/facet-reflect/src/peek/enum_.rs
@@ -24,6 +24,7 @@ impl core::fmt::Debug for PeekEnum<'_, '_, '_> {
 }
 
 /// Returns the enum definition if the shape represents an enum, None otherwise
+#[inline]
 pub fn peek_enum<'shape>(shape: &'shape Shape) -> Option<EnumType<'shape>> {
     match shape.ty {
         facet_core::Type::User(UserType::Enum(enum_ty)) => Some(enum_ty),
@@ -32,11 +33,13 @@ pub fn peek_enum<'shape>(shape: &'shape Shape) -> Option<EnumType<'shape>> {
 }
 
 /// Returns the enum representation if the shape represents an enum, None otherwise
+#[inline]
 pub fn peek_enum_repr(shape: &Shape) -> Option<EnumRepr> {
     peek_enum(shape).map(|enum_def| enum_def.enum_repr)
 }
 
 /// Returns the enum variants if the shape represents an enum, None otherwise
+#[inline]
 pub fn peek_enum_variants<'shape>(shape: &'shape Shape) -> Option<&'shape [Variant<'shape>]> {
     peek_enum(shape).map(|enum_def| enum_def.variants)
 }
@@ -249,6 +252,7 @@ impl<'mem, 'facet, 'shape> PeekEnum<'mem, 'facet, 'shape> {
 }
 
 impl<'mem, 'facet, 'shape> HasFields<'mem, 'facet, 'shape> for PeekEnum<'mem, 'facet, 'shape> {
+    #[inline]
     fn fields(&self) -> FieldIter<'mem, 'facet, 'shape> {
         FieldIter::new_enum(*self)
     }

--- a/facet-reflect/src/peek/fields.rs
+++ b/facet-reflect/src/peek/fields.rs
@@ -43,6 +43,7 @@ enum FieldIterState<'mem, 'facet, 'shape> {
 }
 
 impl<'mem, 'facet, 'shape> FieldIter<'mem, 'facet, 'shape> {
+    #[inline]
     pub(crate) fn new_struct(struct_: PeekStruct<'mem, 'facet, 'shape>) -> Self {
         Self {
             range: 0..struct_.ty.fields.len(),
@@ -50,6 +51,7 @@ impl<'mem, 'facet, 'shape> FieldIter<'mem, 'facet, 'shape> {
         }
     }
 
+    #[inline]
     pub(crate) fn new_enum(enum_: PeekEnum<'mem, 'facet, 'shape>) -> Self {
         // Get the fields of the active variant
         let variant = match enum_.active_variant() {
@@ -67,6 +69,7 @@ impl<'mem, 'facet, 'shape> FieldIter<'mem, 'facet, 'shape> {
         }
     }
 
+    #[inline]
     pub(crate) fn new_tuple(tuple: PeekTuple<'mem, 'facet, 'shape>) -> Self {
         Self {
             range: 0..tuple.len(),
@@ -115,6 +118,7 @@ impl<'mem, 'facet, 'shape> FieldIter<'mem, 'facet, 'shape> {
 impl<'mem, 'facet, 'shape> Iterator for FieldIter<'mem, 'facet, 'shape> {
     type Item = (Field<'shape>, Peek<'mem, 'facet, 'shape>);
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let index = self.range.next()?;
@@ -127,12 +131,14 @@ impl<'mem, 'facet, 'shape> Iterator for FieldIter<'mem, 'facet, 'shape> {
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.range.size_hint()
     }
 }
 
 impl DoubleEndedIterator for FieldIter<'_, '_, '_> {
+    #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         loop {
             let index = self.range.next_back()?;

--- a/facet-reflect/src/peek/list.rs
+++ b/facet-reflect/src/peek/list.rs
@@ -14,6 +14,7 @@ pub struct PeekListIter<'mem, 'facet, 'shape> {
 impl<'mem, 'facet, 'shape> Iterator for PeekListIter<'mem, 'facet, 'shape> {
     type Item = Peek<'mem, 'facet, 'shape>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let item_ptr = match self.state {
             PeekListIterState::Ptr { data, stride } => {
@@ -35,6 +36,7 @@ impl<'mem, 'facet, 'shape> Iterator for PeekListIter<'mem, 'facet, 'shape> {
         Some(unsafe { Peek::unchecked_new(item_ptr, self.def.t()) })
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let remaining = self.len.saturating_sub(self.index);
         (remaining, Some(remaining))
@@ -44,6 +46,7 @@ impl<'mem, 'facet, 'shape> Iterator for PeekListIter<'mem, 'facet, 'shape> {
 impl ExactSizeIterator for PeekListIter<'_, '_, '_> {}
 
 impl Drop for PeekListIter<'_, '_, '_> {
+    #[inline]
     fn drop(&mut self) {
         match self.state {
             PeekListIterState::Iter { iter } => unsafe {
@@ -60,6 +63,7 @@ impl<'mem, 'facet, 'shape> IntoIterator for &'mem PeekList<'mem, 'facet, 'shape>
     type Item = Peek<'mem, 'facet, 'shape>;
     type IntoIter = PeekListIter<'mem, 'facet, 'shape>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
@@ -85,21 +89,25 @@ impl Debug for PeekList<'_, '_, '_> {
 
 impl<'mem, 'facet, 'shape> PeekList<'mem, 'facet, 'shape> {
     /// Creates a new peek list
+    #[inline]
     pub fn new(value: Peek<'mem, 'facet, 'shape>, def: ListDef<'shape>) -> Self {
         Self { value, def }
     }
 
     /// Get the length of the list
+    #[inline]
     pub fn len(&self) -> usize {
         unsafe { (self.def.vtable.len)(self.value.data().thin().unwrap()) }
     }
 
     /// Returns true if the list is empty
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Get an item from the list at the specified index
+    #[inline]
     pub fn get(&self, index: usize) -> Option<Peek<'mem, 'facet, 'shape>> {
         let item = unsafe { (self.def.vtable.get)(self.value.data().thin().unwrap(), index)? };
 
@@ -138,6 +146,7 @@ impl<'mem, 'facet, 'shape> PeekList<'mem, 'facet, 'shape> {
     }
 
     /// Def getter
+    #[inline]
     pub fn def(&self) -> ListDef<'shape> {
         self.def
     }

--- a/facet-reflect/src/peek/list_like.rs
+++ b/facet-reflect/src/peek/list_like.rs
@@ -24,6 +24,7 @@ pub enum ListLikeDef<'shape> {
 
 impl<'shape> ListLikeDef<'shape> {
     /// Returns the shape of the items in the list
+    #[inline]
     pub fn t(&self) -> &'shape Shape<'shape> {
         match self {
             ListLikeDef::List(v) => v.t(),
@@ -45,6 +46,7 @@ pub struct PeekListLikeIter<'mem, 'facet, 'shape> {
 impl<'mem, 'facet, 'shape> Iterator for PeekListLikeIter<'mem, 'facet, 'shape> {
     type Item = Peek<'mem, 'facet, 'shape>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let item_ptr = match self.state {
             PeekListLikeIterState::Ptr { data, stride } => {
@@ -64,6 +66,7 @@ impl<'mem, 'facet, 'shape> Iterator for PeekListLikeIter<'mem, 'facet, 'shape> {
         Some(unsafe { Peek::unchecked_new(item_ptr, self.def.t()) })
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let remaining = self.len.saturating_sub(self.index);
         (remaining, Some(remaining))
@@ -76,6 +79,7 @@ impl<'mem, 'facet, 'shape> IntoIterator for &'mem PeekListLike<'mem, 'facet, 'sh
     type Item = Peek<'mem, 'facet, 'shape>;
     type IntoIter = PeekListLikeIter<'mem, 'facet, 'shape>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
@@ -93,6 +97,7 @@ enum PeekListLikeIterState<'mem> {
 }
 
 impl Drop for PeekListLikeIterState<'_> {
+    #[inline]
     fn drop(&mut self) {
         match self {
             Self::Iter { iter, vtable } => unsafe { (vtable.dealloc)(*iter) },
@@ -119,6 +124,7 @@ impl<'mem, 'facet, 'shape> Debug for PeekListLike<'mem, 'facet, 'shape> {
 
 impl<'mem, 'facet, 'shape> PeekListLike<'mem, 'facet, 'shape> {
     /// Creates a new peek list
+    #[inline]
     pub fn new(value: Peek<'mem, 'facet, 'shape>, def: ListLikeDef<'shape>) -> Self {
         let len = match def {
             ListLikeDef::List(v) => unsafe { (v.vtable.len)(value.data().thin().unwrap()) },
@@ -129,11 +135,13 @@ impl<'mem, 'facet, 'shape> PeekListLike<'mem, 'facet, 'shape> {
     }
 
     /// Get the length of the list
+    #[inline]
     pub fn len(&self) -> usize {
         self.len
     }
 
     /// Returns true if the list is empty
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -213,6 +221,7 @@ impl<'mem, 'facet, 'shape> PeekListLike<'mem, 'facet, 'shape> {
     }
 
     /// Def getter
+    #[inline]
     pub fn def(&self) -> ListLikeDef<'shape> {
         self.def
     }

--- a/facet-reflect/src/peek/map.rs
+++ b/facet-reflect/src/peek/map.rs
@@ -11,6 +11,7 @@ pub struct PeekMapIter<'mem, 'facet, 'shape> {
 impl<'mem, 'facet, 'shape> Iterator for PeekMapIter<'mem, 'facet, 'shape> {
     type Item = (Peek<'mem, 'facet, 'shape>, Peek<'mem, 'facet, 'shape>);
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
             let next = (self.map.def.vtable.iter_vtable.next)(self.iter);
@@ -25,6 +26,7 @@ impl<'mem, 'facet, 'shape> Iterator for PeekMapIter<'mem, 'facet, 'shape> {
 }
 
 impl<'mem, 'facet, 'shape> Drop for PeekMapIter<'mem, 'facet, 'shape> {
+    #[inline]
     fn drop(&mut self) {
         unsafe { (self.map.def.vtable.iter_vtable.dealloc)(self.iter) }
     }
@@ -34,6 +36,7 @@ impl<'mem, 'facet, 'shape> IntoIterator for &'mem PeekMap<'mem, 'facet, 'shape> 
     type Item = (Peek<'mem, 'facet, 'shape>, Peek<'mem, 'facet, 'shape>);
     type IntoIter = PeekMapIter<'mem, 'facet, 'shape>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
@@ -55,21 +58,25 @@ impl<'mem, 'facet, 'shape> core::fmt::Debug for PeekMap<'mem, 'facet, 'shape> {
 
 impl<'mem, 'facet, 'shape> PeekMap<'mem, 'facet, 'shape> {
     /// Constructor
+    #[inline]
     pub fn new(value: Peek<'mem, 'facet, 'shape>, def: MapDef<'shape>) -> Self {
         Self { value, def }
     }
 
     /// Get the number of entries in the map
+    #[inline]
     pub fn len(&self) -> usize {
         unsafe { (self.def.vtable.len_fn)(self.value.data().thin().unwrap()) }
     }
 
     /// Returns true if the map is empty
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Check if the map contains a key
+    #[inline]
     pub fn contains_key(&self, key: &impl facet_core::Facet<'facet>) -> bool {
         unsafe {
             let key_ptr = PtrConst::new(key);
@@ -78,6 +85,7 @@ impl<'mem, 'facet, 'shape> PeekMap<'mem, 'facet, 'shape> {
     }
 
     /// Get a value from the map for the given key
+    #[inline]
     pub fn get<'k>(
         &self,
         key: &'k impl facet_core::Facet<'facet>,
@@ -91,6 +99,7 @@ impl<'mem, 'facet, 'shape> PeekMap<'mem, 'facet, 'shape> {
     }
 
     /// Returns an iterator over the key-value pairs in the map
+    #[inline]
     pub fn iter(self) -> PeekMapIter<'mem, 'facet, 'shape> {
         let iter_init_with_value_fn = self.def.vtable.iter_vtable.init_with_value.unwrap();
         let iter = unsafe { iter_init_with_value_fn(self.value.data().thin().unwrap()) };
@@ -98,6 +107,7 @@ impl<'mem, 'facet, 'shape> PeekMap<'mem, 'facet, 'shape> {
     }
 
     /// Def getter
+    #[inline]
     pub fn def(&self) -> MapDef<'shape> {
         self.def
     }

--- a/facet-reflect/src/peek/option.rs
+++ b/facet-reflect/src/peek/option.rs
@@ -36,6 +36,7 @@ impl<'mem, 'facet, 'shape> PeekOption<'mem, 'facet, 'shape> {
     }
 
     /// Returns the inner value as a Peek if the option is Some, None otherwise
+    #[inline]
     pub fn value(self) -> Option<crate::Peek<'mem, 'facet, 'shape>> {
         unsafe {
             (self.vtable().get_value_fn)(self.value.data().thin().unwrap())

--- a/facet-reflect/src/peek/set.rs
+++ b/facet-reflect/src/peek/set.rs
@@ -10,6 +10,7 @@ pub struct PeekSetIter<'mem, 'facet, 'shape> {
 impl<'mem, 'facet, 'shape> Iterator for PeekSetIter<'mem, 'facet, 'shape> {
     type Item = Peek<'mem, 'facet, 'shape>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
             let next = (self.set.def.vtable.iter_vtable.next)(self.iter)?;
@@ -19,6 +20,7 @@ impl<'mem, 'facet, 'shape> Iterator for PeekSetIter<'mem, 'facet, 'shape> {
 }
 
 impl<'mem, 'facet, 'shape> Drop for PeekSetIter<'mem, 'facet, 'shape> {
+    #[inline]
     fn drop(&mut self) {
         unsafe { (self.set.def.vtable.iter_vtable.dealloc)(self.iter) }
     }
@@ -28,6 +30,7 @@ impl<'mem, 'facet, 'shape> IntoIterator for &'mem PeekSet<'mem, 'facet, 'shape> 
     type Item = Peek<'mem, 'facet, 'shape>;
     type IntoIter = PeekSetIter<'mem, 'facet, 'shape>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
@@ -49,21 +52,25 @@ impl<'mem, 'facet, 'shape> core::fmt::Debug for PeekSet<'mem, 'facet, 'shape> {
 
 impl<'mem, 'facet, 'shape> PeekSet<'mem, 'facet, 'shape> {
     /// Constructor
+    #[inline]
     pub fn new(value: Peek<'mem, 'facet, 'shape>, def: SetDef<'shape>) -> Self {
         Self { value, def }
     }
 
     /// Returns true if the set is empty
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Get the number of entries in the set
+    #[inline]
     pub fn len(&self) -> usize {
         unsafe { (self.def.vtable.len_fn)(self.value.data().thin().unwrap()) }
     }
 
     /// Returns an iterator over the values in the set
+    #[inline]
     pub fn iter(self) -> PeekSetIter<'mem, 'facet, 'shape> {
         let iter_init_with_value_fn = self.def.vtable.iter_vtable.init_with_value.unwrap();
         let iter = unsafe { iter_init_with_value_fn(self.value.data().thin().unwrap()) };
@@ -71,6 +78,7 @@ impl<'mem, 'facet, 'shape> PeekSet<'mem, 'facet, 'shape> {
     }
 
     /// Def getter
+    #[inline]
     pub fn def(&self) -> SetDef<'shape> {
         self.def
     }

--- a/facet-reflect/src/peek/smartptr.rs
+++ b/facet-reflect/src/peek/smartptr.rs
@@ -16,6 +16,7 @@ pub struct PeekSmartPointer<'mem, 'facet, 'shape> {
 impl<'mem, 'facet, 'shape> PeekSmartPointer<'mem, 'facet, 'shape> {
     /// Returns a reference to the smart pointer definition.
     #[must_use]
+    #[inline]
     pub fn def(&self) -> &SmartPointerDef<'shape> {
         &self.def
     }
@@ -23,6 +24,7 @@ impl<'mem, 'facet, 'shape> PeekSmartPointer<'mem, 'facet, 'shape> {
     /// Borrows the inner value of the smart pointer.
     ///
     /// Returns `None` if the smart pointer doesn't have a borrow function or pointee shape.
+    #[inline]
     pub fn borrow_inner(&self) -> Option<Peek<'mem, 'facet, 'shape>> {
         let borrow_fn = self.def.vtable.borrow_fn?;
         let pointee_shape = self.def.pointee()?;

--- a/facet-reflect/src/peek/tuple.rs
+++ b/facet-reflect/src/peek/tuple.rs
@@ -32,16 +32,19 @@ impl Debug for PeekTuple<'_, '_, '_> {
 
 impl<'mem, 'facet, 'shape> PeekTuple<'mem, 'facet, 'shape> {
     /// Get the number of fields in this tuple
+    #[inline]
     pub fn len(&self) -> usize {
         self.ty.fields.len()
     }
 
     /// Returns true if this tuple has no fields
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Access a field by index
+    #[inline]
     pub fn field(&self, index: usize) -> Option<Peek<'mem, 'facet, 'shape>> {
         if index >= self.len() {
             return None;
@@ -57,16 +60,19 @@ impl<'mem, 'facet, 'shape> PeekTuple<'mem, 'facet, 'shape> {
     }
 
     /// Iterate over all fields
+    #[inline]
     pub fn fields(&self) -> FieldIter<'mem, 'facet, 'shape> {
         FieldIter::new_tuple(*self)
     }
 
     /// Type information
+    #[inline]
     pub fn ty(&self) -> TupleType<'shape> {
         self.ty
     }
 
     /// Internal peek value
+    #[inline]
     pub fn value(&self) -> Peek<'mem, 'facet, 'shape> {
         self.value
     }

--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -19,6 +19,7 @@ pub struct ValueId<'shape> {
 }
 
 impl<'shape> ValueId<'shape> {
+    #[inline]
     pub(crate) fn new(shape: &'shape Shape<'shape>, ptr: *const u8) -> Self {
         Self { shape, ptr }
     }
@@ -83,6 +84,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     }
 
     /// Returns a unique identifier for this value, usable for cycle detection
+    #[inline]
     pub fn id(&self) -> ValueId<'shape> {
         ValueId::new(self.shape, self.data.as_byte_ptr())
     }
@@ -197,6 +199,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     }
 
     /// Get the scalar type if set.
+    #[inline]
     pub fn scalar_type(&self) -> Option<ScalarType> {
         ScalarType::try_from_shape(self.shape)
     }
@@ -240,6 +243,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
 
     /// Try to get the value as a byte slice if it's a &[u8] type
     /// Returns None if the value is not a byte slice or couldn't be extracted
+    #[inline]
     pub fn as_bytes(&self) -> Option<&'mem [u8]> {
         // Check if it's a direct &[u8]
         if let Type::Pointer(PointerType::Reference(vpt)) = self.shape.ty {
@@ -254,6 +258,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     }
 
     /// Tries to identify this value as a struct
+    #[inline]
     pub fn into_struct(self) -> Result<PeekStruct<'mem, 'facet, 'shape>, ReflectError<'shape>> {
         if let Type::User(UserType::Struct(ty)) = self.shape.ty {
             Ok(PeekStruct { value: self, ty })
@@ -266,6 +271,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     }
 
     /// Tries to identify this value as an enum
+    #[inline]
     pub fn into_enum(self) -> Result<PeekEnum<'mem, 'facet, 'shape>, ReflectError<'shape>> {
         if let Type::User(UserType::Enum(ty)) = self.shape.ty {
             Ok(PeekEnum { value: self, ty })
@@ -278,6 +284,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     }
 
     /// Tries to identify this value as a map
+    #[inline]
     pub fn into_map(self) -> Result<PeekMap<'mem, 'facet, 'shape>, ReflectError<'shape>> {
         if let Def::Map(def) = self.shape.def {
             Ok(PeekMap { value: self, def })
@@ -290,6 +297,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     }
 
     /// Tries to identify this value as a set
+    #[inline]
     pub fn into_set(self) -> Result<PeekSet<'mem, 'facet, 'shape>, ReflectError<'shape>> {
         if let Def::Set(def) = self.shape.def {
             Ok(PeekSet { value: self, def })
@@ -302,6 +310,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     }
 
     /// Tries to identify this value as a list
+    #[inline]
     pub fn into_list(self) -> Result<PeekList<'mem, 'facet, 'shape>, ReflectError<'shape>> {
         if let Def::List(def) = self.shape.def {
             return Ok(PeekList { value: self, def });
@@ -314,6 +323,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     }
 
     /// Tries to identify this value as a list, array or slice
+    #[inline]
     pub fn into_list_like(
         self,
     ) -> Result<PeekListLike<'mem, 'facet, 'shape>, ReflectError<'shape>> {
@@ -353,6 +363,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     }
 
     /// Tries to identify this value as a smart pointer
+    #[inline]
     pub fn into_smart_pointer(
         self,
     ) -> Result<PeekSmartPointer<'mem, 'facet, 'shape>, ReflectError<'shape>> {
@@ -367,6 +378,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     }
 
     /// Tries to identify this value as an option
+    #[inline]
     pub fn into_option(
         self,
     ) -> Result<super::PeekOption<'mem, 'facet, 'shape>, ReflectError<'shape>> {
@@ -381,6 +393,7 @@ impl<'mem, 'facet, 'shape> Peek<'mem, 'facet, 'shape> {
     }
 
     /// Tries to identify this value as a tuple
+    #[inline]
     pub fn into_tuple(self) -> Result<PeekTuple<'mem, 'facet, 'shape>, ReflectError<'shape>> {
         if let Type::User(UserType::Struct(struct_type)) = self.shape.ty {
             if struct_type.kind == StructKind::Tuple {
@@ -473,12 +486,14 @@ impl<'mem, 'facet, 'shape> core::fmt::Debug for Peek<'mem, 'facet, 'shape> {
 }
 
 impl<'mem, 'facet, 'shape> core::cmp::PartialEq for Peek<'mem, 'facet, 'shape> {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.partial_eq(other).unwrap_or(false)
     }
 }
 
 impl<'mem, 'facet, 'shape> core::cmp::PartialOrd for Peek<'mem, 'facet, 'shape> {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         self.partial_cmp(other).unwrap_or(None)
     }

--- a/facet-reflect/src/scalar.rs
+++ b/facet-reflect/src/scalar.rs
@@ -1,5 +1,4 @@
 use core::any::TypeId;
-#[cfg(feature = "alloc")]
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use facet_core::{ConstTypeId, Shape};

--- a/facet-reflect/src/scalar.rs
+++ b/facet-reflect/src/scalar.rs
@@ -1,3 +1,5 @@
+use core::any::TypeId;
+#[cfg(feature = "alloc")]
 use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use facet_core::{ConstTypeId, Shape};
@@ -59,61 +61,64 @@ pub enum ScalarType {
 
 impl ScalarType {
     /// Infer the type from a shape definition.
+    #[inline]
     pub fn try_from_shape(shape: &Shape<'_>) -> Option<Self> {
+        let type_id = shape.id.get();
+
         #[cfg(feature = "alloc")]
-        if shape.id == ConstTypeId::of::<alloc::string::String>() {
+        if type_id == TypeId::of::<alloc::string::String>() {
             return Some(ScalarType::String);
-        } else if shape.id == ConstTypeId::of::<alloc::borrow::Cow<'_, str>>() {
+        } else if type_id == TypeId::of::<alloc::borrow::Cow<'_, str>>() {
             return Some(ScalarType::CowStr);
-        } else if shape.id == ConstTypeId::of::<str>() {
+        } else if type_id == TypeId::of::<str>() {
             return Some(ScalarType::Str);
-        } else if shape.id == ConstTypeId::of::<core::net::SocketAddr>() {
+        } else if type_id == TypeId::of::<core::net::SocketAddr>() {
             return Some(ScalarType::SocketAddr);
         }
 
-        if shape.id == ConstTypeId::of::<()>() {
+        if type_id == TypeId::of::<()>() {
             Some(Self::Unit)
-        } else if shape.id == ConstTypeId::of::<bool>() {
+        } else if type_id == TypeId::of::<bool>() {
             Some(ScalarType::Bool)
-        } else if shape.id == ConstTypeId::of::<char>() {
+        } else if type_id == TypeId::of::<char>() {
             Some(ScalarType::Char)
-        } else if shape.id == ConstTypeId::of::<&str>() {
+        } else if type_id == TypeId::of::<&str>() {
             Some(ScalarType::Str)
-        } else if shape.id == ConstTypeId::of::<f32>() {
+        } else if type_id == TypeId::of::<f32>() {
             Some(ScalarType::F32)
-        } else if shape.id == ConstTypeId::of::<f64>() {
+        } else if type_id == TypeId::of::<f64>() {
             Some(ScalarType::F64)
-        } else if shape.id == ConstTypeId::of::<u8>() {
+        } else if type_id == TypeId::of::<u8>() {
             Some(ScalarType::U8)
-        } else if shape.id == ConstTypeId::of::<u16>() {
+        } else if type_id == TypeId::of::<u16>() {
             Some(ScalarType::U16)
-        } else if shape.id == ConstTypeId::of::<u32>() {
+        } else if type_id == TypeId::of::<u32>() {
             Some(ScalarType::U32)
-        } else if shape.id == ConstTypeId::of::<u64>() {
+        } else if type_id == TypeId::of::<u64>() {
             Some(ScalarType::U64)
-        } else if shape.id == ConstTypeId::of::<u128>() {
+        } else if type_id == TypeId::of::<u128>() {
             Some(ScalarType::U128)
-        } else if shape.id == ConstTypeId::of::<usize>() {
+        } else if type_id == TypeId::of::<usize>() {
             Some(ScalarType::USize)
-        } else if shape.id == ConstTypeId::of::<i8>() {
+        } else if type_id == TypeId::of::<i8>() {
             Some(ScalarType::I8)
-        } else if shape.id == ConstTypeId::of::<i16>() {
+        } else if type_id == TypeId::of::<i16>() {
             Some(ScalarType::I16)
-        } else if shape.id == ConstTypeId::of::<i32>() {
+        } else if type_id == TypeId::of::<i32>() {
             Some(ScalarType::I32)
-        } else if shape.id == ConstTypeId::of::<i64>() {
+        } else if type_id == TypeId::of::<i64>() {
             Some(ScalarType::I64)
-        } else if shape.id == ConstTypeId::of::<i128>() {
+        } else if type_id == TypeId::of::<i128>() {
             Some(ScalarType::I128)
-        } else if shape.id == ConstTypeId::of::<isize>() {
+        } else if type_id == TypeId::of::<isize>() {
             Some(ScalarType::ISize)
-        } else if shape.id == ConstTypeId::of::<IpAddr>() {
+        } else if type_id == TypeId::of::<IpAddr>() {
             Some(ScalarType::IpAddr)
-        } else if shape.id == ConstTypeId::of::<Ipv4Addr>() {
+        } else if type_id == TypeId::of::<Ipv4Addr>() {
             Some(ScalarType::Ipv4Addr)
-        } else if shape.id == ConstTypeId::of::<Ipv6Addr>() {
+        } else if type_id == TypeId::of::<Ipv6Addr>() {
             Some(ScalarType::Ipv6Addr)
-        } else if shape.id == ConstTypeId::of::<ConstTypeId>() {
+        } else if type_id == TypeId::of::<ConstTypeId>() {
             Some(ScalarType::ConstTypeId)
         } else {
             None


### PR DESCRIPTION
Here's my results of tinkering with reflection benchmarks and profilers.

The challenge is hard because it's difficult to know what actually matters, especially for a broad API with many potential use cases. It's super hard to get really conclusive, but these changes are quite conservative and should fall in the "well at least it can't hurt" category.

I've attacked the problem from a couple of angles:

1. Profiling existing benchmarks, especially `json`.
2. Profiling a new microbenchmark, `reflect`.
3. Manually looking at the disassembly for a couple of probably-hot functions to make educated guesses about performance impact.

I've been using Visual Studio and AMD uProf to measure and analyze the results.

## Findings / Guidance

**Key takeaway:** Facet is pretty fast, and there's not a huge amount of low-hanging fruit left. Big improvements mostly have to come from refactoring or redesign of internal structures, and sometimes whole APIs. There is very probably some room for improvement, especially on the happy path, and I imagine that it would mostly look like lifting validation checks out of the way.

### Enable LTO: ~20% improvement for free

I think everyone who cares about performance will be enabling LTO no matter what, and it makes a big difference. The `Deserialize - Nested (depth=15)` benchmark went from consistently ~1.3ms to consistently ~1.1ms with this change on my machine. This PR enables LTO for release builds in the monorepo, which just affects the default baseline for all future benchmarks.

### If you're allocating 1, why not allocate 2?

The stack in `Partial` is always allocated with 1 element, but every type that is not a primitive has a minimum "depth" of at least 2 frames, so you are basically guaranteed to get an immediate reallocation. Meanwhile, there is generally no difference in allocator performance between allocating 64 bytes or 128 bytes, or even 256 bytes.

This PR changes `Partial::alloc_shape()` to preallocate 4 frames instead of 1, cutting single-level struct deserialization time in half (because they are dominated by the allocation). Even for deeper structs, this change should still prevent at least 2 reallocations, because the reallocation policy of `Vec` is to double its capacity, so we get to amortized territory much quicker.

### Minimize indirect calls

LLVM can't see through function pointers in most cases, especially the `fn() -> TypeId` inside of `ConstTypeId`. It can't tell that the function always returns the same value, so a long if-else chain of `id == ConstTypeId::of::<...>()` will result in repeated indirect calls, and will prevent other optimization passes, such as jump tables.

This PR makes `ConstTypeId::get()` public, and changes `ScalarType::try_from_shape()` to call the `fn() -> TypeId` once and then compare against the raw `TypeId` instead, yielding much better codegen - particularly when inlined.

### Inline small functions

This does basically nothing when LTO is enabled, but I have conservatively added `#[inline]` to many obvious candidates. These are small non-generic functions that typically just delegate to another function, potentially through a function pointer. You can say that it doesn't really matter, since LTO will be enabled for everyone who cares, but I do think there are workflows where you semi-care about performance for fast compile times during development (like `--opt-level=1` for the main project and `--opt-level=3` for deps).

I've not had any luck getting anything out of inlining bigger functions like `Partial::end()` or `Partial::begin_nth_field()` - these can be made faster, but not without changing how they work.

### Struct size matters a little bit

Did you know that LLVM sometimes generates `imul` instructions for random-access `slice[index]` lookups? ([godbolt](https://godbolt.org/z/5n3Yobsqj)) It happens when `size_of::<Foo>() >= 56`, and when `size_of::<Foo>() / 8` is uneven after that. We're well into micro-optimization territory here, but I found it interesting.

The `Field` struct is currently 88 bytes, and there are quite a few index-based lookups on those in very hot paths. I would recommend splitting the struct into a hot and a cold part, where the cold part is accessible through a pointer in the hot part. Cold fields would probably be `doc`, `attributes`, `flattened`.