### PR TITLE
feat: add VSafeString for HTML-safe strings

### DIFF
--- a/facet-value/src/value.rs
+++ b/facet-value/src/value.rs
@@ -55,7 +55,7 @@ use crate::bytes::VBytes;
 use crate::datetime::VDateTime;
 use crate::number::VNumber;
 use crate::object::VObject;
-use crate::string::VString;
+use crate::string::{VSafeString, VString};
 
 /// Alignment for heap-allocated values. Using 8-byte alignment gives us 3 tag bits.
 pub(crate) const ALIGNMENT: usize = 8;
@@ -384,6 +384,33 @@ impl Value {
     pub fn as_string_mut(&mut self) -> Option<&mut VString> {
         if self.is_string() {
             Some(unsafe { &mut *(self as *mut Value as *mut VString) })
+        } else {
+            None
+        }
+    }
+
+    /// Returns `true` if this is a safe string (marked as pre-escaped HTML, etc.).
+    ///
+    /// A safe string is a string with the safe flag set. Inline strings are never safe.
+    #[must_use]
+    pub fn is_safe_string(&self) -> bool {
+        self.as_string().is_some_and(|s| s.is_safe())
+    }
+
+    /// Gets a reference to this value as a `VSafeString`. Returns `None` if not a safe string.
+    #[must_use]
+    pub fn as_safe_string(&self) -> Option<&VSafeString> {
+        if self.is_safe_string() {
+            Some(unsafe { &*(self as *const Value as *const VSafeString) })
+        } else {
+            None
+        }
+    }
+
+    /// Gets a mutable reference to this value as a `VSafeString`.
+    pub fn as_safe_string_mut(&mut self) -> Option<&mut VSafeString> {
+        if self.is_safe_string() {
+            Some(unsafe { &mut *(self as *mut Value as *mut VSafeString) })
         } else {
             None
         }


### PR DESCRIPTION
## Summary

Add a `VSafeString` type for template engines that need to mark strings as "safe" (pre-escaped HTML that shouldn't be escaped again).

Closes #1026

### Implementation

- Uses the high bit of `StringHeader.len` as a safe flag (`SAFE_FLAG = 1usize << (usize::BITS - 1)`)
- Shares tag 1 with regular strings (no tag slot wasted)
- Safe strings are always heap-allocated since inline strings don't have room for the flag
- Works on both 32-bit (~2GB max) and 64-bit systems

### API

**New type: `VSafeString`**
- `VSafeString::new(s: &str)` - create a safe string (always heap-allocated)
- `len()`, `is_empty()`, `as_str()`, `as_bytes()` - standard string methods
- `into_value()`, `into_string()` - conversions

**VString additions:**
- `is_safe() -> bool` - check if safe flag is set
- `into_safe() -> VSafeString` - convert to safe string (promotes inline→heap)

**Value additions:**
- `is_safe_string() -> bool` - check if this is a safe string
- `as_safe_string() -> Option<&VSafeString>` - get as safe string reference
- `as_safe_string_mut() -> Option<&mut VSafeString>` - mutable reference

### Behavior

- `value.is_string()` returns `true` for both `VString` and `VSafeString`
- `value.as_string()` returns `Some` for both (safe string IS a string)
- Cloning preserves the safe flag
- Safe strings properly deallocate (masks length when computing layout)

## Test plan

- [x] Round-trip test: `VSafeString::new(s).as_str() == s`
- [x] Flag preservation through clone
- [x] Inline promotion: short safe strings work correctly
- [x] `is_string()` / `as_string()` work for both types
- [x] `is_safe_string()` / `as_safe_string()` only match safe strings
- [x] All 131 tests pass with `cargo nextest run -p facet-value`