### PR TITLE
docs: fix typos

### DIFF
--- a/facet-core/src/types/def/mod.rs
+++ b/facet-core/src/types/def/mod.rs
@@ -47,12 +47,12 @@ pub enum Def {
     /// e.g. `HashMap<String, T>`
     Map(MapDef),
 
-    /// Unique set of homogenous values
+    /// Unique set of homogeneous values
     ///
     /// e.g. `HashSet<T>`
     Set(SetDef),
 
-    /// Ordered list of heterogenous values, variable size
+    /// Ordered list of heterogeneous values, variable size
     ///
     /// e.g. `Vec<T>`
     List(ListDef),

--- a/facet-macros-emit/src/generics.rs
+++ b/facet-macros-emit/src/generics.rs
@@ -336,7 +336,7 @@ mod tests {
     use crate::LifetimeName;
     use quote::{ToTokens as _, quote};
 
-    // Helper to render ToTokens implementors to string for comparison
+    // Helper to render ToTokens implementers to string for comparison
     fn render_to_string<T: quote::ToTokens>(t: T) -> String {
         quote!(#t).to_string()
     }

--- a/facet-macros-parse/src/function/fn_shape_input.rs
+++ b/facet-macros-parse/src/function/fn_shape_input.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use unsynn::*;
 
-// Re-use the generics parser from our other module
+// Reuse the generics parser from our other module
 use crate::generics::GenericParams;
 
 unsynn! {

--- a/facet-macros-parse/src/function/func_sig.rs
+++ b/facet-macros-parse/src/function/func_sig.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use unsynn::*;
 
-// Re-use the types from our other modules
+// Reuse the types from our other modules
 use crate::func_params::Parameter;
 use crate::generics::GenericParams;
 use crate::ret_type::ReturnType;

--- a/facet-macros-parse/src/function/type_params.rs
+++ b/facet-macros-parse/src/function/type_params.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use unsynn::*;
 
-// Re-use the generics parser
+// Reuse the generics parser
 use crate::generics::GenericParams;
 
 /// Extract just the type parameter names from generic parameters

--- a/facet-reflect/src/error.rs
+++ b/facet-reflect/src/error.rs
@@ -108,7 +108,7 @@ pub enum ReflectError {
     /// An unknown error occurred.
     Unknown,
 
-    /// An error occured while putting
+    /// An error occurred while putting
     TryFromError {
         /// The shape of the value being converted from.
         src_shape: &'static Shape,

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -145,7 +145,7 @@ enum PartialState {
 
 /// A type-erased, heap-allocated, partially-initialized value.
 ///
-/// [Partial] keeps track of the state of initialiation of the underlying
+/// [Partial] keeps track of the state of initialization of the underlying
 /// value: if we're building `struct S { a: u32, b: String }`, we may
 /// have initialized `a`, or `b`, or both, or neither.
 ///

--- a/facet-reflect/src/partial/partial_api.rs
+++ b/facet-reflect/src/partial/partial_api.rs
@@ -778,7 +778,7 @@ impl<'facet> Partial<'facet> {
         fr.deinit();
 
         // SAFETY: `fr.shape` and `src_shape` are the same, so they have the same size,
-        // and the preconditions for this function are that `src_value` is fully intialized.
+        // and the preconditions for this function are that `src_value` is fully initialized.
         unsafe {
             // unwrap safety: the only failure condition for copy_from is that shape is unsized,
             // which is not possible for `Partial`

--- a/facet-reflect/src/peek/list_like.rs
+++ b/facet-reflect/src/peek/list_like.rs
@@ -6,12 +6,12 @@ use core::{fmt::Debug, marker::PhantomData};
 /// Fields for types which act like lists
 #[derive(Clone, Copy)]
 pub enum ListLikeDef {
-    /// Ordered list of heterogenous values, variable size
+    /// Ordered list of heterogeneous values, variable size
     ///
     /// e.g. `Vec<T>`
     List(facet_core::ListDef),
 
-    /// Fixed-size array of heterogenous values
+    /// Fixed-size array of heterogeneous values
     ///
     /// e.g. `[T; 32]`
     Array(facet_core::ArrayDef),


### PR DESCRIPTION
Found via `codespell -S CHANGELOG.md -L ue,ser,statics,welp,optiona`