### PR TITLE
feat(facet-json): add from_slice_owned and from_str_owned for owned deserialization

### DIFF
--- a/facet-json/src/lib.rs
+++ b/facet-json/src/lib.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs)]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![doc = include_str!("../README.md")]
 
 extern crate alloc;
@@ -8,7 +8,10 @@ extern crate alloc;
 pub use facet_reflect::{Span, Spanned};
 
 mod deserialize;
-pub use deserialize::{JsonDeserializer, JsonError, JsonErrorKind, from_slice, from_str};
+pub use deserialize::{
+    JsonDeserializer, JsonError, JsonErrorKind, from_slice, from_slice_owned, from_str,
+    from_str_owned,
+};
 
 mod serialize;
 pub use serialize::*;


### PR DESCRIPTION
## Summary

Adds new deserialization functions that don't require the input to outlive the result:
- `from_slice_owned<T: Facet<'static>>(input: &[u8]) -> Result<T>`
- `from_str_owned<T: Facet<'static>>(input: &str) -> Result<T>`

This enables deserializing from temporary buffers, solving the issue reported in #1052 where integrating with axum's `FromRequest` was impossible due to lifetime constraints.

## Changes

- Add `allow_borrow` field to `JsonDeserializer` to track whether borrowing is allowed
- Add `new_owned()` constructor that disables borrowing
- Add runtime checks that error when attempting to deserialize into `&str` with borrowing disabled
- Add `from_slice_owned` and `from_str_owned` public functions with `Facet<'static>` bounds
- Add comprehensive tests for owned deserialization

## Safety

The implementation uses carefully audited `unsafe` code to work around lifetime constraints:
1. The `Facet<'static>` bound on the new functions guarantees the target type contains no borrowed data
2. The `allow_borrow: false` flag causes runtime errors if deserialization tries to borrow into `&str`
3. The transmutes only affect phantom lifetime markers in `Partial` and `HeapValue`, not actual data

## Test plan

- [x] Added tests for basic owned deserialization
- [x] Added tests for escaped strings
- [x] Added test simulating the axum use case (temporary buffer)
- [x] Added tests for nested structs and vectors
- [x] All 307 existing facet-json tests pass
- [x] Pre-push hooks pass (clippy, doc tests)

Fixes #1052