### PR TITLE
feat: optimize field attribute lookup from O(n) to O(1)

### DIFF
--- a/facet-core/src/impls_core/nonnull.rs
+++ b/facet-core/src/impls_core/nonnull.rs
@@ -1,8 +1,8 @@
 use core::ptr::NonNull;
 
 use crate::{
-    Def, Facet, Field, KnownPointer, PointerDef, PointerFlags, PointerVTable, PtrConst, Repr,
-    ShapeBuilder, ShapeRef, StructKind, StructType, Type, UserType, value_vtable,
+    Def, Facet, Field, FieldFlags, KnownPointer, PointerDef, PointerFlags, PointerVTable, PtrConst,
+    Repr, ShapeBuilder, ShapeRef, StructKind, StructType, Type, UserType, value_vtable,
 };
 
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for core::ptr::NonNull<T> {
@@ -24,6 +24,9 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for core::ptr::NonNull<T> {
                     name: "pointer",
                     shape: ShapeRef::Static(<*mut T>::SHAPE),
                     offset: 0,
+                    flags: FieldFlags::empty(),
+                    rename: None,
+                    alias: None,
                     attributes: &[],
                     doc: &[],
                 }]

--- a/facet-core/src/impls_core/ops.rs
+++ b/facet-core/src/impls_core/ops.rs
@@ -1,4 +1,6 @@
-use crate::{Def, Facet, Field, Shape, ShapeRef, StructType, Type, VTableView, ValueVTable};
+use crate::{
+    Def, Facet, Field, FieldFlags, Shape, ShapeRef, StructType, Type, VTableView, ValueVTable,
+};
 use core::mem;
 
 unsafe impl<'a, Idx: Facet<'a>> Facet<'a> for core::ops::Range<Idx> {
@@ -41,6 +43,9 @@ unsafe impl<'a, Idx: Facet<'a>> Facet<'a> for core::ops::Range<Idx> {
                             name: "start",
                             shape: ShapeRef::Static(Idx::SHAPE),
                             offset: mem::offset_of!(core::ops::Range<Idx>, start),
+                            flags: FieldFlags::empty(),
+                            rename: None,
+                            alias: None,
                             attributes: &[],
                             doc: &[],
                         },
@@ -48,6 +53,9 @@ unsafe impl<'a, Idx: Facet<'a>> Facet<'a> for core::ops::Range<Idx> {
                             name: "end",
                             shape: ShapeRef::Static(Idx::SHAPE),
                             offset: mem::offset_of!(core::ops::Range<Idx>, end),
+                            flags: FieldFlags::empty(),
+                            rename: None,
+                            alias: None,
                             attributes: &[],
                             doc: &[],
                         },

--- a/facet-core/src/impls_core/option.rs
+++ b/facet-core/src/impls_core/option.rs
@@ -1,10 +1,10 @@
 use core::{cmp::Ordering, hash::Hash, mem::MaybeUninit, ptr::NonNull};
 
 use crate::{
-    Def, EnumRepr, EnumType, Facet, Field, OptionDef, OptionVTable, PtrConst, PtrMut, PtrUninit,
-    Repr, Shape, ShapeBuilder, ShapeRef, StructKind, StructType, TryBorrowInnerError, TryFromError,
-    TryIntoInnerError, Type, TypeParam, TypedPtrUninit, UserType, VTableView, Variant, shape_util,
-    value_vtable,
+    Def, EnumRepr, EnumType, Facet, Field, FieldFlags, OptionDef, OptionVTable, PtrConst, PtrMut,
+    PtrUninit, Repr, Shape, ShapeBuilder, ShapeRef, StructKind, StructType, TryBorrowInnerError,
+    TryFromError, TryIntoInnerError, Type, TypeParam, TypedPtrUninit, UserType, VTableView,
+    Variant, shape_util, value_vtable,
 };
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for Option<T> {
     const SHAPE: &'static Shape = &const {
@@ -224,6 +224,9 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Option<T> {
                                             name: "0",
                                             shape: ShapeRef::Static(T::SHAPE),
                                             offset: 0,
+                                            flags: FieldFlags::empty(),
+                                            rename: None,
+                                            alias: None,
                                             attributes: &[],
                                             doc: &[],
                                         }]

