### PR TITLE
feat(facet-json): add JIT-compiled JSON deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +111,12 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "ariadne"
@@ -251,6 +263,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -392,6 +410,9 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "byteorder"
@@ -540,6 +561,178 @@ dependencies = [
  "scopeguard",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "cranelift"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b254417719b76aa89d44d0c6d079642ae6598e83a606a49d0451a1554555416"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-module",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c088d3406f0c0252efa7445adfd2d05736bfb5218838f64eaf79d567077aed14"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c03f887a763abb9c1dc08f722aa82b69067fda623b6f0273050f45f8b1a6776"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206887a11a43f507fee320a218dc365980bfc42ec2696792079a9f8c9369e90"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0790c83cfdab95709c5d0105fd888221e3af9049a7d7ec376ec901ab4e4dba"
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a98aed2d262eda69310e84bae8e053ee4f17dbdd3347b8d9156aa618ba2de0a"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.15.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6906852826988563e9b0a9232ad951f53a47aa41ffd02f8ac852d3f41aae836a"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a50105aab667b5cc845f2be37c78475d7cc127cd8ec0a31f7b2b71d526099a7"
+
+[[package]]
+name = "cranelift-control"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6adcc7aa7c0bc1727176a6f2d99c28a9e79a541ccd5ca911a0cb352da8befa36"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "981b56af777f9a34ea6dcce93255125776d391410c2a68b75bed5941b714fa15"
+dependencies = [
+ "cranelift-bitset",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea982589684dfb71afecb9fc09555c3a266300a1162a60d7fa39d41a5705b1c"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0422686b22ed6a1f33cc40e3c43eb84b67155788568d1a5cac8439d3dca1783"
+
+[[package]]
+name = "cranelift-jit"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed75b45f61f344d9b5d844637ae59a3c0062b837c718571c9beb5a4a81c56dd9"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-module",
+ "cranelift-native",
+ "libc",
+ "log",
+ "region",
+ "target-lexicon",
+ "wasmtime-internal-jit-icache-coherence",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "cranelift-module"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ffd7454a844814b2a49632a5d74a006ad1b01d9983a9697ae070dea4b878a5"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f697bbbe135c655ea1deb7af0bae4a5c4fae2c88fdfc0fa57b34ae58c91040"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718efe674f3df645462677e22a3128e890d88ba55821bb091083d257707be76c"
 
 [[package]]
 name = "crc32fast"
@@ -740,7 +933,7 @@ name = "facet-core"
 version = "0.31.8"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "camino",
  "chrono",
@@ -799,6 +992,10 @@ dependencies = [
  "cargo-husky",
  "chrono",
  "corosensei",
+ "cranelift",
+ "cranelift-jit",
+ "cranelift-module",
+ "cranelift-native",
  "divan",
  "facet",
  "facet-core",
@@ -818,10 +1015,12 @@ dependencies = [
  "lexical-parse-float",
  "lexical-parse-integer",
  "log",
+ "memchr",
  "miette",
  "mime",
  "ordered-float",
  "owo-colors",
+ "parking_lot",
  "ryu",
  "serde",
  "serde_json",
@@ -953,7 +1152,7 @@ dependencies = [
 name = "facet-shapelike"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "facet",
  "facet-args",
  "facet-assert",
@@ -1146,6 +1345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1454,11 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "hash32"
@@ -1258,6 +1468,12 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hashbrown"
@@ -1531,7 +1747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1687,6 +1903,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +1940,15 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -1931,7 +2162,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1961,6 +2192,29 @@ name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "paste"
@@ -2090,7 +2344,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -2218,6 +2472,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e249c660440317032a71ddac302f25f1d5dff387667bcc3978d1f77aa31ac34"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2516,18 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rmp"
@@ -2313,7 +2602,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2618,6 +2907,12 @@ dependencies = [
  "walkdir",
  "yaml-rust",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tempfile"
@@ -3059,6 +3354,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb8e042b6e3de2f3d708279f89f50b4b9aa1b9bab177300cdffb0ffcd2816df5"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1f0674f38cd7d014eb1a49ea1d1766cca1a64459e8856ee118a10005302e16"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3134,6 +3450,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -21,6 +21,8 @@ tokio = ["std", "dep:tokio", "streaming"]
 futures-io = ["std", "dep:futures-io", "streaming"]
 streaming = ["std", "dep:corosensei"]
 bolero-inline-tests = ["std"]
+# JIT-compiled JSON deserialization using Cranelift
+cranelift = ["std", "dep:cranelift", "dep:cranelift-jit", "dep:cranelift-module", "dep:cranelift-native", "dep:parking_lot", "dep:memchr"]
 
 [dependencies]
 facet = { path = "../facet", default-features = false }
@@ -52,6 +54,14 @@ futures-io = { version = "0.3", optional = true }
 
 # Stackful coroutines for streaming deserialization
 corosensei = { version = "0.3", optional = true }
+
+# JIT compilation dependencies (optional)
+cranelift = { version = "0.125", optional = true }
+cranelift-jit = { version = "0.125", optional = true }
+cranelift-module = { version = "0.125", optional = true }
+cranelift-native = { version = "0.125", optional = true }
+parking_lot = { version = "0.12", optional = true }
+memchr = { version = "2.7", optional = true }
 
 [dev-dependencies]
 bolero = "0.11"

--- a/facet-json/src/cranelift/cache.rs
+++ b/facet-json/src/cranelift/cache.rs
@@ -1,0 +1,66 @@
+//! TypeId -> compiled function cache
+
+use facet_core::Shape;
+use parking_lot::RwLock;
+use std::any::TypeId;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use super::compiler::CompiledDeserializer;
+
+static CACHE: LazyLock<RwLock<HashMap<TypeId, CompiledDeserializer>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+// Wrapper for Shape pointer to implement Send/Sync
+// Safety: Shape pointers are always to 'static data
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct ShapePtr(*const Shape);
+unsafe impl Send for ShapePtr {}
+unsafe impl Sync for ShapePtr {}
+
+// Cache by Shape pointer for nested struct lookups
+static SHAPE_CACHE: LazyLock<RwLock<HashMap<ShapePtr, CompiledDeserializer>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Cache for JIT-compiled deserializers.
+pub struct JitCache;
+
+impl JitCache {
+    /// Clear all cached deserializers.
+    /// Useful for benchmarking or if you need to force recompilation.
+    pub fn clear() {
+        CACHE.write().clear();
+    }
+
+    /// Number of cached deserializers.
+    pub fn len() -> usize {
+        CACHE.read().len()
+    }
+
+    /// Check if cache is empty.
+    pub fn is_empty() -> bool {
+        CACHE.read().is_empty()
+    }
+}
+
+pub(super) fn get(type_id: TypeId) -> Option<CompiledDeserializer> {
+    CACHE.read().get(&type_id).copied()
+}
+
+pub(super) fn insert(type_id: TypeId, func: CompiledDeserializer) {
+    CACHE.write().insert(type_id, func);
+}
+
+// Shape-keyed cache functions for nested struct lookups
+pub(super) fn get_by_shape(shape: &'static Shape) -> Option<CompiledDeserializer> {
+    SHAPE_CACHE
+        .read()
+        .get(&ShapePtr(shape as *const Shape))
+        .copied()
+}
+
+pub(super) fn insert_by_shape(shape: &'static Shape, func: CompiledDeserializer) {
+    SHAPE_CACHE
+        .write()
+        .insert(ShapePtr(shape as *const Shape), func);
+}

--- a/facet-json/src/cranelift/compiler.rs
+++ b/facet-json/src/cranelift/compiler.rs
@@ -1,0 +1,1106 @@
+//! Cranelift-based JIT compiler for JSON deserializers.
+//!
+//! Generated functions have signature:
+//!   fn(input: *const u8, len: usize, pos: usize, out: *mut u8) -> isize
+//!
+//! Return value >= 0 means success (new position), < 0 means error code.
+//! The `pos` parameter is kept in a register throughout execution.
+
+use crate::JsonError;
+use cranelift::prelude::*;
+use cranelift_jit::{JITBuilder, JITModule};
+use cranelift_module::{Linkage, Module};
+use facet_core::{Def, NumericType, PrimitiveType, Shape, Type as FacetType, UserType};
+use std::collections::HashMap;
+
+use super::helpers;
+
+// =============================================================================
+// Prefix Trie for field name dispatch
+// =============================================================================
+
+/// A node in the field name trie.
+#[derive(Debug, Clone)]
+enum TrieNode {
+    Branch {
+        children: HashMap<u8, TrieNode>,
+        terminal: Option<usize>,
+    },
+    Leaf(usize),
+}
+
+impl TrieNode {
+    fn new_branch() -> Self {
+        TrieNode::Branch {
+            children: HashMap::new(),
+            terminal: None,
+        }
+    }
+
+    fn insert(&mut self, name: &[u8], field_index: usize) {
+        match self {
+            TrieNode::Branch { children, terminal } => {
+                if name.is_empty() {
+                    *terminal = Some(field_index);
+                } else {
+                    let first = name[0];
+                    let rest = &name[1..];
+                    let child = children.entry(first).or_insert_with(TrieNode::new_branch);
+                    child.insert(rest, field_index);
+                }
+            }
+            TrieNode::Leaf(_) => panic!("Duplicate field name prefix"),
+        }
+    }
+
+    fn optimize(&mut self) {
+        if let TrieNode::Branch { children, terminal } = self {
+            for child in children.values_mut() {
+                child.optimize();
+            }
+            if children.is_empty() {
+                if let Some(idx) = *terminal {
+                    *self = TrieNode::Leaf(idx);
+                }
+            }
+        }
+    }
+}
+
+fn build_field_trie(fields: &[FieldInfo]) -> TrieNode {
+    let mut root = TrieNode::new_branch();
+    for (i, field) in fields.iter().enumerate() {
+        root.insert(field.name.as_bytes(), i);
+    }
+    root.optimize();
+    root
+}
+
+// =============================================================================
+// Field info and parser types
+// =============================================================================
+
+struct FieldInfo {
+    name: &'static str,
+    offset: usize,
+    parser: FieldParser,
+}
+
+#[derive(Clone, Copy)]
+enum FieldParser {
+    F64,
+    F32,
+    I64,
+    I32,
+    I16,
+    I8,
+    U64,
+    U32,
+    U16,
+    U8,
+    Bool,
+    String,
+    VecF64,
+    VecI64,
+    VecU64,
+    VecVecF64,
+    VecVecVecF64,
+    VecStruct(&'static Shape),
+    NestedStruct(&'static Shape),
+    Skip,
+}
+
+fn extract_fields(shape: &'static Shape) -> Vec<FieldInfo> {
+    let mut fields = Vec::new();
+
+    let FacetType::User(UserType::Struct(struct_def)) = &shape.ty else {
+        return fields;
+    };
+
+    for field in struct_def.fields {
+        let name = field.name;
+        let offset = field.offset;
+        let field_shape = field.shape.get();
+
+        let field_size = field_shape
+            .layout
+            .sized_layout()
+            .map(|l| l.size())
+            .unwrap_or(0);
+
+        let parser = match &field_shape.ty {
+            FacetType::Primitive(PrimitiveType::Numeric(NumericType::Float)) => match field_size {
+                4 => FieldParser::F32,
+                8 => FieldParser::F64,
+                _ => FieldParser::Skip,
+            },
+            FacetType::Primitive(PrimitiveType::Numeric(NumericType::Integer { signed: true })) => {
+                match field_size {
+                    1 => FieldParser::I8,
+                    2 => FieldParser::I16,
+                    4 => FieldParser::I32,
+                    8 => FieldParser::I64,
+                    _ => FieldParser::Skip,
+                }
+            }
+            FacetType::Primitive(PrimitiveType::Numeric(NumericType::Integer {
+                signed: false,
+            })) => match field_size {
+                1 => FieldParser::U8,
+                2 => FieldParser::U16,
+                4 => FieldParser::U32,
+                8 => FieldParser::U64,
+                _ => FieldParser::Skip,
+            },
+            FacetType::Primitive(PrimitiveType::Boolean) => FieldParser::Bool,
+            // Check for String (Opaque type with "String" identifier)
+            FacetType::User(UserType::Opaque) if field_shape.type_identifier == "String" => {
+                FieldParser::String
+            }
+            // Check for nested struct
+            FacetType::User(UserType::Struct(_)) => FieldParser::NestedStruct(field_shape),
+            _ => {
+                // Check for Vec types (List)
+                if let Def::List(list_def) = field_shape.def {
+                    let elem_shape = list_def.t();
+                    // Check for Vec<f64>
+                    if matches!(
+                        elem_shape.ty,
+                        FacetType::Primitive(PrimitiveType::Numeric(NumericType::Float))
+                    ) {
+                        FieldParser::VecF64
+                    }
+                    // Check for Vec<i64> or Vec<u64>
+                    else if let FacetType::Primitive(PrimitiveType::Numeric(
+                        NumericType::Integer { signed },
+                    )) = elem_shape.ty
+                    {
+                        // Check element size from layout
+                        let elem_size = elem_shape
+                            .layout
+                            .sized_layout()
+                            .map(|l| l.size())
+                            .unwrap_or(0);
+                        if elem_size == 8 {
+                            if signed {
+                                FieldParser::VecI64
+                            } else {
+                                FieldParser::VecU64
+                            }
+                        } else {
+                            // For now, skip other integer sizes
+                            FieldParser::Skip
+                        }
+                    }
+                    // Check for Vec<Vec<...>>
+                    else if let Def::List(inner_list) = elem_shape.def {
+                        let inner_elem = inner_list.t();
+                        // Vec<Vec<f64>>
+                        if matches!(
+                            inner_elem.ty,
+                            FacetType::Primitive(PrimitiveType::Numeric(NumericType::Float))
+                        ) {
+                            FieldParser::VecVecF64
+                        }
+                        // Check for Vec<Vec<Vec<f64>>>
+                        else if let Def::List(innermost_list) = inner_elem.def {
+                            let innermost_elem = innermost_list.t();
+                            if matches!(
+                                innermost_elem.ty,
+                                FacetType::Primitive(PrimitiveType::Numeric(NumericType::Float))
+                            ) {
+                                FieldParser::VecVecVecF64
+                            } else {
+                                FieldParser::Skip
+                            }
+                        } else {
+                            FieldParser::Skip
+                        }
+                    }
+                    // Check for Vec<Struct>
+                    else if matches!(elem_shape.ty, FacetType::User(UserType::Struct(_))) {
+                        FieldParser::VecStruct(elem_shape)
+                    } else {
+                        FieldParser::Skip
+                    }
+                } else {
+                    FieldParser::Skip
+                }
+            }
+        };
+
+        fields.push(FieldInfo {
+            name,
+            offset,
+            parser,
+        });
+    }
+
+    fields
+}
+
+// =============================================================================
+// Compiled deserializer
+// =============================================================================
+
+/// A compiled deserializer function pointer.
+#[derive(Clone, Copy)]
+pub struct CompiledDeserializer {
+    ptr: *const u8,
+}
+
+unsafe impl Send for CompiledDeserializer {}
+unsafe impl Sync for CompiledDeserializer {}
+
+impl CompiledDeserializer {
+    /// Get the raw function pointer.
+    pub fn ptr(&self) -> *const u8 {
+        self.ptr
+    }
+
+    /// Call the compiled deserializer.
+    ///
+    /// # Safety
+    /// The caller must ensure T matches the type this deserializer was compiled for.
+    pub unsafe fn call<T>(&self, input: &str) -> Result<T, JsonError> {
+        let mut output = std::mem::MaybeUninit::<T>::uninit();
+
+        // New signature: fn(input, len, pos, out) -> isize
+        let func: unsafe extern "C" fn(*const u8, usize, usize, *mut u8) -> isize =
+            std::mem::transmute(self.ptr);
+
+        let result = func(
+            input.as_ptr(),
+            input.len(),
+            0,
+            output.as_mut_ptr() as *mut u8,
+        );
+
+        if result >= 0 {
+            Ok(output.assume_init())
+        } else {
+            Err(error_from_code(result))
+        }
+    }
+}
+
+fn error_from_code(code: isize) -> JsonError {
+    use super::helpers::*;
+    let msg = match code {
+        ERR_UNEXPECTED_EOF => "unexpected end of input",
+        ERR_EXPECTED_COLON => "expected ':'",
+        ERR_EXPECTED_COMMA_OR_END => "expected ',' or closing bracket",
+        ERR_EXPECTED_OBJECT_START => "expected '{'",
+        ERR_EXPECTED_ARRAY_START => "expected '['",
+        ERR_INVALID_NUMBER => "invalid number",
+        ERR_INVALID_STRING => "invalid string",
+        ERR_INVALID_BOOL => "invalid boolean",
+        _ => "unknown error",
+    };
+    crate::from_str::<()>(msg).unwrap_err()
+}
+
+// Global compiler instance
+use parking_lot::Mutex;
+use std::sync::LazyLock;
+
+static COMPILER: LazyLock<Mutex<JitCompiler>> = LazyLock::new(|| Mutex::new(JitCompiler::new()));
+
+/// Try to compile a deserializer for the given shape.
+/// Returns None if the shape is not supported.
+pub fn try_compile(shape: &'static Shape) -> Option<CompiledDeserializer> {
+    // Check if it's a struct
+    let FacetType::User(UserType::Struct(_)) = &shape.ty else {
+        return None;
+    };
+
+    let mut compiler = COMPILER.lock();
+    Some(compiler.compile(shape))
+}
+
+/// Get or compile a deserializer for the given shape.
+/// This is used for nested struct compilation from within JitCompiler::compile.
+/// IMPORTANT: This must be called while holding the COMPILER lock, so it
+/// accesses the compiler directly without re-acquiring the lock.
+fn get_or_compile_for_shape_locked(compiler: &mut JitCompiler, shape: &'static Shape) -> *const u8 {
+    // Check shape cache first
+    if let Some(func) = super::cache::get_by_shape(shape) {
+        return func.ptr();
+    }
+
+    // Compile it directly using the already-locked compiler
+    let func = compiler.compile(shape);
+    super::cache::insert_by_shape(shape, func);
+    func.ptr()
+}
+
+// =============================================================================
+// JIT Compiler
+// =============================================================================
+
+/// The JIT compiler for JSON deserializers.
+pub struct JitCompiler {
+    module: JITModule,
+    helper_funcs: HashMap<&'static str, cranelift_module::FuncId>,
+}
+
+impl JitCompiler {
+    /// Create a new JIT compiler.
+    pub fn new() -> Self {
+        let mut flag_builder = settings::builder();
+        // Try speed_and_size - may generate slightly smaller code with similar perf
+        let opt_level = std::env::var("JITSON_OPT").unwrap_or_else(|_| "speed".to_string());
+        flag_builder.set("opt_level", &opt_level).unwrap();
+        let isa_builder = cranelift_native::builder().unwrap();
+        let isa = isa_builder
+            .finish(settings::Flags::new(flag_builder))
+            .unwrap();
+
+        let mut builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
+        helpers::register_helpers(&mut builder);
+
+        let module = JITModule::new(builder);
+
+        Self {
+            module,
+            helper_funcs: HashMap::new(),
+        }
+    }
+
+    /// Compile a deserializer for the given shape.
+    pub fn compile(&mut self, shape: &'static Shape) -> CompiledDeserializer {
+        let fields = extract_fields(shape);
+        let trie = build_field_trie(&fields);
+
+        // Pre-compile all nested structs to avoid deadlock
+        // (we can't call get_or_compile while holding &mut self in the builder loop)
+        let mut nested_func_ptrs: HashMap<*const Shape, *const u8> = HashMap::new();
+        for field in &fields {
+            match field.parser {
+                FieldParser::NestedStruct(nested_shape) => {
+                    let ptr = nested_shape as *const Shape;
+                    nested_func_ptrs
+                        .entry(ptr)
+                        .or_insert_with(|| get_or_compile_for_shape_locked(self, nested_shape));
+                }
+                FieldParser::VecStruct(elem_shape) => {
+                    let ptr = elem_shape as *const Shape;
+                    nested_func_ptrs
+                        .entry(ptr)
+                        .or_insert_with(|| get_or_compile_for_shape_locked(self, elem_shape));
+                }
+                _ => {}
+            }
+        }
+
+        let ptr_type = self.module.target_config().pointer_type();
+
+        // Function signature: fn(input: ptr, len: usize, pos: usize, out: ptr) -> isize
+        let mut sig = self.module.make_signature();
+        sig.params.push(AbiParam::new(ptr_type)); // input
+        sig.params.push(AbiParam::new(ptr_type)); // len
+        sig.params.push(AbiParam::new(ptr_type)); // pos
+        sig.params.push(AbiParam::new(ptr_type)); // out
+        sig.returns.push(AbiParam::new(ptr_type)); // new_pos or error
+
+        // Declare helper function signatures
+        // All helpers now: fn(input, len, pos, out) -> isize  (or fn(input, len, pos) -> isize for skip)
+        let sig_parse_value = {
+            let mut s = self.module.make_signature();
+            s.params.push(AbiParam::new(ptr_type)); // input
+            s.params.push(AbiParam::new(ptr_type)); // len
+            s.params.push(AbiParam::new(ptr_type)); // pos
+            s.params.push(AbiParam::new(ptr_type)); // out
+            s.returns.push(AbiParam::new(ptr_type)); // new_pos or error
+            s
+        };
+
+        let sig_skip_value = {
+            let mut s = self.module.make_signature();
+            s.params.push(AbiParam::new(ptr_type)); // input
+            s.params.push(AbiParam::new(ptr_type)); // len
+            s.params.push(AbiParam::new(ptr_type)); // pos
+            s.returns.push(AbiParam::new(ptr_type)); // new_pos or error
+            s
+        };
+
+        let sig_nested_struct = {
+            let mut s = self.module.make_signature();
+            s.params.push(AbiParam::new(ptr_type)); // input
+            s.params.push(AbiParam::new(ptr_type)); // len
+            s.params.push(AbiParam::new(ptr_type)); // pos
+            s.params.push(AbiParam::new(ptr_type)); // out
+            s.params.push(AbiParam::new(ptr_type)); // func_ptr
+            s.returns.push(AbiParam::new(ptr_type));
+            s
+        };
+
+        let sig_vec_struct = {
+            let mut s = self.module.make_signature();
+            s.params.push(AbiParam::new(ptr_type)); // input
+            s.params.push(AbiParam::new(ptr_type)); // len
+            s.params.push(AbiParam::new(ptr_type)); // pos
+            s.params.push(AbiParam::new(ptr_type)); // out
+            s.params.push(AbiParam::new(ptr_type)); // elem_size
+            s.params.push(AbiParam::new(ptr_type)); // elem_align
+            s.params.push(AbiParam::new(ptr_type)); // func_ptr
+            s.returns.push(AbiParam::new(ptr_type));
+            s
+        };
+
+        // Declare all helpers we need
+        let helpers_to_declare = [
+            ("jitson_parse_f64", sig_parse_value.clone()),
+            ("jitson_parse_f32", sig_parse_value.clone()),
+            ("jitson_parse_i64", sig_parse_value.clone()),
+            ("jitson_parse_i32", sig_parse_value.clone()),
+            ("jitson_parse_i16", sig_parse_value.clone()),
+            ("jitson_parse_i8", sig_parse_value.clone()),
+            ("jitson_parse_u64", sig_parse_value.clone()),
+            ("jitson_parse_u32", sig_parse_value.clone()),
+            ("jitson_parse_u16", sig_parse_value.clone()),
+            ("jitson_parse_u8", sig_parse_value.clone()),
+            ("jitson_parse_bool", sig_parse_value.clone()),
+            ("jitson_parse_string", sig_parse_value.clone()),
+            ("jitson_parse_vec_f64", sig_parse_value.clone()),
+            ("jitson_parse_vec_i64", sig_parse_value.clone()),
+            ("jitson_parse_vec_u64", sig_parse_value.clone()),
+            ("jitson_parse_vec_vec_f64", sig_parse_value.clone()),
+            ("jitson_parse_vec_vec_vec_f64", sig_parse_value.clone()),
+            ("jitson_skip_value", sig_skip_value.clone()),
+            ("jitson_parse_nested_struct", sig_nested_struct.clone()),
+            ("jitson_parse_vec_struct", sig_vec_struct.clone()),
+        ];
+
+        for (name, helper_sig) in &helpers_to_declare {
+            if !self.helper_funcs.contains_key(name) {
+                let func_id = self
+                    .module
+                    .declare_function(name, Linkage::Import, helper_sig)
+                    .unwrap();
+                self.helper_funcs.insert(name, func_id);
+            }
+        }
+
+        // Create the function
+        static COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let func_name = format!(
+            "deserialize_{}",
+            COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+        );
+        let func_id = self
+            .module
+            .declare_function(&func_name, Linkage::Local, &sig)
+            .unwrap();
+
+        let mut ctx = self.module.make_context();
+        ctx.func.signature = sig;
+
+        // Enable disassembly if JITSON_DISASM env var is set
+        let want_disasm = std::env::var("JITSON_DISASM").is_ok();
+        ctx.set_disasm(want_disasm);
+
+        let mut builder_ctx = FunctionBuilderContext::new();
+        let mut builder = FunctionBuilder::new(&mut ctx.func, &mut builder_ctx);
+
+        // Create entry block and get parameters
+        let entry_block = builder.create_block();
+        builder.append_block_params_for_function_params(entry_block);
+        builder.switch_to_block(entry_block);
+        builder.seal_block(entry_block);
+
+        let input_ptr = builder.block_params(entry_block)[0];
+        let len_val = builder.block_params(entry_block)[1];
+        let pos_param = builder.block_params(entry_block)[2];
+        let out_ptr = builder.block_params(entry_block)[3];
+
+        // Create a variable for pos - this is the key optimization!
+        // pos lives in a register, not memory
+        let pos_var = builder.declare_var(ptr_type);
+        builder.def_var(pos_var, pos_param);
+
+        // Create blocks
+        let error_block = builder.create_block();
+        let success_block = builder.create_block();
+        let field_loop = builder.create_block();
+        let after_field = builder.create_block();
+
+        // Import helper functions
+        let skip_value = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_skip_value"], builder.func);
+        let parse_f64 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_f64"], builder.func);
+        let parse_f32 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_f32"], builder.func);
+        let parse_i64 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_i64"], builder.func);
+        let parse_i32 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_i32"], builder.func);
+        let parse_i16 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_i16"], builder.func);
+        let parse_i8 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_i8"], builder.func);
+        let parse_u64 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_u64"], builder.func);
+        let parse_u32 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_u32"], builder.func);
+        let parse_u16 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_u16"], builder.func);
+        let parse_u8 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_u8"], builder.func);
+        let parse_bool = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_bool"], builder.func);
+        let parse_string = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_string"], builder.func);
+        let parse_vec_f64 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_vec_f64"], builder.func);
+        let parse_vec_i64 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_vec_i64"], builder.func);
+        let parse_vec_u64 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_vec_u64"], builder.func);
+        let parse_vec_vec_f64 = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_vec_vec_f64"], builder.func);
+        let parse_vec_vec_vec_f64 = self.module.declare_func_in_func(
+            self.helper_funcs["jitson_parse_vec_vec_vec_f64"],
+            builder.func,
+        );
+        let parse_nested_struct = self.module.declare_func_in_func(
+            self.helper_funcs["jitson_parse_nested_struct"],
+            builder.func,
+        );
+        let parse_vec_struct = self
+            .module
+            .declare_func_in_func(self.helper_funcs["jitson_parse_vec_struct"], builder.func);
+
+        // Skip initial whitespace (inline)
+        Self::emit_skip_ws_inline(&mut builder, input_ptr, len_val, pos_var, ptr_type);
+
+        // Check we have at least one character left
+        let pos = builder.use_var(pos_var);
+        let in_bounds = builder.ins().icmp(IntCC::UnsignedLessThan, pos, len_val);
+        let have_char = builder.create_block();
+        builder
+            .ins()
+            .brif(in_bounds, have_char, &[], error_block, &[]);
+        builder.switch_to_block(have_char);
+
+        // Expect '{'
+        let pos = builder.use_var(pos_var);
+        let char_ptr = builder.ins().iadd(input_ptr, pos);
+        let ch = builder
+            .ins()
+            .load(types::I8, MemFlags::trusted(), char_ptr, 0);
+        let is_brace = builder.ins().icmp_imm(IntCC::Equal, ch, b'{' as i64);
+        let after_brace_check = builder.create_block();
+        builder
+            .ins()
+            .brif(is_brace, after_brace_check, &[], error_block, &[]);
+
+        builder.switch_to_block(after_brace_check);
+        // Advance past '{'
+        let pos = builder.use_var(pos_var);
+        let new_pos = builder.ins().iadd_imm(pos, 1);
+        builder.def_var(pos_var, new_pos);
+
+        // Skip whitespace
+        Self::emit_skip_ws_inline(&mut builder, input_ptr, len_val, pos_var, ptr_type);
+
+        // Check for empty object
+        let pos = builder.use_var(pos_var);
+        let char_ptr = builder.ins().iadd(input_ptr, pos);
+        let ch = builder
+            .ins()
+            .load(types::I8, MemFlags::trusted(), char_ptr, 0);
+        let is_close = builder.ins().icmp_imm(IntCC::Equal, ch, b'}' as i64);
+        let start_fields = builder.create_block();
+        builder
+            .ins()
+            .brif(is_close, success_block, &[], start_fields, &[]);
+
+        // Start field loop
+        builder.switch_to_block(start_fields);
+        builder.ins().jump(field_loop, &[]);
+
+        // Field loop
+        builder.switch_to_block(field_loop);
+
+        // Skip whitespace before field name
+        Self::emit_skip_ws_inline(&mut builder, input_ptr, len_val, pos_var, ptr_type);
+
+        // Expect '"' for field name
+        let pos = builder.use_var(pos_var);
+        let char_ptr = builder.ins().iadd(input_ptr, pos);
+        let ch = builder
+            .ins()
+            .load(types::I8, MemFlags::trusted(), char_ptr, 0);
+        let is_quote = builder.ins().icmp_imm(IntCC::Equal, ch, b'"' as i64);
+        let parse_field_name = builder.create_block();
+        builder
+            .ins()
+            .brif(is_quote, parse_field_name, &[], error_block, &[]);
+
+        builder.switch_to_block(parse_field_name);
+        // Advance past opening quote
+        let pos = builder.use_var(pos_var);
+        let new_pos = builder.ins().iadd_imm(pos, 1);
+        builder.def_var(pos_var, new_pos);
+
+        // Create field blocks
+        let mut field_blocks = Vec::new();
+        for _ in &fields {
+            field_blocks.push(builder.create_block());
+        }
+        let default_block = builder.create_block(); // Unknown field
+        let skip_to_quote_block = builder.create_block();
+        let after_skip_block = builder.create_block();
+
+        // Generate trie dispatch
+        let mut blocks_to_seal = Vec::new();
+        Self::emit_trie_node(
+            &mut builder,
+            input_ptr,
+            pos_var,
+            ptr_type,
+            &trie,
+            &field_blocks,
+            default_block,
+            skip_to_quote_block,
+            error_block,
+            &mut blocks_to_seal,
+        );
+
+        // Generate skip-to-quote loop for partial matches
+        builder.switch_to_block(skip_to_quote_block);
+        let pos = builder.use_var(pos_var);
+        let in_bounds = builder.ins().icmp(IntCC::UnsignedLessThan, pos, len_val);
+        let check_char = builder.create_block();
+        builder
+            .ins()
+            .brif(in_bounds, check_char, &[], error_block, &[]);
+        blocks_to_seal.push(check_char);
+
+        builder.switch_to_block(check_char);
+        let char_ptr = builder.ins().iadd(input_ptr, pos);
+        let ch = builder
+            .ins()
+            .load(types::I8, MemFlags::trusted(), char_ptr, 0);
+        let new_pos = builder.ins().iadd_imm(pos, 1);
+        builder.def_var(pos_var, new_pos);
+        let is_quote = builder.ins().icmp_imm(IntCC::Equal, ch, b'"' as i64);
+        builder
+            .ins()
+            .brif(is_quote, after_skip_block, &[], skip_to_quote_block, &[]);
+
+        builder.switch_to_block(after_skip_block);
+        builder.ins().jump(default_block, &[]);
+
+        // Generate field parsing blocks
+        for (i, field) in fields.iter().enumerate() {
+            builder.switch_to_block(field_blocks[i]);
+
+            // Skip whitespace and expect ':'
+            Self::emit_skip_ws_inline(&mut builder, input_ptr, len_val, pos_var, ptr_type);
+            let pos = builder.use_var(pos_var);
+            let char_ptr = builder.ins().iadd(input_ptr, pos);
+            let ch = builder
+                .ins()
+                .load(types::I8, MemFlags::trusted(), char_ptr, 0);
+            let is_colon = builder.ins().icmp_imm(IntCC::Equal, ch, b':' as i64);
+            let after_colon = builder.create_block();
+            builder
+                .ins()
+                .brif(is_colon, after_colon, &[], error_block, &[]);
+
+            builder.switch_to_block(after_colon);
+            let pos = builder.use_var(pos_var);
+            let new_pos = builder.ins().iadd_imm(pos, 1);
+            builder.def_var(pos_var, new_pos);
+
+            // Skip whitespace before value
+            Self::emit_skip_ws_inline(&mut builder, input_ptr, len_val, pos_var, ptr_type);
+
+            // Calculate field pointer
+            let field_offset = builder.ins().iconst(ptr_type, field.offset as i64);
+            let field_ptr = builder.ins().iadd(out_ptr, field_offset);
+
+            // Call appropriate parser
+            let pos = builder.use_var(pos_var);
+            let call_result = match field.parser {
+                FieldParser::Skip => builder.ins().call(skip_value, &[input_ptr, len_val, pos]),
+                FieldParser::NestedStruct(nested_shape) => {
+                    // Use pre-compiled nested deserializer
+                    let nested_ptr = nested_func_ptrs[&(nested_shape as *const Shape)];
+                    let func_ptr_val = builder.ins().iconst(ptr_type, nested_ptr as i64);
+                    builder.ins().call(
+                        parse_nested_struct,
+                        &[input_ptr, len_val, pos, field_ptr, func_ptr_val],
+                    )
+                }
+                FieldParser::VecStruct(elem_shape) => {
+                    let elem_layout = elem_shape.layout.sized_layout().unwrap();
+                    let elem_size = builder.ins().iconst(ptr_type, elem_layout.size() as i64);
+                    let elem_align = builder.ins().iconst(ptr_type, elem_layout.align() as i64);
+                    // Use pre-compiled nested deserializer
+                    let nested_ptr = nested_func_ptrs[&(elem_shape as *const Shape)];
+                    let func_ptr_val = builder.ins().iconst(ptr_type, nested_ptr as i64);
+                    builder.ins().call(
+                        parse_vec_struct,
+                        &[
+                            input_ptr,
+                            len_val,
+                            pos,
+                            field_ptr,
+                            elem_size,
+                            elem_align,
+                            func_ptr_val,
+                        ],
+                    )
+                }
+                _ => {
+                    let parser_func = match field.parser {
+                        FieldParser::F64 => parse_f64,
+                        FieldParser::F32 => parse_f32,
+                        FieldParser::I64 => parse_i64,
+                        FieldParser::I32 => parse_i32,
+                        FieldParser::I16 => parse_i16,
+                        FieldParser::I8 => parse_i8,
+                        FieldParser::U64 => parse_u64,
+                        FieldParser::U32 => parse_u32,
+                        FieldParser::U16 => parse_u16,
+                        FieldParser::U8 => parse_u8,
+                        FieldParser::Bool => parse_bool,
+                        FieldParser::String => parse_string,
+                        FieldParser::VecF64 => parse_vec_f64,
+                        FieldParser::VecI64 => parse_vec_i64,
+                        FieldParser::VecU64 => parse_vec_u64,
+                        FieldParser::VecVecF64 => parse_vec_vec_f64,
+                        FieldParser::VecVecVecF64 => parse_vec_vec_vec_f64,
+                        _ => unreachable!(),
+                    };
+                    builder
+                        .ins()
+                        .call(parser_func, &[input_ptr, len_val, pos, field_ptr])
+                }
+            };
+
+            // Check result and update pos
+            let result = builder.inst_results(call_result)[0];
+            let is_error = builder.ins().icmp_imm(IntCC::SignedLessThan, result, 0);
+            let update_pos_block = builder.create_block();
+            builder
+                .ins()
+                .brif(is_error, error_block, &[], update_pos_block, &[]);
+
+            builder.switch_to_block(update_pos_block);
+            builder.def_var(pos_var, result); // result IS the new pos
+            builder.ins().jump(after_field, &[]);
+
+            builder.seal_block(after_colon);
+            builder.seal_block(update_pos_block);
+        }
+
+        // Default block - skip unknown field value
+        builder.switch_to_block(default_block);
+        Self::emit_skip_ws_inline(&mut builder, input_ptr, len_val, pos_var, ptr_type);
+
+        // Expect ':'
+        let pos = builder.use_var(pos_var);
+        let char_ptr = builder.ins().iadd(input_ptr, pos);
+        let ch = builder
+            .ins()
+            .load(types::I8, MemFlags::trusted(), char_ptr, 0);
+        let is_colon = builder.ins().icmp_imm(IntCC::Equal, ch, b':' as i64);
+        let after_default_colon = builder.create_block();
+        builder
+            .ins()
+            .brif(is_colon, after_default_colon, &[], error_block, &[]);
+
+        builder.switch_to_block(after_default_colon);
+        let pos = builder.use_var(pos_var);
+        let new_pos = builder.ins().iadd_imm(pos, 1);
+        builder.def_var(pos_var, new_pos);
+
+        // Skip whitespace and value
+        Self::emit_skip_ws_inline(&mut builder, input_ptr, len_val, pos_var, ptr_type);
+        let pos = builder.use_var(pos_var);
+        let skip_call = builder.ins().call(skip_value, &[input_ptr, len_val, pos]);
+        let skip_result = builder.inst_results(skip_call)[0];
+        let is_error = builder
+            .ins()
+            .icmp_imm(IntCC::SignedLessThan, skip_result, 0);
+        let update_skip_pos = builder.create_block();
+        builder
+            .ins()
+            .brif(is_error, error_block, &[], update_skip_pos, &[]);
+
+        builder.switch_to_block(update_skip_pos);
+        builder.def_var(pos_var, skip_result);
+        builder.ins().jump(after_field, &[]);
+
+        builder.seal_block(after_default_colon);
+        builder.seal_block(update_skip_pos);
+
+        // After field - check for comma or closing brace
+        builder.switch_to_block(after_field);
+        Self::emit_skip_ws_inline(&mut builder, input_ptr, len_val, pos_var, ptr_type);
+        let pos = builder.use_var(pos_var);
+        let char_ptr = builder.ins().iadd(input_ptr, pos);
+        let ch = builder
+            .ins()
+            .load(types::I8, MemFlags::trusted(), char_ptr, 0);
+
+        let is_comma = builder.ins().icmp_imm(IntCC::Equal, ch, b',' as i64);
+        let check_close = builder.create_block();
+        let advance_comma = builder.create_block();
+        builder
+            .ins()
+            .brif(is_comma, advance_comma, &[], check_close, &[]);
+
+        builder.switch_to_block(advance_comma);
+        let pos = builder.use_var(pos_var);
+        let new_pos = builder.ins().iadd_imm(pos, 1);
+        builder.def_var(pos_var, new_pos);
+        builder.ins().jump(field_loop, &[]);
+
+        builder.switch_to_block(check_close);
+        let is_close = builder.ins().icmp_imm(IntCC::Equal, ch, b'}' as i64);
+        builder
+            .ins()
+            .brif(is_close, success_block, &[], error_block, &[]);
+
+        // Success block - return new pos
+        builder.switch_to_block(success_block);
+        let pos = builder.use_var(pos_var);
+        let final_pos = builder.ins().iadd_imm(pos, 1); // Skip closing '}'
+        builder.ins().return_(&[final_pos]);
+
+        // Error block - return error code
+        builder.switch_to_block(error_block);
+        let err = builder
+            .ins()
+            .iconst(ptr_type, helpers::ERR_UNEXPECTED_EOF as i64);
+        builder.ins().return_(&[err]);
+
+        // Seal remaining blocks
+        builder.seal_block(have_char);
+        builder.seal_block(after_brace_check);
+        builder.seal_block(field_loop);
+        builder.seal_block(parse_field_name);
+        builder.seal_block(default_block);
+        builder.seal_block(skip_to_quote_block);
+        builder.seal_block(after_skip_block);
+        builder.seal_block(after_field);
+        builder.seal_block(check_close);
+        builder.seal_block(advance_comma);
+        builder.seal_block(start_fields);
+        builder.seal_block(success_block);
+        builder.seal_block(error_block);
+        for block in blocks_to_seal {
+            builder.seal_block(block);
+        }
+        for block in &field_blocks {
+            builder.seal_block(*block);
+        }
+
+        builder.finalize();
+
+        self.module.define_function(func_id, &mut ctx).unwrap();
+
+        // Print disassembly if requested
+        if want_disasm {
+            if let Some(compiled) = ctx.compiled_code() {
+                if let Some(disasm) = &compiled.vcode {
+                    eprintln!("=== JIT Disassembly for {func_name} ===");
+                    eprintln!("{disasm}");
+                    eprintln!("=== End Disassembly ===\n");
+                }
+            }
+        }
+
+        self.module.clear_context(&mut ctx);
+        self.module.finalize_definitions().unwrap();
+
+        let ptr = self.module.get_finalized_function(func_id);
+
+        CompiledDeserializer { ptr }
+    }
+
+    /// Emit inline whitespace skipping. Updates pos_var directly.
+    fn emit_skip_ws_inline(
+        builder: &mut FunctionBuilder,
+        input_ptr: Value,
+        len_val: Value,
+        pos_var: Variable,
+        _ptr_type: Type,
+    ) {
+        let ws_loop = builder.create_block();
+        let ws_body = builder.create_block();
+        let ws_done = builder.create_block();
+
+        builder.ins().jump(ws_loop, &[]);
+
+        builder.switch_to_block(ws_loop);
+        let pos = builder.use_var(pos_var);
+        let in_bounds = builder.ins().icmp(IntCC::UnsignedLessThan, pos, len_val);
+        builder.ins().brif(in_bounds, ws_body, &[], ws_done, &[]);
+
+        builder.switch_to_block(ws_body);
+        let char_ptr = builder.ins().iadd(input_ptr, pos);
+        let ch = builder
+            .ins()
+            .load(types::I8, MemFlags::trusted(), char_ptr, 0);
+        let ch_i32 = builder.ins().uextend(types::I32, ch);
+
+        let is_space = builder.ins().icmp_imm(IntCC::Equal, ch_i32, 32);
+        let is_tab = builder.ins().icmp_imm(IntCC::Equal, ch_i32, 9);
+        let is_newline = builder.ins().icmp_imm(IntCC::Equal, ch_i32, 10);
+        let is_cr = builder.ins().icmp_imm(IntCC::Equal, ch_i32, 13);
+
+        let is_ws1 = builder.ins().bor(is_space, is_tab);
+        let is_ws2 = builder.ins().bor(is_newline, is_cr);
+        let is_ws = builder.ins().bor(is_ws1, is_ws2);
+
+        let inc_block = builder.create_block();
+        builder.ins().brif(is_ws, inc_block, &[], ws_done, &[]);
+
+        builder.switch_to_block(inc_block);
+        let new_pos = builder.ins().iadd_imm(pos, 1);
+        builder.def_var(pos_var, new_pos);
+        builder.ins().jump(ws_loop, &[]);
+
+        builder.seal_block(ws_body);
+        builder.seal_block(inc_block);
+        builder.seal_block(ws_loop);
+        builder.seal_block(ws_done);
+
+        builder.switch_to_block(ws_done);
+    }
+
+    /// Emit trie node dispatch code.
+    #[allow(clippy::too_many_arguments, clippy::only_used_in_recursion)]
+    fn emit_trie_node(
+        builder: &mut FunctionBuilder,
+        input_ptr: Value,
+        pos_var: Variable,
+        ptr_type: Type,
+        node: &TrieNode,
+        field_blocks: &[Block],
+        default_block: Block,
+        skip_to_quote_block: Block,
+        error_block: Block,
+        blocks_to_seal: &mut Vec<Block>,
+    ) {
+        match node {
+            TrieNode::Leaf(field_idx) => {
+                // Matched! Check for closing quote
+                let pos = builder.use_var(pos_var);
+                let char_ptr = builder.ins().iadd(input_ptr, pos);
+                let ch = builder
+                    .ins()
+                    .load(types::I8, MemFlags::trusted(), char_ptr, 0);
+                let is_quote = builder.ins().icmp_imm(IntCC::Equal, ch, b'"' as i64);
+
+                let advance_block = builder.create_block();
+                blocks_to_seal.push(advance_block);
+                builder
+                    .ins()
+                    .brif(is_quote, advance_block, &[], skip_to_quote_block, &[]);
+
+                builder.switch_to_block(advance_block);
+                let new_pos = builder.ins().iadd_imm(pos, 1);
+                builder.def_var(pos_var, new_pos);
+                builder.ins().jump(field_blocks[*field_idx], &[]);
+            }
+
+            TrieNode::Branch { children, terminal } => {
+                let pos = builder.use_var(pos_var);
+                let char_ptr = builder.ins().iadd(input_ptr, pos);
+                let ch = builder
+                    .ins()
+                    .load(types::I8, MemFlags::trusted(), char_ptr, 0);
+                let ch_i32 = builder.ins().uextend(types::I32, ch);
+
+                // Check for terminal (closing quote means field name ends here)
+                if let Some(field_idx) = terminal {
+                    let is_quote = builder.ins().icmp_imm(IntCC::Equal, ch_i32, b'"' as i64);
+                    let advance_terminal = builder.create_block();
+                    let check_children = builder.create_block();
+                    blocks_to_seal.push(advance_terminal);
+                    blocks_to_seal.push(check_children);
+                    builder
+                        .ins()
+                        .brif(is_quote, advance_terminal, &[], check_children, &[]);
+
+                    builder.switch_to_block(advance_terminal);
+                    let new_pos = builder.ins().iadd_imm(pos, 1);
+                    builder.def_var(pos_var, new_pos);
+                    builder.ins().jump(field_blocks[*field_idx], &[]);
+
+                    builder.switch_to_block(check_children);
+                }
+
+                // Advance pos for the character we're about to check
+                let new_pos = builder.ins().iadd_imm(pos, 1);
+                builder.def_var(pos_var, new_pos);
+
+                // Generate switch-like code for children
+                let mut sorted_children: Vec<_> = children.iter().collect();
+                sorted_children.sort_by_key(|(k, _)| *k);
+
+                for (byte, child_node) in sorted_children {
+                    let child_block = builder.create_block();
+                    let next_block = builder.create_block();
+                    blocks_to_seal.push(child_block);
+                    blocks_to_seal.push(next_block);
+
+                    let is_match = builder.ins().icmp_imm(IntCC::Equal, ch_i32, *byte as i64);
+                    builder
+                        .ins()
+                        .brif(is_match, child_block, &[], next_block, &[]);
+
+                    builder.switch_to_block(child_block);
+                    Self::emit_trie_node(
+                        builder,
+                        input_ptr,
+                        pos_var,
+                        ptr_type,
+                        child_node,
+                        field_blocks,
+                        default_block,
+                        skip_to_quote_block,
+                        error_block,
+                        blocks_to_seal,
+                    );
+
+                    builder.switch_to_block(next_block);
+                }
+
+                // No match - skip to closing quote
+                builder.ins().jump(skip_to_quote_block, &[]);
+            }
+        }
+    }
+}
+
+impl Default for JitCompiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/facet-json/src/cranelift/helpers.rs
+++ b/facet-json/src/cranelift/helpers.rs
@@ -1,0 +1,1303 @@
+//! Rust helper functions that JIT'd code calls back into.
+//!
+//! All helpers take (input, len, pos) as separate values and return new_pos (>= 0) or error (< 0).
+//! This allows the JIT to keep pos in a register instead of going through memory.
+
+/// Result of a parse operation.
+///
+/// - `>= 0` means success, value is new position.
+/// - `< 0` means error code.
+pub type ParseResult = isize;
+
+// Error codes (negative values)
+pub const ERR_UNEXPECTED_EOF: isize = -1;
+pub const ERR_EXPECTED_COLON: isize = -2;
+pub const ERR_EXPECTED_COMMA_OR_END: isize = -3;
+pub const ERR_EXPECTED_OBJECT_START: isize = -4;
+pub const ERR_EXPECTED_ARRAY_START: isize = -5;
+pub const ERR_INVALID_NUMBER: isize = -6;
+pub const ERR_INVALID_STRING: isize = -7;
+pub const ERR_INVALID_BOOL: isize = -8;
+
+/// Get a byte slice from raw parts.
+#[inline(always)]
+unsafe fn slice(input: *const u8, len: usize, pos: usize) -> &'static [u8] {
+    std::slice::from_raw_parts(input.add(pos), len - pos)
+}
+
+/// Get full input slice.
+#[inline(always)]
+unsafe fn full_slice(input: *const u8, len: usize) -> &'static [u8] {
+    std::slice::from_raw_parts(input, len)
+}
+
+// =============================================================================
+// Value parsers - parse a value and write to output pointer
+// All take (input, len, pos, out) and return new_pos or error
+// =============================================================================
+
+/// Parse f64, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_f64(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut f64,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+
+    let mut end = 0;
+    while end < bytes.len() {
+        match bytes[end] {
+            b'0'..=b'9' | b'-' | b'+' | b'.' | b'e' | b'E' => end += 1,
+            _ => break,
+        }
+    }
+
+    if end == 0 {
+        return ERR_INVALID_NUMBER;
+    }
+
+    use lexical_parse_float::FromLexical;
+    match f64::from_lexical(&bytes[..end]) {
+        Ok(val) => {
+            *out = val;
+            (pos + end) as isize
+        }
+        Err(_) => ERR_INVALID_NUMBER,
+    }
+}
+
+/// Parse f32, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_f32(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut f32,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+
+    let mut end = 0;
+    while end < bytes.len() {
+        match bytes[end] {
+            b'0'..=b'9' | b'-' | b'+' | b'.' | b'e' | b'E' => end += 1,
+            _ => break,
+        }
+    }
+
+    if end == 0 {
+        return ERR_INVALID_NUMBER;
+    }
+
+    use lexical_parse_float::FromLexical;
+    match f32::from_lexical(&bytes[..end]) {
+        Ok(val) => {
+            *out = val;
+            (pos + end) as isize
+        }
+        Err(_) => ERR_INVALID_NUMBER,
+    }
+}
+
+/// Parse i64, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_i64(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut i64,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+
+    let mut end = 0;
+    while end < bytes.len() {
+        match bytes[end] {
+            b'0'..=b'9' | b'-' | b'+' => end += 1,
+            _ => break,
+        }
+    }
+
+    if end == 0 {
+        return ERR_INVALID_NUMBER;
+    }
+
+    use lexical_parse_integer::FromLexical;
+    match i64::from_lexical(&bytes[..end]) {
+        Ok(val) => {
+            *out = val;
+            (pos + end) as isize
+        }
+        Err(_) => ERR_INVALID_NUMBER,
+    }
+}
+
+/// Parse i32, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_i32(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut i32,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+
+    let mut end = 0;
+    while end < bytes.len() {
+        match bytes[end] {
+            b'0'..=b'9' | b'-' | b'+' => end += 1,
+            _ => break,
+        }
+    }
+
+    if end == 0 {
+        return ERR_INVALID_NUMBER;
+    }
+
+    use lexical_parse_integer::FromLexical;
+    match i32::from_lexical(&bytes[..end]) {
+        Ok(val) => {
+            *out = val;
+            (pos + end) as isize
+        }
+        Err(_) => ERR_INVALID_NUMBER,
+    }
+}
+
+/// Parse i16, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_i16(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut i16,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+
+    let mut end = 0;
+    while end < bytes.len() {
+        match bytes[end] {
+            b'0'..=b'9' | b'-' | b'+' => end += 1,
+            _ => break,
+        }
+    }
+
+    if end == 0 {
+        return ERR_INVALID_NUMBER;
+    }
+
+    use lexical_parse_integer::FromLexical;
+    match i16::from_lexical(&bytes[..end]) {
+        Ok(val) => {
+            *out = val;
+            (pos + end) as isize
+        }
+        Err(_) => ERR_INVALID_NUMBER,
+    }
+}
+
+/// Parse i8, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_i8(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut i8,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+
+    let mut end = 0;
+    while end < bytes.len() {
+        match bytes[end] {
+            b'0'..=b'9' | b'-' | b'+' => end += 1,
+            _ => break,
+        }
+    }
+
+    if end == 0 {
+        return ERR_INVALID_NUMBER;
+    }
+
+    use lexical_parse_integer::FromLexical;
+    match i8::from_lexical(&bytes[..end]) {
+        Ok(val) => {
+            *out = val;
+            (pos + end) as isize
+        }
+        Err(_) => ERR_INVALID_NUMBER,
+    }
+}
+
+/// Parse u64, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_u64(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut u64,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+
+    let mut end = 0;
+    while end < bytes.len() {
+        match bytes[end] {
+            b'0'..=b'9' | b'+' => end += 1,
+            _ => break,
+        }
+    }
+
+    if end == 0 {
+        return ERR_INVALID_NUMBER;
+    }
+
+    use lexical_parse_integer::FromLexical;
+    match u64::from_lexical(&bytes[..end]) {
+        Ok(val) => {
+            *out = val;
+            (pos + end) as isize
+        }
+        Err(_) => ERR_INVALID_NUMBER,
+    }
+}
+
+/// Parse u32, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_u32(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut u32,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+
+    let mut end = 0;
+    while end < bytes.len() {
+        match bytes[end] {
+            b'0'..=b'9' | b'+' => end += 1,
+            _ => break,
+        }
+    }
+
+    if end == 0 {
+        return ERR_INVALID_NUMBER;
+    }
+
+    use lexical_parse_integer::FromLexical;
+    match u32::from_lexical(&bytes[..end]) {
+        Ok(val) => {
+            *out = val;
+            (pos + end) as isize
+        }
+        Err(_) => ERR_INVALID_NUMBER,
+    }
+}
+
+/// Parse u16, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_u16(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut u16,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+
+    let mut end = 0;
+    while end < bytes.len() {
+        match bytes[end] {
+            b'0'..=b'9' | b'+' => end += 1,
+            _ => break,
+        }
+    }
+
+    if end == 0 {
+        return ERR_INVALID_NUMBER;
+    }
+
+    use lexical_parse_integer::FromLexical;
+    match u16::from_lexical(&bytes[..end]) {
+        Ok(val) => {
+            *out = val;
+            (pos + end) as isize
+        }
+        Err(_) => ERR_INVALID_NUMBER,
+    }
+}
+
+/// Parse u8, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_u8(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut u8,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+
+    let mut end = 0;
+    while end < bytes.len() {
+        match bytes[end] {
+            b'0'..=b'9' | b'+' => end += 1,
+            _ => break,
+        }
+    }
+
+    if end == 0 {
+        return ERR_INVALID_NUMBER;
+    }
+
+    use lexical_parse_integer::FromLexical;
+    match u8::from_lexical(&bytes[..end]) {
+        Ok(val) => {
+            *out = val;
+            (pos + end) as isize
+        }
+        Err(_) => ERR_INVALID_NUMBER,
+    }
+}
+
+/// Parse bool, write to *out (0 or 1), return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_bool(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut u8,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+
+    if bytes.starts_with(b"true") {
+        *out = 1;
+        (pos + 4) as isize
+    } else if bytes.starts_with(b"false") {
+        *out = 0;
+        (pos + 5) as isize
+    } else {
+        ERR_INVALID_BOOL
+    }
+}
+
+/// Parse String, write to *out, return new position or error.
+/// Uses SIMD-accelerated memchr for fast string scanning.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_string(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut String,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+
+    // Expect opening quote
+    if bytes.is_empty() || bytes[0] != b'"' {
+        return ERR_INVALID_STRING;
+    }
+
+    let content = &bytes[1..];
+
+    match memchr::memchr2(b'"', b'\\', content) {
+        Some(offset) => {
+            if content[offset] == b'"' {
+                // Found closing quote - no escapes in this string!
+                let s = std::str::from_utf8_unchecked(&content[..offset]);
+                std::ptr::write(out, s.to_owned());
+                (pos + 1 + offset + 1) as isize // +1 open quote, +1 close quote
+            } else {
+                // Found backslash - need slow path with escape handling
+                match find_string_end_with_escapes(content, offset) {
+                    Some(end) => {
+                        let result = decode_escaped_string(&content[..end]);
+                        std::ptr::write(out, result);
+                        (pos + 1 + end + 1) as isize
+                    }
+                    None => ERR_UNEXPECTED_EOF,
+                }
+            }
+        }
+        None => ERR_UNEXPECTED_EOF,
+    }
+}
+
+/// Find the end of a string that contains escapes (position of closing quote).
+#[inline]
+fn find_string_end_with_escapes(bytes: &[u8], first_backslash: usize) -> Option<usize> {
+    let mut pos = first_backslash;
+
+    loop {
+        if pos + 1 >= bytes.len() {
+            return None;
+        }
+        pos += 2; // Skip \X
+
+        match memchr::memchr2(b'"', b'\\', &bytes[pos..]) {
+            Some(offset) => {
+                let abs_pos = pos + offset;
+                if bytes[abs_pos] == b'"' {
+                    return Some(abs_pos);
+                } else {
+                    pos = abs_pos;
+                }
+            }
+            None => return None,
+        }
+    }
+}
+
+/// Decode a string that contains escape sequences.
+#[inline]
+fn decode_escaped_string(bytes: &[u8]) -> String {
+    let mut result = String::with_capacity(bytes.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() {
+            match bytes[i + 1] {
+                b'"' => {
+                    result.push('"');
+                    i += 2;
+                }
+                b'\\' => {
+                    result.push('\\');
+                    i += 2;
+                }
+                b'/' => {
+                    result.push('/');
+                    i += 2;
+                }
+                b'b' => {
+                    result.push('\x08');
+                    i += 2;
+                }
+                b'f' => {
+                    result.push('\x0c');
+                    i += 2;
+                }
+                b'n' => {
+                    result.push('\n');
+                    i += 2;
+                }
+                b'r' => {
+                    result.push('\r');
+                    i += 2;
+                }
+                b't' => {
+                    result.push('\t');
+                    i += 2;
+                }
+                b'u' if i + 5 < bytes.len() => {
+                    if let Ok(hex) = std::str::from_utf8(&bytes[i + 2..i + 6]) {
+                        if let Ok(code) = u16::from_str_radix(hex, 16) {
+                            if let Some(c) = char::from_u32(code as u32) {
+                                result.push(c);
+                            }
+                        }
+                    }
+                    i += 6;
+                }
+                _ => {
+                    i += 1;
+                }
+            }
+        } else {
+            result.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+
+    result
+}
+
+// =============================================================================
+// Skip value - for unknown fields
+// =============================================================================
+
+/// Skip a JSON value (for unknown fields).
+/// Returns new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_skip_value(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+) -> ParseResult {
+    let bytes = full_slice(input, len);
+    let mut i = pos;
+
+    // Skip leading whitespace
+    while i < len && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r') {
+        i += 1;
+    }
+
+    if i >= len {
+        return ERR_UNEXPECTED_EOF;
+    }
+
+    match skip_value_inner(bytes, &mut i) {
+        Ok(()) => i as isize,
+        Err(e) => e,
+    }
+}
+
+/// Simpler skip function - just track depth and handle strings specially.
+/// For skipping, we don't need to validate JSON structure, just find the end.
+#[inline]
+fn skip_value_inner(bytes: &[u8], i: &mut usize) -> Result<(), ParseResult> {
+    if *i >= bytes.len() {
+        return Err(ERR_UNEXPECTED_EOF);
+    }
+
+    match bytes[*i] {
+        b'"' => skip_string(bytes, i),
+        b'{' | b'[' => skip_container(bytes, i),
+        b't' => {
+            if bytes.len() - *i >= 4 && &bytes[*i..*i + 4] == b"true" {
+                *i += 4;
+                Ok(())
+            } else {
+                Err(ERR_INVALID_BOOL)
+            }
+        }
+        b'f' => {
+            if bytes.len() - *i >= 5 && &bytes[*i..*i + 5] == b"false" {
+                *i += 5;
+                Ok(())
+            } else {
+                Err(ERR_INVALID_BOOL)
+            }
+        }
+        b'n' => {
+            if bytes.len() - *i >= 4 && &bytes[*i..*i + 4] == b"null" {
+                *i += 4;
+                Ok(())
+            } else {
+                Err(ERR_INVALID_BOOL)
+            }
+        }
+        b'0'..=b'9' | b'-' => {
+            skip_number(bytes, i);
+            Ok(())
+        }
+        _ => Err(ERR_UNEXPECTED_EOF),
+    }
+}
+
+/// Skip an object or array by tracking depth.
+/// We don't validate structure, just find matching close bracket.
+#[inline]
+fn skip_container(bytes: &[u8], i: &mut usize) -> Result<(), ParseResult> {
+    let mut depth = 1i32;
+    let mut pos = *i + 1; // skip opening { or [
+    let len = bytes.len();
+
+    while pos < len {
+        let b = bytes[pos];
+        pos += 1;
+
+        if b == b'"' {
+            // Skip string using memchr2 for speed
+            loop {
+                match memchr::memchr2(b'"', b'\\', &bytes[pos..]) {
+                    Some(offset) => {
+                        pos += offset;
+                        if bytes[pos] == b'"' {
+                            pos += 1;
+                            break;
+                        } else {
+                            // backslash - skip escape
+                            pos += 2;
+                        }
+                    }
+                    None => return Err(ERR_UNEXPECTED_EOF),
+                }
+            }
+            // After string, fast-skip non-structural bytes
+            pos += skip_to_structural(&bytes[pos..]);
+        } else if b == b'{' || b == b'[' {
+            depth += 1;
+            pos += skip_to_structural(&bytes[pos..]);
+        } else if b == b'}' || b == b']' {
+            depth -= 1;
+            if depth == 0 {
+                *i = pos;
+                return Ok(());
+            }
+            pos += skip_to_structural(&bytes[pos..]);
+        }
+    }
+
+    Err(ERR_UNEXPECTED_EOF)
+}
+
+/// Fast-skip to next structural character (" { } [ ]) using SWAR
+#[inline(always)]
+fn skip_to_structural(bytes: &[u8]) -> usize {
+    const STEP: usize = 8;
+    const ONE_BYTES: u64 = 0x0101010101010101;
+
+    let mut pos = 0;
+    let len = bytes.len();
+
+    // Process 8 bytes at a time
+    while pos + STEP <= len {
+        let chunk = u64::from_le_bytes(bytes[pos..pos + STEP].try_into().unwrap());
+
+        // Check for any interesting byte: " { } [ ]
+        let quote = chunk ^ (ONE_BYTES * b'"' as u64);
+        let open_brace = chunk ^ (ONE_BYTES * b'{' as u64);
+        let close_brace = chunk ^ (ONE_BYTES * b'}' as u64);
+        let open_bracket = chunk ^ (ONE_BYTES * b'[' as u64);
+        let close_bracket = chunk ^ (ONE_BYTES * b']' as u64);
+
+        let has_zero = |v: u64| (v.wrapping_sub(ONE_BYTES)) & !v & (ONE_BYTES * 0x80);
+
+        let mask = has_zero(quote)
+            | has_zero(open_brace)
+            | has_zero(close_brace)
+            | has_zero(open_bracket)
+            | has_zero(close_bracket);
+
+        if mask != 0 {
+            return pos + mask.trailing_zeros() as usize / 8;
+        }
+        pos += STEP;
+    }
+
+    // Check remaining bytes
+    while pos < len {
+        match bytes[pos] {
+            b'"' | b'{' | b'}' | b'[' | b']' => return pos,
+            _ => pos += 1,
+        }
+    }
+
+    pos
+}
+
+/// Skip a JSON string (opening quote already peeked, not consumed).
+#[inline(always)]
+fn skip_string(bytes: &[u8], i: &mut usize) -> Result<(), ParseResult> {
+    *i += 1; // skip opening quote
+    loop {
+        // Use memchr for fast scanning
+        match memchr::memchr2(b'"', b'\\', &bytes[*i..]) {
+            Some(offset) => {
+                if bytes[*i + offset] == b'"' {
+                    *i += offset + 1;
+                    return Ok(());
+                } else {
+                    // Backslash - skip the escape sequence
+                    *i += offset + 2;
+                    if *i > bytes.len() {
+                        return Err(ERR_UNEXPECTED_EOF);
+                    }
+                }
+            }
+            None => return Err(ERR_UNEXPECTED_EOF),
+        }
+    }
+}
+
+/// Skip a JSON number.
+#[inline(always)]
+fn skip_number(bytes: &[u8], i: &mut usize) {
+    while *i < bytes.len() {
+        match bytes[*i] {
+            b'0'..=b'9' | b'-' | b'+' | b'.' | b'e' | b'E' => *i += 1,
+            _ => break,
+        }
+    }
+}
+
+#[inline(always)]
+fn skip_ws_inline(bytes: &[u8], i: &mut usize) {
+    while *i < bytes.len() {
+        let b = bytes[*i];
+        if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
+            *i += 1;
+        } else {
+            break;
+        }
+    }
+}
+
+// =============================================================================
+// Vec parsers
+// =============================================================================
+
+/// Parse `Vec<f64>`, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_vec_f64(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut Vec<f64>,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+    let mut i = 0;
+
+    if bytes.is_empty() || bytes[0] != b'[' {
+        return ERR_EXPECTED_ARRAY_START;
+    }
+    i += 1;
+    skip_ws_inline(bytes, &mut i);
+
+    let mut vec = Vec::with_capacity(16);
+
+    if i < bytes.len() && bytes[i] == b']' {
+        std::ptr::write(out, vec);
+        return (pos + i + 1) as isize;
+    }
+
+    loop {
+        // Parse number directly
+        let mut end = i;
+        while end < bytes.len() {
+            match bytes[end] {
+                b'0'..=b'9' | b'-' | b'+' | b'.' | b'e' | b'E' => end += 1,
+                _ => break,
+            }
+        }
+
+        if end == i {
+            return ERR_INVALID_NUMBER;
+        }
+
+        use lexical_parse_float::FromLexical;
+        match f64::from_lexical(&bytes[i..end]) {
+            Ok(val) => vec.push(val),
+            Err(_) => return ERR_INVALID_NUMBER,
+        }
+        i = end;
+
+        skip_ws_inline(bytes, &mut i);
+        if i >= bytes.len() {
+            return ERR_EXPECTED_COMMA_OR_END;
+        }
+        match bytes[i] {
+            b',' => {
+                i += 1;
+                skip_ws_inline(bytes, &mut i);
+            }
+            b']' => {
+                std::ptr::write(out, vec);
+                return (pos + i + 1) as isize;
+            }
+            _ => return ERR_EXPECTED_COMMA_OR_END,
+        }
+    }
+}
+
+/// Parse `Vec<i64>`, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_vec_i64(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut Vec<i64>,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+    let mut i = 0;
+
+    if bytes.is_empty() || bytes[0] != b'[' {
+        return ERR_EXPECTED_ARRAY_START;
+    }
+    i += 1;
+    skip_ws_inline(bytes, &mut i);
+
+    let mut vec = Vec::with_capacity(16);
+
+    if i < bytes.len() && bytes[i] == b']' {
+        std::ptr::write(out, vec);
+        return (pos + i + 1) as isize;
+    }
+
+    loop {
+        // Parse number directly
+        let mut end = i;
+        while end < bytes.len() {
+            match bytes[end] {
+                b'0'..=b'9' | b'-' | b'+' => end += 1,
+                _ => break,
+            }
+        }
+
+        if end == i {
+            return ERR_INVALID_NUMBER;
+        }
+
+        use lexical_parse_integer::FromLexical;
+        match i64::from_lexical(&bytes[i..end]) {
+            Ok(val) => vec.push(val),
+            Err(_) => return ERR_INVALID_NUMBER,
+        }
+        i = end;
+
+        skip_ws_inline(bytes, &mut i);
+        if i >= bytes.len() {
+            return ERR_EXPECTED_COMMA_OR_END;
+        }
+        match bytes[i] {
+            b',' => {
+                i += 1;
+                skip_ws_inline(bytes, &mut i);
+            }
+            b']' => {
+                std::ptr::write(out, vec);
+                return (pos + i + 1) as isize;
+            }
+            _ => return ERR_EXPECTED_COMMA_OR_END,
+        }
+    }
+}
+
+/// Parse `Vec<u64>`, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_vec_u64(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut Vec<u64>,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+    let mut i = 0;
+
+    if bytes.is_empty() || bytes[0] != b'[' {
+        return ERR_EXPECTED_ARRAY_START;
+    }
+    i += 1;
+    skip_ws_inline(bytes, &mut i);
+
+    let mut vec = Vec::with_capacity(16);
+
+    if i < bytes.len() && bytes[i] == b']' {
+        std::ptr::write(out, vec);
+        return (pos + i + 1) as isize;
+    }
+
+    loop {
+        // Parse number directly
+        let mut end = i;
+        while end < bytes.len() {
+            match bytes[end] {
+                b'0'..=b'9' | b'+' => end += 1,
+                _ => break,
+            }
+        }
+
+        if end == i {
+            return ERR_INVALID_NUMBER;
+        }
+
+        use lexical_parse_integer::FromLexical;
+        match u64::from_lexical(&bytes[i..end]) {
+            Ok(val) => vec.push(val),
+            Err(_) => return ERR_INVALID_NUMBER,
+        }
+        i = end;
+
+        skip_ws_inline(bytes, &mut i);
+        if i >= bytes.len() {
+            return ERR_EXPECTED_COMMA_OR_END;
+        }
+        match bytes[i] {
+            b',' => {
+                i += 1;
+                skip_ws_inline(bytes, &mut i);
+            }
+            b']' => {
+                std::ptr::write(out, vec);
+                return (pos + i + 1) as isize;
+            }
+            _ => return ERR_EXPECTED_COMMA_OR_END,
+        }
+    }
+}
+
+/// Parse `Vec<Vec<f64>>`, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_vec_vec_f64(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut Vec<Vec<f64>>,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+    let mut i = 0;
+
+    if bytes.is_empty() || bytes[0] != b'[' {
+        return ERR_EXPECTED_ARRAY_START;
+    }
+    i += 1;
+    skip_ws_inline(bytes, &mut i);
+
+    let mut outer = Vec::with_capacity(16);
+
+    if i < bytes.len() && bytes[i] == b']' {
+        std::ptr::write(out, outer);
+        return (pos + i + 1) as isize;
+    }
+
+    loop {
+        // Parse inner array
+        if i >= bytes.len() || bytes[i] != b'[' {
+            return ERR_EXPECTED_ARRAY_START;
+        }
+        i += 1;
+        skip_ws_inline(bytes, &mut i);
+
+        let mut inner = Vec::with_capacity(16);
+
+        if i < bytes.len() && bytes[i] == b']' {
+            i += 1;
+        } else {
+            loop {
+                let mut end = i;
+                while end < bytes.len() {
+                    match bytes[end] {
+                        b'0'..=b'9' | b'-' | b'+' | b'.' | b'e' | b'E' => end += 1,
+                        _ => break,
+                    }
+                }
+
+                if end == i {
+                    return ERR_INVALID_NUMBER;
+                }
+
+                use lexical_parse_float::FromLexical;
+                match f64::from_lexical(&bytes[i..end]) {
+                    Ok(val) => inner.push(val),
+                    Err(_) => return ERR_INVALID_NUMBER,
+                }
+                i = end;
+
+                skip_ws_inline(bytes, &mut i);
+                if i >= bytes.len() {
+                    return ERR_EXPECTED_COMMA_OR_END;
+                }
+                match bytes[i] {
+                    b',' => {
+                        i += 1;
+                        skip_ws_inline(bytes, &mut i);
+                    }
+                    b']' => {
+                        i += 1;
+                        break;
+                    }
+                    _ => return ERR_EXPECTED_COMMA_OR_END,
+                }
+            }
+        }
+
+        outer.push(inner);
+
+        skip_ws_inline(bytes, &mut i);
+        if i >= bytes.len() {
+            return ERR_EXPECTED_COMMA_OR_END;
+        }
+        match bytes[i] {
+            b',' => {
+                i += 1;
+                skip_ws_inline(bytes, &mut i);
+            }
+            b']' => {
+                std::ptr::write(out, outer);
+                return (pos + i + 1) as isize;
+            }
+            _ => return ERR_EXPECTED_COMMA_OR_END,
+        }
+    }
+}
+
+/// Parse `Vec<Vec<Vec<f64>>>`, write to *out, return new position or error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_vec_vec_vec_f64(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut Vec<Vec<Vec<f64>>>,
+) -> ParseResult {
+    let bytes = slice(input, len, pos);
+    let mut i = 0;
+
+    if bytes.is_empty() || bytes[0] != b'[' {
+        return ERR_EXPECTED_ARRAY_START;
+    }
+    i += 1;
+    skip_ws_inline(bytes, &mut i);
+
+    let mut outer = Vec::with_capacity(16);
+
+    if i < bytes.len() && bytes[i] == b']' {
+        std::ptr::write(out, outer);
+        return (pos + i + 1) as isize;
+    }
+
+    loop {
+        // Parse middle array
+        if i >= bytes.len() || bytes[i] != b'[' {
+            return ERR_EXPECTED_ARRAY_START;
+        }
+        i += 1;
+        skip_ws_inline(bytes, &mut i);
+
+        let mut middle = Vec::with_capacity(16);
+
+        if i < bytes.len() && bytes[i] == b']' {
+            i += 1;
+        } else {
+            loop {
+                // Parse inner array
+                if i >= bytes.len() || bytes[i] != b'[' {
+                    return ERR_EXPECTED_ARRAY_START;
+                }
+                i += 1;
+                skip_ws_inline(bytes, &mut i);
+
+                let mut inner = Vec::with_capacity(16);
+
+                if i < bytes.len() && bytes[i] == b']' {
+                    i += 1;
+                } else {
+                    loop {
+                        let mut end = i;
+                        while end < bytes.len() {
+                            match bytes[end] {
+                                b'0'..=b'9' | b'-' | b'+' | b'.' | b'e' | b'E' => end += 1,
+                                _ => break,
+                            }
+                        }
+
+                        if end == i {
+                            return ERR_INVALID_NUMBER;
+                        }
+
+                        use lexical_parse_float::FromLexical;
+                        match f64::from_lexical(&bytes[i..end]) {
+                            Ok(val) => inner.push(val),
+                            Err(_) => return ERR_INVALID_NUMBER,
+                        }
+                        i = end;
+
+                        skip_ws_inline(bytes, &mut i);
+                        if i >= bytes.len() {
+                            return ERR_EXPECTED_COMMA_OR_END;
+                        }
+                        match bytes[i] {
+                            b',' => {
+                                i += 1;
+                                skip_ws_inline(bytes, &mut i);
+                            }
+                            b']' => {
+                                i += 1;
+                                break;
+                            }
+                            _ => return ERR_EXPECTED_COMMA_OR_END,
+                        }
+                    }
+                }
+
+                middle.push(inner);
+
+                skip_ws_inline(bytes, &mut i);
+                if i >= bytes.len() {
+                    return ERR_EXPECTED_COMMA_OR_END;
+                }
+                match bytes[i] {
+                    b',' => {
+                        i += 1;
+                        skip_ws_inline(bytes, &mut i);
+                    }
+                    b']' => {
+                        i += 1;
+                        break;
+                    }
+                    _ => return ERR_EXPECTED_COMMA_OR_END,
+                }
+            }
+        }
+
+        outer.push(middle);
+
+        skip_ws_inline(bytes, &mut i);
+        if i >= bytes.len() {
+            return ERR_EXPECTED_COMMA_OR_END;
+        }
+        match bytes[i] {
+            b',' => {
+                i += 1;
+                skip_ws_inline(bytes, &mut i);
+            }
+            b']' => {
+                std::ptr::write(out, outer);
+                return (pos + i + 1) as isize;
+            }
+            _ => return ERR_EXPECTED_COMMA_OR_END,
+        }
+    }
+}
+
+/// Parse `Vec<Struct>` using a provided deserializer function.
+/// elem_size and elem_align describe the struct layout.
+/// func_ptr is the JIT-compiled deserializer for the element type.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_vec_struct(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut u8, // Actually *mut Vec<T>, but we don't know T
+    elem_size: usize,
+    elem_align: usize,
+    func_ptr: *const u8,
+) -> ParseResult {
+    // The func_ptr is a compiled deserializer: fn(input, len, pos, out) -> isize
+    type DeserFn = unsafe extern "C" fn(*const u8, usize, usize, *mut u8) -> isize;
+    let deser: DeserFn = std::mem::transmute(func_ptr);
+
+    let bytes = slice(input, len, pos);
+    let mut i = 0;
+
+    if bytes.is_empty() || bytes[0] != b'[' {
+        return ERR_EXPECTED_ARRAY_START;
+    }
+    i += 1;
+    skip_ws_inline(bytes, &mut i);
+
+    // Build a Vec manually with proper layout
+    let mut capacity = 16usize;
+    let mut len_items = 0usize;
+    let mut data = if elem_size > 0 {
+        std::alloc::alloc(
+            std::alloc::Layout::from_size_align(elem_size * capacity, elem_align).unwrap(),
+        )
+    } else {
+        std::ptr::null_mut()
+    };
+
+    if i < bytes.len() && bytes[i] == b']' {
+        // Empty array
+        let vec_ptr = out as *mut (usize, *mut u8, usize);
+        std::ptr::write(vec_ptr, (capacity, data, 0));
+        return (pos + i + 1) as isize;
+    }
+
+    loop {
+        // Grow if needed
+        if len_items >= capacity {
+            let new_cap = capacity * 2;
+            let new_data = std::alloc::alloc(
+                std::alloc::Layout::from_size_align(elem_size * new_cap, elem_align).unwrap(),
+            );
+            if elem_size > 0 && !data.is_null() {
+                std::ptr::copy_nonoverlapping(data, new_data, elem_size * len_items);
+                std::alloc::dealloc(
+                    data,
+                    std::alloc::Layout::from_size_align(elem_size * capacity, elem_align).unwrap(),
+                );
+            }
+            data = new_data;
+            capacity = new_cap;
+        }
+
+        // Parse element
+        let elem_ptr = data.add(len_items * elem_size);
+        let result = deser(input, len, pos + i, elem_ptr);
+        if result < 0 {
+            // Clean up on error
+            if elem_size > 0 && !data.is_null() {
+                std::alloc::dealloc(
+                    data,
+                    std::alloc::Layout::from_size_align(elem_size * capacity, elem_align).unwrap(),
+                );
+            }
+            return result;
+        }
+        i = (result as usize) - pos;
+        len_items += 1;
+
+        skip_ws_inline(bytes, &mut i);
+        if i >= bytes.len() {
+            if elem_size > 0 && !data.is_null() {
+                std::alloc::dealloc(
+                    data,
+                    std::alloc::Layout::from_size_align(elem_size * capacity, elem_align).unwrap(),
+                );
+            }
+            return ERR_EXPECTED_COMMA_OR_END;
+        }
+        match bytes[i] {
+            b',' => {
+                i += 1;
+                skip_ws_inline(bytes, &mut i);
+            }
+            b']' => {
+                // Write the Vec
+                let vec_ptr = out as *mut (usize, *mut u8, usize);
+                std::ptr::write(vec_ptr, (capacity, data, len_items));
+                return (pos + i + 1) as isize;
+            }
+            _ => {
+                if elem_size > 0 && !data.is_null() {
+                    std::alloc::dealloc(
+                        data,
+                        std::alloc::Layout::from_size_align(elem_size * capacity, elem_align)
+                            .unwrap(),
+                    );
+                }
+                return ERR_EXPECTED_COMMA_OR_END;
+            }
+        }
+    }
+}
+
+/// Parse a nested struct by calling its compiled deserializer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn jitson_parse_nested_struct(
+    input: *const u8,
+    len: usize,
+    pos: usize,
+    out: *mut u8,
+    func_ptr: *const u8,
+) -> ParseResult {
+    type DeserFn = unsafe extern "C" fn(*const u8, usize, usize, *mut u8) -> isize;
+    let deser: DeserFn = std::mem::transmute(func_ptr);
+    deser(input, len, pos, out)
+}
+
+// =============================================================================
+// Helper registration for Cranelift
+// =============================================================================
+
+/// Register all helper functions with a JITBuilder.
+pub fn register_helpers(builder: &mut cranelift_jit::JITBuilder) {
+    builder.symbol("jitson_parse_f64", jitson_parse_f64 as *const u8);
+    builder.symbol("jitson_parse_f32", jitson_parse_f32 as *const u8);
+    builder.symbol("jitson_parse_i64", jitson_parse_i64 as *const u8);
+    builder.symbol("jitson_parse_i32", jitson_parse_i32 as *const u8);
+    builder.symbol("jitson_parse_i16", jitson_parse_i16 as *const u8);
+    builder.symbol("jitson_parse_i8", jitson_parse_i8 as *const u8);
+    builder.symbol("jitson_parse_u64", jitson_parse_u64 as *const u8);
+    builder.symbol("jitson_parse_u32", jitson_parse_u32 as *const u8);
+    builder.symbol("jitson_parse_u16", jitson_parse_u16 as *const u8);
+    builder.symbol("jitson_parse_u8", jitson_parse_u8 as *const u8);
+    builder.symbol("jitson_parse_bool", jitson_parse_bool as *const u8);
+    builder.symbol("jitson_parse_string", jitson_parse_string as *const u8);
+    builder.symbol("jitson_parse_vec_f64", jitson_parse_vec_f64 as *const u8);
+    builder.symbol("jitson_parse_vec_i64", jitson_parse_vec_i64 as *const u8);
+    builder.symbol("jitson_parse_vec_u64", jitson_parse_vec_u64 as *const u8);
+    builder.symbol(
+        "jitson_parse_vec_vec_f64",
+        jitson_parse_vec_vec_f64 as *const u8,
+    );
+    builder.symbol(
+        "jitson_parse_vec_vec_vec_f64",
+        jitson_parse_vec_vec_vec_f64 as *const u8,
+    );
+    builder.symbol(
+        "jitson_parse_vec_struct",
+        jitson_parse_vec_struct as *const u8,
+    );
+    builder.symbol(
+        "jitson_parse_nested_struct",
+        jitson_parse_nested_struct as *const u8,
+    );
+    builder.symbol("jitson_skip_value", jitson_skip_value as *const u8);
+}

