### PR TITLE
Allow facet-json to build with no-default-features

### DIFF
--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -15,9 +15,9 @@ default = ["rich-diagnostics"]
 
 [dependencies]
 facet-core = { version = "0.27.16", path = "../facet-core", default-features = false }
-facet-deserialize = { version = "0.24.22", path = "../facet-deserialize", default-features = false }
+facet-deserialize = { version = "0.24.22", path = "../facet-deserialize", default-features = false, features = ["std"] }
 facet-reflect = { version = "0.27.16", path = "../facet-reflect", default-features = false }
-facet-serialize = { version = "0.24.18", path = "../facet-serialize", default-features = false }
+facet-serialize = { version = "0.24.18", path = "../facet-serialize", default-features = false, features = ["std"] }
 itoa = "1.0.15"
 lexical-parse-float = "1.0.5"
 lexical-parse-integer = "1.0.5"


### PR DESCRIPTION
`facet-json` doesn't currently build when `default-features = false` because that disables the `std` features of all the underlying crates, and `no-std`/`no-alloc` doesn't necessarily compile in all of the facet crates atm. 

It's also just not reasonable to expect a general-purpose json serializer/deserializer to work out-of-the-box without std at the moment, so I think this is the correct solution to this problem. 