--- a/facet-core/src/impls_core/scalar.rs
+++ b/facet-core/src/impls_core/scalar.rs
@@ -394,6 +394,9 @@ macro_rules! impl_facet_for_nonzero {
                                 name: "0",
                                 shape: ShapeRef::Static(<$type>::SHAPE),
                                 offset: 0,
+                                flags: FieldFlags::empty(),
+                                rename: None,
+                                alias: None,
                                 attributes: &[],
                                 doc: &[],
                             }]

--- a/facet-core/src/impls_num_complex.rs
+++ b/facet-core/src/impls_num_complex.rs
@@ -127,20 +127,28 @@ unsafe impl<'facet, T: Facet<'facet>> Facet<'facet> for Complex<T> {
 }
 
 const fn complex_fields<'facet, T: Facet<'facet>>() -> &'static [Field; 2] {
-    &[
-        Field {
-            name: "re",
-            shape: ShapeRef::Static(T::SHAPE),
-            offset: offset_of!(Complex<T>, re),
-            attributes: &[],
-            doc: &["Real portion of the complex number"],
-        },
-        Field {
-            name: "im",
-            shape: ShapeRef::Static(T::SHAPE),
-            offset: offset_of!(Complex<T>, im),
-            attributes: &[],
-            doc: &["Imaginary portion of the complex number"],
-        },
-    ]
+    &const {
+        [
+            Field {
+                name: "re",
+                shape: ShapeRef::Static(T::SHAPE),
+                offset: offset_of!(Complex<T>, re),
+                flags: FieldFlags::empty(),
+                rename: None,
+                alias: None,
+                attributes: &[],
+                doc: &["Real portion of the complex number"],
+            },
+            Field {
+                name: "im",
+                shape: ShapeRef::Static(T::SHAPE),
+                offset: offset_of!(Complex<T>, im),
+                flags: FieldFlags::empty(),
+                rename: None,
+                alias: None,
+                attributes: &[],
+                doc: &["Imaginary portion of the complex number"],
+            },
+        ]
+    }
 }

