### PR TITLE
Fix `#[facet(default = ...)]` in facet-toml

### DIFF
--- a/facet-toml/src/deserialize/mod.rs
+++ b/facet-toml/src/deserialize/mod.rs
@@ -169,15 +169,16 @@ fn deserialize_as_struct<'input, 'a, 'shape>(
         match field_item {
             Some(field_item) => deserialize_item(toml, wip, field_item)?,
             None => {
-                if let Def::Option(..) = field.shape().def {
-                    // Default of `Option<T>` is `None`
-                    reflect!(wip, toml, item.span(), set_default());
-                } else if field.flags.contains(FieldFlags::DEFAULT) {
+                if field.flags.contains(FieldFlags::DEFAULT) {
                     // Handle the default - set_default internally handles custom default functions safely
                     if field.shape().is(Characteristic::Default)
                         || field.vtable.default_fn.is_some()
                     {
-                        reflect!(wip, toml, item.span(), set_default());
+                        if let Some(field_default_fn) = field.vtable.default_fn {
+                            reflect!(wip, toml, item.span(), set_field_default(field_default_fn));
+                        } else {
+                            reflect!(wip, toml, item.span(), set_default());
+                        }
                     } else {
                         // Throw an error when there's a "default" attribute but no implementation for the type
                         return Err(TomlDeError::new(
@@ -191,6 +192,9 @@ fn deserialize_as_struct<'input, 'a, 'shape>(
                             wip.path(),
                         ));
                     }
+                } else if let Def::Option(..) = field.shape().def {
+                    // Default of `Option<T>` is `None`
+                    reflect!(wip, toml, item.span(), set_default());
                 } else if field.shape().is_type::<()>() {
                     // Default of `()` is `()`
                     reflect!(wip, toml, item.span(), set_default());

--- a/facet-toml/tests/deserialize/struct_.rs
+++ b/facet-toml/tests/deserialize/struct_.rs
@@ -281,3 +281,29 @@ fn test_default_struct_fields() {
         },
     );
 }
+
+#[test]
+fn test_root_struct_deserialize_defaults() {
+    fn default_string() -> String {
+        "hi".to_string()
+    }
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct Root {
+        #[facet(default = 42)]
+        a: i32,
+        #[facet(default = Some(true))]
+        b: Option<bool>,
+        #[facet(default = default_string())]
+        c: String,
+    }
+
+    assert_eq!(
+        facet_toml::from_str::<Root>("")?,
+        Root {
+            a: 42,
+            b: Some(true),
+            c: "hi".to_string()
+        },
+    );
+}


### PR DESCRIPTION
Noticed the toml deserializer wasn't respecting `#[facet(default = ...)]`.

This fixes it by re-ordering the if-else chain to check for `default` before checking if the type is `Option<T>` and also calling `set_field_default` instead of `set_default` when `field.vtable.default_fn` is present.