### PR TITLE
feat: add container-level proxy attribute support (#1109)

### DIFF
--- a/facet-core/src/impls_alloc/boxed.rs
+++ b/facet-core/src/impls_alloc/boxed.rs
@@ -119,6 +119,7 @@ unsafe impl<'a, T: ?Sized + Facet<'a>> Facet<'a> for Box<T> {
             attributes: &[],
             type_tag: None,
             inner: Some(T::SHAPE),
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_alloc/cow.rs
+++ b/facet-core/src/impls_alloc/cow.rs
@@ -71,5 +71,6 @@ where
         attributes: &[],
         type_tag: None,
         inner: None,
+        proxy: None,
     };
 }

--- a/facet-core/src/impls_alloc/vec.rs
+++ b/facet-core/src/impls_alloc/vec.rs
@@ -105,6 +105,7 @@ where
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_bytes.rs
+++ b/facet-core/src/impls_bytes.rs
@@ -99,6 +99,7 @@ unsafe impl Facet<'_> for Bytes {
             attributes: &[],
             type_tag: None,
             inner: Some(BytesMut::SHAPE),
+            proxy: None,
         }
     };
 }
@@ -182,6 +183,7 @@ unsafe impl Facet<'_> for BytesMut {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_camino.rs
+++ b/facet-core/src/impls_camino.rs
@@ -60,6 +60,7 @@ unsafe impl Facet<'_> for Utf8PathBuf {
             attributes: &[],
             type_tag: None,
             inner: Some(<String as Facet>::SHAPE),
+            proxy: None,
         }
     };
 }
@@ -82,6 +83,7 @@ unsafe impl Facet<'_> for Utf8Path {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_chrono.rs
+++ b/facet-core/src/impls_chrono.rs
@@ -63,6 +63,7 @@ unsafe impl Facet<'_> for DateTime<Utc> {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }
@@ -124,6 +125,7 @@ unsafe impl Facet<'_> for DateTime<FixedOffset> {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }
@@ -187,6 +189,7 @@ unsafe impl Facet<'_> for DateTime<Local> {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }
@@ -258,6 +261,7 @@ unsafe impl Facet<'_> for NaiveDateTime {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }
@@ -319,6 +323,7 @@ unsafe impl Facet<'_> for NaiveDate {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }
@@ -384,6 +389,7 @@ unsafe impl Facet<'_> for NaiveTime {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_core/array.rs
+++ b/facet-core/src/impls_core/array.rs
@@ -96,6 +96,7 @@ where
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_core/ops.rs
+++ b/facet-core/src/impls_core/ops.rs
@@ -72,6 +72,7 @@ unsafe impl<'a, Idx: Facet<'a>> Facet<'a> for core::ops::Range<Idx> {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_core/pointer.rs
+++ b/facet-core/src/impls_core/pointer.rs
@@ -80,6 +80,7 @@ unsafe impl<'a, T: Facet<'a> + ?Sized> Facet<'a> for *const T {
             attributes: &[],
             type_tag: None,
             inner: Some(T::SHAPE),
+            proxy: None,
         }
     };
 }
@@ -158,6 +159,7 @@ unsafe impl<'a, T: Facet<'a> + ?Sized> Facet<'a> for *mut T {
             attributes: &[],
             type_tag: None,
             inner: Some(T::SHAPE),
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_core/scalar.rs
+++ b/facet-core/src/impls_core/scalar.rs
@@ -407,6 +407,7 @@ macro_rules! impl_facet_for_nonzero {
                     attributes: &[],
                     type_tag: None,
                     inner: Some(<$type as Facet>::SHAPE),
+                    proxy: None,
                 }
             };
         }

--- a/facet-core/src/impls_core/simd.rs
+++ b/facet-core/src/impls_core/simd.rs
@@ -28,6 +28,7 @@ macro_rules! impl_facet_for_simd {
                     attributes: &[],
                     type_tag: None,
                     inner: None,
+                    proxy: None,
                 }
             };
         }

--- a/facet-core/src/impls_core/tuple.rs
+++ b/facet-core/src/impls_core/tuple.rs
@@ -113,6 +113,7 @@ macro_rules! impl_facet_for_tuple {
                     attributes: &[],
                     type_tag: None,
                     inner: None,
+            proxy: None,
                 }
             };
         }

