### PR TITLE
feat: add IndexMap support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,6 +609,7 @@ dependencies = [
  "chrono",
  "facet-testhelpers",
  "impls",
+ "indexmap",
  "jiff",
  "num-complex",
  "ordered-float",

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -40,6 +40,8 @@ bytes = ["alloc", "dep:bytes"]
 num-complex = ["dep:num-complex"]
 # Provide Facet trait implementations for ruint::Uint and ruint::Bits
 ruint = ["dep:ruint"]
+# Provide Facet trait implementations for indexmap::IndexMap and indexmap::IndexSet
+indexmap = ["alloc", "dep:indexmap"]
 
 # Provide Facet trait implementations for tuples up to size 12. Without it,
 # Facet is only implemented for tuples up to size 4.
@@ -72,6 +74,7 @@ jiff = { version = "0.2.15", optional = true }
 bytes = { version = "1.10.1", optional = true, default-features = false }
 num-complex = { version = "0.4.6", optional = true, default-features = false }
 ruint = { version = "1.17.0", optional = true, default-features = false }
+indexmap = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]
 facet-testhelpers = { path = "../facet-testhelpers" }

--- a/facet-core/src/impls_indexmap.rs
+++ b/facet-core/src/impls_indexmap.rs
@@ -1,0 +1,130 @@
+use alloc::boxed::Box;
+use core::hash::BuildHasher;
+use core::ptr::NonNull;
+use indexmap::IndexMap;
+
+use crate::ptr::{PtrConst, PtrMut};
+
+use crate::{
+    Def, Facet, IterVTable, MapDef, MapVTable, MarkerTraits, Shape, Type, TypeParam, UserType,
+    ValueVTable,
+};
+
+type IndexMapIterator<'mem, K, V> = indexmap::map::Iter<'mem, K, V>;
+
+unsafe impl<'a, K, V, S> Facet<'a> for IndexMap<K, V, S>
+where
+    K: Facet<'a> + core::cmp::Eq + core::hash::Hash,
+    V: Facet<'a>,
+    S: 'a + Default + BuildHasher,
+{
+    const SHAPE: &'static Shape = &const {
+        Shape::builder_for_sized::<Self>()
+            .vtable(
+                ValueVTable::builder::<Self>()
+                    .marker_traits({
+                        let arg_dependent_traits = MarkerTraits::SEND
+                            .union(MarkerTraits::SYNC)
+                            .union(MarkerTraits::EQ)
+                            .union(MarkerTraits::UNPIN)
+                            .union(MarkerTraits::UNWIND_SAFE)
+                            .union(MarkerTraits::REF_UNWIND_SAFE);
+                        arg_dependent_traits
+                            .intersection(V::SHAPE.vtable.marker_traits())
+                            .intersection(K::SHAPE.vtable.marker_traits())
+                    })
+                    .type_name(|f, opts| {
+                        write!(f, "{}<", Self::SHAPE.type_identifier)?;
+                        if let Some(opts) = opts.for_children() {
+                            K::SHAPE.vtable.type_name()(f, opts)?;
+                            write!(f, ", ")?;
+                            V::SHAPE.vtable.type_name()(f, opts)?;
+                        } else {
+                            write!(f, "…")?;
+                        }
+                        write!(f, ">")
+                    })
+                    .default_in_place({
+                        Some(|target| unsafe { target.put(Self::default()).into() })
+                    })
+                    .build(),
+            )
+            .type_identifier("IndexMap")
+            .type_params(&[
+                TypeParam {
+                    name: "K",
+                    shape: K::SHAPE,
+                },
+                TypeParam {
+                    name: "V",
+                    shape: V::SHAPE,
+                },
+            ])
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::Map(
+                MapDef::builder()
+                    .k(K::SHAPE)
+                    .v(V::SHAPE)
+                    .vtable(
+                        &const {
+                            MapVTable::builder()
+                                .init_in_place_with_capacity(|uninit, capacity| unsafe {
+                                    uninit
+                                        .put(Self::with_capacity_and_hasher(capacity, S::default()))
+                                })
+                                .insert(|ptr, key, value| unsafe {
+                                    let map = ptr.as_mut::<IndexMap<K, V, S>>();
+                                    let key = key.read::<K>();
+                                    let value = value.read::<V>();
+                                    map.insert(key, value);
+                                })
+                                .len(|ptr| unsafe {
+                                    let map = ptr.get::<IndexMap<K, V, S>>();
+                                    map.len()
+                                })
+                                .contains_key(|ptr, key| unsafe {
+                                    let map = ptr.get::<IndexMap<K, V, S>>();
+                                    map.contains_key(key.get::<K>())
+                                })
+                                .get_value_ptr(|ptr, key| unsafe {
+                                    let map = ptr.get::<IndexMap<K, V, S>>();
+                                    map.get(key.get::<K>())
+                                        .map(|v| PtrConst::new(NonNull::from(v)))
+                                })
+                                .iter_vtable(
+                                    IterVTable::builder()
+                                        .init_with_value(|ptr| unsafe {
+                                            let map = ptr.get::<IndexMap<K, V, S>>();
+                                            let iter: IndexMapIterator<'_, K, V> = map.iter();
+                                            let iter_state = Box::new(iter);
+                                            PtrMut::new(NonNull::new_unchecked(Box::into_raw(
+                                                iter_state,
+                                            )
+                                                as *mut u8))
+                                        })
+                                        .next(|iter_ptr| unsafe {
+                                            let state =
+                                                iter_ptr.as_mut::<IndexMapIterator<'_, K, V>>();
+                                            state.next().map(|(key, value)| {
+                                                (
+                                                    PtrConst::new(NonNull::from(key)),
+                                                    PtrConst::new(NonNull::from(value)),
+                                                )
+                                            })
+                                        })
+                                        .dealloc(|iter_ptr| unsafe {
+                                            drop(Box::from_raw(
+                                                iter_ptr.as_ptr::<IndexMapIterator<'_, K, V>>()
+                                                    as *mut IndexMapIterator<'_, K, V>,
+                                            ));
+                                        })
+                                        .build(),
+                                )
+                                .build()
+                        },
+                    )
+                    .build(),
+            ))
+            .build()
+    };
+}

--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -67,6 +67,9 @@ mod impls_num_complex;
 #[cfg(feature = "ruint")]
 mod impls_ruint;
 
+#[cfg(feature = "indexmap")]
+mod impls_indexmap;
+
 // Const type Id
 mod typeid;
 pub use typeid::*;

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -44,6 +44,9 @@ url = ["facet-core/url"] # Provide Facet trait implementations for url::Url
 ruint = [
     "facet-core/ruint",
 ] # Provide Facet trait implementations for ruint types
+indexmap = [
+    "facet-core/indexmap",
+] # Provide Facet trait implementations for indexmap::IndexMap and indexmap::IndexSet
 
 # Provide Facet trait implementations for tuples up to size 12. Without it,
 # Facet is only implemented for tuples up to size 4.


### PR DESCRIPTION
## Summary

- Adds `Facet` implementation for `indexmap::IndexMap<K, V, S>` behind an `indexmap` feature flag
- Useful for serialization scenarios where key ordering matters (like GitHub Actions YAML workflows)
- Full `MapDef` and `MapVTable` support including iteration

## Test plan

- [x] `cargo check --features indexmap` passes
- [x] `cargo nextest run --features indexmap` passes (1842 tests)

Closes #1032