### PR TITLE
fix(xml): respect rename attribute and avoid redundant xmlns on children

### DIFF
--- a/facet-xml/src/deserialize.rs
+++ b/facet-xml/src/deserialize.rs
@@ -90,7 +90,7 @@ fn get_variant_display_name(variant: &Variant) -> &'static str {
 }
 
 /// Get the display name for a shape (respecting `rename` attribute).
-fn get_shape_display_name(shape: &facet_core::Shape) -> &'static str {
+pub(crate) fn get_shape_display_name(shape: &facet_core::Shape) -> &'static str {
     if let Some(renamed) = shape.get_builtin_attr_value::<&str>("rename") {
         return renamed;
     }


### PR DESCRIPTION
- Root element now uses `get_shape_display_name` to respect `rename` attribute
- Track current default namespace during serialization
- Only emit `xmlns="..."` when namespace differs from inherited default
- Child elements with same namespace as parent no longer emit redundant xmlns

Before:
```xml
<Svg xmlns="http://www.w3.org/2000/svg" viewBox="...">
  <circle xmlns="http://www.w3.org/2000/svg" .../>
```

After:
```xml
<svg xmlns="http://www.w3.org/2000/svg" viewBox="...">
  <circle .../>
```