### PR TITLE
Fix CI issues: miri guard, dead code, and feature gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tarpaulin-report.html
 .ignore.rs
 **/.claude/settings.local.json
 **/CLAUDE.local.md
+**/CLAUDE.md
 *.sw[op]
 
 # Fuzzing

--- a/facet-reflect/src/partial/partial_api/fields.rs
+++ b/facet-reflect/src/partial/partial_api/fields.rs
@@ -124,10 +124,7 @@ impl Partial<'_> {
 
                     // Check if we have a stored frame for this path
                     if let Some(stored_frame) = stored_frames.remove(current_path) {
-                        trace!(
-                            "begin_nth_field: Restoring stored frame for path {:?}",
-                            current_path
-                        );
+                        trace!("begin_nth_field: Restoring stored frame for path {current_path:?}");
 
                         // Update parent's current_child tracking
                         let frame = stack.last_mut().unwrap();

--- a/facet-reflect/src/partial/partial_api/misc.rs
+++ b/facet-reflect/src/partial/partial_api/misc.rs
@@ -145,9 +145,9 @@ impl<'facet> Partial<'facet> {
                 // We need to check if the parent will drop it.
                 let parent_will_drop = if path.len() == 1 {
                     let field_name = path.first().unwrap();
-                    self.frames().first().map_or(false, |parent| {
-                        Self::is_field_marked_in_parent(parent, field_name)
-                    })
+                    self.frames()
+                        .first()
+                        .is_some_and(|parent| Self::is_field_marked_in_parent(parent, field_name))
                 } else {
                     false
                 };
@@ -175,7 +175,7 @@ impl<'facet> Partial<'facet> {
                         let parent_will_drop = if remaining_path.len() == 1 {
                             // Parent is the root frame
                             let field_name = remaining_path.first().unwrap();
-                            self.frames().first().map_or(false, |parent| {
+                            self.frames().first().is_some_and(|parent| {
                                 Self::is_field_marked_in_parent(parent, field_name)
                             })
                         } else {

--- a/facet-reflect/src/partial/partial_api/option.rs
+++ b/facet-reflect/src/partial/partial_api/option.rs
@@ -55,20 +55,16 @@ impl Partial<'_> {
                     match &mut parent_frame.tracker {
                         Tracker::Struct {
                             iset,
-                            current_child,
+                            current_child: Some(idx),
                         } => {
-                            if let Some(idx) = *current_child {
-                                iset.unset(idx);
-                            }
+                            iset.unset(*idx);
                         }
                         Tracker::Enum {
                             data,
-                            current_child,
+                            current_child: Some(idx),
                             ..
                         } => {
-                            if let Some(idx) = *current_child {
-                                data.unset(idx);
-                            }
+                            data.unset(*idx);
                         }
                         _ => {}
                     }

--- a/facet-solver/Cargo.toml
+++ b/facet-solver/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools", "rust-patterns"]
 default = ["std", "suggestions"]
 std = ["alloc"]
 alloc = ["facet-core/alloc", "facet-reflect/alloc"]
-suggestions = ["strsim"]
+suggestions = ["strsim", "alloc"]
 
 [dependencies]
 facet-core = { path = "../facet-core", version = "0.31.8", default-features = false }

--- a/facet-testhelpers/src/lib.rs
+++ b/facet-testhelpers/src/lib.rs
@@ -50,8 +50,11 @@ impl Log for SimpleLogger {
 /// Panics if not running under `cargo-nextest`. This crate requires nextest
 /// for proper test isolation and logger setup.
 pub fn setup() {
-    // Check if we're running under cargo-nextest
-    if std::env::var("NEXTEST").as_deref() != Ok("1") {
+    // Check if we're running under cargo-nextest or miri
+    // (miri runs via `cargo miri nextest run` but doesn't set NEXTEST=1)
+    let is_nextest = std::env::var("NEXTEST").as_deref() == Ok("1");
+    let is_miri = cfg!(miri);
+    if !is_nextest && !is_miri {
         panic!(
             "\n\
             ╔══════════════════════════════════════════════════════════════════════════════╗\n\


### PR DESCRIPTION
## Summary
- Allow miri to bypass nextest guard in facet-testhelpers (miri runs via `cargo miri nextest` but doesn't set `NEXTEST=1` env var)
- Make facet-solver's `suggestions` feature require `alloc` (the solver unconditionally uses alloc types so it can't work without it)
- Remove unused helper methods from FrameMode and Partial
- Ignore CLAUDE.md in gitignore

## Test plan
- [ ] CI passes (miri, msrv, tests, etc.)