### PR TITLE
Add DynamicValue support for deserializing into facet_value::Value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,6 +514,7 @@ dependencies = [
  "facet-showcase",
  "facet-solver",
  "facet-testhelpers",
+ "facet-value",
  "flate2",
  "insta",
  "itoa",
@@ -615,6 +616,7 @@ dependencies = [
  "facet",
  "facet-core",
  "facet-testhelpers",
+ "facet-value",
  "insta",
  "log",
  "miette",
@@ -705,6 +707,9 @@ dependencies = [
 [[package]]
 name = "facet-value"
 version = "0.1.0"
+dependencies = [
+ "facet-core",
+]
 
 [[package]]
 name = "facet-xdr"

--- a/facet-core/src/types/def/dynamic_value.rs
+++ b/facet-core/src/types/def/dynamic_value.rs
@@ -1,0 +1,611 @@
+//! Definition for dynamic value types that can hold any value at runtime.
+//!
+//! This is used for types like `facet_value::Value` or `serde_json::Value`
+//! that determine their structure at runtime rather than compile time.
+
+use crate::ptr::{PtrConst, PtrMut, PtrUninit};
+
+/// Definition for dynamic value types.
+///
+/// Unlike other `Def` variants that describe a fixed structure, `DynamicValueDef`
+/// describes a type that can hold any of: null, bool, number, string, bytes,
+/// array, or object - determined at runtime.
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct DynamicValueDef {
+    /// Vtable for interacting with the dynamic value
+    pub vtable: &'static DynamicValueVTable,
+}
+
+impl DynamicValueDef {
+    /// Returns a builder for DynamicValueDef
+    pub const fn builder() -> DynamicValueDefBuilder {
+        DynamicValueDefBuilder::new()
+    }
+}
+
+/// Builder for DynamicValueDef
+pub struct DynamicValueDefBuilder {
+    vtable: Option<&'static DynamicValueVTable>,
+}
+
+impl DynamicValueDefBuilder {
+    /// Creates a new DynamicValueDefBuilder
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self { vtable: None }
+    }
+
+    /// Sets the vtable for the DynamicValueDef
+    pub const fn vtable(mut self, vtable: &'static DynamicValueVTable) -> Self {
+        self.vtable = Some(vtable);
+        self
+    }
+
+    /// Builds the DynamicValueDef
+    pub const fn build(self) -> DynamicValueDef {
+        DynamicValueDef {
+            vtable: self.vtable.unwrap(),
+        }
+    }
+}
+
+// ============================================================================
+// Scalar setters
+// ============================================================================
+
+/// Set the value to null.
+///
+/// # Safety
+///
+/// `dst` must point to uninitialized memory of the correct size and alignment.
+/// After this call, `dst` is fully initialized.
+pub type DynSetNullFn = unsafe fn(dst: PtrUninit<'_>);
+
+/// Set the value to a boolean.
+///
+/// # Safety
+///
+/// `dst` must point to uninitialized memory of the correct size and alignment.
+/// After this call, `dst` is fully initialized.
+pub type DynSetBoolFn = unsafe fn(dst: PtrUninit<'_>, value: bool);
+
+/// Set the value to a signed 64-bit integer.
+///
+/// # Safety
+///
+/// `dst` must point to uninitialized memory of the correct size and alignment.
+/// After this call, `dst` is fully initialized.
+pub type DynSetI64Fn = unsafe fn(dst: PtrUninit<'_>, value: i64);
+
+/// Set the value to an unsigned 64-bit integer.
+///
+/// # Safety
+///
+/// `dst` must point to uninitialized memory of the correct size and alignment.
+/// After this call, `dst` is fully initialized.
+pub type DynSetU64Fn = unsafe fn(dst: PtrUninit<'_>, value: u64);
+
+/// Set the value to a 64-bit float.
+///
+/// # Safety
+///
+/// `dst` must point to uninitialized memory of the correct size and alignment.
+/// After this call, `dst` is fully initialized.
+/// Returns `false` if the value is not representable (e.g., NaN/Infinity when not supported).
+pub type DynSetF64Fn = unsafe fn(dst: PtrUninit<'_>, value: f64) -> bool;
+
+/// Set the value to a string.
+///
+/// # Safety
+///
+/// `dst` must point to uninitialized memory of the correct size and alignment.
+/// After this call, `dst` is fully initialized.
+pub type DynSetStrFn = unsafe fn(dst: PtrUninit<'_>, value: &str);
+
+/// Set the value to bytes.
+///
+/// # Safety
+///
+/// `dst` must point to uninitialized memory of the correct size and alignment.
+/// After this call, `dst` is fully initialized.
+pub type DynSetBytesFn = unsafe fn(dst: PtrUninit<'_>, value: &[u8]);
+
+// ============================================================================
+// Array operations
+// ============================================================================
+
+/// Initialize the value as an empty array.
+///
+/// # Safety
+///
+/// `dst` must point to uninitialized memory of the correct size and alignment.
+/// After this call, `dst` is initialized as an empty array.
+pub type DynBeginArrayFn = unsafe fn(dst: PtrUninit<'_>);
+
+/// Push an element to the array.
+///
+/// The element is moved out of `element` (not dropped, but the memory can be deallocated).
+///
+/// # Safety
+///
+/// `array` must point to an initialized dynamic value that is an array.
+/// `element` must point to an initialized dynamic value to push.
+pub type DynPushArrayElementFn = unsafe fn(array: PtrMut<'_>, element: PtrMut<'_>);
+
+/// Finalize the array (optional, for shrinking capacity etc.).
+///
+/// # Safety
+///
+/// `array` must point to an initialized dynamic value that is an array.
+pub type DynEndArrayFn = unsafe fn(array: PtrMut<'_>);
+
+// ============================================================================
+// Object operations
+// ============================================================================
+
+/// Initialize the value as an empty object.
+///
+/// # Safety
+///
+/// `dst` must point to uninitialized memory of the correct size and alignment.
+/// After this call, `dst` is initialized as an empty object.
+pub type DynBeginObjectFn = unsafe fn(dst: PtrUninit<'_>);
+
+/// Insert a key-value pair into the object.
+///
+/// The value is moved out of `value` (not dropped, but the memory can be deallocated).
+///
+/// # Safety
+///
+/// `object` must point to an initialized dynamic value that is an object.
+/// `value` must point to an initialized dynamic value to insert.
+pub type DynInsertObjectEntryFn = unsafe fn(object: PtrMut<'_>, key: &str, value: PtrMut<'_>);
+
+/// Finalize the object (optional, for shrinking capacity etc.).
+///
+/// # Safety
+///
+/// `object` must point to an initialized dynamic value that is an object.
+pub type DynEndObjectFn = unsafe fn(object: PtrMut<'_>);
+
+// ============================================================================
+// Read operations (for Peek / serialization)
+// ============================================================================
+
+/// The kind of value stored in a dynamic value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DynValueKind {
+    /// Null value
+    Null,
+    /// Boolean value
+    Bool,
+    /// Number value (integer or float)
+    Number,
+    /// String value
+    String,
+    /// Binary data
+    Bytes,
+    /// Array of values
+    Array,
+    /// Object (string keys, dynamic values)
+    Object,
+}
+
+/// Get the kind of value stored.
+///
+/// # Safety
+///
+/// `value` must point to an initialized dynamic value.
+pub type DynGetKindFn = unsafe fn(value: PtrConst<'_>) -> DynValueKind;
+
+/// Get a boolean value. Returns None if not a bool.
+///
+/// # Safety
+///
+/// `value` must point to an initialized dynamic value.
+pub type DynGetBoolFn = unsafe fn(value: PtrConst<'_>) -> Option<bool>;
+
+/// Get a signed 64-bit integer value. Returns None if not representable as i64.
+///
+/// # Safety
+///
+/// `value` must point to an initialized dynamic value.
+pub type DynGetI64Fn = unsafe fn(value: PtrConst<'_>) -> Option<i64>;
+
+/// Get an unsigned 64-bit integer value. Returns None if not representable as u64.
+///
+/// # Safety
+///
+/// `value` must point to an initialized dynamic value.
+pub type DynGetU64Fn = unsafe fn(value: PtrConst<'_>) -> Option<u64>;
+
+/// Get a 64-bit float value. Returns None if not a number.
+///
+/// # Safety
+///
+/// `value` must point to an initialized dynamic value.
+pub type DynGetF64Fn = unsafe fn(value: PtrConst<'_>) -> Option<f64>;
+
+/// Get a string reference. Returns None if not a string.
+///
+/// # Safety
+///
+/// `value` must point to an initialized dynamic value.
+/// The returned reference is valid for the lifetime of the value.
+pub type DynGetStrFn = for<'a> unsafe fn(value: PtrConst<'a>) -> Option<&'a str>;
+
+/// Get a bytes reference. Returns None if not bytes.
+///
+/// # Safety
+///
+/// `value` must point to an initialized dynamic value.
+/// The returned reference is valid for the lifetime of the value.
+pub type DynGetBytesFn = for<'a> unsafe fn(value: PtrConst<'a>) -> Option<&'a [u8]>;
+
+/// Get the length of an array. Returns None if not an array.
+///
+/// # Safety
+///
+/// `value` must point to an initialized dynamic value.
+pub type DynArrayLenFn = unsafe fn(value: PtrConst<'_>) -> Option<usize>;
+
+/// Get an element from an array by index. Returns None if not an array or index out of bounds.
+///
+/// # Safety
+///
+/// `value` must point to an initialized dynamic value.
+pub type DynArrayGetFn = unsafe fn(value: PtrConst<'_>, index: usize) -> Option<PtrConst<'_>>;
+
+/// Get the length of an object. Returns None if not an object.
+///
+/// # Safety
+///
+/// `value` must point to an initialized dynamic value.
+pub type DynObjectLenFn = unsafe fn(value: PtrConst<'_>) -> Option<usize>;
+
+/// Get a key-value pair from an object by index. Returns None if not an object or index out of bounds.
+///
+/// # Safety
+///
+/// `value` must point to an initialized dynamic value.
+pub type DynObjectGetEntryFn =
+    for<'a> unsafe fn(value: PtrConst<'a>, index: usize) -> Option<(&'a str, PtrConst<'a>)>;
+
+/// Get a value from an object by key. Returns None if not an object or key not found.
+///
+/// # Safety
+///
+/// `value` must point to an initialized dynamic value.
+pub type DynObjectGetFn = for<'a> unsafe fn(value: PtrConst<'a>, key: &str) -> Option<PtrConst<'a>>;
+
+// ============================================================================
+// VTable
+// ============================================================================
+
+/// Virtual table for dynamic value types.
+///
+/// This provides all the operations needed to build and read dynamic values
+/// without knowing their concrete type at compile time.
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct DynamicValueVTable {
+    // --- Scalar setters (required) ---
+    /// Set to null
+    pub set_null: DynSetNullFn,
+    /// Set to boolean
+    pub set_bool: DynSetBoolFn,
+    /// Set to i64
+    pub set_i64: DynSetI64Fn,
+    /// Set to u64
+    pub set_u64: DynSetU64Fn,
+    /// Set to f64 (returns false if value not representable)
+    pub set_f64: DynSetF64Fn,
+    /// Set to string
+    pub set_str: DynSetStrFn,
+    /// Set to bytes (optional - not all dynamic value types support bytes)
+    pub set_bytes: Option<DynSetBytesFn>,
+
+    // --- Array operations (required) ---
+    /// Initialize as empty array
+    pub begin_array: DynBeginArrayFn,
+    /// Push element to array
+    pub push_array_element: DynPushArrayElementFn,
+    /// Finalize array (optional)
+    pub end_array: Option<DynEndArrayFn>,
+
+    // --- Object operations (required) ---
+    /// Initialize as empty object
+    pub begin_object: DynBeginObjectFn,
+    /// Insert key-value pair
+    pub insert_object_entry: DynInsertObjectEntryFn,
+    /// Finalize object (optional)
+    pub end_object: Option<DynEndObjectFn>,
+
+    // --- Read operations (for serialization/Peek) ---
+    /// Get the kind of value
+    pub get_kind: DynGetKindFn,
+    /// Get bool value
+    pub get_bool: DynGetBoolFn,
+    /// Get i64 value
+    pub get_i64: DynGetI64Fn,
+    /// Get u64 value
+    pub get_u64: DynGetU64Fn,
+    /// Get f64 value
+    pub get_f64: DynGetF64Fn,
+    /// Get string reference
+    pub get_str: DynGetStrFn,
+    /// Get bytes reference
+    pub get_bytes: Option<DynGetBytesFn>,
+    /// Get array length
+    pub array_len: DynArrayLenFn,
+    /// Get array element by index
+    pub array_get: DynArrayGetFn,
+    /// Get object length
+    pub object_len: DynObjectLenFn,
+    /// Get object entry by index
+    pub object_get_entry: DynObjectGetEntryFn,
+    /// Get object value by key
+    pub object_get: DynObjectGetFn,
+}
+
+impl core::fmt::Debug for DynamicValueVTable {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DynamicValueVTable").finish_non_exhaustive()
+    }
+}
+
+impl DynamicValueVTable {
+    /// Returns a builder for DynamicValueVTable
+    pub const fn builder() -> DynamicValueVTableBuilder {
+        DynamicValueVTableBuilder::new()
+    }
+}
+
+/// Builder for DynamicValueVTable
+pub struct DynamicValueVTableBuilder {
+    set_null: Option<DynSetNullFn>,
+    set_bool: Option<DynSetBoolFn>,
+    set_i64: Option<DynSetI64Fn>,
+    set_u64: Option<DynSetU64Fn>,
+    set_f64: Option<DynSetF64Fn>,
+    set_str: Option<DynSetStrFn>,
+    set_bytes: Option<DynSetBytesFn>,
+    begin_array: Option<DynBeginArrayFn>,
+    push_array_element: Option<DynPushArrayElementFn>,
+    end_array: Option<DynEndArrayFn>,
+    begin_object: Option<DynBeginObjectFn>,
+    insert_object_entry: Option<DynInsertObjectEntryFn>,
+    end_object: Option<DynEndObjectFn>,
+    get_kind: Option<DynGetKindFn>,
+    get_bool: Option<DynGetBoolFn>,
+    get_i64: Option<DynGetI64Fn>,
+    get_u64: Option<DynGetU64Fn>,
+    get_f64: Option<DynGetF64Fn>,
+    get_str: Option<DynGetStrFn>,
+    get_bytes: Option<DynGetBytesFn>,
+    array_len: Option<DynArrayLenFn>,
+    array_get: Option<DynArrayGetFn>,
+    object_len: Option<DynObjectLenFn>,
+    object_get_entry: Option<DynObjectGetEntryFn>,
+    object_get: Option<DynObjectGetFn>,
+}
+
+impl DynamicValueVTableBuilder {
+    /// Creates a new DynamicValueVTableBuilder with all fields set to None
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self {
+            set_null: None,
+            set_bool: None,
+            set_i64: None,
+            set_u64: None,
+            set_f64: None,
+            set_str: None,
+            set_bytes: None,
+            begin_array: None,
+            push_array_element: None,
+            end_array: None,
+            begin_object: None,
+            insert_object_entry: None,
+            end_object: None,
+            get_kind: None,
+            get_bool: None,
+            get_i64: None,
+            get_u64: None,
+            get_f64: None,
+            get_str: None,
+            get_bytes: None,
+            array_len: None,
+            array_get: None,
+            object_len: None,
+            object_get_entry: None,
+            object_get: None,
+        }
+    }
+
+    /// Sets the set_null function
+    pub const fn set_null(mut self, f: DynSetNullFn) -> Self {
+        self.set_null = Some(f);
+        self
+    }
+
+    /// Sets the set_bool function
+    pub const fn set_bool(mut self, f: DynSetBoolFn) -> Self {
+        self.set_bool = Some(f);
+        self
+    }
+
+    /// Sets the set_i64 function
+    pub const fn set_i64(mut self, f: DynSetI64Fn) -> Self {
+        self.set_i64 = Some(f);
+        self
+    }
+
+    /// Sets the set_u64 function
+    pub const fn set_u64(mut self, f: DynSetU64Fn) -> Self {
+        self.set_u64 = Some(f);
+        self
+    }
+
+    /// Sets the set_f64 function
+    pub const fn set_f64(mut self, f: DynSetF64Fn) -> Self {
+        self.set_f64 = Some(f);
+        self
+    }
+
+    /// Sets the set_str function
+    pub const fn set_str(mut self, f: DynSetStrFn) -> Self {
+        self.set_str = Some(f);
+        self
+    }
+
+    /// Sets the set_bytes function
+    pub const fn set_bytes(mut self, f: DynSetBytesFn) -> Self {
+        self.set_bytes = Some(f);
+        self
+    }
+
+    /// Sets the begin_array function
+    pub const fn begin_array(mut self, f: DynBeginArrayFn) -> Self {
+        self.begin_array = Some(f);
+        self
+    }
+
+    /// Sets the push_array_element function
+    pub const fn push_array_element(mut self, f: DynPushArrayElementFn) -> Self {
+        self.push_array_element = Some(f);
+        self
+    }
+
+    /// Sets the end_array function
+    pub const fn end_array(mut self, f: DynEndArrayFn) -> Self {
+        self.end_array = Some(f);
+        self
+    }
+
+    /// Sets the begin_object function
+    pub const fn begin_object(mut self, f: DynBeginObjectFn) -> Self {
+        self.begin_object = Some(f);
+        self
+    }
+
+    /// Sets the insert_object_entry function
+    pub const fn insert_object_entry(mut self, f: DynInsertObjectEntryFn) -> Self {
+        self.insert_object_entry = Some(f);
+        self
+    }
+
+    /// Sets the end_object function
+    pub const fn end_object(mut self, f: DynEndObjectFn) -> Self {
+        self.end_object = Some(f);
+        self
+    }
+
+    /// Sets the get_kind function
+    pub const fn get_kind(mut self, f: DynGetKindFn) -> Self {
+        self.get_kind = Some(f);
+        self
+    }
+
+    /// Sets the get_bool function
+    pub const fn get_bool(mut self, f: DynGetBoolFn) -> Self {
+        self.get_bool = Some(f);
+        self
+    }
+
+    /// Sets the get_i64 function
+    pub const fn get_i64(mut self, f: DynGetI64Fn) -> Self {
+        self.get_i64 = Some(f);
+        self
+    }
+
+    /// Sets the get_u64 function
+    pub const fn get_u64(mut self, f: DynGetU64Fn) -> Self {
+        self.get_u64 = Some(f);
+        self
+    }
+
+    /// Sets the get_f64 function
+    pub const fn get_f64(mut self, f: DynGetF64Fn) -> Self {
+        self.get_f64 = Some(f);
+        self
+    }
+
+    /// Sets the get_str function
+    pub const fn get_str(mut self, f: DynGetStrFn) -> Self {
+        self.get_str = Some(f);
+        self
+    }
+
+    /// Sets the get_bytes function
+    pub const fn get_bytes(mut self, f: DynGetBytesFn) -> Self {
+        self.get_bytes = Some(f);
+        self
+    }
+
+    /// Sets the array_len function
+    pub const fn array_len(mut self, f: DynArrayLenFn) -> Self {
+        self.array_len = Some(f);
+        self
+    }
+
+    /// Sets the array_get function
+    pub const fn array_get(mut self, f: DynArrayGetFn) -> Self {
+        self.array_get = Some(f);
+        self
+    }
+
+    /// Sets the object_len function
+    pub const fn object_len(mut self, f: DynObjectLenFn) -> Self {
+        self.object_len = Some(f);
+        self
+    }
+
+    /// Sets the object_get_entry function
+    pub const fn object_get_entry(mut self, f: DynObjectGetEntryFn) -> Self {
+        self.object_get_entry = Some(f);
+        self
+    }
+
+    /// Sets the object_get function
+    pub const fn object_get(mut self, f: DynObjectGetFn) -> Self {
+        self.object_get = Some(f);
+        self
+    }
+
+    /// Builds the DynamicValueVTable
+    ///
+    /// # Panics
+    ///
+    /// Panics if required fields are not set.
+    pub const fn build(self) -> DynamicValueVTable {
+        DynamicValueVTable {
+            set_null: self.set_null.unwrap(),
+            set_bool: self.set_bool.unwrap(),
+            set_i64: self.set_i64.unwrap(),
+            set_u64: self.set_u64.unwrap(),
+            set_f64: self.set_f64.unwrap(),
+            set_str: self.set_str.unwrap(),
+            set_bytes: self.set_bytes,
+            begin_array: self.begin_array.unwrap(),
+            push_array_element: self.push_array_element.unwrap(),
+            end_array: self.end_array,
+            begin_object: self.begin_object.unwrap(),
+            insert_object_entry: self.insert_object_entry.unwrap(),
+            end_object: self.end_object,
+            get_kind: self.get_kind.unwrap(),
+            get_bool: self.get_bool.unwrap(),
+            get_i64: self.get_i64.unwrap(),
+            get_u64: self.get_u64.unwrap(),
+            get_f64: self.get_f64.unwrap(),
+            get_str: self.get_str.unwrap(),
+            get_bytes: self.get_bytes,
+            array_len: self.array_len.unwrap(),
+            array_get: self.array_get.unwrap(),
+            object_len: self.object_len.unwrap(),
+            object_get_entry: self.object_get_entry.unwrap(),
+            object_get: self.object_get.unwrap(),
+        }
+    }
+}

--- a/facet-core/src/types/def/mod.rs
+++ b/facet-core/src/types/def/mod.rs
@@ -30,6 +30,9 @@ pub use function::*;
 mod ndarray;
 pub use ndarray::*;
 
+mod dynamic_value;
+pub use dynamic_value::*;
+
 /// The semantic definition of a shape: is it more like a scalar, a map, a list?
 #[derive(Clone, Copy)]
 #[repr(C)]
@@ -83,6 +86,11 @@ pub enum Def {
 
     /// Pointer types like `Arc<T>`, `Rc<T>`, etc.
     Pointer(PointerDef),
+
+    /// Dynamic value that can hold any type at runtime.
+    ///
+    /// e.g. `facet_value::Value`, `serde_json::Value`
+    DynamicValue(DynamicValueDef),
 }
 
 impl core::fmt::Debug for Def {
@@ -106,6 +114,7 @@ impl core::fmt::Debug for Def {
                     write!(f, "SmartPointer<opaque>")
                 }
             }
+            Def::DynamicValue(_) => write!(f, "DynamicValue"),
         }
     }
 }
@@ -174,6 +183,14 @@ impl Def {
     pub fn into_pointer(self) -> Result<PointerDef, Self> {
         match self {
             Self::Pointer(def) => Ok(def),
+            _ => Err(self),
+        }
+    }
+
+    /// Returns the `DynamicValueDef` wrapped in an `Ok` if this is a [`Def::DynamicValue`].
+    pub fn into_dynamic_value(self) -> Result<DynamicValueDef, Self> {
+        match self {
+            Self::DynamicValue(def) => Ok(def),
             _ => Err(self),
         }
     }

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -33,6 +33,7 @@ ryu = "1"
 [dev-dependencies]
 bytes = { version = "1.10.1" }
 camino = { version = "1" }
+facet-value = { path = "../facet-value" }
 facet = { path = "../facet", features = [
     "bytes",
     "camino",

--- a/facet-json/tests/value.rs
+++ b/facet-json/tests/value.rs
@@ -1,0 +1,97 @@
+use facet_json::from_str;
+use facet_testhelpers::test;
+use facet_value::Value;
+
+#[test]
+fn deserialize_null_into_value() {
+    let v: Value = from_str("null").unwrap();
+    assert!(v.is_null());
+}
+
+#[test]
+fn deserialize_true_into_value() {
+    let v: Value = from_str("true").unwrap();
+    assert_eq!(v.as_bool(), Some(true));
+}
+
+#[test]
+fn deserialize_false_into_value() {
+    let v: Value = from_str("false").unwrap();
+    assert_eq!(v.as_bool(), Some(false));
+}
+
+#[test]
+fn deserialize_integer_into_value() {
+    let v: Value = from_str("42").unwrap();
+    assert_eq!(v.as_number().and_then(|n| n.to_i64()), Some(42));
+}
+
+#[test]
+fn deserialize_negative_integer_into_value() {
+    let v: Value = from_str("-123").unwrap();
+    assert_eq!(v.as_number().and_then(|n| n.to_i64()), Some(-123));
+}
+
+#[test]
+fn deserialize_float_into_value() {
+    let v: Value = from_str("3.15").unwrap();
+    let f = v.as_number().and_then(|n| n.to_f64()).unwrap();
+    assert!((f - 3.15).abs() < 0.001);
+}
+
+#[test]
+fn deserialize_string_into_value() {
+    let v: Value = from_str(r#""hello world""#).unwrap();
+    assert_eq!(v.as_string().map(|s| s.as_str()), Some("hello world"));
+}
+
+#[test]
+fn deserialize_empty_string_into_value() {
+    let v: Value = from_str(r#""""#).unwrap();
+    assert_eq!(v.as_string().map(|s| s.as_str()), Some(""));
+}
+
+#[test]
+fn deserialize_empty_array_into_value() {
+    let v: Value = from_str("[]").unwrap();
+    let arr = v.as_array().unwrap();
+    assert!(arr.is_empty());
+}
+
+#[test]
+fn deserialize_integer_array_into_value() {
+    let v: Value = from_str("[1, 2, 3]").unwrap();
+    let arr = v.as_array().unwrap();
+    assert_eq!(arr.len(), 3);
+    assert_eq!(arr[0].as_number().and_then(|n| n.to_i64()), Some(1));
+    assert_eq!(arr[1].as_number().and_then(|n| n.to_i64()), Some(2));
+    assert_eq!(arr[2].as_number().and_then(|n| n.to_i64()), Some(3));
+}
+
+#[test]
+fn deserialize_mixed_array_into_value() {
+    let v: Value = from_str(r#"[1, "two", true, null]"#).unwrap();
+    let arr = v.as_array().unwrap();
+    assert_eq!(arr.len(), 4);
+    assert_eq!(arr[0].as_number().and_then(|n| n.to_i64()), Some(1));
+    assert_eq!(arr[1].as_string().map(|s| s.as_str()), Some("two"));
+    assert_eq!(arr[2].as_bool(), Some(true));
+    assert!(arr[3].is_null());
+}
+
+#[test]
+fn deserialize_nested_array_into_value() {
+    let v: Value = from_str("[[1, 2], [3, 4]]").unwrap();
+    let arr = v.as_array().unwrap();
+    assert_eq!(arr.len(), 2);
+
+    let inner0 = arr[0].as_array().unwrap();
+    assert_eq!(inner0.len(), 2);
+    assert_eq!(inner0[0].as_number().and_then(|n| n.to_i64()), Some(1));
+    assert_eq!(inner0[1].as_number().and_then(|n| n.to_i64()), Some(2));
+
+    let inner1 = arr[1].as_array().unwrap();
+    assert_eq!(inner1.len(), 2);
+    assert_eq!(inner1[0].as_number().and_then(|n| n.to_i64()), Some(3));
+    assert_eq!(inner1[1].as_number().and_then(|n| n.to_i64()), Some(4));
+}

--- a/facet-reflect/Cargo.toml
+++ b/facet-reflect/Cargo.toml
@@ -56,6 +56,7 @@ miette = { version = "7", optional = true }
 [dev-dependencies]
 facet = { path = "../facet" }
 facet-testhelpers = { path = "../facet-testhelpers" }
+facet-value = { path = "../facet-value" }
 insta = "1.43.1"
 log = "0.4.27"
 tempfile = "3.20.0"

--- a/facet-reflect/docs/partial-ownership-redesign.md
+++ b/facet-reflect/docs/partial-ownership-redesign.md
@@ -1,0 +1,445 @@
+# Partial Ownership Redesign
+
+## Problem Statement
+
+The current `Partial` implementation has multiple sources of truth for tracking whether data is initialized:
+
+1. `frame.is_init: bool` on child frames
+2. Parent's `Tracker::Struct { iset, .. }` marking which fields are initialized
+
+This leads to aliasing problems where both parent and child believe they're responsible for dropping the same memory, causing double-frees. The complexity is compounded in deferred mode where frames can be stored and revisited.
+
+## Current Issues
+
+### Double-Free Scenario
+```
+Parent Frame (FuzzTarget)
+├── tracker: Struct { iset: [name=✓, count=✓, ...] }
+│
+Child Frame (name field)
+├── data: ptr to FuzzTarget.name  ← SAME memory
+├── is_init: true
+├── ownership: Field
+```
+
+On drop, both parent (via iset) and child (via is_init) may try to drop the same data.
+
+### Deferred Mode Complexity
+
+When `end()` stores a frame in `stored_frames`:
+- The frame is detached from the stack
+- Parent's iset may or may not reflect the field's state
+- Drop logic must reconcile these states with ~200 lines of complex code
+
+## Proposed Design
+
+### Core Invariant
+
+**For any memory location, exactly ONE entity is responsible for dropping it at any time.**
+
+This is achieved through explicit ownership transfer: when navigating into a field, the parent temporarily relinquishes responsibility; when returning, responsibility is restored.
+
+### Data Structures
+
+```rust
+/// Whether a frame's data is initialized and the frame is responsible for it
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum FrameState {
+    /// Data is not initialized, nothing to drop
+    Uninitialized,
+    /// Data is initialized, this frame is responsible for dropping it
+    Initialized,
+}
+
+/// Who owns the allocation and how responsibility is tracked
+#[derive(Debug)]
+pub(crate) enum FrameOwnership {
+    /// This frame owns the heap allocation itself.
+    /// On drop: deallocate the memory.
+    /// Parent's iset: N/A (no parent tracks this)
+    Owned,
+
+    /// This frame points to a field within a parent's allocation.
+    /// The parent's iset[field_idx] was CLEARED when this frame was created.
+    /// On drop: deinit if Initialized, but do NOT deallocate.
+    /// On successful end(): parent's iset[field_idx] will be SET.
+    ///
+    /// Note: Currently `Field` is a unit variant and `current_child` tracks the index.
+    /// After migration, `Field { field_idx }` replaces `current_child` - the child
+    /// frame knows its own index, enabling `end()` to set the right iset bit.
+    Field {
+        field_idx: usize,
+    },
+
+    /// This frame's allocation is managed elsewhere (e.g., map key/value buffers).
+    /// On drop: deinit if Initialized, but do NOT deallocate.
+    /// Parent's iset: not modified (these are temporary buffers, not struct fields)
+    ManagedElsewhere,
+}
+
+pub(crate) struct Frame {
+    /// Address of the value
+    pub(crate) data: PtrUninit<'static>,
+
+    /// Shape of the value
+    pub(crate) shape: &'static Shape,
+
+    /// Whether this frame is responsible for initialized data
+    pub(crate) state: FrameState,
+
+    /// Tracks partial initialization (which struct fields, list state, etc.)
+    pub(crate) tracker: Tracker,
+
+    /// Ownership model for this frame
+    pub(crate) ownership: FrameOwnership,
+}
+```
+
+### FrameState Semantics by Type
+
+**Scalars**: `state = Initialized` means the value has been written via `put_*`.
+
+**Structs**: `state = Initialized` means "drop glue should run". The drop glue iterates
+`iset` and drops only fields where `iset[idx] = true`. A struct can be `Initialized`
+even with only some fields set - it will correctly drop just those fields.
+
+**Collections (List, Map, Set)**: `state = Initialized` means the collection itself
+exists (e.g., `Vec::new()` was called). Elements are tracked separately via vtable
+functions, not iset.
+
+**Arrays**: Like structs, use `iset` to track which elements are initialized.
+`state = Initialized` means drop glue should run (which respects iset).
+
+### Tracker Simplification
+
+The current `Tracker::Struct` has:
+```rust
+Tracker::Struct {
+    iset: ISet,
+    current_child: Option<usize>,  // ← Can be removed
+}
+```
+
+The `current_child` field exists only for drop logic to determine "which field are we
+currently inside". With the new model, this is unnecessary:
+- When we enter a field, parent's `iset[idx]` is cleared
+- Parent can never drop a field we're currently in
+- No lookup needed at drop time
+
+After migration, `Tracker::Struct` simplifies to just `{ iset: ISet }`. Same applies
+to `Tracker::Array` and `Tracker::Enum`.
+
+### Operation Semantics
+
+#### `begin_nth_field(idx)`
+
+```
+Before:
+  Parent iset[idx] = ✓ (or ✗ if field wasn't init)
+
+Action:
+  1. was_init = parent.iset[idx]
+  2. parent.iset[idx] = ✗           ← Parent relinquishes responsibility
+  3. Push child Frame {
+       state: if was_init { Initialized } else { Uninitialized },
+       ownership: Field { field_idx: idx },
+       ...
+     }
+
+After:
+  Parent iset[idx] = ✗
+  Child is solely responsible for the field
+```
+
+#### `end()` in Strict Mode
+
+```
+Before:
+  Child frame on stack, parent iset[idx] = ✗
+
+Action:
+  1. Validate child is fully initialized
+  2. Pop child frame
+  3. parent.iset[idx] = ✓           ← Parent reclaims responsibility
+
+After:
+  Parent iset[idx] = ✓
+  Child frame gone, parent is responsible
+```
+
+#### `end()` in Deferred Mode
+
+```
+Before:
+  Child frame on stack, parent iset[idx] = ✗
+
+Action:
+  1. Pop child frame
+  2. Store in stored_frames
+  3. parent.iset[idx] stays ✗       ← Parent still NOT responsible
+
+After:
+  Parent iset[idx] = ✗
+  Stored frame is responsible (tracked by its FrameState)
+```
+
+#### `finish_deferred()`
+
+```
+Before:
+  Stored frames with their FrameState
+  Parent iset has those fields cleared
+
+Action:
+  For each stored frame (deepest first):
+    1. Validate fully initialized
+    2. parent.iset[field_idx] = ✓   ← Transfer responsibility to parent
+    3. Discard stored frame (no deinit needed, parent now owns)
+
+After:
+  All stored frames processed
+  Parent iset reflects all initialized fields
+```
+
+#### Drop (Partial dropped without proper cleanup)
+
+```
+1. Process stored_frames:
+   For each stored frame:
+     - If state == Initialized: deinit (drop the data)
+     - Parent's iset[field_idx] is ✗, so parent won't touch it
+
+2. Process stack frames (top to bottom):
+   For each frame:
+     Match ownership:
+       Owned:
+         - If state == Initialized: deinit
+         - Deallocate memory
+
+       Field { field_idx }:
+         - If state == Initialized: deinit
+         - Parent's iset[field_idx] is ✗, so parent won't touch it
+         - Do NOT deallocate (parent owns allocation)
+
+       ManagedElsewhere:
+         - If state == Initialized: deinit
+         - Do NOT deallocate
+
+3. When parent frame is processed:
+   - Its deinit() only drops fields where iset[idx] = ✓
+   - All fields we navigated into have iset = ✗
+   - No double-free possible
+```
+
+### Deferred Mode Specifics
+
+#### Stored Frame Structure
+
+```rust
+struct StoredFrame {
+    frame: Frame,
+    path: KeyPath,  // For nested field navigation
+}
+```
+
+The `Frame::ownership` contains `Field { field_idx }` which tells us which field of the parent this was. The `path` tells us how to find the parent (for nested fields).
+
+#### Restoring a Stored Frame
+
+When `begin_nth_field` is called and finds a stored frame:
+
+```
+Action:
+  1. Remove frame from stored_frames
+  2. Push frame to stack
+  3. (Parent's iset[idx] is already ✗ from when frame was first created)
+
+The frame's FrameState is preserved, so we know if it was Initialized.
+```
+
+### Invariants
+
+1. **Single Responsibility**: For any field, either:
+   - Parent's iset has it marked (parent responsible), OR
+   - A frame exists for it on stack or in stored_frames (frame responsible)
+   - Never both.
+
+2. **Ownership Transfer**:
+   - `begin_*` clears parent's iset → child responsible
+   - `end()` (strict) sets parent's iset → parent responsible
+   - `end()` (deferred) keeps parent's iset clear → stored frame responsible
+   - `finish_deferred()` sets parent's iset → parent responsible
+
+3. **Drop Safety**:
+   - Frames deinit based on their own FrameState
+   - Parents deinit based on their own iset
+   - These never overlap due to the ownership transfer protocol
+
+## Migration Path
+
+### Step 1: Add `iset.unset(idx)` in `begin_nth_struct_field`
+
+In `internal.rs`, after reading `was_field_init`:
+```rust
+let was_field_init = match &mut frame.tracker {
+    Tracker::Struct { iset, current_child } => {
+        *current_child = Some(idx);
+        let was_init = iset.get(idx);
+        iset.unset(idx);  // ← ADD THIS: parent relinquishes responsibility
+        was_init
+    }
+    _ => unreachable!(),
+};
+```
+
+Same pattern for `begin_nth_array_element` and `begin_nth_enum_field`.
+
+### Step 2: Verify `end()` already sets iset
+
+The current code (misc.rs:632-634) already does:
+```rust
+iset.set(idx);
+*current_child = None;
+```
+
+This is correct - parent reclaims responsibility on successful `end()`.
+
+### Step 3: Simplify drop logic
+
+The current ~200 lines of drop logic (mod.rs:1154-1351) can be replaced with:
+```rust
+impl Drop for Partial {
+    fn drop(&mut self) {
+        // 1. Deinit stored frames (deferred mode)
+        if let FrameMode::Deferred { stored_frames, .. } = &mut self.mode {
+            for (_, mut frame) in stored_frames.drain(..) {
+                if frame.state == FrameState::Initialized {
+                    frame.deinit();
+                }
+                // Don't deallocate - Field ownership means parent owns memory
+            }
+        }
+
+        // 2. Pop and deinit stack frames
+        while let Some(mut frame) = self.mode.stack_mut().pop() {
+            if frame.state == FrameState::Initialized {
+                frame.deinit();
+            }
+            if let FrameOwnership::Owned = frame.ownership {
+                frame.dealloc();
+            }
+        }
+    }
+}
+```
+
+No `parent_will_drop` checks. No `is_field_marked_in_parent`. No special cases.
+Each frame's `state` is the sole authority on whether it should deinit.
+
+### Step 4: Remove `current_child` from Tracker variants
+
+Once drop logic doesn't need it:
+```rust
+// Before
+Tracker::Struct { iset: ISet, current_child: Option<usize> }
+// After
+Tracker::Struct { iset: ISet }
+```
+
+### Step 5: Rename `is_init` to `state`
+
+Change `Frame::is_init: bool` to `Frame::state: FrameState` for clarity.
+Could keep as bool if preferred - the semantics matter more than the name.
+
+## Type-Specific Behavior
+
+### Structs and Arrays (iset-based)
+
+The ownership transfer protocol applies directly:
+- `begin_nth_field` / `begin_nth_element`: clear parent's `iset[idx]`
+- `end()`: set parent's `iset[idx]`
+- Drop: each side only drops what their iset says
+
+### Collections (List, Map, Set)
+
+Collections use a **different mechanism** - not iset-based ownership transfer:
+- Element frames have `FrameOwnership::Owned` (they allocate element memory)
+- On `end()`, ownership transfers via vtable function (`push_fn`, `insert_fn`)
+- The vtable function **moves** the data out of the element frame
+- Element frame is then deallocated (but not deinited - data was moved)
+- Collection's own drop glue handles dropping all elements
+
+No iset involved. The "ownership transfer" is a move into the collection.
+
+### DynamicValue Arrays
+
+Same as collections - elements are pushed via `push_array_element` vtable function.
+Element frames have `Owned` ownership. No special handling needed.
+
+### Option Types
+
+`begin_some()` doesn't use iset. The `Tracker::Option` tracks whether we're building
+the inner value. On `end()`, the option is marked as `Some`. Similar transfer protocol
+but simpler (only one "slot").
+
+### Nested Deferred Fields
+
+Path `["a", "b"]` means frame "b" is a field of frame "a", which is stored.
+- When navigating into "a": parent's `iset["a"]` cleared
+- When navigating into "b": "a"'s `iset["b"]` cleared
+- When "b" is stored: "a"'s `iset["b"]` stays clear
+- When "a" is stored: parent's `iset["a"]` stays clear
+
+Ownership is clean at every level.
+
+## Code Removal Summary
+
+After migration, the following can be removed:
+
+### From `mod.rs` Drop impl (~150 lines)
+- `is_field_marked_in_parent()` helper
+- `unmark_field_in_parent()` helper
+- All `parent_will_drop` logic
+- All `is_initialized_collection_with_partial_state` special cases
+- The entire stored_frames cleanup loop complexity
+
+### From Tracker variants
+- `current_child: Option<usize>` from `Tracker::Struct`
+- `current_child: Option<usize>` from `Tracker::Array`
+- `current_child: Option<usize>` from `Tracker::Enum`
+
+### From deferred mode
+- Path-based parent lookup for drop
+- Complex depth calculations for "should we deinit"
+
+## Alternatives Considered
+
+### Keep is_init, fix drop logic
+We've been doing this. Each fix reveals new edge cases. The fundamental aliasing problem remains.
+
+### Remove is_init entirely, only use parent's iset
+Doesn't work for `Owned` frames which have no parent. Also complicates deferred mode where frames are detached.
+
+### Store parent reference in each frame
+Complicates memory management. Parent indices change as stack grows/shrinks.
+
+## Conclusion
+
+The ownership transfer model provides a clean invariant: at any moment, exactly one entity
+is responsible for each piece of data.
+
+**The key insight**: `begin_field` should immediately clear the parent's iset, not wait
+until `end()` or drop time to figure out who's responsible.
+
+**Why this works**: The current code tries to maintain two sources of truth (`is_init` and
+`iset`) and reconcile them at drop time. This is fundamentally broken because:
+1. Both can be true for the same memory (aliasing)
+2. Drop logic must guess which one "really" owns the data
+3. Deferred mode adds stored frames as a third source of truth
+
+The fix is simple: make `iset` authoritative for struct fields. When you enter a field,
+clear the bit. When you leave, set it. At any point, exactly one of these is true:
+- Parent's `iset[idx] = true` → parent drops it
+- Child frame exists → child drops it (based on its own state)
+
+No reconciliation needed. No guessing. No special cases.

--- a/facet-reflect/fuzz/Cargo.lock
+++ b/facet-reflect/fuzz/Cargo.lock
@@ -92,9 +92,7 @@ dependencies = [
 name = "facet-reflect"
 version = "0.31.8"
 dependencies = [
- "bitflags",
  "facet-core",
- "indexset",
 ]
 
 [[package]]
@@ -104,7 +102,15 @@ dependencies = [
  "arbitrary",
  "facet",
  "facet-reflect",
+ "facet-value",
  "libfuzzer-sys",
+]
+
+[[package]]
+name = "facet-value"
+version = "0.1.0"
+dependencies = [
+ "facet-core",
 ]
 
 [[package]]
@@ -112,15 +118,6 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
-
-[[package]]
-name = "ftree"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae0379499242d3b9355c5069b43b9417def8c9b09903b930db1fe49318dc9e9"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "getrandom"
@@ -139,15 +136,6 @@ name = "impls"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
-
-[[package]]
-name = "indexset"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff794cab64c942437d60272e215f923d466b23dfa6c999cdd0cafe5b6d170805"
-dependencies = [
- "ftree",
-]
 
 [[package]]
 name = "jobserver"
@@ -210,36 +198,6 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
- "serde_derive",
-]
-
-[[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "shlex"

--- a/facet-reflect/fuzz/Cargo.toml
+++ b/facet-reflect/fuzz/Cargo.toml
@@ -17,6 +17,9 @@ path = "../../facet"
 [dependencies.facet-reflect]
 path = ".."
 
+[dependencies.facet-value]
+path = "../../facet-value"
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]

--- a/facet-reflect/fuzz/fuzz_targets/fuzz_partial.rs
+++ b/facet-reflect/fuzz/fuzz_targets/fuzz_partial.rs
@@ -3,8 +3,10 @@
 use arbitrary::{Arbitrary, Unstructured};
 use facet::Facet;
 use facet_reflect::{Partial, Resolution};
+use facet_value::Value;
 use libfuzzer_sys::fuzz_target;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 // Target types
 #[derive(Facet, Debug)]
@@ -15,6 +17,9 @@ struct FuzzTarget {
     items: Vec<String>,
     mapping: HashMap<String, u32>,
     maybe: Option<String>,
+    tags: HashSet<String>,
+    boxed: Box<i32>,
+    shared: Arc<String>,
 }
 
 #[derive(Facet, Debug)]
@@ -31,6 +36,9 @@ enum PartialOp {
     BeginNthField(u8),
     SetU32(u32),
     SetI32(i32),
+    SetI64(i64),
+    SetF64(f64),
+    SetBool(bool),
     SetString(SmallString),
     End,
     BeginList,
@@ -38,8 +46,13 @@ enum PartialOp {
     BeginMap,
     BeginKey,
     BeginValue,
+    BeginSet,
+    BeginSetItem,
     BeginSome,
     BeginInner,
+    BeginSmartPtr,
+    SetDefault,
+    SetNthFieldToDefault(u8),
     BeginDeferred,
     FinishDeferred,
     Build,
@@ -53,6 +66,9 @@ enum FieldChoice {
     Items,
     Mapping,
     Maybe,
+    Tags,
+    Boxed,
+    Shared,
     X,
     Y,
     Label,
@@ -68,6 +84,9 @@ impl FieldChoice {
             FieldChoice::Items => "items",
             FieldChoice::Mapping => "mapping",
             FieldChoice::Maybe => "maybe",
+            FieldChoice::Tags => "tags",
+            FieldChoice::Boxed => "boxed",
+            FieldChoice::Shared => "shared",
             FieldChoice::X => "x",
             FieldChoice::Y => "y",
             FieldChoice::Label => "label",
@@ -104,6 +123,15 @@ fn apply_op(partial: &mut Partial<'_>, op: &PartialOp) {
         PartialOp::SetI32(v) => {
             let _ = partial.set(*v);
         }
+        PartialOp::SetI64(v) => {
+            let _ = partial.set(*v);
+        }
+        PartialOp::SetF64(v) => {
+            let _ = partial.set(*v);
+        }
+        PartialOp::SetBool(v) => {
+            let _ = partial.set(*v);
+        }
         PartialOp::SetString(s) => {
             let _ = partial.set(s.0.clone());
         }
@@ -125,11 +153,26 @@ fn apply_op(partial: &mut Partial<'_>, op: &PartialOp) {
         PartialOp::BeginValue => {
             let _ = partial.begin_value();
         }
+        PartialOp::BeginSet => {
+            let _ = partial.begin_set();
+        }
+        PartialOp::BeginSetItem => {
+            let _ = partial.begin_set_item();
+        }
         PartialOp::BeginSome => {
             let _ = partial.begin_some();
         }
         PartialOp::BeginInner => {
             let _ = partial.begin_inner();
+        }
+        PartialOp::BeginSmartPtr => {
+            let _ = partial.begin_smart_ptr();
+        }
+        PartialOp::SetDefault => {
+            let _ = partial.set_default();
+        }
+        PartialOp::SetNthFieldToDefault(idx) => {
+            let _ = partial.set_nth_field_to_default(*idx as usize);
         }
         PartialOp::BeginDeferred => {
             let resolution = Resolution::new();
@@ -144,15 +187,37 @@ fn apply_op(partial: &mut Partial<'_>, op: &PartialOp) {
     }
 }
 
-fuzz_target!(|ops: Vec<PartialOp>| {
+/// Which target type to fuzz
+#[derive(Arbitrary, Debug, Clone)]
+enum TargetType {
+    FuzzTarget,
+    DynamicValue,
+}
+
+fuzz_target!(|input: (TargetType, Vec<PartialOp>)| {
+    let (target_type, ops) = input;
+
     // Limit sequence length to avoid timeouts
     let ops = if ops.len() > 100 { &ops[..100] } else { &ops };
 
-    if let Ok(mut typed_partial) = Partial::alloc::<FuzzTarget>() {
-        let partial = typed_partial.inner_mut();
-        for op in ops {
-            apply_op(partial, op);
+    match target_type {
+        TargetType::FuzzTarget => {
+            if let Ok(mut typed_partial) = Partial::alloc::<FuzzTarget>() {
+                let partial = typed_partial.inner_mut();
+                for op in ops {
+                    apply_op(partial, op);
+                }
+                // Partial is dropped here - must not leak or crash
+            }
         }
-        // Partial is dropped here - must not leak or crash
+        TargetType::DynamicValue => {
+            if let Ok(mut typed_partial) = Partial::alloc::<Value>() {
+                let partial = typed_partial.inner_mut();
+                for op in ops {
+                    apply_op(partial, op);
+                }
+                // Partial is dropped here - must not leak or crash
+            }
+        }
     }
 });

--- a/facet-reflect/src/error.rs
+++ b/facet-reflect/src/error.rs
@@ -5,8 +5,7 @@ use facet_core::{Characteristic, EnumType, FieldError, Shape, TryFromError};
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[non_exhaustive]
 pub enum TrackerKind {
-    Uninit,
-    Init,
+    Scalar,
     Array,
     Struct,
     SmartPointer,
@@ -16,6 +15,7 @@ pub enum TrackerKind {
     Map,
     Set,
     Option,
+    DynamicValue,
 }
 
 /// Errors that can occur when reflecting on types.

--- a/facet-reflect/src/partial/partial_api.rs
+++ b/facet-reflect/src/partial/partial_api.rs
@@ -13,7 +13,8 @@ use core::{marker::PhantomData, mem::ManuallyDrop, ptr::NonNull};
 use crate::{
     Guard, HeapValue, Partial, Peek, ReflectError, Resolution, TypedPartial,
     partial::{
-        Frame, FrameMode, FrameOwnership, MapInsertState, PartialState, Tracker, iset::ISet,
+        DynamicValueState, Frame, FrameMode, FrameOwnership, MapInsertState, PartialState, Tracker,
+        iset::ISet,
     },
     trace,
 };

--- a/facet-reflect/src/partial/partial_api/ptr.rs
+++ b/facet-reflect/src/partial/partial_api/ptr.rs
@@ -8,130 +8,132 @@ impl Partial<'_> {
     pub fn begin_smart_ptr(&mut self) -> Result<&mut Self, ReflectError> {
         crate::trace!("begin_smart_ptr()");
         self.require_active()?;
-        let frame = self.frames_mut().last_mut().unwrap();
 
-        // Check that we have a SmartPointer
-        match &frame.shape.def {
-            Def::Pointer(smart_ptr_def) if smart_ptr_def.constructible_from_pointee() => {
-                // Get the pointee shape
-                let pointee_shape = match smart_ptr_def.pointee() {
-                    Some(shape) => shape,
-                    None => {
-                        return Err(ReflectError::OperationFailed {
-                            shape: frame.shape,
-                            operation: "Smart pointer must have a pointee shape",
-                        });
-                    }
-                };
+        // Check that we have a SmartPointer and get necessary data
+        let (smart_ptr_def, pointee_shape) = {
+            let frame = self.frames().last().unwrap();
 
-                if pointee_shape.layout.sized_layout().is_ok() {
-                    // pointee is sized, we can allocate it — for `Arc<T>` we'll be allocating a `T` and
-                    // holding onto it. We'll build a new Arc with it when ending the smart pointer frame.
-
-                    if matches!(frame.tracker, Tracker::Uninit) {
-                        frame.tracker = Tracker::SmartPointer {
-                            is_initialized: false,
-                        };
-                    }
-
-                    let inner_layout = match pointee_shape.layout.sized_layout() {
-                        Ok(layout) => layout,
-                        Err(_) => {
-                            return Err(ReflectError::Unsized {
-                                shape: pointee_shape,
-                                operation: "begin_smart_ptr, calculating inner value layout",
-                            });
-                        }
-                    };
-                    let inner_ptr: *mut u8 = unsafe { ::alloc::alloc::alloc(inner_layout) };
-                    let Some(inner_ptr) = NonNull::new(inner_ptr) else {
-                        return Err(ReflectError::OperationFailed {
-                            shape: frame.shape,
-                            operation: "failed to allocate memory for smart pointer inner value",
-                        });
-                    };
-
-                    // Push a new frame for the inner value
-                    self.frames_mut().push(Frame::new(
-                        PtrUninit::new(inner_ptr),
-                        pointee_shape,
-                        FrameOwnership::Owned,
-                    ));
-                } else {
-                    // pointee is unsized, we only support a handful of cases there
-                    if pointee_shape == str::SHAPE {
-                        crate::trace!("Pointee is str");
-
-                        // Allocate space for a String
-                        let string_layout = String::SHAPE
-                            .layout
-                            .sized_layout()
-                            .expect("String must have a sized layout");
-                        let string_ptr: *mut u8 = unsafe { ::alloc::alloc::alloc(string_layout) };
-                        let Some(string_ptr) = NonNull::new(string_ptr) else {
+            match &frame.shape.def {
+                Def::Pointer(smart_ptr_def) if smart_ptr_def.constructible_from_pointee() => {
+                    let pointee_shape = match smart_ptr_def.pointee() {
+                        Some(shape) => shape,
+                        None => {
                             return Err(ReflectError::OperationFailed {
                                 shape: frame.shape,
-                                operation: "failed to allocate memory for string",
+                                operation: "Smart pointer must have a pointee shape",
                             });
-                        };
-                        let mut frame = Frame::new(
-                            PtrUninit::new(string_ptr),
-                            String::SHAPE,
-                            FrameOwnership::Owned,
-                        );
-                        frame.tracker = Tracker::Uninit;
-                        self.frames_mut().push(frame);
-                    } else if let Type::Sequence(SequenceType::Slice(_st)) = pointee_shape.ty {
-                        crate::trace!("Pointee is [{}]", _st.t);
-
-                        // Get the slice builder vtable
-                        let slice_builder_vtable = smart_ptr_def
-                            .vtable
-                            .slice_builder_vtable
-                            .ok_or(ReflectError::OperationFailed {
-                                shape: frame.shape,
-                                operation: "smart pointer does not support slice building",
-                            })?;
-
-                        // Create a new builder
-                        let builder_ptr = (slice_builder_vtable.new_fn)();
-
-                        // Deallocate the original Arc allocation before replacing with slice builder
-                        if let FrameOwnership::Owned = frame.ownership {
-                            if let Ok(layout) = frame.shape.layout.sized_layout() {
-                                if layout.size() > 0 {
-                                    unsafe {
-                                        ::alloc::alloc::dealloc(
-                                            frame.data.as_mut_byte_ptr(),
-                                            layout,
-                                        )
-                                    };
-                                }
-                            }
                         }
+                    };
+                    (*smart_ptr_def, pointee_shape)
+                }
+                _ => {
+                    return Err(ReflectError::OperationFailed {
+                        shape: frame.shape,
+                        operation: "push_smart_ptr can only be called on compatible types",
+                    });
+                }
+            }
+        };
 
-                        // Update the current frame to use the slice builder
-                        frame.data = builder_ptr.as_uninit();
-                        frame.tracker = Tracker::SmartPointerSlice {
-                            vtable: slice_builder_vtable,
-                            building_item: false,
-                        };
-                        // The slice builder memory is managed by the vtable, not by us
-                        frame.ownership = FrameOwnership::ManagedElsewhere;
-                    } else {
-                        return Err(ReflectError::OperationFailed {
-                            shape: frame.shape,
-                            operation: "push_smart_ptr can only be called on pointers to supported pointee types",
-                        });
+        // Handle re-initialization if the smart pointer is already initialized
+        self.prepare_for_reinitialization();
+
+        let frame = self.frames_mut().last_mut().unwrap();
+
+        if pointee_shape.layout.sized_layout().is_ok() {
+            // pointee is sized, we can allocate it — for `Arc<T>` we'll be allocating a `T` and
+            // holding onto it. We'll build a new Arc with it when ending the smart pointer frame.
+
+            frame.tracker = Tracker::SmartPointer;
+
+            let inner_layout = match pointee_shape.layout.sized_layout() {
+                Ok(layout) => layout,
+                Err(_) => {
+                    return Err(ReflectError::Unsized {
+                        shape: pointee_shape,
+                        operation: "begin_smart_ptr, calculating inner value layout",
+                    });
+                }
+            };
+            let inner_ptr: *mut u8 = unsafe { ::alloc::alloc::alloc(inner_layout) };
+            let Some(inner_ptr) = NonNull::new(inner_ptr) else {
+                return Err(ReflectError::OperationFailed {
+                    shape: frame.shape,
+                    operation: "failed to allocate memory for smart pointer inner value",
+                });
+            };
+
+            // Push a new frame for the inner value
+            self.frames_mut().push(Frame::new(
+                PtrUninit::new(inner_ptr),
+                pointee_shape,
+                FrameOwnership::Owned,
+            ));
+        } else {
+            // pointee is unsized, we only support a handful of cases there
+            if pointee_shape == str::SHAPE {
+                crate::trace!("Pointee is str");
+
+                // Allocate space for a String
+                let string_layout = String::SHAPE
+                    .layout
+                    .sized_layout()
+                    .expect("String must have a sized layout");
+                let string_ptr: *mut u8 = unsafe { ::alloc::alloc::alloc(string_layout) };
+                let Some(string_ptr) = NonNull::new(string_ptr) else {
+                    return Err(ReflectError::OperationFailed {
+                        shape: frame.shape,
+                        operation: "failed to allocate memory for string",
+                    });
+                };
+                let frame = Frame::new(
+                    PtrUninit::new(string_ptr),
+                    String::SHAPE,
+                    FrameOwnership::Owned,
+                );
+                // Frame::new already sets tracker = Scalar and is_init = false
+                self.frames_mut().push(frame);
+            } else if let Type::Sequence(SequenceType::Slice(_st)) = pointee_shape.ty {
+                crate::trace!("Pointee is [{}]", _st.t);
+
+                // Get the slice builder vtable
+                let slice_builder_vtable = smart_ptr_def.vtable.slice_builder_vtable.ok_or(
+                    ReflectError::OperationFailed {
+                        shape: frame.shape,
+                        operation: "smart pointer does not support slice building",
+                    },
+                )?;
+
+                // Create a new builder
+                let builder_ptr = (slice_builder_vtable.new_fn)();
+
+                // Deallocate the original Arc allocation before replacing with slice builder
+                if let FrameOwnership::Owned = frame.ownership {
+                    if let Ok(layout) = frame.shape.layout.sized_layout() {
+                        if layout.size() > 0 {
+                            unsafe {
+                                ::alloc::alloc::dealloc(frame.data.as_mut_byte_ptr(), layout)
+                            };
+                        }
                     }
                 }
 
-                Ok(self)
+                // Update the current frame to use the slice builder
+                frame.data = builder_ptr.as_uninit();
+                frame.tracker = Tracker::SmartPointerSlice {
+                    vtable: slice_builder_vtable,
+                    building_item: false,
+                };
+                // The slice builder memory is managed by the vtable, not by us
+                frame.ownership = FrameOwnership::ManagedElsewhere;
+            } else {
+                return Err(ReflectError::OperationFailed {
+                    shape: frame.shape,
+                    operation: "push_smart_ptr can only be called on pointers to supported pointee types",
+                });
             }
-            _ => Err(ReflectError::OperationFailed {
-                shape: frame.shape,
-                operation: "push_smart_ptr can only be called on compatible types",
-            }),
         }
+
+        Ok(self)
     }
 }

--- a/facet-reflect/tests/double_free_test.rs
+++ b/facet-reflect/tests/double_free_test.rs
@@ -1,0 +1,130 @@
+use facet_reflect::{Partial, Resolution};
+use facet_value::Value;
+
+/// Test various scenarios that might trigger double-free in DynamicValue + deferred mode
+#[test]
+fn test_dynamic_value_double_free_scenario_1() {
+    // Scenario: BeginList -> BeginDeferred -> BeginListItem -> End (store element) -> more ops
+    let mut partial = Partial::alloc::<Value>().unwrap();
+    let p = partial.inner_mut();
+
+    let _ = p.begin_list();
+    let _ = p.begin_deferred(Resolution::new());
+    let _ = p.begin_list_item();
+    let _ = p.set("test".to_string());
+    let _ = p.end();
+    // Element frame is now stored in stored_frames
+    let _ = p.begin_list_item();
+    let _ = p.set("test2".to_string());
+    let _ = p.end();
+    // Another element stored
+    drop(partial);
+    eprintln!("Scenario 1: Dropped!");
+}
+
+#[test]
+fn test_dynamic_value_double_free_scenario_2() {
+    // Scenario: Multiple deferred attempts and nested operations
+    let mut partial = Partial::alloc::<Value>().unwrap();
+    let p = partial.inner_mut();
+
+    // Try to enter deferred mode twice (second should fail)
+    let _ = p.begin_deferred(Resolution::new());
+    let _ = p.begin_deferred(Resolution::new()); // Should fail but continue
+    let _ = p.set("test".to_string());
+    drop(partial);
+    eprintln!("Scenario 2: Dropped!");
+}
+
+#[test]
+fn test_dynamic_value_double_free_scenario_3() {
+    // Scenario: BeginList + BeginDeferred + BeginListItem + BeginInner combo
+    let mut partial = Partial::alloc::<Value>().unwrap();
+    let p = partial.inner_mut();
+
+    let _ = p.begin_list();
+    let _ = p.begin_deferred(Resolution::new());
+    let _ = p.begin_list_item();
+    let _ = p.begin_inner(); // This might trigger prepare_for_reinitialization
+    let _ = p.end();
+    drop(partial);
+    eprintln!("Scenario 3: Dropped!");
+}
+
+#[test]
+fn test_dynamic_value_double_free_scenario_4() {
+    // Scenario based on fuzzer output: mixing SetDefault, SetString, BeginInner
+    let mut partial = Partial::alloc::<Value>().unwrap();
+    let p = partial.inner_mut();
+
+    let _ = p.begin_deferred(Resolution::new());
+    let _ = p.set_default();
+    let _ = p.set_default();
+    let _ = p.set_default();
+    let _ = p.set_default();
+    let _ = p.set(42i32);
+    let _ = p.begin_deferred(Resolution::new()); // Should fail
+    let _ = p.set("rjbbhgh".to_string());
+    let _ = p.begin_inner();
+    let _ = p.end();
+    drop(partial);
+    eprintln!("Scenario 4: Dropped!");
+}
+
+#[test]
+fn test_dynamic_value_double_free_scenario_5() {
+    // Scenario: Deeply nested begin_list operations
+    let mut partial = Partial::alloc::<Value>().unwrap();
+    let p = partial.inner_mut();
+
+    let _ = p.begin_list();
+    let _ = p.begin_list();
+    let _ = p.begin_deferred(Resolution::new());
+    let _ = p.begin_list();
+    let _ = p.begin_list();
+    let _ = p.begin_deferred(Resolution::new()); // Should fail
+    let _ = p.end();
+    let _ = p.end();
+    let _ = p.finish_deferred();
+    drop(partial);
+    eprintln!("Scenario 5: Dropped!");
+}
+
+#[test]
+fn test_dynamic_value_double_free_scenario_6() {
+    // Scenario: BeginValue operations mixed with deferred
+    let mut partial = Partial::alloc::<Value>().unwrap();
+    let p = partial.inner_mut();
+
+    let _ = p.begin_list();
+    let _ = p.begin_list_item();
+    let _ = p.begin_list();
+    let _ = p.begin_deferred(Resolution::new());
+    let _ = p.begin_list_item();
+    let _ = p.set("test".to_string());
+    let _ = p.end();
+    let _ = p.finish_deferred();
+    let _ = p.end();
+    let _ = p.end();
+    drop(partial);
+    eprintln!("Scenario 6: Dropped!");
+}
+
+#[test]
+fn test_dynamic_value_nested_list_with_string() {
+    // Focus on the 7-byte string case
+    let mut partial = Partial::alloc::<Value>().unwrap();
+    let p = partial.inner_mut();
+
+    // Create a nested array structure
+    let _ = p.begin_list(); // Outer array
+    let _ = p.begin_list_item();
+    let _ = p.begin_list(); // Inner array
+    let _ = p.begin_deferred(Resolution::new());
+    let _ = p.begin_list_item();
+    let _ = p.set("1234567".to_string()); // 7 bytes
+    let _ = p.end();
+    // Drop without finishing deferred
+    drop(partial);
+    eprintln!("Nested list with string: Dropped!");
+}

--- a/facet-reflect/tests/dynamic_value_segv_test.rs
+++ b/facet-reflect/tests/dynamic_value_segv_test.rs
@@ -1,0 +1,31 @@
+use facet_reflect::{Partial, Resolution};
+use facet_value::Value;
+
+/// Test that DynamicValue (Value) works correctly with deferred mode and list operations.
+/// This reproduces a SEGV found by fuzzing.
+#[test]
+fn test_dynamic_value_deferred_list_segv() {
+    let mut partial = Partial::alloc::<Value>().unwrap();
+    let p = partial.inner_mut();
+
+    // BeginList - initializes as dynamic array
+    let r = p.begin_list();
+    eprintln!("begin_list: {:?}", r.is_ok());
+
+    // BeginDeferred - enters deferred mode
+    let resolution = Resolution::new();
+    let r = p.begin_deferred(resolution);
+    eprintln!("begin_deferred: {:?}", r.is_ok());
+
+    // BeginListItem - pushes element frame
+    let r = p.begin_list_item();
+    eprintln!("begin_list_item: {:?}", r.is_ok());
+
+    // End - in deferred mode
+    let r = p.end();
+    eprintln!("end: {:?}", r.is_ok());
+
+    // Drop
+    drop(partial);
+    eprintln!("Dropped!");
+}

--- a/facet-reflect/tests/map_leak_test.rs
+++ b/facet-reflect/tests/map_leak_test.rs
@@ -1,0 +1,36 @@
+use facet::Facet;
+use facet_reflect::Partial;
+use std::collections::HashMap;
+
+#[derive(Facet, Debug)]
+struct FuzzTarget {
+    name: String,
+    count: u32,
+    mapping: HashMap<String, u32>,
+}
+
+/// Test that a map with a partially completed insert (key initialized, awaiting value)
+/// doesn't leak memory when prepare_for_reinitialization is called (e.g., via begin_inner).
+///
+/// This reproduces a bug found by fuzzing where begin_inner() would call
+/// prepare_for_reinitialization(), which would drop the HashMap and reset the tracker
+/// to Scalar, but would NOT clean up the allocated key buffer in the PushingValue state.
+#[test]
+fn test_map_leak_on_reinit_during_partial_insert() {
+    let mut partial = Partial::alloc::<FuzzTarget>().unwrap();
+    let p = partial.inner_mut();
+
+    // Set up a map with a partial insert
+    let _ = p.begin_field("mapping");
+    let _ = p.begin_map();
+    let _ = p.begin_key();
+    let _ = p.set("p".to_string());
+    let _ = p.end(); // Transitions to PushingValue { key_ptr, value_ptr: None }
+
+    // Now call begin_inner which triggers prepare_for_reinitialization
+    // This used to leak the key buffer because cleanup_partial_state wasn't called
+    let _ = p.begin_inner();
+
+    // Drop - should not leak the key "p"
+    drop(partial);
+}

--- a/facet-reflect/tests/partial/map.rs
+++ b/facet-reflect/tests/partial/map.rs
@@ -154,7 +154,7 @@ fn list_wrong_begin_list() -> Result<(), IPanic> {
         hv.begin_list()
             .unwrap_err()
             .to_string()
-            .contains("begin_list can only be called on List types")
+            .contains("begin_list can only be called on List or DynamicValue types")
     );
     Ok(())
 }

--- a/facet-value/Cargo.toml
+++ b/facet-value/Cargo.toml
@@ -12,8 +12,9 @@ categories = ["encoding", "data-structures"]
 [features]
 default = ["std"]
 std = ["alloc"]
-alloc = []
+alloc = ["facet-core/alloc"]
 
 [dependencies]
+facet-core = { path = "../facet-core", version = "0.31.8", default-features = false }
 
 [dev-dependencies]

--- a/facet-value/src/array.rs
+++ b/facet-value/src/array.rs
@@ -80,7 +80,7 @@ impl VArray {
     }
 
     fn header_mut(&mut self) -> &mut ArrayHeader {
-        unsafe { &mut *(self.0.heap_ptr() as *mut ArrayHeader) }
+        unsafe { &mut *(self.0.heap_ptr_mut() as *mut ArrayHeader) }
     }
 
     fn items_ptr(&self) -> *const Value {
@@ -88,7 +88,8 @@ impl VArray {
     }
 
     fn items_ptr_mut(&mut self) -> *mut Value {
-        unsafe { (self.header_mut() as *mut ArrayHeader).add(1).cast() }
+        // Use heap_ptr_mut directly to preserve mutable provenance
+        unsafe { (self.0.heap_ptr_mut() as *mut ArrayHeader).add(1).cast() }
     }
 
     /// Creates a new empty array.
@@ -496,6 +497,14 @@ impl AsMut<Value> for VArray {
 impl From<VArray> for Value {
     fn from(arr: VArray) -> Self {
         arr.0
+    }
+}
+
+impl VArray {
+    /// Converts this VArray into a Value, consuming self.
+    #[inline]
+    pub fn into_value(self) -> Value {
+        self.0
     }
 }
 

--- a/facet-value/src/bytes.rs
+++ b/facet-value/src/bytes.rs
@@ -271,6 +271,14 @@ impl From<VBytes> for Value {
     }
 }
 
+impl VBytes {
+    /// Converts this VBytes into a Value, consuming self.
+    #[inline]
+    pub fn into_value(self) -> Value {
+        self.0
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl From<&[u8]> for Value {
     fn from(data: &[u8]) -> Self {

--- a/facet-value/src/facet_impl.rs
+++ b/facet-value/src/facet_impl.rs
@@ -1,0 +1,379 @@
+//! Facet implementation for Value, enabling deserialization from any format.
+
+use core::ptr::NonNull;
+
+use facet_core::{
+    ConstTypeId, Def, DynValueKind, DynamicValueDef, DynamicValueVTable, Facet, MarkerTraits,
+    PtrConst, PtrMut, PtrUninit, Shape, ShapeLayout, Type, TypeNameOpts, UserType, ValueVTable,
+};
+
+use crate::{VArray, VBytes, VNumber, VObject, VString, Value};
+
+// ============================================================================
+// Scalar setters
+// ============================================================================
+
+unsafe fn dyn_set_null(dst: PtrUninit<'_>) {
+    unsafe {
+        let ptr = dst.as_mut_byte_ptr() as *mut Value;
+        ptr.write(Value::NULL);
+    }
+}
+
+unsafe fn dyn_set_bool(dst: PtrUninit<'_>, value: bool) {
+    unsafe {
+        let ptr = dst.as_mut_byte_ptr() as *mut Value;
+        ptr.write(Value::from(value));
+    }
+}
+
+unsafe fn dyn_set_i64(dst: PtrUninit<'_>, value: i64) {
+    unsafe {
+        let ptr = dst.as_mut_byte_ptr() as *mut Value;
+        ptr.write(VNumber::from_i64(value).into_value());
+    }
+}
+
+unsafe fn dyn_set_u64(dst: PtrUninit<'_>, value: u64) {
+    unsafe {
+        let ptr = dst.as_mut_byte_ptr() as *mut Value;
+        ptr.write(VNumber::from_u64(value).into_value());
+    }
+}
+
+unsafe fn dyn_set_f64(dst: PtrUninit<'_>, value: f64) -> bool {
+    unsafe {
+        let ptr = dst.as_mut_byte_ptr() as *mut Value;
+        match VNumber::from_f64(value) {
+            Some(num) => {
+                ptr.write(num.into_value());
+                true
+            }
+            None => {
+                // NaN or infinity - write null as fallback and return false
+                ptr.write(Value::NULL);
+                false
+            }
+        }
+    }
+}
+
+unsafe fn dyn_set_str(dst: PtrUninit<'_>, value: &str) {
+    unsafe {
+        let ptr = dst.as_mut_byte_ptr() as *mut Value;
+        ptr.write(VString::new(value).into_value());
+    }
+}
+
+unsafe fn dyn_set_bytes(dst: PtrUninit<'_>, value: &[u8]) {
+    unsafe {
+        let ptr = dst.as_mut_byte_ptr() as *mut Value;
+        ptr.write(VBytes::new(value).into_value());
+    }
+}
+
+// ============================================================================
+// Array operations
+// ============================================================================
+
+unsafe fn dyn_begin_array(dst: PtrUninit<'_>) {
+    unsafe {
+        let ptr = dst.as_mut_byte_ptr() as *mut Value;
+        ptr.write(VArray::new().into_value());
+    }
+}
+
+unsafe fn dyn_push_array_element(array: PtrMut<'_>, element: PtrMut<'_>) {
+    unsafe {
+        let array_ptr = array.as_mut_byte_ptr() as *mut Value;
+        let element_ptr = element.as_mut_byte_ptr() as *mut Value;
+
+        // Read the element (moving it out)
+        let element_value = element_ptr.read();
+
+        // Get the array and push
+        let array_value = &mut *array_ptr;
+        if let Some(arr) = array_value.as_array_mut() {
+            arr.push(element_value);
+        }
+    }
+}
+
+// ============================================================================
+// Object operations
+// ============================================================================
+
+unsafe fn dyn_begin_object(dst: PtrUninit<'_>) {
+    unsafe {
+        let ptr = dst.as_mut_byte_ptr() as *mut Value;
+        ptr.write(VObject::new().into_value());
+    }
+}
+
+unsafe fn dyn_insert_object_entry(object: PtrMut<'_>, key: &str, value: PtrMut<'_>) {
+    unsafe {
+        let object_ptr = object.as_mut_byte_ptr() as *mut Value;
+        let value_ptr = value.as_mut_byte_ptr() as *mut Value;
+
+        // Read the value (moving it out)
+        let entry_value = value_ptr.read();
+
+        // Get the object and insert
+        let object_value = &mut *object_ptr;
+        if let Some(obj) = object_value.as_object_mut() {
+            obj.insert(key, entry_value);
+        }
+    }
+}
+
+// ============================================================================
+// Read operations
+// ============================================================================
+
+unsafe fn dyn_get_kind(value: PtrConst<'_>) -> DynValueKind {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        let v = &*ptr;
+        match v.value_type() {
+            crate::ValueType::Null => DynValueKind::Null,
+            crate::ValueType::Bool => DynValueKind::Bool,
+            crate::ValueType::Number => DynValueKind::Number,
+            crate::ValueType::String => DynValueKind::String,
+            crate::ValueType::Bytes => DynValueKind::Bytes,
+            crate::ValueType::Array => DynValueKind::Array,
+            crate::ValueType::Object => DynValueKind::Object,
+        }
+    }
+}
+
+unsafe fn dyn_get_bool(value: PtrConst<'_>) -> Option<bool> {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        (*ptr).as_bool()
+    }
+}
+
+unsafe fn dyn_get_i64(value: PtrConst<'_>) -> Option<i64> {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        (*ptr).as_number().and_then(|n| n.to_i64())
+    }
+}
+
+unsafe fn dyn_get_u64(value: PtrConst<'_>) -> Option<u64> {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        (*ptr).as_number().and_then(|n| n.to_u64())
+    }
+}
+
+unsafe fn dyn_get_f64(value: PtrConst<'_>) -> Option<f64> {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        (*ptr).as_number().map(|n| n.to_f64_lossy())
+    }
+}
+
+unsafe fn dyn_get_str<'a>(value: PtrConst<'a>) -> Option<&'a str> {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        (*ptr).as_string().map(|s| s.as_str())
+    }
+}
+
+unsafe fn dyn_get_bytes<'a>(value: PtrConst<'a>) -> Option<&'a [u8]> {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        (*ptr).as_bytes().map(|b| b.as_slice())
+    }
+}
+
+unsafe fn dyn_array_len(value: PtrConst<'_>) -> Option<usize> {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        (*ptr).as_array().map(|a| a.len())
+    }
+}
+
+unsafe fn dyn_array_get(value: PtrConst<'_>, index: usize) -> Option<PtrConst<'_>> {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        (*ptr).as_array().and_then(|a| {
+            a.get(index)
+                .map(|elem| PtrConst::new(NonNull::new_unchecked(elem as *const Value as *mut u8)))
+        })
+    }
+}
+
+unsafe fn dyn_object_len(value: PtrConst<'_>) -> Option<usize> {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        (*ptr).as_object().map(|o| o.len())
+    }
+}
+
+unsafe fn dyn_object_get_entry<'a>(
+    value: PtrConst<'a>,
+    index: usize,
+) -> Option<(&'a str, PtrConst<'a>)> {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        (*ptr).as_object().and_then(|o| {
+            o.iter().nth(index).map(|(k, v)| {
+                (
+                    k.as_str(),
+                    PtrConst::new(NonNull::new_unchecked(v as *const Value as *mut u8)),
+                )
+            })
+        })
+    }
+}
+
+unsafe fn dyn_object_get<'a>(value: PtrConst<'a>, key: &str) -> Option<PtrConst<'a>> {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        (*ptr).as_object().and_then(|o| {
+            o.get(key)
+                .map(|v| PtrConst::new(NonNull::new_unchecked(v as *const Value as *mut u8)))
+        })
+    }
+}
+
+// ============================================================================
+// VTable and Shape
+// ============================================================================
+
+static DYNAMIC_VALUE_VTABLE: DynamicValueVTable = DynamicValueVTable::builder()
+    .set_null(dyn_set_null)
+    .set_bool(dyn_set_bool)
+    .set_i64(dyn_set_i64)
+    .set_u64(dyn_set_u64)
+    .set_f64(dyn_set_f64)
+    .set_str(dyn_set_str)
+    .set_bytes(dyn_set_bytes)
+    .begin_array(dyn_begin_array)
+    .push_array_element(dyn_push_array_element)
+    .begin_object(dyn_begin_object)
+    .insert_object_entry(dyn_insert_object_entry)
+    .get_kind(dyn_get_kind)
+    .get_bool(dyn_get_bool)
+    .get_i64(dyn_get_i64)
+    .get_u64(dyn_get_u64)
+    .get_f64(dyn_get_f64)
+    .get_str(dyn_get_str)
+    .get_bytes(dyn_get_bytes)
+    .array_len(dyn_array_len)
+    .array_get(dyn_array_get)
+    .object_len(dyn_object_len)
+    .object_get_entry(dyn_object_get_entry)
+    .object_get(dyn_object_get)
+    .build();
+
+static DYNAMIC_VALUE_DEF: DynamicValueDef = DynamicValueDef::builder()
+    .vtable(&DYNAMIC_VALUE_VTABLE)
+    .build();
+
+// Value vtable functions for the standard Facet machinery
+
+unsafe fn value_drop_in_place(value: PtrMut<'_>) -> PtrUninit<'_> {
+    unsafe {
+        let ptr = value.as_mut_byte_ptr() as *mut Value;
+        core::ptr::drop_in_place(ptr);
+        PtrUninit::new(NonNull::new_unchecked(ptr as *mut u8))
+    }
+}
+
+unsafe fn value_clone_into<'src, 'dst>(src: PtrConst<'src>, dst: PtrUninit<'dst>) -> PtrMut<'dst> {
+    unsafe {
+        let src_ptr = src.as_byte_ptr() as *const Value;
+        let dst_ptr = dst.as_mut_byte_ptr() as *mut Value;
+        dst_ptr.write((*src_ptr).clone());
+        PtrMut::new(NonNull::new_unchecked(dst_ptr as *mut u8))
+    }
+}
+
+unsafe fn value_debug(value: PtrConst<'_>, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    unsafe {
+        let ptr = value.as_byte_ptr() as *const Value;
+        core::fmt::Debug::fmt(&*ptr, f)
+    }
+}
+
+unsafe fn value_default_in_place(dst: PtrUninit<'_>) -> PtrMut<'_> {
+    unsafe {
+        let ptr = dst.as_mut_byte_ptr() as *mut Value;
+        ptr.write(Value::default());
+        PtrMut::new(NonNull::new_unchecked(ptr as *mut u8))
+    }
+}
+
+unsafe fn value_partial_eq(a: PtrConst<'_>, b: PtrConst<'_>) -> bool {
+    unsafe {
+        let a_ptr = a.as_byte_ptr() as *const Value;
+        let b_ptr = b.as_byte_ptr() as *const Value;
+        *a_ptr == *b_ptr
+    }
+}
+
+/// Wrapper to allow hashing through a `&mut dyn Hasher`
+struct HasherWrapper<'a>(&'a mut dyn core::hash::Hasher);
+
+impl core::hash::Hasher for HasherWrapper<'_> {
+    fn finish(&self) -> u64 {
+        self.0.finish()
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.write(bytes)
+    }
+}
+
+unsafe fn value_hash(value: PtrConst<'_>, hasher: &mut dyn core::hash::Hasher) {
+    unsafe {
+        use core::hash::Hash;
+        let ptr = value.as_byte_ptr() as *const Value;
+        let mut wrapper = HasherWrapper(hasher);
+        (*ptr).hash(&mut wrapper);
+    }
+}
+
+fn value_type_name(f: &mut core::fmt::Formatter<'_>, _opts: TypeNameOpts) -> core::fmt::Result {
+    write!(f, "Value")
+}
+
+static VALUE_VTABLE: ValueVTable = ValueVTable {
+    type_name: value_type_name,
+    marker_traits: MarkerTraits::SEND.union(MarkerTraits::SYNC),
+    drop_in_place: Some(value_drop_in_place),
+    invariants: None,
+    display: None,
+    debug: Some(value_debug),
+    default_in_place: Some(value_default_in_place),
+    clone_into: Some(value_clone_into),
+    partial_eq: Some(value_partial_eq),
+    partial_ord: None,
+    ord: None,
+    hash: Some(value_hash),
+    parse: None,
+    try_from: None,
+    try_into_inner: None,
+    try_borrow_inner: None,
+};
+
+/// The static shape for `Value`.
+pub static VALUE_SHAPE: Shape = Shape {
+    id: ConstTypeId::of::<Value>(),
+    layout: ShapeLayout::Sized(core::alloc::Layout::new::<Value>()),
+    vtable: VALUE_VTABLE,
+    ty: Type::User(UserType::Opaque),
+    def: Def::DynamicValue(DYNAMIC_VALUE_DEF),
+    type_identifier: "Value",
+    type_params: &[],
+    doc: &[" A dynamic value that can hold null, bool, number, string, bytes, array, or object."],
+    attributes: &[],
+    type_tag: None,
+    inner: None,
+};
+
+unsafe impl Facet<'_> for Value {
+    const SHAPE: &'static Shape = &VALUE_SHAPE;
+}

--- a/facet-value/src/lib.rs
+++ b/facet-value/src/lib.rs
@@ -42,3 +42,8 @@ pub use array::*;
 
 mod object;
 pub use object::*;
+
+#[cfg(feature = "alloc")]
+mod facet_impl;
+#[cfg(feature = "alloc")]
+pub use facet_impl::VALUE_SHAPE;

--- a/facet-value/src/number.rs
+++ b/facet-value/src/number.rs
@@ -73,7 +73,7 @@ impl VNumber {
 
     #[allow(dead_code)]
     fn header_mut(&mut self) -> &mut NumberHeader {
-        unsafe { &mut *(self.0.heap_ptr() as *mut NumberHeader) }
+        unsafe { &mut *(self.0.heap_ptr_mut() as *mut NumberHeader) }
     }
 
     /// Creates a number from an i64.
@@ -432,6 +432,14 @@ impl AsMut<Value> for VNumber {
 impl From<VNumber> for Value {
     fn from(n: VNumber) -> Self {
         n.0
+    }
+}
+
+impl VNumber {
+    /// Converts this VNumber into a Value, consuming self.
+    #[inline]
+    pub fn into_value(self) -> Value {
+        self.0
     }
 }
 

--- a/facet-value/src/object.rs
+++ b/facet-value/src/object.rs
@@ -91,7 +91,7 @@ impl VObject {
     }
 
     fn header_mut(&mut self) -> &mut ObjectHeader {
-        unsafe { &mut *(self.0.heap_ptr() as *mut ObjectHeader) }
+        unsafe { &mut *(self.0.heap_ptr_mut() as *mut ObjectHeader) }
     }
 
     fn items_ptr(&self) -> *const KeyValuePair {
@@ -99,7 +99,8 @@ impl VObject {
     }
 
     fn items_ptr_mut(&mut self) -> *mut KeyValuePair {
-        unsafe { (self.header_mut() as *mut ObjectHeader).add(1).cast() }
+        // Use heap_ptr_mut directly to preserve mutable provenance
+        unsafe { (self.0.heap_ptr_mut() as *mut ObjectHeader).add(1).cast() }
     }
 
     fn items(&self) -> &[KeyValuePair] {
@@ -534,6 +535,14 @@ impl AsMut<Value> for VObject {
 impl From<VObject> for Value {
     fn from(obj: VObject) -> Self {
         obj.0
+    }
+}
+
+impl VObject {
+    /// Converts this VObject into a Value, consuming self.
+    #[inline]
+    pub fn into_value(self) -> Value {
+        self.0
     }
 }
 

--- a/facet-value/src/string.rs
+++ b/facet-value/src/string.rs
@@ -289,6 +289,14 @@ impl From<VString> for Value {
     }
 }
 
+impl VString {
+    /// Converts this VString into a Value, consuming self.
+    #[inline]
+    pub fn into_value(self) -> Value {
+        self.0
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl From<&str> for Value {
     fn from(s: &str) -> Self {

--- a/facet-value/src/value.rs
+++ b/facet-value/src/value.rs
@@ -183,6 +183,13 @@ impl Value {
         (tagged & !(ALIGNMENT - 1)) as *mut u8
     }
 
+    /// Get the actual heap pointer with mutable provenance (strips the tag bits).
+    /// Safety: Must only be called on non-inline values.
+    pub(crate) unsafe fn heap_ptr_mut(&mut self) -> *mut u8 {
+        // Use map_addr to preserve provenance from the mutable reference
+        self.ptr.as_ptr().map_addr(|a| a & !(ALIGNMENT - 1))
+    }
+
     /// Update the heap pointer while preserving the tag.
     /// Safety: New pointer must be non-null and aligned to ALIGNMENT.
     pub(crate) unsafe fn set_ptr(&mut self, ptr: *mut u8) {


### PR DESCRIPTION
## Summary

This adds support for deserializing JSON (and potentially other formats) into `facet_value::Value` without format crates needing to depend on `facet-value` directly.

- Add `Def::DynamicValue` variant with vtable for building dynamic values
- Implement `Facet` trait for `Value` in facet-value
- Extend `Partial` to handle DynamicValue scalars via `set_into_dynamic_value`
- Add `deserialize_dynamic_value` handler in facet-json

**Currently supports scalar values only** (null, bool, numbers, strings). Arrays and objects are stubbed with TODO errors - the plan is to extend the existing `begin_list`/`begin_map` APIs rather than creating parallel `_dynamic` methods.

## Test plan

- [x] Added tests in `facet-json/tests/value.rs` for deserializing scalars into Value
- [ ] Array deserialization (pending)
- [ ] Object deserialization (pending)