--- a/facet-core/src/impls_indexmap.rs
+++ b/facet-core/src/impls_indexmap.rs
@@ -110,6 +110,7 @@ where
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_jiff.rs
+++ b/facet-core/src/impls_jiff.rs
@@ -58,6 +58,7 @@ unsafe impl Facet<'_> for Zoned {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }
@@ -120,6 +121,7 @@ unsafe impl Facet<'_> for Timestamp {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }
@@ -181,6 +183,7 @@ unsafe impl Facet<'_> for DateTime {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_ordered_float.rs
+++ b/facet-core/src/impls_ordered_float.rs
@@ -93,6 +93,7 @@ macro_rules! impl_facet_for_ordered_float_and_notnan {
                     attributes: &[],
                     type_tag: None,
                     inner: Some(<$float as Facet>::SHAPE),
+                    proxy: None,
                 }
             };
         }
@@ -193,6 +194,7 @@ macro_rules! impl_facet_for_ordered_float_and_notnan {
                     attributes: &[],
                     type_tag: None,
                     inner: Some(<$float as Facet>::SHAPE),
+                    proxy: None,
                 }
             };
         }

--- a/facet-core/src/impls_ruint.rs
+++ b/facet-core/src/impls_ruint.rs
@@ -19,6 +19,7 @@ unsafe impl<'facet, const BITS: usize, const LIMBS: usize> Facet<'facet> for Uin
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }
@@ -40,6 +41,7 @@ unsafe impl<'facet, const BITS: usize, const LIMBS: usize> Facet<'facet> for Bit
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_std/hashmap.rs
+++ b/facet-core/src/impls_std/hashmap.rs
@@ -111,6 +111,7 @@ where
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }
@@ -129,6 +130,7 @@ unsafe impl Facet<'_> for RandomState {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_std/hashset.rs
+++ b/facet-core/src/impls_std/hashset.rs
@@ -94,6 +94,7 @@ where
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_std/path.rs
+++ b/facet-core/src/impls_std/path.rs
@@ -18,6 +18,7 @@ unsafe impl Facet<'_> for std::path::PathBuf {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }
@@ -40,6 +41,7 @@ unsafe impl Facet<'_> for std::path::Path {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_time.rs
+++ b/facet-core/src/impls_time.rs
@@ -68,6 +68,7 @@ unsafe impl Facet<'_> for UtcDateTime {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }
@@ -137,6 +138,7 @@ unsafe impl Facet<'_> for OffsetDateTime {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_ulid.rs
+++ b/facet-core/src/impls_ulid.rs
@@ -68,6 +68,7 @@ unsafe impl Facet<'_> for Ulid {
             attributes: &[],
             type_tag: None,
             inner: Some(<String as Facet>::SHAPE),
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_url.rs
+++ b/facet-core/src/impls_url.rs
@@ -76,6 +76,7 @@ unsafe impl Facet<'_> for Url {
             attributes: &[],
             type_tag: None,
             inner: Some(<String as Facet>::SHAPE),
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/impls_uuid.rs
+++ b/facet-core/src/impls_uuid.rs
@@ -69,6 +69,7 @@ unsafe impl Facet<'_> for Uuid {
             attributes: &[],
             type_tag: None,
             inner: Some(<String as Facet>::SHAPE),
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/opaque.rs
+++ b/facet-core/src/opaque.rs
@@ -19,6 +19,7 @@ unsafe impl<'facet, T: 'facet> Facet<'facet> for Opaque<T> {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         }
     };
 }

--- a/facet-core/src/types/ty/field.rs
+++ b/facet-core/src/types/ty/field.rs
@@ -217,6 +217,29 @@ pub type ProxyConvertOutFn = for<'mem> unsafe fn(
     proxy_ptr: PtrUninit<'mem>,
 ) -> Result<PtrMut<'mem>, alloc::string::String>;
 
