### PR TITLE
Add facet-value crate for memory-efficient dynamic values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-value"
+version = "0.1.0"
+
+[[package]]
 name = "facet-xdr"
 version = "0.31.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
 
     # utilities
     "facet-diff",
+    "facet-value",
 
     # showcase infrastructure
     "facet-showcase",

--- a/facet-value/Cargo.toml
+++ b/facet-value/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "facet-value"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Memory-efficient dynamic value type for facet, supporting JSON-like data plus bytes"
+keywords = ["serialization", "value", "dynamic", "json"]
+categories = ["encoding", "data-structures"]
+
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+
+[dependencies]
+
+[dev-dependencies]

--- a/facet-value/README.md
+++ b/facet-value/README.md
@@ -1,0 +1,61 @@
+# facet-value
+
+[![Coverage Status](https://coveralls.io/repos/github/facet-rs/facet-value/badge.svg?branch=main)](https://coveralls.io/github/facet-rs/facet?branch=main)
+[![crates.io](https://img.shields.io/crates/v/facet-value.svg)](https://crates.io/crates/facet-value)
+[![documentation](https://docs.rs/facet-value/badge.svg)](https://docs.rs/facet-value)
+[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/facet-value.svg)](./LICENSE)
+[![Discord](https://img.shields.io/discord/1379550208551026748?logo=discord&label=discord)](https://discord.gg/JhD7CwCJ8F)
+
+# facet-value
+
+A memory-efficient dynamic value type for representing structured data, with support for bytes.
+
+## Sponsors
+
+Thanks to all individual sponsors:
+
+<p> <a href="https://github.com/sponsors/fasterthanlime">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-light.svg" height="40" alt="GitHub Sponsors">
+</picture>
+</a> <a href="https://patreon.com/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-light.svg" height="40" alt="Patreon">
+    </picture>
+</a> </p>
+
+...along with corporate sponsors:
+
+<p> <a href="https://aws.amazon.com">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-light.svg" height="40" alt="AWS">
+</picture>
+</a> <a href="https://zed.dev">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-light.svg" height="40" alt="Zed">
+</picture>
+</a> <a href="https://depot.dev?utm_source=facet">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-light.svg" height="40" alt="Depot">
+</picture>
+</a> </p>
+
+...without whom this work could not exist.
+
+## Special thanks
+
+The facet logo was drawn by [Misiasart](https://misiasart.com/).
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/facet-rs/facet/blob/main/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/facet-rs/facet/blob/main/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/facet-value/README.md.in
+++ b/facet-value/README.md.in
@@ -1,0 +1,3 @@
+# facet-value
+
+A memory-efficient dynamic value type for representing structured data, with support for bytes.

--- a/facet-value/src/array.rs
+++ b/facet-value/src/array.rs
@@ -1,0 +1,572 @@
+//! Array value type.
+
+#[cfg(feature = "alloc")]
+use alloc::alloc::{Layout, alloc, dealloc, realloc};
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+use core::borrow::{Borrow, BorrowMut};
+use core::cmp::Ordering;
+use core::fmt::{self, Debug, Formatter};
+use core::hash::{Hash, Hasher};
+use core::iter::FromIterator;
+use core::ops::{Deref, DerefMut, Index, IndexMut};
+use core::slice::SliceIndex;
+use core::{cmp, ptr};
+
+use crate::value::{TypeTag, Value};
+
+/// Header for heap-allocated arrays.
+#[repr(C, align(8))]
+struct ArrayHeader {
+    /// Number of elements
+    len: usize,
+    /// Capacity (number of elements that can be stored)
+    cap: usize,
+    // Array of Value follows immediately after
+}
+
+/// An array value.
+///
+/// `VArray` is a dynamic array of `Value`s, similar to `Vec<Value>`.
+/// The length and capacity are stored in a heap-allocated header.
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct VArray(pub(crate) Value);
+
+impl VArray {
+    fn layout(cap: usize) -> Layout {
+        Layout::new::<ArrayHeader>()
+            .extend(Layout::array::<Value>(cap).unwrap())
+            .unwrap()
+            .0
+            .pad_to_align()
+    }
+
+    #[cfg(feature = "alloc")]
+    fn alloc(cap: usize) -> *mut ArrayHeader {
+        unsafe {
+            let layout = Self::layout(cap);
+            let ptr = alloc(layout).cast::<ArrayHeader>();
+            (*ptr).len = 0;
+            (*ptr).cap = cap;
+            ptr
+        }
+    }
+
+    #[cfg(feature = "alloc")]
+    fn realloc_ptr(ptr: *mut ArrayHeader, new_cap: usize) -> *mut ArrayHeader {
+        unsafe {
+            let old_cap = (*ptr).cap;
+            let old_layout = Self::layout(old_cap);
+            let new_layout = Self::layout(new_cap);
+            let new_ptr =
+                realloc(ptr.cast::<u8>(), old_layout, new_layout.size()).cast::<ArrayHeader>();
+            (*new_ptr).cap = new_cap;
+            new_ptr
+        }
+    }
+
+    #[cfg(feature = "alloc")]
+    fn dealloc_ptr(ptr: *mut ArrayHeader) {
+        unsafe {
+            let cap = (*ptr).cap;
+            let layout = Self::layout(cap);
+            dealloc(ptr.cast::<u8>(), layout);
+        }
+    }
+
+    fn header(&self) -> &ArrayHeader {
+        unsafe { &*(self.0.heap_ptr() as *const ArrayHeader) }
+    }
+
+    fn header_mut(&mut self) -> &mut ArrayHeader {
+        unsafe { &mut *(self.0.heap_ptr() as *mut ArrayHeader) }
+    }
+
+    fn items_ptr(&self) -> *const Value {
+        unsafe { (self.header() as *const ArrayHeader).add(1).cast() }
+    }
+
+    fn items_ptr_mut(&mut self) -> *mut Value {
+        unsafe { (self.header_mut() as *mut ArrayHeader).add(1).cast() }
+    }
+
+    /// Creates a new empty array.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
+    /// Creates a new array with the specified capacity.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn with_capacity(cap: usize) -> Self {
+        unsafe {
+            let ptr = Self::alloc(cap);
+            VArray(Value::new_ptr(ptr.cast(), TypeTag::ArrayOrTrue))
+        }
+    }
+
+    /// Returns the number of elements.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.header().len
+    }
+
+    /// Returns `true` if the array is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the capacity.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.header().cap
+    }
+
+    /// Returns a slice of the elements.
+    #[must_use]
+    pub fn as_slice(&self) -> &[Value] {
+        unsafe { core::slice::from_raw_parts(self.items_ptr(), self.len()) }
+    }
+
+    /// Returns a mutable slice of the elements.
+    pub fn as_mut_slice(&mut self) -> &mut [Value] {
+        unsafe { core::slice::from_raw_parts_mut(self.items_ptr_mut(), self.len()) }
+    }
+
+    /// Reserves capacity for at least `additional` more elements.
+    #[cfg(feature = "alloc")]
+    pub fn reserve(&mut self, additional: usize) {
+        let current_cap = self.capacity();
+        let desired_cap = self
+            .len()
+            .checked_add(additional)
+            .expect("capacity overflow");
+
+        if current_cap >= desired_cap {
+            return;
+        }
+
+        let new_cap = cmp::max(current_cap * 2, desired_cap.max(4));
+
+        unsafe {
+            let new_ptr = Self::realloc_ptr(self.0.heap_ptr().cast(), new_cap);
+            self.0.set_ptr(new_ptr.cast());
+        }
+    }
+
+    /// Pushes an element onto the back.
+    #[cfg(feature = "alloc")]
+    pub fn push(&mut self, value: impl Into<Value>) {
+        self.reserve(1);
+        unsafe {
+            let len = self.header().len;
+            let ptr = self.items_ptr_mut().add(len);
+            ptr.write(value.into());
+            self.header_mut().len = len + 1;
+        }
+    }
+
+    /// Pops an element from the back.
+    pub fn pop(&mut self) -> Option<Value> {
+        let len = self.len();
+        if len == 0 {
+            return None;
+        }
+        unsafe {
+            self.header_mut().len = len - 1;
+            let ptr = self.items_ptr_mut().add(len - 1);
+            Some(ptr.read())
+        }
+    }
+
+    /// Inserts an element at the specified index.
+    #[cfg(feature = "alloc")]
+    pub fn insert(&mut self, index: usize, value: impl Into<Value>) {
+        let len = self.len();
+        assert!(index <= len, "index out of bounds");
+
+        self.reserve(1);
+
+        unsafe {
+            let ptr = self.items_ptr_mut().add(index);
+            // Shift elements to the right
+            if index < len {
+                ptr::copy(ptr, ptr.add(1), len - index);
+            }
+            ptr.write(value.into());
+            self.header_mut().len = len + 1;
+        }
+    }
+
+    /// Removes and returns the element at the specified index.
+    pub fn remove(&mut self, index: usize) -> Option<Value> {
+        let len = self.len();
+        if index >= len {
+            return None;
+        }
+
+        unsafe {
+            let ptr = self.items_ptr_mut().add(index);
+            let value = ptr.read();
+            // Shift elements to the left
+            if index < len - 1 {
+                ptr::copy(ptr.add(1), ptr, len - index - 1);
+            }
+            self.header_mut().len = len - 1;
+            Some(value)
+        }
+    }
+
+    /// Removes an element by swapping it with the last element.
+    /// More efficient than `remove` but doesn't preserve order.
+    pub fn swap_remove(&mut self, index: usize) -> Option<Value> {
+        let len = self.len();
+        if index >= len {
+            return None;
+        }
+
+        self.as_mut_slice().swap(index, len - 1);
+        self.pop()
+    }
+
+    /// Clears the array.
+    pub fn clear(&mut self) {
+        while self.pop().is_some() {}
+    }
+
+    /// Truncates the array to the specified length.
+    pub fn truncate(&mut self, len: usize) {
+        while self.len() > len {
+            self.pop();
+        }
+    }
+
+    /// Gets an element by index.
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<&Value> {
+        self.as_slice().get(index)
+    }
+
+    /// Gets a mutable element by index.
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut Value> {
+        self.as_mut_slice().get_mut(index)
+    }
+
+    /// Shrinks the capacity to match the length.
+    #[cfg(feature = "alloc")]
+    pub fn shrink_to_fit(&mut self) {
+        let len = self.len();
+        let cap = self.capacity();
+
+        if len < cap {
+            unsafe {
+                let new_ptr = Self::realloc_ptr(self.0.heap_ptr().cast(), len);
+                self.0.set_ptr(new_ptr.cast());
+            }
+        }
+    }
+
+    pub(crate) fn clone_impl(&self) -> Value {
+        let mut new = VArray::with_capacity(self.len());
+        for v in self.as_slice() {
+            new.push(v.clone());
+        }
+        new.0
+    }
+
+    pub(crate) fn drop_impl(&mut self) {
+        self.clear();
+        unsafe {
+            Self::dealloc_ptr(self.0.heap_ptr().cast());
+        }
+    }
+}
+
+// === Iterator ===
+
+/// Iterator over owned `Value`s from a `VArray`.
+pub struct ArrayIntoIter {
+    array: VArray,
+}
+
+impl Iterator for ArrayIntoIter {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.array.is_empty() {
+            None
+        } else {
+            self.array.remove(0)
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.array.len();
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for ArrayIntoIter {}
+
+impl IntoIterator for VArray {
+    type Item = Value;
+    type IntoIter = ArrayIntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ArrayIntoIter { array: self }
+    }
+}
+
+impl<'a> IntoIterator for &'a VArray {
+    type Item = &'a Value;
+    type IntoIter = core::slice::Iter<'a, Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.as_slice().iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut VArray {
+    type Item = &'a mut Value;
+    type IntoIter = core::slice::IterMut<'a, Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.as_mut_slice().iter_mut()
+    }
+}
+
+// === Deref ===
+
+impl Deref for VArray {
+    type Target = [Value];
+
+    fn deref(&self) -> &[Value] {
+        self.as_slice()
+    }
+}
+
+impl DerefMut for VArray {
+    fn deref_mut(&mut self) -> &mut [Value] {
+        self.as_mut_slice()
+    }
+}
+
+impl Borrow<[Value]> for VArray {
+    fn borrow(&self) -> &[Value] {
+        self.as_slice()
+    }
+}
+
+impl BorrowMut<[Value]> for VArray {
+    fn borrow_mut(&mut self) -> &mut [Value] {
+        self.as_mut_slice()
+    }
+}
+
+impl AsRef<[Value]> for VArray {
+    fn as_ref(&self) -> &[Value] {
+        self.as_slice()
+    }
+}
+
+// === Index ===
+
+impl<I: SliceIndex<[Value]>> Index<I> for VArray {
+    type Output = I::Output;
+
+    fn index(&self, index: I) -> &Self::Output {
+        &self.as_slice()[index]
+    }
+}
+
+impl<I: SliceIndex<[Value]>> IndexMut<I> for VArray {
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        &mut self.as_mut_slice()[index]
+    }
+}
+
+// === Comparison ===
+
+impl PartialEq for VArray {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for VArray {}
+
+impl PartialOrd for VArray {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // Element-wise comparison
+        let mut iter1 = self.iter();
+        let mut iter2 = other.iter();
+        loop {
+            match (iter1.next(), iter2.next()) {
+                (Some(a), Some(b)) => match a.partial_cmp(b) {
+                    Some(Ordering::Equal) => continue,
+                    other => return other,
+                },
+                (None, None) => return Some(Ordering::Equal),
+                (Some(_), None) => return Some(Ordering::Greater),
+                (None, Some(_)) => return Some(Ordering::Less),
+            }
+        }
+    }
+}
+
+impl Hash for VArray {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state);
+    }
+}
+
+impl Debug for VArray {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self.as_slice(), f)
+    }
+}
+
+impl Default for VArray {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// === FromIterator / Extend ===
+
+#[cfg(feature = "alloc")]
+impl<T: Into<Value>> FromIterator<T> for VArray {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let (lower, _) = iter.size_hint();
+        let mut array = VArray::with_capacity(lower);
+        for v in iter {
+            array.push(v);
+        }
+        array
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Into<Value>> Extend<T> for VArray {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        let iter = iter.into_iter();
+        let (lower, _) = iter.size_hint();
+        self.reserve(lower);
+        for v in iter {
+            self.push(v);
+        }
+    }
+}
+
+// === From implementations ===
+
+#[cfg(feature = "alloc")]
+impl<T: Into<Value>> From<Vec<T>> for VArray {
+    fn from(vec: Vec<T>) -> Self {
+        vec.into_iter().collect()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T: Into<Value> + Clone> From<&[T]> for VArray {
+    fn from(slice: &[T]) -> Self {
+        slice.iter().cloned().collect()
+    }
+}
+
+// === Value conversions ===
+
+impl AsRef<Value> for VArray {
+    fn as_ref(&self) -> &Value {
+        &self.0
+    }
+}
+
+impl AsMut<Value> for VArray {
+    fn as_mut(&mut self) -> &mut Value {
+        &mut self.0
+    }
+}
+
+impl From<VArray> for Value {
+    fn from(arr: VArray) -> Self {
+        arr.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let arr = VArray::new();
+        assert!(arr.is_empty());
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_push_pop() {
+        let mut arr = VArray::new();
+        arr.push(Value::from(1));
+        arr.push(Value::from(2));
+        arr.push(Value::from(3));
+
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr.pop().unwrap().as_number().unwrap().to_i64(), Some(3));
+        assert_eq!(arr.pop().unwrap().as_number().unwrap().to_i64(), Some(2));
+        assert_eq!(arr.pop().unwrap().as_number().unwrap().to_i64(), Some(1));
+        assert!(arr.pop().is_none());
+    }
+
+    #[test]
+    fn test_insert_remove() {
+        let mut arr = VArray::new();
+        arr.push(Value::from(1));
+        arr.push(Value::from(3));
+        arr.insert(1, Value::from(2));
+
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_number().unwrap().to_i64(), Some(1));
+        assert_eq!(arr[1].as_number().unwrap().to_i64(), Some(2));
+        assert_eq!(arr[2].as_number().unwrap().to_i64(), Some(3));
+
+        let removed = arr.remove(1).unwrap();
+        assert_eq!(removed.as_number().unwrap().to_i64(), Some(2));
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_clone() {
+        let mut arr = VArray::new();
+        arr.push(Value::from("hello"));
+        arr.push(Value::from(42));
+
+        let arr2 = arr.clone();
+        assert_eq!(arr, arr2);
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut arr = VArray::new();
+        arr.push(Value::from(1));
+        arr.push(Value::from(2));
+
+        let sum: i64 = arr
+            .iter()
+            .map(|v| v.as_number().unwrap().to_i64().unwrap())
+            .sum();
+        assert_eq!(sum, 3);
+    }
+
+    #[test]
+    fn test_collect() {
+        let arr: VArray = vec![1i64, 2, 3].into_iter().map(Value::from).collect();
+        assert_eq!(arr.len(), 3);
+    }
+}

--- a/facet-value/src/bytes.rs
+++ b/facet-value/src/bytes.rs
@@ -1,0 +1,339 @@
+//! Bytes value type for binary data.
+
+#[cfg(feature = "alloc")]
+use alloc::alloc::{Layout, alloc, dealloc};
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::cmp::Ordering;
+use core::fmt::{self, Debug, Formatter};
+use core::hash::{Hash, Hasher};
+use core::ops::Deref;
+use core::ptr;
+
+use crate::value::{TypeTag, Value};
+
+/// Header for heap-allocated bytes.
+#[repr(C, align(8))]
+struct BytesHeader {
+    /// Length of the data in bytes
+    len: usize,
+    // Byte data follows immediately after
+}
+
+/// A binary data value.
+///
+/// `VBytes` stores arbitrary binary data. This is useful for binary serialization
+/// formats like MessagePack, CBOR, etc. that support raw bytes.
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct VBytes(pub(crate) Value);
+
+impl VBytes {
+    fn layout(len: usize) -> Layout {
+        Layout::new::<BytesHeader>()
+            .extend(Layout::array::<u8>(len).unwrap())
+            .unwrap()
+            .0
+            .pad_to_align()
+    }
+
+    #[cfg(feature = "alloc")]
+    fn alloc(data: &[u8]) -> *mut BytesHeader {
+        unsafe {
+            let layout = Self::layout(data.len());
+            let ptr = alloc(layout).cast::<BytesHeader>();
+            (*ptr).len = data.len();
+
+            // Copy byte data
+            let data_ptr = ptr.add(1).cast::<u8>();
+            ptr::copy_nonoverlapping(data.as_ptr(), data_ptr, data.len());
+
+            ptr
+        }
+    }
+
+    #[cfg(feature = "alloc")]
+    fn dealloc_ptr(ptr: *mut BytesHeader) {
+        unsafe {
+            let len = (*ptr).len;
+            let layout = Self::layout(len);
+            dealloc(ptr.cast::<u8>(), layout);
+        }
+    }
+
+    fn header(&self) -> &BytesHeader {
+        unsafe { &*(self.0.heap_ptr() as *const BytesHeader) }
+    }
+
+    fn data_ptr(&self) -> *const u8 {
+        unsafe { (self.header() as *const BytesHeader).add(1).cast() }
+    }
+
+    /// Creates new bytes from a byte slice.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn new(data: &[u8]) -> Self {
+        if data.is_empty() {
+            return Self::empty();
+        }
+        unsafe {
+            let ptr = Self::alloc(data);
+            VBytes(Value::new_ptr(ptr.cast(), TypeTag::BytesOrFalse))
+        }
+    }
+
+    /// Creates empty bytes.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn empty() -> Self {
+        unsafe {
+            let layout = Self::layout(0);
+            let ptr = alloc(layout).cast::<BytesHeader>();
+            (*ptr).len = 0;
+            VBytes(Value::new_ptr(ptr.cast(), TypeTag::BytesOrFalse))
+        }
+    }
+
+    /// Returns the length of the bytes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.header().len
+    }
+
+    /// Returns `true` if the bytes are empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the data as a byte slice.
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.data_ptr(), self.len()) }
+    }
+
+    pub(crate) fn clone_impl(&self) -> Value {
+        VBytes::new(self.as_slice()).0
+    }
+
+    pub(crate) fn drop_impl(&mut self) {
+        unsafe {
+            Self::dealloc_ptr(self.0.heap_ptr().cast());
+        }
+    }
+}
+
+impl Deref for VBytes {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl Borrow<[u8]> for VBytes {
+    fn borrow(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl AsRef<[u8]> for VBytes {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl PartialEq for VBytes {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for VBytes {}
+
+impl PartialOrd for VBytes {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for VBytes {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_slice().cmp(other.as_slice())
+    }
+}
+
+impl Hash for VBytes {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state);
+    }
+}
+
+impl Debug for VBytes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // Display as hex for readability
+        write!(f, "b\"")?;
+        for byte in self.as_slice() {
+            write!(f, "\\x{byte:02x}")?;
+        }
+        write!(f, "\"")
+    }
+}
+
+impl Default for VBytes {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+// === PartialEq with [u8] ===
+
+impl PartialEq<[u8]> for VBytes {
+    fn eq(&self, other: &[u8]) -> bool {
+        self.as_slice() == other
+    }
+}
+
+impl PartialEq<VBytes> for [u8] {
+    fn eq(&self, other: &VBytes) -> bool {
+        self == other.as_slice()
+    }
+}
+
+impl PartialEq<&[u8]> for VBytes {
+    fn eq(&self, other: &&[u8]) -> bool {
+        self.as_slice() == *other
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl PartialEq<Vec<u8>> for VBytes {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl PartialEq<VBytes> for Vec<u8> {
+    fn eq(&self, other: &VBytes) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+// === From implementations ===
+
+#[cfg(feature = "alloc")]
+impl From<&[u8]> for VBytes {
+    fn from(data: &[u8]) -> Self {
+        Self::new(data)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<Vec<u8>> for VBytes {
+    fn from(data: Vec<u8>) -> Self {
+        Self::new(&data)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<&Vec<u8>> for VBytes {
+    fn from(data: &Vec<u8>) -> Self {
+        Self::new(data)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<VBytes> for Vec<u8> {
+    fn from(b: VBytes) -> Self {
+        b.as_slice().to_vec()
+    }
+}
+
+// === Value conversions ===
+
+impl AsRef<Value> for VBytes {
+    fn as_ref(&self) -> &Value {
+        &self.0
+    }
+}
+
+impl AsMut<Value> for VBytes {
+    fn as_mut(&mut self) -> &mut Value {
+        &mut self.0
+    }
+}
+
+impl From<VBytes> for Value {
+    fn from(b: VBytes) -> Self {
+        b.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<&[u8]> for Value {
+    fn from(data: &[u8]) -> Self {
+        VBytes::new(data).0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<Vec<u8>> for Value {
+    fn from(data: Vec<u8>) -> Self {
+        VBytes::new(&data).0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let b = VBytes::new(&[1, 2, 3, 4, 5]);
+        assert_eq!(b.as_slice(), &[1, 2, 3, 4, 5]);
+        assert_eq!(b.len(), 5);
+        assert!(!b.is_empty());
+    }
+
+    #[test]
+    fn test_empty() {
+        let b = VBytes::empty();
+        assert_eq!(b.as_slice(), &[]);
+        assert_eq!(b.len(), 0);
+        assert!(b.is_empty());
+    }
+
+    #[test]
+    fn test_equality() {
+        let a = VBytes::new(&[1, 2, 3]);
+        let b = VBytes::new(&[1, 2, 3]);
+        let c = VBytes::new(&[4, 5, 6]);
+
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_eq!(a, [1, 2, 3].as_slice());
+    }
+
+    #[test]
+    fn test_clone() {
+        let a = VBytes::new(&[0xDE, 0xAD, 0xBE, 0xEF]);
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_ordering() {
+        let a = VBytes::new(&[1, 2, 3]);
+        let b = VBytes::new(&[1, 2, 4]);
+        assert!(a < b);
+    }
+
+    #[test]
+    fn test_debug() {
+        let b = VBytes::new(&[0xDE, 0xAD]);
+        let s = format!("{b:?}");
+        assert_eq!(s, "b\"\\xde\\xad\"");
+    }
+}

--- a/facet-value/src/lib.rs
+++ b/facet-value/src/lib.rs
@@ -1,0 +1,41 @@
+//! `facet-value` provides a memory-efficient dynamic value type for representing
+//! structured data similar to JSON, but with added support for binary data (bytes).
+//!
+//! # Features
+//!
+//! - **Pointer-sized `Value` type**: The main `Value` type is exactly one pointer in size
+//! - **Seven value types**: Null, Bool, Number, String, Bytes, Array, Object
+//! - **`no_std` compatible**: Works with just `alloc`, no standard library required
+//! - **Bytes support**: First-class support for binary data (useful for MessagePack, CBOR, etc.)
+//!
+//! # Design
+//!
+//! `Value` uses a tagged pointer representation with 8-byte alignment, giving us 3 tag bits
+//! to distinguish between value types. Inline values (null, true, false) don't require
+//! heap allocation.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![warn(missing_docs)]
+#![warn(clippy::std_instead_of_core)]
+#![warn(clippy::std_instead_of_alloc)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+mod value;
+pub use value::*;
+
+mod number;
+pub use number::*;
+
+mod string;
+pub use string::*;
+
+mod bytes;
+pub use bytes::*;
+
+mod array;
+pub use array::*;
+
+mod object;
+pub use object::*;

--- a/facet-value/src/number.rs
+++ b/facet-value/src/number.rs
@@ -1,0 +1,511 @@
+//! Number value type with efficient storage for various numeric types.
+
+#[cfg(feature = "alloc")]
+use alloc::alloc::{Layout, alloc, dealloc};
+use core::cmp::Ordering;
+use core::fmt::{self, Debug, Formatter};
+use core::hash::{Hash, Hasher};
+
+use crate::value::{TypeTag, Value};
+
+/// Internal representation of number type.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum NumberType {
+    /// Signed 64-bit integer
+    I64 = 0,
+    /// Unsigned 64-bit integer
+    U64 = 1,
+    /// 64-bit floating point
+    F64 = 2,
+}
+
+/// Header for heap-allocated numbers.
+#[repr(C, align(8))]
+struct NumberHeader {
+    /// Type discriminant
+    type_: NumberType,
+    /// Padding
+    _pad: [u8; 7],
+    /// The actual number data (i64, u64, or f64)
+    data: NumberData,
+}
+
+#[repr(C)]
+union NumberData {
+    i: i64,
+    u: u64,
+    f: f64,
+}
+
+/// A JSON number value.
+///
+/// `VNumber` can represent integers (signed and unsigned) and floating point numbers.
+/// It stores the number in the most appropriate internal format.
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct VNumber(pub(crate) Value);
+
+impl VNumber {
+    fn layout() -> Layout {
+        Layout::new::<NumberHeader>()
+    }
+
+    #[cfg(feature = "alloc")]
+    fn alloc(type_: NumberType) -> *mut NumberHeader {
+        unsafe {
+            let ptr = alloc(Self::layout()).cast::<NumberHeader>();
+            (*ptr).type_ = type_;
+            ptr
+        }
+    }
+
+    #[cfg(feature = "alloc")]
+    fn dealloc(ptr: *mut NumberHeader) {
+        unsafe {
+            dealloc(ptr.cast::<u8>(), Self::layout());
+        }
+    }
+
+    fn header(&self) -> &NumberHeader {
+        unsafe { &*(self.0.heap_ptr() as *const NumberHeader) }
+    }
+
+    #[allow(dead_code)]
+    fn header_mut(&mut self) -> &mut NumberHeader {
+        unsafe { &mut *(self.0.heap_ptr() as *mut NumberHeader) }
+    }
+
+    /// Creates a number from an i64.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn from_i64(v: i64) -> Self {
+        unsafe {
+            let ptr = Self::alloc(NumberType::I64);
+            (*ptr).data.i = v;
+            VNumber(Value::new_ptr(ptr.cast(), TypeTag::Number))
+        }
+    }
+
+    /// Creates a number from a u64.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn from_u64(v: u64) -> Self {
+        // If it fits in i64, use that for consistency
+        if let Ok(i) = i64::try_from(v) {
+            Self::from_i64(i)
+        } else {
+            unsafe {
+                let ptr = Self::alloc(NumberType::U64);
+                (*ptr).data.u = v;
+                VNumber(Value::new_ptr(ptr.cast(), TypeTag::Number))
+            }
+        }
+    }
+
+    /// Creates a number from an f64.
+    ///
+    /// Returns `None` if the value is NaN or infinite.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn from_f64(v: f64) -> Option<Self> {
+        if !v.is_finite() {
+            return None;
+        }
+        unsafe {
+            let ptr = Self::alloc(NumberType::F64);
+            (*ptr).data.f = v;
+            Some(VNumber(Value::new_ptr(ptr.cast(), TypeTag::Number)))
+        }
+    }
+
+    /// Returns the number zero.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn zero() -> Self {
+        Self::from_i64(0)
+    }
+
+    /// Returns the number one.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn one() -> Self {
+        Self::from_i64(1)
+    }
+
+    /// Converts to i64 if it can be represented exactly.
+    #[must_use]
+    pub fn to_i64(&self) -> Option<i64> {
+        let hd = self.header();
+        unsafe {
+            match hd.type_ {
+                NumberType::I64 => Some(hd.data.i),
+                NumberType::U64 => i64::try_from(hd.data.u).ok(),
+                NumberType::F64 => {
+                    let f = hd.data.f;
+                    // Check if in range and is a whole number via round-trip cast
+                    if f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+                        let i = f as i64;
+                        if i as f64 == f {
+                            return Some(i);
+                        }
+                    }
+                    None
+                }
+            }
+        }
+    }
+
+    /// Converts to u64 if it can be represented exactly.
+    #[must_use]
+    pub fn to_u64(&self) -> Option<u64> {
+        let hd = self.header();
+        unsafe {
+            match hd.type_ {
+                NumberType::I64 => u64::try_from(hd.data.i).ok(),
+                NumberType::U64 => Some(hd.data.u),
+                NumberType::F64 => {
+                    let f = hd.data.f;
+                    // Check if in range and is a whole number via round-trip cast
+                    if f >= 0.0 && f <= u64::MAX as f64 {
+                        let u = f as u64;
+                        if u as f64 == f {
+                            return Some(u);
+                        }
+                    }
+                    None
+                }
+            }
+        }
+    }
+
+    /// Converts to f64 if it can be represented exactly.
+    #[must_use]
+    pub fn to_f64(&self) -> Option<f64> {
+        let hd = self.header();
+        unsafe {
+            match hd.type_ {
+                NumberType::I64 => {
+                    let i = hd.data.i;
+                    let f = i as f64;
+                    if f as i64 == i { Some(f) } else { None }
+                }
+                NumberType::U64 => {
+                    let u = hd.data.u;
+                    let f = u as f64;
+                    if f as u64 == u { Some(f) } else { None }
+                }
+                NumberType::F64 => Some(hd.data.f),
+            }
+        }
+    }
+
+    /// Converts to f64, potentially losing precision.
+    #[must_use]
+    pub fn to_f64_lossy(&self) -> f64 {
+        let hd = self.header();
+        unsafe {
+            match hd.type_ {
+                NumberType::I64 => hd.data.i as f64,
+                NumberType::U64 => hd.data.u as f64,
+                NumberType::F64 => hd.data.f,
+            }
+        }
+    }
+
+    /// Converts to i32 if it can be represented exactly.
+    #[must_use]
+    pub fn to_i32(&self) -> Option<i32> {
+        self.to_i64().and_then(|v| i32::try_from(v).ok())
+    }
+
+    /// Converts to u32 if it can be represented exactly.
+    #[must_use]
+    pub fn to_u32(&self) -> Option<u32> {
+        self.to_u64().and_then(|v| u32::try_from(v).ok())
+    }
+
+    /// Converts to f32 if it can be represented exactly.
+    #[must_use]
+    pub fn to_f32(&self) -> Option<f32> {
+        self.to_f64().and_then(|f| {
+            let f32_val = f as f32;
+            if f32_val as f64 == f {
+                Some(f32_val)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Returns true if this number was created from a floating point value.
+    #[must_use]
+    pub fn is_float(&self) -> bool {
+        self.header().type_ == NumberType::F64
+    }
+
+    /// Returns true if this number is an integer (signed or unsigned).
+    #[must_use]
+    pub fn is_integer(&self) -> bool {
+        matches!(self.header().type_, NumberType::I64 | NumberType::U64)
+    }
+
+    pub(crate) fn clone_impl(&self) -> Value {
+        let hd = self.header();
+        unsafe {
+            match hd.type_ {
+                NumberType::I64 => Self::from_i64(hd.data.i).0,
+                NumberType::U64 => {
+                    let ptr = Self::alloc(NumberType::U64);
+                    (*ptr).data.u = hd.data.u;
+                    Value::new_ptr(ptr.cast(), TypeTag::Number)
+                }
+                NumberType::F64 => Self::from_f64(hd.data.f).unwrap().0,
+            }
+        }
+    }
+
+    pub(crate) fn drop_impl(&mut self) {
+        unsafe {
+            Self::dealloc(self.0.heap_ptr().cast());
+        }
+    }
+}
+
+impl PartialEq for VNumber {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for VNumber {}
+
+impl PartialOrd for VNumber {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for VNumber {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let h1 = self.header();
+        let h2 = other.header();
+
+        unsafe {
+            // Fast path: same type
+            if h1.type_ == h2.type_ {
+                match h1.type_ {
+                    NumberType::I64 => h1.data.i.cmp(&h2.data.i),
+                    NumberType::U64 => h1.data.u.cmp(&h2.data.u),
+                    NumberType::F64 => h1.data.f.partial_cmp(&h2.data.f).unwrap_or(Ordering::Equal),
+                }
+            } else {
+                // Cross-type comparison: convert to f64 for simplicity
+                // (This loses precision for very large integers, but is simple)
+                self.to_f64_lossy()
+                    .partial_cmp(&other.to_f64_lossy())
+                    .unwrap_or(Ordering::Equal)
+            }
+        }
+    }
+}
+
+impl Hash for VNumber {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Hash based on the "canonical" representation
+        if let Some(i) = self.to_i64() {
+            0u8.hash(state); // discriminant for integer
+            i.hash(state);
+        } else if let Some(u) = self.to_u64() {
+            1u8.hash(state); // discriminant for large unsigned
+            u.hash(state);
+        } else if let Some(f) = self.to_f64() {
+            2u8.hash(state); // discriminant for float
+            f.to_bits().hash(state);
+        }
+    }
+}
+
+impl Debug for VNumber {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if let Some(i) = self.to_i64() {
+            Debug::fmt(&i, f)
+        } else if let Some(u) = self.to_u64() {
+            Debug::fmt(&u, f)
+        } else if let Some(fl) = self.to_f64() {
+            Debug::fmt(&fl, f)
+        } else {
+            f.write_str("NaN")
+        }
+    }
+}
+
+impl Default for VNumber {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+// === From implementations ===
+
+macro_rules! impl_from_int {
+    ($($t:ty => $method:ident),* $(,)?) => {
+        $(
+            #[cfg(feature = "alloc")]
+            impl From<$t> for VNumber {
+                fn from(v: $t) -> Self {
+                    Self::$method(v as _)
+                }
+            }
+
+            #[cfg(feature = "alloc")]
+            impl From<$t> for Value {
+                fn from(v: $t) -> Self {
+                    VNumber::from(v).0
+                }
+            }
+        )*
+    };
+}
+
+impl_from_int! {
+    i8 => from_i64,
+    i16 => from_i64,
+    i32 => from_i64,
+    i64 => from_i64,
+    isize => from_i64,
+    u8 => from_i64,
+    u16 => from_i64,
+    u32 => from_i64,
+    u64 => from_u64,
+    usize => from_u64,
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<f32> for VNumber {
+    type Error = ();
+
+    fn try_from(v: f32) -> Result<Self, Self::Error> {
+        Self::from_f64(f64::from(v)).ok_or(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl TryFrom<f64> for VNumber {
+    type Error = ();
+
+    fn try_from(v: f64) -> Result<Self, Self::Error> {
+        Self::from_f64(v).ok_or(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<f32> for Value {
+    fn from(v: f32) -> Self {
+        VNumber::from_f64(f64::from(v))
+            .map(|n| n.0)
+            .unwrap_or(Value::NULL)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<f64> for Value {
+    fn from(v: f64) -> Self {
+        VNumber::from_f64(v).map(|n| n.0).unwrap_or(Value::NULL)
+    }
+}
+
+// === Conversion traits ===
+
+impl AsRef<Value> for VNumber {
+    fn as_ref(&self) -> &Value {
+        &self.0
+    }
+}
+
+impl AsMut<Value> for VNumber {
+    fn as_mut(&mut self) -> &mut Value {
+        &mut self.0
+    }
+}
+
+impl From<VNumber> for Value {
+    fn from(n: VNumber) -> Self {
+        n.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_i64() {
+        let n = VNumber::from_i64(42);
+        assert_eq!(n.to_i64(), Some(42));
+        assert_eq!(n.to_u64(), Some(42));
+        assert_eq!(n.to_f64(), Some(42.0));
+        assert!(n.is_integer());
+        assert!(!n.is_float());
+    }
+
+    #[test]
+    fn test_negative() {
+        let n = VNumber::from_i64(-100);
+        assert_eq!(n.to_i64(), Some(-100));
+        assert_eq!(n.to_u64(), None);
+        assert_eq!(n.to_f64(), Some(-100.0));
+    }
+
+    #[test]
+    fn test_large_u64() {
+        let v = u64::MAX;
+        let n = VNumber::from_u64(v);
+        assert_eq!(n.to_u64(), Some(v));
+        assert_eq!(n.to_i64(), None);
+    }
+
+    #[test]
+    fn test_f64() {
+        let n = VNumber::from_f64(2.5).unwrap();
+        assert_eq!(n.to_f64(), Some(2.5));
+        assert_eq!(n.to_i64(), None); // has fractional part
+        assert!(n.is_float());
+        assert!(!n.is_integer());
+    }
+
+    #[test]
+    fn test_f64_whole() {
+        let n = VNumber::from_f64(42.0).unwrap();
+        assert_eq!(n.to_f64(), Some(42.0));
+        assert_eq!(n.to_i64(), Some(42)); // whole number
+    }
+
+    #[test]
+    fn test_nan_rejected() {
+        assert!(VNumber::from_f64(f64::NAN).is_none());
+        assert!(VNumber::from_f64(f64::INFINITY).is_none());
+        assert!(VNumber::from_f64(f64::NEG_INFINITY).is_none());
+    }
+
+    #[test]
+    fn test_equality() {
+        let a = VNumber::from_i64(42);
+        let b = VNumber::from_i64(42);
+        let c = VNumber::from_f64(42.0).unwrap();
+
+        assert_eq!(a, b);
+        assert_eq!(a, c); // integer 42 equals float 42.0
+    }
+
+    #[test]
+    fn test_ordering() {
+        let a = VNumber::from_i64(1);
+        let b = VNumber::from_i64(2);
+        let c = VNumber::from_f64(1.5).unwrap();
+
+        assert!(a < b);
+        assert!(a < c);
+        assert!(c < b);
+    }
+}

--- a/facet-value/src/object.rs
+++ b/facet-value/src/object.rs
@@ -1,0 +1,631 @@
+//! Object (map) value type.
+
+#[cfg(feature = "alloc")]
+use alloc::alloc::{Layout, alloc, dealloc, realloc};
+#[cfg(feature = "alloc")]
+use alloc::borrow::ToOwned;
+#[cfg(feature = "alloc")]
+use alloc::collections::BTreeMap;
+use core::fmt::{self, Debug, Formatter};
+use core::hash::{Hash, Hasher};
+use core::iter::FromIterator;
+use core::ops::{Index, IndexMut};
+use core::{cmp, mem, ptr};
+
+#[cfg(feature = "std")]
+use std::collections::HashMap;
+
+use crate::string::VString;
+use crate::value::{TypeTag, Value};
+
+/// A key-value pair.
+#[repr(C)]
+struct KeyValuePair {
+    key: VString,
+    value: Value,
+}
+
+/// Header for heap-allocated objects.
+#[repr(C, align(8))]
+struct ObjectHeader {
+    /// Number of key-value pairs
+    len: usize,
+    /// Capacity
+    cap: usize,
+    // Array of KeyValuePair follows immediately after
+}
+
+/// An object (map) value.
+///
+/// `VObject` is an ordered map of string keys to `Value`s.
+/// It preserves insertion order and uses linear search for lookups.
+/// This is efficient for small objects (which are common in JSON).
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct VObject(pub(crate) Value);
+
+impl VObject {
+    fn layout(cap: usize) -> Layout {
+        Layout::new::<ObjectHeader>()
+            .extend(Layout::array::<KeyValuePair>(cap).unwrap())
+            .unwrap()
+            .0
+            .pad_to_align()
+    }
+
+    #[cfg(feature = "alloc")]
+    fn alloc(cap: usize) -> *mut ObjectHeader {
+        unsafe {
+            let layout = Self::layout(cap);
+            let ptr = alloc(layout).cast::<ObjectHeader>();
+            (*ptr).len = 0;
+            (*ptr).cap = cap;
+            ptr
+        }
+    }
+
+    #[cfg(feature = "alloc")]
+    fn realloc_ptr(ptr: *mut ObjectHeader, new_cap: usize) -> *mut ObjectHeader {
+        unsafe {
+            let old_cap = (*ptr).cap;
+            let old_layout = Self::layout(old_cap);
+            let new_layout = Self::layout(new_cap);
+            let new_ptr =
+                realloc(ptr.cast::<u8>(), old_layout, new_layout.size()).cast::<ObjectHeader>();
+            (*new_ptr).cap = new_cap;
+            new_ptr
+        }
+    }
+
+    #[cfg(feature = "alloc")]
+    fn dealloc_ptr(ptr: *mut ObjectHeader) {
+        unsafe {
+            let cap = (*ptr).cap;
+            let layout = Self::layout(cap);
+            dealloc(ptr.cast::<u8>(), layout);
+        }
+    }
+
+    fn header(&self) -> &ObjectHeader {
+        unsafe { &*(self.0.heap_ptr() as *const ObjectHeader) }
+    }
+
+    fn header_mut(&mut self) -> &mut ObjectHeader {
+        unsafe { &mut *(self.0.heap_ptr() as *mut ObjectHeader) }
+    }
+
+    fn items_ptr(&self) -> *const KeyValuePair {
+        unsafe { (self.header() as *const ObjectHeader).add(1).cast() }
+    }
+
+    fn items_ptr_mut(&mut self) -> *mut KeyValuePair {
+        unsafe { (self.header_mut() as *mut ObjectHeader).add(1).cast() }
+    }
+
+    fn items(&self) -> &[KeyValuePair] {
+        unsafe { core::slice::from_raw_parts(self.items_ptr(), self.len()) }
+    }
+
+    fn items_mut(&mut self) -> &mut [KeyValuePair] {
+        unsafe { core::slice::from_raw_parts_mut(self.items_ptr_mut(), self.len()) }
+    }
+
+    /// Creates a new empty object.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
+    /// Creates a new object with the specified capacity.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn with_capacity(cap: usize) -> Self {
+        unsafe {
+            let ptr = Self::alloc(cap);
+            VObject(Value::new_ptr(ptr.cast(), TypeTag::Object))
+        }
+    }
+
+    /// Returns the number of entries.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.header().len
+    }
+
+    /// Returns `true` if the object is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the capacity.
+    #[must_use]
+    pub fn capacity(&self) -> usize {
+        self.header().cap
+    }
+
+    /// Reserves capacity for at least `additional` more entries.
+    #[cfg(feature = "alloc")]
+    pub fn reserve(&mut self, additional: usize) {
+        let current_cap = self.capacity();
+        let desired_cap = self
+            .len()
+            .checked_add(additional)
+            .expect("capacity overflow");
+
+        if current_cap >= desired_cap {
+            return;
+        }
+
+        let new_cap = cmp::max(current_cap * 2, desired_cap.max(4));
+
+        unsafe {
+            let new_ptr = Self::realloc_ptr(self.0.heap_ptr().cast(), new_cap);
+            self.0.set_ptr(new_ptr.cast());
+        }
+    }
+
+    /// Finds the index of a key.
+    fn find_key(&self, key: &str) -> Option<usize> {
+        self.items().iter().position(|kv| kv.key.as_str() == key)
+    }
+
+    /// Gets a value by key.
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.find_key(key).map(|i| &self.items()[i].value)
+    }
+
+    /// Gets a mutable value by key.
+    pub fn get_mut(&mut self, key: &str) -> Option<&mut Value> {
+        self.find_key(key).map(|i| &mut self.items_mut()[i].value)
+    }
+
+    /// Gets a key-value pair by key.
+    #[must_use]
+    pub fn get_key_value(&self, key: &str) -> Option<(&VString, &Value)> {
+        self.find_key(key).map(|i| {
+            let kv = &self.items()[i];
+            (&kv.key, &kv.value)
+        })
+    }
+
+    /// Returns `true` if the object contains the key.
+    #[must_use]
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.find_key(key).is_some()
+    }
+
+    /// Inserts a key-value pair. Returns the old value if the key existed.
+    #[cfg(feature = "alloc")]
+    pub fn insert(&mut self, key: impl Into<VString>, value: impl Into<Value>) -> Option<Value> {
+        let key = key.into();
+        let value = value.into();
+
+        if let Some(i) = self.find_key(key.as_str()) {
+            // Key exists, replace value
+            Some(mem::replace(&mut self.items_mut()[i].value, value))
+        } else {
+            // New key
+            self.reserve(1);
+            unsafe {
+                let len = self.header().len;
+                let ptr = self.items_ptr_mut().add(len);
+                ptr.write(KeyValuePair { key, value });
+                self.header_mut().len = len + 1;
+            }
+            None
+        }
+    }
+
+    /// Removes a key-value pair. Returns the value if the key existed.
+    pub fn remove(&mut self, key: &str) -> Option<Value> {
+        self.remove_entry(key).map(|(_, v)| v)
+    }
+
+    /// Removes and returns a key-value pair.
+    pub fn remove_entry(&mut self, key: &str) -> Option<(VString, Value)> {
+        let idx = self.find_key(key)?;
+        let len = self.len();
+
+        unsafe {
+            let ptr = self.items_ptr_mut().add(idx);
+            let kv = ptr.read();
+
+            // Shift remaining elements
+            if idx < len - 1 {
+                ptr::copy(ptr.add(1), ptr, len - idx - 1);
+            }
+
+            self.header_mut().len = len - 1;
+            Some((kv.key, kv.value))
+        }
+    }
+
+    /// Clears the object.
+    pub fn clear(&mut self) {
+        while !self.is_empty() {
+            unsafe {
+                let len = self.header().len;
+                self.header_mut().len = len - 1;
+                let ptr = self.items_ptr_mut().add(len - 1);
+                ptr::drop_in_place(ptr);
+            }
+        }
+    }
+
+    /// Returns an iterator over keys.
+    pub fn keys(&self) -> impl Iterator<Item = &VString> {
+        self.items().iter().map(|kv| &kv.key)
+    }
+
+    /// Returns an iterator over values.
+    pub fn values(&self) -> impl Iterator<Item = &Value> {
+        self.items().iter().map(|kv| &kv.value)
+    }
+
+    /// Returns an iterator over mutable values.
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut Value> {
+        self.items_mut().iter_mut().map(|kv| &mut kv.value)
+    }
+
+    /// Returns an iterator over key-value pairs.
+    pub fn iter(&self) -> Iter<'_> {
+        Iter {
+            inner: self.items().iter(),
+        }
+    }
+
+    /// Returns an iterator over mutable key-value pairs.
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
+        IterMut {
+            inner: self.items_mut().iter_mut(),
+        }
+    }
+
+    /// Shrinks the capacity to match the length.
+    #[cfg(feature = "alloc")]
+    pub fn shrink_to_fit(&mut self) {
+        let len = self.len();
+        let cap = self.capacity();
+
+        if len < cap {
+            unsafe {
+                let new_ptr = Self::realloc_ptr(self.0.heap_ptr().cast(), len);
+                self.0.set_ptr(new_ptr.cast());
+            }
+        }
+    }
+
+    pub(crate) fn clone_impl(&self) -> Value {
+        let mut new = VObject::with_capacity(self.len());
+        for kv in self.items() {
+            new.insert(kv.key.clone(), kv.value.clone());
+        }
+        new.0
+    }
+
+    pub(crate) fn drop_impl(&mut self) {
+        self.clear();
+        unsafe {
+            Self::dealloc_ptr(self.0.heap_ptr().cast());
+        }
+    }
+}
+
+// === Iterators ===
+
+/// Iterator over `(&VString, &Value)` pairs.
+pub struct Iter<'a> {
+    inner: core::slice::Iter<'a, KeyValuePair>,
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = (&'a VString, &'a Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|kv| (&kv.key, &kv.value))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl ExactSizeIterator for Iter<'_> {}
+
+/// Iterator over `(&VString, &mut Value)` pairs.
+pub struct IterMut<'a> {
+    inner: core::slice::IterMut<'a, KeyValuePair>,
+}
+
+impl<'a> Iterator for IterMut<'a> {
+    type Item = (&'a VString, &'a mut Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|kv| (&kv.key, &mut kv.value))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl ExactSizeIterator for IterMut<'_> {}
+
+/// Iterator over owned `(VString, Value)` pairs.
+pub struct ObjectIntoIter {
+    object: VObject,
+}
+
+impl Iterator for ObjectIntoIter {
+    type Item = (VString, Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.object.is_empty() {
+            None
+        } else {
+            // Remove from the front to preserve order
+            let key = self.object.items()[0].key.as_str().to_owned();
+            self.object.remove_entry(&key)
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.object.len();
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for ObjectIntoIter {}
+
+impl IntoIterator for VObject {
+    type Item = (VString, Value);
+    type IntoIter = ObjectIntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ObjectIntoIter { object: self }
+    }
+}
+
+impl<'a> IntoIterator for &'a VObject {
+    type Item = (&'a VString, &'a Value);
+    type IntoIter = Iter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut VObject {
+    type Item = (&'a VString, &'a mut Value);
+    type IntoIter = IterMut<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+// === Index ===
+
+impl Index<&str> for VObject {
+    type Output = Value;
+
+    fn index(&self, key: &str) -> &Value {
+        self.get(key).expect("key not found")
+    }
+}
+
+impl IndexMut<&str> for VObject {
+    fn index_mut(&mut self, key: &str) -> &mut Value {
+        self.get_mut(key).expect("key not found")
+    }
+}
+
+// === Comparison ===
+
+impl PartialEq for VObject {
+    fn eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+        for (k, v) in self.iter() {
+            if other.get(k.as_str()) != Some(v) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl Eq for VObject {}
+
+impl Hash for VObject {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Hash length and then each key-value pair
+        // Note: This doesn't depend on order, which is correct for map semantics
+        self.len().hash(state);
+
+        // Sum hashes to make order-independent (XOR is order-independent)
+        let mut total: u64 = 0;
+        for (k, _v) in self.iter() {
+            // Simple hash combining for each pair
+            let mut kh: u64 = 0;
+            for byte in k.as_bytes() {
+                kh = kh.wrapping_mul(31).wrapping_add(*byte as u64);
+            }
+            // Just XOR the key hash contribution
+            total ^= kh;
+        }
+        total.hash(state);
+    }
+}
+
+impl Debug for VObject {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
+    }
+}
+
+impl Default for VObject {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// === FromIterator / Extend ===
+
+#[cfg(feature = "alloc")]
+impl<K: Into<VString>, V: Into<Value>> FromIterator<(K, V)> for VObject {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let (lower, _) = iter.size_hint();
+        let mut obj = VObject::with_capacity(lower);
+        for (k, v) in iter {
+            obj.insert(k, v);
+        }
+        obj
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<K: Into<VString>, V: Into<Value>> Extend<(K, V)> for VObject {
+    fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
+        let iter = iter.into_iter();
+        let (lower, _) = iter.size_hint();
+        self.reserve(lower);
+        for (k, v) in iter {
+            self.insert(k, v);
+        }
+    }
+}
+
+// === From implementations ===
+
+#[cfg(feature = "std")]
+impl<K: Into<VString>, V: Into<Value>> From<HashMap<K, V>> for VObject {
+    fn from(map: HashMap<K, V>) -> Self {
+        map.into_iter().collect()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<K: Into<VString>, V: Into<Value>> From<BTreeMap<K, V>> for VObject {
+    fn from(map: BTreeMap<K, V>) -> Self {
+        map.into_iter().collect()
+    }
+}
+
+// === Value conversions ===
+
+impl AsRef<Value> for VObject {
+    fn as_ref(&self) -> &Value {
+        &self.0
+    }
+}
+
+impl AsMut<Value> for VObject {
+    fn as_mut(&mut self) -> &mut Value {
+        &mut self.0
+    }
+}
+
+impl From<VObject> for Value {
+    fn from(obj: VObject) -> Self {
+        obj.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let obj = VObject::new();
+        assert!(obj.is_empty());
+        assert_eq!(obj.len(), 0);
+    }
+
+    #[test]
+    fn test_insert_get() {
+        let mut obj = VObject::new();
+        obj.insert("name", Value::from("Alice"));
+        obj.insert("age", Value::from(30));
+
+        assert_eq!(obj.len(), 2);
+        assert!(obj.contains_key("name"));
+        assert!(obj.contains_key("age"));
+        assert!(!obj.contains_key("email"));
+
+        assert_eq!(
+            obj.get("name").unwrap().as_string().unwrap().as_str(),
+            "Alice"
+        );
+        assert_eq!(
+            obj.get("age").unwrap().as_number().unwrap().to_i64(),
+            Some(30)
+        );
+    }
+
+    #[test]
+    fn test_insert_replace() {
+        let mut obj = VObject::new();
+        assert!(obj.insert("key", Value::from(1)).is_none());
+        assert!(obj.insert("key", Value::from(2)).is_some());
+        assert_eq!(obj.len(), 1);
+        assert_eq!(
+            obj.get("key").unwrap().as_number().unwrap().to_i64(),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut obj = VObject::new();
+        obj.insert("a", Value::from(1));
+        obj.insert("b", Value::from(2));
+        obj.insert("c", Value::from(3));
+
+        let removed = obj.remove("b");
+        assert!(removed.is_some());
+        assert_eq!(obj.len(), 2);
+        assert!(!obj.contains_key("b"));
+    }
+
+    #[test]
+    fn test_clone() {
+        let mut obj = VObject::new();
+        obj.insert("key", Value::from("value"));
+
+        let obj2 = obj.clone();
+        assert_eq!(obj, obj2);
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut obj = VObject::new();
+        obj.insert("a", Value::from(1));
+        obj.insert("b", Value::from(2));
+
+        let keys: Vec<_> = obj.keys().map(|k| k.as_str()).collect();
+        assert_eq!(keys, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_collect() {
+        let obj: VObject = vec![("a", Value::from(1)), ("b", Value::from(2))]
+            .into_iter()
+            .collect();
+        assert_eq!(obj.len(), 2);
+    }
+
+    #[test]
+    fn test_index() {
+        let mut obj = VObject::new();
+        obj.insert("key", Value::from(42));
+
+        assert_eq!(obj["key"].as_number().unwrap().to_i64(), Some(42));
+    }
+}

--- a/facet-value/src/string.rs
+++ b/facet-value/src/string.rs
@@ -1,0 +1,371 @@
+//! String value type.
+
+#[cfg(feature = "alloc")]
+use alloc::alloc::{Layout, alloc, dealloc};
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+use core::borrow::Borrow;
+use core::cmp::Ordering;
+use core::fmt::{self, Debug, Formatter};
+use core::hash::{Hash, Hasher};
+use core::ops::Deref;
+use core::ptr;
+
+use crate::value::{TypeTag, Value};
+
+/// Header for heap-allocated strings.
+#[repr(C, align(8))]
+struct StringHeader {
+    /// Length of the string in bytes
+    len: usize,
+    // String data follows immediately after
+}
+
+/// A string value.
+///
+/// `VString` stores UTF-8 string data. Unlike some implementations, strings are
+/// not interned - each `VString` owns its own copy of the data.
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct VString(pub(crate) Value);
+
+impl VString {
+    fn layout(len: usize) -> Layout {
+        Layout::new::<StringHeader>()
+            .extend(Layout::array::<u8>(len).unwrap())
+            .unwrap()
+            .0
+            .pad_to_align()
+    }
+
+    #[cfg(feature = "alloc")]
+    fn alloc(s: &str) -> *mut StringHeader {
+        unsafe {
+            let layout = Self::layout(s.len());
+            let ptr = alloc(layout).cast::<StringHeader>();
+            (*ptr).len = s.len();
+
+            // Copy string data
+            let data_ptr = ptr.add(1).cast::<u8>();
+            ptr::copy_nonoverlapping(s.as_ptr(), data_ptr, s.len());
+
+            ptr
+        }
+    }
+
+    #[cfg(feature = "alloc")]
+    fn dealloc_ptr(ptr: *mut StringHeader) {
+        unsafe {
+            let len = (*ptr).len;
+            let layout = Self::layout(len);
+            dealloc(ptr.cast::<u8>(), layout);
+        }
+    }
+
+    fn header(&self) -> &StringHeader {
+        unsafe { &*(self.0.heap_ptr() as *const StringHeader) }
+    }
+
+    fn data_ptr(&self) -> *const u8 {
+        unsafe { (self.header() as *const StringHeader).add(1).cast() }
+    }
+
+    /// Creates a new string from a `&str`.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn new(s: &str) -> Self {
+        if s.is_empty() {
+            return Self::empty();
+        }
+        unsafe {
+            let ptr = Self::alloc(s);
+            VString(Value::new_ptr(ptr.cast(), TypeTag::StringOrNull))
+        }
+    }
+
+    /// Creates an empty string.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn empty() -> Self {
+        // For empty strings, we still allocate a header with len=0
+        // This keeps the code simpler
+        unsafe {
+            let layout = Self::layout(0);
+            let ptr = alloc(layout).cast::<StringHeader>();
+            (*ptr).len = 0;
+            VString(Value::new_ptr(ptr.cast(), TypeTag::StringOrNull))
+        }
+    }
+
+    /// Returns the length of the string in bytes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.header().len
+    }
+
+    /// Returns `true` if the string is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the string as a `&str`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        unsafe {
+            let bytes = core::slice::from_raw_parts(self.data_ptr(), self.len());
+            core::str::from_utf8_unchecked(bytes)
+        }
+    }
+
+    /// Returns the string as a byte slice.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.data_ptr(), self.len()) }
+    }
+
+    pub(crate) fn clone_impl(&self) -> Value {
+        VString::new(self.as_str()).0
+    }
+
+    pub(crate) fn drop_impl(&mut self) {
+        unsafe {
+            Self::dealloc_ptr(self.0.heap_ptr().cast());
+        }
+    }
+}
+
+impl Deref for VString {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for VString {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for VString {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<[u8]> for VString {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl PartialEq for VString {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for VString {}
+
+impl PartialOrd for VString {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for VString {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl Hash for VString {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl Debug for VString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl fmt::Display for VString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), f)
+    }
+}
+
+impl Default for VString {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+// === PartialEq with str ===
+
+impl PartialEq<str> for VString {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<VString> for str {
+    fn eq(&self, other: &VString) -> bool {
+        self == other.as_str()
+    }
+}
+
+impl PartialEq<&str> for VString {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl PartialEq<String> for VString {
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl PartialEq<VString> for String {
+    fn eq(&self, other: &VString) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+// === From implementations ===
+
+#[cfg(feature = "alloc")]
+impl From<&str> for VString {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<String> for VString {
+    fn from(s: String) -> Self {
+        Self::new(&s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<&String> for VString {
+    fn from(s: &String) -> Self {
+        Self::new(s)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<VString> for String {
+    fn from(s: VString) -> Self {
+        s.as_str().into()
+    }
+}
+
+// === Value conversions ===
+
+impl AsRef<Value> for VString {
+    fn as_ref(&self) -> &Value {
+        &self.0
+    }
+}
+
+impl AsMut<Value> for VString {
+    fn as_mut(&mut self) -> &mut Value {
+        &mut self.0
+    }
+}
+
+impl From<VString> for Value {
+    fn from(s: VString) -> Self {
+        s.0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<&str> for Value {
+    fn from(s: &str) -> Self {
+        VString::new(s).0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<String> for Value {
+    fn from(s: String) -> Self {
+        VString::new(&s).0
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<&String> for Value {
+    fn from(s: &String) -> Self {
+        VString::new(s).0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let s = VString::new("hello");
+        assert_eq!(s.as_str(), "hello");
+        assert_eq!(s.len(), 5);
+        assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn test_empty() {
+        let s = VString::empty();
+        assert_eq!(s.as_str(), "");
+        assert_eq!(s.len(), 0);
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn test_equality() {
+        let a = VString::new("hello");
+        let b = VString::new("hello");
+        let c = VString::new("world");
+
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_eq!(a, "hello");
+        assert_eq!(a.as_str(), "hello");
+    }
+
+    #[test]
+    fn test_clone() {
+        let a = VString::new("test");
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_unicode() {
+        let s = VString::new("hello 世界 🌍");
+        assert_eq!(s.as_str(), "hello 世界 🌍");
+    }
+
+    #[test]
+    fn test_deref() {
+        let s = VString::new("hello");
+        assert!(s.starts_with("hel"));
+        assert!(s.ends_with("llo"));
+    }
+
+    #[test]
+    fn test_ordering() {
+        let a = VString::new("apple");
+        let b = VString::new("banana");
+        assert!(a < b);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds new `facet-value` crate inspired by [ijson](https://lib.rs/crates/ijson)
- Provides a pointer-sized `Value` type using tagged pointers (3 tag bits via 8-byte alignment)
- Includes `VBytes` type for binary format support (MessagePack, CBOR, etc.)
- `no_std` compatible with `alloc` feature

## Design

Following ijson's advice: struct-based API with `destructure()` methods rather than exposed enum (allows backward-compatible representation changes).

**Seven value types:**
| Type | Storage |
|------|---------|
| Null | inline (no alloc) |
| Bool | inline (no alloc) |
| Number | heap (`i64`/`u64`/`f64`) |
| String | heap (UTF-8) |
| Bytes | heap (binary) |
| Array | heap (dynamic) |
| Object | heap (ordered map) |

**Differences from ijson:**
- No string interning (simpler, `no_std` friendly)
- No small number optimization (yet)
- Added `VBytes` for binary formats

## Test plan

- [x] All 39 unit tests pass
- [ ] CI passes