### PR TITLE
feat: make repr(transparent) imply facet(transparent) for single-field tuple structs

### DIFF
--- a/facet-json/tests/transparent.rs
+++ b/facet-json/tests/transparent.rs
@@ -155,3 +155,63 @@ fn transparent_string_as_map_key() {
     );
     assert_eq!(map.len(), 3);
 }
+
+#[test]
+fn repr_transparent_implies_facet_transparent() {
+    let markup = r#"
+        "I look like a string"
+    "#;
+
+    // #[repr(transparent)] should automatically imply #[facet(transparent)]
+    // No need to add #[facet(transparent)] separately
+    #[derive(Facet, Clone, Debug)]
+    #[repr(transparent)]
+    struct MyString(String);
+
+    let t: MyString = from_str(markup).unwrap();
+    assert_eq!(t.0, "I look like a string".to_string());
+}
+
+#[test]
+fn repr_transparent_u64() {
+    use std::num::NonZeroU64;
+
+    let markup = r#"
+        42
+    "#;
+
+    // Test that repr(transparent) works with numeric wrappers
+    #[derive(Facet, Clone, Debug)]
+    #[repr(transparent)]
+    struct MyU64(NonZeroU64);
+
+    let n: MyU64 = from_str(markup).unwrap();
+    assert_eq!(n.0, NonZeroU64::new(42).unwrap());
+}
+
+#[test]
+fn repr_transparent_as_map_key() {
+    use std::collections::HashMap;
+
+    // Test that repr(transparent) works as map keys (just like facet(transparent))
+    #[derive(Facet, Clone, Debug, PartialEq, Eq, Hash)]
+    #[repr(transparent)]
+    struct UserId(String);
+
+    let markup = r#"
+        {
+            "user123": "Alice",
+            "user456": "Bob"
+        }
+    "#;
+
+    let map: HashMap<UserId, String> = from_str(markup).unwrap();
+    assert_eq!(
+        map.get(&UserId("user123".to_string())),
+        Some(&"Alice".to_string())
+    );
+    assert_eq!(
+        map.get(&UserId("user456".to_string())),
+        Some(&"Bob".to_string())
+    );
+}

--- a/facet-macro-parse/src/parsed.rs
+++ b/facet-macro-parse/src/parsed.rs
@@ -735,6 +735,11 @@ impl PAttrs {
             .any(|a| a.is_builtin() && a.key_str() == key)
     }
 
+    /// Check if `#[repr(transparent)]` is present
+    pub fn is_repr_transparent(&self) -> bool {
+        matches!(self.repr, PRepr::Transparent)
+    }
+
     /// Get the args of a builtin attribute with the given key (if present)
     pub fn get_builtin_args(&self, key: &str) -> Option<String> {
         self.facet


### PR DESCRIPTION
## Summary
- When a tuple struct has `#[repr(transparent)]` and exactly 0 or 1 fields, the facet derive macro now automatically uses transparent semantics
- This removes the need to also add `#[facet(transparent)]` for common newtype wrapper patterns
- For tuple structs with multiple fields (e.g., with PhantomData), `repr(transparent)` does NOT automatically imply `facet(transparent)` since facet's transparent semantics only support 0-1 fields

## Test plan
- [x] Added new tests for `#[repr(transparent)]` implying facet transparent behavior
- [x] Verified existing `tuple_struct_generic` test with `repr(transparent)` and PhantomData still compiles (it does NOT use transparent semantics)
- [x] All 2059 tests pass
- [x] nostd-ci passes

Closes #1172