### PR TITLE
Add facet-assert/diff/pretty support for facet_value::Value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,11 @@ dependencies = [
 name = "facet-value"
 version = "0.1.0"
 dependencies = [
+ "facet-assert",
  "facet-core",
+ "facet-diff",
+ "facet-pretty",
+ "facet-reflect",
 ]
 
 [[package]]

--- a/facet-reflect/src/peek/dynamic_value.rs
+++ b/facet-reflect/src/peek/dynamic_value.rs
@@ -1,0 +1,210 @@
+//! Support for peeking into DynamicValue types like `facet_value::Value`
+
+use facet_core::{DynValueKind, DynamicValueDef};
+
+use super::Peek;
+
+/// Lets you read from a dynamic value (implements read-only operations for DynamicValue types)
+///
+/// This is used for types like `facet_value::Value` that can hold any of:
+/// null, bool, number, string, bytes, array, or object - determined at runtime.
+#[derive(Clone, Copy)]
+pub struct PeekDynamicValue<'mem, 'facet> {
+    /// the underlying peek value
+    pub(crate) value: Peek<'mem, 'facet>,
+
+    /// the definition of the dynamic value
+    pub(crate) def: DynamicValueDef,
+}
+
+impl<'mem, 'facet> PeekDynamicValue<'mem, 'facet> {
+    /// Returns the dynamic value definition
+    #[inline(always)]
+    pub fn def(&self) -> DynamicValueDef {
+        self.def
+    }
+
+    /// Returns the underlying peek value
+    #[inline(always)]
+    pub fn peek(&self) -> Peek<'mem, 'facet> {
+        self.value
+    }
+
+    /// Returns the kind of value stored
+    #[inline]
+    pub fn kind(&self) -> DynValueKind {
+        unsafe { (self.def.vtable.get_kind)(self.value.data()) }
+    }
+
+    /// Returns true if the value is null
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        self.kind() == DynValueKind::Null
+    }
+
+    /// Returns the boolean value if this is a bool, None otherwise
+    #[inline]
+    pub fn as_bool(&self) -> Option<bool> {
+        unsafe { (self.def.vtable.get_bool)(self.value.data()) }
+    }
+
+    /// Returns the i64 value if representable, None otherwise
+    #[inline]
+    pub fn as_i64(&self) -> Option<i64> {
+        unsafe { (self.def.vtable.get_i64)(self.value.data()) }
+    }
+
+    /// Returns the u64 value if representable, None otherwise
+    #[inline]
+    pub fn as_u64(&self) -> Option<u64> {
+        unsafe { (self.def.vtable.get_u64)(self.value.data()) }
+    }
+
+    /// Returns the f64 value if this is a number, None otherwise
+    #[inline]
+    pub fn as_f64(&self) -> Option<f64> {
+        unsafe { (self.def.vtable.get_f64)(self.value.data()) }
+    }
+
+    /// Returns the string value if this is a string, None otherwise
+    #[inline]
+    pub fn as_str(&self) -> Option<&'mem str> {
+        unsafe { (self.def.vtable.get_str)(self.value.data()) }
+    }
+
+    /// Returns the bytes value if this is bytes, None otherwise
+    #[inline]
+    pub fn as_bytes(&self) -> Option<&'mem [u8]> {
+        self.def
+            .vtable
+            .get_bytes
+            .and_then(|f| unsafe { f(self.value.data()) })
+    }
+
+    /// Returns the length of the array if this is an array, None otherwise
+    #[inline]
+    pub fn array_len(&self) -> Option<usize> {
+        unsafe { (self.def.vtable.array_len)(self.value.data()) }
+    }
+
+    /// Returns an element from the array by index, None if not an array or index out of bounds
+    #[inline]
+    pub fn array_get(&self, index: usize) -> Option<Peek<'mem, 'facet>> {
+        let ptr = unsafe { (self.def.vtable.array_get)(self.value.data(), index)? };
+        // The element is also a DynamicValue with the same shape
+        Some(unsafe { Peek::unchecked_new(ptr, self.value.shape()) })
+    }
+
+    /// Returns the length of the object if this is an object, None otherwise
+    #[inline]
+    pub fn object_len(&self) -> Option<usize> {
+        unsafe { (self.def.vtable.object_len)(self.value.data()) }
+    }
+
+    /// Returns a key-value pair from the object by index, None if not an object or index out of bounds
+    #[inline]
+    pub fn object_get_entry(&self, index: usize) -> Option<(&'mem str, Peek<'mem, 'facet>)> {
+        let (key, value_ptr) =
+            unsafe { (self.def.vtable.object_get_entry)(self.value.data(), index)? };
+        // The value is also a DynamicValue with the same shape
+        Some((key, unsafe {
+            Peek::unchecked_new(value_ptr, self.value.shape())
+        }))
+    }
+
+    /// Returns a value from the object by key, None if not an object or key not found
+    #[inline]
+    pub fn object_get(&self, key: &str) -> Option<Peek<'mem, 'facet>> {
+        let ptr = unsafe { (self.def.vtable.object_get)(self.value.data(), key)? };
+        // The value is also a DynamicValue with the same shape
+        Some(unsafe { Peek::unchecked_new(ptr, self.value.shape()) })
+    }
+
+    /// Returns an iterator over array elements if this is an array
+    #[inline]
+    pub fn array_iter(&self) -> Option<PeekDynamicValueArrayIter<'mem, 'facet>> {
+        let len = self.array_len()?;
+        Some(PeekDynamicValueArrayIter {
+            dyn_value: *self,
+            index: 0,
+            len,
+        })
+    }
+
+    /// Returns an iterator over object entries if this is an object
+    #[inline]
+    pub fn object_iter(&self) -> Option<PeekDynamicValueObjectIter<'mem, 'facet>> {
+        let len = self.object_len()?;
+        Some(PeekDynamicValueObjectIter {
+            dyn_value: *self,
+            index: 0,
+            len,
+        })
+    }
+}
+
+/// Iterator over array elements in a dynamic value
+pub struct PeekDynamicValueArrayIter<'mem, 'facet> {
+    dyn_value: PeekDynamicValue<'mem, 'facet>,
+    index: usize,
+    len: usize,
+}
+
+impl<'mem, 'facet> Iterator for PeekDynamicValueArrayIter<'mem, 'facet> {
+    type Item = Peek<'mem, 'facet>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        let item = self.dyn_value.array_get(self.index)?;
+        self.index += 1;
+        Some(item)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.len.saturating_sub(self.index);
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for PeekDynamicValueArrayIter<'_, '_> {}
+
+/// Iterator over object entries in a dynamic value
+pub struct PeekDynamicValueObjectIter<'mem, 'facet> {
+    dyn_value: PeekDynamicValue<'mem, 'facet>,
+    index: usize,
+    len: usize,
+}
+
+impl<'mem, 'facet> Iterator for PeekDynamicValueObjectIter<'mem, 'facet> {
+    type Item = (&'mem str, Peek<'mem, 'facet>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        let entry = self.dyn_value.object_get_entry(self.index)?;
+        self.index += 1;
+        Some(entry)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.len.saturating_sub(self.index);
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for PeekDynamicValueObjectIter<'_, '_> {}
+
+impl core::fmt::Debug for PeekDynamicValue<'_, '_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PeekDynamicValue")
+            .field("kind", &self.kind())
+            .finish_non_exhaustive()
+    }
+}

--- a/facet-reflect/src/peek/mod.rs
+++ b/facet-reflect/src/peek/mod.rs
@@ -36,6 +36,9 @@ pub use pointer::*;
 mod tuple;
 pub use tuple::*;
 
+mod dynamic_value;
+pub use dynamic_value::*;
+
 #[cfg(feature = "alloc")]
 mod owned;
 #[cfg(feature = "alloc")]

--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -8,8 +8,8 @@ use facet_core::{Field, FieldAttribute};
 use crate::{PeekNdArray, PeekSet, ReflectError, ScalarType};
 
 use super::{
-    tuple::TupleType, ListLikeDef, PeekEnum, PeekList, PeekListLike, PeekMap, PeekOption,
-    PeekPointer, PeekStruct, PeekTuple,
+    tuple::TupleType, ListLikeDef, PeekDynamicValue, PeekEnum, PeekList, PeekListLike, PeekMap,
+    PeekOption, PeekPointer, PeekStruct, PeekTuple,
 };
 
 #[cfg(feature = "alloc")]
@@ -431,6 +431,19 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
         } else {
             Err(ReflectError::WasNotA {
                 expected: "tuple",
+                actual: self.shape,
+            })
+        }
+    }
+
+    /// Tries to identify this value as a dynamic value (like `facet_value::Value`)
+    #[inline]
+    pub fn into_dynamic_value(self) -> Result<PeekDynamicValue<'mem, 'facet>, ReflectError> {
+        if let Def::DynamicValue(def) = self.shape.def {
+            Ok(PeekDynamicValue { value: self, def })
+        } else {
+            Err(ReflectError::WasNotA {
+                expected: "dynamic value",
                 actual: self.shape,
             })
         }

--- a/facet-value/Cargo.toml
+++ b/facet-value/Cargo.toml
@@ -18,3 +18,7 @@ alloc = ["facet-core/alloc"]
 facet-core = { path = "../facet-core", version = "0.31.8", default-features = false }
 
 [dev-dependencies]
+facet-assert = { path = "../facet-assert" }
+facet-diff = { path = "../facet-diff" }
+facet-pretty = { path = "../facet-pretty" }
+facet-reflect = { path = "../facet-reflect" }

--- a/facet-value/tests/assert_diff_pretty.rs
+++ b/facet-value/tests/assert_diff_pretty.rs
@@ -1,0 +1,255 @@
+//! Tests for facet-assert, facet-diff, and facet-pretty support for Value
+
+use facet_assert::{Sameness, assert_same, check_same};
+use facet_diff::FacetDiff;
+use facet_pretty::FacetPretty;
+use facet_value::value;
+
+// ============================================================================
+// facet-assert tests
+// ============================================================================
+
+#[test]
+fn test_value_vs_value_same() {
+    let v1 = value!([1, 2, 3]);
+    let v2 = value!([1, 2, 3]);
+    assert_same!(v1, v2);
+}
+
+#[test]
+fn test_value_vs_value_different() {
+    let v1 = value!([1, 2, 3]);
+    let v2 = value!([1, 2, 4]);
+    match check_same(&v1, &v2) {
+        Sameness::Different(_) => {} // expected
+        Sameness::Same => panic!("expected Different, got Same"),
+        Sameness::Opaque { type_name } => panic!("expected Different, got Opaque: {type_name}"),
+    }
+}
+
+#[test]
+fn test_value_array_vs_vec_same() {
+    let v = value!([1, 2, 3]);
+    let vec: Vec<i64> = vec![1, 2, 3];
+    assert_same!(v, vec);
+}
+
+#[test]
+fn test_vec_vs_value_array_same() {
+    let vec: Vec<i64> = vec![1, 2, 3];
+    let v = value!([1, 2, 3]);
+    assert_same!(vec, v);
+}
+
+#[test]
+fn test_value_array_vs_vec_different_length() {
+    let v = value!([1, 2, 3, 4]);
+    let vec: Vec<i64> = vec![1, 2, 3];
+    match check_same(&v, &vec) {
+        Sameness::Different(_) => {} // expected
+        Sameness::Same => panic!("expected Different, got Same"),
+        Sameness::Opaque { type_name } => panic!("expected Different, got Opaque: {type_name}"),
+    }
+}
+
+#[test]
+fn test_value_array_vs_vec_different_content() {
+    let v = value!([1, 2, 99]);
+    let vec: Vec<i64> = vec![1, 2, 3];
+    match check_same(&v, &vec) {
+        Sameness::Different(_) => {} // expected
+        Sameness::Same => panic!("expected Different, got Same"),
+        Sameness::Opaque { type_name } => panic!("expected Different, got Opaque: {type_name}"),
+    }
+}
+
+#[test]
+fn test_value_string_vs_string_same() {
+    let v = value!("hello");
+    let s = String::from("hello");
+    assert_same!(v, s);
+}
+
+#[test]
+fn test_value_string_vs_string_different() {
+    let v = value!("hello");
+    let s = String::from("world");
+    match check_same(&v, &s) {
+        Sameness::Different(_) => {} // expected
+        Sameness::Same => panic!("expected Different, got Same"),
+        Sameness::Opaque { type_name } => panic!("expected Different, got Opaque: {type_name}"),
+    }
+}
+
+#[test]
+fn test_value_number_vs_i64_same() {
+    let v = value!(42);
+    let n: i64 = 42;
+    assert_same!(v, n);
+}
+
+#[test]
+fn test_value_number_vs_i64_different() {
+    let v = value!(42);
+    let n: i64 = 43;
+    match check_same(&v, &n) {
+        Sameness::Different(_) => {} // expected
+        Sameness::Same => panic!("expected Different, got Same"),
+        Sameness::Opaque { type_name } => panic!("expected Different, got Opaque: {type_name}"),
+    }
+}
+
+#[test]
+fn test_value_bool_vs_bool_same() {
+    let v = value!(true);
+    let b = true;
+    assert_same!(v, b);
+}
+
+#[test]
+fn test_value_bool_vs_bool_different() {
+    let v = value!(true);
+    let b = false;
+    match check_same(&v, &b) {
+        Sameness::Different(_) => {} // expected
+        Sameness::Same => panic!("expected Different, got Same"),
+        Sameness::Opaque { type_name } => panic!("expected Different, got Opaque: {type_name}"),
+    }
+}
+
+#[test]
+fn test_nested_value_vs_nested_vec() {
+    // Nested arrays
+    let v = value!([[1, 2], [3, 4]]);
+    let vec: Vec<Vec<i64>> = vec![vec![1, 2], vec![3, 4]];
+    assert_same!(v, vec);
+}
+
+#[test]
+fn test_value_object_vs_value_object_same() {
+    let v1 = value!({"name": "Alice", "age": 30});
+    let v2 = value!({"name": "Alice", "age": 30});
+    assert_same!(v1, v2);
+}
+
+#[test]
+fn test_value_object_vs_value_object_different() {
+    let v1 = value!({"name": "Alice", "age": 30});
+    let v2 = value!({"name": "Bob", "age": 30});
+    match check_same(&v1, &v2) {
+        Sameness::Different(_) => {} // expected
+        Sameness::Same => panic!("expected Different, got Same"),
+        Sameness::Opaque { type_name } => panic!("expected Different, got Opaque: {type_name}"),
+    }
+}
+
+// ============================================================================
+// facet-diff tests
+// ============================================================================
+
+#[test]
+fn test_diff_value_equal() {
+    let v1 = value!([1, 2, 3]);
+    let v2 = value!([1, 2, 3]);
+    let diff = v1.diff(&v2);
+    assert!(diff.is_equal());
+}
+
+#[test]
+fn test_diff_value_not_equal() {
+    let v1 = value!([1, 2, 3]);
+    let v2 = value!([1, 2, 4]);
+    let diff = v1.diff(&v2);
+    assert!(!diff.is_equal());
+}
+
+#[test]
+fn test_diff_value_object_equal() {
+    let v1 = value!({"a": 1, "b": 2});
+    let v2 = value!({"a": 1, "b": 2});
+    let diff = v1.diff(&v2);
+    assert!(diff.is_equal());
+}
+
+#[test]
+fn test_diff_value_object_different_value() {
+    let v1 = value!({"a": 1, "b": 2});
+    let v2 = value!({"a": 1, "b": 3});
+    let diff = v1.diff(&v2);
+    assert!(!diff.is_equal());
+}
+
+#[test]
+fn test_diff_value_object_different_keys() {
+    let v1 = value!({"a": 1, "b": 2});
+    let v2 = value!({"a": 1, "c": 2});
+    let diff = v1.diff(&v2);
+    assert!(!diff.is_equal());
+}
+
+// ============================================================================
+// facet-pretty tests
+// ============================================================================
+
+#[test]
+fn test_pretty_value_null() {
+    let v = value!(null);
+    let pretty = v.pretty().to_string();
+    assert!(pretty.contains("null"), "pretty output: {pretty}");
+}
+
+#[test]
+fn test_pretty_value_bool() {
+    let v = value!(true);
+    let pretty = v.pretty().to_string();
+    assert!(pretty.contains("true"), "pretty output: {pretty}");
+}
+
+#[test]
+fn test_pretty_value_number() {
+    let v = value!(42);
+    let pretty = v.pretty().to_string();
+    assert!(pretty.contains("42"), "pretty output: {pretty}");
+}
+
+#[test]
+fn test_pretty_value_string() {
+    let v = value!("hello");
+    let pretty = v.pretty().to_string();
+    assert!(pretty.contains("hello"), "pretty output: {pretty}");
+}
+
+#[test]
+fn test_pretty_value_array() {
+    let v = value!([1, 2, 3]);
+    let pretty = v.pretty().to_string();
+    // Should contain the array elements
+    assert!(pretty.contains("1"), "pretty output: {pretty}");
+    assert!(pretty.contains("2"), "pretty output: {pretty}");
+    assert!(pretty.contains("3"), "pretty output: {pretty}");
+}
+
+#[test]
+fn test_pretty_value_object() {
+    let v = value!({"name": "Alice", "age": 30});
+    let pretty = v.pretty().to_string();
+    // Should contain the keys and values
+    assert!(pretty.contains("name"), "pretty output: {pretty}");
+    assert!(pretty.contains("Alice"), "pretty output: {pretty}");
+    assert!(pretty.contains("age"), "pretty output: {pretty}");
+    assert!(pretty.contains("30"), "pretty output: {pretty}");
+}
+
+#[test]
+fn test_pretty_nested_value() {
+    let v = value!({
+        "users": [
+            {"name": "Alice"},
+            {"name": "Bob"}
+        ]
+    });
+    let pretty = v.pretty().to_string();
+    assert!(pretty.contains("users"), "pretty output: {pretty}");
+    assert!(pretty.contains("Alice"), "pretty output: {pretty}");
+    assert!(pretty.contains("Bob"), "pretty output: {pretty}");
+}


### PR DESCRIPTION
## Summary

This adds full support for comparing, diffing, and pretty-printing `facet_value::Value` types through the facet reflection system.

- **facet-reflect**: Add `PeekDynamicValue` for inspecting DynamicValue types
- **facet-assert**: Enable structural comparison between Value and concrete types (e.g., `value!([1, 2, 3])` == `vec![1, 2, 3]`)
- **facet-diff**: Add DynamicValue diffing support with proper sequence/struct diffs
- **facet-pretty**: Add DynamicValue formatting with proper indentation

## Test plan

- [x] 27 new tests covering Value comparisons, diffs, and pretty printing
- [x] Cross-type comparisons (Value array vs Vec, Value string vs String, etc.)
- [x] Value vs Value comparisons for all types
- [x] Nested structure support