### PR TITLE
fix(macros): enable auto-deref for predicate attributes

### DIFF
--- a/facet-yaml/tests/serialize/struct_.rs
+++ b/facet-yaml/tests/serialize/struct_.rs
@@ -235,8 +235,7 @@ fn test_skip_serializing_if_none() -> Result<()> {
 fn test_skip_serializing_if_custom_predicate() -> Result<()> {
     facet_testhelpers::setup();
 
-    #[allow(clippy::ptr_arg)] // see https://github.com/facet-rs/facet/issues/1036
-    fn is_empty(s: &String) -> bool {
+    fn is_empty(s: &str) -> bool {
         s.is_empty()
     }
 


### PR DESCRIPTION
## Summary

Instead of transmuting the user's predicate function directly (which requires exact type match), generate a wrapper function that calls the predicate at the call site. This enables Rust's auto-deref coercion.

## Before

```rust
// Required exact type match - triggers clippy::ptr_arg warning
#[allow(clippy::ptr_arg)]
fn is_empty(s: &String) -> bool { s.is_empty() }

#[derive(Facet)]
struct Config {
    #[facet(skip_serializing_if = is_empty)]
    description: String,
}
```

## After

```rust
// Now works with auto-deref - idiomatic Rust
fn is_empty(s: &str) -> bool { s.is_empty() }

#[derive(Facet)]
struct Config {
    #[facet(skip_serializing_if = is_empty)]
    description: String,
}
```

## Implementation

This is a general improvement to the `predicate` variant kind in `define_attr_grammar!`, benefiting all attributes that use it (not just `skip_serializing_if`).

The generated code changes from:
```rust
// Before: direct transmute requires exact type match
transmute::<fn(&$ty) -> bool, SkipSerializingIfFn>(user_predicate)
```

To:
```rust
// After: wrapper function enables auto-deref at call site
unsafe fn __predicate_wrapper(ptr: PtrConst<'_>) -> bool {
    let predicate = user_predicate;
    predicate(ptr.get::<$ty>())  // auto-deref happens here
}
__predicate_wrapper as SkipSerializingIfFn
```

## Test plan

- [x] Updated `test_skip_serializing_if_custom_predicate` to use `fn is_empty(s: &str)` instead of `fn is_empty(s: &String)`
- [x] All 1844 tests pass

Closes #1036