### PR TITLE
Add Facet implementation for Result<T, E>

### DIFF
--- a/facet-core/src/impls_core/mod.rs
+++ b/facet-core/src/impls_core/mod.rs
@@ -8,6 +8,7 @@ mod ops;
 mod option;
 mod pointer;
 mod reference;
+mod result;
 mod scalar;
 mod slice;
 mod tuple;

--- a/facet-core/src/impls_core/result.rs
+++ b/facet-core/src/impls_core/result.rs
@@ -1,0 +1,198 @@
+use core::{cmp::Ordering, ptr::NonNull};
+
+use crate::{
+    Def, Facet, PtrConst, ResultDef, ResultVTable, Shape, Type, UserType, shape_util, value_vtable,
+};
+
+unsafe impl<'a, T: Facet<'a>, E: Facet<'a>> Facet<'a> for Result<T, E> {
+    const SHAPE: &'static Shape = &const {
+        Shape::builder_for_sized::<Self>()
+            .vtable({
+                let mut vtable = value_vtable!(core::result::Result<T, E>, |f, opts| {
+                    write!(f, "{}", Self::SHAPE.type_identifier)?;
+                    if let Some(opts) = opts.for_children() {
+                        write!(f, "<")?;
+                        (T::SHAPE.vtable.type_name())(f, opts)?;
+                        write!(f, ", ")?;
+                        (E::SHAPE.vtable.type_name())(f, opts)?;
+                        write!(f, ">")?;
+                    } else {
+                        write!(f, "<…>")?;
+                    }
+                    Ok(())
+                });
+
+                {
+                    let vtable_sized = &mut vtable;
+                    vtable_sized.debug = if T::SHAPE.is_debug() && E::SHAPE.is_debug() {
+                        Some(|this, f| {
+                            let this = unsafe { this.get::<Self>() };
+                            match this {
+                                Ok(value) => f
+                                    .debug_tuple("Ok")
+                                    .field(&shape_util::Debug {
+                                        ptr: PtrConst::new(value.into()),
+                                        f: T::SHAPE.vtable.debug.unwrap(),
+                                    })
+                                    .finish(),
+                                Err(err) => f
+                                    .debug_tuple("Err")
+                                    .field(&shape_util::Debug {
+                                        ptr: PtrConst::new(err.into()),
+                                        f: E::SHAPE.vtable.debug.unwrap(),
+                                    })
+                                    .finish(),
+                            }
+                        })
+                    } else {
+                        None
+                    };
+
+                    vtable_sized.partial_eq =
+                        if T::SHAPE.is_partial_eq() && E::SHAPE.is_partial_eq() {
+                            Some(|a, b| unsafe {
+                                let a = a.get::<Self>();
+                                let b = b.get::<Self>();
+                                match (a, b) {
+                                    (Ok(a), Ok(b)) => T::SHAPE.vtable.partial_eq.unwrap()(
+                                        PtrConst::new(a.into()),
+                                        PtrConst::new(b.into()),
+                                    ),
+                                    (Err(a), Err(b)) => E::SHAPE.vtable.partial_eq.unwrap()(
+                                        PtrConst::new(a.into()),
+                                        PtrConst::new(b.into()),
+                                    ),
+                                    _ => false,
+                                }
+                            })
+                        } else {
+                            None
+                        };
+
+                    vtable_sized.partial_ord =
+                        if T::SHAPE.is_partial_ord() && E::SHAPE.is_partial_ord() {
+                            Some(|a, b| unsafe {
+                                let a = a.get::<Self>();
+                                let b = b.get::<Self>();
+                                match (a, b) {
+                                    (Ok(a), Ok(b)) => T::SHAPE.vtable.partial_ord.unwrap()(
+                                        PtrConst::new(a.into()),
+                                        PtrConst::new(b.into()),
+                                    ),
+                                    (Err(a), Err(b)) => E::SHAPE.vtable.partial_ord.unwrap()(
+                                        PtrConst::new(a.into()),
+                                        PtrConst::new(b.into()),
+                                    ),
+                                    (Ok(_), Err(_)) => Some(Ordering::Greater),
+                                    (Err(_), Ok(_)) => Some(Ordering::Less),
+                                }
+                            })
+                        } else {
+                            None
+                        };
+
+                    vtable_sized.ord = if T::SHAPE.is_ord() && E::SHAPE.is_ord() {
+                        Some(|a, b| unsafe {
+                            let a = a.get::<Self>();
+                            let b = b.get::<Self>();
+                            match (a, b) {
+                                (Ok(a), Ok(b)) => T::SHAPE.vtable.ord.unwrap()(
+                                    PtrConst::new(a.into()),
+                                    PtrConst::new(b.into()),
+                                ),
+                                (Err(a), Err(b)) => E::SHAPE.vtable.ord.unwrap()(
+                                    PtrConst::new(a.into()),
+                                    PtrConst::new(b.into()),
+                                ),
+                                (Ok(_), Err(_)) => Ordering::Greater,
+                                (Err(_), Ok(_)) => Ordering::Less,
+                            }
+                        })
+                    } else {
+                        None
+                    };
+
+                    vtable_sized.hash = if T::SHAPE.is_hash() && E::SHAPE.is_hash() {
+                        Some(|this, hasher| unsafe {
+                            use core::hash::Hash;
+                            let this = this.get::<Self>();
+                            match this {
+                                Ok(value) => {
+                                    (
+                                        0u8,
+                                        shape_util::Hash {
+                                            ptr: PtrConst::new(value.into()),
+                                            f: T::SHAPE.vtable.hash.unwrap(),
+                                        },
+                                    )
+                                        .hash(&mut { hasher });
+                                }
+                                Err(err) => {
+                                    (
+                                        1u8,
+                                        shape_util::Hash {
+                                            ptr: PtrConst::new(err.into()),
+                                            f: E::SHAPE.vtable.hash.unwrap(),
+                                        },
+                                    )
+                                        .hash(&mut { hasher });
+                                }
+                            }
+                        })
+                    } else {
+                        None
+                    };
+                }
+
+                vtable
+            })
+            .type_identifier("Result")
+            .type_params(&[
+                crate::TypeParam {
+                    name: "T",
+                    shape: T::SHAPE,
+                },
+                crate::TypeParam {
+                    name: "E",
+                    shape: E::SHAPE,
+                },
+            ])
+            // Result's layout is complex and depends on T and E, so we treat it as Opaque
+            // and rely on the ResultDef vtable for interaction
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::Result(
+                ResultDef::builder()
+                    .t(T::SHAPE)
+                    .e(E::SHAPE)
+                    .vtable(
+                        const {
+                            &ResultVTable::builder()
+                                .is_ok(|result| unsafe { result.get::<Result<T, E>>().is_ok() })
+                                .get_ok(|result| unsafe {
+                                    result
+                                        .get::<Result<T, E>>()
+                                        .as_ref()
+                                        .ok()
+                                        .map(|t| PtrConst::new(NonNull::from(t)))
+                                })
+                                .get_err(|result| unsafe {
+                                    result
+                                        .get::<Result<T, E>>()
+                                        .as_ref()
+                                        .err()
+                                        .map(|e| PtrConst::new(NonNull::from(e)))
+                                })
+                                .init_ok(|result, value| unsafe {
+                                    result.put(Result::<T, E>::Ok(value.read::<T>()))
+                                })
+                                .init_err(|result, value| unsafe {
+                                    result.put(Result::<T, E>::Err(value.read::<E>()))
+                                })
+                                .build()
+                        },
+                    )
+                    .build(),
+            ))
+            .build()
+    };
+}

