### PR TITLE
Fix the compile error on missing `#[repr(...)]` annotation for enums

### DIFF
--- a/facet-macros-emit/src/process_enum.rs
+++ b/facet-macros-emit/src/process_enum.rs
@@ -557,7 +557,7 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
         }
         PRepr::Rust(None) => {
             return quote! {
-                compile_error!("Facet requires enums to have an explicit representation (e.g., #[repr(C)], #[repr(u8)])")
+                compile_error!("Facet requires enums to have an explicit representation (e.g., #[repr(C)], #[repr(u8)])");
             };
         }
     };


### PR DESCRIPTION
Before this fix:
```
error: proc-macro derive produced unparsable tokens
  --> decondenser-cli/src/config.rs:44:10
   |
44 | #[derive(Facet)]
   |          ^^^^^

error: Facet requires enums to have an explicit representation (e.g., #[repr(C)], #[repr(u8)])
  --> decondenser-cli/src/config.rs:44:10
   |
44 | #[derive(Facet)]
   |          ^^^^^
   |
```

After the fix (the "produced unparseable tokens" error is now gone):

```
error: Facet requires enums to have an explicit representation (e.g., #[repr(C)], #[repr(u8)])
  --> decondenser-cli/src/config.rs:44:10
   |
44 | #[derive(Facet)]
   |          ^^^^^
```