### PR TITLE
feat(facet-xml): add custom float formatter option for serialization

### DIFF
--- a/facet-xml/src/lib.rs
+++ b/facet-xml/src/lib.rs
@@ -132,8 +132,8 @@ pub use deserialize::{
 
 // Re-export serialization
 pub use serialize::{
-    SerializeOptions, to_string, to_string_pretty, to_string_with_options, to_writer,
-    to_writer_pretty, to_writer_with_options,
+    FloatFormatter, SerializeOptions, to_string, to_string_pretty, to_string_with_options,
+    to_writer, to_writer_pretty, to_writer_with_options,
 };
 
 mod xml;

--- a/facet-xml/tests/minimal.rs
+++ b/facet-xml/tests/minimal.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use facet::Facet;
 use facet_xml as xml;
 
@@ -258,4 +260,93 @@ fn test_pretty_roundtrip() {
     let xml_output = xml::to_string_pretty(&person).unwrap();
     let parsed: Person = xml::from_str(&xml_output).unwrap();
     assert_eq!(parsed, person);
+}
+
+// ============================================================================
+// Float formatter tests
+// ============================================================================
+
+#[derive(Facet, Debug, PartialEq)]
+struct Point {
+    #[facet(xml::attribute)]
+    x: f64,
+    #[facet(xml::attribute)]
+    y: f64,
+}
+
+/// Custom float formatter that mimics C's %g behavior:
+/// - 6 significant digits
+/// - Trim trailing zeros
+/// - Trim trailing decimal point
+fn fmt_g(value: f64, w: &mut dyn Write) -> std::io::Result<()> {
+    // Use 6 significant digits like %g
+    let s = format!("{value:.6}");
+    let s = s.trim_end_matches('0').trim_end_matches('.');
+    write!(w, "{s}")
+}
+
+#[test]
+fn test_float_formatter_attribute() {
+    let point = Point { x: 1.5, y: 2.0 };
+    let options = xml::SerializeOptions::new().float_formatter(fmt_g);
+    let xml_output = xml::to_string_with_options(&point, &options).unwrap();
+    // Without formatter: x="1.5" y="2" (default Display)
+    // With formatter: x="1.5" y="2" (trimmed zeros)
+    assert_eq!(xml_output, r#"<Point x="1.5" y="2"/>"#);
+}
+
+#[test]
+fn test_float_formatter_long_decimal() {
+    // This value has floating-point representation issues
+    let point = Point {
+        x: 38.160000000000004,
+        y: 139.98337649086284,
+    };
+    let options = xml::SerializeOptions::new().float_formatter(fmt_g);
+    let xml_output = xml::to_string_with_options(&point, &options).unwrap();
+    // Should be nicely formatted, not the full precision mess
+    assert_eq!(xml_output, r#"<Point x="38.16" y="139.983376"/>"#);
+}
+
+#[test]
+fn test_float_formatter_default() {
+    // Without a custom formatter, uses default Display
+    let point = Point { x: 1.5, y: 2.0 };
+    let xml_output = xml::to_string(&point).unwrap();
+    // Default Display keeps the full representation
+    assert_eq!(xml_output, r#"<Point x="1.5" y="2"/>"#);
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Circle {
+    #[facet(xml::element)]
+    radius: f64,
+}
+
+#[test]
+fn test_float_formatter_element() {
+    let circle = Circle {
+        radius: 1.234_567_890_123_456,
+    };
+    let options = xml::SerializeOptions::new().float_formatter(fmt_g);
+    let xml_output = xml::to_string_with_options(&circle, &options).unwrap();
+    // Element content should also use the formatter
+    assert_eq!(xml_output, r#"<Circle><radius>1.234568</radius></Circle>"#);
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct PointF32 {
+    #[facet(xml::attribute)]
+    x: f32,
+    #[facet(xml::attribute)]
+    y: f32,
+}
+
+#[test]
+fn test_float_formatter_f32() {
+    // f32 values should be upcast to f64 and formatted
+    let point = PointF32 { x: 1.5, y: 2.0 };
+    let options = xml::SerializeOptions::new().float_formatter(fmt_g);
+    let xml_output = xml::to_string_with_options(&point, &options).unwrap();
+    assert_eq!(xml_output, r#"<PointF32 x="1.5" y="2"/>"#);
 }


### PR DESCRIPTION
## Summary

- Add `FloatFormatter` type alias for `fn(f64, &mut dyn Write) -> std::io::Result<()>`
- Add `float_formatter()` builder method to `SerializeOptions`
- Update `XmlSerializer` to use the custom formatter for f32/f64 values (both attributes and element content)

This allows users to control how floating-point numbers are serialized to XML, which is useful for:
- Controlling precision (e.g., matching C's `%g` formatting with 6 significant digits)
- Trimming trailing zeros for cleaner output
- SVG generation where coordinates like `cx="38.160000000000004"` should be `cx="38.16"`

## Example usage

```rust
use std::io::Write;
use facet_xml::{SerializeOptions, to_string_with_options};

fn fmt_g(value: f64, w: &mut dyn Write) -> std::io::Result<()> {
    let s = format!("{value:.6}");
    let s = s.trim_end_matches('0').trim_end_matches('.');
    write!(w, "{s}")
}

let options = SerializeOptions::new().float_formatter(fmt_g);
let xml = to_string_with_options(&point, &options)?;
```

## Test plan

- [x] Added tests for custom float formatter on attributes
- [x] Added tests for custom float formatter on element content  
- [x] Added tests for f32 upcast to f64
- [x] Added test for long decimal precision
- [x] All existing tests pass