### PR TITLE
feat(facet-yaml): make owned deserialization the default

### DIFF
--- a/facet-yaml/src/axum.rs
+++ b/facet-yaml/src/axum.rs
@@ -84,7 +84,7 @@ where
             kind: YamlRejectionKind::InvalidUtf8,
         })?;
 
-        let value: T = crate::from_str_owned(body_str).map_err(|e| YamlRejection {
+        let value: T = crate::from_str(body_str).map_err(|e| YamlRejection {
             kind: YamlRejectionKind::Deserialize(e),
         })?;
 

--- a/facet-yaml/src/lib.rs
+++ b/facet-yaml/src/lib.rs
@@ -33,7 +33,7 @@ mod error;
 #[cfg(feature = "std")]
 mod serialize;
 
-pub use deserialize::{from_str, from_str_owned};
+pub use deserialize::{from_str, from_str_borrowed};
 pub use error::{YamlError, YamlErrorKind};
 #[cfg(feature = "std")]
 pub use serialize::{to_string, to_writer};

--- a/facet-yaml/tests/deserialize/from_str.rs
+++ b/facet-yaml/tests/deserialize/from_str.rs
@@ -23,3 +23,44 @@ fn test_deserialize_person() {
         }
     );
 }
+
+/// Tests the use case from issue #1074 - parsing a config file from a temporary buffer.
+/// This demonstrates that `from_str` works with owned types without requiring the input
+/// to outlive the result.
+#[derive(Debug, Facet, PartialEq)]
+struct Config {
+    name: String,
+    port: u16,
+}
+
+fn load_config_from_temp_buffer() -> Config {
+    // Simulate reading a config file into a temporary buffer (e.g., HTTP request body)
+    let yaml_content = String::from("name: myapp\nport: 8080");
+
+    // The key feature: yaml_content is dropped after this function returns,
+    // but the Config is fully owned and can outlive the input buffer.
+    // This would NOT work with borrowed deserialization.
+    facet_yaml::from_str(&yaml_content).unwrap()
+}
+
+#[test]
+fn test_owned_deserialization_from_temp_buffer() {
+    // This tests issue #1074 - the ability to parse owned values from temporary buffers
+    let config = load_config_from_temp_buffer();
+    assert_eq!(config.name, "myapp");
+    assert_eq!(config.port, 8080);
+}
+
+/// Tests that both from_str (owned) and from_str_borrowed work correctly.
+#[test]
+fn test_from_str_vs_from_str_borrowed() {
+    let yaml = "name: test\nport: 3000";
+
+    // Owned deserialization - input doesn't need to outlive result
+    let config_owned: Config = facet_yaml::from_str(yaml).unwrap();
+
+    // Borrowed deserialization - input must outlive result (but we can still use it here)
+    let config_borrowed: Config = facet_yaml::from_str_borrowed(yaml).unwrap();
+
+    assert_eq!(config_owned, config_borrowed);
+}


### PR DESCRIPTION
## Summary

This aligns `facet-yaml`'s API with `facet-json` for consistency:

- `from_str<T: Facet<'static>>(&str)` is now the **default** (owned deserialization)
- `from_str_borrowed<'input, 'facet, T: Facet<'facet>>(&'input str)` for zero-copy deserialization

This allows parsing YAML from temporary buffers (e.g., HTTP request bodies, config files read into `String`) without lifetime constraints.

### Before
```rust
// This didn't work - yaml_content would need to outlive config
fn load_config() -> Config {
    let yaml_content = String::from("name: myapp\nport: 8080");
    facet_yaml::from_str(&yaml_content).unwrap()
}
```

### After
```rust
// Now works! Input doesn't need to outlive the result.
fn load_config() -> Config {
    let yaml_content = String::from("name: myapp\nport: 8080");
    facet_yaml::from_str(&yaml_content).unwrap()
}
```

## Changes

- Updated `from_str` to be owned (no lifetime constraints, `T: Facet<'static>`)
- Renamed old `from_str` to `from_str_borrowed` for zero-copy use cases
- Updated all deserializer methods to use `const BORROW: bool` generic parameter
- Added tests demonstrating the use case from the issue

Closes #1074

## Test plan

- [x] All existing facet-yaml tests pass (66 tests)
- [x] Doc tests pass
- [x] Added new tests for owned deserialization from temp buffer
- [x] API is consistent with facet-json