### PR TITLE
Relax S: Facet constraint for HashMap impl

### DIFF
--- a/facet-core/src/impls_std/hashmap.rs
+++ b/facet-core/src/impls_std/hashmap.rs
@@ -15,7 +15,7 @@ unsafe impl<'a, K, V, S> Facet<'a> for HashMap<K, V, S>
 where
     K: Facet<'a> + core::cmp::Eq + core::hash::Hash,
     V: Facet<'a>,
-    S: Facet<'a> + Default + BuildHasher,
+    S: 'a + Default + BuildHasher,
 {
     const VTABLE: &'static ValueVTable = &const {
         ValueVTable::builder::<Self>()
@@ -56,10 +56,6 @@ where
                 TypeParam {
                     name: "V",
                     shape: || V::SHAPE,
-                },
-                TypeParam {
-                    name: "S",
-                    shape: || S::SHAPE,
                 },
             ])
             .ty(Type::User(UserType::Opaque))

--- a/facet/tests/generics.rs
+++ b/facet/tests/generics.rs
@@ -135,16 +135,13 @@ fn type_params_vec_f64() {
 fn type_params_hash_map_string_u8() {
     use std::collections::HashMap;
     let shape = HashMap::<String, u8>::SHAPE;
-    assert_eq!(shape.type_params.len(), 3);
+    assert_eq!(shape.type_params.len(), 2);
     let k = &shape.type_params[0];
     let v = &shape.type_params[1];
-    let s = &shape.type_params[2];
     assert_eq!(k.name, "K");
     assert_eq!(v.name, "V");
-    assert_eq!(s.name, "S");
     assert_eq!(k.shape(), String::SHAPE);
     assert_eq!(v.shape(), u8::SHAPE);
-    assert_eq!(s.shape().to_string(), "RandomState");
 }
 
 #[test]


### PR DESCRIPTION
This allows the impl to cover third-party hashers like ahash. On the flip side, we lose type information for the hasher itself.

Closes #867.