### PR TITLE
feat(facet-reflect): make Peek covariant over 'facet lifetime

### DIFF
--- a/facet-reflect/tests/compile_tests.rs
+++ b/facet-reflect/tests/compile_tests.rs
@@ -255,7 +255,9 @@ fn test_peek_contravariant_shrinking() {
     let test = CompilationTest {
         name: "contravariant_shrinking",
         source: include_str!("peek/compile_tests/contravariant_shrinking.rs"),
-        expected_errors: &["error[E0521]: borrowed data escapes outside of function"],
+        // With covariant Peek, the error changes from E0521 to E0515
+        // The code still fails to compile, just for a different reason
+        expected_errors: &["error[E0515]: cannot return value referencing temporary value"],
     };
 
     run_compilation_test(&test);

--- a/facet-reflect/tests/peek/covariance.rs
+++ b/facet-reflect/tests/peek/covariance.rs
@@ -1,0 +1,57 @@
+//! Tests demonstrating that Peek is covariant over 'facet.
+//!
+//! Covariance means Peek<'mem, 'static> can be used where Peek<'mem, 'a> is expected.
+//! This is safe because:
+//! - Covariance only allows shrinking lifetimes ('static -> 'a), not growing
+//! - Data valid for 'static is valid for any shorter lifetime
+//! - The 'mem lifetime and borrow checker prevent references from escaping
+//!
+//! See: https://github.com/facet-rs/facet/discussions/1128
+
+use facet::Facet;
+use facet_reflect::Peek;
+
+#[derive(Debug, Facet)]
+struct Borrowed<'a> {
+    data: &'a str,
+}
+
+/// Demonstrates that Peek<'_, 'static> can be passed where Peek<'_, 'a> is expected.
+#[test]
+fn peek_static_usable_as_shorter_lifetime() {
+    static STATIC_DATA: &str = "I am truly static";
+    let borrowed_static: Borrowed<'static> = Borrowed { data: STATIC_DATA };
+
+    // Create a Peek<'_, 'static>
+    let peek_static: Peek<'_, 'static> = Peek::new(&borrowed_static);
+
+    // This function accepts Peek<'_, 'a> for any 'a
+    fn use_peek<'a>(peek: Peek<'_, 'a>) -> &'a str {
+        let borrowed: &Borrowed<'a> = peek.get::<Borrowed<'a>>().unwrap();
+        borrowed.data
+    }
+
+    // With covariance, peek_static can be used here
+    // The 'static lifetime shrinks to match 'a
+    let result = use_peek(peek_static);
+    assert_eq!(result, "I am truly static");
+}
+
+/// Shows that Peek with different 'facet lifetimes can be unified.
+#[test]
+fn peek_lifetime_unification() {
+    static STATIC_DATA: &str = "static";
+    let owned = String::from("owned");
+
+    let static_borrowed: Borrowed<'static> = Borrowed { data: STATIC_DATA };
+    let owned_borrowed: Borrowed<'_> = Borrowed { data: &owned };
+
+    let peek_static: Peek<'_, 'static> = Peek::new(&static_borrowed);
+    let peek_owned: Peek<'_, '_> = Peek::new(&owned_borrowed);
+
+    // Both peeks can be passed to a function expecting the same lifetime
+    // peek_static's 'static shrinks to match peek_owned's shorter lifetime
+    fn takes_two<'a>(_p1: Peek<'_, 'a>, _p2: Peek<'_, 'a>) {}
+
+    takes_two(peek_static, peek_owned);
+}

--- a/facet-reflect/tests/peek/mod.rs
+++ b/facet-reflect/tests/peek/mod.rs
@@ -1,3 +1,4 @@
+mod covariance;
 mod dst;
 mod enum_;
 mod list;


### PR DESCRIPTION
## Summary

Makes `Peek` covariant over the `'facet` lifetime parameter, allowing `Peek<'mem, 'static>` to be used where `Peek<'mem, 'a>` is expected.

This addresses the issue raised in #1128 where users couldn't mix `Peek<'_, 'static>` (for constants like `true`) and `Peek<'_, 'a>` (for values with borrowing) in a common data structure.

## Why this is safe

Covariance only allows **shrinking** lifetimes (`'static` → `'a`), not growing them:

1. **Safe direction**: `Peek<'_, 'static>` → `Peek<'_, 'a>` ✓
   - Data valid for `'static` is valid for any shorter lifetime
   
2. **Blocked direction**: `Peek<'_, 'a>` → `Peek<'_, 'static>` ✗
   - Would require contravariance (which would be unsound)
   - The dangerous "growing" direction remains blocked

Additional protections:
- The `'mem` lifetime on `PtrConst` ensures memory validity
- The borrow checker prevents references from escaping

## Note on Partial

`Partial` remains **invariant** because it writes data, requiring the stricter lifetime bound. We verified that contravariant `Partial` causes UB (demonstrated via Miri).

## Test plan

- [x] All existing tests pass
- [x] Added new covariance tests demonstrating the feature works
- [x] Compile-fail tests still catch dangerous patterns
- [x] Updated `test_peek_contravariant_shrinking` expected error (error code changed but code still fails to compile)

Closes #1128