### PR TITLE
fix(facet-kdl): simplify children node name override syntax

### DIFF
--- a/docs/content/guide/attributes.md
+++ b/docs/content/guide/attributes.md
@@ -678,6 +678,18 @@ struct Dependency {
     #[facet(kdl::property)]
     features: Vec<String>,
 }
+
+// For children collections, you can specify a custom node name:
+#[derive(Facet)]
+struct Config {
+    // Matches "dependency" nodes (auto-singularized from field name)
+    #[facet(kdl::children)]
+    dependencies: Vec<Dependency>,
+
+    // Matches "extra" nodes (custom node name)
+    #[facet(kdl::children = "extra")]
+    extras: Vec<Extra>,
+}
 ```
 
 ### Args attributes

--- a/facet-kdl/src/lib.rs
+++ b/facet-kdl/src/lib.rs
@@ -31,6 +31,7 @@ pub use self::axum::KdlRejection;
 // After importing `use facet_kdl as kdl;`, users can write:
 //   #[facet(kdl::child)]
 //   #[facet(kdl::children)]
+//   #[facet(kdl::children = "custom_name")]
 //   #[facet(kdl::property)]
 //   #[facet(kdl::argument)]
 //   #[facet(kdl::arguments)]
@@ -47,8 +48,12 @@ facet::define_attr_grammar! {
 
     /// KDL attribute types for field and container configuration.
     pub enum Attr {
-        /// Marks a field as a single KDL child node
-        Child,
+        /// Marks a field as a single KDL child node.
+        ///
+        /// Can optionally specify a custom node name to match:
+        /// - `#[facet(kdl::child)]` - matches by field name
+        /// - `#[facet(kdl::child = "custom")]` - matches nodes named "custom"
+        Child(Option<&'static str>),
         /// Marks a field as collecting multiple KDL children into a Vec, HashMap, or Set.
         ///
         /// When a struct has a single `#[facet(kdl::children)]` field, all child nodes
@@ -65,9 +70,9 @@ facet::define_attr_grammar! {
         /// - `ies` ending: `dependency` → `dependencies`
         /// - `es` ending: `box` → `boxes`
         ///
-        /// To override automatic singularization, use `node_name`:
-        /// - `#[facet(kdl::children, kdl::node_name = "kiddo")]` matches nodes named `kiddo`
-        Children,
+        /// To override automatic singularization, specify a custom node name:
+        /// - `#[facet(kdl::children = "kiddo")]` matches nodes named `kiddo`
+        Children(Option<&'static str>),
         /// Marks a field as a KDL property (key=value)
         Property,
         /// Marks a field as a single KDL positional argument
@@ -81,16 +86,10 @@ facet::define_attr_grammar! {
         /// ```ignore
         /// #[derive(Facet)]
         /// struct Node {
-        ///     #[facet(kdl::name)]
+        ///     #[facet(kdl::node_name)]
         ///     name: String,
         /// }
         /// ```
-        Name,
-        /// Override the expected node name for matching children in `kdl::children` fields.
-        /// By default, nodes are matched by singularizing the field name.
-        /// Use this alongside `kdl::children` to specify a custom node name.
-        ///
-        /// Example: `#[facet(kdl::children, kdl::node_name = "kiddo")]`
-        NodeName(&'static str),
+        NodeName,
     }
 }

--- a/facet-kdl/tests/basic.rs
+++ b/facet-kdl/tests/basic.rs
@@ -98,7 +98,7 @@ fn canon_example() {
 
     #[derive(Facet, PartialEq, Debug)]
     struct Dependency {
-        #[facet(kdl::name)]
+        #[facet(kdl::node_name)]
         name: String,
         #[facet(kdl::argument)]
         version: String,
@@ -110,7 +110,7 @@ fn canon_example() {
 
     #[derive(Facet, PartialEq, Debug)]
     struct Script {
-        #[facet(kdl::name)]
+        #[facet(kdl::node_name)]
         name: String,
         #[facet(kdl::argument)]
         body: String,
@@ -216,7 +216,7 @@ fn key_value_map_with_node_name() {
 
     #[derive(Facet, PartialEq, Debug)]
     struct Setting {
-        #[facet(kdl::name)]
+        #[facet(kdl::node_name)]
         key: String,
         #[facet(kdl::argument)]
         value: String,

--- a/facet-kdl/tests/diagnostics.rs
+++ b/facet-kdl/tests/diagnostics.rs
@@ -141,7 +141,7 @@ fn miette_multiple_validation_errors() {
 
     #[derive(Facet, Debug)]
     struct Task {
-        #[facet(kdl::name)]
+        #[facet(kdl::node_name)]
         name: String,
         #[facet(kdl::property)]
         #[facet(default)]

--- a/facet-kdl/tests/serialize.rs
+++ b/facet-kdl/tests/serialize.rs
@@ -221,7 +221,7 @@ fn serialize_node_name_children() {
 
     #[derive(Facet, PartialEq, Debug)]
     struct Setting {
-        #[facet(kdl::name)]
+        #[facet(kdl::node_name)]
         key: String,
         #[facet(kdl::argument)]
         value: String,

--- a/facet-shapelike/src/tests.rs
+++ b/facet-shapelike/src/tests.rs
@@ -24,7 +24,7 @@ struct KdlAttributes {
     arg: bool,
     #[facet(kdl::arguments)]
     args: Vec<i32>,
-    #[facet(kdl::name)]
+    #[facet(kdl::node_name)]
     name: String,
 }
 


### PR DESCRIPTION
## Summary

- Simplifies the syntax for specifying custom node names for `kdl::children` fields
- Restores `kdl::node_name` to its original purpose of capturing node names

### Before
```rust
#[facet(kdl::children, kdl::node_name = "kiddo")]
children: Vec<Child>,
```

### After
```rust
#[facet(kdl::children = "kiddo")]
children: Vec<Child>,
```

This is a breaking change but improves ergonomics by putting the node name directly on the attribute it modifies.

## Changes

- Add `OptionalStr` variant kind to attr grammar for `Option<&'static str>`
- Refactor attr grammar parsing to use unsynn instead of string matching
- Change `kdl::children` and `kdl::child` to accept optional string value
- Rename `kdl::name` back to `kdl::node_name` for capturing node names
- Update deserializer to read node name from children attribute value
- Update all tests and documentation

Fixes: #1182