### PR TITLE
feat(facet-core): add Write trait for no_std serialization

### DIFF
--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -99,6 +99,10 @@ pub unsafe trait Facet<'facet>: 'facet {
 
 mod shape_util;
 
+// Write trait for serializers
+mod write;
+pub use write::Write;
+
 /// Re-export paste for use in macros
 #[doc(hidden)]
 pub use paste;

--- a/facet-core/src/write.rs
+++ b/facet-core/src/write.rs
@@ -1,0 +1,73 @@
+//! A `no_std` compatible `Write` trait for serialization.
+//!
+//! This trait is used by facet serializers (like `facet-json`) to write output
+//! without depending on `std::io::Write`, enabling `no_std` support.
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+/// A `no_std` compatible write trait used by facet serializers.
+///
+/// This trait provides a simple interface for writing bytes, designed to work
+/// in `no_std` environments while remaining compatible with standard library types.
+pub trait Write {
+    /// Write all bytes from the buffer to the writer.
+    fn write(&mut self, buf: &[u8]);
+
+    /// If the writer supports it, reserve space for `additional` bytes.
+    ///
+    /// This is an optimization hint and may be ignored by implementations.
+    fn reserve(&mut self, additional: usize);
+}
+
+#[cfg(feature = "alloc")]
+impl Write for Vec<u8> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) {
+        self.extend_from_slice(buf);
+    }
+
+    #[inline]
+    fn reserve(&mut self, additional: usize) {
+        Vec::reserve(self, additional);
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl Write for &mut Vec<u8> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) {
+        self.extend_from_slice(buf);
+    }
+
+    #[inline]
+    fn reserve(&mut self, additional: usize) {
+        Vec::reserve(self, additional);
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl Write for bytes::BytesMut {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) {
+        self.extend_from_slice(buf);
+    }
+
+    #[inline]
+    fn reserve(&mut self, additional: usize) {
+        bytes::BytesMut::reserve(self, additional);
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl Write for &mut bytes::BytesMut {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) {
+        self.extend_from_slice(buf);
+    }
+
+    #[inline]
+    fn reserve(&mut self, additional: usize) {
+        bytes::BytesMut::reserve(self, additional);
+    }
+}

--- a/facet-json/src/lib.rs
+++ b/facet-json/src/lib.rs
@@ -4,8 +4,6 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
-
 // Re-export span types from facet-reflect
 pub use facet_reflect::{Span, Spanned};
 
@@ -20,34 +18,11 @@ mod tokenizer;
 mod raw_json;
 pub use raw_json::RawJson;
 
-/// `no_std` compatible Write trait used by the json serializer.
-pub trait JsonWrite {
-    /// Write all these bytes to the writer.
-    fn write(&mut self, buf: &[u8]);
-
-    /// If the writer supports it, reserve space for `len` additional bytes.
-    fn reserve(&mut self, additional: usize);
-}
-
-impl JsonWrite for &mut Vec<u8> {
-    fn write(&mut self, buf: &[u8]) {
-        self.extend(buf);
-    }
-
-    fn reserve(&mut self, additional: usize) {
-        Vec::reserve(self, additional)
-    }
-}
-
-impl JsonWrite for Vec<u8> {
-    fn write(&mut self, buf: &[u8]) {
-        self.extend(buf);
-    }
-
-    fn reserve(&mut self, additional: usize) {
-        Vec::reserve(self, additional)
-    }
-}
+/// Re-export the `Write` trait from facet-core for backwards compatibility.
+///
+/// This trait is used by the JSON serializer to write output without depending
+/// on `std::io::Write`, enabling `no_std` support.
+pub use facet_core::Write as JsonWrite;
 
 /// Properly escapes and writes a JSON string
 #[inline]


### PR DESCRIPTION
## Summary

- Move the `Write` trait from `facet-json` to `facet-core` so it can be reused by other format crates (`facet-yaml`, `facet-xml`, etc.) for `no_std` support
- Add `Write` trait with `write(&[u8])` and `reserve(usize)` methods
- Implement `Write` for `Vec<u8>`, `&mut Vec<u8>` (with alloc feature)
- Implement `Write` for `bytes::BytesMut` (with bytes feature)
- Re-export as `JsonWrite` in facet-json for backwards compatibility
- Add `to_writer_std` and `to_writer_std_pretty` functions in facet-json that accept `std::io::Write` (with std feature, enabled by default)

## Test plan

- [x] All existing facet-json tests pass (300 tests)
- [x] facet-core tests pass
- [x] no_std CI checks pass (`just nostd-ci`)
- [x] clippy passes
- [x] Doc tests pass

Closes #1050