### PR TITLE
Add facet-assert crate for structural assertions without PartialEq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-assert"
+version = "0.31.0"
+dependencies = [
+ "facet",
+ "facet-core",
+ "facet-pretty",
+ "facet-reflect",
+ "facet-showcase",
+ "owo-colors",
+]
+
+[[package]]
 name = "facet-core"
 version = "0.31.8"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
 
     # utilities
     "facet-diff",
+    "facet-assert",
 
     # showcase infrastructure
     "facet-showcase",

--- a/docs/build-website.rs
+++ b/docs/build-website.rs
@@ -57,6 +57,7 @@ fn main() {
             ("facet-kdl", "kdl_showcase", "kdl"),
             ("facet-json", "json_showcase", "json"),
             ("facet-yaml", "yaml_showcase", "yaml"),
+            ("facet-assert", "assert_showcase", "assert"),
         ];
 
         let handles: Vec<_> = showcases

--- a/docs/content/showcases/assert.md
+++ b/docs/content/showcases/assert.md
@@ -1,0 +1,135 @@
++++
+title = "facet-assert: Structural Assertions"
++++
+
+<div class="showcase">
+
+## Same Values
+
+<section class="scenario">
+<p class="description">Two values with identical content pass <code>assert_same!</code> — no <code>PartialEq</code> required.</p>
+<div class="target-type">
+<h4>Target Type</h4>
+<pre style="background-color:#1a1b26;">
+<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
+</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Config </span><span style="color:#9abdf5;">{
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">debug</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">tags</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Vec</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
+</span><span style="color:#9abdf5;">}</span></pre>
+
+</div>
+<div class="success">
+<h4>Success</h4>
+<pre><code><span style="font-weight:bold">Config</span><span style="opacity:0.7"> {</span>
+  <span style="color:#56b6c2">host</span><span style="opacity:0.7">: </span><span style="color:rgb(188,224,81)">localhost</span><span style="opacity:0.7">,</span>
+  <span style="color:#56b6c2">port</span><span style="opacity:0.7">: </span><span style="color:rgb(224,186,81)">8080</span><span style="opacity:0.7">,</span>
+  <span style="color:#56b6c2">debug</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="opacity:0.7">,</span>
+  <span style="color:#56b6c2">tags</span><span style="opacity:0.7">: </span><span style="font-weight:bold">Vec&lt;String&gt;</span><span style="opacity:0.7"> [</span>
+    <span style="color:rgb(188,224,81)">prod</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(188,224,81)">api</span><span style="opacity:0.7">,</span>
+  <span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
+<span style="opacity:0.7">}</span></code></pre>
+</div>
+</section>
+
+## Cross-Type Comparison
+
+<section class="scenario">
+<p class="description">Different type names (<code>Config</code> vs <code>ConfigV2</code>) with the same structure are considered "same". Useful for comparing DTOs across API versions or testing serialization roundtrips.</p>
+<div class="target-type">
+<h4>Target Type</h4>
+<pre style="background-color:#1a1b26;">
+<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
+</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Config </span><span style="color:#9abdf5;">{
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">debug</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">tags</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Vec</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
+</span><span style="color:#9abdf5;">}</span></pre>
+
+</div>
+<div class="success">
+<h4>Success</h4>
+<pre><code><span style="font-weight:bold">Config</span><span style="opacity:0.7"> {</span>
+  <span style="color:#56b6c2">host</span><span style="opacity:0.7">: </span><span style="color:rgb(188,224,81)">localhost</span><span style="opacity:0.7">,</span>
+  <span style="color:#56b6c2">port</span><span style="opacity:0.7">: </span><span style="color:rgb(224,186,81)">8080</span><span style="opacity:0.7">,</span>
+  <span style="color:#56b6c2">debug</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="opacity:0.7">,</span>
+  <span style="color:#56b6c2">tags</span><span style="opacity:0.7">: </span><span style="font-weight:bold">Vec&lt;String&gt;</span><span style="opacity:0.7"> [</span>
+    <span style="color:rgb(188,224,81)">prod</span><span style="opacity:0.7">,</span>
+  <span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
+<span style="opacity:0.7">}</span></code></pre>
+</div>
+</section>
+
+## Nested Structs
+
+<section class="scenario">
+<p class="description">Nested structs are compared recursively, field by field.</p>
+<div class="target-type">
+<h4>Target Type</h4>
+<pre style="background-color:#1a1b26;">
+<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
+</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Person </span><span style="color:#9abdf5;">{
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">age</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">address</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> Address,
+</span><span style="color:#9abdf5;">}
+</span><span style="color:#c0caf5;">
+</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
+</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Address </span><span style="color:#9abdf5;">{
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">street</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
+</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">city</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
+</span><span style="color:#9abdf5;">}</span></pre>
+
+</div>
+<div class="success">
+<h4>Success</h4>
+<pre><code><span style="font-weight:bold">Person</span><span style="opacity:0.7"> {</span>
+  <span style="color:#56b6c2">name</span><span style="opacity:0.7">: </span><span style="color:rgb(188,224,81)">Alice</span><span style="opacity:0.7">,</span>
+  <span style="color:#56b6c2">age</span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">30</span><span style="opacity:0.7">,</span>
+  <span style="color:#56b6c2">address</span><span style="opacity:0.7">: </span><span style="font-weight:bold">Address</span><span style="opacity:0.7"> {</span>
+    <span style="color:#56b6c2">street</span><span style="opacity:0.7">: </span><span style="color:rgb(188,224,81)">123 Main St</span><span style="opacity:0.7">,</span>
+    <span style="color:#56b6c2">city</span><span style="opacity:0.7">: </span><span style="color:rgb(188,224,81)">Springfield</span><span style="opacity:0.7">,</span>
+  <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
+<span style="opacity:0.7">}</span></code></pre>
+</div>
+</section>
+
+## Structural Diff
+
+<section class="scenario">
+<p class="description">When values differ, you get a precise structural diff showing exactly which fields changed and at what path — not just a wall of red/green text.</p>
+<div class="diff-output">
+<h4>Diff Output</h4>
+<pre><code><span style="font-weight:bold">.host</span>:
+  <span style="color:#e06c75">- localhost</span>
+  <span style="color:#98c379">+ prod.example.com</span>
+<span style="font-weight:bold">.port</span>:
+  <span style="color:#e06c75">- 8080</span>
+  <span style="color:#98c379">+ 443</span>
+<span style="font-weight:bold">.debug</span>:
+  <span style="color:#e06c75">- true</span>
+  <span style="color:#98c379">+ false</span>
+<span style="font-weight:bold">.tags[1]</span> (only in left):
+  <span style="color:#e06c75">- api</span>
+</code></pre>
+</div>
+</section>
+
+## Vector Differences
+
+<section class="scenario">
+<p class="description">Vector comparisons show exactly which indices differ, which elements were added, and which were removed.</p>
+<div class="diff-output">
+<h4>Diff Output</h4>
+<pre><code><span style="font-weight:bold">[2]</span>:
+  <span style="color:#e06c75">- 3</span>
+  <span style="color:#98c379">+ 99</span>
+<span style="font-weight:bold">[4]</span> (only in left):
+  <span style="color:#e06c75">- 5</span>
+</code></pre>
+</div>
+</section>
+</div>

--- a/docs/content/showcases/json.md
+++ b/docs/content/showcases/json.md
@@ -295,16 +295,16 @@ title = "facet-json Comprehensive Showcase"
 <div class="success">
 <h4>Success</h4>
 <pre><code><span style="font-weight:bold">HashMap&lt;i32, &amp;str&gt;</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(224,81,93)">2</span><span style="opacity:0.7">: </span><span style="color:#e5c07b">two</span><span style="opacity:0.7">,</span>
   <span style="color:rgb(224,81,93)">1</span><span style="opacity:0.7">: </span><span style="color:#e5c07b">one</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(224,81,93)">2</span><span style="opacity:0.7">: </span><span style="color:#e5c07b">two</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <div class="serialized-output">
 <h4>JSON Output</h4>
 <pre style="background-color:#1a1b26;">
 <span style="color:#9abdf5;">{
-</span><span style="color:#c0caf5;">  </span><span style="color:#89ddff;">&quot;</span><span style="color:#7aa2f7;">2</span><span style="color:#89ddff;">&quot;: &quot;</span><span style="color:#9ece6a;">two</span><span style="color:#89ddff;">&quot;,
-</span><span style="color:#c0caf5;">  </span><span style="color:#89ddff;">&quot;</span><span style="color:#7aa2f7;">1</span><span style="color:#89ddff;">&quot;: &quot;</span><span style="color:#9ece6a;">one</span><span style="color:#89ddff;">&quot;
+</span><span style="color:#c0caf5;">  </span><span style="color:#89ddff;">&quot;</span><span style="color:#7aa2f7;">1</span><span style="color:#89ddff;">&quot;: &quot;</span><span style="color:#9ece6a;">one</span><span style="color:#89ddff;">&quot;,
+</span><span style="color:#c0caf5;">  </span><span style="color:#89ddff;">&quot;</span><span style="color:#7aa2f7;">2</span><span style="color:#89ddff;">&quot;: &quot;</span><span style="color:#9ece6a;">two</span><span style="color:#89ddff;">&quot;
 </span><span style="color:#9abdf5;">}</span></pre>
 
 </div>

--- a/docs/content/showcases/yaml.md
+++ b/docs/content/showcases/yaml.md
@@ -229,16 +229,16 @@ title = "facet-yaml Comprehensive Showcase"
 <div class="success">
 <h4>Success</h4>
 <pre><code><span style="font-weight:bold">HashMap&lt;String, i32&gt;</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(188,224,81)">two</span><span style="opacity:0.7">: </span><span style="color:rgb(224,81,93)">2</span><span style="opacity:0.7">,</span>
   <span style="color:rgb(188,224,81)">one</span><span style="opacity:0.7">: </span><span style="color:rgb(224,81,93)">1</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(188,224,81)">two</span><span style="opacity:0.7">: </span><span style="color:rgb(224,81,93)">2</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <div class="serialized-output">
 <h4>YAML Output</h4>
 <pre style="background-color:#1a1b26;">
 <span style="color:#c0caf5;">---
-</span><span style="color:#f7768e;">two</span><span style="color:#89ddff;">: </span><span style="color:#ff9e64;">2
-</span><span style="color:#f7768e;">one</span><span style="color:#89ddff;">: </span><span style="color:#ff9e64;">1</span></pre>
+</span><span style="color:#f7768e;">one</span><span style="color:#89ddff;">: </span><span style="color:#ff9e64;">1
+</span><span style="color:#f7768e;">two</span><span style="color:#89ddff;">: </span><span style="color:#ff9e64;">2</span></pre>
 
 </div>
 </section>
@@ -256,16 +256,16 @@ title = "facet-yaml Comprehensive Showcase"
 <div class="success">
 <h4>Success</h4>
 <pre><code><span style="font-weight:bold">HashMap&lt;i32, &amp;str&gt;</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(224,81,93)">2</span><span style="opacity:0.7">: </span><span style="color:#e5c07b">two</span><span style="opacity:0.7">,</span>
   <span style="color:rgb(224,81,93)">1</span><span style="opacity:0.7">: </span><span style="color:#e5c07b">one</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(224,81,93)">2</span><span style="opacity:0.7">: </span><span style="color:#e5c07b">two</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <div class="serialized-output">
 <h4>YAML Output</h4>
 <pre style="background-color:#1a1b26;">
 <span style="color:#c0caf5;">---
-</span><span style="color:#ff9e64;">2</span><span style="color:#89ddff;">: </span><span style="color:#9ece6a;">two
-</span><span style="color:#ff9e64;">1</span><span style="color:#89ddff;">: </span><span style="color:#9ece6a;">one</span></pre>
+</span><span style="color:#ff9e64;">1</span><span style="color:#89ddff;">: </span><span style="color:#9ece6a;">one
+</span><span style="color:#ff9e64;">2</span><span style="color:#89ddff;">: </span><span style="color:#9ece6a;">two</span></pre>
 
 </div>
 </section>

--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -37,8 +37,9 @@
     <main class="content {% if page.path is starting_with("/showcases/") %}showcase-container{% endif %}">
         {% if page.path is starting_with("/showcases/") %}
         <nav class="format-nav">
-            <a href="/showcases/kdl/" {% if page.path == "/showcases/kdl/" %}class="active"{% endif %}>KDL</a>
+            <a href="/showcases/assert/" {% if page.path == "/showcases/assert/" %}class="active"{% endif %}>Assert</a>
             <a href="/showcases/json/" {% if page.path == "/showcases/json/" %}class="active"{% endif %}>JSON</a>
+            <a href="/showcases/kdl/" {% if page.path == "/showcases/kdl/" %}class="active"{% endif %}>KDL</a>
             <a href="/showcases/yaml/" {% if page.path == "/showcases/yaml/" %}class="active"{% endif %}>YAML</a>
         </nav>
         {% endif %}

--- a/facet-assert/Cargo.toml
+++ b/facet-assert/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "facet-assert"
+version = "0.31.0"
+edition = "2024"
+rust-version = "1.87.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/facet-rs/facet"
+description = "Pretty assertions for Facet types - no PartialEq required"
+keywords = ["facet", "assert", "testing", "diff", "comparison"]
+categories = ["development-tools", "development-tools::testing"]
+
+[dependencies]
+facet = { path = "../facet" }
+facet-core = { path = "../facet-core" }
+facet-reflect = { path = "../facet-reflect" }
+facet-pretty = { path = "../facet-pretty" }
+
+[dev-dependencies]
+facet = { path = "../facet" }
+facet-showcase = { path = "../facet-showcase" }
+owo-colors = "4"

--- a/facet-assert/README.md
+++ b/facet-assert/README.md
@@ -1,0 +1,155 @@
+# facet-assert
+
+[![Coverage Status](https://coveralls.io/repos/github/facet-rs/facet-assert/badge.svg?branch=main)](https://coveralls.io/github/facet-rs/facet?branch=main)
+[![crates.io](https://img.shields.io/crates/v/facet-assert.svg)](https://crates.io/crates/facet-assert)
+[![documentation](https://docs.rs/facet-assert/badge.svg)](https://docs.rs/facet-assert)
+[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/facet-assert.svg)](./LICENSE)
+[![Discord](https://img.shields.io/discord/1379550208551026748?logo=discord&label=discord)](https://discord.gg/JhD7CwCJ8F)
+
+Pretty assertions for [Facet](https://github.com/facet-rs/facet) types.
+
+## What makes this different?
+
+### No `PartialEq` required
+
+Standard Rust assertions need `PartialEq`:
+
+```text
+assert_eq!(a, b); // Requires: PartialEq + Debug
+```
+
+`facet-assert` uses **structural comparison via reflection**:
+
+```text
+assert_same!(a, b); // Requires: Facet (that's it!)
+```
+
+This works because Facet gives us full introspection into any type's structure.
+
+### Structural sameness, not type identity
+
+Two values are "same" if they have **the same structure and values** — even if
+they have different type names:
+
+```ignore
+#[derive(Facet)]
+struct PersonV1 { name: String, age: u32 }
+
+#[derive(Facet)]
+struct PersonV2 { name: String, age: u32 }
+
+let a = PersonV1 { name: "Alice".into(), age: 30 };
+let b = PersonV2 { name: "Alice".into(), age: 30 };
+
+assert_same!(a, b); // Passes! Same structure, same values.
+```
+
+This is useful for:
+- Comparing DTOs across API versions
+- Testing serialization roundtrips (JSON → struct → JSON)
+- Comparing values parsed from different formats (YAML vs TOML vs JSON)
+
+### Smart structural diffs
+
+When values differ, you get a **structural diff** — not just line-by-line text
+comparison. We know which fields changed:
+
+```text
+.host:
+  - localhost
+  + prod.example.com
+.port:
+  - 8080
+  + 443
+.tags[1] (only in left):
+  - api
+```
+
+Instead of a wall of red/green like traditional diff tools.
+
+### Opaque types fail clearly
+
+If a type cannot be inspected (opaque), the assertion fails with a clear message
+rather than silently giving wrong results:
+
+```text
+assertion `assert_same!(left, right)` failed: cannot compare opaque type `SomeOpaqueType`
+```
+
+## Usage
+
+```ignore
+use facet::Facet;
+use facet_assert::assert_same;
+
+#[derive(Facet)]
+struct Config {
+    host: String,
+    port: u16,
+    debug: bool,
+}
+
+#[test]
+fn test_config_parsing() {
+    let from_json: Config = parse_json("...");
+    let from_yaml: Config = parse_yaml("...");
+
+    assert_same!(from_json, from_yaml);
+}
+```
+
+## Macros
+
+- `assert_same!(a, b)` — panics if `a` and `b` are not structurally same
+- `assert_same!(a, b, "message {}", x)` — with custom message
+- `debug_assert_same!(...)` — only in debug builds
+
+## Sponsors
+
+Thanks to all individual sponsors:
+
+<p> <a href="https://github.com/sponsors/fasterthanlime">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-light.svg" height="40" alt="GitHub Sponsors">
+</picture>
+</a> <a href="https://patreon.com/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-light.svg" height="40" alt="Patreon">
+    </picture>
+</a> </p>
+
+...along with corporate sponsors:
+
+<p> <a href="https://aws.amazon.com">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-light.svg" height="40" alt="AWS">
+</picture>
+</a> <a href="https://zed.dev">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-light.svg" height="40" alt="Zed">
+</picture>
+</a> <a href="https://depot.dev?utm_source=facet">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-light.svg" height="40" alt="Depot">
+</picture>
+</a> </p>
+
+...without whom this work could not exist.
+
+## Special thanks
+
+The facet logo was drawn by [Misiasart](https://misiasart.com/).
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/facet-rs/facet/blob/main/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/facet-rs/facet/blob/main/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/facet-assert/README.md.in
+++ b/facet-assert/README.md.in
@@ -1,0 +1,97 @@
+Pretty assertions for [Facet](https://github.com/facet-rs/facet) types.
+
+## What makes this different?
+
+### No `PartialEq` required
+
+Standard Rust assertions need `PartialEq`:
+
+```text
+assert_eq!(a, b); // Requires: PartialEq + Debug
+```
+
+`facet-assert` uses **structural comparison via reflection**:
+
+```text
+assert_same!(a, b); // Requires: Facet (that's it!)
+```
+
+This works because Facet gives us full introspection into any type's structure.
+
+### Structural sameness, not type identity
+
+Two values are "same" if they have **the same structure and values** — even if
+they have different type names:
+
+```ignore
+#[derive(Facet)]
+struct PersonV1 { name: String, age: u32 }
+
+#[derive(Facet)]
+struct PersonV2 { name: String, age: u32 }
+
+let a = PersonV1 { name: "Alice".into(), age: 30 };
+let b = PersonV2 { name: "Alice".into(), age: 30 };
+
+assert_same!(a, b); // Passes! Same structure, same values.
+```
+
+This is useful for:
+- Comparing DTOs across API versions
+- Testing serialization roundtrips (JSON → struct → JSON)
+- Comparing values parsed from different formats (YAML vs TOML vs JSON)
+
+### Smart structural diffs
+
+When values differ, you get a **structural diff** — not just line-by-line text
+comparison. We know which fields changed:
+
+```text
+.host:
+  - localhost
+  + prod.example.com
+.port:
+  - 8080
+  + 443
+.tags[1] (only in left):
+  - api
+```
+
+Instead of a wall of red/green like traditional diff tools.
+
+### Opaque types fail clearly
+
+If a type cannot be inspected (opaque), the assertion fails with a clear message
+rather than silently giving wrong results:
+
+```text
+assertion `assert_same!(left, right)` failed: cannot compare opaque type `SomeOpaqueType`
+```
+
+## Usage
+
+```ignore
+use facet::Facet;
+use facet_assert::assert_same;
+
+#[derive(Facet)]
+struct Config {
+    host: String,
+    port: u16,
+    debug: bool,
+}
+
+#[test]
+fn test_config_parsing() {
+    let from_json: Config = parse_json("...");
+    let from_yaml: Config = parse_yaml("...");
+
+    assert_same!(from_json, from_yaml);
+}
+```
+
+## Macros
+
+- `assert_same!(a, b)` — panics if `a` and `b` are not structurally same
+- `assert_same!(a, b, "message {}", x)` — with custom message
+- `debug_assert_same!(...)` — only in debug builds

--- a/facet-assert/examples/assert_showcase.rs
+++ b/facet-assert/examples/assert_showcase.rs
@@ -1,0 +1,232 @@
+//! facet-assert Showcase
+//!
+//! Demonstrates structural assertions without PartialEq.
+//!
+//! Run with: cargo run -p facet-assert --example assert_showcase
+
+use facet::Facet;
+use facet_assert::{Sameness, assert_same, check_same};
+use facet_showcase::{Language, OutputMode, ShowcaseRunner, ansi_to_html};
+use owo_colors::OwoColorize;
+
+// A type that does NOT implement PartialEq or Debug!
+#[derive(Facet)]
+struct Config {
+    host: String,
+    port: u16,
+    debug: bool,
+    tags: Vec<String>,
+}
+
+// Different type name, same structure
+#[derive(Facet)]
+struct ConfigV2 {
+    host: String,
+    port: u16,
+    debug: bool,
+    tags: Vec<String>,
+}
+
+#[derive(Facet)]
+struct Person {
+    name: String,
+    age: u32,
+    address: Address,
+}
+
+#[derive(Facet)]
+struct Address {
+    street: String,
+    city: String,
+}
+
+fn main() {
+    let mut runner =
+        ShowcaseRunner::new("facet-assert: Structural Assertions").language(Language::Rust);
+    let mode = runner.mode();
+
+    runner.header();
+
+    // Scenario 1: Same values pass
+    scenario_same_values(&mut runner, mode);
+
+    // Scenario 2: Different types, same structure
+    scenario_cross_type(&mut runner, mode);
+
+    // Scenario 3: Nested structs
+    scenario_nested(&mut runner, mode);
+
+    // Scenario 4: Show what a diff looks like
+    scenario_diff_output(&mut runner, mode);
+
+    // Scenario 5: Vector differences
+    scenario_vector_diff(&mut runner, mode);
+
+    runner.footer();
+}
+
+fn scenario_same_values(runner: &mut ShowcaseRunner, _mode: OutputMode) {
+    let config1 = Config {
+        host: "localhost".into(),
+        port: 8080,
+        debug: true,
+        tags: vec!["prod".into(), "api".into()],
+    };
+    let config2 = Config {
+        host: "localhost".into(),
+        port: 8080,
+        debug: true,
+        tags: vec!["prod".into(), "api".into()],
+    };
+
+    // This passes!
+    assert_same!(config1, config2);
+
+    runner
+        .scenario("Same Values")
+        .description(
+            "Two values with identical content pass `assert_same!` — no `PartialEq` required.",
+        )
+        .target_type::<Config>()
+        .success(&config1)
+        .finish();
+}
+
+fn scenario_cross_type(runner: &mut ShowcaseRunner, _mode: OutputMode) {
+    let v1 = Config {
+        host: "localhost".into(),
+        port: 8080,
+        debug: true,
+        tags: vec!["prod".into()],
+    };
+    let v2 = ConfigV2 {
+        host: "localhost".into(),
+        port: 8080,
+        debug: true,
+        tags: vec!["prod".into()],
+    };
+
+    // This passes! Different types, same structure.
+    assert_same!(v1, v2);
+
+    let mut scenario = runner.scenario("Cross-Type Comparison");
+    scenario = scenario.description(
+        "Different type names (`Config` vs `ConfigV2`) with the same structure are considered \"same\". \
+         Useful for comparing DTOs across API versions or testing serialization roundtrips.",
+    );
+    scenario = scenario.target_type::<Config>();
+    scenario = scenario.success(&v1);
+    scenario.finish();
+}
+
+fn scenario_nested(runner: &mut ShowcaseRunner, _mode: OutputMode) {
+    let person1 = Person {
+        name: "Alice".into(),
+        age: 30,
+        address: Address {
+            street: "123 Main St".into(),
+            city: "Springfield".into(),
+        },
+    };
+    let person2 = Person {
+        name: "Alice".into(),
+        age: 30,
+        address: Address {
+            street: "123 Main St".into(),
+            city: "Springfield".into(),
+        },
+    };
+
+    assert_same!(person1, person2);
+
+    runner
+        .scenario("Nested Structs")
+        .description("Nested structs are compared recursively, field by field.")
+        .target_type::<Person>()
+        .success(&person1)
+        .finish();
+}
+
+fn scenario_diff_output(runner: &mut ShowcaseRunner, mode: OutputMode) {
+    let config_a = Config {
+        host: "localhost".into(),
+        port: 8080,
+        debug: true,
+        tags: vec!["prod".into(), "api".into()],
+    };
+    let config_b = Config {
+        host: "prod.example.com".into(),
+        port: 443,
+        debug: false,
+        tags: vec!["prod".into()],
+    };
+
+    let diff = match check_same(&config_a, &config_b) {
+        Sameness::Different(d) => d,
+        _ => unreachable!(),
+    };
+
+    print_diff_scenario(
+        runner,
+        mode,
+        "Structural Diff",
+        "When values differ, you get a precise structural diff showing exactly which fields changed \
+         and at what path — not just a wall of red/green text.",
+        &diff,
+    );
+}
+
+fn scenario_vector_diff(runner: &mut ShowcaseRunner, mode: OutputMode) {
+    let a = vec![1, 2, 3, 4, 5];
+    let b = vec![1, 2, 99, 4];
+
+    let diff = match check_same(&a, &b) {
+        Sameness::Different(d) => d,
+        _ => unreachable!(),
+    };
+
+    print_diff_scenario(
+        runner,
+        mode,
+        "Vector Differences",
+        "Vector comparisons show exactly which indices differ, which elements were added, \
+         and which were removed.",
+        &diff,
+    );
+}
+
+fn print_diff_scenario(
+    _runner: &mut ShowcaseRunner,
+    mode: OutputMode,
+    name: &str,
+    description: &str,
+    diff: &str,
+) {
+    match mode {
+        OutputMode::Terminal => {
+            println!();
+            println!("{}", "═".repeat(78).dimmed());
+            println!("{} {}", "SCENARIO:".bold().cyan(), name.bold().white());
+            println!("{}", "─".repeat(78).dimmed());
+            println!("{}", description.dimmed());
+            println!("{}", "═".repeat(78).dimmed());
+            println!();
+            println!("{}", "Diff Output:".bold().yellow());
+            println!("{}", "─".repeat(60).dimmed());
+            print!("{diff}");
+            println!("{}", "─".repeat(60).dimmed());
+        }
+        OutputMode::Markdown => {
+            println!();
+            println!("## {name}");
+            println!();
+            println!("<section class=\"scenario\">");
+            println!("<p class=\"description\">{description}</p>");
+            println!("<div class=\"diff-output\">");
+            println!("<h4>Diff Output</h4>");
+            println!("<pre><code>{}</code></pre>", ansi_to_html(diff));
+            println!("</div>");
+            println!("</section>");
+        }
+    }
+}

--- a/facet-assert/src/lib.rs
+++ b/facet-assert/src/lib.rs
@@ -1,0 +1,195 @@
+#![warn(missing_docs)]
+#![forbid(unsafe_code)]
+#![doc = include_str!("../README.md")]
+
+//! Pretty assertions for Facet types.
+//!
+//! Unlike `assert_eq!` which requires `PartialEq`, `assert_same!` works with any
+//! `Facet` type by doing structural comparison via reflection.
+
+mod same;
+
+pub use same::{Sameness, check_same};
+
+/// Asserts that two values are structurally the same.
+///
+/// This macro does not require `PartialEq` - it uses Facet reflection to
+/// compare values structurally. Two values are "same" if they have the same
+/// structure and the same field values, even if they have different type names.
+///
+/// # Panics
+///
+/// Panics if the values are not structurally same, displaying a colored diff
+/// showing exactly what differs.
+///
+/// Also panics if either value contains an opaque type that cannot be inspected.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_assert::assert_same;
+///
+/// #[derive(Facet)]
+/// struct Person {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// let a = Person { name: "Alice".into(), age: 30 };
+/// let b = Person { name: "Alice".into(), age: 30 };
+/// assert_same!(a, b);
+/// ```
+#[macro_export]
+macro_rules! assert_same {
+    ($left:expr, $right:expr $(,)?) => {
+        match $crate::check_same(&$left, &$right) {
+            $crate::Sameness::Same => {}
+            $crate::Sameness::Different(diff) => {
+                panic!(
+                    "assertion `assert_same!(left, right)` failed\n\n{diff}\n"
+                );
+            }
+            $crate::Sameness::Opaque { type_name } => {
+                panic!(
+                    "assertion `assert_same!(left, right)` failed: cannot compare opaque type `{type_name}`"
+                );
+            }
+        }
+    };
+    ($left:expr, $right:expr, $($arg:tt)+) => {
+        match $crate::check_same(&$left, &$right) {
+            $crate::Sameness::Same => {}
+            $crate::Sameness::Different(diff) => {
+                panic!(
+                    "assertion `assert_same!(left, right)` failed: {}\n\n{diff}\n",
+                    format_args!($($arg)+)
+                );
+            }
+            $crate::Sameness::Opaque { type_name } => {
+                panic!(
+                    "assertion `assert_same!(left, right)` failed: {}: cannot compare opaque type `{type_name}`",
+                    format_args!($($arg)+)
+                );
+            }
+        }
+    };
+}
+
+/// Asserts that two values are structurally the same (debug builds only).
+///
+/// Like [`assert_same!`], but only enabled in debug builds.
+#[macro_export]
+macro_rules! debug_assert_same {
+    ($($arg:tt)*) => {
+        if cfg!(debug_assertions) {
+            $crate::assert_same!($($arg)*);
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use facet::Facet;
+
+    #[derive(Facet)]
+    struct Person {
+        name: String,
+        age: u32,
+    }
+
+    #[derive(Facet)]
+    struct PersonV2 {
+        name: String,
+        age: u32,
+    }
+
+    #[derive(Facet)]
+    struct Different {
+        name: String,
+        score: f64,
+    }
+
+    #[test]
+    fn same_type_same_values() {
+        let a = Person {
+            name: "Alice".into(),
+            age: 30,
+        };
+        let b = Person {
+            name: "Alice".into(),
+            age: 30,
+        };
+        assert_same!(a, b);
+    }
+
+    #[test]
+    fn different_types_same_structure() {
+        let a = Person {
+            name: "Alice".into(),
+            age: 30,
+        };
+        let b = PersonV2 {
+            name: "Alice".into(),
+            age: 30,
+        };
+        assert_same!(a, b);
+    }
+
+    #[test]
+    fn same_type_different_values() {
+        let a = Person {
+            name: "Alice".into(),
+            age: 30,
+        };
+        let b = Person {
+            name: "Bob".into(),
+            age: 30,
+        };
+
+        match check_same(&a, &b) {
+            Sameness::Different(_) => {} // expected
+            other => panic!(
+                "expected Different, got {:?}",
+                matches!(other, Sameness::Same)
+            ),
+        }
+    }
+
+    #[test]
+    fn primitives() {
+        assert_same!(42i32, 42i32);
+        assert_same!("hello", "hello");
+        assert_same!(true, true);
+    }
+
+    #[test]
+    fn vectors() {
+        let a = vec![1, 2, 3];
+        let b = vec![1, 2, 3];
+        assert_same!(a, b);
+    }
+
+    #[test]
+    fn vectors_different() {
+        let a = vec![1, 2, 3];
+        let b = vec![1, 2, 4];
+
+        match check_same(&a, &b) {
+            Sameness::Different(_) => {} // expected
+            _ => panic!("expected Different"),
+        }
+    }
+
+    #[test]
+    fn options() {
+        let a: Option<i32> = Some(42);
+        let b: Option<i32> = Some(42);
+        assert_same!(a, b);
+
+        let c: Option<i32> = None;
+        let d: Option<i32> = None;
+        assert_same!(c, d);
+    }
+}

--- a/facet-assert/src/same.rs
+++ b/facet-assert/src/same.rs
@@ -1,0 +1,479 @@
+//! Structural sameness checking for Facet types.
+
+use core::fmt;
+use facet_core::{Def, Facet, Type, UserType};
+use facet_pretty::PrettyPrinter;
+use facet_reflect::{HasFields, Peek};
+
+/// Result of checking if two values are structurally the same.
+pub enum Sameness {
+    /// The values are structurally the same.
+    Same,
+    /// The values differ - contains a formatted diff.
+    Different(String),
+    /// Encountered an opaque type that cannot be compared.
+    Opaque {
+        /// The type name of the opaque type.
+        type_name: &'static str,
+    },
+}
+
+/// Check if two Facet values are structurally the same.
+///
+/// This does NOT require `PartialEq` - it walks the structure via reflection.
+/// Two values are "same" if they have the same structure and values, even if
+/// they have different type names.
+///
+/// Returns [`Sameness::Opaque`] if either value contains an opaque type.
+pub fn check_same<'f, T: Facet<'f>, U: Facet<'f>>(left: &T, right: &U) -> Sameness {
+    let left_peek = Peek::new(left);
+    let right_peek = Peek::new(right);
+
+    let mut differ = Differ::new();
+    match differ.check(left_peek, right_peek) {
+        CheckResult::Same => Sameness::Same,
+        CheckResult::Different => Sameness::Different(differ.into_diff()),
+        CheckResult::Opaque { type_name } => Sameness::Opaque { type_name },
+    }
+}
+
+enum CheckResult {
+    Same,
+    Different,
+    Opaque { type_name: &'static str },
+}
+
+struct Differ {
+    /// Differences found, stored as lines
+    diffs: Vec<DiffLine>,
+    /// Current path for context
+    path: Vec<PathSegment>,
+}
+
+enum PathSegment {
+    Field(&'static str),
+    Index(usize),
+    Variant(&'static str),
+    Key(String),
+}
+
+impl fmt::Display for PathSegment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PathSegment::Field(name) => write!(f, ".{name}"),
+            PathSegment::Index(i) => write!(f, "[{i}]"),
+            PathSegment::Variant(name) => write!(f, "::{name}"),
+            PathSegment::Key(k) => write!(f, "[{k:?}]"),
+        }
+    }
+}
+
+enum DiffLine {
+    Changed {
+        path: String,
+        left: String,
+        right: String,
+    },
+    OnlyLeft {
+        path: String,
+        value: String,
+    },
+    OnlyRight {
+        path: String,
+        value: String,
+    },
+}
+
+impl Differ {
+    fn new() -> Self {
+        Self {
+            diffs: Vec::new(),
+            path: Vec::new(),
+        }
+    }
+
+    fn current_path(&self) -> String {
+        if self.path.is_empty() {
+            "root".to_string()
+        } else {
+            let mut s = String::new();
+            for seg in &self.path {
+                s.push_str(&seg.to_string());
+            }
+            s
+        }
+    }
+
+    fn format_value(peek: Peek<'_, '_>) -> String {
+        let printer = PrettyPrinter::default().with_colors(false);
+        printer.format_peek(peek).to_string()
+    }
+
+    fn record_changed(&mut self, left: Peek<'_, '_>, right: Peek<'_, '_>) {
+        self.diffs.push(DiffLine::Changed {
+            path: self.current_path(),
+            left: Self::format_value(left),
+            right: Self::format_value(right),
+        });
+    }
+
+    fn record_only_left(&mut self, left: Peek<'_, '_>) {
+        self.diffs.push(DiffLine::OnlyLeft {
+            path: self.current_path(),
+            value: Self::format_value(left),
+        });
+    }
+
+    fn record_only_right(&mut self, right: Peek<'_, '_>) {
+        self.diffs.push(DiffLine::OnlyRight {
+            path: self.current_path(),
+            value: Self::format_value(right),
+        });
+    }
+
+    fn into_diff(self) -> String {
+        use std::fmt::Write;
+
+        let mut out = String::new();
+
+        for diff in self.diffs {
+            match diff {
+                DiffLine::Changed { path, left, right } => {
+                    writeln!(out, "\x1b[1m{path}\x1b[0m:").unwrap();
+                    writeln!(out, "  \x1b[31m- {left}\x1b[0m").unwrap();
+                    writeln!(out, "  \x1b[32m+ {right}\x1b[0m").unwrap();
+                }
+                DiffLine::OnlyLeft { path, value } => {
+                    writeln!(out, "\x1b[1m{path}\x1b[0m (only in left):").unwrap();
+                    writeln!(out, "  \x1b[31m- {value}\x1b[0m").unwrap();
+                }
+                DiffLine::OnlyRight { path, value } => {
+                    writeln!(out, "\x1b[1m{path}\x1b[0m (only in right):").unwrap();
+                    writeln!(out, "  \x1b[32m+ {value}\x1b[0m").unwrap();
+                }
+            }
+        }
+
+        out
+    }
+
+    fn check(&mut self, left: Peek<'_, '_>, right: Peek<'_, '_>) -> CheckResult {
+        // Handle Option BEFORE innermost_peek (since Option's try_borrow_inner fails)
+        if matches!(left.shape().def, Def::Option(_)) && matches!(right.shape().def, Def::Option(_))
+        {
+            return self.check_options(left, right);
+        }
+
+        // Unwrap transparent wrappers (like NonZero, newtype wrappers)
+        let left = left.innermost_peek();
+        let right = right.innermost_peek();
+
+        // Try scalar comparison first (for leaf values like String, i32, etc.)
+        // Scalars are compared by their formatted representation.
+        if matches!(left.shape().def, Def::Scalar) && matches!(right.shape().def, Def::Scalar) {
+            let left_str = Self::format_value(left);
+            let right_str = Self::format_value(right);
+            if left_str == right_str {
+                return CheckResult::Same;
+            } else {
+                self.record_changed(left, right);
+                return CheckResult::Different;
+            }
+        }
+
+        // Try to compare structurally based on type/def
+        // Note: Many types are UserType::Opaque but still have a useful Def (like Vec -> Def::List)
+        // So we check Def first before giving up on Opaque types.
+
+        // Handle lists/arrays/slices (Vec is Opaque but has Def::List)
+        if left.into_list_like().is_ok() && right.into_list_like().is_ok() {
+            return self.check_lists(left, right);
+        }
+
+        // Handle maps
+        if matches!(left.shape().def, Def::Map(_)) && matches!(right.shape().def, Def::Map(_)) {
+            return self.check_maps(left, right);
+        }
+
+        // Handle smart pointers
+        if matches!(left.shape().def, Def::Pointer(_))
+            && matches!(right.shape().def, Def::Pointer(_))
+        {
+            return self.check_pointers(left, right);
+        }
+
+        // Handle structs
+        if let (Type::User(UserType::Struct(_)), Type::User(UserType::Struct(_))) =
+            (left.shape().ty, right.shape().ty)
+        {
+            return self.check_structs(left, right);
+        }
+
+        // Handle enums
+        if let (Type::User(UserType::Enum(_)), Type::User(UserType::Enum(_))) =
+            (left.shape().ty, right.shape().ty)
+        {
+            return self.check_enums(left, right);
+        }
+
+        // At this point, if either is Opaque and we haven't handled it above, fail
+        if matches!(left.shape().ty, Type::User(UserType::Opaque)) {
+            return CheckResult::Opaque {
+                type_name: left.shape().type_identifier,
+            };
+        }
+        if matches!(right.shape().ty, Type::User(UserType::Opaque)) {
+            return CheckResult::Opaque {
+                type_name: right.shape().type_identifier,
+            };
+        }
+
+        // Fallback: format and compare
+        let left_str = Self::format_value(left);
+        let right_str = Self::format_value(right);
+        if left_str == right_str {
+            CheckResult::Same
+        } else {
+            self.record_changed(left, right);
+            CheckResult::Different
+        }
+    }
+
+    fn check_structs(&mut self, left: Peek<'_, '_>, right: Peek<'_, '_>) -> CheckResult {
+        let left_struct = left.into_struct().unwrap();
+        let right_struct = right.into_struct().unwrap();
+
+        let mut any_different = false;
+        let mut seen_fields = std::collections::HashSet::new();
+
+        // Check all fields in left
+        for (field, left_value) in left_struct.fields() {
+            seen_fields.insert(field.name);
+            self.path.push(PathSegment::Field(field.name));
+
+            if let Ok(right_value) = right_struct.field_by_name(field.name) {
+                match self.check(left_value, right_value) {
+                    CheckResult::Same => {}
+                    CheckResult::Different => any_different = true,
+                    opaque @ CheckResult::Opaque { .. } => {
+                        self.path.pop();
+                        return opaque;
+                    }
+                }
+            } else {
+                // Field only in left
+                self.record_only_left(left_value);
+                any_different = true;
+            }
+
+            self.path.pop();
+        }
+
+        // Check fields only in right
+        for (field, right_value) in right_struct.fields() {
+            if !seen_fields.contains(field.name) {
+                self.path.push(PathSegment::Field(field.name));
+                self.record_only_right(right_value);
+                any_different = true;
+                self.path.pop();
+            }
+        }
+
+        if any_different {
+            CheckResult::Different
+        } else {
+            CheckResult::Same
+        }
+    }
+
+    fn check_enums(&mut self, left: Peek<'_, '_>, right: Peek<'_, '_>) -> CheckResult {
+        let left_enum = left.into_enum().unwrap();
+        let right_enum = right.into_enum().unwrap();
+
+        let left_variant = left_enum.active_variant().unwrap();
+        let right_variant = right_enum.active_variant().unwrap();
+
+        // Different variants = different
+        if left_variant.name != right_variant.name {
+            self.record_changed(left, right);
+            return CheckResult::Different;
+        }
+
+        // Same variant - check fields
+        self.path.push(PathSegment::Variant(left_variant.name));
+
+        let mut any_different = false;
+        let mut seen_fields = std::collections::HashSet::new();
+
+        for (field, left_value) in left_enum.fields() {
+            seen_fields.insert(field.name);
+            self.path.push(PathSegment::Field(field.name));
+
+            if let Ok(Some(right_value)) = right_enum.field_by_name(field.name) {
+                match self.check(left_value, right_value) {
+                    CheckResult::Same => {}
+                    CheckResult::Different => any_different = true,
+                    opaque @ CheckResult::Opaque { .. } => {
+                        self.path.pop();
+                        self.path.pop();
+                        return opaque;
+                    }
+                }
+            } else {
+                self.record_only_left(left_value);
+                any_different = true;
+            }
+
+            self.path.pop();
+        }
+
+        for (field, right_value) in right_enum.fields() {
+            if !seen_fields.contains(field.name) {
+                self.path.push(PathSegment::Field(field.name));
+                self.record_only_right(right_value);
+                any_different = true;
+                self.path.pop();
+            }
+        }
+
+        self.path.pop();
+
+        if any_different {
+            CheckResult::Different
+        } else {
+            CheckResult::Same
+        }
+    }
+
+    fn check_options(&mut self, left: Peek<'_, '_>, right: Peek<'_, '_>) -> CheckResult {
+        let left_opt = left.into_option().unwrap();
+        let right_opt = right.into_option().unwrap();
+
+        match (left_opt.value(), right_opt.value()) {
+            (None, None) => CheckResult::Same,
+            (Some(l), Some(r)) => self.check(l, r),
+            (Some(_), None) | (None, Some(_)) => {
+                self.record_changed(left, right);
+                CheckResult::Different
+            }
+        }
+    }
+
+    fn check_lists(&mut self, left: Peek<'_, '_>, right: Peek<'_, '_>) -> CheckResult {
+        let left_list = left.into_list_like().unwrap();
+        let right_list = right.into_list_like().unwrap();
+
+        let left_items: Vec<_> = left_list.iter().collect();
+        let right_items: Vec<_> = right_list.iter().collect();
+
+        let mut any_different = false;
+        let min_len = left_items.len().min(right_items.len());
+
+        // Compare common elements
+        for i in 0..min_len {
+            self.path.push(PathSegment::Index(i));
+
+            match self.check(left_items[i], right_items[i]) {
+                CheckResult::Same => {}
+                CheckResult::Different => any_different = true,
+                opaque @ CheckResult::Opaque { .. } => {
+                    self.path.pop();
+                    return opaque;
+                }
+            }
+
+            self.path.pop();
+        }
+
+        // Elements only in left (removed)
+        for (i, item) in left_items.iter().enumerate().skip(min_len) {
+            self.path.push(PathSegment::Index(i));
+            self.record_only_left(*item);
+            any_different = true;
+            self.path.pop();
+        }
+
+        // Elements only in right (added)
+        for (i, item) in right_items.iter().enumerate().skip(min_len) {
+            self.path.push(PathSegment::Index(i));
+            self.record_only_right(*item);
+            any_different = true;
+            self.path.pop();
+        }
+
+        if any_different {
+            CheckResult::Different
+        } else {
+            CheckResult::Same
+        }
+    }
+
+    fn check_maps(&mut self, left: Peek<'_, '_>, right: Peek<'_, '_>) -> CheckResult {
+        let left_map = left.into_map().unwrap();
+        let right_map = right.into_map().unwrap();
+
+        let mut any_different = false;
+        let mut seen_keys = std::collections::HashSet::new();
+
+        for (left_key, left_value) in left_map.iter() {
+            let key_str = Self::format_value(left_key);
+            seen_keys.insert(key_str.clone());
+            self.path.push(PathSegment::Key(key_str));
+
+            // Try to find matching key in right map
+            let mut found = false;
+            for (right_key, right_value) in right_map.iter() {
+                if Self::format_value(left_key) == Self::format_value(right_key) {
+                    found = true;
+                    match self.check(left_value, right_value) {
+                        CheckResult::Same => {}
+                        CheckResult::Different => any_different = true,
+                        opaque @ CheckResult::Opaque { .. } => {
+                            self.path.pop();
+                            return opaque;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            if !found {
+                self.record_only_left(left_value);
+                any_different = true;
+            }
+
+            self.path.pop();
+        }
+
+        // Check keys only in right
+        for (right_key, right_value) in right_map.iter() {
+            let key_str = Self::format_value(right_key);
+            if !seen_keys.contains(&key_str) {
+                self.path.push(PathSegment::Key(key_str));
+                self.record_only_right(right_value);
+                any_different = true;
+                self.path.pop();
+            }
+        }
+
+        if any_different {
+            CheckResult::Different
+        } else {
+            CheckResult::Same
+        }
+    }
+
+    fn check_pointers(&mut self, left: Peek<'_, '_>, right: Peek<'_, '_>) -> CheckResult {
+        let left_ptr = left.into_pointer().unwrap();
+        let right_ptr = right.into_pointer().unwrap();
+
+        match (left_ptr.borrow_inner(), right_ptr.borrow_inner()) {
+            (Some(left_inner), Some(right_inner)) => self.check(left_inner, right_inner),
+            (None, None) => CheckResult::Same,
+            _ => {
+                self.record_changed(left, right);
+                CheckResult::Different
+            }
+        }
+    }
+}

--- a/facet-toml/Cargo.toml
+++ b/facet-toml/Cargo.toml
@@ -42,7 +42,3 @@ eyre = "0.6.12"
 facet = { path = "../facet" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 snapbox = "0.6.21"
-
-[[test]]
-name = "toml_rs_serde"
-path = "tests/toml-rs-compat/serde/main.rs"


### PR DESCRIPTION
## Summary

Adds a new `facet-assert` crate providing `assert_same!` which compares values structurally via Facet reflection, without requiring `PartialEq` or `Debug`.

**Key features:**
- **No `PartialEq` required** - uses Facet reflection for comparison
- **Structural sameness** - different types with same structure are "same" (useful for comparing DTOs across API versions, serialization roundtrips, etc.)
- **Smart diffs** - shows exactly which field at which path differs, not just a wall of red/green
- **Opaque types fail clearly** - if a type can't be inspected, you get a clear error message

**Example:**
```rust
#[derive(Facet)]
struct Config { host: String, port: u16 }

let a = Config { host: "localhost".into(), port: 8080 };
let b = Config { host: "localhost".into(), port: 8080 };
assert_same!(a, b);  // No PartialEq needed!
```

**Diff output example:**
```
.host:
  - localhost
  + prod.example.com
.port:
  - 8080
  + 443
.tags[1] (only in left):
  - api
```

## Test plan

- [x] Unit tests pass (`cargo test -p facet-assert`)
- [x] Example runs successfully (`cargo run -p facet-assert --example assert_showcase`)
- [ ] Add facet-showcase integration for website (will follow up)