--- a/facet-core/src/types/def/mod.rs
+++ b/facet-core/src/types/def/mod.rs
@@ -21,6 +21,9 @@ pub use set::*;
 mod option;
 pub use option::*;
 
+mod result;
+pub use result::*;
+
 mod pointer;
 pub use pointer::*;
 
@@ -84,6 +87,11 @@ pub enum Def {
     /// e.g. `Option<T>`
     Option(OptionDef),
 
+    /// Result
+    ///
+    /// e.g. `Result<T, E>`
+    Result(ResultDef),
+
     /// Pointer types like `Arc<T>`, `Rc<T>`, etc.
     Pointer(PointerDef),
 
@@ -107,6 +115,7 @@ impl core::fmt::Debug for Def {
             Def::Array(array_def) => write!(f, "Array<{}; {}>", array_def.t, array_def.n),
             Def::Slice(slice_def) => write!(f, "Slice<{}>", slice_def.t),
             Def::Option(option_def) => write!(f, "Option<{}>", option_def.t),
+            Def::Result(result_def) => write!(f, "Result<{}, {}>", result_def.t, result_def.e),
             Def::Pointer(smart_ptr_def) => {
                 if let Some(pointee) = smart_ptr_def.pointee {
                     write!(f, "SmartPointer<{pointee}>")
@@ -176,6 +185,13 @@ impl Def {
     pub fn into_option(self) -> Result<OptionDef, Self> {
         match self {
             Self::Option(def) => Ok(def),
+            _ => Err(self),
+        }
+    }
+    /// Returns the `ResultDef` wrapped in an `Ok` if this is a [`Def::Result`].
+    pub fn into_result(self) -> Result<ResultDef, Self> {
+        match self {
+            Self::Result(def) => Ok(def),
             _ => Err(self),
         }
     }

--- a/facet-core/src/types/def/result.rs
+++ b/facet-core/src/types/def/result.rs
@@ -1,0 +1,220 @@
+use super::Shape;
+use crate::ptr::{PtrConst, PtrMut, PtrUninit};
+
+/// Describes a Result — including a vtable to query and alter its state,
+/// and the inner shapes (the `T` and `E` in `Result<T, E>`).
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct ResultDef {
+    /// vtable for interacting with the result
+    pub vtable: &'static ResultVTable,
+
+    /// shape of the Ok type
+    pub t: &'static Shape,
+
+    /// shape of the Err type
+    pub e: &'static Shape,
+}
+
+impl ResultDef {
+    /// Returns a builder for ResultDef
+    pub const fn builder() -> ResultDefBuilder {
+        ResultDefBuilder::new()
+    }
+
+    /// Returns the Ok type shape of the result
+    pub const fn t(&self) -> &'static Shape {
+        self.t
+    }
+
+    /// Returns the Err type shape of the result
+    pub const fn e(&self) -> &'static Shape {
+        self.e
+    }
+}
+
+/// Builder for ResultDef
+pub struct ResultDefBuilder {
+    vtable: Option<&'static ResultVTable>,
+    t: Option<&'static Shape>,
+    e: Option<&'static Shape>,
+}
+
+impl ResultDefBuilder {
+    /// Creates a new ResultDefBuilder
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self {
+            vtable: None,
+            t: None,
+            e: None,
+        }
+    }
+
+    /// Sets the vtable for the ResultDef
+    pub const fn vtable(mut self, vtable: &'static ResultVTable) -> Self {
+        self.vtable = Some(vtable);
+        self
+    }
+
+    /// Sets the Ok type shape for the ResultDef
+    pub const fn t(mut self, t: &'static Shape) -> Self {
+        self.t = Some(t);
+        self
+    }
+
+    /// Sets the Err type shape for the ResultDef
+    pub const fn e(mut self, e: &'static Shape) -> Self {
+        self.e = Some(e);
+        self
+    }
+
+    /// Builds the ResultDef
+    pub const fn build(self) -> ResultDef {
+        ResultDef {
+            vtable: self.vtable.unwrap(),
+            t: self.t.unwrap(),
+            e: self.e.unwrap(),
+        }
+    }
+}
+
+/// Check if a result is Ok
+///
+/// # Safety
+///
+/// The `result` parameter must point to aligned, initialized memory of the correct type.
+pub type ResultIsOkFn = for<'result> unsafe fn(result: PtrConst<'result>) -> bool;
+
+/// Get the Ok value contained in a result, if present
+///
+/// # Safety
+///
+/// The `result` parameter must point to aligned, initialized memory of the correct type.
+pub type ResultGetOkFn =
+    for<'result> unsafe fn(result: PtrConst<'result>) -> Option<PtrConst<'result>>;
+
+/// Get the Err value contained in a result, if present
+///
+/// # Safety
+///
+/// The `result` parameter must point to aligned, initialized memory of the correct type.
+pub type ResultGetErrFn =
+    for<'result> unsafe fn(result: PtrConst<'result>) -> Option<PtrConst<'result>>;
+
+/// Initialize a result with Ok(value)
+///
+/// # Safety
+///
+/// The `result` parameter must point to uninitialized memory of sufficient size.
+/// The function must properly initialize the memory.
+/// `value` is moved out of (with [`core::ptr::read`]) — it should be deallocated afterwards (e.g.
+/// with [`core::mem::forget`]) but NOT dropped.
+pub type ResultInitOkFn =
+    for<'result> unsafe fn(result: PtrUninit<'result>, value: PtrConst<'_>) -> PtrMut<'result>;
+
+/// Initialize a result with Err(value)
+///
+/// # Safety
+///
+/// The `result` parameter must point to uninitialized memory of sufficient size.
+/// The function must properly initialize the memory.
+/// `value` is moved out of (with [`core::ptr::read`]) — it should be deallocated afterwards (e.g.
+/// with [`core::mem::forget`]) but NOT dropped.
+pub type ResultInitErrFn =
+    for<'result> unsafe fn(result: PtrUninit<'result>, value: PtrConst<'_>) -> PtrMut<'result>;
+
+/// Virtual table for `Result<T, E>`
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct ResultVTable {
+    /// cf. [`ResultIsOkFn`]
+    pub is_ok_fn: ResultIsOkFn,
+
+    /// cf. [`ResultGetOkFn`]
+    pub get_ok_fn: ResultGetOkFn,
+
+    /// cf. [`ResultGetErrFn`]
+    pub get_err_fn: ResultGetErrFn,
+
+    /// cf. [`ResultInitOkFn`]
+    pub init_ok_fn: ResultInitOkFn,
+
+    /// cf. [`ResultInitErrFn`]
+    pub init_err_fn: ResultInitErrFn,
+}
+
+impl ResultVTable {
+    /// Returns a builder for ResultVTable
+    pub const fn builder() -> ResultVTableBuilder {
+        ResultVTableBuilder::new()
+    }
+}
+
+/// Builds a [`ResultVTable`]
+pub struct ResultVTableBuilder {
+    is_ok_fn: Option<ResultIsOkFn>,
+    get_ok_fn: Option<ResultGetOkFn>,
+    get_err_fn: Option<ResultGetErrFn>,
+    init_ok_fn: Option<ResultInitOkFn>,
+    init_err_fn: Option<ResultInitErrFn>,
+}
+
+impl ResultVTableBuilder {
+    /// Creates a new [`ResultVTableBuilder`] with all fields set to `None`.
+    #[allow(clippy::new_without_default)]
+    pub const fn new() -> Self {
+        Self {
+            is_ok_fn: None,
+            get_ok_fn: None,
+            get_err_fn: None,
+            init_ok_fn: None,
+            init_err_fn: None,
+        }
+    }
+
+    /// Sets the is_ok_fn field
+    pub const fn is_ok(mut self, f: ResultIsOkFn) -> Self {
+        self.is_ok_fn = Some(f);
+        self
+    }
+
+    /// Sets the get_ok_fn field
+    pub const fn get_ok(mut self, f: ResultGetOkFn) -> Self {
+        self.get_ok_fn = Some(f);
+        self
+    }
+
+    /// Sets the get_err_fn field
+    pub const fn get_err(mut self, f: ResultGetErrFn) -> Self {
+        self.get_err_fn = Some(f);
+        self
+    }
+
+    /// Sets the init_ok_fn field
+    pub const fn init_ok(mut self, f: ResultInitOkFn) -> Self {
+        self.init_ok_fn = Some(f);
+        self
+    }
+
+    /// Sets the init_err_fn field
+    pub const fn init_err(mut self, f: ResultInitErrFn) -> Self {
+        self.init_err_fn = Some(f);
+        self
+    }
+
+    /// Builds the [`ResultVTable`] from the current state of the builder.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if any of the required fields are `None`.
+    pub const fn build(self) -> ResultVTable {
+        ResultVTable {
+            is_ok_fn: self.is_ok_fn.unwrap(),
+            get_ok_fn: self.get_ok_fn.unwrap(),
+            get_err_fn: self.get_err_fn.unwrap(),
+            init_ok_fn: self.init_ok_fn.unwrap(),
+            init_err_fn: self.init_err_fn.unwrap(),
+        }
+    }
+}

