### PR TITLE
Unescape double-quotes and backslash in docstrings (#913 squashed+rebased)

### DIFF
--- a/facet-macros-emit/src/lib.rs
+++ b/facet-macros-emit/src/lib.rs
@@ -15,6 +15,8 @@ mod process_struct;
 mod derive;
 pub use derive::*;
 
+mod unescaping;
+
 #[cfg(feature = "function")]
 pub mod function;
 

--- a/facet-macros-emit/src/parsed.rs
+++ b/facet-macros-emit/src/parsed.rs
@@ -1,4 +1,4 @@
-use crate::{BoundedGenericParams, RenameRule};
+use crate::{BoundedGenericParams, RenameRule, unescaping::unescape};
 use facet_macros_parse::{Ident, ReprInner, ToTokens, TokenStream};
 use quote::quote;
 
@@ -395,8 +395,9 @@ impl PAttrs {
         for attr in attrs {
             match &attr.body.content {
                 facet_macros_parse::AttributeInner::Doc(doc_attr) => {
-                    // Handle doc comments
-                    doc_lines.push(doc_attr.value.as_str().replace("\\\"", "\""));
+                    let unescaped_text =
+                        unescape(doc_attr).expect("invalid escape sequence in doc string");
+                    doc_lines.push(unescaped_text);
                 }
                 facet_macros_parse::AttributeInner::Repr(repr_attr) => {
                     if repr.is_some() {

--- a/facet-macros-emit/src/unescaping.rs
+++ b/facet-macros-emit/src/unescaping.rs
@@ -1,0 +1,125 @@
+//! Processes string escapes and unescapes them for docstrings.
+
+use facet_macros_parse::DocInner;
+
+#[derive(Debug)]
+pub enum UnescapeError {
+    /// An illegal character was found following a backslash escape sequence (e.g., `\x`, `\n`, `\t`)
+    IllegalCharacterFollowingBackslash {
+        character_index: usize,
+        found: char,
+        string: String,
+    },
+    /// The string ended unexpectedly after a backslash character (e.g., `"hello world\"`)
+    UnexpectedEofFollowingBackslash {
+        character_index: usize,
+        string: String,
+    },
+}
+
+impl std::fmt::Display for UnescapeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UnescapeError::IllegalCharacterFollowingBackslash {
+                character_index,
+                found,
+                string,
+            } => {
+                write!(
+                    f,
+                    "Illegal character following a backslash at index {character_index} in {string:?}: found '{found}'"
+                )
+            }
+            UnescapeError::UnexpectedEofFollowingBackslash {
+                character_index,
+                string,
+            } => {
+                write!(
+                    f,
+                    "Unexpected end of file following a backslash at index {character_index} in {string:?}"
+                )
+            }
+        }
+    }
+}
+
+/// Unescapes a string that has backslashes, double quotes, and single quotes escaped with a preceding backslash.
+pub fn unescape(doc_attr: &DocInner) -> Result<String, UnescapeError> {
+    unescape_inner(doc_attr.value.as_str())
+}
+
+/// Private helper to avoid inappropriate use on strings not from a doc attribute.
+/// Exists to make testing easier.
+fn unescape_inner(s: &str) -> Result<String, UnescapeError> {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.char_indices();
+
+    while let Some((i, c)) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some((_, '\\')) => out.push('\\'),
+                Some((_, '"')) => out.push('"'),
+                Some((_, '\'')) => out.push('\''),
+                Some((_, found)) => {
+                    return Err(UnescapeError::IllegalCharacterFollowingBackslash {
+                        character_index: i,
+                        found,
+                        string: s.to_string(),
+                    });
+                }
+                None => {
+                    return Err(UnescapeError::UnexpectedEofFollowingBackslash {
+                        character_index: i,
+                        string: s.to_string(),
+                    });
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unescape_basic() {
+        assert_eq!(unescape_inner("hello").unwrap(), "hello");
+        assert_eq!(
+            unescape_inner(r#"hello \"world\""#).unwrap(),
+            r#"hello "world""#
+        );
+        assert_eq!(
+            unescape_inner(r#"hello \'world\'"#).unwrap(),
+            r#"hello 'world'"#
+        );
+        assert_eq!(unescape_inner(r#"back\\slash"#).unwrap(), r#"back\slash"#);
+    }
+
+    #[test]
+    fn test_unescape_errors() {
+        match unescape_inner(r#"invalid \x escape"#) {
+            Err(UnescapeError::IllegalCharacterFollowingBackslash {
+                character_index,
+                found,
+                ..
+            }) => {
+                assert_eq!(character_index, 8);
+                assert_eq!(found, 'x');
+            }
+            _ => panic!("Expected IllegalCharacterFollowingBackslash"),
+        }
+
+        match unescape_inner(r#"trailing backslash \"#) {
+            Err(UnescapeError::UnexpectedEofFollowingBackslash {
+                character_index, ..
+            }) => {
+                assert_eq!(character_index, 19);
+            }
+            _ => panic!("Expected UnexpectedEofFollowingBackslash"),
+        }
+    }
+}

--- a/facet-macros-emit/tests/evaluation/backslash_test.rs
+++ b/facet-macros-emit/tests/evaluation/backslash_test.rs
@@ -1,0 +1,26 @@
+use facet::Facet;
+use facet::Type;
+use facet::UserType;
+
+#[repr(u32)]
+#[derive(Facet)]
+enum Bruh {
+    /// Joe loves \bold{pizza}
+    /// Five backslashes: \\\\\
+    /// Six backslashes: \\\\\\
+    /// Five backslashes and a quote: \\\\\"
+    /// Six backslashes and a quote: \\\\\\"
+    #[expect(unused)]
+    Joe,
+}
+fn main() {
+    let Type::User(UserType::Enum(ty)) = Bruh::SHAPE.ty else {
+        unreachable!("Expected EntityId to be an enum");
+    };
+    let doc = &ty.variants[0].doc;
+    assert_eq!(doc[0], r#" Joe loves \bold{pizza}"#);
+    assert_eq!(doc[1], r#" Five backslashes: \\\\\"#);
+    assert_eq!(doc[2], r#" Six backslashes: \\\\\\"#);
+    assert_eq!(doc[3], r#" Five backslashes and a quote: \\\\\""#);
+    assert_eq!(doc[4], r#" Six backslashes and a quote: \\\\\\""#);
+}

--- a/facet-macros-emit/tests/evaluation/complex_doc.rs
+++ b/facet-macros-emit/tests/evaluation/complex_doc.rs
@@ -1,0 +1,63 @@
+use facet::Facet;
+use facet::Type;
+use facet::UserType;
+
+#[derive(Facet)]
+#[repr(u32)]
+enum Complex {
+    /// This is a complex docstring with various escape sequences:
+    /// 1. Double quotes: "quoted" and \"escaped quote\"
+    /// 2. Single quotes: 'quoted' and \'escaped quote\'
+    /// 3. Backslashes: \\ (single backslash) and \\\\ (double backslash)
+    /// 4. Mixed: \\" (backslash quote) and \\\" (backslash escaped quote)
+    /// 5. Trailing backslash: \\
+    /// 6. ASCII symbols: ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _ ` a b c d e f g h i j k l m n o p q r s t u v w x y z { | } ~
+    #[expect(unused)]
+    Variant,
+}
+
+fn main() {
+    let Type::User(UserType::Enum(ty)) = Complex::SHAPE.ty else {
+        unreachable!("Expected EntityId to be an enum");
+    };
+    let doc_lines = &ty.variants[0].doc;
+
+    // Read own source code
+    // file!() returns the path to the file. In the test environment, this is likely src/main.rs
+    // and the CWD is the project root, so this should work.
+    let source = std::fs::read_to_string(file!()).expect("Failed to read source file");
+    let lines: Vec<&str> = source.lines().collect();
+
+    let start_idx = lines
+        .iter()
+        .position(|l| l.contains("enum Complex {"))
+        .expect("Could not find enum start")
+        + 1;
+    let end_idx = lines
+        .iter()
+        .position(|l| l.contains("#[expect"))
+        .expect("Could not find enum end");
+
+    let expected_lines: Vec<String> = lines[start_idx..end_idx]
+        .iter()
+        .filter(|l| l.trim().starts_with("///"))
+        .map(|l| {
+            // Split on "///" and take the second part to get the content including the leading space
+            let parts: Vec<&str> = l.splitn(2, "///").collect();
+            parts[1].to_string()
+        })
+        .collect();
+
+    assert_eq!(doc_lines.len(), expected_lines.len(), "Line count mismatch");
+
+    for (i, (actual, expected)) in doc_lines.iter().zip(expected_lines.iter()).enumerate() {
+        assert_eq!(
+            actual,
+            expected,
+            "Mismatch at line {}\nExpected: '{}'\nActual:   '{}'",
+            i + 1,
+            expected,
+            actual
+        );
+    }
+}

--- a/facet-macros-emit/tests/evaluation/double_quotes.rs
+++ b/facet-macros-emit/tests/evaluation/double_quotes.rs
@@ -1,0 +1,18 @@
+use facet::Facet;
+use facet::Type;
+use facet::UserType;
+
+#[repr(u32)]
+#[derive(Facet)]
+enum Bruh {
+    /// He said "hello"
+    #[expect(unused)]
+    Greeting,
+}
+fn main() {
+    let Type::User(UserType::Enum(ty)) = Bruh::SHAPE.ty else {
+        unreachable!("Expected EntityId to be an enum");
+    };
+    let doc = ty.variants[0].doc[0];
+    assert!(doc == " He said \"hello\"", "Unexpected docstring, does it contain any unexpected escape sequences? : {}", doc);
+}

--- a/facet-macros-emit/tests/evaluation/mod.rs
+++ b/facet-macros-emit/tests/evaluation/mod.rs
@@ -1,0 +1,217 @@
+use std::fs;
+use std::path::Path;
+
+use owo_colors::OwoColorize;
+
+/// Test case structure for evaluation tests
+struct EvaluationTest {
+    /// Source code to compile
+    source: &'static str,
+    /// Name of the test for reporting purposes
+    name: &'static str,
+}
+
+/// Run a single evaluation test that is expected to compile and run successfully
+fn run_evaluation_test(test: &EvaluationTest) -> Result<(), String> {
+    println!(
+        "{}",
+        format_args!("Running test: {}", test.name).blue().bold()
+    );
+
+    // Create a random temp directory for the Cargo project
+    let temp_dir =
+        tempfile::tempdir().map_err(|e| format!("Failed to create temp directory: {e}"))?;
+    let project_dir = temp_dir.path();
+    println!(
+        "{}",
+        format_args!("  Project directory: {}", project_dir.display()).dimmed()
+    );
+
+    // Get absolute paths to the facet crates
+    let workspace_dir = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    let facet_path = workspace_dir.join("facet");
+    let facet_reflect_path = workspace_dir.join("facet-reflect");
+
+    // Create src directory
+    fs::create_dir(project_dir.join("src"))
+        .map_err(|e| format!("Failed to create src directory: {e}"))?;
+
+    // Create Cargo.toml with dependencies
+    // Use a unique package name to avoid race conditions when sharing CARGO_TARGET_DIR
+    let cargo_toml = format!(
+        r#"
+[package]
+name = "facet-test-project-{}"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+eyre = "0.6"
+facet = {{ path = {:?} }}
+facet-reflect = {{ path = {:?} }}
+    "#,
+        test.name,
+        facet_path.display(),
+        facet_reflect_path.display()
+    );
+
+    // Write the Cargo.toml file
+    fs::write(project_dir.join("Cargo.toml"), cargo_toml)
+        .map_err(|e| format!("Failed to write Cargo.toml: {e}"))?;
+
+    // Write the main.rs file
+    fs::write(project_dir.join("src").join("main.rs"), test.source)
+        .map_err(|e| format!("Failed to write main.rs: {e}"))?;
+
+    // Run cargo build
+    let mut build_cmd = std::process::Command::new("cargo");
+    build_cmd
+        .current_dir(project_dir)
+        .args(["build", "--color=always"])
+        .env("CARGO_TERM_COLOR", "always")
+        .env("CARGO_TARGET_DIR", "/tmp/ui_tests/target"); // Set consistent target directory
+
+    let build_output = build_cmd
+        .output()
+        .map_err(|e| format!("Failed to execute cargo build: {e}"))?;
+
+    // Check if compilation succeeded
+    let build_exit_code = build_output.status.code().unwrap_or(1);
+    let build_stderr = String::from_utf8_lossy(&build_output.stderr);
+    let build_stdout = String::from_utf8_lossy(&build_output.stdout);
+
+    if build_exit_code != 0 {
+        println!("{}", "❌ Test failed:".bright_red().bold());
+        println!(
+            "{}",
+            "  The code failed to compile, but it should have succeeded".red()
+        );
+
+        // Print the build output for debugging
+        println!("{}", "\nCompiler error output:".yellow().bold());
+        println!("{build_stderr}");
+
+        if !build_stdout.is_empty() {
+            println!("{}", "\nCompiler standard output:".yellow());
+            println!("{build_stdout}");
+        }
+
+        return Err(format!(
+            "Test '{}' failed to compile with exit code {}",
+            test.name, build_exit_code
+        ));
+    } else {
+        println!("{}", "  ✓ Compilation succeeded".green());
+    }
+
+    // Run the compiled program
+    let mut run_cmd = std::process::Command::new("cargo");
+    run_cmd
+        .current_dir(project_dir)
+        .args(["run", "--color=always"])
+        .env("CARGO_TERM_COLOR", "always")
+        .env("CARGO_TARGET_DIR", "/tmp/ui_tests/target");
+
+    let run_output = run_cmd
+        .output()
+        .map_err(|e| format!("Failed to execute cargo run: {e}"))?;
+
+    // Check if the program ran successfully
+    let run_exit_code = run_output.status.code().unwrap_or(1);
+    let run_stderr = String::from_utf8_lossy(&run_output.stderr);
+    let run_stdout = String::from_utf8_lossy(&run_output.stdout);
+
+    if run_exit_code != 0 {
+        println!("{}", "❌ Test failed:".bright_red().bold());
+        println!(
+            "{}",
+            format_args!("  The program exited with non-zero status code: {run_exit_code}").red()
+        );
+
+        // Print the runtime output for debugging
+        if !run_stdout.is_empty() {
+            println!("{}", "\nProgram standard output:".yellow().bold());
+            println!("{run_stdout}");
+        }
+
+        if !run_stderr.is_empty() {
+            println!("{}", "\nProgram error output:".yellow().bold());
+            println!("{run_stderr}");
+        }
+
+        return Err(format!(
+            "Test '{}' exited with non-zero status code: {}",
+            test.name, run_exit_code
+        ));
+    } else {
+        println!("{}", "  ✓ Program ran successfully".green());
+    }
+
+    // Print output if present (for informational purposes)
+    if !run_stdout.is_empty() {
+        println!(
+            "{}",
+            format_args!("  Program output:\n{run_stdout}").dimmed()
+        );
+    }
+
+    println!(
+        "{}",
+        format_args!("  ✓ Test '{}' passed", test.name)
+            .green()
+            .bold()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_single_quotes() -> Result<(), String> {
+    // Define the test case
+    let test = EvaluationTest {
+        name: "single_quotes",
+        source: include_str!("./single_quotes.rs"),
+    };
+
+    // Run the test
+    run_evaluation_test(&test)?;
+    Ok(())
+}
+
+#[test]
+fn test_double_quotes() -> Result<(), String> {
+    // Define the test case
+    let test = EvaluationTest {
+        name: "double_quotes",
+        source: include_str!("./double_quotes.rs"),
+    };
+
+    // Run the test
+    run_evaluation_test(&test)?;
+    Ok(())
+}
+
+#[test]
+fn test_backslash() -> Result<(), String> {
+    // Define the test case
+    let test = EvaluationTest {
+        name: "backslash_test",
+        source: include_str!("./backslash_test.rs"),
+    };
+
+    // Run the test
+    run_evaluation_test(&test)?;
+    Ok(())
+}
+
+#[test]
+fn test_complex_doc() -> Result<(), String> {
+    // Define the test case
+    let test = EvaluationTest {
+        name: "complex_doc",
+        source: include_str!("./complex_doc.rs"),
+    };
+
+    // Run the test
+    run_evaluation_test(&test)?;
+    Ok(())
+}

--- a/facet-macros-emit/tests/evaluation/single_quotes.rs
+++ b/facet-macros-emit/tests/evaluation/single_quotes.rs
@@ -1,0 +1,18 @@
+use facet::Facet;
+use facet::Type;
+use facet::UserType;
+
+#[repr(u32)]
+#[derive(Facet)]
+enum Bruh {
+    /// Welcome to Joe's!
+    #[expect(unused)]
+    Joes,
+}
+fn main() {
+    let Type::User(UserType::Enum(ty)) = Bruh::SHAPE.ty else {
+        unreachable!("Expected EntityId to be an enum");
+    };
+    let doc = ty.variants[0].doc[0];
+    assert!(doc == " Welcome to Joe's!", "Unexpected docstring, does it contain any unexpected escape sequences? : {}", doc);
+}

--- a/facet-macros-emit/tests/mod.rs
+++ b/facet-macros-emit/tests/mod.rs
@@ -2,3 +2,5 @@
 mod compile_tests;
 
 mod codegen;
+
+mod evaluation;


### PR DESCRIPTION
Squashed, rebased, and slightly cleaned up version of #913 by @TeamDman 