### PR TITLE
fix(facet-reflect): fix UB in `Peek::as_str()` for bare `str` types

### DIFF
--- a/facet-diff/tests/snapshots/diff_snapshots__diff_value_nested_vs_nested_struct.snap
+++ b/facet-diff/tests/snapshots/diff_snapshots__diff_value_nested_vs_nested_struct.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-diff/tests/diff_snapshots.rs
+assertion_line: 1418
 expression: "format_diff_comparison(&a, &b)"
 ---
 ╭Before─────────────────────────╮
@@ -24,8 +25,7 @@ expression: "format_diff_comparison(&a, &b)"
 ╰───────────────────────────────╯
 ╔Diff═══════════════════════════╗
 ║{                              ║
-║  .. 1 unchanged field         ║
+║  .. 2 unchanged fields        ║
 ║  address: (structurally equal)║
-║  name: "Alice" → "Alice"      ║
 ║}                              ║
 ╚═══════════════════════════════╝

--- a/facet-diff/tests/snapshots/diff_snapshots__diff_value_nested_vs_nested_struct_different.snap
+++ b/facet-diff/tests/snapshots/diff_snapshots__diff_value_nested_vs_nested_struct_different.snap
@@ -1,5 +1,6 @@
 ---
 source: facet-diff/tests/diff_snapshots.rs
+assertion_line: 1439
 expression: "format_diff_comparison(&a, &b)"
 ---
 ╭Before─────────────────────────────────────╮
@@ -24,11 +25,11 @@ expression: "format_diff_comparison(&a, &b)"
 ╰───────────────────────────────────────────╯
 ╔Diff═══════════════════════════════════════╗
 ║{                                          ║
+║  .. 1 unchanged field                     ║
 ║  address: {                               ║
 ║    .. 1 unchanged field                   ║
 ║    street: "123 Main St" → "456 Oak Ave"  ║
 ║  }                                        ║
 ║  age: 30 → 31                             ║
-║  name: "Alice" → "Alice"                  ║
 ║}                                          ║
 ╚═══════════════════════════════════════════╝


### PR DESCRIPTION
## Summary
- Fixes #1082
- The `as_str()` method was using `get::<&str>()` for bare `str` shapes, which caused UB when the str data was empty (reading 16 bytes from a 0-byte allocation)
- The fix distinguishes between bare `str` (where data is a wide pointer to str bytes) and `&str` (where data points to a stored fat pointer)
- This also fixes string equality comparison in facet-diff, which now correctly identifies equal string fields as unchanged

## Test plan
- [x] Added unit tests for `Peek::new("").as_str()` and related cases
- [x] All 1961 tests pass
- [x] Miri passes without detecting UB
- [x] Updated 2 facet-diff snapshots that now show improved behavior (correctly identifying equal strings as unchanged)