### PR TITLE
Vendor facet-serialize into facet-args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,15 +450,16 @@ dependencies = [
 name = "facet-args"
 version = "0.19.17"
 dependencies = [
+ "ariadne",
  "eyre",
  "facet",
  "facet-core",
- "facet-deserialize",
  "facet-pretty",
  "facet-reflect",
  "facet-testhelpers 0.17.5",
  "insta",
  "log",
+ "owo-colors",
 ]
 
 [[package]]

--- a/facet-args/Cargo.toml
+++ b/facet-args/Cargo.toml
@@ -13,8 +13,9 @@ categories = ["command-line-interface"]
 [dependencies]
 facet-reflect = { path = "../facet-reflect", version = "0.27.15" }
 facet-core = { path = "../facet-core", version = "0.27.15" }
-facet-deserialize = { path = "../facet-deserialize", version = "0.24.21" }
 log = "0.4.27"
+owo-colors = "4.2.2"
+ariadne = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
 eyre = "0.6.12"
@@ -22,3 +23,7 @@ facet = { path = "../facet" }
 facet-pretty = { path = "../facet-pretty" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 insta = "1.43.1"
+
+[features]
+default = ["rich-diagnostics"]
+rich-diagnostics = ["dep:ariadne"]

--- a/facet-args/src/arg.rs
+++ b/facet-args/src/arg.rs
@@ -1,5 +1,5 @@
+use crate::deserialize::{Subspan, SubspanMeta};
 use alloc::borrow::Cow;
-use facet_deserialize::{Subspan, SubspanMeta};
 
 #[derive(Debug)]
 pub(crate) enum ArgType<'a> {

--- a/facet-args/src/deserialize.rs
+++ b/facet-args/src/deserialize.rs
@@ -1,0 +1,2145 @@
+#![warn(missing_docs)]
+#![warn(clippy::std_instead_of_core)]
+#![warn(clippy::std_instead_of_alloc)]
+
+extern crate alloc;
+
+use alloc::string::ToString;
+use alloc::{vec, vec::Vec};
+use core::fmt::Debug;
+use facet_core::{NumericType, PrimitiveType};
+
+mod debug;
+mod error;
+use alloc::borrow::Cow;
+pub use debug::InputDebug;
+
+pub use error::*;
+
+mod span;
+use facet_core::{Characteristic, Def, Facet, FieldFlags, PointerType, StructKind, Type, UserType};
+use owo_colors::OwoColorize;
+pub use span::*;
+
+use facet_reflect::{HeapValue, Partial, ReflectError};
+use log::trace;
+
+#[derive(PartialEq, Debug, Clone)]
+/// A scalar value used during deserialization.
+/// `u64` and `i64` are separated because `i64` doesn't fit in `u64`,
+/// but having `u64` is a fast path for 64-bit architectures — no need to
+/// go through `u128` / `i128` for everything
+pub enum Scalar<'input> {
+    /// Owned or borrowed string data.
+    String(Cow<'input, str>),
+    /// Unsigned 64-bit integer scalar.
+    U64(u64),
+    /// Signed 64-bit integer scalar.
+    I64(i64),
+    /// 64-bit floating-point scalar.
+    F64(f64),
+    /// 128-bit unsigned integer scalar.
+    U128(u128),
+    /// 128-bit signed integer scalar.
+    I128(i128),
+    /// Boolean scalar.
+    Bool(bool),
+    /// Null scalar (e.g. for formats supporting explicit null).
+    Null,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+/// Expected next input token or structure during deserialization.
+pub enum Expectation {
+    /// Accept a value.
+    Value,
+    /// Expect an object key or the end of an object.
+    ObjectKeyOrObjectClose,
+    /// Expect a value inside an object.
+    ObjectVal,
+    /// Expect a list item or the end of a list.
+    ListItemOrListClose,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+/// Outcome of parsing the next input element.
+pub enum Outcome<'input> {
+    /// Parsed a scalar value.
+    Scalar(Scalar<'input>),
+    /// Starting a list/array.
+    ListStarted,
+    /// Ending a list/array.
+    ListEnded,
+    /// Starting an object/map.
+    ObjectStarted,
+    /// Ending an object/map.
+    ObjectEnded,
+    /// Resegmenting input into subspans.
+    Resegmented(Vec<Subspan>),
+}
+
+impl<'input> From<Scalar<'input>> for Outcome<'input> {
+    fn from(scalar: Scalar<'input>) -> Self {
+        Outcome::Scalar(scalar)
+    }
+}
+
+use core::fmt;
+
+/// Display implementation for `Outcome`, focusing on user-friendly descriptions.
+impl fmt::Display for Outcome<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Outcome::Scalar(scalar) => write!(f, "scalar {scalar}"),
+            Outcome::ListStarted => write!(f, "list start"),
+            Outcome::ListEnded => write!(f, "list end"),
+            Outcome::ObjectStarted => write!(f, "object start"),
+            Outcome::ObjectEnded => write!(f, "object end"),
+            Outcome::Resegmented(_) => write!(f, "resegment"),
+        }
+    }
+}
+
+/// Display implementation for `Scalar`, for use in displaying `Outcome`.
+impl fmt::Display for Scalar<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Scalar::String(s) => write!(f, "string \"{s}\""),
+            Scalar::U64(val) => write!(f, "u64 {val}"),
+            Scalar::I64(val) => write!(f, "i64 {val}"),
+            Scalar::F64(val) => write!(f, "f64 {val}"),
+            Scalar::U128(val) => write!(f, "u128 {val}"),
+            Scalar::I128(val) => write!(f, "i128 {val}"),
+            Scalar::Bool(val) => write!(f, "bool {val}"),
+            Scalar::Null => write!(f, "null"),
+        }
+    }
+}
+
+impl Outcome<'_> {
+    fn into_owned(self) -> Outcome<'static> {
+        match self {
+            Outcome::Scalar(scalar) => {
+                let owned_scalar = match scalar {
+                    Scalar::String(cow) => Scalar::String(Cow::Owned(cow.into_owned())),
+                    Scalar::U64(val) => Scalar::U64(val),
+                    Scalar::I64(val) => Scalar::I64(val),
+                    Scalar::F64(val) => Scalar::F64(val),
+                    Scalar::U128(val) => Scalar::U128(val),
+                    Scalar::I128(val) => Scalar::I128(val),
+                    Scalar::Bool(val) => Scalar::Bool(val),
+                    Scalar::Null => Scalar::Null,
+                };
+                Outcome::Scalar(owned_scalar)
+            }
+            Outcome::ListStarted => Outcome::ListStarted,
+            Outcome::ListEnded => Outcome::ListEnded,
+            Outcome::ObjectStarted => Outcome::ObjectStarted,
+            Outcome::ObjectEnded => Outcome::ObjectEnded,
+            Outcome::Resegmented(subspans) => {
+                let owned_subspans = subspans
+                    .into_iter()
+                    .map(|s| Subspan {
+                        offset: s.offset,
+                        len: s.len,
+                        meta: s.meta,
+                    })
+                    .collect();
+                Outcome::Resegmented(owned_subspans)
+            }
+        }
+    }
+}
+
+/// Carries the current parsing state and the in-progress value during deserialization.
+/// This bundles the mutable context that must be threaded through parsing steps.
+pub struct NextData<'input, 'facet, 'shape, C = Cooked, I = [u8]>
+where
+    'input: 'facet,
+    I: ?Sized + 'input,
+{
+    /// The offset we're supposed to start parsing from
+    start: usize,
+
+    /// Controls the parsing flow and stack state.
+    runner: StackRunner<'input, C, I>,
+
+    /// Holds the intermediate representation of the value being built.
+    pub wip: Partial<'facet, 'shape>,
+}
+
+impl<'input, 'facet, 'shape, C, I> NextData<'input, 'facet, 'shape, C, I>
+where
+    'input: 'facet,
+    I: ?Sized + 'input,
+{
+    /// Returns the input (from the start! not from the current position)
+    pub fn input(&self) -> &'input I {
+        self.runner.input
+    }
+
+    /// Returns the parsing start offset.
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Access the substack
+    pub fn substack(&self) -> &Substack<C> {
+        &self.runner.substack
+    }
+}
+
+/// The result of advancing the parser: updated state and parse outcome or error.
+pub type NextResult<'input, 'facet, 'shape, T, E, C, I = [u8]> =
+    (NextData<'input, 'facet, 'shape, C, I>, Result<T, E>);
+
+/// Trait defining a deserialization format.
+/// Provides the next parsing step based on current state and expected input.
+pub trait Format {
+    /// The kind of input this format consumes, parameterized by input lifetime.
+    ///
+    /// * `JsonFmt` => `Input<'input> = [u8]`
+    /// * `CliFmt`  => `Input<'input> = [&'input str]`
+    type Input<'input>: ?Sized;
+
+    /// The type of span used by this format (Raw or Cooked)
+    type SpanType: Debug + SubstackBehavior + 'static;
+
+    /// The lowercase source ID of the format, used for error reporting.
+    fn source(&self) -> &'static str;
+
+    /// Advance the parser with current state and expectation, producing the next outcome or error.
+    #[allow(clippy::type_complexity)]
+    fn next<'input, 'facet, 'shape>(
+        &mut self,
+        nd: NextData<'input, 'facet, 'shape, Self::SpanType, Self::Input<'input>>,
+        expectation: Expectation,
+    ) -> NextResult<
+        'input,
+        'facet,
+        'shape,
+        Spanned<Outcome<'input>, Self::SpanType>,
+        Spanned<DeserErrorKind<'shape>, Self::SpanType>,
+        Self::SpanType,
+        Self::Input<'input>,
+    >
+    where
+        'shape: 'input;
+
+    /// Skip the next value; used to ignore an input.
+    #[allow(clippy::type_complexity)]
+    fn skip<'input, 'facet, 'shape>(
+        &mut self,
+        nd: NextData<'input, 'facet, 'shape, Self::SpanType, Self::Input<'input>>,
+    ) -> NextResult<
+        'input,
+        'facet,
+        'shape,
+        Span<Self::SpanType>,
+        Spanned<DeserErrorKind<'shape>, Self::SpanType>,
+        Self::SpanType,
+        Self::Input<'input>,
+    >
+    where
+        'shape: 'input;
+}
+
+/// Trait handling conversion regardless of `Format::SpanType` to `Span<Cooked>`
+pub trait ToCooked<'input, F: Format> {
+    /// Convert a span to a Cooked span (with byte index over the input, not format-specific index)
+    fn to_cooked(self, format: &F, input: &'input F::Input<'input>) -> Span<Cooked>;
+}
+
+impl<'input, F: Format> ToCooked<'input, F> for Span<Cooked> {
+    #[inline]
+    fn to_cooked(self, _format: &F, _input: &'input F::Input<'input>) -> Span<Cooked> {
+        self
+    }
+}
+
+impl<'input, F: Format<SpanType = Raw, Input<'input> = [&'input str]>> ToCooked<'input, F>
+    for Span<Raw>
+{
+    #[inline]
+    fn to_cooked(self, _format: &F, input: &'input [&'input str]) -> Span<Cooked> {
+        if self.start >= input.len() {
+            // start points past the end of the args;
+            // use byte offset = total length of whole input minus 1, len = 1
+            let mut total_len = 0;
+            for (i, arg) in input.iter().enumerate() {
+                total_len += arg.len();
+                if i < input.len() - 1 {
+                    total_len += 1; // space after each arg except last
+                }
+            }
+            return Span::<Cooked>::new(total_len.saturating_sub(1), 1);
+        }
+
+        // Calculate start position by summing lengths of preceding args plus spaces
+        let mut start = 0;
+        for arg in input.iter().take(self.start) {
+            start += arg.len() + 1; // +1 for space between args
+        }
+
+        // Length is the length of the current arg
+        let len = input[self.start].len();
+
+        Span::<Cooked>::new(start, len)
+    }
+}
+
+/// Instructions guiding the parsing flow, indicating the next expected action or token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Instruction {
+    /// Expect a value, specifying the context or reason.
+    Value(ValueReason),
+    /// Skip the next value; used to ignore an input.
+    SkipValue,
+    /// Indicate completion of a structure or value; triggers popping from stack.
+    Pop(PopReason),
+    /// Expect an object key or the end of an object.
+    ObjectKeyOrObjectClose,
+    /// Expect a list item or the end of a list.
+    ListItemOrListClose,
+    /// Triggers clearing a substack.
+    SubstackClose,
+}
+
+/// Reasons for expecting a value, reflecting the current parse context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueReason {
+    /// Parsing at the root level.
+    TopLevel,
+    /// Parsing a value inside an object.
+    ObjectVal,
+}
+
+/// Reasons for popping a state from the stack, indicating why a scope is ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PopReason {
+    /// Ending the top-level parsing scope.
+    TopLevel,
+    /// Ending a value within an object.
+    ObjectVal,
+    /// Ending value within a list
+    ListVal,
+    /// Ending a `Some()` in an option
+    Some,
+    /// Ending a smart pointer (ie. wrapping a `T` back into a `Box<T>`, or `Arc<T>` etc.)
+    SmartPointer,
+    /// Ending a wrapper value such as a newtype
+    Wrapper,
+}
+
+mod deser_impl {
+    use super::*;
+
+    /// Deserialize a value of type `T` from raw input bytes using format `F`.
+    ///
+    /// This function sets up the initial working state and drives the deserialization process,
+    /// ensuring that the resulting value is fully materialized and valid.
+    pub fn deserialize<'input, 'facet, 'shape, T, F>(
+        input: &'input F::Input<'input>,
+        format: &mut F,
+    ) -> Result<T, DeserError<'input, 'shape, Cooked>>
+    where
+        T: Facet<'facet>,
+        F: Format + 'shape,
+        F::Input<'input>: InputDebug,
+        F::SpanType: core::fmt::Debug,
+        Span<F::SpanType>: ToCooked<'input, F>,
+        'input: 'facet,
+        'shape: 'input,
+    {
+        // Run the entire deserialization process and capture any errors
+        let result: Result<T, DeserError<'input, 'shape, Cooked>> = {
+            let source = format.source();
+
+            // Step 1: Allocate shape
+            let wip = match Partial::alloc_shape(T::SHAPE) {
+                Ok(wip) => wip,
+                Err(e) => {
+                    let default_span = Span::<F::SpanType>::default();
+                    // let cooked_span = cook_span_dispatch!(format, default_span, input);
+                    let cooked_span = default_span.to_cooked(format, input);
+                    return Err(DeserError::new_reflect(e, input, cooked_span, source));
+                }
+            };
+
+            // Step 2: Run deserialize_wip
+            let heap_value = match deserialize_wip(wip, input, format) {
+                Ok(val) => val,
+                Err(e) => {
+                    let cooked_span = e.span.to_cooked(format, input);
+
+                    // Create a completely new error variable with the Cooked type
+                    let cooked_error = DeserError {
+                        input: e.input,
+                        span: cooked_span,
+                        kind: e.kind,
+                        source_id: e.source_id,
+                    };
+
+                    return Err(cooked_error);
+                }
+            };
+
+            // Step 3: Materialize
+            match heap_value.materialize() {
+                Ok(val) => Ok(val),
+                Err(e) => {
+                    let default_span = Span::<F::SpanType>::default();
+                    let cooked_span = default_span.to_cooked(format, input);
+                    return Err(DeserError::new_reflect(e, input, cooked_span, source));
+                }
+            }
+        };
+
+        // Apply span conversion for errors from materialization
+        match result {
+            Ok(value) => Ok(value),
+            Err(mut error) => {
+                let new_span = error.span.to_cooked(format, input);
+
+                if new_span != error.span {
+                    error = DeserError {
+                        input: error.input,
+                        span: new_span,
+                        kind: error.kind,
+                        source_id: error.source_id,
+                    };
+                }
+
+                Err(error)
+            }
+        }
+    }
+}
+
+/// Deserialize a value of type `T` from raw input bytes using format `F`.
+///
+/// This function sets up the initial working state and drives the deserialization process,
+/// ensuring that the resulting value is fully materialized and valid.
+pub fn deserialize<'input, 'facet, 'shape, T, F>(
+    input: &'input F::Input<'input>,
+    format: F,
+) -> Result<T, DeserError<'input, 'shape, Cooked>>
+where
+    T: Facet<'facet>,
+    F: Format + 'shape,
+    F::Input<'input>: InputDebug,
+    F::SpanType: core::fmt::Debug,
+    Span<F::SpanType>: ToCooked<'input, F>,
+    'input: 'facet,
+    'shape: 'input,
+{
+    let mut format_copy = format;
+    deser_impl::deserialize(input, &mut format_copy)
+}
+
+/// Deserializes a working-in-progress value into a fully materialized heap value.
+/// This function drives the parsing loop until the entire input is consumed and the value is complete.
+pub fn deserialize_wip<'input, 'facet, 'shape, F>(
+    mut wip: Partial<'facet, 'shape>,
+    input: &'input F::Input<'input>,
+    format: &mut F,
+) -> Result<HeapValue<'facet, 'shape>, DeserError<'input, 'shape, Cooked>>
+where
+    F: Format + 'shape,
+    F::SpanType: SubstackBehavior,
+    F::Input<'input>: InputDebug,
+    Span<F::SpanType>: ToCooked<'input, F>,
+    'input: 'facet,
+    'shape: 'input,
+{
+    // This struct is just a bundle of the state that we need to pass around all the time.
+    let mut runner = StackRunner {
+        original_input: input,
+        input,
+        stack: vec![
+            Instruction::Pop(PopReason::TopLevel),
+            Instruction::Value(ValueReason::TopLevel),
+        ],
+        substack: Substack::new(),
+        last_span: Span::new(0, 0),
+        format_source: format.source(),
+        array_indices: Vec::new(),
+        enum_tuple_field_count: None,
+        enum_tuple_current_field: None,
+    };
+
+    macro_rules! next {
+        ($runner:ident, $wip:ident, $expectation:expr, $method:ident) => {{
+            let nd = NextData {
+                start: $runner.last_span.end(), // or supply the appropriate start value if available
+                runner: $runner,
+                wip: $wip,
+            };
+            let (nd, res) = format.next(nd, $expectation);
+            $runner = nd.runner;
+            $wip = nd.wip;
+            let outcome = res.map_err(|span_kind| {
+                $runner.last_span = span_kind.span;
+                let error = $runner.err(span_kind.node);
+                // Convert the error's span to Cooked
+                DeserError {
+                    input: error.input,
+                    span: error.span.to_cooked(format, input),
+                    kind: error.kind,
+                    source_id: error.source_id,
+                }
+            })?;
+            if F::SpanType::USES_SUBSTACK {
+                if !$runner.substack.get().is_empty() {
+                    trace!("Substack: {}", "carried".cyan());
+                } else {
+                    trace!("Substack: {}", "-".red());
+                }
+            }
+            $runner.last_span = outcome.span;
+            if F::SpanType::USES_SUBSTACK {
+                if let Outcome::Resegmented(subspans) = &outcome.node {
+                    $runner.substack = subspans.clone().into();
+                }
+            }
+            $wip = $runner.$method($wip, outcome).map_err(|error| {
+                DeserError {
+                    input:  error.input,
+                    span:   error.span.to_cooked(format, input),
+                    kind:   error.kind,
+                    source_id: error.source_id,
+                }
+            })?;
+        }};
+    }
+
+    loop {
+        // Note: frames_count() is no longer available in the new Partial API
+        // This was used for debugging/assertions only
+
+        let insn = match runner.stack.pop() {
+            Some(insn) => insn,
+            None => unreachable!("Instruction stack is empty"),
+        };
+
+        trace!("Instruction {:?}", insn.bright_red());
+
+        match insn {
+            Instruction::Pop(reason) => {
+                wip = runner.pop(wip, reason).map_err(|error| {
+                    // Convert the error's span to Cooked
+                    DeserError {
+                        input: error.input,
+                        span: error.span.to_cooked(format, input),
+                        kind: error.kind,
+                        source_id: error.source_id,
+                    }
+                })?;
+
+                if reason == PopReason::TopLevel {
+                    // Exit all nested frames (e.g., from flattened fields) before building
+                    while wip.frame_count() > 1 {
+                        wip.end().map_err(|e| {
+                            let reflect_error = runner.reflect_err(e);
+                            DeserError {
+                                input: reflect_error.input,
+                                span: reflect_error.span.to_cooked(format, input),
+                                kind: reflect_error.kind,
+                                source_id: reflect_error.source_id,
+                            }
+                        })?;
+                    }
+
+                    return wip.build().map_err(|e| {
+                        let reflect_error = runner.reflect_err(e);
+                        // Convert the reflection error's span to Cooked
+                        DeserError {
+                            input: reflect_error.input,
+                            span: reflect_error.span.to_cooked(format, input),
+                            kind: reflect_error.kind,
+                            source_id: reflect_error.source_id,
+                        }
+                    });
+                } else {
+                    wip.end().map_err(|e| {
+                        let reflect_error = runner.reflect_err(e);
+                        // Convert the reflection error's span to Cooked
+                        DeserError {
+                            input: reflect_error.input,
+                            span: reflect_error.span.to_cooked(format, input),
+                            kind: reflect_error.kind,
+                            source_id: reflect_error.source_id,
+                        }
+                    })?;
+                }
+            }
+            Instruction::Value(_why) => {
+                let expectation = match _why {
+                    ValueReason::TopLevel => Expectation::Value,
+                    ValueReason::ObjectVal => Expectation::ObjectVal,
+                };
+                next!(runner, wip, expectation, value);
+            }
+            Instruction::ObjectKeyOrObjectClose => {
+                next!(
+                    runner,
+                    wip,
+                    Expectation::ObjectKeyOrObjectClose,
+                    object_key_or_object_close
+                );
+            }
+            Instruction::ListItemOrListClose => {
+                next!(
+                    runner,
+                    wip,
+                    Expectation::ListItemOrListClose,
+                    list_item_or_list_close
+                );
+            }
+            Instruction::SubstackClose => {
+                runner.substack.clear();
+            }
+            Instruction::SkipValue => {
+                // Call F::skip to skip over the next value in the input
+                let nd = NextData {
+                    start: runner.last_span.end(),
+                    runner,
+                    wip,
+                };
+                let (nd, res) = format.skip(nd);
+                runner = nd.runner;
+                wip = nd.wip;
+                // Only propagate error, don't modify wip, since skip just advances input
+                let span = res.map_err(|span_kind| {
+                    runner.last_span = span_kind.span;
+                    let error = runner.err(span_kind.node);
+                    // Convert the error's span to Cooked
+                    DeserError {
+                        input: error.input,
+                        span: error.span.to_cooked(format, input),
+                        kind: error.kind,
+                        source_id: error.source_id,
+                    }
+                })?;
+                // do the actual skip
+                runner.last_span = span;
+            }
+        }
+    }
+}
+
+/// Helper function to check if an f64 has no fractional part
+/// This is needed for no-std compatibility where f64::fract() is not available
+#[inline]
+fn has_no_fractional_part(value: f64) -> bool {
+    value == (value as i64) as f64
+}
+
+/// Trait for numeric type conversions
+trait NumericConvert {
+    fn to_i8(&self) -> Option<i8>;
+    fn to_i16(&self) -> Option<i16>;
+    fn to_i32(&self) -> Option<i32>;
+    fn to_i64(&self) -> Option<i64>;
+    fn to_i128(&self) -> Option<i128>;
+    fn to_isize(&self) -> Option<isize>;
+
+    fn to_u8(&self) -> Option<u8>;
+    fn to_u16(&self) -> Option<u16>;
+    fn to_u32(&self) -> Option<u32>;
+    fn to_u64(&self) -> Option<u64>;
+    fn to_u128(&self) -> Option<u128>;
+    fn to_usize(&self) -> Option<usize>;
+
+    fn to_f32(&self) -> Option<f32>;
+    fn to_f64(&self) -> Option<f64>;
+}
+
+impl NumericConvert for u64 {
+    fn to_i8(&self) -> Option<i8> {
+        (*self).try_into().ok()
+    }
+    fn to_i16(&self) -> Option<i16> {
+        (*self).try_into().ok()
+    }
+    fn to_i32(&self) -> Option<i32> {
+        (*self).try_into().ok()
+    }
+    fn to_i64(&self) -> Option<i64> {
+        (*self).try_into().ok()
+    }
+    fn to_i128(&self) -> Option<i128> {
+        Some(*self as i128)
+    }
+    fn to_isize(&self) -> Option<isize> {
+        (*self).try_into().ok()
+    }
+
+    fn to_u8(&self) -> Option<u8> {
+        (*self).try_into().ok()
+    }
+    fn to_u16(&self) -> Option<u16> {
+        (*self).try_into().ok()
+    }
+    fn to_u32(&self) -> Option<u32> {
+        (*self).try_into().ok()
+    }
+    fn to_u64(&self) -> Option<u64> {
+        Some(*self)
+    }
+    fn to_u128(&self) -> Option<u128> {
+        Some(*self as u128)
+    }
+    fn to_usize(&self) -> Option<usize> {
+        (*self).try_into().ok()
+    }
+
+    fn to_f32(&self) -> Option<f32> {
+        Some(*self as f32)
+    }
+    fn to_f64(&self) -> Option<f64> {
+        Some(*self as f64)
+    }
+}
+
+impl NumericConvert for i64 {
+    fn to_i8(&self) -> Option<i8> {
+        (*self).try_into().ok()
+    }
+    fn to_i16(&self) -> Option<i16> {
+        (*self).try_into().ok()
+    }
+    fn to_i32(&self) -> Option<i32> {
+        (*self).try_into().ok()
+    }
+    fn to_i64(&self) -> Option<i64> {
+        Some(*self)
+    }
+    fn to_i128(&self) -> Option<i128> {
+        Some(*self as i128)
+    }
+    fn to_isize(&self) -> Option<isize> {
+        (*self).try_into().ok()
+    }
+
+    fn to_u8(&self) -> Option<u8> {
+        (*self).try_into().ok()
+    }
+    fn to_u16(&self) -> Option<u16> {
+        (*self).try_into().ok()
+    }
+    fn to_u32(&self) -> Option<u32> {
+        (*self).try_into().ok()
+    }
+    fn to_u64(&self) -> Option<u64> {
+        (*self).try_into().ok()
+    }
+    fn to_u128(&self) -> Option<u128> {
+        (*self).try_into().ok()
+    }
+    fn to_usize(&self) -> Option<usize> {
+        (*self).try_into().ok()
+    }
+
+    fn to_f32(&self) -> Option<f32> {
+        Some(*self as f32)
+    }
+    fn to_f64(&self) -> Option<f64> {
+        Some(*self as f64)
+    }
+}
+
+impl NumericConvert for f64 {
+    fn to_i8(&self) -> Option<i8> {
+        if has_no_fractional_part(*self) && *self >= i8::MIN as f64 && *self <= i8::MAX as f64 {
+            Some(*self as i8)
+        } else {
+            None
+        }
+    }
+    fn to_i16(&self) -> Option<i16> {
+        if has_no_fractional_part(*self) && *self >= i16::MIN as f64 && *self <= i16::MAX as f64 {
+            Some(*self as i16)
+        } else {
+            None
+        }
+    }
+    fn to_i32(&self) -> Option<i32> {
+        if has_no_fractional_part(*self) && *self >= i32::MIN as f64 && *self <= i32::MAX as f64 {
+            Some(*self as i32)
+        } else {
+            None
+        }
+    }
+    fn to_i64(&self) -> Option<i64> {
+        if has_no_fractional_part(*self) && *self >= i64::MIN as f64 && *self <= i64::MAX as f64 {
+            Some(*self as i64)
+        } else {
+            None
+        }
+    }
+    fn to_i128(&self) -> Option<i128> {
+        if has_no_fractional_part(*self) && *self >= i128::MIN as f64 && *self <= i128::MAX as f64 {
+            Some(*self as i128)
+        } else {
+            None
+        }
+    }
+    fn to_isize(&self) -> Option<isize> {
+        if has_no_fractional_part(*self) && *self >= isize::MIN as f64 && *self <= isize::MAX as f64
+        {
+            Some(*self as isize)
+        } else {
+            None
+        }
+    }
+
+    fn to_u8(&self) -> Option<u8> {
+        if has_no_fractional_part(*self) && *self >= 0.0 && *self <= u8::MAX as f64 {
+            Some(*self as u8)
+        } else {
+            None
+        }
+    }
+    fn to_u16(&self) -> Option<u16> {
+        if has_no_fractional_part(*self) && *self >= 0.0 && *self <= u16::MAX as f64 {
+            Some(*self as u16)
+        } else {
+            None
+        }
+    }
+    fn to_u32(&self) -> Option<u32> {
+        if has_no_fractional_part(*self) && *self >= 0.0 && *self <= u32::MAX as f64 {
+            Some(*self as u32)
+        } else {
+            None
+        }
+    }
+    fn to_u64(&self) -> Option<u64> {
+        if has_no_fractional_part(*self) && *self >= 0.0 && *self <= u64::MAX as f64 {
+            Some(*self as u64)
+        } else {
+            None
+        }
+    }
+    fn to_u128(&self) -> Option<u128> {
+        if has_no_fractional_part(*self) && *self >= 0.0 && *self <= u128::MAX as f64 {
+            Some(*self as u128)
+        } else {
+            None
+        }
+    }
+    fn to_usize(&self) -> Option<usize> {
+        if has_no_fractional_part(*self) && *self >= 0.0 && *self <= usize::MAX as f64 {
+            Some(*self as usize)
+        } else {
+            None
+        }
+    }
+
+    fn to_f32(&self) -> Option<f32> {
+        Some(*self as f32)
+    }
+    fn to_f64(&self) -> Option<f64> {
+        Some(*self)
+    }
+}
+
+impl NumericConvert for u128 {
+    fn to_i8(&self) -> Option<i8> {
+        (*self).try_into().ok()
+    }
+    fn to_i16(&self) -> Option<i16> {
+        (*self).try_into().ok()
+    }
+    fn to_i32(&self) -> Option<i32> {
+        (*self).try_into().ok()
+    }
+    fn to_i64(&self) -> Option<i64> {
+        (*self).try_into().ok()
+    }
+    fn to_i128(&self) -> Option<i128> {
+        Some(*self as i128)
+    }
+    fn to_isize(&self) -> Option<isize> {
+        (*self).try_into().ok()
+    }
+
+    fn to_u8(&self) -> Option<u8> {
+        (*self).try_into().ok()
+    }
+    fn to_u16(&self) -> Option<u16> {
+        (*self).try_into().ok()
+    }
+    fn to_u32(&self) -> Option<u32> {
+        (*self).try_into().ok()
+    }
+    fn to_u64(&self) -> Option<u64> {
+        (*self).try_into().ok()
+    }
+    fn to_u128(&self) -> Option<u128> {
+        Some(*self)
+    }
+    fn to_usize(&self) -> Option<usize> {
+        (*self).try_into().ok()
+    }
+
+    fn to_f32(&self) -> Option<f32> {
+        Some(*self as f32)
+    }
+    fn to_f64(&self) -> Option<f64> {
+        Some(*self as f64)
+    }
+}
+
+impl NumericConvert for i128 {
+    fn to_i8(&self) -> Option<i8> {
+        (*self).try_into().ok()
+    }
+    fn to_i16(&self) -> Option<i16> {
+        (*self).try_into().ok()
+    }
+    fn to_i32(&self) -> Option<i32> {
+        (*self).try_into().ok()
+    }
+    fn to_i64(&self) -> Option<i64> {
+        (*self).try_into().ok()
+    }
+    fn to_i128(&self) -> Option<i128> {
+        Some(*self)
+    }
+    fn to_isize(&self) -> Option<isize> {
+        (*self).try_into().ok()
+    }
+
+    fn to_u8(&self) -> Option<u8> {
+        (*self).try_into().ok()
+    }
+    fn to_u16(&self) -> Option<u16> {
+        (*self).try_into().ok()
+    }
+    fn to_u32(&self) -> Option<u32> {
+        (*self).try_into().ok()
+    }
+    fn to_u64(&self) -> Option<u64> {
+        (*self).try_into().ok()
+    }
+    fn to_u128(&self) -> Option<u128> {
+        (*self).try_into().ok()
+    }
+    fn to_usize(&self) -> Option<usize> {
+        (*self).try_into().ok()
+    }
+
+    fn to_f32(&self) -> Option<f32> {
+        Some(*self as f32)
+    }
+    fn to_f64(&self) -> Option<f64> {
+        Some(*self as f64)
+    }
+}
+
+#[doc(hidden)]
+/// Maintains the parsing state and context necessary to drive deserialization.
+///
+/// This struct tracks what the parser expects next, manages input position,
+/// and remembers the span of the last processed token to provide accurate error reporting.
+pub struct StackRunner<'input, C = Cooked, I: ?Sized + 'input = [u8]> {
+    /// A version of the input that doesn't advance as we parse.
+    pub original_input: &'input I,
+
+    /// The raw input data being deserialized.
+    pub input: &'input I,
+
+    /// Stack of parsing instructions guiding the control flow.
+    pub stack: Vec<Instruction>,
+
+    /// Subspan storage, if the format uses them.
+    pub substack: Substack<C>,
+
+    /// Span of the last processed token, for accurate error reporting.
+    pub last_span: Span<C>,
+
+    /// Format source identifier for error reporting
+    pub format_source: &'static str,
+
+    /// Array index tracking - maps depth to current index for arrays
+    pub array_indices: Vec<usize>,
+
+    /// Tuple variant field tracking - number of fields in current enum tuple variant
+    pub enum_tuple_field_count: Option<usize>,
+
+    /// Tuple variant field tracking - current field index being processed
+    pub enum_tuple_current_field: Option<usize>,
+}
+
+impl<'input, 'shape, C, I: ?Sized + 'input> StackRunner<'input, C, I>
+where
+    I: InputDebug,
+{
+    /// Convenience function to create a DeserError using the original input and last_span.
+    fn err(&self, kind: DeserErrorKind<'shape>) -> DeserError<'input, 'shape, C> {
+        DeserError::new(
+            kind,
+            self.original_input,
+            self.last_span,
+            self.format_source,
+        )
+    }
+
+    /// Convenience function to create a DeserError from a ReflectError,
+    /// using the original input and last_span for context.
+    fn reflect_err(&self, err: ReflectError<'shape>) -> DeserError<'input, 'shape, C> {
+        DeserError::new_reflect(err, self.original_input, self.last_span, self.format_source)
+    }
+
+    pub fn pop<'facet>(
+        &mut self,
+        mut wip: Partial<'facet, 'shape>,
+        reason: PopReason,
+    ) -> Result<Partial<'facet, 'shape>, DeserError<'input, 'shape, C>> {
+        trace!(
+            "--- STACK has {:?} {}",
+            self.stack.green(),
+            "(POP)".bright_yellow()
+        );
+        trace!("Popping because {:?}", reason.yellow());
+
+        let container_shape = wip.shape();
+        match container_shape.ty {
+            Type::User(UserType::Struct(sd)) => {
+                let mut has_unset = false;
+
+                trace!("Let's check all fields are initialized");
+                for (index, field) in sd.fields.iter().enumerate() {
+                    let is_set = wip.is_field_set(index).map_err(|err| {
+                        trace!("Error checking field set status: {err:?}");
+                        self.reflect_err(err)
+                    })?;
+                    if !is_set {
+                        if field.flags.contains(FieldFlags::DEFAULT) {
+                            wip.begin_nth_field(index)
+                                .map_err(|e| self.reflect_err(e))?;
+
+                            // Check for field-level default function first, then type-level default
+                            if let Some(field_default_fn) = field.vtable.default_fn {
+                                wip.set_field_default(field_default_fn)
+                                    .map_err(|e| self.reflect_err(e))?;
+                                trace!(
+                                    "Field #{} {} @ {} was set to default value (via field default function)",
+                                    index.yellow(),
+                                    field.name.green(),
+                                    field.offset.blue(),
+                                );
+                            } else if field.shape().is(Characteristic::Default) {
+                                wip.set_default().map_err(|e| self.reflect_err(e))?;
+                                trace!(
+                                    "Field #{} {} @ {} was set to default value (via type default impl)",
+                                    index.yellow(),
+                                    field.name.green(),
+                                    field.offset.blue(),
+                                );
+                            } else {
+                                return Err(self.reflect_err(
+                                    ReflectError::DefaultAttrButNoDefaultImpl {
+                                        shape: field.shape(),
+                                    },
+                                ));
+                            }
+                            wip.end().map_err(|e| self.reflect_err(e))?;
+                        } else {
+                            trace!(
+                                "Field #{} {} @ {} is not initialized",
+                                index.yellow(),
+                                field.name.green(),
+                                field.offset.blue(),
+                            );
+                            has_unset = true;
+                        }
+                    }
+                }
+
+                if has_unset {
+                    if container_shape.has_default_attr() {
+                        // let's allocate and build a default value
+                        let default_val = Partial::alloc_shape(container_shape)
+                            .map_err(|e| self.reflect_err(e))?
+                            .set_default()
+                            .map_err(|e| self.reflect_err(e))?
+                            .build()
+                            .map_err(|e| self.reflect_err(e))?;
+                        let peek = default_val.peek().into_struct().unwrap();
+
+                        for (index, field) in sd.fields.iter().enumerate() {
+                            let is_set = wip.is_field_set(index).map_err(|err| {
+                                trace!("Error checking field set status: {err:?}");
+                                self.reflect_err(err)
+                            })?;
+                            if !is_set {
+                                trace!(
+                                    "Field #{} {} @ {} is being set to default value (from default instance)",
+                                    index.yellow(),
+                                    field.name.green(),
+                                    field.offset.blue(),
+                                );
+                                wip.begin_nth_field(index)
+                                    .map_err(|e| self.reflect_err(e))?;
+                                // Get the field as a Peek from the default value
+                                let def_field = peek.field(index).unwrap();
+                                wip.set_from_peek(&def_field)
+                                    .map_err(|e| self.reflect_err(e))?;
+                                wip.end().map_err(|e| self.reflect_err(e))?;
+                            }
+                        }
+                    } else {
+                        // Find the first uninitialized field to report in the error
+                        for (index, field) in sd.fields.iter().enumerate() {
+                            let is_set = wip.is_field_set(index).map_err(|err| {
+                                trace!("Error checking field set status: {err:?}");
+                                self.reflect_err(err)
+                            })?;
+                            if !is_set {
+                                return Err(self.reflect_err(ReflectError::UninitializedField {
+                                    shape: container_shape,
+                                    field_name: field.name,
+                                }));
+                            }
+                        }
+                    }
+                }
+            }
+            Type::User(UserType::Enum(ed)) => {
+                trace!("Checking if enum is initialized correctly");
+
+                // Check if a variant has been selected
+                if let Some(variant) = wip.selected_variant() {
+                    trace!("Variant {} is selected", variant.name.blue());
+
+                    // Check if all fields in the variant are initialized
+                    if !variant.data.fields.is_empty() {
+                        let mut has_unset = false;
+
+                        for (index, field) in variant.data.fields.iter().enumerate() {
+                            let is_set = wip.is_field_set(index).map_err(|err| {
+                                trace!("Error checking field set status: {err:?}");
+                                self.reflect_err(err)
+                            })?;
+
+                            if !is_set {
+                                if field.flags.contains(FieldFlags::DEFAULT) {
+                                    wip.begin_nth_field(index)
+                                        .map_err(|e| self.reflect_err(e))?;
+
+                                    // Check for field-level default function first, then type-level default
+                                    if let Some(field_default_fn) = field.vtable.default_fn {
+                                        wip.set_field_default(field_default_fn)
+                                            .map_err(|e| self.reflect_err(e))?;
+                                        trace!(
+                                            "Field #{} @ {} in variant {} was set to default value (via field default function)",
+                                            index.yellow(),
+                                            field.offset.blue(),
+                                            variant.name
+                                        );
+                                    } else if field.shape().is(Characteristic::Default) {
+                                        wip.set_default().map_err(|e| self.reflect_err(e))?;
+                                        trace!(
+                                            "Field #{} @ {} in variant {} was set to default value (via type default impl)",
+                                            index.yellow(),
+                                            field.offset.blue(),
+                                            variant.name
+                                        );
+                                    } else {
+                                        return Err(self.reflect_err(
+                                            ReflectError::DefaultAttrButNoDefaultImpl {
+                                                shape: field.shape(),
+                                            },
+                                        ));
+                                    }
+                                    wip.end().map_err(|e| self.reflect_err(e))?;
+                                } else {
+                                    trace!(
+                                        "Field #{} @ {} in variant {} is not initialized",
+                                        index.yellow(),
+                                        field.offset.blue(),
+                                        variant.name
+                                    );
+                                    has_unset = true;
+                                }
+                            }
+                        }
+
+                        if has_unset {
+                            if container_shape.has_default_attr() {
+                                trace!(
+                                    "Enum has DEFAULT attr but variant has uninitialized fields"
+                                );
+                                // Handle similar to struct, allocate and build default value for variant
+                                let default_val = Partial::alloc_shape(container_shape)
+                                    .map_err(|e| self.reflect_err(e))?
+                                    .set_default()
+                                    .map_err(|e| self.reflect_err(e))?
+                                    .build()
+                                    .map_err(|e| self.reflect_err(e))?;
+
+                                let peek = default_val.peek();
+                                let peek_enum =
+                                    peek.into_enum().map_err(|e| self.reflect_err(e))?;
+                                let default_variant = peek_enum
+                                    .active_variant()
+                                    .map_err(|e| self.err(DeserErrorKind::VariantError(e)))?;
+
+                                if default_variant.name == variant.name {
+                                    // It's the same variant, fill in the missing fields
+                                    for (index, _field) in variant.data.fields.iter().enumerate() {
+                                        let is_set = wip.is_field_set(index).map_err(|err| {
+                                            trace!("Error checking field set status: {err:?}");
+                                            self.reflect_err(err)
+                                        })?;
+                                        if !is_set {
+                                            if let Ok(Some(def_field)) = peek_enum.field(index) {
+                                                wip.begin_nth_field(index)
+                                                    .map_err(|e| self.reflect_err(e))?;
+                                                wip.set_from_peek(&def_field)
+                                                    .map_err(|e| self.reflect_err(e))?;
+                                                wip.end().map_err(|e| self.reflect_err(e))?;
+                                            }
+                                        }
+                                    }
+                                }
+                            } else {
+                                // Find the first uninitialized field to report in the error
+                                for (index, field) in variant.data.fields.iter().enumerate() {
+                                    let is_set = wip.is_field_set(index).map_err(|err| {
+                                        trace!("Error checking field set status: {err:?}");
+                                        self.reflect_err(err)
+                                    })?;
+                                    if !is_set {
+                                        return Err(self.reflect_err(
+                                            ReflectError::UninitializedEnumField {
+                                                shape: container_shape,
+                                                variant_name: variant.name,
+                                                field_name: field.name,
+                                            },
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else if container_shape.has_default_attr() {
+                    // No variant selected, but enum has default attribute - set to default
+                    trace!("No variant selected but enum has DEFAULT attr; setting to default");
+                    let default_val = Partial::alloc_shape(container_shape)
+                        .map_err(|e| self.reflect_err(e))?
+                        .set_default()
+                        .map_err(|e| self.reflect_err(e))?
+                        .build()
+                        .map_err(|e| self.reflect_err(e))?;
+
+                    let peek = default_val.peek();
+                    let peek_enum = peek.into_enum().map_err(|e| self.reflect_err(e))?;
+                    let default_variant_idx = peek_enum
+                        .variant_index()
+                        .map_err(|e| self.err(DeserErrorKind::VariantError(e)))?;
+
+                    // Select the default variant
+                    wip.select_nth_variant(default_variant_idx)
+                        .map_err(|e| self.reflect_err(e))?;
+
+                    // Copy all fields from default value
+                    let variant = &ed.variants[default_variant_idx];
+                    for (index, _field) in variant.data.fields.iter().enumerate() {
+                        if let Ok(Some(def_field)) = peek_enum.field(index) {
+                            wip.begin_nth_field(index)
+                                .map_err(|e| self.reflect_err(e))?;
+                            wip.set_from_peek(&def_field)
+                                .map_err(|e| self.reflect_err(e))?;
+                            wip.end().map_err(|e| self.reflect_err(e))?;
+                        }
+                    }
+                }
+            }
+            _ => {
+                trace!(
+                    "Thing being popped is not a container I guess (it's a {}, innermost is {})",
+                    wip.shape(),
+                    wip.innermost_shape()
+                );
+            }
+        }
+        Ok(wip)
+    }
+
+    /// Internal common handler for GotScalar outcome, to deduplicate code.
+    /// Helper to set numeric values with type conversion
+    fn set_numeric_value<'facet>(
+        &self,
+        wip: &mut Partial<'facet, 'shape>,
+        value: &dyn NumericConvert,
+    ) -> Result<(), DeserError<'input, 'shape, C>>
+    where
+        'input: 'facet,
+    {
+        let shape = wip.innermost_shape();
+
+        let Type::Primitive(PrimitiveType::Numeric(numeric_type)) = shape.ty else {
+            return Err(self.err(DeserErrorKind::UnsupportedType {
+                got: shape,
+                wanted: "numeric type",
+            }));
+        };
+
+        // Get the size from the layout
+        let size_bytes = shape
+            .layout
+            .sized_layout()
+            .map_err(|_| {
+                self.err(DeserErrorKind::UnsupportedType {
+                    got: shape,
+                    wanted: "sized numeric type",
+                })
+            })?
+            .size();
+
+        if matches!(shape.def, Def::Scalar) {
+            // Helper closure to convert and set numeric value
+            macro_rules! convert_and_set {
+                ($converter:expr, $target_type:expr) => {{
+                    let converted = $converter.ok_or_else(|| {
+                        self.err(DeserErrorKind::NumericConversion {
+                            from: "numeric",
+                            to: $target_type,
+                        })
+                    })?;
+                    wip.set(converted).map_err(|e| self.reflect_err(e))?;
+                }};
+            }
+
+            match numeric_type {
+                NumericType::Integer { signed } => {
+                    // First check if the shape is specifically usize or isize
+                    if !signed && shape.is_type::<usize>() {
+                        convert_and_set!(value.to_usize(), "usize")
+                    } else if signed && shape.is_type::<isize>() {
+                        convert_and_set!(value.to_isize(), "isize")
+                    } else {
+                        // Then check by size
+                        match (size_bytes, signed) {
+                            (1, true) => convert_and_set!(value.to_i8(), "i8"),
+                            (2, true) => convert_and_set!(value.to_i16(), "i16"),
+                            (4, true) => convert_and_set!(value.to_i32(), "i32"),
+                            (8, true) => convert_and_set!(value.to_i64(), "i64"),
+                            (16, true) => convert_and_set!(value.to_i128(), "i128"),
+                            (1, false) => convert_and_set!(value.to_u8(), "u8"),
+                            (2, false) => convert_and_set!(value.to_u16(), "u16"),
+                            (4, false) => convert_and_set!(value.to_u32(), "u32"),
+                            (8, false) => convert_and_set!(value.to_u64(), "u64"),
+                            (16, false) => convert_and_set!(value.to_u128(), "u128"),
+                            _ => {
+                                return Err(self.err(DeserErrorKind::NumericConversion {
+                                    from: "numeric",
+                                    to: if signed {
+                                        "unknown signed integer size"
+                                    } else {
+                                        "unknown unsigned integer size"
+                                    },
+                                }));
+                            }
+                        }
+                    }
+                }
+                NumericType::Float => match size_bytes {
+                    4 => convert_and_set!(value.to_f32(), "f32"),
+                    8 => convert_and_set!(value.to_f64(), "f64"),
+                    _ => {
+                        return Err(self.err(DeserErrorKind::NumericConversion {
+                            from: "numeric",
+                            to: "unknown float size",
+                        }));
+                    }
+                },
+            }
+        } else {
+            // Not a scalar def - cannot convert
+            return Err(self.err(DeserErrorKind::UnsupportedType {
+                got: shape,
+                wanted: "scalar type",
+            }));
+        }
+
+        Ok(())
+    }
+
+    fn handle_scalar<'facet>(
+        &self,
+        wip: &mut Partial<'facet, 'shape>,
+        scalar: Scalar<'input>,
+    ) -> Result<(), DeserError<'input, 'shape, C>>
+    where
+        'input: 'facet, // 'input outlives 'facet
+    {
+        match scalar {
+            Scalar::String(cow) => {
+                match wip.innermost_shape().ty {
+                    Type::User(UserType::Enum(_)) => {
+                        if wip.selected_variant().is_some() {
+                            // If we already have a variant selected, just put the string
+                            wip.set(cow).map_err(|e| self.reflect_err(e))?;
+                        } else {
+                            // Try to select the variant
+                            match wip.find_variant(&cow) {
+                                Some((variant_index, _)) => {
+                                    wip.select_nth_variant(variant_index)
+                                        .map_err(|e| self.reflect_err(e))?;
+                                }
+                                None => {
+                                    return Err(self.err(DeserErrorKind::NoSuchVariant {
+                                        name: cow.to_string(),
+                                        enum_shape: wip.innermost_shape(),
+                                    }));
+                                }
+                            }
+                        }
+                    }
+                    Type::Pointer(PointerType::Reference(_))
+                        if wip.innermost_shape().is_type::<&str>() =>
+                    {
+                        // This is for handling the &str type
+                        // The Cow may be Borrowed (we may have an owned string but need a &str)
+                        match cow {
+                            Cow::Borrowed(s) => wip.set(s).map_err(|e| self.reflect_err(e))?,
+                            Cow::Owned(s) => wip.set(s).map_err(|e| self.reflect_err(e))?,
+                        }; // Add semicolon to ignore the return value
+                    }
+                    _ => {
+                        // Check if this is a scalar type that can be parsed from a string
+                        let shape = wip.innermost_shape();
+                        if matches!(shape.def, Def::Scalar) {
+                            // Try parse_from_str for scalar types that might parse from strings
+                            // (like IpAddr, UUID, Path, etc.)
+                            match wip.parse_from_str(cow.as_ref()) {
+                                Ok(_) => {
+                                    // Successfully parsed
+                                }
+                                Err(parse_err) => {
+                                    // Parsing failed - check if it's because parse isn't supported
+                                    // or if parsing actually failed
+                                    match parse_err {
+                                        ReflectError::OperationFailed {
+                                            shape: _,
+                                            operation,
+                                        } if operation.contains("does not support parsing") => {
+                                            // Type doesn't have a parse function, try direct conversion
+                                            wip.set(cow.to_string())
+                                                .map_err(|e| self.reflect_err(e))?;
+                                        }
+                                        _ => {
+                                            // Actual parsing failure
+                                            return Err(self.err(DeserErrorKind::ReflectError(
+                                                ReflectError::OperationFailed {
+                                                    shape,
+                                                    operation: "Failed to parse string value",
+                                                },
+                                            )));
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            // Not a scalar, just set as String
+                            wip.set(cow.to_string()).map_err(|e| self.reflect_err(e))?;
+                        }
+                    }
+                }
+            }
+            Scalar::U64(value) => {
+                self.set_numeric_value(wip, &value)?;
+            }
+            Scalar::I64(value) => {
+                self.set_numeric_value(wip, &value)?;
+            }
+            Scalar::F64(value) => {
+                self.set_numeric_value(wip, &value)?;
+            }
+            Scalar::U128(value) => {
+                self.set_numeric_value(wip, &value)?;
+            }
+            Scalar::I128(value) => {
+                self.set_numeric_value(wip, &value)?;
+            }
+            Scalar::Bool(value) => {
+                wip.set(value).map_err(|e| self.reflect_err(e))?;
+            }
+            Scalar::Null => {
+                wip.set_default().map_err(|e| self.reflect_err(e))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Handle value parsing
+    fn value<'facet>(
+        &mut self,
+        mut wip: Partial<'facet, 'shape>,
+        outcome: Spanned<Outcome<'input>, C>,
+    ) -> Result<Partial<'facet, 'shape>, DeserError<'input, 'shape, C>>
+    where
+        'input: 'facet, // 'input must outlive 'facet
+    {
+        trace!(
+            "--- STACK has {:?} {}",
+            self.stack.green(),
+            "(VALUE)".bright_yellow()
+        );
+
+        let original_shape = wip.shape();
+        trace!("Handling value of type {}", original_shape.blue());
+
+        // Handle null values
+        if matches!(outcome.node, Outcome::Scalar(Scalar::Null)) {
+            wip.set_default().map_err(|e| self.reflect_err(e))?;
+            return Ok(wip);
+        }
+
+        // Resolve the innermost value to deserialize
+        let mut smart_pointer_begun = false;
+        loop {
+            trace!("  Loop iteration: current shape is {}", wip.shape().blue());
+            if matches!(wip.shape().def, Def::Option(_)) {
+                trace!("  Starting Some(_) option for {}", wip.shape().blue());
+                wip.begin_some().map_err(|e| self.reflect_err(e))?;
+                self.stack.push(Instruction::Pop(PopReason::Some));
+            } else if let Def::SmartPointer(inner) = wip.shape().def {
+                // Check if we've already begun this smart pointer
+                // (this can happen with slice pointees where the shape doesn't change)
+                if smart_pointer_begun {
+                    break;
+                }
+                if let Some(pointee) = inner.pointee() {
+                    trace!(
+                        "  Starting smart pointer for {} (pointee is {})",
+                        wip.shape().blue(),
+                        pointee.yellow(),
+                    );
+                } else {
+                    trace!(
+                        "  Starting smart pointer for {} (no pointee)",
+                        wip.shape().blue()
+                    );
+                }
+                trace!("  About to call begin_smart_ptr()");
+                wip.begin_smart_ptr().map_err(|e| self.reflect_err(e))?;
+                trace!(
+                    "  After begin_smart_ptr(), shape is now {}",
+                    wip.shape().blue()
+                );
+                self.stack.push(Instruction::Pop(PopReason::SmartPointer));
+                smart_pointer_begun = true;
+            } else if let Some(inner_fn) = wip.shape().inner {
+                let inner = inner_fn();
+                trace!(
+                    "  Starting wrapped value for {} (inner is {})",
+                    wip.shape().blue(),
+                    inner.yellow()
+                );
+                wip.begin_inner().map_err(|e| self.reflect_err(e))?;
+                self.stack.push(Instruction::Pop(PopReason::Wrapper));
+            } else {
+                break;
+            }
+        }
+
+        if wip.shape() != original_shape {
+            trace!(
+                "Handling shape {} as innermost {}",
+                original_shape.blue(),
+                wip.shape().yellow()
+            );
+        }
+
+        match outcome.node {
+            Outcome::Scalar(s) => {
+                trace!("Parsed scalar value: {}", s.cyan());
+                self.handle_scalar(&mut wip, s)?;
+            }
+            Outcome::ListStarted => {
+                let shape = wip.innermost_shape();
+
+                // First check if this is a tuple struct (including empty tuples)
+                if let Type::User(UserType::Struct(st)) = shape.ty {
+                    if st.kind == StructKind::Tuple {
+                        trace!(
+                            "Array starting for tuple struct ({}) with {} fields!",
+                            shape.blue(),
+                            st.fields.len()
+                        );
+
+                        // Non-empty tuples need to process list events
+                        trace!("Beginning pushback");
+                        self.stack.push(Instruction::ListItemOrListClose);
+                        return Ok(wip);
+                    }
+                }
+
+                match shape.def {
+                    Def::Array(_) => {
+                        trace!("Array starting for array ({})!", shape.blue());
+                        // We'll initialize the array elements one by one through the pushback workflow
+                        // Don't call put_default, as arrays need different initialization
+                    }
+                    Def::Slice(_) => {
+                        trace!("Array starting for slice ({})!", shape.blue());
+                    }
+                    Def::List(_) => {
+                        trace!("Array starting for list ({})!", shape.blue());
+                        wip.set_default().map_err(|e| self.reflect_err(e))?;
+                    }
+                    _ => {
+                        // Check if we're building a smart pointer slice
+                        if matches!(shape.def, Def::SmartPointer(_)) && smart_pointer_begun {
+                            trace!("Array starting for smart pointer slice ({})!", shape.blue());
+                            wip.begin_list().map_err(|e| self.reflect_err(e))?;
+                        } else if let Type::User(user_ty) = shape.ty {
+                            // For non-collection types, check the Type enum
+                            match user_ty {
+                                UserType::Enum(_) => {
+                                    trace!("Array starting for enum ({})!", shape.blue());
+                                    // Check if we have a tuple variant selected
+                                    if let Some(variant) = wip.selected_variant() {
+                                        use facet_core::StructKind;
+                                        if variant.data.kind == StructKind::Tuple {
+                                            // For tuple variants, we'll handle array elements as tuple fields
+                                            // Initialize tuple field tracking
+                                            self.enum_tuple_field_count =
+                                                Some(variant.data.fields.len());
+                                            self.enum_tuple_current_field = Some(0);
+                                        } else {
+                                            return Err(self.err(DeserErrorKind::UnsupportedType {
+                                                got: shape,
+                                                wanted: "tuple variant for array deserialization",
+                                            }));
+                                        }
+                                    } else {
+                                        return Err(self.err(DeserErrorKind::UnsupportedType {
+                                            got: shape,
+                                            wanted: "enum with variant selected",
+                                        }));
+                                    }
+                                }
+                                UserType::Struct(_) => {
+                                    // Regular struct shouldn't be parsed from array
+                                    // (Tuples are already handled above)
+                                    return Err(self.err(DeserErrorKind::UnsupportedType {
+                                        got: shape,
+                                        wanted: "array, list, tuple, or slice",
+                                    }));
+                                }
+                                _ => {
+                                    return Err(self.err(DeserErrorKind::UnsupportedType {
+                                        got: shape,
+                                        wanted: "array, list, tuple, or slice",
+                                    }));
+                                }
+                            }
+                        } else {
+                            return Err(self.err(DeserErrorKind::UnsupportedType {
+                                got: shape,
+                                wanted: "array, list, tuple, or slice",
+                            }));
+                        }
+                    }
+                }
+                trace!("Beginning pushback");
+                self.stack.push(Instruction::ListItemOrListClose);
+
+                // Only call begin_list() for actual lists, not arrays
+                match shape.def {
+                    Def::List(_) => {
+                        wip.begin_list().map_err(|e| self.reflect_err(e))?;
+                    }
+                    Def::Array(_) => {
+                        // Arrays don't need begin_list()
+                        // Initialize index tracking for this array
+                        self.array_indices.push(0);
+                    }
+                    Def::Slice(_) => {
+                        // Slices don't need begin_list()
+                        // They will be populated element by element
+                    }
+                    _ => {
+                        // For other types like tuples, no special initialization needed
+                    }
+                }
+            }
+            Outcome::ListEnded => {
+                trace!("List closing");
+                // Clean up array index tracking if this was an array
+                let shape = wip.shape();
+                if matches!(shape.def, Def::Array(_)) {
+                    self.array_indices.pop();
+                }
+                wip.end().map_err(|e| self.reflect_err(e))?;
+            }
+            Outcome::ObjectStarted => {
+                let shape = wip.shape();
+                match shape.def {
+                    Def::Map(_md) => {
+                        trace!("Object starting for map value ({})!", shape.blue());
+                        wip.begin_map().map_err(|e| self.reflect_err(e))?;
+                    }
+                    _ => {
+                        // For non-collection types, check the Type enum
+                        if let Type::User(user_ty) = shape.ty {
+                            match user_ty {
+                                UserType::Enum(_) => {
+                                    trace!("Object starting for enum value ({})!", shape.blue());
+                                    // nothing to do here
+                                }
+                                UserType::Struct(_) => {
+                                    trace!("Object starting for struct value ({})!", shape.blue());
+                                    // nothing to do here
+                                }
+                                _ => {
+                                    return Err(self.err(DeserErrorKind::UnsupportedType {
+                                        got: shape,
+                                        wanted: "map, enum, or struct",
+                                    }));
+                                }
+                            }
+                        } else if let Type::User(UserType::Struct(struct_type)) = shape.ty {
+                            if struct_type.kind == StructKind::Tuple {
+                                // This could be a tuple that was serialized as an object
+                                // Despite this being unusual, we'll handle it here for robustness
+                                trace!(
+                                    "Object starting for tuple ({}) with {} fields - unusual but handling",
+                                    shape.blue(),
+                                    struct_type.fields.len()
+                                );
+                                // Tuples are treated as structs
+                            }
+                        } else {
+                            return Err(self.err(DeserErrorKind::UnsupportedType {
+                                got: shape,
+                                wanted: "map, enum, struct, or tuple",
+                            }));
+                        }
+                    }
+                }
+
+                self.stack.push(Instruction::ObjectKeyOrObjectClose);
+            }
+            Outcome::Resegmented(subspans) => {
+                trace!("Resegmented with {} subspans (value)", subspans.len());
+                // Push an instruction to process the current argument again
+                // (but this time it will use the subspan from the substack)
+                // self.stack.push(Instruction::ObjectKeyOrObjectClose);
+                // 1) Go back to expecting another value
+                // self.stack.push(Instruction::Pop(PopReason::ObjectVal));
+                // self.stack.push(Instruction::Value(ValueReason::ObjectVal));
+            }
+            Outcome::ObjectEnded => todo!(),
+        }
+        Ok(wip)
+    }
+
+    fn object_key_or_object_close<'facet>(
+        &mut self,
+        mut wip: Partial<'facet, 'shape>,
+        outcome: Spanned<Outcome<'input>, C>,
+    ) -> Result<Partial<'facet, 'shape>, DeserError<'input, 'shape, C>>
+    where
+        'input: 'facet,
+    {
+        trace!(
+            "STACK: {:?} {}",
+            self.stack.green(),
+            "(OK/OC)".bright_yellow()
+        );
+        trace!("SUBSTACK: {:?}", self.substack.get().bright_green());
+        match outcome.node {
+            Outcome::Scalar(Scalar::String(key)) => {
+                trace!("Parsed object key: {}", key.cyan());
+
+                let mut ignore = false;
+                let mut needs_pop = true;
+                let mut handled_by_flatten = false;
+                let has_substack = !self.substack.get().is_empty();
+
+                let shape = wip.innermost_shape();
+                match shape.ty {
+                    Type::User(UserType::Struct(sd)) => {
+                        // First try to find a direct field match
+                        if let Some(index) = wip.field_index(&key) {
+                            trace!("It's a struct field");
+                            wip.begin_nth_field(index)
+                                .map_err(|e| self.reflect_err(e))?;
+                        } else {
+                            trace!(
+                                "Did not find direct field match in innermost shape {}",
+                                shape.blue()
+                            );
+
+                            // Check for flattened fields
+                            let mut found_in_flatten = false;
+                            for (index, field) in sd.fields.iter().enumerate() {
+                                if field.flags.contains(FieldFlags::FLATTEN) {
+                                    trace!("Found flattened field #{index}");
+                                    // Enter the flattened field
+                                    wip.begin_nth_field(index)
+                                        .map_err(|e| self.reflect_err(e))?;
+
+                                    // Check if this flattened field has the requested key
+                                    if let Some(subfield_index) = wip.field_index(&key) {
+                                        trace!("Found key {key} in flattened field");
+                                        wip.begin_nth_field(subfield_index)
+                                            .map_err(|e| self.reflect_err(e))?;
+                                        found_in_flatten = true;
+                                        handled_by_flatten = true;
+                                        break;
+                                    } else if let Some((_variant_index, _variant)) =
+                                        wip.find_variant(&key)
+                                    {
+                                        trace!("Found key {key} in flattened field");
+                                        wip.select_variant_named(&key)
+                                            .map_err(|e| self.reflect_err(e))?;
+                                        found_in_flatten = true;
+                                        break;
+                                    } else {
+                                        // Key not in this flattened field, go back up
+                                        wip.end().map_err(|e| self.reflect_err(e))?;
+                                    }
+                                }
+                            }
+
+                            if !found_in_flatten {
+                                if wip.shape().has_deny_unknown_fields_attr() {
+                                    trace!(
+                                        "It's not a struct field AND we're denying unknown fields"
+                                    );
+                                    return Err(self.err(DeserErrorKind::UnknownField {
+                                        field_name: key.to_string(),
+                                        shape: wip.shape(),
+                                    }));
+                                } else {
+                                    trace!(
+                                        "It's not a struct field and we're ignoring unknown fields"
+                                    );
+                                    ignore = true;
+                                }
+                            }
+                        }
+                    }
+                    Type::User(UserType::Enum(_ed)) => match wip.find_variant(&key) {
+                        Some((index, variant)) => {
+                            trace!(
+                                "Selecting variant {}::{}",
+                                wip.shape().blue(),
+                                variant.name.yellow(),
+                            );
+                            wip.select_nth_variant(index)
+                                .map_err(|e| self.reflect_err(e))?;
+
+                            // Let's see what's in the variant — if it's tuple-like with only one field, we want to push field 0
+                            if matches!(variant.data.kind, StructKind::Tuple)
+                                && variant.data.fields.len() == 1
+                            {
+                                trace!(
+                                    "Tuple variant {}::{} encountered, pushing field 0",
+                                    wip.shape().blue(),
+                                    variant.name.yellow()
+                                );
+                                wip.begin_nth_field(0).map_err(|e| self.reflect_err(e))?;
+                                self.stack.push(Instruction::Pop(PopReason::ObjectVal));
+                            }
+
+                            needs_pop = false;
+                        }
+                        None => {
+                            if let Some(_variant_index) = wip.selected_variant() {
+                                trace!(
+                                    "Already have a variant selected, treating {} as struct field of {}::{}",
+                                    key,
+                                    wip.shape().blue(),
+                                    wip.selected_variant().unwrap().name.yellow(),
+                                );
+                                // Try to find the field index of the key within the selected variant
+                                if let Some(index) = wip.field_index(&key) {
+                                    trace!("Found field {} in selected variant", key.blue());
+                                    wip.begin_nth_field(index)
+                                        .map_err(|e| self.reflect_err(e))?;
+                                } else if wip.shape().has_deny_unknown_fields_attr() {
+                                    trace!("Unknown field in variant and denying unknown fields");
+                                    return Err(self.err(DeserErrorKind::UnknownField {
+                                        field_name: key.to_string(),
+                                        shape: wip.shape(),
+                                    }));
+                                } else {
+                                    trace!(
+                                        "Ignoring unknown field '{}' in variant '{}::{}'",
+                                        key,
+                                        wip.shape(),
+                                        wip.selected_variant().unwrap().name
+                                    );
+                                    ignore = true;
+                                }
+                            } else {
+                                return Err(self.err(DeserErrorKind::NoSuchVariant {
+                                    name: key.to_string(),
+                                    enum_shape: wip.shape(),
+                                }));
+                            }
+                        }
+                    },
+                    _ => {
+                        // Check if it's a map
+                        if let Def::Map(map_def) = shape.def {
+                            wip.begin_key().map_err(|e| self.reflect_err(e))?;
+
+                            // Check if the map key type is transparent (has an inner shape)
+                            let key_shape = map_def.k();
+                            if key_shape.inner.is_some() {
+                                // For transparent types, we need to navigate into the inner type
+                                // The inner type should be String for JSON object keys
+                                // Use begin_inner for consistency with begin_* naming convention
+                                wip.begin_inner().map_err(|e| self.reflect_err(e))?;
+                                wip.set(key.to_string()).map_err(|e| self.reflect_err(e))?;
+                                wip.end().map_err(|e| self.reflect_err(e))?; // End inner
+                            } else {
+                                // For non-transparent types, set the string directly
+                                wip.set(key.to_string()).map_err(|e| self.reflect_err(e))?;
+                            }
+
+                            wip.end().map_err(|e| self.reflect_err(e))?; // Complete the key frame
+                            wip.begin_value().map_err(|e| self.reflect_err(e))?;
+                        } else {
+                            return Err(self.err(DeserErrorKind::Unimplemented(
+                                "object key for non-struct/map",
+                            )));
+                        }
+                    }
+                }
+
+                self.stack.push(Instruction::ObjectKeyOrObjectClose);
+                if ignore {
+                    self.stack.push(Instruction::SkipValue);
+                } else {
+                    if needs_pop && !handled_by_flatten {
+                        trace!("Pushing Pop insn to stack (ObjectVal)");
+                        self.stack.push(Instruction::Pop(PopReason::ObjectVal));
+                        if has_substack {
+                            trace!("Pushing SubstackClose insn to stack");
+                            self.stack.push(Instruction::SubstackClose);
+                        }
+                    } else if handled_by_flatten {
+                        // For flattened fields, we only need one pop for the field itself.
+                        // The flattened struct should remain active until the outer object is finished.
+                        trace!("Pushing Pop insn to stack (ObjectVal) for flattened field");
+                        self.stack.push(Instruction::Pop(PopReason::ObjectVal));
+                        if has_substack {
+                            trace!("Pushing SubstackClose insn to stack");
+                            self.stack.push(Instruction::SubstackClose);
+                        }
+                    }
+                    self.stack.push(Instruction::Value(ValueReason::ObjectVal));
+                }
+                Ok(wip)
+            }
+            Outcome::ObjectEnded => {
+                trace!("Object closing");
+                Ok(wip)
+            }
+            Outcome::Resegmented(subspans) => {
+                trace!(
+                    "Resegmented into {} subspans ({:?}) - obj. key/close",
+                    subspans.len(),
+                    subspans
+                );
+                // stay in the same state: parse another 'object key'
+                self.stack.push(Instruction::ObjectKeyOrObjectClose);
+                Ok(wip)
+            }
+            _ => Err(self.err(DeserErrorKind::UnexpectedOutcome {
+                got: outcome.node.into_owned(),
+                wanted: "scalar or object close",
+            })),
+        }
+    }
+
+    fn list_item_or_list_close<'facet>(
+        &mut self,
+        mut wip: Partial<'facet, 'shape>,
+        outcome: Spanned<Outcome<'input>, C>,
+    ) -> Result<Partial<'facet, 'shape>, DeserError<'input, 'shape, C>>
+    where
+        'input: 'facet,
+    {
+        trace!(
+            "--- STACK has {:?} {}",
+            self.stack.green(),
+            "(LI/LC)".bright_yellow()
+        );
+        match outcome.node {
+            Outcome::ListEnded => {
+                trace!("List close");
+                // Clean up array index tracking if this was an array
+                let shape = wip.shape();
+                if matches!(shape.def, Def::Array(_)) {
+                    self.array_indices.pop();
+                }
+
+                // Clean up enum tuple variant tracking if this was an enum tuple
+                if let Type::User(UserType::Enum(_)) = shape.ty {
+                    if self.enum_tuple_field_count.is_some() {
+                        trace!("Enum tuple variant list ended");
+                        self.enum_tuple_field_count = None;
+                        self.enum_tuple_current_field = None;
+                    }
+                }
+
+                // Special case: if we're at an empty tuple, we've successfully parsed it
+                if let Type::User(UserType::Struct(st)) = shape.ty {
+                    if st.kind == StructKind::Tuple && st.fields.is_empty() {
+                        trace!("Empty tuple parsed from []");
+                        // The empty tuple is complete - no fields to initialize
+                    }
+                }
+
+                // Don't end the list here - let the Pop instruction handle it
+                Ok(wip)
+            }
+            _ => {
+                self.stack.push(Instruction::ListItemOrListClose);
+                self.stack.push(Instruction::Pop(PopReason::ListVal));
+
+                trace!(
+                    "Expecting list item, doing a little push before doing value with outcome {}",
+                    outcome.magenta()
+                );
+                trace!("Before push, wip.shape is {}", wip.shape().blue());
+
+                // Different handling for arrays vs lists
+                let shape = wip.shape();
+                match shape.def {
+                    Def::Array(ad) => {
+                        // Arrays use the last index in our tracking vector
+                        if let Some(current_index) = self.array_indices.last().copied() {
+                            // Check bounds
+                            if current_index >= ad.n {
+                                return Err(self.err(DeserErrorKind::ArrayOverflow {
+                                    shape,
+                                    max_len: ad.n,
+                                }));
+                            }
+
+                            // Set this array element
+                            wip.begin_nth_element(current_index)
+                                .map_err(|e| self.reflect_err(e))?;
+
+                            // Increment the index for next time
+                            if let Some(last) = self.array_indices.last_mut() {
+                                *last += 1;
+                            }
+                        } else {
+                            // This shouldn't happen if we properly initialize in ListStarted
+                            return Err(self.err(DeserErrorKind::Unimplemented(
+                                "Array index tracking not initialized",
+                            )));
+                        }
+                    }
+                    Def::List(_) => {
+                        wip.begin_list_item().map_err(|e| self.reflect_err(e))?;
+                    }
+                    _ => {
+                        // Check if this is a smart pointer with slice pointee
+                        if matches!(shape.def, Def::SmartPointer(_)) {
+                            trace!("List item for smart pointer slice");
+                            wip.begin_list_item().map_err(|e| self.reflect_err(e))?;
+                        }
+                        // Check if this is an enum tuple variant
+                        else if let Type::User(UserType::Enum(_)) = shape.ty {
+                            if let (Some(field_count), Some(current_field)) =
+                                (self.enum_tuple_field_count, self.enum_tuple_current_field)
+                            {
+                                if current_field >= field_count {
+                                    // Too many elements for this tuple variant
+                                    return Err(self.err(DeserErrorKind::ArrayOverflow {
+                                        shape,
+                                        max_len: field_count,
+                                    }));
+                                }
+
+                                // Process this tuple field
+                                wip.begin_nth_enum_field(current_field)
+                                    .map_err(|e| self.reflect_err(e))?;
+
+                                // Advance to next field
+                                self.enum_tuple_current_field = Some(current_field + 1);
+                            } else {
+                                return Err(self.err(DeserErrorKind::UnsupportedType {
+                                    got: shape,
+                                    wanted: "enum with tuple variant selected",
+                                }));
+                            }
+                        }
+                        // Check if this is a tuple
+                        else if let Type::User(UserType::Struct(struct_type)) = shape.ty {
+                            if struct_type.kind == StructKind::Tuple {
+                                // Tuples use field indexing
+                                // Find the next uninitialized field
+                                let mut field_index = None;
+                                for i in 0..struct_type.fields.len() {
+                                    if !wip.is_field_set(i).map_err(|e| self.reflect_err(e))? {
+                                        field_index = Some(i);
+                                        break;
+                                    }
+                                }
+
+                                if let Some(idx) = field_index {
+                                    wip.begin_nth_field(idx).map_err(|e| self.reflect_err(e))?;
+                                } else {
+                                    // All fields are set, this is too many elements
+                                    return Err(self.err(DeserErrorKind::ArrayOverflow {
+                                        shape,
+                                        max_len: struct_type.fields.len(),
+                                    }));
+                                }
+                            } else {
+                                // Not a tuple struct
+                                return Err(self.err(DeserErrorKind::UnsupportedType {
+                                    got: shape,
+                                    wanted: "array, list, or tuple",
+                                }));
+                            }
+                        } else {
+                            // Not a struct type at all
+                            return Err(self.err(DeserErrorKind::UnsupportedType {
+                                got: shape,
+                                wanted: "array, list, or tuple",
+                            }));
+                        }
+                    }
+                }
+
+                trace!(" After push, wip.shape is {}", wip.shape().cyan());
+
+                // Special handling: if we're now at an empty tuple and we see a list start,
+                // we can handle the flexible coercion from []
+                if matches!(outcome.node, Outcome::ListStarted) {
+                    if let Type::User(UserType::Struct(st)) = wip.shape().ty {
+                        if st.kind == StructKind::Tuple && st.fields.is_empty() {
+                            trace!(
+                                "Empty tuple field with list start - initializing empty tuple and expecting immediate close"
+                            );
+                            // Initialize the empty tuple with default value since it has no fields to fill
+                            wip.set_default().map_err(|e| self.reflect_err(e))?;
+                            // Continue processing - we still need to handle the list close
+                        }
+                    }
+                }
+
+                wip = self.value(wip, outcome)?;
+                Ok(wip)
+            }
+        }
+    }
+}

--- a/facet-args/src/deserialize/debug.rs
+++ b/facet-args/src/deserialize/debug.rs
@@ -1,0 +1,44 @@
+//! Debug utilities for deserialization formats.
+
+use super::span::Span;
+use alloc::borrow::Cow;
+
+/// Trait for handling input data in error reporting and debugging.
+/// Provides methods to convert input slices to human-readable strings
+/// and to create byte arrays for error storage.
+pub trait InputDebug {
+    /// Returns a string representation of the input at the given span.
+    /// Used for pretty error messages in diagnostics.
+    fn slice(&self, span: Span) -> &str;
+
+    /// Converts the input to a borrowed or owned byte array.
+    /// Used when constructing error objects that need to store input data.
+    fn as_cow(&self) -> Cow<'_, [u8]>;
+}
+
+impl InputDebug for [u8] {
+    fn slice(&self, span: Span) -> &str {
+        core::str::from_utf8(&self[span.start()..span.end()]).unwrap_or("<invalid utf8>")
+    }
+
+    fn as_cow(&self) -> Cow<'_, [u8]> {
+        alloc::borrow::Cow::Borrowed(self)
+    }
+}
+
+impl InputDebug for [&str] {
+    fn slice(&self, span: Span) -> &str {
+        // Simplified implementation - just return the argument at that position if it exists
+        if span.start() < self.len() {
+            self[span.start()]
+        } else {
+            "<out of bounds>"
+        }
+    }
+
+    fn as_cow(&self) -> Cow<'_, [u8]> {
+        // For CLI args, we join them for error reporting
+        let joined = self.join(" ");
+        Cow::Owned(joined.into_bytes())
+    }
+}

--- a/facet-args/src/deserialize/error.rs
+++ b/facet-args/src/deserialize/error.rs
@@ -1,0 +1,492 @@
+#[cfg(feature = "rich-diagnostics")]
+use ariadne::{Color, Config, IndexType, Label, Report, ReportKind, Source};
+
+use alloc::string::String;
+
+use facet_core::{Shape, Type, UserType};
+use facet_reflect::{ReflectError, VariantError};
+use owo_colors::OwoColorize;
+
+use super::debug::InputDebug;
+use super::{Cooked, Outcome, Span};
+
+/// A JSON parse error, with context. Never would've guessed huh.
+pub struct DeserError<'input, 'shape, C = Cooked> {
+    /// The input associated with the error.
+    pub input: alloc::borrow::Cow<'input, [u8]>,
+
+    /// Where the error occured
+    pub span: Span<C>,
+
+    /// The specific error that occurred while parsing the JSON.
+    pub kind: DeserErrorKind<'shape>,
+
+    /// The source identifier for error reporting
+    pub source_id: &'static str,
+}
+
+impl<'input, 'shape, C> DeserError<'input, 'shape, C> {
+    /// Converts the error into an owned error.
+    pub fn into_owned(self) -> DeserError<'static, 'shape, C> {
+        DeserError {
+            input: self.input.into_owned().into(),
+            span: self.span,
+            kind: self.kind,
+            source_id: self.source_id,
+        }
+    }
+
+    /// Sets the span of this error
+    pub fn with_span<D>(self, span: Span<D>) -> DeserError<'input, 'shape, D> {
+        DeserError {
+            input: self.input,
+            span,
+            kind: self.kind,
+            source_id: self.source_id,
+        }
+    }
+}
+
+/// An error kind for JSON parsing.
+#[derive(Debug, Clone)]
+pub enum DeserErrorKind<'shape> {
+    /// An unexpected byte was encountered in the input.
+    UnexpectedByte {
+        /// The byte that was found.
+        got: u8,
+        /// The expected value as a string description.
+        wanted: &'static str,
+    },
+
+    /// An unexpected character was encountered in the input.
+    UnexpectedChar {
+        /// The character that was found.
+        got: char,
+        /// The expected value as a string description.
+        wanted: &'static str,
+    },
+
+    /// An unexpected outcome was encountered in the input.
+    UnexpectedOutcome {
+        /// The outcome that was found.
+        got: Outcome<'static>,
+        /// The expected value as a string description.
+        wanted: &'static str,
+    },
+
+    /// The input ended unexpectedly while parsing JSON.
+    UnexpectedEof {
+        /// The expected value as a string description.
+        wanted: &'static str,
+    },
+
+    /// Indicates a value was expected to follow an element in the input.
+    MissingValue {
+        /// Describes what type of value was expected.
+        expected: &'static str,
+        /// The element that requires the missing value.
+        field: String,
+    },
+
+    /// A required struct field was missing at the end of JSON input.
+    MissingField(&'static str),
+
+    /// A number is out of range.
+    NumberOutOfRange(f64),
+
+    /// An unexpected String was encountered in the input.
+    StringAsNumber(String),
+
+    /// An unexpected field name was encountered in the input.
+    UnknownField {
+        /// The name of the field that was not recognized
+        field_name: String,
+
+        /// The shape definition where the unknown field was encountered
+        shape: &'shape Shape<'shape>,
+    },
+
+    /// A string that could not be built into valid UTF-8 Unicode
+    InvalidUtf8(String),
+
+    /// An error occurred while reflecting a type.
+    ReflectError(ReflectError<'shape>),
+
+    /// Some feature is not yet implemented (under development).
+    Unimplemented(&'static str),
+
+    /// An unsupported type was encountered.
+    UnsupportedType {
+        /// The shape we got
+        got: &'shape Shape<'shape>,
+
+        /// The shape we wanted
+        wanted: &'static str,
+    },
+
+    /// An enum variant name that doesn't exist in the enum definition.
+    NoSuchVariant {
+        /// The name of the variant that was not found
+        name: String,
+
+        /// The enum shape definition where the variant was looked up
+        enum_shape: &'shape Shape<'shape>,
+    },
+
+    /// An error occurred when reflecting an enum variant (index) from a user type.
+    VariantError(VariantError),
+
+    /// Too many elements for an array.
+    ArrayOverflow {
+        /// The array shape
+        shape: &'shape Shape<'shape>,
+
+        /// Maximum allowed length
+        max_len: usize,
+    },
+
+    /// Failed to convert numeric type.
+    NumericConversion {
+        /// Source type name
+        from: &'static str,
+
+        /// Target type name
+        to: &'static str,
+    },
+}
+
+impl<'input, 'shape, C> DeserError<'input, 'shape, C> {
+    /// Creates a new deser error, preserving input and location context for accurate reporting.
+    pub fn new<I>(
+        kind: DeserErrorKind<'shape>,
+        input: &'input I,
+        span: Span<C>,
+        source_id: &'static str,
+    ) -> Self
+    where
+        I: ?Sized + 'input + InputDebug,
+    {
+        Self {
+            input: input.as_cow(),
+            span,
+            kind,
+            source_id,
+        }
+    }
+
+    /// Constructs a reflection-related deser error, keeping contextual information intact.
+    pub(crate) fn new_reflect<I>(
+        e: ReflectError<'shape>,
+        input: &'input I,
+        span: Span<C>,
+        source_id: &'static str,
+    ) -> Self
+    where
+        I: ?Sized + 'input + InputDebug,
+    {
+        DeserError::new(DeserErrorKind::ReflectError(e), input, span, source_id)
+    }
+
+    /// Sets the source ID for this error
+    pub fn with_source_id(mut self, source_id: &'static str) -> Self {
+        self.source_id = source_id;
+        self
+    }
+
+    /// Provides a human-friendly message wrapper to improve error readability.
+    pub fn message(&self) -> DeserErrorMessage<'_, '_, C> {
+        DeserErrorMessage(self)
+    }
+}
+
+/// A wrapper type for displaying deser error messages
+pub struct DeserErrorMessage<'input, 'shape, C = Cooked>(&'input DeserError<'input, 'shape, C>);
+
+impl core::fmt::Display for DeserErrorMessage<'_, '_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match &self.0.kind {
+            DeserErrorKind::UnexpectedByte { got, wanted } => write!(
+                f,
+                "Unexpected byte: got 0x{:02X}, wanted {}",
+                got.red(),
+                wanted.yellow()
+            ),
+            DeserErrorKind::UnexpectedChar { got, wanted } => write!(
+                f,
+                "Unexpected character: got '{}', wanted {}",
+                got.red(),
+                wanted.yellow()
+            ),
+            DeserErrorKind::UnexpectedOutcome { got, wanted } => {
+                write!(f, "Unexpected {}, wanted {}", got.red(), wanted.yellow())
+            }
+            DeserErrorKind::UnexpectedEof { wanted } => {
+                write!(f, "Unexpected end of file: wanted {}", wanted.red())
+            }
+            DeserErrorKind::MissingValue { expected, field } => {
+                write!(f, "Missing {} for {}", expected.red(), field.yellow())
+            }
+            DeserErrorKind::MissingField(fld) => write!(f, "Missing required field: {}", fld.red()),
+            DeserErrorKind::NumberOutOfRange(n) => {
+                write!(f, "Number out of range: {}", n.red())
+            }
+            DeserErrorKind::StringAsNumber(s) => {
+                write!(f, "Expected a string but got number: {}", s.red())
+            }
+            DeserErrorKind::UnknownField { field_name, shape } => {
+                write!(
+                    f,
+                    "Unknown field: {} for shape {}",
+                    field_name.red(),
+                    shape.yellow()
+                )
+            }
+            DeserErrorKind::InvalidUtf8(e) => write!(f, "Invalid UTF-8 encoding: {}", e.red()),
+            DeserErrorKind::ReflectError(e) => write!(f, "{e}"),
+            DeserErrorKind::Unimplemented(s) => {
+                write!(f, "Feature not yet implemented: {}", s.yellow())
+            }
+            DeserErrorKind::UnsupportedType { got, wanted } => {
+                write!(
+                    f,
+                    "Unsupported type: got {}, wanted {}",
+                    got.red(),
+                    wanted.green()
+                )
+            }
+            DeserErrorKind::NoSuchVariant { name, enum_shape } => {
+                if let Type::User(UserType::Enum(ed)) = enum_shape.ty {
+                    write!(
+                        f,
+                        "Enum variant not found: {} in enum {}. Available variants: [",
+                        name.red(),
+                        enum_shape.yellow()
+                    )?;
+
+                    let mut first = true;
+                    for variant in ed.variants.iter() {
+                        if !first {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", variant.name.green())?;
+                        first = false;
+                    }
+
+                    write!(f, "]")?;
+                    Ok(())
+                } else {
+                    write!(
+                        f,
+                        "Enum variant not found: {} in non-enum type {}",
+                        name.red(),
+                        enum_shape.yellow()
+                    )?;
+                    Ok(())
+                }
+            }
+            DeserErrorKind::VariantError(e) => {
+                write!(f, "Variant error: {e}")
+            }
+            DeserErrorKind::ArrayOverflow { shape, max_len } => {
+                write!(
+                    f,
+                    "Too many elements for array {}: maximum {} elements allowed",
+                    shape.blue(),
+                    max_len.yellow()
+                )
+            }
+            DeserErrorKind::NumericConversion { from, to } => {
+                write!(
+                    f,
+                    "Cannot convert {} to {}: value out of range or precision loss",
+                    from.red(),
+                    to.green()
+                )
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "rich-diagnostics"))]
+impl core::fmt::Display for DeserError<'_, '_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} at byte {}", self.message(), self.span.start(),)
+    }
+}
+
+#[cfg(feature = "rich-diagnostics")]
+impl core::fmt::Display for DeserError<'_, '_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Try to convert input to utf8 for source display, otherwise fallback to error
+        let Ok(orig_input_str) = core::str::from_utf8(&self.input[..]) else {
+            return write!(f, "(JSON input was invalid UTF-8)");
+        };
+
+        let source_id = self.source_id;
+        let mut span_start = self.span.start();
+        let mut span_end = self.span.end();
+        use alloc::borrow::Cow;
+        let mut input_str: Cow<'_, str> = Cow::Borrowed(orig_input_str);
+
+        // --- Context-sensitive truncation logic ---
+        // When the error occurs very far into a huge (often one-line) input,
+        // such as minified JSON, it's annoying to display hundreds or thousands of
+        // preceding and trailing characters. Instead, we seek to trim the displayed
+        // "source" to just enough around the offending line/location, but only if
+        // we can do this cleanly.
+        //
+        // Our approach:
+        // - Find the full line that `span_start` is within, using memchr for newlines before and after.
+        // - Only proceed if both `span_start` and `span_end` are within this line (i.e., error doesn't span lines).
+        // - If there are more than 180 characters before/after the span on this line, truncate to show
+        //   "...<80 chars>SPANTEXT<80 chars>..." and adjust the display offsets to ensure ariadne points
+        //   to the correct span inside the trimmed display.
+        //
+        // Rationale: this avoids a sea of whitespace for extremely long lines (common in compact JSON).
+
+        let mut did_truncate = false;
+
+        {
+            // Find the line bounds containing span_start
+            let bytes = self.input.as_ref();
+            let line_start = bytes[..span_start]
+                .iter()
+                .rposition(|&b| b == b'\n')
+                .map(|pos| pos + 1)
+                .unwrap_or(0);
+            let line_end = bytes[span_start..]
+                .iter()
+                .position(|&b| b == b'\n')
+                .map(|pos| span_start + pos)
+                .unwrap_or(bytes.len());
+
+            // Check if span fits within one line
+            if span_end <= line_end {
+                // How much context do we have before and after the span in this line?
+                let before_chars = span_start - line_start;
+                let after_chars = line_end.saturating_sub(span_end);
+
+                // Only trim if context is long enough
+                if before_chars > 180 || after_chars > 180 {
+                    let trim_left = if before_chars > 180 {
+                        before_chars - 80
+                    } else {
+                        0
+                    };
+                    let trim_right = if after_chars > 180 {
+                        after_chars - 80
+                    } else {
+                        0
+                    };
+
+                    let new_start = line_start + trim_left;
+                    let new_end = line_end - trim_right;
+
+                    let truncated = &orig_input_str[new_start..new_end];
+
+                    let left_ellipsis = if trim_left > 0 { "…" } else { "" };
+                    let right_ellipsis = if trim_right > 0 { "…" } else { "" };
+
+                    let mut buf = String::with_capacity(
+                        left_ellipsis.len() + truncated.len() + right_ellipsis.len(),
+                    );
+                    buf.push_str(left_ellipsis);
+                    buf.push_str(truncated);
+                    buf.push_str(right_ellipsis);
+
+                    // Adjust span offsets to align with the trimmed string
+                    span_start = span_start - new_start + left_ellipsis.len();
+                    span_end = span_end - new_start + left_ellipsis.len();
+
+                    input_str = Cow::Owned(buf);
+
+                    did_truncate = true; // mark that truncation occurred
+                    // Done!
+                }
+            }
+            // If the span goes across lines or we cannot cleanly trim, display the full input as fallback
+        }
+
+        if did_truncate {
+            writeln!(
+                f,
+                "{}",
+                "WARNING: Input was truncated for display. Byte indexes in the error below do not match original input.".yellow().bold()
+            )?;
+        }
+
+        let mut report = Report::build(ReportKind::Error, (source_id, span_start..span_end))
+            .with_config(Config::new().with_index_type(IndexType::Byte));
+
+        let label = Label::new((source_id, span_start..span_end))
+            .with_message(self.message())
+            .with_color(Color::Red);
+
+        report = report.with_label(label);
+
+        let source = Source::from(input_str);
+
+        struct FmtWriter<'a, 'b: 'a> {
+            f: &'a mut core::fmt::Formatter<'b>,
+            error: Option<core::fmt::Error>,
+        }
+
+        impl core::fmt::Write for FmtWriter<'_, '_> {
+            fn write_str(&mut self, s: &str) -> core::fmt::Result {
+                if self.error.is_some() {
+                    // Already failed, do nothing
+                    return Err(core::fmt::Error);
+                }
+                if let Err(e) = self.f.write_str(s) {
+                    self.error = Some(e);
+                    Err(core::fmt::Error)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+
+        struct IoWriter<'a, 'b: 'a> {
+            inner: FmtWriter<'a, 'b>,
+        }
+
+        impl std::io::Write for IoWriter<'_, '_> {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                match core::str::from_utf8(buf) {
+                    Ok(s) => match core::fmt::Write::write_str(&mut self.inner, s) {
+                        Ok(()) => Ok(buf.len()),
+                        Err(_) => Err(std::io::ErrorKind::Other.into()),
+                    },
+                    Err(_) => Err(std::io::ErrorKind::InvalidData.into()),
+                }
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let cache = (source_id, &source);
+
+        let fmt_writer = FmtWriter { f, error: None };
+        let mut io_writer = IoWriter { inner: fmt_writer };
+
+        if report.finish().write(cache, &mut io_writer).is_err() {
+            return write!(f, "Error formatting with ariadne");
+        }
+
+        // Check if our adapter ran into a formatting error
+        if io_writer.inner.error.is_some() {
+            return write!(f, "Error writing ariadne output to fmt::Formatter");
+        }
+
+        Ok(())
+    }
+}
+
+impl core::fmt::Debug for DeserError<'_, '_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self, f)
+    }
+}
+
+impl core::error::Error for DeserError<'_, '_> {}

--- a/facet-args/src/deserialize/span.rs
+++ b/facet-args/src/deserialize/span.rs
@@ -24,18 +24,6 @@ pub struct Span<C = Cooked> {
     _p: PhantomData<C>,
 }
 
-/// Trait for types that can be annotated with a Span.
-pub trait Spannable<C = Cooked>: Sized {
-    /// Annotate this value with a span, wrapping it in `Spanned<Self, C>`
-    fn with_span(self, span: Span<C>) -> Spanned<Self, C>;
-}
-
-impl<T, C> Spannable<C> for T {
-    fn with_span(self, span: Span<C>) -> Spanned<Self, C> {
-        Spanned { node: self, span }
-    }
-}
-
 impl<C> Span<C> {
     /// Creates a new span with the given start position and length
     pub fn new(start: Pos, len: usize) -> Self {
@@ -153,15 +141,6 @@ impl<C> Substack<C> {
         }
     }
 
-    /// Pop the most recently added subspan
-    pub fn pop(&mut self) -> Option<Subspan> {
-        if let Some(spans) = &mut self.spans {
-            spans.pop()
-        } else {
-            None
-        }
-    }
-
     /// Clear all subspans
     pub fn clear(&mut self) {
         if let Some(spans) = &mut self.spans {
@@ -183,48 +162,6 @@ impl<C> From<Vec<Subspan>> for Substack<C> {
             _marker: PhantomData,
         }
     }
-}
-
-impl Substack<Raw> {
-    /// Add a subspan for Raw spans
-    pub fn add(&mut self, offset: usize, len: usize, meta: Option<SubspanMeta>) {
-        if self.spans.is_none() {
-            self.spans = Some(Vec::new());
-        }
-
-        if let Some(spans) = &mut self.spans {
-            spans.push(Subspan { offset, len, meta });
-        }
-    }
-
-    /// Add a simple subspan with just offset and length
-    pub fn add_simple(&mut self, offset: usize, len: usize) {
-        self.add(offset, len, None);
-    }
-
-    /// Add a delimiter subspan
-    pub fn add_delimiter(&mut self, offset: usize, len: usize, delimiter: char) {
-        self.add(offset, len, Some(SubspanMeta::Delimiter(delimiter)));
-    }
-
-    /// Add a key-value subspan
-    pub fn add_key_value(&mut self, offset: usize, len: usize) {
-        self.add(offset, len, Some(SubspanMeta::KeyValue));
-    }
-}
-
-impl Substack<Cooked> {
-    /// Add a span for Cooked spans (does nothing)
-    pub fn add(&mut self, _offset: usize, _len: usize, _meta: Option<SubspanMeta>) {}
-
-    /// Add a simple subspan (does nothing for Cooked)
-    pub fn add_simple(&mut self, _offset: usize, _len: usize) {}
-
-    /// Add a delimiter subspan (does nothing for Cooked)
-    pub fn add_delimiter(&mut self, _offset: usize, _len: usize, _delimiter: char) {}
-
-    /// Add a key-value subspan (does nothing for Cooked)
-    pub fn add_key_value(&mut self, _offset: usize, _len: usize) {}
 }
 
 /// This trait allows the compiler to optimize away `Substack`-related code

--- a/facet-args/src/deserialize/span.rs
+++ b/facet-args/src/deserialize/span.rs
@@ -1,0 +1,243 @@
+use alloc::vec::Vec;
+use core::fmt;
+use core::marker::PhantomData;
+
+/// A Cooked variant of a Span (byte indexed)
+#[derive(Debug, PartialEq)]
+pub enum Cooked {}
+
+/// A Raw variant of a Span (format-specific index)
+#[derive(Debug, PartialEq)]
+pub enum Raw {}
+
+/// Position in the input (byte index)
+pub type Pos = usize;
+
+/// A span in the input, with a start position and length
+#[derive(Debug, PartialEq, Eq)]
+pub struct Span<C = Cooked> {
+    /// Starting position of the span in bytes
+    pub start: Pos,
+    /// Length of the span in bytes
+    pub len: usize,
+    /// Hold on to C
+    _p: PhantomData<C>,
+}
+
+/// Trait for types that can be annotated with a Span.
+pub trait Spannable<C = Cooked>: Sized {
+    /// Annotate this value with a span, wrapping it in `Spanned<Self, C>`
+    fn with_span(self, span: Span<C>) -> Spanned<Self, C>;
+}
+
+impl<T, C> Spannable<C> for T {
+    fn with_span(self, span: Span<C>) -> Spanned<Self, C> {
+        Spanned { node: self, span }
+    }
+}
+
+impl<C> Span<C> {
+    /// Creates a new span with the given start position and length
+    pub fn new(start: Pos, len: usize) -> Self {
+        Span {
+            start,
+            len,
+            _p: PhantomData,
+        }
+    }
+    /// Start position of the span
+    pub fn start(&self) -> Pos {
+        self.start
+    }
+    /// Length of the span
+    pub fn len(&self) -> usize {
+        self.len
+    }
+    /// Returns `true` if this span has zero length
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+    /// End position (start + length)
+    pub fn end(&self) -> Pos {
+        self.start + self.len
+    }
+}
+
+impl<C> Default for Span<C> {
+    fn default() -> Self {
+        Span {
+            start: 0,
+            len: 0,
+            _p: PhantomData,
+        }
+    }
+}
+
+/// A value of type `T` annotated with its `Span`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Spanned<T, C = Cooked> {
+    /// The actual data/value being wrapped
+    pub node: T,
+    /// The span information indicating the position and length in the source
+    pub span: Span<C>,
+}
+
+impl<T: fmt::Display, C> fmt::Display for Spanned<T, C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} at {}-{}",
+            self.node,
+            self.span.start(),
+            self.span.end()
+        )
+    }
+}
+
+// Copy + Clone not auto-derived for PhantomData
+// https://stackoverflow.com/a/31371094/2668831
+
+impl<C> Clone for Span<C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<C> Copy for Span<C> {}
+
+/// A Subspan variant of a Span
+#[derive(Clone, Debug, PartialEq)]
+pub struct Subspan {
+    /// Offset from parent span's start
+    pub offset: usize,
+    /// Length of the subspan
+    pub len: usize,
+    /// Optional metadata (like delimiter information)
+    pub meta: Option<SubspanMeta>,
+}
+
+/// Metadata about a subspan, providing context for how the subspan relates
+/// to the parent span or other subspans.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum SubspanMeta {
+    /// Indicates the subspan is part of a delimited sequence,
+    /// storing the delimiter character (e.g., ',' in "1,2,3")
+    Delimiter(char),
+
+    /// Indicates the subspan represents one side of a key-value pair
+    /// (e.g., in "--key=value" or "-k=val")
+    KeyValue,
+    // Other metadata cases as needed...
+}
+
+/// Container for subspans based on span type
+pub struct Substack<C> {
+    spans: Option<Vec<Subspan>>,
+    _marker: PhantomData<C>,
+}
+
+impl<C> Substack<C> {
+    /// Initialise subspan stack as None
+    pub fn new() -> Self {
+        Substack {
+            spans: None,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Get all stored spans
+    pub fn get(&self) -> &[Subspan] {
+        match &self.spans {
+            Some(spans) => spans,
+            None => &[], // Return empty slice if no spans are stored
+        }
+    }
+
+    /// Pop the most recently added subspan
+    pub fn pop(&mut self) -> Option<Subspan> {
+        if let Some(spans) = &mut self.spans {
+            spans.pop()
+        } else {
+            None
+        }
+    }
+
+    /// Clear all subspans
+    pub fn clear(&mut self) {
+        if let Some(spans) = &mut self.spans {
+            spans.clear();
+        }
+    }
+}
+
+impl<C> Default for Substack<C> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<C> From<Vec<Subspan>> for Substack<C> {
+    fn from(subspans: Vec<Subspan>) -> Self {
+        Substack {
+            spans: Some(subspans),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl Substack<Raw> {
+    /// Add a subspan for Raw spans
+    pub fn add(&mut self, offset: usize, len: usize, meta: Option<SubspanMeta>) {
+        if self.spans.is_none() {
+            self.spans = Some(Vec::new());
+        }
+
+        if let Some(spans) = &mut self.spans {
+            spans.push(Subspan { offset, len, meta });
+        }
+    }
+
+    /// Add a simple subspan with just offset and length
+    pub fn add_simple(&mut self, offset: usize, len: usize) {
+        self.add(offset, len, None);
+    }
+
+    /// Add a delimiter subspan
+    pub fn add_delimiter(&mut self, offset: usize, len: usize, delimiter: char) {
+        self.add(offset, len, Some(SubspanMeta::Delimiter(delimiter)));
+    }
+
+    /// Add a key-value subspan
+    pub fn add_key_value(&mut self, offset: usize, len: usize) {
+        self.add(offset, len, Some(SubspanMeta::KeyValue));
+    }
+}
+
+impl Substack<Cooked> {
+    /// Add a span for Cooked spans (does nothing)
+    pub fn add(&mut self, _offset: usize, _len: usize, _meta: Option<SubspanMeta>) {}
+
+    /// Add a simple subspan (does nothing for Cooked)
+    pub fn add_simple(&mut self, _offset: usize, _len: usize) {}
+
+    /// Add a delimiter subspan (does nothing for Cooked)
+    pub fn add_delimiter(&mut self, _offset: usize, _len: usize, _delimiter: char) {}
+
+    /// Add a key-value subspan (does nothing for Cooked)
+    pub fn add_key_value(&mut self, _offset: usize, _len: usize) {}
+}
+
+/// This trait allows the compiler to optimize away `Substack`-related code
+/// for formats with span types that don't use subspans, making it zero-cost.
+pub trait SubstackBehavior {
+    /// Whether to use subspans in the `deserialize_wip` instruction stack loop.
+    const USES_SUBSTACK: bool;
+}
+
+impl SubstackBehavior for Raw {
+    const USES_SUBSTACK: bool = true;
+}
+
+impl SubstackBehavior for Cooked {
+    const USES_SUBSTACK: bool = false;
+}

--- a/facet-args/src/fields.rs
+++ b/facet-args/src/fields.rs
@@ -1,7 +1,8 @@
 use alloc::borrow::Cow;
 use alloc::string::ToString;
 use facet_core::{FieldAttribute, Shape, Type, UserType};
-use facet_deserialize::{
+
+use crate::deserialize::{
     DeserErrorKind, Outcome, Raw, Scalar, Span, Spanned, Subspan, SubspanMeta,
 };
 use facet_reflect::Partial;

--- a/facet-args/src/format.rs
+++ b/facet-args/src/format.rs
@@ -1,14 +1,14 @@
 use crate::arg::{ArgType, extract_subspan};
+use crate::deserialize::{
+    DeserError, DeserErrorKind, Expectation, Format, NextData, NextResult, Outcome, Raw, Scalar,
+    Span, Spanned,
+};
 use crate::fields::*;
 use crate::parse::parse_scalar;
 use crate::results::*;
 use alloc::borrow::Cow;
 use core::fmt;
 use facet_core::Facet;
-use facet_deserialize::{
-    DeserError, DeserErrorKind, Expectation, Format, NextData, NextResult, Outcome, Raw, Scalar,
-    Span, Spanned,
-};
 
 /// Command-line argument format for Facet deserialization
 pub struct Cli;
@@ -26,7 +26,7 @@ pub fn from_slice<'input, 'facet, 'shape, T: Facet<'facet>>(
 where
     'input: 'facet + 'shape,
 {
-    facet_deserialize::deserialize(args, Cli)
+    crate::deserialize::deserialize(args, Cli)
 }
 
 /// Parse command line arguments provided by std::env::args() into a Facet-compatible type

--- a/facet-args/src/lib.rs
+++ b/facet-args/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 pub mod format;
 
 pub(crate) mod arg;
+pub(crate) mod deserialize;
 pub(crate) mod fields;
 pub(crate) mod parse;
 pub(crate) mod results;

--- a/facet-args/src/parse.rs
+++ b/facet-args/src/parse.rs
@@ -1,5 +1,5 @@
+use crate::deserialize::{Outcome, Raw, Scalar, Span, Spanned};
 use alloc::borrow::Cow;
-use facet_deserialize::{Outcome, Raw, Scalar, Span, Spanned};
 
 pub(crate) fn parse_scalar<'a>(arg: &'a str, span: Span<Raw>) -> Spanned<Outcome<'a>, Raw> {
     // Try to parse numbers in order of specificity

--- a/facet-args/src/results.rs
+++ b/facet-args/src/results.rs
@@ -1,5 +1,5 @@
+use crate::deserialize::{DeserErrorKind, Outcome, Raw, Scalar, Span, Spanned, Subspan};
 use alloc::borrow::Cow;
-use facet_deserialize::{DeserErrorKind, Outcome, Raw, Scalar, Span, Spanned, Subspan};
 
 /// General purpose wrapper for results
 pub(crate) fn wrap_result<'input, 'shape, T>(

--- a/facet-macros-emit/src/function/emit.rs
+++ b/facet-macros-emit/src/function/emit.rs
@@ -12,7 +12,7 @@ pub fn facet_fn(_attr: TokenStream, item: TokenStream) -> TokenStream {
     result.to_string().parse().unwrap()
 }
 
-/// Entry point for the fn_shape procedural macro  
+/// Entry point for the fn_shape procedural macro
 pub fn fn_shape(input: TokenStream) -> TokenStream {
     let parsed = parse_fn_shape_input(input);
     let result = generate_fn_shape_call(parsed);
@@ -27,7 +27,7 @@ pub fn generate_function_shape(parsed: FunctionSignature) -> TokenStream {
     let return_type = parsed.return_type;
     let body = parsed.body;
 
-    let hidden_mod = Ident::new(&format!("__fn_shape_{}", fn_name), Span::call_site());
+    let hidden_mod = Ident::new(&format!("__fn_shape_{fn_name}"), Span::call_site());
     let shape_name = Ident::new(
         &format!("{}_SHAPE", fn_name.to_string().to_uppercase()),
         Span::call_site(),

--- a/facet-macros-emit/tests/compile_tests/mod.rs
+++ b/facet-macros-emit/tests/compile_tests/mod.rs
@@ -125,7 +125,7 @@ facet-reflect = {{ path = {:?} }}
         } else {
             println!(
                 "{}",
-                format_args!("  ✓ Found expected error: '{}'", expected_error).green()
+                format_args!("  ✓ Found expected error: '{expected_error}'").green()
             );
         }
     }
@@ -134,16 +134,16 @@ facet-reflect = {{ path = {:?} }}
     if !missing_errors.is_empty() {
         println!("{}", "\n❌ MISSING EXPECTED ERRORS:".bright_red().bold());
         for error in &missing_errors {
-            println!("{}", format_args!("  - '{}'", error).red());
+            println!("{}", format_args!("  - '{error}'").red());
         }
 
         // Print the error output for debugging
         println!("{}", "\nCompiler error output:".yellow().bold());
-        println!("{}", stderr);
+        println!("{stderr}");
 
         if !stdout.is_empty() {
             println!("{}", "\nCompiler standard output:".yellow());
-            println!("{}", stdout);
+            println!("{stdout}");
         }
 
         panic!(

--- a/facet-macros-parse/src/function/fn_shape_input.rs
+++ b/facet-macros-parse/src/function/fn_shape_input.rs
@@ -34,7 +34,7 @@ pub fn parse_fn_shape_input(input: TokenStream) -> ParsedFnShapeInput {
             ParsedFnShapeInput { name, generics }
         }
         Err(err) => {
-            panic!("Failed to parse fn_shape input: {}", err);
+            panic!("Failed to parse fn_shape input: {err}");
         }
     }
 }

--- a/facet-macros-parse/src/function/func_sig.rs
+++ b/facet-macros-parse/src/function/func_sig.rs
@@ -118,7 +118,7 @@ pub fn parse_function_signature(input: TokenStream) -> FunctionSignature {
             }
         }
         Err(err) => {
-            panic!("Failed to parse function signature: {}", err);
+            panic!("Failed to parse function signature: {err}");
         }
     }
 }

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -524,7 +524,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
         self.require_active()?;
 
         let fr = self.frames.last_mut().unwrap();
-        crate::trace!("set_shape({:?})", src_shape);
+        crate::trace!("set_shape({src_shape:?})");
         if !fr.shape.is_shape(src_shape) {
             let err = ReflectError::WrongShape {
                 expected: fr.shape,
@@ -1645,7 +1645,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
             };
 
             // Allocate space for the element
-            crate::trace!("Pointee is a slice of {}", element_shape);
+            crate::trace!("Pointee is a slice of {element_shape}");
             let element_layout = match element_shape.layout.sized_layout() {
                 Ok(layout) => layout,
                 Err(_) => {
@@ -1846,7 +1846,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
                 let result = unsafe { try_from_fn(inner_ptr, inner_shape, parent_frame.data) };
 
                 if let Err(e) = result {
-                    trace!("Conversion failed: {:?}", e);
+                    trace!("Conversion failed: {e:?}");
 
                     // Deallocate the inner value's memory since conversion failed
                     if let FrameOwnership::Owned = popped_frame.ownership {
@@ -2590,8 +2590,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
                 // This allows setting values of the inner type which will be converted
                 // The automatic conversion detection in end() will handle the conversion
                 trace!(
-                    "begin_inner: Creating frame for inner type {} (parent is {})",
-                    inner_shape, parent_shape
+                    "begin_inner: Creating frame for inner type {inner_shape} (parent is {parent_shape})"
                 );
                 self.frames
                     .push(Frame::new(inner_data, inner_shape, FrameOwnership::Owned));
@@ -2600,10 +2599,7 @@ impl<'facet, 'shape> Partial<'facet, 'shape> {
             } else {
                 // For wrapper types without try_from, navigate to the first field
                 // This is a common pattern for newtype wrappers
-                trace!(
-                    "begin_inner: No try_from for {}, using field navigation",
-                    parent_shape
-                );
+                trace!("begin_inner: No try_from for {parent_shape}, using field navigation");
                 self.begin_nth_field(0)
             }
         } else {

--- a/facet-reflect/tests/compile_tests.rs
+++ b/facet-reflect/tests/compile_tests.rs
@@ -101,10 +101,10 @@ facet-reflect = {{ path = {:?} }}
 
     // Generate a unique target directory based on the test name and source code
     let source_hash = hash_source(test.name, test.source);
-    let target_dir = format!("/tmp/ui_tests/target_{}", source_hash);
+    let target_dir = format!("/tmp/ui_tests/target_{source_hash}");
     println!(
         "{}",
-        format_args!("  Target directory: {}", target_dir).dimmed()
+        format_args!("  Target directory: {target_dir}").dimmed()
     );
 
     // Run cargo build
@@ -147,7 +147,7 @@ facet-reflect = {{ path = {:?} }}
         } else {
             println!(
                 "{}",
-                format_args!("  ✓ Found expected error: '{}'", expected_error).green()
+                format_args!("  ✓ Found expected error: '{expected_error}'").green()
             );
         }
     }
@@ -156,16 +156,16 @@ facet-reflect = {{ path = {:?} }}
     if !missing_errors.is_empty() {
         println!("{}", "\n❌ MISSING EXPECTED ERRORS:".bright_red().bold());
         for error in &missing_errors {
-            println!("{}", format_args!("  - '{}'", error).red());
+            println!("{}", format_args!("  - '{error}'").red());
         }
 
         // Print the error output for debugging
         println!("{}", "\nCompiler error output:".yellow().bold());
-        println!("{}", stderr);
+        println!("{stderr}");
 
         if !stdout.is_empty() {
             println!("{}", "\nCompiler standard output:".yellow());
-            println!("{}", stdout);
+            println!("{stdout}");
         }
 
         panic!(

--- a/facet/tests/functions.rs
+++ b/facet/tests/functions.rs
@@ -112,7 +112,7 @@ fn function_shape_debug_output() {
     }
 
     let shape = fn_shape!(debug_test);
-    let debug_output = format!("{:?}", shape);
+    let debug_output = format!("{shape:?}");
 
     // Check that debug output contains expected information
     assert!(debug_output.contains("debug_test"));


### PR DESCRIPTION
Right now, facet-serialize is "too generic" — different parts of it are being used by json/msgpack/etc. on one wide, and args on the other side.

By splitting it, we'll let two copies of it evolve separately.