### PR TITLE
Add built-in 'alias' attribute.

### DIFF
--- a/facet-core/src/types/mod.rs
+++ b/facet-core/src/types/mod.rs
@@ -354,6 +354,12 @@ impl Shape {
         self.get_builtin_attr_value::<&'static str>("rename_all")
     }
 
+    /// Returns the `alias`ed name if present.
+    #[inline]
+    pub fn get_alias_attr(&self) -> Option<&'static str> {
+        self.get_builtin_attr_value::<&'static str>("alias")
+    }
+
     /// Returns true if this enum is untagged.
     #[inline]
     pub fn is_untagged(&self) -> bool {

--- a/facet-macros-impl/src/attr_grammar/make_parse_attr.rs
+++ b/facet-macros-impl/src/attr_grammar/make_parse_attr.rs
@@ -243,7 +243,7 @@ enum VariantKind {
     Unit,
     Newtype(TokenStream2),
     /// Newtype holding `&'static str` - stored directly for facet-core access.
-    /// Used for attributes like `tag`, `content`, `rename`, `rename_all`.
+    /// Used for attributes like `tag`, `content`, `rename`, `rename_all`, `alias`.
     NewtypeStr,
     NewtypeOptionChar,
     Struct(proc_macro2::Ident),

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -126,6 +126,13 @@ pub mod builtin {
             /// kebab-case, SCREAMING-KEBAB-CASE
             RenameAll(&'static str),
 
+            /// Aliases a field or variant during deserialization.
+            ///
+            /// Usage: `#[facet(alias = "additional_name")]`
+            ///
+            /// Allows for deserializing a field from either the alias or the original name.
+            Alias(&'static str),
+
             /// For internally/adjacently tagged enums: the field name for the tag.
             ///
             /// Usage: `#[facet(tag = "type")]`


### PR DESCRIPTION
## Context

Adds `alias` as a recognized "built-in" attribute alongside others like `sensitive`, `rename`, etc. I only added _support_ for the attribute itself, but didn't implement its usage in any of the existing crates.