### PR TITLE
Fix hardcoded absolute paths in compile_errors_showcase

### DIFF
--- a/facet-kdl/examples/compile_errors_showcase.rs
+++ b/facet-kdl/examples/compile_errors_showcase.rs
@@ -37,18 +37,26 @@ fn compile_snippet(code: &str) -> String {
     // Create project structure
     fs::create_dir_all(&src_dir).unwrap();
 
-    // Write Cargo.toml
+    // Write Cargo.toml with paths relative to this crate's location
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let facet_path = Path::new(manifest_dir).join("../facet");
+    let facet_kdl_path = Path::new(manifest_dir);
+
     fs::write(
         test_dir.join("Cargo.toml"),
-        r#"[package]
+        format!(
+            r#"[package]
 name = "test"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-facet = { path = "/Users/amos/bearcove/facet/facet" }
-facet-kdl = { path = "/Users/amos/bearcove/facet/facet-kdl" }
+facet = {{ path = "{}" }}
+facet-kdl = {{ path = "{}" }}
 "#,
+            facet_path.display(),
+            facet_kdl_path.display()
+        ),
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `/Users/amos/bearcove/facet` paths with dynamic paths using `CARGO_MANIFEST_DIR`
- Fixes CI failure where the compile errors showcase couldn't find the facet dependency

## Test plan
- [x] `cargo build --example compile_errors_showcase -p facet-kdl` compiles
- [x] `cargo run --example compile_errors_showcase -p facet-kdl` runs successfully