### PR TITLE
facet-shapelike

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-shapelike"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "facet",
+ "facet-args",
+ "facet-assert",
+ "facet-core",
+ "facet-json",
+ "facet-kdl",
+ "facet-macros",
+ "facet-postcard",
+ "facet-reflect",
+ "facet-xml",
+]
+
+[[package]]
 name = "facet-showcase"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ members = [
     # dev tooling
     "facet-bloatbench",
     "xtask",
+
+    "facet-shapelike"
 ]
 exclude = [
     # proto-attr experiment uses nightly features

--- a/facet-postcard/src/serialize.rs
+++ b/facet-postcard/src/serialize.rs
@@ -24,8 +24,14 @@ use alloc::{borrow::Cow, string::String, vec::Vec};
 /// ```
 #[cfg(feature = "alloc")]
 pub fn to_vec<T: Facet<'static>>(value: &T) -> Result<Vec<u8>, SerializeError> {
-    let mut buffer = Vec::new();
     let peek = Peek::new(value);
+    ptr_to_vec(peek)
+}
+
+/// Serializes any Facet Reflect Peek to postcard bytes.
+#[cfg(feature = "alloc")]
+pub fn ptr_to_vec<'mem>(peek: Peek<'mem, 'static>) -> Result<Vec<u8>, SerializeError> {
+    let mut buffer = Vec::new();
     serialize_value(peek, &mut buffer)?;
     Ok(buffer)
 }

--- a/facet-shapelike/Cargo.toml
+++ b/facet-shapelike/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "facet-shapelike"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+bitflags = "2.10.0"
+facet = { path = "../facet", version = "0.31.8", features = ["alloc"] }
+facet-core = { path = "../facet-core", version = "0.31.8", features = ["alloc"] }
+facet-macros = { path = "../facet-macros", version = "0.31.8" }
+facet-postcard = { path = "../facet-postcard", version = "0.1.0" }
+facet-reflect = { path = "../facet-reflect", default-features = false }
+
+[dev-dependencies]
+facet-json = { path = "../facet-json", version = "0.31.0" }
+facet-kdl = { path = "../facet-kdl", version = "0.31.0" }
+facet-assert = { path = "../facet-assert", version = "0.31.0" }
+facet-xml = { path = "../facet-xml", version = "0.31.0" }
+facet-args = { path = "../facet-args", version = "0.31.0" }

