### PR TITLE
docs: add serialization examples for proxy attribute and Shape FAQ

### DIFF
--- a/docs/content/guide/ecosystem.md
+++ b/docs/content/guide/ecosystem.md
@@ -221,8 +221,19 @@ impl TryFrom<&ExternalType> for ExternalTypeProxy {
 struct MyWrapper {
     name: String,
     #[facet(opaque, proxy = ExternalTypeProxy)]
-    internal: ExternalType,  // Serializes via the proxy
+    internal: ExternalType,
 }
+
+// Serialization: ExternalType → proxy → JSON string
+let wrapper = MyWrapper {
+    name: "example".into(),
+    internal: ExternalType::new(),
+};
+let json = facet_json::to_string(&wrapper);
+// {"name":"example","internal":"...serialized form..."}
+
+// Deserialization: JSON → proxy → ExternalType
+let parsed: MyWrapper = facet_json::from_str(&json).unwrap();
 ```
 
 See the [Attributes Reference](@/guide/attributes.md#opaque) for details on `opaque` and `proxy`.

--- a/docs/content/guide/faq.md
+++ b/docs/content/guide/faq.md
@@ -37,6 +37,17 @@ Yes. [`facet-core`](https://docs.rs/facet-core) is `no_std` compatible. Format c
 
 facet targets the latest stable Rust. Check the CI configuration for the current MSRV (minimum supported Rust version).
 
+### Why doesn't `Shape` implement `Facet`?
+
+`Shape` contains types that cannot be serialized or deserialized:
+
+1. **Function pointers** — stored in attributes like `default`, `skip_serializing_if`, and `invariants`
+2. **`ConstTypeId`** — compile-time type identifiers that have no meaningful serialized form
+
+If you're looking for a generic value type that can hold any facet-compatible data, use [`facet_value::Value`](https://docs.rs/facet-value).
+
+If you genuinely need to compare, diff, or store shapes at runtime, see the [WIP shapelike PR](https://github.com/facet-rs/facet/pull/1105).
+
 ## Usage
 
 ### How do I deserialize from JSON?


### PR DESCRIPTION
## Summary

- Add explicit serialization/deserialization round-trip examples to all proxy examples in `attributes.md` (CustomId, Color/Theme, HexU64, Arc)
- Add serialization example to `ecosystem.md` proxy section
- Add FAQ entry explaining why `Shape` doesn't implement `Facet` (function pointers, `ConstTypeId` are not serializable)

## Context

Users reading the proxy documentation might not realize serialization is fully supported since the examples only showed deserialization direction. Now all examples show:
1. Creating a value
2. Serializing with `facet_json::to_string()`
3. The expected JSON output
4. Round-trip back to deserialization

Closes #1092