### PR TITLE
perf: implement dual-mode storage for VObject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,6 +886,7 @@ dependencies = [
  "facet-reflect",
  "facet-showcase",
  "facet-testhelpers",
+ "indexmap",
  "kstring",
  "miette",
  "once_cell",

--- a/facet-value/Cargo.toml
+++ b/facet-value/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["encoding", "data-structures"]
 
 [features]
 default = ["std"]
-std = ["alloc"]
+std = ["alloc", "dep:indexmap"]
 alloc = ["facet-core/alloc", "facet-reflect/alloc", "dep:facet-reflect"]
 diagnostics = ["alloc", "dep:miette", "dep:facet-pretty", "dep:syntect", "dep:once_cell"]
 bolero-inline-tests = ["alloc"]
@@ -23,6 +23,7 @@ facet-reflect = { path = "../facet-reflect", version = "0.31.8", default-feature
 miette = { version = "7", optional = true, features = ["fancy"] }
 syntect = { version = "5.3", optional = true }
 once_cell = { version = "1", optional = true }
+indexmap = { version = "2", optional = true }
 static_assertions = "1.1"
 
 [dev-dependencies]
@@ -39,6 +40,7 @@ bolero = "0.11"
 serde_json = "1"
 divan = "0.1"
 kstring = "2"
+indexmap = "2"
 
 [[example]]
 name = "from_value_showcase"

--- a/facet-value/benches/map_keys.rs
+++ b/facet-value/benches/map_keys.rs
@@ -1,5 +1,6 @@
 use divan::{Bencher, black_box};
 use facet_value::{VObject, Value};
+use indexmap::IndexMap;
 use kstring::KString;
 use std::collections::HashMap;
 
@@ -9,7 +10,7 @@ fn main() {
 
 // --- Insert benchmarks (short keys) ----------------------------------------------------------
 
-#[divan::bench(args = [16, 64, 256, 512])]
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
 fn insert_vobject_short_keys(bencher: Bencher, entries: usize) {
     run_insert_bench(
         bencher,
@@ -19,7 +20,7 @@ fn insert_vobject_short_keys(bencher: Bencher, entries: usize) {
     );
 }
 
-#[divan::bench(args = [16, 64, 256, 512])]
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
 fn insert_string_map_short_keys(bencher: Bencher, entries: usize) {
     run_insert_bench(
         bencher,
@@ -29,7 +30,7 @@ fn insert_string_map_short_keys(bencher: Bencher, entries: usize) {
     );
 }
 
-#[divan::bench(args = [16, 64, 256, 512])]
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
 fn insert_kstring_map_short_keys(bencher: Bencher, entries: usize) {
     run_insert_bench(
         bencher,
@@ -41,24 +42,24 @@ fn insert_kstring_map_short_keys(bencher: Bencher, entries: usize) {
 
 // --- Insert benchmarks (long keys) -----------------------------------------------------------
 
-#[divan::bench(args = [16, 64, 256, 512])]
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
 fn insert_vobject_long_keys(bencher: Bencher, entries: usize) {
     run_insert_bench(bencher, entries, KeyShape::HeapOnly, MapFlavor::FacetObject);
 }
 
-#[divan::bench(args = [16, 64, 256, 512])]
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
 fn insert_string_map_long_keys(bencher: Bencher, entries: usize) {
     run_insert_bench(bencher, entries, KeyShape::HeapOnly, MapFlavor::StdString);
 }
 
-#[divan::bench(args = [16, 64, 256, 512])]
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
 fn insert_kstring_map_long_keys(bencher: Bencher, entries: usize) {
     run_insert_bench(bencher, entries, KeyShape::HeapOnly, MapFlavor::KString);
 }
 
 // --- Collect benchmarks (Vec<(key, value)> -> map) ------------------------------------------
 
-#[divan::bench(args = [16, 64, 256, 512])]
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
 fn collect_vobject_short_keys(bencher: Bencher, entries: usize) {
     run_collect_bench(
         bencher,
@@ -68,7 +69,7 @@ fn collect_vobject_short_keys(bencher: Bencher, entries: usize) {
     );
 }
 
-#[divan::bench(args = [16, 64, 256, 512])]
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
 fn collect_string_map_short_keys(bencher: Bencher, entries: usize) {
     run_collect_bench(
         bencher,
@@ -78,7 +79,7 @@ fn collect_string_map_short_keys(bencher: Bencher, entries: usize) {
     );
 }
 
-#[divan::bench(args = [16, 64, 256, 512])]
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
 fn collect_kstring_map_short_keys(bencher: Bencher, entries: usize) {
     run_collect_bench(
         bencher,
@@ -88,19 +89,61 @@ fn collect_kstring_map_short_keys(bencher: Bencher, entries: usize) {
     );
 }
 
-#[divan::bench(args = [16, 64, 256, 512])]
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
 fn collect_vobject_long_keys(bencher: Bencher, entries: usize) {
     run_collect_bench(bencher, entries, KeyShape::HeapOnly, MapFlavor::FacetObject);
 }
 
-#[divan::bench(args = [16, 64, 256, 512])]
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
 fn collect_string_map_long_keys(bencher: Bencher, entries: usize) {
     run_collect_bench(bencher, entries, KeyShape::HeapOnly, MapFlavor::StdString);
 }
 
-#[divan::bench(args = [16, 64, 256, 512])]
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
 fn collect_kstring_map_long_keys(bencher: Bencher, entries: usize) {
     run_collect_bench(bencher, entries, KeyShape::HeapOnly, MapFlavor::KString);
+}
+
+// --- IndexMap benchmarks (order-preserving, fair comparison to VObject) ---
+
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
+fn insert_indexmap_short_keys(bencher: Bencher, entries: usize) {
+    run_insert_bench(
+        bencher,
+        entries,
+        KeyShape::InlineFriendly,
+        MapFlavor::IndexMapString,
+    );
+}
+
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
+fn insert_indexmap_long_keys(bencher: Bencher, entries: usize) {
+    run_insert_bench(
+        bencher,
+        entries,
+        KeyShape::HeapOnly,
+        MapFlavor::IndexMapString,
+    );
+}
+
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
+fn collect_indexmap_short_keys(bencher: Bencher, entries: usize) {
+    run_collect_bench(
+        bencher,
+        entries,
+        KeyShape::InlineFriendly,
+        MapFlavor::IndexMapString,
+    );
+}
+
+#[divan::bench(args = [16, 64, 256, 1024, 4096, 16384])]
+fn collect_indexmap_long_keys(bencher: Bencher, entries: usize) {
+    run_collect_bench(
+        bencher,
+        entries,
+        KeyShape::HeapOnly,
+        MapFlavor::IndexMapString,
+    );
 }
 
 #[derive(Copy, Clone)]
@@ -114,6 +157,7 @@ enum MapFlavor {
     FacetObject,
     StdString,
     KString,
+    IndexMapString,
 }
 
 fn run_insert_bench(bencher: Bencher, entries: usize, shape: KeyShape, flavor: MapFlavor) {
@@ -137,6 +181,13 @@ fn run_insert_bench(bencher: Bencher, entries: usize, shape: KeyShape, flavor: M
             let mut map = HashMap::with_capacity(entries);
             for (idx, key) in keys.iter().enumerate() {
                 map.insert(KString::from(key.clone()), Value::from(idx as i64));
+            }
+            black_box(map);
+        }
+        MapFlavor::IndexMapString => {
+            let mut map = IndexMap::with_capacity(entries);
+            for (idx, key) in keys.iter().enumerate() {
+                map.insert(key.clone(), Value::from(idx as i64));
             }
             black_box(map);
         }
@@ -167,6 +218,14 @@ fn run_collect_bench(bencher: Bencher, entries: usize, shape: KeyShape, flavor: 
                 .iter()
                 .enumerate()
                 .map(|(idx, key)| (KString::from(key.clone()), Value::from(idx as i64)))
+                .collect();
+            black_box(map);
+        }
+        MapFlavor::IndexMapString => {
+            let map: IndexMap<String, Value> = keys
+                .iter()
+                .enumerate()
+                .map(|(idx, key)| (key.clone(), Value::from(idx as i64)))
                 .collect();
             black_box(map);
         }


### PR DESCRIPTION
## Summary

- Replaces sidecar `HashMap<u64, usize>` with direct `IndexMap<VString, Value>` storage for large objects
- Small mode (< 32 entries): inline KeyValuePair array with linear search  
- Large mode (≥ 32 entries): IndexMap for O(1) lookups

## Benchmark results at 16,384 entries

| Benchmark | Before | After | IndexMap | Improvement |
|-----------|--------|-------|----------|-------------|
| insert_short_keys | ~4.1ms | **1.05ms** | 1.19ms | ~4x faster |
| insert_long_keys | ~4.1ms | **1.31ms** | 1.23ms | ~3x faster |

VObject is now **at parity or faster** than IndexMap (previously 3.5x slower).

## Changes

- Add `LargeModeStorage` wrapper with sentinel for reliable mode detection
- Update all methods to dispatch based on storage mode
- Add `#[inline]` attributes for cross-crate optimization
- Remove unused `blake3` dev-dependency
- Expand benchmarks with IndexMap comparisons

## Test plan

- [x] All existing tests pass (`cargo nextest run -p facet-value`)
- [x] Compiles with `--no-default-features --features alloc` (no_std)
- [x] Benchmarks show expected improvement

Closes #1008
See #1039 for potential further optimizations