### PR TITLE
fix(facet-kdl): skip solver disambiguation when variant matched by node name

### DIFF
--- a/facet-kdl/src/deserialize.rs
+++ b/facet-kdl/src/deserialize.rs
@@ -609,8 +609,11 @@ impl<'input, 'facet> KdlDeserializer<'input> {
         );
         // Use solver when we have flattened fields OR an enum that needs variant
         // disambiguation (presence/shape-based).
+        // BUT: if we already matched a variant by node name (variant_fields is Some),
+        // we don't need solver disambiguation - the node name already told us which variant.
         let is_enum = matches!(partial.shape().ty, Type::User(UserType::Enum(_)));
-        if has_flatten(fields_for_matching) || is_enum {
+        let needs_enum_disambiguation = is_enum && variant_fields.is_none();
+        if has_flatten(fields_for_matching) || needs_enum_disambiguation {
             // Use solver-based deserialization for flattened fields
             log::trace!(" Using solver-based deserialization");
             partial = self.deserialize_entries_with_solver(


### PR DESCRIPTION
## Summary

- Fix enum variant disambiguation when using `#[facet(kdl::children)]` with `Vec<Enum>` where multiple variants have identical field structures
- The node name (e.g., `save-screenshot`) should be used as the discriminator, not the solver
- Previously, even after successfully matching a variant by node name, the code would still invoke the solver for enum disambiguation, causing "Ambiguous" errors

## Problem

When deserializing this KDL:

```kdl
keymap {
    save-screenshot keys=s
    copy-to-clipboard keys=<enter>
}
```

Into an enum where `SaveScreenshot` and `CopyToClipboard` have identical fields (`keys: String`), the solver would report "Ambiguous: multiple resolutions match" even though the node names clearly indicate which variant to use.

## Solution

Skip solver-based disambiguation when a variant has already been matched by node name (`variant_fields.is_some()`). The node name already told us which variant to use.

## Test plan

- [x] Added test `vec_enum_children_same_fields_kebab_case` reproducing the exact issue
- [x] All existing facet-kdl tests pass (95 tests)