--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -150,6 +150,7 @@ pub mod 𝟋 {
     pub use crate::EnumType as 𝟋ETy;
     pub use crate::Facet as 𝟋Fct;
     pub use crate::Field as 𝟋Fld;
+    pub use crate::FieldFlags as 𝟋FF;
     pub use crate::MarkerTraits as 𝟋Mt;
     pub use crate::Repr as 𝟋Repr;
     pub use crate::Shape as 𝟋Shp;
@@ -184,6 +185,8 @@ pub mod 𝟋 {
     pub const 𝟋NOAT: &[crate::FieldAttribute] = &[];
     /// Empty doc slice
     pub const 𝟋NODOC: &[&str] = &[];
+    /// Empty flags
+    pub const 𝟋NOFL: crate::FieldFlags = crate::FieldFlags::empty();
 
     // === Type Aliases ===
     /// PhantomData type for shadow structs, invariant in lifetime `'a`.

--- a/facet-core/src/types/ty/bitflags.rs
+++ b/facet-core/src/types/ty/bitflags.rs
@@ -1,0 +1,180 @@
+//! A simple bitflags macro for defining flag types.
+//!
+//! This provides a lightweight alternative to the `bitflags` crate,
+//! generating a struct with associated constants and bitwise operations.
+
+/// Defines a bitflags struct with the given flags.
+///
+/// # Example
+///
+/// ```ignore
+/// bitflags! {
+///     /// Documentation for the flags struct
+///     pub struct MyFlags: u32 {
+///         /// First flag
+///         const FLAG_A = 1 << 0;
+///         /// Second flag
+///         const FLAG_B = 1 << 1;
+///     }
+/// }
+/// ```
+///
+/// This generates:
+/// - A struct `MyFlags(u32)` with `Copy`, `Clone`, `Debug`, `Default`, `PartialEq`, `Eq`, `Hash`
+/// - Associated constants `MyFlags::FLAG_A`, `MyFlags::FLAG_B`, etc.
+/// - An `empty()` constructor
+/// - `contains(&self, other: Self) -> bool`
+/// - `insert(&mut self, other: Self)`
+/// - `remove(&mut self, other: Self)`
+/// - `is_empty(&self) -> bool`
+/// - Bitwise operators: `|`, `&`, `^`, `!`, `|=`, `&=`, `^=`
+#[macro_export]
+macro_rules! bitflags {
+    (
+        $(#[$outer:meta])*
+        $vis:vis struct $Name:ident : $T:ty {
+            $(
+                $(#[$inner:meta])*
+                const $FLAG:ident = $value:expr;
+            )*
+        }
+    ) => {
+        $(#[$outer])*
+        #[derive(Copy, Clone, Default, PartialEq, Eq, Hash)]
+        #[repr(transparent)]
+        $vis struct $Name($T);
+
+        impl $Name {
+            $(
+                $(#[$inner])*
+                pub const $FLAG: Self = Self($value);
+            )*
+
+            /// An empty set of flags.
+            #[inline]
+            pub const fn empty() -> Self {
+                Self(0)
+            }
+
+            /// Returns `true` if no flags are set.
+            #[inline]
+            pub const fn is_empty(self) -> bool {
+                self.0 == 0
+            }
+
+            /// Returns `true` if all flags in `other` are contained in `self`.
+            #[inline]
+            pub const fn contains(self, other: Self) -> bool {
+                (self.0 & other.0) == other.0
+            }
+
+            /// Inserts the flags in `other` into `self`.
+            #[inline]
+            pub fn insert(&mut self, other: Self) {
+                self.0 |= other.0;
+            }
+
+            /// Removes the flags in `other` from `self`.
+            #[inline]
+            pub fn remove(&mut self, other: Self) {
+                self.0 &= !other.0;
+            }
+
+            /// Returns the union of `self` and `other`.
+            #[inline]
+            pub const fn union(self, other: Self) -> Self {
+                Self(self.0 | other.0)
+            }
+
+            /// Returns the intersection of `self` and `other`.
+            #[inline]
+            pub const fn intersection(self, other: Self) -> Self {
+                Self(self.0 & other.0)
+            }
+
+            /// Returns the raw bits.
+            #[inline]
+            pub const fn bits(self) -> $T {
+                self.0
+            }
+
+            /// Creates from raw bits (unchecked).
+            #[inline]
+            pub const fn from_bits_retain(bits: $T) -> Self {
+                Self(bits)
+            }
+        }
+
+        impl ::core::fmt::Debug for $Name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                let mut first = true;
+                $(
+                    if self.contains(Self::$FLAG) {
+                        if !first {
+                            write!(f, " | ")?;
+                        }
+                        write!(f, stringify!($FLAG))?;
+                        first = false;
+                    }
+                )*
+                if first {
+                    write!(f, "(empty)")?;
+                }
+                Ok(())
+            }
+        }
+
+        impl ::core::ops::BitOr for $Name {
+            type Output = Self;
+            #[inline]
+            fn bitor(self, rhs: Self) -> Self {
+                Self(self.0 | rhs.0)
+            }
+        }
+
+        impl ::core::ops::BitOrAssign for $Name {
+            #[inline]
+            fn bitor_assign(&mut self, rhs: Self) {
+                self.0 |= rhs.0;
+            }
+        }
+
+        impl ::core::ops::BitAnd for $Name {
+            type Output = Self;
+            #[inline]
+            fn bitand(self, rhs: Self) -> Self {
+                Self(self.0 & rhs.0)
+            }
+        }
+
+        impl ::core::ops::BitAndAssign for $Name {
+            #[inline]
+            fn bitand_assign(&mut self, rhs: Self) {
+                self.0 &= rhs.0;
+            }
+        }
+
+        impl ::core::ops::BitXor for $Name {
+            type Output = Self;
+            #[inline]
+            fn bitxor(self, rhs: Self) -> Self {
+                Self(self.0 ^ rhs.0)
+            }
+        }
+
+        impl ::core::ops::BitXorAssign for $Name {
+            #[inline]
+            fn bitxor_assign(&mut self, rhs: Self) {
+                self.0 ^= rhs.0;
+            }
+        }
+
+        impl ::core::ops::Not for $Name {
+            type Output = Self;
+            #[inline]
+            fn not(self) -> Self {
+                Self(!self.0)
+            }
+        }
+    };
+}

--- a/facet-core/src/types/ty/mod.rs
+++ b/facet-core/src/types/ty/mod.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+mod bitflags;
+
 mod field;
 pub use field::*;
 

--- a/facet-reflect/src/spanned.rs
+++ b/facet-reflect/src/spanned.rs
@@ -3,7 +3,8 @@
 use core::{mem, ops::Deref};
 
 use facet_core::{
-    Def, Facet, Field, Shape, ShapeRef, StructType, Type, TypeParam, UserType, ValueVTable,
+    Def, Facet, Field, FieldFlags, Shape, ShapeRef, StructType, Type, TypeParam, UserType,
+    ValueVTable,
 };
 
 /// Source span with offset and length.
@@ -77,6 +78,9 @@ unsafe impl Facet<'_> for Span {
                         name: "offset",
                         shape: ShapeRef::Static(<usize as Facet>::SHAPE),
                         offset: mem::offset_of!(Span, offset),
+                        flags: FieldFlags::empty(),
+                        rename: None,
+                        alias: None,
                         attributes: &[],
                         doc: &[],
                     },
@@ -84,6 +88,9 @@ unsafe impl Facet<'_> for Span {
                         name: "len",
                         shape: ShapeRef::Static(<usize as Facet>::SHAPE),
                         offset: mem::offset_of!(Span, len),
+                        flags: FieldFlags::empty(),
+                        rename: None,
+                        alias: None,
                         attributes: &[],
                         doc: &[],
                     },
@@ -202,6 +209,9 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Spanned<T> {
                         name: "value",
                         shape: ShapeRef::Static(T::SHAPE),
                         offset: mem::offset_of!(Spanned<T>, value),
+                        flags: FieldFlags::empty(),
+                        rename: None,
+                        alias: None,
                         attributes: &[],
                         doc: &[],
                     },
@@ -209,6 +219,9 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Spanned<T> {
                         name: "span",
                         shape: ShapeRef::Static(Span::SHAPE),
                         offset: mem::offset_of!(Spanned<T>, span),
+                        flags: FieldFlags::empty(),
+                        rename: None,
+                        alias: None,
                         attributes: &[],
                         doc: &[],
                     },


### PR DESCRIPTION
## Summary

This PR adds infrastructure for O(1) attribute lookup on `Field`, addressing #1130.

- Adds a custom `bitflags!` macro in `facet-core` (no external dependency)
- Introduces `FieldFlags` bitfield for boolean attributes: `SENSITIVE`, `FLATTEN`, `SKIP`, `SKIP_SERIALIZING`, `SKIP_DESERIALIZING`, `CHILD`, `RECURSIVE_TYPE`, `HAS_DEFAULT`
- Adds dedicated `rename` and `alias` fields to `Field` struct
- Extends `FieldBuilder` with `.flags()`, `.rename()`, `.alias()` methods
- Adds `#[storage(flag)]` and `#[storage(field)]` annotations to the grammar DSL
- Updates derive macro to route builtin attrs to appropriate storage (flags/fields vs attributes slice)
- Accessor methods like `is_sensitive()`, `should_skip()`, `rename()` now use O(1) flag/field checks

## Test plan

- [x] All 2041 tests pass
- [x] Clippy passes
- [x] Format check passes