### PR TITLE
fix(facet-reflect): Use `'mem` as return lifetime of `Peek::get()` to prevent lifetime issue "function was supposed to return data with lifetime `'mem` but it is returning data with lifetime `'a`"

### DIFF
--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -217,7 +217,7 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
     ///
     /// Panics if the shape doesn't match the type `T`.
     #[inline]
-    pub fn get<T: Facet<'facet> + ?Sized>(&self) -> Result<&T, ReflectError> {
+    pub fn get<T: Facet<'facet> + ?Sized>(&self) -> Result<&'mem T, ReflectError> {
         if self.shape != T::SHAPE {
             Err(ReflectError::WrongShape {
                 expected: self.shape,

--- a/facet-reflect/tests/peek/get.rs
+++ b/facet-reflect/tests/peek/get.rs
@@ -1,0 +1,19 @@
+use facet_reflect::Peek;
+
+#[test]
+fn test_peek_get_via_mem() {
+    fn retrieve_via_as_str<'a, 'mem, 'facet>(peek: &'a Peek<'mem, 'facet>) -> &'mem str {
+        peek.as_str().unwrap()
+    }
+
+    fn retrieve_via_get<'a, 'mem, 'facet>(peek: &'a Peek<'mem, 'facet>) -> &'mem str {
+        peek.get::<str>().unwrap()
+    }
+
+    let s = String::from("abc");
+    let peek = Peek::new(s.as_str());
+    let s1 = retrieve_via_as_str(&peek);
+    assert_eq!(s1, "abc");
+    let s2 = retrieve_via_get(&peek);
+    assert_eq!(s2, "abc");
+}

--- a/facet-reflect/tests/peek/mod.rs
+++ b/facet-reflect/tests/peek/mod.rs
@@ -1,6 +1,7 @@
 mod covariance;
 mod dst;
 mod enum_;
+mod get;
 mod list;
 mod list_like;
 mod map;


### PR DESCRIPTION
Hi, I ran into the issue that the return lifetime of `Peek::get` was that of &self, rather than `'mem`. This fix attempts to address this issue.

Full disclosure: I haven't done much around `unsafe`, lifetimes and pointer shenanigans, so a good look is definitely warranted.

My understanding is that the lifetime of the underlying data pointer is `'mem` so returning a reference with that lifetime _should_ be ok.
`Peek::as_str()` and `Peek::data()` also return with a `'mem` lifetime, which seems to support this interpretation.

I also ran the test suite and the `just miri` without any errors.

Please let me know if there are any issues.

Note: I did not run the pre-commit hook, since I am currently on my windows machine. I hope the formatting, etc is ok, but feel free to touch it up.