### PR TITLE
Preserve KDL parse error diagnostics

### DIFF
--- a/facet-kdl/src/error.rs
+++ b/facet-kdl/src/error.rs
@@ -229,6 +229,10 @@ impl miette::Diagnostic for KdlError {
     }
 
     fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        // For parse errors, delegate to the inner kdl::KdlError which has the source
+        if let KdlErrorKind::Parse(kdl_err) = &self.kind {
+            return kdl_err.source_code();
+        }
         self.source_code
             .as_ref()
             .map(|s| s as &dyn miette::SourceCode)
@@ -267,6 +271,14 @@ impl miette::Diagnostic for KdlError {
         } else {
             None
         }
+    }
+
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn miette::Diagnostic> + 'a>> {
+        // For parse errors, delegate to the inner kdl::KdlError which has sub-diagnostics
+        if let KdlErrorKind::Parse(kdl_err) = &self.kind {
+            return kdl_err.related();
+        }
+        None
     }
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {

--- a/facet-kdl/tests/parse_error_test.rs
+++ b/facet-kdl/tests/parse_error_test.rs
@@ -1,0 +1,78 @@
+use facet::Facet;
+use facet_kdl as fkdl;
+use miette::Diagnostic;
+
+#[test]
+fn test_kdl_booleans() {
+    let inputs = [
+        "foo true",
+        "foo false",
+        "foo #true",
+        "foo #false",
+        r#"foo "true""#,
+    ];
+
+    for input in inputs {
+        let result = input.parse::<kdl::KdlDocument>();
+        println!("{:30} -> {:?}", input, result.is_ok());
+        if let Err(e) = &result {
+            for d in &e.diagnostics {
+                println!("   Error: {:?}", d.message);
+            }
+        }
+    }
+}
+
+/// Test that KDL parse errors preserve the underlying diagnostic information.
+/// This ensures that when the kdl crate returns rich error diagnostics,
+/// facet-kdl properly exposes them through miette::Diagnostic.
+#[test]
+fn parse_error_preserves_diagnostics() {
+    #[derive(Debug, Facet)]
+    struct Config {
+        #[facet(fkdl::child)]
+        node: Node,
+    }
+
+    #[derive(Debug, Facet)]
+    struct Node {
+        #[facet(fkdl::argument)]
+        value: bool,
+    }
+
+    // This KDL is invalid - "true" without # is not a valid boolean in KDL 2.0
+    let input = r#"node true"#;
+
+    let result: Result<Config, _> = facet_kdl::from_str(input);
+    assert!(result.is_err());
+
+    let err = result.unwrap_err();
+
+    // The error should have source_code (from the kdl error)
+    assert!(
+        err.source_code().is_some(),
+        "Parse error should expose source_code from kdl::KdlError"
+    );
+
+    // The error should have related diagnostics (the actual parse errors)
+    let related: Vec<_> = err.related().into_iter().flatten().collect();
+    assert!(
+        !related.is_empty(),
+        "Parse error should expose related diagnostics from kdl::KdlError"
+    );
+
+    // Verify we can render this with miette
+    use miette::{GraphicalReportHandler, GraphicalTheme};
+    let mut output = String::new();
+    let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode());
+    handler.render_report(&mut output, &err).unwrap();
+
+    println!("Parse error diagnostic:\n{output}");
+
+    // The rendered output should contain useful information about the parse error
+    // (not just "Failed to parse KDL document")
+    assert!(
+        output.contains("true") || output.contains("identifier") || output.contains("Expected"),
+        "Rendered error should contain details about the parse failure, got:\n{output}"
+    );
+}


### PR DESCRIPTION
## Summary

When the `kdl` crate fails to parse a KDL document, it provides rich diagnostic information (line numbers, spans, labels). Previously, facet-kdl wrapped the error but lost all this information - users only saw "Failed to parse KDL document".

## Changes

Modified the `miette::Diagnostic` impl for `KdlError` to delegate to the inner `kdl::KdlError` for parse errors:
- `source_code()` now returns the source from the inner error
- `related()` exposes the sub-diagnostics from `kdl::KdlError`

## Before

```
  × Failed to parse KDL document
```

## After

```
  × Failed to parse KDL document

Error:
  × Expected identifier string
   ╭────
 1 │ server host="localhost" enabled=true
   ·                                 ──┬─
   ·                                   ╰── not identifier string
   ╰────
```

## Also includes

- Test verifying parse error diagnostics are preserved
- Two syntax error scenarios in the KDL showcase