--- a/facet-reflect/src/error.rs
+++ b/facet-reflect/src/error.rs
@@ -15,6 +15,7 @@ pub enum TrackerKind {
     Map,
     Set,
     Option,
+    Result,
     DynamicValue,
 }
 

--- a/facet-reflect/src/partial/partial_api.rs
+++ b/facet-reflect/src/partial/partial_api.rs
@@ -33,6 +33,7 @@ mod maps;
 mod misc;
 mod option;
 mod ptr;
+mod result;
 mod set;
 mod sets;
 mod shorthands;

--- a/facet-reflect/src/partial/partial_api/fields.rs
+++ b/facet-reflect/src/partial/partial_api/fields.rs
@@ -66,9 +66,20 @@ impl Partial<'_> {
                     })
                 }
             }
+            Tracker::Result { building_inner, .. } => {
+                // For Results, index 0 represents the inner value (Ok or Err)
+                if index == 0 {
+                    Ok(!building_inner)
+                } else {
+                    Err(ReflectError::InvalidOperation {
+                        operation: "is_field_set",
+                        reason: "Result only has one field (index 0)",
+                    })
+                }
+            }
             _ => Err(ReflectError::InvalidOperation {
                 operation: "is_field_set",
-                reason: "Current frame is not a struct, enum variant, or option",
+                reason: "Current frame is not a struct, enum variant, option, or result",
             }),
         }
     }