+#[cfg(feature = "alloc")]
+/// Definition of a proxy type for serialization/deserialization.
+///
+/// This is used when `#[facet(proxy = ProxyType)]` is applied at the container level
+/// (struct or enum). It stores everything needed to convert values to/from the proxy type.
+///
+/// The user must implement:
+/// - `TryFrom<ProxyType> for OriginalType` (for deserialization: proxy → original)
+/// - `TryFrom<&OriginalType> for ProxyType` (for serialization: original → proxy)
+#[derive(Clone, Copy)]
+pub struct ProxyDef {
+    /// The shape of the proxy type.
+    pub shape: &'static super::Shape,
+
+    /// Function to convert FROM proxy type INTO the original type.
+    /// Used during deserialization.
+    pub convert_in: ProxyConvertInFn,
+
+    /// Function to convert FROM original type OUT TO proxy type.
+    /// Used during serialization.
+    pub convert_out: ProxyConvertOutFn,
+}
+
 impl Field {
     /// Returns the shape of the inner type
     #[inline]

--- a/facet-json/tests/proxy_container.rs
+++ b/facet-json/tests/proxy_container.rs
@@ -1,0 +1,249 @@
+//! Tests for container-level proxy attribute (#1109).
+//!
+//! Container-level proxy allows `#[facet(proxy = ProxyType)]` at the struct/enum level,
+//! so any field of that type automatically uses the proxy without per-field annotations.
+//! This includes nested types like `Vec<Mine>`, `Option<Mine>`, etc.
+
+use facet::Facet;
+use facet_json as json;
+
+/// Proxy type that represents an integer as a string for serialization.
+/// This is the proxy type that will be used at the container level.
+#[derive(Facet, Clone, Debug)]
+#[facet(transparent)]
+pub struct IntAsString(pub String);
+
+/// A type with container-level proxy.
+/// Any `MyInt` value will serialize/deserialize through `IntAsString`.
+#[derive(Facet, Debug, Clone, PartialEq)]
+#[facet(proxy = IntAsString)]
+pub struct MyInt {
+    pub value: i32,
+}
+
+/// Convert from proxy (deserialization)
+impl TryFrom<IntAsString> for MyInt {
+    type Error = std::num::ParseIntError;
+    fn try_from(proxy: IntAsString) -> Result<Self, Self::Error> {
+        Ok(MyInt {
+            value: proxy.0.parse()?,
+        })
+    }
+}
+
+/// Convert to proxy (serialization)
+impl TryFrom<&MyInt> for IntAsString {
+    type Error = std::convert::Infallible;
+    fn try_from(v: &MyInt) -> Result<Self, Self::Error> {
+        Ok(IntAsString(v.value.to_string()))
+    }
+}
+
+/// Test basic container-level proxy on a simple field.
+#[test]
+fn test_basic_container_proxy() {
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct Wrapper {
+        pub item: MyInt,
+    }
+
+    // Deserialization: JSON string "42" should deserialize to MyInt { value: 42 }
+    let json = r#"{"item":"42"}"#;
+    let wrapper: Wrapper = json::from_str(json).unwrap();
+    assert_eq!(wrapper.item, MyInt { value: 42 });
+
+    // Serialization: MyInt { value: 42 } should serialize to JSON string "42"
+    let serialized = json::to_string(&wrapper);
+    assert_eq!(serialized, r#"{"item":"42"}"#);
+}
+
+/// Test container-level proxy with Vec<T>.
+/// When serializing Vec<MyInt>, each element should use the proxy.
+#[test]
+fn test_vec_with_container_proxy() {
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct Collection {
+        pub items: Vec<MyInt>,
+    }
+
+    // Deserialization
+    let json = r#"{"items":["1","2","3"]}"#;
+    let collection: Collection = json::from_str(json).unwrap();
+    assert_eq!(collection.items.len(), 3);
+    assert_eq!(collection.items[0], MyInt { value: 1 });
+    assert_eq!(collection.items[1], MyInt { value: 2 });
+    assert_eq!(collection.items[2], MyInt { value: 3 });
+
+    // Serialization
+    let serialized = json::to_string(&collection);
+    assert_eq!(serialized, r#"{"items":["1","2","3"]}"#);
+}
+
+/// Test container-level proxy with Option<T>.
+#[test]
+fn test_option_with_container_proxy() {
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct MaybeInt {
+        pub value: Option<MyInt>,
+    }
+
+    // With Some value
+    let json = r#"{"value":"42"}"#;
+    let maybe: MaybeInt = json::from_str(json).unwrap();
+    assert_eq!(maybe.value, Some(MyInt { value: 42 }));
+
+    let serialized = json::to_string(&maybe);
+    assert_eq!(serialized, r#"{"value":"42"}"#);
+
+    // With null
+    let json2 = r#"{"value":null}"#;
+    let maybe2: MaybeInt = json::from_str(json2).unwrap();
+    assert!(maybe2.value.is_none());
+
+    let serialized2 = json::to_string(&maybe2);
+    assert_eq!(serialized2, r#"{"value":null}"#);
+}
+
+/// Test container-level proxy with nested Vec<Vec<T>>.
+#[test]
+fn test_nested_vec_with_container_proxy() {
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct NestedCollection {
+        pub matrix: Vec<Vec<MyInt>>,
+    }
+
+    let json = r#"{"matrix":[["1","2"],["3","4"]]}"#;
+    let nested: NestedCollection = json::from_str(json).unwrap();
+    assert_eq!(nested.matrix.len(), 2);
+    assert_eq!(
+        nested.matrix[0],
+        vec![MyInt { value: 1 }, MyInt { value: 2 }]
+    );
+    assert_eq!(
+        nested.matrix[1],
+        vec![MyInt { value: 3 }, MyInt { value: 4 }]
+    );
+
+    let serialized = json::to_string(&nested);
+    assert_eq!(serialized, r#"{"matrix":[["1","2"],["3","4"]]}"#);
+}
+
+/// Test that field-level proxy overrides container-level proxy.
+#[test]
+fn test_field_proxy_overrides_container_proxy() {
+    /// Alternative proxy that uses hex encoding
+    #[derive(Facet, Clone, Debug)]
+    #[facet(transparent)]
+    pub struct HexIntProxy(pub String);
+
+    impl TryFrom<HexIntProxy> for MyInt {
+        type Error = std::num::ParseIntError;
+        fn try_from(proxy: HexIntProxy) -> Result<Self, Self::Error> {
+            // Parse as hex (without 0x prefix for simplicity)
+            Ok(MyInt {
+                value: i32::from_str_radix(&proxy.0, 16)?,
+            })
+        }
+    }
+
+    impl TryFrom<&MyInt> for HexIntProxy {
+        type Error = std::convert::Infallible;
+        fn try_from(v: &MyInt) -> Result<Self, Self::Error> {
+            Ok(HexIntProxy(format!("{:x}", v.value)))
+        }
+    }
+
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct Mixed {
+        // Uses container-level proxy (IntAsString - decimal)
+        pub decimal: MyInt,
+        // Uses field-level proxy (HexIntProxy - hex)
+        #[facet(proxy = HexIntProxy)]
+        pub hex: MyInt,
+    }
+
+    let json = r#"{"decimal":"255","hex":"ff"}"#;
+    let mixed: Mixed = json::from_str(json).unwrap();
+    assert_eq!(mixed.decimal, MyInt { value: 255 });
+    assert_eq!(mixed.hex, MyInt { value: 255 });
+
+    let serialized = json::to_string(&mixed);
+    assert_eq!(serialized, r#"{"decimal":"255","hex":"ff"}"#);
+}
+
+/// Test round-trip serialization/deserialization.
+#[test]
+fn test_round_trip() {
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct Complex {
+        pub single: MyInt,
+        pub optional: Option<MyInt>,
+        pub list: Vec<MyInt>,
+    }
+
+    let original = Complex {
+        single: MyInt { value: 100 },
+        optional: Some(MyInt { value: 200 }),
+        list: vec![MyInt { value: 1 }, MyInt { value: 2 }, MyInt { value: 3 }],
+    };
+
+    let serialized = json::to_string(&original);
+    let deserialized: Complex = json::from_str(&serialized).unwrap();
+    assert_eq!(original, deserialized);
+}
+
+/// Test container-level proxy on an enum.
+#[test]
+fn test_enum_container_proxy() {
+    /// An enum with container-level proxy
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    #[facet(proxy = IntAsString)]
+    #[repr(C)]
+    pub enum MyIntEnum {
+        Value { value: i32 },
+    }
+
+    impl TryFrom<IntAsString> for MyIntEnum {
+        type Error = std::num::ParseIntError;
+        fn try_from(proxy: IntAsString) -> Result<Self, Self::Error> {
+            Ok(MyIntEnum::Value {
+                value: proxy.0.parse()?,
+            })
+        }
+    }
+
+    impl TryFrom<&MyIntEnum> for IntAsString {
+        type Error = std::convert::Infallible;
+        fn try_from(v: &MyIntEnum) -> Result<Self, Self::Error> {
+            match v {
+                MyIntEnum::Value { value } => Ok(IntAsString(value.to_string())),
+            }
+        }
+    }
+
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct EnumWrapper {
+        pub item: MyIntEnum,
+    }
+
+    let json = r#"{"item":"42"}"#;
+    let wrapper: EnumWrapper = json::from_str(json).unwrap();
+    assert_eq!(wrapper.item, MyIntEnum::Value { value: 42 });
+
+    let serialized = json::to_string(&wrapper);
+    assert_eq!(serialized, r#"{"item":"42"}"#);
+}
+
+/// Test deserialization error propagation from proxy conversion.
+#[test]
+fn test_proxy_conversion_error() {
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct Wrapper {
+        pub item: MyInt,
+    }
+
+    // Invalid integer string should fail
+    let json = r#"{"item":"not_a_number"}"#;
+    let result: Result<Wrapper, _> = json::from_str(json);
+    assert!(result.is_err());
+}

--- a/facet-macro-parse/Cargo.toml
+++ b/facet-macro-parse/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 description = "Parser for facet derive macros - takes TokenStream and returns parsed type representations"
 

--- a/facet-macros-impl/src/process_struct.rs
+++ b/facet-macros-impl/src/process_struct.rs
@@ -931,11 +931,12 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
                 // - crate: sets the facet crate path
                 // - traits: compile-time directive for vtable generation
                 // - auto_traits: compile-time directive for vtable generation
+                // - proxy: sets Shape::proxy for container-level proxy
                 if attr.is_builtin() {
                     let key = attr.key_str();
                     !matches!(
                         key.as_str(),
-                        "invariants" | "crate" | "traits" | "auto_traits"
+                        "invariants" | "crate" | "traits" | "auto_traits" | "proxy"
                     )
                 } else {
                     true
@@ -958,6 +959,57 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
     let type_tag_call = {
         if let Some(type_tag) = ps.container.attrs.get_builtin_args("type_tag") {
             quote! { .type_tag(#type_tag) }
+        } else {
+            quote! {}
+        }
+    };
+
+    // Container-level proxy from PStruct - generates ProxyDef with conversion functions
+    let proxy_call = {
+        if let Some(attr) = ps
+            .container
+            .attrs
+            .facet
+            .iter()
+            .find(|a| a.is_builtin() && a.key_str() == "proxy")
+        {
+            let proxy_type = &attr.args;
+            let struct_type = &struct_name_ident;
+            let bgp_display = ps.container.bgp.display_without_bounds();
+
+            quote! {
+                .proxy(&const {
+                    extern crate alloc as __alloc;
+
+                    unsafe fn __proxy_convert_in<'mem>(
+                        proxy_ptr: #facet_crate::PtrConst<'mem>,
+                        field_ptr: #facet_crate::PtrUninit<'mem>,
+                    ) -> ::core::result::Result<#facet_crate::PtrMut<'mem>, __alloc::string::String> {
+                        let proxy: #proxy_type = proxy_ptr.read();
+                        match <#struct_type #bgp_display as ::core::convert::TryFrom<#proxy_type>>::try_from(proxy) {
+                            ::core::result::Result::Ok(value) => ::core::result::Result::Ok(field_ptr.put(value)),
+                            ::core::result::Result::Err(e) => ::core::result::Result::Err(__alloc::string::ToString::to_string(&e)),
+                        }
+                    }
+
+                    unsafe fn __proxy_convert_out<'mem>(
+                        field_ptr: #facet_crate::PtrConst<'mem>,
+                        proxy_ptr: #facet_crate::PtrUninit<'mem>,
+                    ) -> ::core::result::Result<#facet_crate::PtrMut<'mem>, __alloc::string::String> {
+                        let field_ref: &#struct_type #bgp_display = field_ptr.get();
+                        match <#proxy_type as ::core::convert::TryFrom<&#struct_type #bgp_display>>::try_from(field_ref) {
+                            ::core::result::Result::Ok(proxy) => ::core::result::Result::Ok(proxy_ptr.put(proxy)),
+                            ::core::result::Result::Err(e) => ::core::result::Result::Err(__alloc::string::ToString::to_string(&e)),
+                        }
+                    }
+
+                    #facet_crate::ProxyDef {
+                        shape: <#proxy_type as #facet_crate::Facet>::SHAPE,
+                        convert_in: __proxy_convert_in,
+                        convert_out: __proxy_convert_out,
+                    }
+                })
+            }
         } else {
             quote! {}
         }
@@ -1259,6 +1311,7 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
                     #doc_call
                     #attributes_call
                     #type_tag_call
+                    #proxy_call
                     #inner_call
                     .build()
             };

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -307,6 +307,11 @@ pub(crate) struct Frame {
 
     /// Whether this frame is for a custom deserialization pipeline
     pub(crate) using_custom_deserialization: bool,
+
+    /// If this frame was created for shape-level proxy deserialization,
+    /// this stores the ProxyDef for the conversion in end().
+    #[cfg(feature = "alloc")]
+    pub(crate) shape_level_proxy: Option<&'static facet_core::ProxyDef>,
 }
 
 #[derive(Debug)]
@@ -488,6 +493,8 @@ impl Frame {
             tracker: Tracker::Scalar,
             ownership,
             using_custom_deserialization: false,
+            #[cfg(feature = "alloc")]
+            shape_level_proxy: None,
         }
     }
 

--- a/facet-reflect/src/spanned.rs
+++ b/facet-reflect/src/spanned.rs
@@ -103,6 +103,7 @@ unsafe impl Facet<'_> for Span {
         attributes: &[],
         type_tag: None,
         inner: None,
+        proxy: None,
     };
 }
 
@@ -233,6 +234,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Spanned<T> {
         attributes: &[],
         type_tag: None,
         inner: None,
+        proxy: None,
     };
 }
 

