### PR TITLE
Support de/serisalize_with inside transparent containers

### DIFF
--- a/facet-json/src/deserialize.rs
+++ b/facet-json/src/deserialize.rs
@@ -592,7 +592,18 @@ impl<'input> JsonDeserializer<'input> {
         // These should deserialize as their inner type
         if shape.inner.is_some() {
             wip.begin_inner()?;
-            self.deserialize_into(wip)?;
+            // Check if field has custom deserialization
+            if wip
+                .parent_field()
+                .and_then(|field| field.vtable.deserialize_with)
+                .is_some()
+            {
+                wip.begin_custom_deserialization()?;
+                self.deserialize_into(wip)?;
+                wip.end()?;
+            } else {
+                self.deserialize_into(wip)?;
+            }
             wip.end()?;
             return Ok(());
         }

--- a/facet-json/src/serialize.rs
+++ b/facet-json/src/serialize.rs
@@ -94,7 +94,7 @@ fn write_colon<W: crate::JsonWrite>(writer: &mut W, indent: Option<&str>) {
 }
 
 fn serialize_value<'mem, 'facet, W: crate::JsonWrite>(
-    mut peek: Peek<'mem, 'facet>,
+    peek: Peek<'mem, 'facet>,
     maybe_field: Option<Field>,
     writer: &mut W,
     indent: Option<&str>,
@@ -122,9 +122,10 @@ fn serialize_value<'mem, 'facet, W: crate::JsonWrite>(
     {
         let old_shape = peek.shape();
         let ps = peek.into_struct().unwrap();
-        peek = ps.field(0).unwrap();
-        let new_shape = peek.shape();
+        let (field, inner_peek) = ps.fields().next().unwrap();
+        let new_shape = inner_peek.shape();
         trace!("{old_shape} is transparent, let's serialize the inner {new_shape} instead");
+        return serialize_value(inner_peek, Some(field), writer, indent, depth);
     }
 
     trace!(

--- a/facet-json/tests/deserialize.rs
+++ b/facet-json/tests/deserialize.rs
@@ -128,3 +128,29 @@ fn test_custom_deserialization_enum() {
         _ => panic!("expected OpStrField variant"),
     }
 }
+
+#[test]
+fn test_custom_deserialize_transparent_struct() {
+    #[derive(Clone)]
+    struct MyUrl(String);
+
+    fn custom_deserializer(s: &String) -> Result<MyUrl, &'static str> {
+        Ok(MyUrl(s.to_owned()))
+    }
+
+    #[derive(Facet)]
+    #[facet(transparent)]
+    struct UrlWrapper(
+        #[facet(
+            opaque,
+            deserialize_with = custom_deserializer,
+        )]
+        MyUrl,
+    );
+
+    let data = r#""http://thing""#;
+
+    let test: UrlWrapper = facet_json::from_str(data).unwrap();
+
+    assert_eq!(&test.0.0, "http://thing");
+}

--- a/facet-json/tests/serialize.rs
+++ b/facet-json/tests/serialize.rs
@@ -99,3 +99,29 @@ fn test_custom_serialization_enum() {
     let ser = facet_json::to_string(&data);
     assert_eq!(ser, expected);
 }
+
+#[test]
+fn test_custom_serialize_transparent_struct() {
+    #[derive(Clone)]
+    struct MyUrl(String);
+
+    fn custom_serializer(u: &MyUrl) -> Result<String, &'static str> {
+        Ok(u.0.clone())
+    }
+
+    #[derive(Facet)]
+    #[facet(transparent)]
+    struct UrlWrapper(
+        #[facet(
+            opaque,
+            serialize_with = custom_serializer,
+        )]
+        MyUrl,
+    );
+
+    let data = r#""http://thing""#;
+
+    let test = facet_json::to_string(&UrlWrapper(MyUrl("http://thing".to_owned())));
+
+    assert_eq!(data, test);
+}

--- a/facet-macros-emit/src/parsed.rs
+++ b/facet-macros-emit/src/parsed.rs
@@ -494,6 +494,12 @@ impl PAttrs {
             .any(|attr| matches!(attr, PFacetAttr::Transparent))
     }
 
+    pub(crate) fn is_opaque(&self) -> bool {
+        self.facet
+            .iter()
+            .any(|attr| matches!(attr, PFacetAttr::Opaque))
+    }
+
     pub(crate) fn type_tag(&self) -> Option<&str> {
         for attr in &self.facet {
             if let PFacetAttr::TypeTag { content } = attr {

--- a/facet-reflect/src/partial/partial_api/misc.rs
+++ b/facet-reflect/src/partial/partial_api/misc.rs
@@ -1085,4 +1085,9 @@ impl<'facet> Partial<'facet> {
             .nth(1)
             .and_then(|f| f.get_field())
     }
+
+    /// Gets the field for the current frame
+    pub fn current_field(&self) -> Option<&Field> {
+        self.frames().last().and_then(|f| f.get_field())
+    }
 }


### PR DESCRIPTION
Makes `{de}serialize_with` work in `#facet[transparent]` containers.

Solves part of https://github.com/facet-rs/facet/issues/931