### PR TITLE
ci: replace clippy-sarif with standard clippy output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,26 +161,12 @@ jobs:
 
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-amd64
-    permissions:
-      security-events: write # to upload sarif results
     steps:
       - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: ✨ Run clippy with SARIF output
-        shell: bash
-        run: |
-          cargo clippy --workspace --all-features --all-targets --message-format=json | clippy-sarif | tee clippy-results.sarif | sarif-fmt
-        continue-on-error: true
-
-      - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: clippy-results.sarif
-          wait-for-processing: true
-
-      - name: Report status
+      - name: ✨ Run clippy
         shell: bash
         run: |
           cargo clippy --workspace --all-features --all-targets --keep-going -- -D warnings --allow deprecated


### PR DESCRIPTION
## Summary

SARIF integration posts individual comments in the PR discussion feed, which becomes unwieldy when there are many warnings. Standard clippy output in the workflow logs is cleaner.

Closes #1024