--- a/facet-reflect/tests/peek/ndarray.rs
+++ b/facet-reflect/tests/peek/ndarray.rs
@@ -150,6 +150,7 @@ unsafe impl<'facet, T: Facet<'facet>> Facet<'facet> for Mat<T> {
         doc: &[],
         attributes: &[],
         inner: None,
+        proxy: None,
     };
 }
 

--- a/facet-value/src/facet_impl.rs
+++ b/facet-value/src/facet_impl.rs
@@ -442,6 +442,7 @@ pub static VALUE_SHAPE: Shape = Shape {
     attributes: &[],
     type_tag: None,
     inner: None,
+    proxy: None,
 };
 
 unsafe impl Facet<'_> for Value {

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -218,6 +218,7 @@ pub mod builtin {
             attributes: &[],
             type_tag: None,
             inner: None,
+            proxy: None,
         };
     }
 }


### PR DESCRIPTION
## Summary
Allow `#[facet(proxy = ProxyType)]` at the struct/enum level, so any field of that type automatically uses the proxy without per-field annotations. This includes nested types like `Vec<Mine>`, `Option<Mine>`.

Closes #1109

## Key Changes
- Add `ProxyDef` type to store proxy shape and conversion functions
- Add `proxy` field to `Shape` struct with O(1) lookup
- Update `ShapeBuilder` with `proxy()` method
- Update macro codegen for structs and enums to handle container proxy
- Add `custom_serialization_from_shape` to `Peek` for serialization
- Add `begin_custom_deserialization_from_shape` to `Partial` for deserialization
- Update facet-json serializer/deserializer to check shape-level proxy
- Field-level proxy takes precedence over container-level proxy

## Example
```rust
// Proxy type
#[derive(Facet)]
#[facet(transparent)]
pub struct IntAsString(pub String);

// Type with container-level proxy - any MyInt will use IntAsString
#[derive(Facet)]
#[facet(proxy = IntAsString)]
pub struct MyInt {
    pub value: i32,
}

impl TryFrom<IntAsString> for MyInt { /* ... */ }
impl TryFrom<&MyInt> for IntAsString { /* ... */ }

// Now Vec<MyInt> works automatically!
#[derive(Facet)]
pub struct Collection {
    pub items: Vec<MyInt>,  // Each element uses IntAsString proxy
}

// {"items":["1","2","3"]} <-> Collection { items: vec![MyInt{value:1}, MyInt{value:2}, MyInt{value:3}] }
```

## Test plan
- [x] Added comprehensive test file `facet-json/tests/proxy_container.rs` with tests for:
  - Basic container-level proxy
  - `Vec<ProxiedType>` serialization/deserialization
  - `Option<ProxiedType>` serialization/deserialization
  - `Vec<Vec<ProxiedType>>` nested types
  - Field-level proxy overriding container-level
  - Round-trip serialization
  - Enum container proxy
  - Error propagation from proxy conversion
- [x] All 2054 workspace tests pass