### PR TITLE
fix: suppress dead_code warnings for reflection-constructed types

### DIFF
--- a/facet-macros-impl/src/process_enum.rs
+++ b/facet-macros-impl/src/process_enum.rs
@@ -622,9 +622,40 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
         )
     };
 
+    // Generate match arms to suppress dead_code warnings on enum variants.
+    // When variants are constructed via reflection (e.g., facet_args::from_std_args()),
+    // the compiler doesn't see them being used and warns about dead code.
+    // This match ensures all variants are "used" from the compiler's perspective.
+    let match_arms: Vec<TokenStream> = pe
+        .variants
+        .iter()
+        .map(|pv| {
+            let variant_ident = match &pv.name.raw {
+                IdentOrLiteral::Ident(id) => id.clone(),
+                IdentOrLiteral::Literal(n) => format_ident!("_{}", n),
+            };
+            match &pv.kind {
+                PVariantKind::Unit => quote! { #enum_name::#variant_ident => {} },
+                PVariantKind::Tuple { .. } => quote! { #enum_name::#variant_ident(..) => {} },
+                PVariantKind::Struct { .. } => quote! { #enum_name::#variant_ident { .. } => {} },
+            }
+        })
+        .collect();
+
     // Generate the impl
     quote! {
         #static_decl
+
+        // Suppress dead_code warnings for enum variants constructed via reflection.
+        // See: https://github.com/facet-rs/facet/issues/996
+        const _: () = {
+            #[allow(dead_code, clippy::multiple_bound_locations)]
+            fn __facet_use_all_variants #bgp_def (__v: &#enum_name #bgp_without_bounds) #where_clauses_tokens {
+                match *__v {
+                    #(#match_arms)*
+                }
+            }
+        };
 
         #[automatically_derived]
         #[allow(non_camel_case_types)]


### PR DESCRIPTION
## Summary
- Generate helper functions that "use" all enum variants and struct types to suppress false positive `dead_code` warnings
- When types are constructed via reflection (e.g., `facet_args::from_std_args()`), the compiler doesn't see them being used directly and warns about dead code
- This is a common pattern in derive macros to work around rustc's dead code analysis

## Test plan
- [x] `cargo nextest run --package facet-macros-impl` - all tests pass
- [x] `cargo nextest run --package facet` - all tests pass  
- [x] `cargo nextest run --package facet-args` - all tests pass
- [x] `just nostd-ci` - no_std compatibility verified

Fixes #996