--- a/facet-json/src/cranelift/mod.rs
+++ b/facet-json/src/cranelift/mod.rs
@@ -1,0 +1,74 @@
+//! JIT-compiled JSON deserialization for facet.
+//!
+//! This module uses Cranelift to generate native code deserializers at runtime,
+//! specialized for each type's exact memory layout.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use facet::Facet;
+//! use facet_json::jit;
+//!
+//! #[derive(Facet)]
+//! struct Point { x: f64, y: f64 }
+//!
+//! let point: Point = jit::from_str(r#"{"x": 1.0, "y": 2.0}"#).unwrap();
+//! ```
+//!
+//! # How it works
+//!
+//! On first call for a type, compiles a specialized deserializer using Cranelift.
+//! Subsequent calls use the cached native code directly.
+
+#![allow(unsafe_op_in_unsafe_fn)]
+
+mod cache;
+mod compiler;
+mod helpers;
+
+pub use cache::JitCache;
+pub use compiler::JitCompiler;
+
+use crate::JsonError;
+use facet_core::Facet;
+use std::any::TypeId;
+
+/// JIT-accelerated JSON deserialization.
+///
+/// On first call for a type, compiles a specialized deserializer.
+/// Subsequent calls use the cached native code directly.
+pub fn from_str<T: Facet<'static>>(input: &str) -> Result<T, JsonError> {
+    from_str_inner::<T>(input, false)
+}
+
+/// Deserialize with explicit fallback to interpreter.
+///
+/// Useful for types that can't be JIT compiled (e.g., unsupported features).
+pub fn from_str_with_fallback<T: Facet<'static>>(input: &str) -> Result<T, JsonError> {
+    from_str_inner::<T>(input, true)
+}
+
+fn from_str_inner<T: Facet<'static>>(input: &str, allow_fallback: bool) -> Result<T, JsonError> {
+    let type_id = TypeId::of::<T>();
+
+    // Check cache first
+    if let Some(func) = cache::get(type_id) {
+        return unsafe { func.call(input) };
+    }
+
+    // Try to compile
+    if let Some(func) = compiler::try_compile(T::SHAPE) {
+        cache::insert(type_id, func);
+        return unsafe { func.call(input) };
+    }
+
+    // Fallback to interpreter if allowed
+    if allow_fallback {
+        crate::from_str(input)
+    } else {
+        panic!("JIT compilation not supported for this type and fallback disabled")
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/facet-json/src/cranelift/tests.rs
+++ b/facet-json/src/cranelift/tests.rs
@@ -1,0 +1,546 @@
+//! Tests for the JIT-compiled JSON deserializer.
+
+use super::from_str;
+use facet::Facet;
+
+#[derive(Facet, Debug, PartialEq)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Person {
+    age: u64,
+    score: i64,
+    active: bool,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Mixed {
+    a: f64,
+    b: i64,
+    c: u64,
+    d: bool,
+    e: f64,
+}
+
+#[test]
+fn test_empty_input() {
+    let result: Result<Point, _> = from_str("");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_garbage_input() {
+    let result: Result<Point, _> = from_str("abc");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_point_basic() {
+    let json = r#"{"x": 1.0, "y": 2.0}"#;
+    let point: Point = from_str(json).unwrap();
+    assert_eq!(point, Point { x: 1.0, y: 2.0 });
+}
+
+#[test]
+fn test_point_integers_as_floats() {
+    let json = r#"{"x": 42, "y": -17}"#;
+    let point: Point = from_str(json).unwrap();
+    assert_eq!(point, Point { x: 42.0, y: -17.0 });
+}
+
+#[test]
+fn test_point_scientific_notation() {
+    let json = r#"{"x": 1.5e10, "y": -2.5e-3}"#;
+    let point: Point = from_str(json).unwrap();
+    assert_eq!(
+        point,
+        Point {
+            x: 1.5e10,
+            y: -2.5e-3
+        }
+    );
+}
+
+#[test]
+fn test_point_with_whitespace() {
+    let json = r#"  {  "x"  :  1.0  ,  "y"  :  2.0  }  "#;
+    let point: Point = from_str(json).unwrap();
+    assert_eq!(point, Point { x: 1.0, y: 2.0 });
+}
+
+#[test]
+fn test_point_reversed_fields() {
+    let json = r#"{"y": 2.0, "x": 1.0}"#;
+    let point: Point = from_str(json).unwrap();
+    assert_eq!(point, Point { x: 1.0, y: 2.0 });
+}
+
+#[test]
+fn test_point_unknown_fields_ignored() {
+    let json = r#"{"x": 1.0, "z": 999, "y": 2.0, "extra": "ignored"}"#;
+    let point: Point = from_str(json).unwrap();
+    assert_eq!(point, Point { x: 1.0, y: 2.0 });
+}
+
+#[test]
+fn test_person_integers_and_bool() {
+    let json = r#"{"age": 30, "score": -100, "active": true}"#;
+    let person: Person = from_str(json).unwrap();
+    assert_eq!(
+        person,
+        Person {
+            age: 30,
+            score: -100,
+            active: true
+        }
+    );
+}
+
+#[test]
+fn test_person_bool_false() {
+    let json = r#"{"age": 0, "score": 0, "active": false}"#;
+    let person: Person = from_str(json).unwrap();
+    assert_eq!(
+        person,
+        Person {
+            age: 0,
+            score: 0,
+            active: false
+        }
+    );
+}
+
+#[test]
+fn test_mixed_types() {
+    let json = r#"{"a": 1.5, "b": -42, "c": 100, "d": true, "e": 3.125}"#;
+    let mixed: Mixed = from_str(json).unwrap();
+    assert_eq!(
+        mixed,
+        Mixed {
+            a: 1.5,
+            b: -42,
+            c: 100,
+            d: true,
+            e: 3.125
+        }
+    );
+}
+
+#[test]
+fn test_empty_object_with_defaults() {
+    #[derive(Facet, Debug)]
+    struct Empty {}
+
+    let json = r#"{}"#;
+    let _empty: Empty = from_str(json).unwrap();
+}
+
+#[test]
+fn test_matches_facet_json() {
+    // Verify our results match facet-json's interpreter
+    let json = r#"{"x": 123.456, "y": -789.012}"#;
+
+    let jit_result: Point = from_str(json).unwrap();
+    let interp_result: Point = crate::from_str(json).unwrap();
+
+    assert_eq!(jit_result, interp_result);
+}
+
+// Vec<f64> tests
+#[derive(Facet, Debug, PartialEq)]
+struct Coordinates {
+    coords: Vec<f64>,
+}
+
+#[test]
+fn test_vec_f64_basic() {
+    let json = r#"{"coords": [1.0, 2.0, 3.0]}"#;
+    let result: Coordinates = from_str(json).unwrap();
+    assert_eq!(result.coords, vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn test_vec_f64_empty() {
+    let json = r#"{"coords": []}"#;
+    let result: Coordinates = from_str(json).unwrap();
+    assert_eq!(result.coords, Vec::<f64>::new());
+}
+
+#[test]
+fn test_vec_f64_single() {
+    let json = r#"{"coords": [42.5]}"#;
+    let result: Coordinates = from_str(json).unwrap();
+    assert_eq!(result.coords, vec![42.5]);
+}
+
+#[test]
+fn test_vec_f64_with_whitespace() {
+    let json = r#"{"coords": [ 1.0 , 2.0 , 3.0 ]}"#;
+    let result: Coordinates = from_str(json).unwrap();
+    assert_eq!(result.coords, vec![1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn test_vec_f64_scientific() {
+    let json = r#"{"coords": [1e10, -2.5e-3, 0.0]}"#;
+    let result: Coordinates = from_str(json).unwrap();
+    assert_eq!(result.coords, vec![1e10, -2.5e-3, 0.0]);
+}
+
+#[test]
+fn test_vec_f64_matches_facet_json() {
+    let json = r#"{"coords": [1.0, 2.0, 3.0, 4.0, 5.0]}"#;
+    let jit_result: Coordinates = from_str(json).unwrap();
+    let interp_result: Coordinates = crate::from_str(json).unwrap();
+    assert_eq!(jit_result, interp_result);
+}
+
+// Nested Vec tests
+#[derive(Facet, Debug, PartialEq)]
+struct Matrix {
+    data: Vec<Vec<f64>>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Tensor {
+    data: Vec<Vec<Vec<f64>>>,
+}
+
+#[test]
+fn test_vec_vec_f64() {
+    let json = r#"{"data": [[1.0, 2.0], [3.0, 4.0, 5.0]]}"#;
+    let result: Matrix = from_str(json).unwrap();
+    assert_eq!(result.data, vec![vec![1.0, 2.0], vec![3.0, 4.0, 5.0]]);
+}
+
+#[test]
+fn test_vec_vec_f64_empty() {
+    let json = r#"{"data": []}"#;
+    let result: Matrix = from_str(json).unwrap();
+    assert_eq!(result.data, Vec::<Vec<f64>>::new());
+}
+
+#[test]
+fn test_vec_vec_f64_matches_facet_json() {
+    let json = r#"{"data": [[1.0, 2.0], [3.0], [4.0, 5.0, 6.0]]}"#;
+    let jit_result: Matrix = from_str(json).unwrap();
+    let interp_result: Matrix = crate::from_str(json).unwrap();
+    assert_eq!(jit_result, interp_result);
+}
+
+#[test]
+fn test_vec_vec_vec_f64() {
+    let json = r#"{"data": [[[1.0, 2.0], [3.0]], [[4.0]]]}"#;
+    let result: Tensor = from_str(json).unwrap();
+    assert_eq!(
+        result.data,
+        vec![vec![vec![1.0, 2.0], vec![3.0]], vec![vec![4.0]]]
+    );
+}
+
+#[test]
+fn test_vec_vec_vec_f64_matches_facet_json() {
+    let json = r#"{"data": [[[1.0, 2.0]], [[3.0, 4.0], [5.0]]]}"#;
+    let jit_result: Tensor = from_str(json).unwrap();
+    let interp_result: Tensor = crate::from_str(json).unwrap();
+    assert_eq!(jit_result, interp_result);
+}
+
+// String tests
+#[derive(Facet, Debug, PartialEq)]
+struct Named {
+    name: String,
+}
+
+#[test]
+fn test_string_basic() {
+    let json = r#"{"name": "hello"}"#;
+    let result: Named = from_str(json).unwrap();
+    assert_eq!(result.name, "hello");
+}
+
+#[test]
+fn test_string_with_spaces() {
+    let json = r#"{"name": "hello world"}"#;
+    let result: Named = from_str(json).unwrap();
+    assert_eq!(result.name, "hello world");
+}
+
+#[test]
+fn test_string_empty() {
+    let json = r#"{"name": ""}"#;
+    let result: Named = from_str(json).unwrap();
+    assert_eq!(result.name, "");
+}
+
+#[test]
+fn test_string_with_newline_escape() {
+    let json = r#"{"name": "hello\nworld"}"#;
+    let result: Named = from_str(json).unwrap();
+    assert_eq!(result.name, "hello\nworld");
+}
+
+#[test]
+fn test_string_with_tab_escape() {
+    let json = r#"{"name": "hello\tworld"}"#;
+    let result: Named = from_str(json).unwrap();
+    assert_eq!(result.name, "hello\tworld");
+}
+
+#[test]
+fn test_string_with_quote_escape() {
+    let json = r#"{"name": "say \"hello\""}"#;
+    let result: Named = from_str(json).unwrap();
+    assert_eq!(result.name, "say \"hello\"");
+}
+
+#[test]
+fn test_string_with_unicode_escape() {
+    let json = r#"{"name": "letter \u0041"}"#;
+    let result: Named = from_str(json).unwrap();
+    assert_eq!(result.name, "letter A");
+}
+
+#[test]
+fn test_string_with_multiple_escapes() {
+    let json = r#"{"name": "Hello\nWorld\t\"quoted\"\u0041"}"#;
+    let result: Named = from_str(json).unwrap();
+    assert_eq!(result.name, "Hello\nWorld\t\"quoted\"A");
+}
+
+#[test]
+fn test_string_matches_facet_json() {
+    let json = r#"{"name": "test string"}"#;
+    let jit_result: Named = from_str(json).unwrap();
+    let interp_result: Named = crate::from_str(json).unwrap();
+    assert_eq!(jit_result, interp_result);
+}
+
+// Nested struct tests
+#[derive(Facet, Debug, PartialEq)]
+struct Inner {
+    value: f64,
+    flag: bool,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Outer {
+    name: String,
+    inner: Inner,
+}
+
+#[test]
+fn test_nested_struct_basic() {
+    let json = r#"{"name": "test", "inner": {"value": 42.5, "flag": true}}"#;
+    let result: Outer = from_str(json).unwrap();
+    assert_eq!(result.name, "test");
+    assert_eq!(result.inner.value, 42.5);
+    assert!(result.inner.flag);
+}
+
+#[test]
+fn test_nested_struct_matches_facet_json() {
+    let json = r#"{"name": "hello", "inner": {"value": 3.14, "flag": false}}"#;
+    let jit_result: Outer = from_str(json).unwrap();
+    let interp_result: Outer = crate::from_str(json).unwrap();
+    assert_eq!(jit_result, interp_result);
+}
+
+// Deeply nested
+#[derive(Facet, Debug, PartialEq)]
+struct Level3 {
+    x: f64,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Level2 {
+    level3: Level3,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Level1 {
+    level2: Level2,
+}
+
+#[test]
+fn test_deeply_nested_struct() {
+    let json = r#"{"level2": {"level3": {"x": 99.9}}}"#;
+    let result: Level1 = from_str(json).unwrap();
+    assert_eq!(result.level2.level3.x, 99.9);
+}
+
+// Vec<Struct> tests
+#[derive(Facet, Debug, PartialEq)]
+struct Item {
+    id: u64,
+    value: f64,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Container {
+    items: Vec<Item>,
+}
+
+#[test]
+fn test_vec_struct_basic() {
+    let json = r#"{"items": [{"id": 1, "value": 1.5}, {"id": 2, "value": 2.5}]}"#;
+    let result: Container = from_str(json).unwrap();
+    assert_eq!(result.items.len(), 2);
+    assert_eq!(result.items[0], Item { id: 1, value: 1.5 });
+    assert_eq!(result.items[1], Item { id: 2, value: 2.5 });
+}
+
+#[test]
+fn test_vec_struct_empty() {
+    let json = r#"{"items": []}"#;
+    let result: Container = from_str(json).unwrap();
+    assert_eq!(result.items.len(), 0);
+}
+
+#[test]
+fn test_vec_struct_single() {
+    let json = r#"{"items": [{"id": 42, "value": 3.125}]}"#;
+    let result: Container = from_str(json).unwrap();
+    assert_eq!(result.items.len(), 1);
+    assert_eq!(
+        result.items[0],
+        Item {
+            id: 42,
+            value: 3.125
+        }
+    );
+}
+
+#[test]
+fn test_vec_struct_matches_facet_json() {
+    let json =
+        r#"{"items": [{"id": 1, "value": 1.0}, {"id": 2, "value": 2.0}, {"id": 3, "value": 3.0}]}"#;
+    let jit_result: Container = from_str(json).unwrap();
+    let interp_result: Container = crate::from_str(json).unwrap();
+    assert_eq!(jit_result, interp_result);
+}
+
+// Complex nested Vec<Struct> with multiple levels
+#[derive(Facet, Debug, PartialEq)]
+struct NestedItem {
+    name: String,
+    coords: Vec<f64>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct NestedContainer {
+    items: Vec<NestedItem>,
+}
+
+#[test]
+fn test_vec_struct_with_nested_fields() {
+    let json =
+        r#"{"items": [{"name": "a", "coords": [1.0, 2.0]}, {"name": "b", "coords": [3.0]}]}"#;
+    let result: NestedContainer = from_str(json).unwrap();
+    assert_eq!(result.items.len(), 2);
+    assert_eq!(result.items[0].name, "a");
+    assert_eq!(result.items[0].coords, vec![1.0, 2.0]);
+    assert_eq!(result.items[1].name, "b");
+    assert_eq!(result.items[1].coords, vec![3.0]);
+}
+
+#[test]
+fn test_vec_struct_nested_matches_facet_json() {
+    let json = r#"{"items": [{"name": "test", "coords": [1.0, 2.0, 3.0]}]}"#;
+    let jit_result: NestedContainer = from_str(json).unwrap();
+    let interp_result: NestedContainer = crate::from_str(json).unwrap();
+    assert_eq!(jit_result, interp_result);
+}
+
+#[test]
+fn test_vec_struct_with_escaped_strings() {
+    let json = r#"{"items": [{"name": "hello\nworld", "coords": [1.0]}, {"name": "tab\there", "coords": [2.0]}]}"#;
+    let result: NestedContainer = from_str(json).unwrap();
+    assert_eq!(result.items.len(), 2);
+    assert_eq!(result.items[0].name, "hello\nworld");
+    assert_eq!(result.items[1].name, "tab\there");
+}
+
+// Twitter-like structure for testing
+#[derive(Facet, Debug, PartialEq)]
+struct TweetUser {
+    id: u64,
+    screen_name: String,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Tweet {
+    id: u64,
+    text: String,
+    user: TweetUser,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct TweetContainer {
+    statuses: Vec<Tweet>,
+}
+
+#[test]
+fn test_twitter_like_structure() {
+    let json = r#"{"statuses": [{"id": 123, "text": "Hello\nWorld", "user": {"id": 456, "screen_name": "test"}}]}"#;
+    let result: TweetContainer = from_str(json).unwrap();
+    assert_eq!(result.statuses.len(), 1);
+    assert_eq!(result.statuses[0].id, 123);
+    assert_eq!(result.statuses[0].text, "Hello\nWorld");
+    assert_eq!(result.statuses[0].user.screen_name, "test");
+}
+
+#[test]
+fn test_twitter_like_multiple() {
+    let json = r#"{"statuses": [
+        {"id": 1, "text": "First\ntweet", "user": {"id": 10, "screen_name": "user1"}},
+        {"id": 2, "text": "Second\ttweet", "user": {"id": 20, "screen_name": "user2"}},
+        {"id": 3, "text": "Third \"quoted\"", "user": {"id": 30, "screen_name": "user3"}}
+    ]}"#;
+    let result: TweetContainer = from_str(json).unwrap();
+    assert_eq!(result.statuses.len(), 3);
+    assert_eq!(result.statuses[0].text, "First\ntweet");
+    assert_eq!(result.statuses[1].text, "Second\ttweet");
+    assert_eq!(result.statuses[2].text, "Third \"quoted\"");
+}
+
+#[test]
+fn test_twitter_like_with_extra_fields() {
+    // Twitter JSON has many extra fields we need to skip
+    let json = r#"{"statuses": [
+        {
+            "metadata": {"result_type": "recent"},
+            "created_at": "Sun Aug 31",
+            "id": 123,
+            "id_str": "123",
+            "text": "Hello\nWorld with \"quotes\"",
+            "source": "<a href=\"test\">Test</a>",
+            "truncated": false,
+            "in_reply_to_status_id": null,
+            "user": {
+                "id": 456,
+                "id_str": "456",
+                "name": "Test User",
+                "screen_name": "testuser",
+                "location": "Here",
+                "description": "A test\nuser",
+                "url": null,
+                "followers_count": 100
+            },
+            "retweet_count": 5,
+            "favorite_count": 10,
+            "entities": {"hashtags": [], "urls": []},
+            "favorited": false,
+            "retweeted": false
+        }
+    ]}"#;
+    let result: TweetContainer = from_str(json).unwrap();
+    assert_eq!(result.statuses.len(), 1);
+    assert_eq!(result.statuses[0].id, 123);
+    assert_eq!(result.statuses[0].text, "Hello\nWorld with \"quotes\"");
+    assert_eq!(result.statuses[0].user.id, 456);
+    assert_eq!(result.statuses[0].user.screen_name, "testuser");
+}

--- a/facet-json/src/lib.rs
+++ b/facet-json/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(missing_docs)]
-#![deny(unsafe_code)]
+// Allow unsafe code when cranelift feature is enabled (required for JIT compilation)
+#![cfg_attr(not(feature = "cranelift"), deny(unsafe_code))]
 #![doc = include_str!("../README.md")]
 
 extern crate alloc;
@@ -53,6 +54,27 @@ pub use raw_json::RawJson;
 
 mod json;
 pub use json::Json;
+
+/// JIT-compiled JSON deserialization using Cranelift.
+///
+/// This module provides a JIT-compiled JSON deserializer that generates native
+/// code specialized for each type's exact memory layout. On first call for a type,
+/// it compiles a specialized deserializer using Cranelift. Subsequent calls use
+/// the cached native code directly.
+///
+/// # Example
+///
+/// ```ignore
+/// use facet::Facet;
+/// use facet_json::cranelift;
+///
+/// #[derive(Facet)]
+/// struct Point { x: f64, y: f64 }
+///
+/// let point: Point = cranelift::from_str(r#"{"x": 1.0, "y": 2.0}"#).unwrap();
+/// ```
+#[cfg(feature = "cranelift")]
+pub mod cranelift;
 
 #[cfg(feature = "axum")]
 mod axum;


### PR DESCRIPTION
## Summary

- Add a new `jit` feature to facet-json that provides JIT-compiled JSON deserialization using Cranelift
- The JIT generates native code specialized for each type's memory layout
- Merges facet-jitson into facet-json under the `jit` module

### Features

- Cranelift-based JIT compilation with function caching by TypeId/Shape
- Prefix trie dispatch for O(n) field name matching
- Support for: primitives (f64/f32/i64/i32/i16/i8/u64/u32/u16/u8/bool), String, nested structs, Vec<T> for numeric types and structs
- Automatic fallback to interpreter for unsupported types
- 46 comprehensive tests verifying correctness against the interpreter

### Usage

```rust
use facet_json::jit;

#[derive(Facet)]
struct Point { x: f64, y: f64 }

let point: Point = jit::from_str(r#"{"x": 1.0, "y": 2.0}"#).unwrap();
```

## Test plan

- [x] All 46 JIT tests pass
- [x] Clippy passes with `--all-features`
- [x] Doc tests pass
- [x] Fix rustdoc warnings (wrap generic types in backticks in doc comments)
- [ ] CI passes