@@ -369,6 +380,9 @@ impl Partial<'_> {
             }
             Tracker::Option { .. } => {
                 unreachable!("can't steal fields from options")
+            }
+            Tracker::Result { .. } => {
+                unreachable!("can't steal fields from results")
             }
             Tracker::DynamicValue { .. } => {
                 unreachable!("can't steal fields from dynamic values")

--- a/facet-reflect/src/partial/partial_api/internal.rs
+++ b/facet-reflect/src/partial/partial_api/internal.rs
@@ -368,6 +368,7 @@ impl<'facet> Partial<'facet> {
             | Tracker::Map { .. }
             | Tracker::Set { .. }
             | Tracker::Option { .. }
+            | Tracker::Result { .. }
             | Tracker::DynamicValue { .. } => true,
         };
         if !needs_cleanup {

--- a/facet-reflect/src/peek/mod.rs
+++ b/facet-reflect/src/peek/mod.rs
@@ -30,6 +30,9 @@ pub use set::*;
 mod option;
 pub use option::*;
 
+mod result;
+pub use result::*;
+
 mod pointer;
 pub use pointer::*;
 

--- a/facet-reflect/src/peek/result.rs
+++ b/facet-reflect/src/peek/result.rs
@@ -1,0 +1,55 @@
+use facet_core::{ResultDef, ResultVTable};
+
+/// Lets you read from a result (implements read-only result operations)
+#[derive(Clone, Copy)]
+pub struct PeekResult<'mem, 'facet> {
+    /// the underlying value
+    pub(crate) value: crate::Peek<'mem, 'facet>,
+
+    /// the definition of the result
+    pub(crate) def: ResultDef,
+}
+
+impl<'mem, 'facet> PeekResult<'mem, 'facet> {
+    /// Returns the result definition
+    #[inline(always)]
+    pub fn def(self) -> ResultDef {
+        self.def
+    }
+
+    /// Returns the result vtable
+    #[inline(always)]
+    pub fn vtable(self) -> &'static ResultVTable {
+        self.def.vtable
+    }
+
+    /// Returns whether the result is Ok
+    #[inline]
+    pub fn is_ok(self) -> bool {
+        unsafe { (self.vtable().is_ok_fn)(self.value.data()) }
+    }
+
+    /// Returns whether the result is Err
+    #[inline]
+    pub fn is_err(self) -> bool {
+        !self.is_ok()
+    }
+
+    /// Returns the Ok value as a Peek if the result is Ok, None otherwise
+    #[inline]
+    pub fn ok(self) -> Option<crate::Peek<'mem, 'facet>> {
+        unsafe {
+            (self.vtable().get_ok_fn)(self.value.data())
+                .map(|inner_data| crate::Peek::unchecked_new(inner_data, self.def.t()))
+        }
+    }
+
+    /// Returns the Err value as a Peek if the result is Err, None otherwise
+    #[inline]
+    pub fn err(self) -> Option<crate::Peek<'mem, 'facet>> {
+        unsafe {
+            (self.vtable().get_err_fn)(self.value.data())
+                .map(|inner_data| crate::Peek::unchecked_new(inner_data, self.def.e()))
+        }
+    }
+}

--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -9,7 +9,7 @@ use crate::{PeekNdArray, PeekSet, ReflectError, ScalarType};
 
 use super::{
     ListLikeDef, PeekDynamicValue, PeekEnum, PeekList, PeekListLike, PeekMap, PeekOption,
-    PeekPointer, PeekStruct, PeekTuple, tuple::TupleType,
+    PeekPointer, PeekResult, PeekStruct, PeekTuple, tuple::TupleType,
 };
 
 #[cfg(feature = "alloc")]
@@ -406,6 +406,19 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
         } else {
             Err(ReflectError::WasNotA {
                 expected: "option",
+                actual: self.shape,
+            })
+        }
+    }
+
+    /// Tries to identify this value as a result
+    #[inline]
+    pub fn into_result(self) -> Result<PeekResult<'mem, 'facet>, ReflectError> {
+        if let Def::Result(def) = self.shape.def {
+            Ok(PeekResult { value: self, def })
+        } else {
+            Err(ReflectError::WasNotA {
+                expected: "result",
                 actual: self.shape,
             })
         }

--- a/facet-reflect/tests/partial/mod.rs
+++ b/facet-reflect/tests/partial/mod.rs
@@ -16,6 +16,7 @@ mod option_leak;
 mod pointer;
 mod pointer_complex;
 mod put_vec_leak;
+mod result_building;
 mod set;
 mod struct_leak;
 mod tuples;

--- a/facet-reflect/tests/partial/result_building.rs
+++ b/facet-reflect/tests/partial/result_building.rs
@@ -1,0 +1,146 @@
+use facet_reflect::Partial;
+use facet_testhelpers::test;
+
+#[test]
+fn test_result_building_ok() {
+    let mut wip = Partial::alloc::<Result<String, i32>>().unwrap();
+
+    // Build Ok("hello")
+    wip = wip.begin_ok().unwrap();
+    wip = wip.set("hello".to_string()).unwrap();
+    wip = wip.end().unwrap();
+
+    let result_value = wip
+        .build()
+        .unwrap()
+        .materialize::<Result<String, i32>>()
+        .unwrap();
+    assert_eq!(result_value, Ok("hello".to_string()));
+}
+
+#[test]
+fn test_result_building_err() {
+    let mut wip = Partial::alloc::<Result<String, i32>>().unwrap();
+
+    // Build Err(42)
+    wip = wip.begin_err().unwrap();
+    wip = wip.set(42i32).unwrap();
+    wip = wip.end().unwrap();
+
+    let result_value = wip
+        .build()
+        .unwrap()
+        .materialize::<Result<String, i32>>()
+        .unwrap();
+    assert_eq!(result_value, Err(42));
+}
+
+#[test]
+fn test_result_building_ok_complex_type() {
+    let mut wip = Partial::alloc::<Result<Vec<i32>, String>>().unwrap();
+
+    // Build Ok(vec![1, 2, 3])
+    wip = wip.begin_ok().unwrap();
+    wip = wip.set(vec![1, 2, 3]).unwrap();
+    wip = wip.end().unwrap();
+
+    let result_value = wip
+        .build()
+        .unwrap()
+        .materialize::<Result<Vec<i32>, String>>()
+        .unwrap();
+    assert_eq!(result_value, Ok(vec![1, 2, 3]));
+}
+
+#[test]
+fn test_result_building_err_complex_type() {
+    let mut wip = Partial::alloc::<Result<i32, Vec<String>>>().unwrap();
+
+    // Build Err(vec!["error1", "error2"])
+    wip = wip.begin_err().unwrap();
+    wip = wip
+        .set(vec!["error1".to_string(), "error2".to_string()])
+        .unwrap();
+    wip = wip.end().unwrap();
+
+    let result_value = wip
+        .build()
+        .unwrap()
+        .materialize::<Result<i32, Vec<String>>>()
+        .unwrap();
+    assert_eq!(
+        result_value,
+        Err(vec!["error1".to_string(), "error2".to_string()])
+    );
+}
+
+#[test]
+fn test_result_in_struct() {
+    #[derive(facet::Facet, Debug, PartialEq)]
+    struct TestStruct {
+        success: Result<String, i32>,
+        failure: Result<String, i32>,
+    }
+
+    let mut wip = Partial::alloc::<TestStruct>().unwrap();
+
+    // Build the success field as Ok
+    wip = wip.begin_nth_field(0).unwrap();
+    wip = wip.begin_ok().unwrap();
+    wip = wip.set("success".to_string()).unwrap();
+    wip = wip.end().unwrap();
+    wip = wip.end().unwrap();
+
+    // Build the failure field as Err
+    wip = wip.begin_nth_field(1).unwrap();
+    wip = wip.begin_err().unwrap();
+    wip = wip.set(404i32).unwrap();
+    wip = wip.end().unwrap();
+    wip = wip.end().unwrap();
+
+    let struct_value = wip.build().unwrap().materialize::<TestStruct>().unwrap();
+    assert_eq!(
+        struct_value,
+        TestStruct {
+            success: Ok("success".to_string()),
+            failure: Err(404),
+        }
+    );
+}
+
+#[test]
+fn explore_result_shape() {
+    // Explore the shape of Result<String, i32> to understand its structure
+    let wip = Partial::alloc::<Result<String, i32>>().unwrap();
+
+    println!("Result<String, i32> shape: {:?}", wip.shape());
+
+    if let facet_core::Def::Result(result_def) = wip.shape().def {
+        println!("Ok type: {:?}", result_def.t());
+        println!("Err type: {:?}", result_def.e());
+        println!("Result vtable: {:?}", result_def.vtable);
+    }
+}
+
+use facet_testhelpers::IPanic;
+
+#[cfg(not(miri))]
+macro_rules! assert_snapshot {
+    ($($tt:tt)*) => {
+        insta::assert_snapshot!($($tt)*)
+    };
+}
+#[cfg(miri)]
+macro_rules! assert_snapshot {
+    ($($tt:tt)*) => {{}};
+}
+
+#[test]
+fn result_uninit() -> Result<(), IPanic> {
+    assert_snapshot!(
+        Partial::alloc::<Result<f64, String>>()?
+            .build()
+            .unwrap_err()
+    );
+    Ok(())
+}

--- a/facet-reflect/tests/partial/snapshots/integration_tests__partial__result_building__result_uninit.snap
+++ b/facet-reflect/tests/partial/snapshots/integration_tests__partial__result_building__result_uninit.snap
@@ -1,0 +1,5 @@
+---
+source: facet-reflect/tests/partial/result_building.rs
+expression: "Partial::alloc::<Result<f64, String>>()? .build().unwrap_err()"
+---
+Value 'Result<f64, String>' was not initialized

--- a/facet-reflect/tests/peek/mod.rs
+++ b/facet-reflect/tests/peek/mod.rs
@@ -7,6 +7,7 @@ mod ndarray;
 mod option;
 mod pointer;
 mod reference;
+mod result;
 mod serialize;
 mod set;
 mod struct_;

--- a/facet-reflect/tests/peek/result.rs
+++ b/facet-reflect/tests/peek/result.rs
@@ -1,0 +1,73 @@
+use facet_reflect::Peek;
+use facet_testhelpers::test;
+
+#[test]
+fn peek_result_ok() {
+    // Test with Ok value
+    let ok_value: Result<i32, String> = Ok(42);
+    let peek_value = Peek::new(&ok_value);
+
+    // Convert to result
+    let peek_result = peek_value
+        .into_result()
+        .expect("Should be convertible to result");
+
+    // Check the Ok variant methods
+    assert!(peek_result.is_ok());
+    assert!(!peek_result.is_err());
+
+    // Get the Ok value
+    let ok_inner = peek_result.ok().expect("Should have an Ok value");
+    let value = ok_inner.get::<i32>().unwrap();
+    assert_eq!(*value, 42);
+
+    // Err should be None
+    assert!(peek_result.err().is_none());
+}
+
+#[test]
+fn peek_result_err() {
+    // Test with Err value
+    let err_value: Result<i32, String> = Err("error message".to_string());
+    let peek_value = Peek::new(&err_value);
+
+    // Convert to result
+    let peek_result = peek_value
+        .into_result()
+        .expect("Should be convertible to result");
+
+    // Check the Err variant methods
+    assert!(!peek_result.is_ok());
+    assert!(peek_result.is_err());
+
+    // Get the Err value
+    let err_inner = peek_result.err().expect("Should have an Err value");
+    let value = err_inner.get::<String>().unwrap();
+    assert_eq!(value, "error message");
+
+    // Ok should be None
+    assert!(peek_result.ok().is_none());
+}
+
+#[test]
+fn peek_result_with_complex_types() {
+    // Test with complex Ok type
+    let ok_value: Result<Vec<i32>, &str> = Ok(vec![1, 2, 3]);
+    let peek_value = Peek::new(&ok_value);
+    let peek_result = peek_value.into_result().unwrap();
+
+    assert!(peek_result.is_ok());
+    let ok_inner = peek_result.ok().unwrap();
+    let value = ok_inner.get::<Vec<i32>>().unwrap();
+    assert_eq!(value, &vec![1, 2, 3]);
+
+    // Test with complex Err type
+    let err_value: Result<i32, Vec<String>> = Err(vec!["error1".to_string(), "error2".to_string()]);
+    let peek_value = Peek::new(&err_value);
+    let peek_result = peek_value.into_result().unwrap();
+
+    assert!(peek_result.is_err());
+    let err_inner = peek_result.err().unwrap();
+    let value = err_inner.get::<Vec<String>>().unwrap();
+    assert_eq!(value, &vec!["error1".to_string(), "error2".to_string()]);
+}


### PR DESCRIPTION
This adds support for the `Result<T, E>` type in facet, mirroring the existing `Option<T>` implementation.

## Summary

This PR implements the `Facet` trait for `Result<T, E>`, enabling facet to work with Rust's core error handling type.

## Changes

### facet-core
- Add `ResultDef` and `ResultVTable` in `types/def/result.rs` - the definition and vtable for Result types
- Add `Def::Result` variant to the `Def` enum
- Implement `Facet` trait for `Result<T, E>` with:
  - Debug support (when both T and E implement Debug)
  - PartialEq support (when both T and E implement PartialEq)
  - PartialOrd/Ord support (when both T and E implement PartialOrd/Ord)
  - Hash support (when both T and E implement Hash)

### facet-reflect
- Add `PeekResult` for reading Result values with `is_ok()`, `is_err()`, `ok()`, and `err()` methods
- Add `Peek::into_result()` method
- Add `TrackerKind::Result` and `Tracker::Result` for tracking Result initialization state
- Add Partial API support:
  - `begin_ok()` - begin building the Ok variant
  - `begin_err()` - begin building the Err variant
  - Proper handling in `end()` to finalize Result construction

### Tests
- Add peek tests for Result in `facet-reflect/tests/peek/result.rs`
- Add partial building tests in `facet-reflect/tests/partial/result_building.rs`

## Use Case

This enables plugin systems and other use cases that need to serialize/deserialize `Result<T, E>` types across FFI boundaries using facet-postcard or other facet serializers.

Closes #990