--- a/facet-shapelike/README.md
+++ b/facet-shapelike/README.md
@@ -1,0 +1,61 @@
+# facet-shapelike
+
+[![Coverage Status](https://coveralls.io/repos/github/facet-rs/facet-shapelike/badge.svg?branch=main)](https://coveralls.io/github/facet-rs/facet?branch=main)
+[![crates.io](https://img.shields.io/crates/v/facet-shapelike.svg)](https://crates.io/crates/facet-shapelike)
+[![documentation](https://docs.rs/facet-shapelike/badge.svg)](https://docs.rs/facet-shapelike)
+[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/facet-shapelike.svg)](./LICENSE)
+[![Discord](https://img.shields.io/discord/1379550208551026748?logo=discord&label=discord)](https://discord.gg/JhD7CwCJ8F)
+
+# facet-shapelike
+
+This implements a struct which is a fully serialiable version of a Shape, called Shapelike, this is useful if you wanna ever use a shape in other program or in another point in type
+
+## Sponsors
+
+Thanks to all individual sponsors:
+
+<p> <a href="https://github.com/sponsors/fasterthanlime">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-light.svg" height="40" alt="GitHub Sponsors">
+</picture>
+</a> <a href="https://patreon.com/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-light.svg" height="40" alt="Patreon">
+    </picture>
+</a> </p>
+
+...along with corporate sponsors:
+
+<p> <a href="https://aws.amazon.com">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-light.svg" height="40" alt="AWS">
+</picture>
+</a> <a href="https://zed.dev">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-light.svg" height="40" alt="Zed">
+</picture>
+</a> <a href="https://depot.dev?utm_source=facet">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-light.svg" height="40" alt="Depot">
+</picture>
+</a> </p>
+
+...without whom this work could not exist.
+
+## Special thanks
+
+The facet logo was drawn by [Misiasart](https://misiasart.com/).
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/facet-rs/facet/blob/main/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/facet-rs/facet/blob/main/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/facet-shapelike/README.md.in
+++ b/facet-shapelike/README.md.in
@@ -1,0 +1,3 @@
+# facet-shapelike
+
+This implements a struct which is a fully serialiable version of a Shape, called Shapelike, this is useful if you wanna ever use a shape in other program or in another point in type

--- a/facet-shapelike/src/lib.rs
+++ b/facet-shapelike/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod shape_like;
+pub mod types;
+
+#[cfg(test)]
+mod tests;

--- a/facet-shapelike/src/shape_like.rs
+++ b/facet-shapelike/src/shape_like.rs
@@ -1,0 +1,574 @@
+use std::ptr::NonNull;
+
+use crate::types::{
+    EnumReprLike, FunctionAbi, KnownPointer, PointerFlags, PrimitiveType, ReprLike, ShapeLayout,
+    StructKindLike,
+};
+use facet::{Facet, PtrConst};
+use facet_core::{
+    ArrayDef, Def, EnumType, ExtensionAttr, Field, FunctionPointerDef, ListDef, MapDef, NdArrayDef,
+    OptionDef, PointerDef, PointerType, ResultDef, SequenceType, SetDef, Shape, SliceDef,
+    StructType, Type, UserType, Variant,
+};
+use facet_reflect::Peek;
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct ShapeLike {
+    pub layout: ShapeLayout,
+    pub ty: TypeLike,
+    pub def: DefLike,
+    pub type_identifier: String,
+    pub type_params: Vec<TypeParamLike>,
+    pub doc: Vec<String>,
+    pub attributes: Vec<ExtensionAttrLike>,
+    pub type_tag: Option<String>,
+    #[facet(recursive_type)]
+    pub inner: Option<Box<ShapeLike>>,
+}
+
+impl From<&Shape> for ShapeLike {
+    fn from(shape: &Shape) -> Self {
+        Self {
+            layout: match shape.layout {
+                facet_core::ShapeLayout::Sized(l) => ShapeLayout::Sized(l.into()),
+                facet_core::ShapeLayout::Unsized => ShapeLayout::Unsized,
+            },
+            ty: (&shape.ty).into(),
+            def: (&shape.def).into(),
+            type_identifier: shape.type_identifier.to_string(),
+            type_params: shape.type_params.iter().map(|item| (item).into()).collect(),
+            doc: shape.doc.iter().map(|s| s.to_string()).collect(),
+            attributes: shape.attributes.iter().map(|item| (item).into()).collect(),
+            type_tag: shape.type_tag.map(|s| s.to_string()),
+            inner: shape.inner.map(|s| Box::new((s).into())),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct TypeParamLike {
+    pub name: String,
+    #[facet(recursive_type)]
+    pub shape: Box<ShapeLike>,
+}
+
+impl From<&facet_core::TypeParam> for TypeParamLike {
+    fn from(tp: &facet_core::TypeParam) -> Self {
+        Self {
+            name: tp.name.to_string(),
+            shape: Box::new((tp.shape).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct ExtensionAttrLike {
+    pub ns: Option<String>,
+    pub key: String,
+    pub data: Vec<u8>,
+    #[facet(recursive_type)]
+    pub shape: Box<ShapeLike>,
+}
+
+impl From<&ExtensionAttr> for ExtensionAttrLike {
+    fn from(attr: &ExtensionAttr) -> Self {
+        let ptr = PtrConst::new(NonNull::new(attr.data as *mut ()).unwrap());
+        let peek = unsafe { Peek::unchecked_new(ptr, attr.shape) };
+        let data = facet_postcard::ptr_to_vec(peek).unwrap();
+        Self {
+            ns: attr.ns.map(|s| s.to_string()),
+            key: attr.key.to_string(),
+            data,
+            shape: Box::new((attr.shape).into()),
+        }
+    }
+}
+
+impl ExtensionAttrLike {
+    pub fn parse_data<T: Facet<'static>>(&self) -> Result<T, facet_postcard::DeserializeError> {
+        facet_postcard::from_bytes(&self.data)
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum TypeLike {
+    Primitive(PrimitiveType),
+    Sequence(SequenceTypeLike),
+    User(UserTypeLike),
+    Pointer(PointerTypeLike),
+}
+
+impl From<&Type> for TypeLike {
+    fn from(ty: &Type) -> Self {
+        match ty {
+            Type::Primitive(p) => TypeLike::Primitive(match p {
+                facet_core::PrimitiveType::Boolean => PrimitiveType::Boolean,
+                facet_core::PrimitiveType::Numeric(n) => PrimitiveType::Numeric(match n {
+                    facet_core::NumericType::Integer { signed } => {
+                        crate::types::NumericType::Integer { signed: *signed }
+                    }
+                    facet_core::NumericType::Float => crate::types::NumericType::Float,
+                }),
+                facet_core::PrimitiveType::Textual(t) => PrimitiveType::Textual(match t {
+                    facet_core::TextualType::Char => crate::types::TextualType::Char,
+                    facet_core::TextualType::Str => crate::types::TextualType::Str,
+                }),
+                facet_core::PrimitiveType::Never => PrimitiveType::Never,
+            }),
+            Type::Sequence(s) => TypeLike::Sequence(s.into()),
+            Type::User(u) => TypeLike::User(u.into()),
+            Type::Pointer(p) => TypeLike::Pointer(p.into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum SequenceTypeLike {
+    Array(ArrayTypeLike),
+    Slice(SliceTypeLike),
+}
+
+impl From<&SequenceType> for SequenceTypeLike {
+    fn from(seq: &SequenceType) -> Self {
+        match seq {
+            SequenceType::Array(a) => SequenceTypeLike::Array(a.into()),
+            SequenceType::Slice(s) => SequenceTypeLike::Slice(s.into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct ArrayTypeLike {
+    #[facet(recursive_type)]
+    pub t: Box<ShapeLike>,
+    pub n: u64,
+}
+
+impl From<&facet_core::ArrayType> for ArrayTypeLike {
+    fn from(a: &facet_core::ArrayType) -> Self {
+        Self {
+            t: Box::new((a.t).into()),
+            n: a.n as u64,
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct SliceTypeLike {
+    #[facet(recursive_type)]
+    pub t: Box<ShapeLike>,
+}
+
+impl From<&facet_core::SliceType> for SliceTypeLike {
+    fn from(s: &facet_core::SliceType) -> Self {
+        Self {
+            t: Box::new((s.t).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum UserTypeLike {
+    Struct(StructTypeLike),
+    Enum(EnumTypeLike),
+    Union(UnionTypeLike),
+    Opaque,
+}
+
+impl From<&UserType> for UserTypeLike {
+    fn from(user: &UserType) -> Self {
+        match user {
+            UserType::Struct(s) => UserTypeLike::Struct(s.into()),
+            UserType::Enum(e) => UserTypeLike::Enum(e.into()),
+            UserType::Union(u) => UserTypeLike::Union(u.into()),
+            UserType::Opaque => UserTypeLike::Opaque,
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct StructTypeLike {
+    pub repr: ReprLike,
+    pub kind: StructKindLike,
+    pub fields: Vec<FieldLike>,
+}
+
+impl From<&StructType> for StructTypeLike {
+    fn from(s: &StructType) -> Self {
+        Self {
+            repr: s.repr.into(),
+            kind: s.kind.into(),
+            fields: s.fields.iter().map(|item| (item).into()).collect(),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct EnumTypeLike {
+    pub repr: ReprLike,
+    pub enum_repr: EnumReprLike,
+    pub variants: Vec<VariantLike>,
+}
+
+impl From<&EnumType> for EnumTypeLike {
+    fn from(e: &EnumType) -> Self {
+        Self {
+            repr: e.repr.into(),
+            enum_repr: e.enum_repr.into(),
+            variants: e.variants.iter().map(|item| (item).into()).collect(),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct UnionTypeLike {
+    pub repr: ReprLike,
+    pub fields: Vec<FieldLike>,
+}
+
+impl From<&facet_core::UnionType> for UnionTypeLike {
+    fn from(u: &facet_core::UnionType) -> Self {
+        Self {
+            repr: u.repr.into(),
+            fields: u.fields.iter().map(|item| (item).into()).collect(),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct FieldLike {
+    pub name: String,
+    #[facet(recursive_type)]
+    pub shape: Box<ShapeLike>,
+    pub offset: usize,
+    pub attributes: Vec<ExtensionAttrLike>,
+    pub doc: Vec<String>,
+}
+
+impl From<&Field> for FieldLike {
+    fn from(f: &Field) -> Self {
+        Self {
+            name: f.name.to_string(),
+            shape: Box::new(f.shape().into()),
+            offset: f.offset,
+            attributes: f.attributes.iter().map(|x| x.into()).collect(),
+            doc: f.doc.iter().map(|x| x.to_string()).collect(),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct VariantLike {
+    pub name: String,
+    pub discriminant: Option<i64>,
+    pub attributes: Vec<ExtensionAttrLike>,
+    pub data: StructTypeLike,
+    pub doc: Vec<String>,
+}
+
+impl From<&Variant> for VariantLike {
+    fn from(v: &Variant) -> Self {
+        Self {
+            name: v.name.to_string(),
+            discriminant: v.discriminant,
+            attributes: v.attributes.iter().map(|item| (item).into()).collect(),
+            data: (&v.data).into(),
+            doc: v.doc.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum PointerTypeLike {
+    Reference(ReferenceTypeLike),
+    Raw(RawTypeLike),
+    Function(FunctionPointerDefLike),
+}
+
+impl From<&PointerType> for PointerTypeLike {
+    fn from(p: &PointerType) -> Self {
+        match p {
+            PointerType::Reference(r) => PointerTypeLike::Reference(r.into()),
+            PointerType::Raw(r) => PointerTypeLike::Raw(r.into()),
+            PointerType::Function(f) => PointerTypeLike::Function(f.into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct ReferenceTypeLike {
+    pub mutable: bool,
+    #[facet(recursive_type)]
+    pub target: Box<ShapeLike>,
+}
+
+impl From<&facet_core::ValuePointerType> for ReferenceTypeLike {
+    fn from(r: &facet_core::ValuePointerType) -> Self {
+        Self {
+            mutable: r.mutable,
+            target: Box::new((r.target).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct RawTypeLike {
+    pub mutable: bool,
+    #[facet(recursive_type)]
+    pub target: Box<ShapeLike>,
+}
+
+impl From<&facet_core::ValuePointerType> for RawTypeLike {
+    fn from(r: &facet_core::ValuePointerType) -> Self {
+        Self {
+            mutable: r.mutable,
+            target: Box::new((r.target).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct FunctionPointerDefLike {
+    pub abi: FunctionAbi,
+    #[facet(recursive_type)]
+    pub parameters: Vec<ShapeLike>,
+    #[facet(recursive_type)]
+    pub return_type: Box<ShapeLike>,
+}
+
+impl From<&FunctionPointerDef> for FunctionPointerDefLike {
+    fn from(f: &FunctionPointerDef) -> Self {
+        Self {
+            abi: match f.abi {
+                facet_core::FunctionAbi::C => FunctionAbi::C,
+                facet_core::FunctionAbi::Rust => FunctionAbi::Rust,
+                facet_core::FunctionAbi::Unknown => FunctionAbi::Unknown,
+            },
+            parameters: f.parameters.iter().map(|&s| s.into()).collect::<Vec<_>>(),
+            return_type: Box::new((f.return_type).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum DefLike {
+    Undefined,
+    Scalar,
+    Map(MapDefLike),
+    Set(SetDefLike),
+    List(ListDefLike),
+    Array(ArrayDefLike),
+    NdArray(NdArrayDefLike),
+    Slice(SliceDefLike),
+    Option(OptionDefLike),
+    Result(ResultDefLike),
+    Pointer(PointerDefLike),
+    DynamicValue,
+}
+
+impl From<&Def> for DefLike {
+    fn from(def: &Def) -> Self {
+        match def {
+            Def::Undefined => DefLike::Undefined,
+            Def::Scalar => DefLike::Scalar,
+            Def::Map(m) => DefLike::Map(m.into()),
+            Def::Set(s) => DefLike::Set(s.into()),
+            Def::List(l) => DefLike::List(l.into()),
+            Def::Array(a) => DefLike::Array(a.into()),
+            Def::NdArray(n) => DefLike::NdArray(n.into()),
+            Def::Slice(s) => DefLike::Slice(s.into()),
+            Def::Option(o) => DefLike::Option(o.into()),
+            Def::Result(r) => DefLike::Result(r.into()),
+            Def::Pointer(p) => DefLike::Pointer(p.into()),
+            Def::DynamicValue(_d) => DefLike::DynamicValue,
+            _ => DefLike::Undefined,
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct MapDefLike {
+    #[facet(recursive_type)]
+    pub k: Box<ShapeLike>,
+    #[facet(recursive_type)]
+    pub v: Box<ShapeLike>,
+}
+
+impl From<&MapDef> for MapDefLike {
+    fn from(m: &MapDef) -> Self {
+        Self {
+            k: Box::new((m.k).into()),
+            v: Box::new((m.v).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct SetDefLike {
+    #[facet(recursive_type)]
+    pub t: Box<ShapeLike>,
+}
+
+impl From<&SetDef> for SetDefLike {
+    fn from(s: &SetDef) -> Self {
+        Self {
+            t: Box::new((s.t).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct ListDefLike {
+    #[facet(recursive_type)]
+    pub t: Box<ShapeLike>,
+}
+
+impl From<&ListDef> for ListDefLike {
+    fn from(l: &ListDef) -> Self {
+        Self {
+            t: Box::new((l.t).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct ArrayDefLike {
+    #[facet(recursive_type)]
+    pub t: Box<ShapeLike>,
+    pub n: u64,
+}
+
+impl From<&ArrayDef> for ArrayDefLike {
+    fn from(a: &ArrayDef) -> Self {
+        Self {
+            t: Box::new((a.t).into()),
+            n: a.n as u64,
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct NdArrayDefLike {
+    #[facet(recursive_type)]
+    pub t: Box<ShapeLike>,
+}
+
+impl From<&NdArrayDef> for NdArrayDefLike {
+    fn from(n: &NdArrayDef) -> Self {
+        Self {
+            t: Box::new((n.t).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct SliceDefLike {
+    #[facet(recursive_type)]
+    pub t: Box<ShapeLike>,
+}
+
+impl From<&SliceDef> for SliceDefLike {
+    fn from(s: &SliceDef) -> Self {
+        Self {
+            t: Box::new((s.t).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct OptionDefLike {
+    #[facet(recursive_type)]
+    pub t: Box<ShapeLike>,
+}
+
+impl From<&OptionDef> for OptionDefLike {
+    fn from(o: &OptionDef) -> Self {
+        Self {
+            t: Box::new((o.t).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct ResultDefLike {
+    #[facet(recursive_type)]
+    pub t: Box<ShapeLike>,
+    #[facet(recursive_type)]
+    pub e: Box<ShapeLike>,
+}
+
+impl From<&ResultDef> for ResultDefLike {
+    fn from(r: &ResultDef) -> Self {
+        Self {
+            t: Box::new((r.t).into()),
+            e: Box::new((r.e).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct PointerDefLike {
+    #[facet(recursive_type)]
+    pub pointee: Option<Box<ShapeLike>>,
+    #[facet(recursive_type)]
+    pub weak: Option<Box<ShapeLike>>,
+    #[facet(recursive_type)]
+    pub strong: Option<Box<ShapeLike>>,
+    pub flags: PointerFlags,
+    pub known: Option<KnownPointer>,
+}
+
+impl From<&PointerDef> for PointerDefLike {
+    fn from(p: &PointerDef) -> Self {
+        Self {
+            pointee: p.pointee.map(|s| Box::new((s).into())),
+            weak: p.weak.map(|f| Box::new((f()).into())),
+            strong: p.strong.map(|s| Box::new((s).into())),
+            flags: PointerFlags::from_bits_truncate(p.flags.bits()),
+            known: p.known.map(|k| match k {
+                facet_core::KnownPointer::Box => KnownPointer::Box,
+                facet_core::KnownPointer::Rc => KnownPointer::Rc,
+                facet_core::KnownPointer::RcWeak => KnownPointer::RcWeak,
+                facet_core::KnownPointer::Arc => KnownPointer::Arc,
+                facet_core::KnownPointer::ArcWeak => KnownPointer::ArcWeak,
+                facet_core::KnownPointer::Cow => KnownPointer::Cow,
+                facet_core::KnownPointer::Pin => KnownPointer::Pin,
+                facet_core::KnownPointer::Cell => KnownPointer::Cell,
+                facet_core::KnownPointer::RefCell => KnownPointer::RefCell,
+                facet_core::KnownPointer::OnceCell => KnownPointer::OnceCell,
+                facet_core::KnownPointer::Mutex => KnownPointer::Mutex,
+                facet_core::KnownPointer::RwLock => KnownPointer::RwLock,
+                facet_core::KnownPointer::NonNull => KnownPointer::NonNull,
+                facet_core::KnownPointer::SharedReference => KnownPointer::SharedReference,
+                facet_core::KnownPointer::ExclusiveReference => KnownPointer::ExclusiveReference,
+            }),
+        }
+    }
+}

--- a/facet-shapelike/src/tests.rs
+++ b/facet-shapelike/src/tests.rs
@@ -1,0 +1,89 @@
+use crate::shape_like::ShapeLike;
+use facet::Facet;
+use facet_args as args;
+use facet_kdl as kdl;
+use facet_xml as xml;
+
+#[derive(Facet)]
+#[repr(C)]
+struct TestStruct {
+    #[facet(kdl::property)]
+    a: u32,
+    b: bool,
+}
+
+#[derive(Facet)]
+struct KdlAttributes {
+    #[facet(kdl::child)]
+    child: u32,
+    #[facet(kdl::children)]
+    children: Vec<String>,
+    #[facet(kdl::property)]
+    prop: String,
+    #[facet(kdl::argument)]
+    arg: bool,
+    #[facet(kdl::arguments)]
+    args: Vec<i32>,
+    #[facet(kdl::name)]
+    name: String,
+}
+
+#[derive(Facet)]
+struct XmlAttributes {
+    #[facet(xml::attribute)]
+    attr: u32,
+    #[facet(xml::element)]
+    elem: String,
+    #[facet(xml::text)]
+    text: String,
+}
+
+#[derive(Facet)]
+struct ArgsAttributes {
+    #[facet(args::positional)]
+    pos: String,
+    #[facet(args::named)]
+    named: bool,
+    #[facet(args::short = 'f')]
+    flag: bool,
+}
+
+#[test]
+fn test_shape_serialization_roundtrip() {
+    let shape = TestStruct::SHAPE;
+    let shape_like: ShapeLike = shape.into();
+    let json = facet_json::to_string(&shape_like);
+    let deserialized: ShapeLike =
+        facet_json::from_str(&json).expect("Failed to deserialize ShapeLike");
+    facet_assert::assert_same!(shape_like, deserialized)
+}
+
+#[test]
+fn test_kdl_attributes_roundtrip() {
+    let shape = KdlAttributes::SHAPE;
+    let shape_like: ShapeLike = shape.into();
+    let json = facet_json::to_string(&shape_like);
+    let deserialized: ShapeLike =
+        facet_json::from_str(&json).expect("Failed to deserialize ShapeLike");
+    facet_assert::assert_same!(shape_like, deserialized)
+}
+
+#[test]
+fn test_xml_attributes_roundtrip() {
+    let shape = XmlAttributes::SHAPE;
+    let shape_like: ShapeLike = shape.into();
+    let json = facet_json::to_string(&shape_like);
+    let deserialized: ShapeLike =
+        facet_json::from_str(&json).expect("Failed to deserialize ShapeLike");
+    facet_assert::assert_same!(shape_like, deserialized)
+}
+
+#[test]
+fn test_args_attributes_roundtrip() {
+    let shape = ArgsAttributes::SHAPE;
+    let shape_like: ShapeLike = shape.into();
+    let json = facet_json::to_string(&shape_like);
+    let deserialized: ShapeLike =
+        facet_json::from_str(&json).expect("Failed to deserialize ShapeLike");
+    facet_assert::assert_same!(shape_like, deserialized)
+}

--- a/facet-shapelike/src/types.rs
+++ b/facet-shapelike/src/types.rs
@@ -1,0 +1,195 @@
+use std::alloc::Layout;
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum PrimitiveType {
+    Boolean,
+    Numeric(NumericType),
+    Textual(TextualType),
+    Never,
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum NumericType {
+    Integer { signed: bool },
+    Float,
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum TextualType {
+    Char,
+    Str,
+}
+
+/// Wrapper for std::alloc::Layout that can derive Facet
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct LayoutLike {
+    pub size: u64,
+    pub align: u64,
+}
+
+impl From<Layout> for LayoutLike {
+    fn from(layout: Layout) -> Self {
+        Self {
+            size: layout.size() as u64,
+            align: layout.align() as u64,
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum ShapeLayout {
+    Sized(LayoutLike),
+    Unsized,
+}
+
+/// Flags to represent various characteristics of pointers
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct PointerFlags {
+    pub weak: bool,
+    pub atomic: bool,
+    pub lock: bool,
+}
+
+impl PointerFlags {
+    pub const EMPTY: Self = Self {
+        weak: false,
+        atomic: false,
+        lock: false,
+    };
+
+    pub fn from_bits_truncate(bits: u8) -> Self {
+        Self {
+            weak: (bits & (1 << 0)) != 0,
+            atomic: (bits & (1 << 1)) != 0,
+            lock: (bits & (1 << 2)) != 0,
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum KnownPointer {
+    Box,
+    Rc,
+    RcWeak,
+    Arc,
+    ArcWeak,
+    Cow,
+    Pin,
+    Cell,
+    RefCell,
+    OnceCell,
+    Mutex,
+    RwLock,
+    NonNull,
+    SharedReference,
+    ExclusiveReference,
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum FunctionAbi {
+    C,
+    Rust,
+    Unknown,
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum BaseRepr {
+    Rust,
+    C,
+    Transparent,
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct ReprLike {
+    pub base: BaseRepr,
+    pub packed: bool,
+}
+
+impl Default for ReprLike {
+    fn default() -> Self {
+        Self {
+            base: BaseRepr::Rust,
+            packed: false,
+        }
+    }
+}
+
+impl From<facet_core::Repr> for ReprLike {
+    fn from(repr: facet_core::Repr) -> Self {
+        use facet_core::BaseRepr as CoreBaseRepr;
+        Self {
+            base: match repr.base {
+                CoreBaseRepr::Rust => BaseRepr::Rust,
+                CoreBaseRepr::C => BaseRepr::C,
+                CoreBaseRepr::Transparent => BaseRepr::Transparent,
+            },
+            packed: repr.packed,
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum StructKindLike {
+    Unit,
+    TupleStruct,
+    Struct,
+    Tuple,
+}
+
+impl From<facet_core::StructKind> for StructKindLike {
+    fn from(kind: facet_core::StructKind) -> Self {
+        use facet_core::StructKind as CoreStructKind;
+        match kind {
+            CoreStructKind::Unit => StructKindLike::Unit,
+            CoreStructKind::TupleStruct => StructKindLike::TupleStruct,
+            CoreStructKind::Struct => StructKindLike::Struct,
+            CoreStructKind::Tuple => StructKindLike::Tuple,
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum EnumReprLike {
+    RustNPO,
+    U8,
+    U16,
+    U32,
+    U64,
+    USize,
+    I8,
+    I16,
+    I32,
+    I64,
+    ISize,
+}
+
+impl From<facet_core::EnumRepr> for EnumReprLike {
+    fn from(repr: facet_core::EnumRepr) -> Self {
+        use facet_core::EnumRepr as CoreEnumRepr;
+        match repr {
+            CoreEnumRepr::RustNPO => EnumReprLike::RustNPO,
+            CoreEnumRepr::U8 => EnumReprLike::U8,
+            CoreEnumRepr::U16 => EnumReprLike::U16,
+            CoreEnumRepr::U32 => EnumReprLike::U32,
+            CoreEnumRepr::U64 => EnumReprLike::U64,
+            CoreEnumRepr::USize => EnumReprLike::USize,
+            CoreEnumRepr::I8 => EnumReprLike::I8,
+            CoreEnumRepr::I16 => EnumReprLike::I16,
+            CoreEnumRepr::I32 => EnumReprLike::I32,
+            CoreEnumRepr::I64 => EnumReprLike::I64,
+            CoreEnumRepr::ISize => EnumReprLike::ISize,
+        }
+    }
+}


### PR DESCRIPTION
introducing Shapelike, its a struct thats a bit like a Shape, this should be treated as the current escape hatch if you really need shape itself to implement Facet, like fx if you wanna diff 2 shapes or if you wanna serialize a shape. Shapelike is a fully owned representation of all the parts of a Shape that it makes sense to serialize (no vtable and typeid), for obvious reason the conversion is a one-way trip.

# things i dont know if i've done right
- should i disable specific features in the dependency on other facet crates?
- should this maybe not be in a seperate crate?
- the name i gave to that function i added to postcard? what should i name it?