### PR TITLE
refactor: rename from_bytes to from_slice in facet-postcard

### DIFF
--- a/facet-postcard/README.md
+++ b/facet-postcard/README.md
@@ -23,7 +23,7 @@ Postcard serialization and deserialization for Facet types.
 
 ```rust
 use facet::Facet;
-use facet_postcard::{to_vec, from_bytes};
+use facet_postcard::{to_vec, from_slice};
 
 #[derive(Debug, Facet)]
 struct Message {
@@ -36,7 +36,7 @@ let msg = Message { id: 42, payload: vec![1, 2, 3] };
 let bytes = to_vec(&msg).unwrap();
 
 // Deserialize
-let decoded: Message = from_bytes(&bytes).unwrap();
+let decoded: Message = from_slice(&bytes).unwrap();
 ```
 
 For `no_std` environments without an allocator, use `to_slice`:

--- a/facet-postcard/README.md.in
+++ b/facet-postcard/README.md.in
@@ -15,7 +15,7 @@ Postcard serialization and deserialization for Facet types.
 
 ```rust
 use facet::Facet;
-use facet_postcard::{to_vec, from_bytes};
+use facet_postcard::{to_vec, from_slice};
 
 #[derive(Debug, Facet)]
 struct Message {
@@ -28,7 +28,7 @@ let msg = Message { id: 42, payload: vec![1, 2, 3] };
 let bytes = to_vec(&msg).unwrap();
 
 // Deserialize
-let decoded: Message = from_bytes(&bytes).unwrap();
+let decoded: Message = from_slice(&bytes).unwrap();
 ```
 
 For `no_std` environments without an allocator, use `to_slice`:

--- a/facet-postcard/fuzz/fuzz_targets/fuzz_deserialize.rs
+++ b/facet-postcard/fuzz/fuzz_targets/fuzz_deserialize.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use facet::Facet;
-use facet_postcard::from_bytes;
+use facet_postcard::from_slice;
 use libfuzzer_sys::fuzz_target;
 
 /// Test deserialization against arbitrary bytes
@@ -44,18 +44,18 @@ enum TestEnum {
 
 fuzz_target!(|data: &[u8]| {
     // Try to deserialize as various types - should not panic
-    let _ = from_bytes::<SimpleStruct>(data);
-    let _ = from_bytes::<NestedStruct>(data);
-    let _ = from_bytes::<VecStruct>(data);
-    let _ = from_bytes::<OptionStruct>(data);
-    let _ = from_bytes::<TestEnum>(data);
-    let _ = from_bytes::<u8>(data);
-    let _ = from_bytes::<u32>(data);
-    let _ = from_bytes::<u64>(data);
-    let _ = from_bytes::<i32>(data);
-    let _ = from_bytes::<String>(data);
-    let _ = from_bytes::<Vec<u8>>(data);
-    let _ = from_bytes::<Vec<u32>>(data);
-    let _ = from_bytes::<Option<u32>>(data);
-    let _ = from_bytes::<(u32, String)>(data);
+    let _ = from_slice::<SimpleStruct>(data);
+    let _ = from_slice::<NestedStruct>(data);
+    let _ = from_slice::<VecStruct>(data);
+    let _ = from_slice::<OptionStruct>(data);
+    let _ = from_slice::<TestEnum>(data);
+    let _ = from_slice::<u8>(data);
+    let _ = from_slice::<u32>(data);
+    let _ = from_slice::<u64>(data);
+    let _ = from_slice::<i32>(data);
+    let _ = from_slice::<String>(data);
+    let _ = from_slice::<Vec<u8>>(data);
+    let _ = from_slice::<Vec<u32>>(data);
+    let _ = from_slice::<Option<u32>>(data);
+    let _ = from_slice::<(u32, String)>(data);
 });

--- a/facet-postcard/fuzz/fuzz_targets/fuzz_roundtrip.rs
+++ b/facet-postcard/fuzz/fuzz_targets/fuzz_roundtrip.rs
@@ -2,7 +2,7 @@
 
 use arbitrary::Arbitrary;
 use facet::Facet;
-use facet_postcard::{from_bytes, to_vec};
+use facet_postcard::{from_slice, to_vec};
 use libfuzzer_sys::fuzz_target;
 
 /// A complex struct with various types for thorough fuzzing
@@ -28,7 +28,7 @@ fuzz_target!(|data: FuzzStruct| {
     // Serialize the arbitrary data
     if let Ok(bytes) = to_vec(&data) {
         // Deserialize it back
-        if let Ok(decoded) = from_bytes::<FuzzStruct>(&bytes) {
+        if let Ok(decoded) = from_slice::<FuzzStruct>(&bytes) {
             // Verify roundtrip
             assert_eq!(data, decoded, "Roundtrip mismatch!");
         }

--- a/facet-postcard/src/axum.rs
+++ b/facet-postcard/src/axum.rs
@@ -78,7 +78,7 @@ where
             })?
             .to_bytes();
 
-        let value: T = crate::from_bytes(&bytes).map_err(|e| PostcardRejection {
+        let value: T = crate::from_slice(&bytes).map_err(|e| PostcardRejection {
             kind: PostcardRejectionKind::Deserialize(e),
         })?;
 

--- a/facet-postcard/tests/arrays_tuples.rs
+++ b/facet-postcard/tests/arrays_tuples.rs
@@ -5,7 +5,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_postcard::{from_bytes, to_vec};
+use facet_postcard::{from_slice, to_vec};
 use postcard::to_allocvec as postcard_to_vec;
 use serde::{Deserialize, Serialize};
 
@@ -29,7 +29,7 @@ mod array_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: ArrayU8_4 = from_bytes(&facet_bytes)?;
+        let decoded: ArrayU8_4 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -49,7 +49,7 @@ mod array_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: ArrayU32_3 = from_bytes(&facet_bytes)?;
+        let decoded: ArrayU32_3 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -67,7 +67,7 @@ mod array_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: ArrayU8_0 = from_bytes(&facet_bytes)?;
+        let decoded: ArrayU8_0 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -85,7 +85,7 @@ mod array_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: ArrayU8_1 = from_bytes(&facet_bytes)?;
+        let decoded: ArrayU8_1 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -108,7 +108,7 @@ mod array_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: ArrayU8_32 = from_bytes(&facet_bytes)?;
+        let decoded: ArrayU8_32 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -128,7 +128,7 @@ mod array_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: ArrayString_2 = from_bytes(&facet_bytes)?;
+        let decoded: ArrayString_2 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -148,7 +148,7 @@ mod array_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NestedArray = from_bytes(&facet_bytes)?;
+        let decoded: NestedArray = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -176,7 +176,7 @@ mod tuple_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: Tuple2 = from_bytes(&facet_bytes)?;
+        let decoded: Tuple2 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -196,7 +196,7 @@ mod tuple_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: Tuple3 = from_bytes(&facet_bytes)?;
+        let decoded: Tuple3 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -214,7 +214,7 @@ mod tuple_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: Tuple1 = from_bytes(&facet_bytes)?;
+        let decoded: Tuple1 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -234,7 +234,7 @@ mod tuple_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: Tuple4 = from_bytes(&facet_bytes)?;
+        let decoded: Tuple4 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -254,7 +254,7 @@ mod tuple_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NestedTuple = from_bytes(&facet_bytes)?;
+        let decoded: NestedTuple = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -275,7 +275,7 @@ mod tuple_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: TupleWithOption = from_bytes(&facet_bytes)?;
+        let decoded: TupleWithOption = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -295,7 +295,7 @@ mod tuple_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: TupleWithVec = from_bytes(&facet_bytes)?;
+        let decoded: TupleWithVec = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -321,7 +321,7 @@ mod unit_tuple_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: UnitTuple = from_bytes(&facet_bytes)?;
+        let decoded: UnitTuple = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }

--- a/facet-postcard/tests/attributes.rs
+++ b/facet-postcard/tests/attributes.rs
@@ -7,7 +7,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_postcard::{from_bytes, to_vec};
+use facet_postcard::{from_slice, to_vec};
 use postcard::to_allocvec as postcard_to_vec;
 use serde::{Deserialize, Serialize};
 
@@ -37,7 +37,7 @@ mod default_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: WithDefault = from_bytes(&facet_bytes)?;
+        let decoded: WithDefault = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -53,7 +53,7 @@ mod default_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: WithDefault = from_bytes(&facet_bytes)?;
+        let decoded: WithDefault = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -81,7 +81,7 @@ mod default_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: WithCustomDefault = from_bytes(&facet_bytes)?;
+        let decoded: WithCustomDefault = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -111,7 +111,7 @@ mod default_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MultipleDefaults = from_bytes(&facet_bytes)?;
+        let decoded: MultipleDefaults = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -153,7 +153,7 @@ mod skip_tests {
         assert_eq!(facet_bytes, postcard_bytes);
 
         // Note: After roundtrip, skipped field will have default value
-        let decoded: WithSkip = from_bytes(&facet_bytes)?;
+        let decoded: WithSkip = from_slice(&facet_bytes)?;
         assert_eq!(decoded.included, 42);
         // skipped field uses Default::default() which is 999
         Ok(())
@@ -229,7 +229,7 @@ mod rename_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: WithRename = from_bytes(&facet_bytes)?;
+        let decoded: WithRename = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -253,7 +253,7 @@ mod rename_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: WithRenameAll = from_bytes(&facet_bytes)?;
+        let decoded: WithRenameAll = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -279,7 +279,7 @@ mod transparent_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: TransparentWrapper = from_bytes(&facet_bytes)?;
+        let decoded: TransparentWrapper = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -297,7 +297,7 @@ mod transparent_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: TransparentString = from_bytes(&facet_bytes)?;
+        let decoded: TransparentString = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -344,7 +344,7 @@ mod combined_attributes {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: CombinedStruct = from_bytes(&facet_bytes)?;
+        let decoded: CombinedStruct = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -380,7 +380,7 @@ mod enum_attributes {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: RenamedVariants = from_bytes(&facet_bytes)?;
+        let decoded: RenamedVariants = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }

--- a/facet-postcard/tests/collections.rs
+++ b/facet-postcard/tests/collections.rs
@@ -2,7 +2,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_postcard::{from_bytes, to_vec};
+use facet_postcard::{from_slice, to_vec};
 use postcard::to_allocvec as postcard_to_vec;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -27,7 +27,7 @@ mod vec_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: VecU32 = from_bytes(&facet_bytes)?;
+        let decoded: VecU32 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -40,7 +40,7 @@ mod vec_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: VecU32 = from_bytes(&facet_bytes)?;
+        let decoded: VecU32 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -55,7 +55,7 @@ mod vec_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: VecU32 = from_bytes(&facet_bytes)?;
+        let decoded: VecU32 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -70,7 +70,7 @@ mod vec_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: VecU32 = from_bytes(&facet_bytes)?;
+        let decoded: VecU32 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -90,7 +90,7 @@ mod vec_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: VecString = from_bytes(&facet_bytes)?;
+        let decoded: VecString = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -108,7 +108,7 @@ mod vec_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: VecU8 = from_bytes(&facet_bytes)?;
+        let decoded: VecU8 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -123,7 +123,7 @@ mod vec_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: VecU8 = from_bytes(&facet_bytes)?;
+        let decoded: VecU8 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -143,7 +143,7 @@ mod vec_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NestedVec = from_bytes(&facet_bytes)?;
+        let decoded: NestedVec = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -171,7 +171,7 @@ mod hashmap_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: HashMapWrapper = from_bytes(&facet_bytes)?;
+        let decoded: HashMapWrapper = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -185,7 +185,7 @@ mod hashmap_tests {
 
         // For HashMap, order is not guaranteed, so we just test roundtrip
         let facet_bytes = to_vec(&wrapper)?;
-        let decoded: HashMapWrapper = from_bytes(&facet_bytes)?;
+        let decoded: HashMapWrapper = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -202,7 +202,7 @@ mod hashmap_tests {
         let wrapper = HashMapWrapper { map };
 
         let bytes = to_vec(&wrapper)?;
-        let decoded: HashMapWrapper = from_bytes(&bytes)?;
+        let decoded: HashMapWrapper = from_slice(&bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -221,7 +221,7 @@ mod hashmap_tests {
         let wrapper = IntKeyMap { map };
 
         let bytes = to_vec(&wrapper)?;
-        let decoded: IntKeyMap = from_bytes(&bytes)?;
+        let decoded: IntKeyMap = from_slice(&bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -249,7 +249,7 @@ mod btreemap_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: BTreeMapWrapper = from_bytes(&facet_bytes)?;
+        let decoded: BTreeMapWrapper = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -267,7 +267,7 @@ mod btreemap_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: BTreeMapWrapper = from_bytes(&facet_bytes)?;
+        let decoded: BTreeMapWrapper = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -297,7 +297,7 @@ mod btreemap_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NestedBTreeMap = from_bytes(&facet_bytes)?;
+        let decoded: NestedBTreeMap = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -325,7 +325,7 @@ mod hashset_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: HashSetWrapper = from_bytes(&facet_bytes)?;
+        let decoded: HashSetWrapper = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -340,7 +340,7 @@ mod hashset_tests {
         let wrapper = HashSetWrapper { set };
 
         let bytes = to_vec(&wrapper)?;
-        let decoded: HashSetWrapper = from_bytes(&bytes)?;
+        let decoded: HashSetWrapper = from_slice(&bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -368,7 +368,7 @@ mod btreeset_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: BTreeSetWrapper = from_bytes(&facet_bytes)?;
+        let decoded: BTreeSetWrapper = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -386,7 +386,7 @@ mod btreeset_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: BTreeSetWrapper = from_bytes(&facet_bytes)?;
+        let decoded: BTreeSetWrapper = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -409,7 +409,7 @@ mod btreeset_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: StringBTreeSet = from_bytes(&facet_bytes)?;
+        let decoded: StringBTreeSet = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -435,7 +435,7 @@ mod option_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: OptionU32 = from_bytes(&facet_bytes)?;
+        let decoded: OptionU32 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -448,7 +448,7 @@ mod option_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: OptionU32 = from_bytes(&facet_bytes)?;
+        let decoded: OptionU32 = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -466,7 +466,7 @@ mod option_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: OptionString = from_bytes(&facet_bytes)?;
+        let decoded: OptionString = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -481,7 +481,7 @@ mod option_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: OptionString = from_bytes(&facet_bytes)?;
+        let decoded: OptionString = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -499,7 +499,7 @@ mod option_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NestedOption = from_bytes(&facet_bytes)?;
+        let decoded: NestedOption = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -512,7 +512,7 @@ mod option_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NestedOption = from_bytes(&facet_bytes)?;
+        let decoded: NestedOption = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -527,7 +527,7 @@ mod option_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NestedOption = from_bytes(&facet_bytes)?;
+        let decoded: NestedOption = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -551,7 +551,7 @@ mod option_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MultipleOptions = from_bytes(&facet_bytes)?;
+        let decoded: MultipleOptions = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -568,7 +568,7 @@ mod option_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MultipleOptions = from_bytes(&facet_bytes)?;
+        let decoded: MultipleOptions = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -585,7 +585,7 @@ mod option_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MultipleOptions = from_bytes(&facet_bytes)?;
+        let decoded: MultipleOptions = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }

--- a/facet-postcard/tests/edge_cases.rs
+++ b/facet-postcard/tests/edge_cases.rs
@@ -2,7 +2,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_postcard::{from_bytes, to_vec};
+use facet_postcard::{from_slice, to_vec};
 use postcard::to_allocvec as postcard_to_vec;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -33,7 +33,7 @@ mod empty_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: AllEmpty = from_bytes(&facet_bytes)?;
+        let decoded: AllEmpty = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -53,7 +53,7 @@ mod empty_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: EmptyNested = from_bytes(&facet_bytes)?;
+        let decoded: EmptyNested = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -103,7 +103,7 @@ mod max_value_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MaxIntegers = from_bytes(&facet_bytes)?;
+        let decoded: MaxIntegers = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -127,7 +127,7 @@ mod max_value_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: Max128 = from_bytes(&facet_bytes)?;
+        let decoded: Max128 = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -181,7 +181,7 @@ mod deeply_nested_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: Level5 = from_bytes(&facet_bytes)?;
+        let decoded: Level5 = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -201,7 +201,7 @@ mod deeply_nested_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: DeeplyNestedOptions = from_bytes(&facet_bytes)?;
+        let decoded: DeeplyNestedOptions = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -216,7 +216,7 @@ mod deeply_nested_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: DeeplyNestedOptions = from_bytes(&facet_bytes)?;
+        let decoded: DeeplyNestedOptions = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -239,7 +239,7 @@ mod deeply_nested_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: DeeplyNestedVecs = from_bytes(&facet_bytes)?;
+        let decoded: DeeplyNestedVecs = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -267,7 +267,7 @@ mod large_data_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: LargeVec = from_bytes(&facet_bytes)?;
+        let decoded: LargeVec = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -282,7 +282,7 @@ mod large_data_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: LargeVec = from_bytes(&facet_bytes)?;
+        let decoded: LargeVec = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -305,7 +305,7 @@ mod large_data_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: LargeMap = from_bytes(&facet_bytes)?;
+        let decoded: LargeMap = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -351,7 +351,7 @@ mod varint_boundary_tests {
                 "Mismatch at boundary value {val}"
             );
 
-            let decoded: VarintBoundary = from_bytes(&facet_bytes)?;
+            let decoded: VarintBoundary = from_slice(&facet_bytes)?;
             assert_eq!(value, decoded, "Roundtrip failed for value {val}");
         }
         Ok(())
@@ -394,7 +394,7 @@ mod varint_boundary_tests {
                 "Mismatch at signed boundary value {val}"
             );
 
-            let decoded: SignedVarintBoundary = from_bytes(&facet_bytes)?;
+            let decoded: SignedVarintBoundary = from_slice(&facet_bytes)?;
             assert_eq!(value, decoded, "Roundtrip failed for signed value {val}");
         }
         Ok(())
@@ -423,7 +423,7 @@ mod special_char_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: SpecialStrings = from_bytes(&facet_bytes)?;
+        let decoded: SpecialStrings = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -438,7 +438,7 @@ mod special_char_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: SpecialStrings = from_bytes(&facet_bytes)?;
+        let decoded: SpecialStrings = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -453,7 +453,7 @@ mod special_char_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: SpecialStrings = from_bytes(&facet_bytes)?;
+        let decoded: SpecialStrings = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -468,7 +468,7 @@ mod special_char_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: SpecialStrings = from_bytes(&facet_bytes)?;
+        let decoded: SpecialStrings = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -492,7 +492,7 @@ mod zst_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: ZeroSized = from_bytes(&facet_bytes)?;
+        let decoded: ZeroSized = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -512,7 +512,7 @@ mod zst_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: VecOfZst = from_bytes(&facet_bytes)?;
+        let decoded: VecOfZst = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -545,7 +545,7 @@ mod zst_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: WithPhantom<String> = from_bytes(&facet_bytes)?;
+        let decoded: WithPhantom<String> = from_slice(&facet_bytes)?;
         assert_eq!(value.value, decoded.value);
         Ok(())
     }

--- a/facet-postcard/tests/enums.rs
+++ b/facet-postcard/tests/enums.rs
@@ -2,7 +2,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_postcard::{from_bytes, to_vec};
+use facet_postcard::{from_slice, to_vec};
 use postcard::to_allocvec as postcard_to_vec;
 use serde::{Deserialize, Serialize};
 
@@ -29,7 +29,7 @@ mod unit_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: UnitEnum = from_bytes(&facet_bytes)?;
+        let decoded: UnitEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -42,7 +42,7 @@ mod unit_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: UnitEnum = from_bytes(&facet_bytes)?;
+        let decoded: UnitEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -55,7 +55,7 @@ mod unit_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: UnitEnum = from_bytes(&facet_bytes)?;
+        let decoded: UnitEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -134,7 +134,7 @@ mod newtype_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NewtypeEnum = from_bytes(&facet_bytes)?;
+        let decoded: NewtypeEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -147,7 +147,7 @@ mod newtype_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NewtypeEnum = from_bytes(&facet_bytes)?;
+        let decoded: NewtypeEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -168,7 +168,7 @@ mod newtype_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NewtypeWithVec = from_bytes(&facet_bytes)?;
+        let decoded: NewtypeWithVec = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -198,7 +198,7 @@ mod tuple_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: TupleEnum = from_bytes(&facet_bytes)?;
+        let decoded: TupleEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -211,7 +211,7 @@ mod tuple_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: TupleEnum = from_bytes(&facet_bytes)?;
+        let decoded: TupleEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -241,7 +241,7 @@ mod struct_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: StructEnum = from_bytes(&facet_bytes)?;
+        let decoded: StructEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -258,7 +258,7 @@ mod struct_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: StructEnum = from_bytes(&facet_bytes)?;
+        let decoded: StructEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -289,7 +289,7 @@ mod mixed_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MixedEnum = from_bytes(&facet_bytes)?;
+        let decoded: MixedEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -302,7 +302,7 @@ mod mixed_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MixedEnum = from_bytes(&facet_bytes)?;
+        let decoded: MixedEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -315,7 +315,7 @@ mod mixed_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MixedEnum = from_bytes(&facet_bytes)?;
+        let decoded: MixedEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -331,7 +331,7 @@ mod mixed_variant_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MixedEnum = from_bytes(&facet_bytes)?;
+        let decoded: MixedEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -368,7 +368,7 @@ mod nested_enum_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: Outer = from_bytes(&facet_bytes)?;
+        let decoded: Outer = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -381,7 +381,7 @@ mod nested_enum_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: Outer = from_bytes(&facet_bytes)?;
+        let decoded: Outer = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -415,7 +415,7 @@ mod option_enum_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: OptionalEnum = from_bytes(&facet_bytes)?;
+        let decoded: OptionalEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -430,7 +430,7 @@ mod option_enum_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: OptionalEnum = from_bytes(&facet_bytes)?;
+        let decoded: OptionalEnum = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -467,7 +467,7 @@ mod vec_enum_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: Colors = from_bytes(&facet_bytes)?;
+        let decoded: Colors = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -480,7 +480,7 @@ mod vec_enum_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: Colors = from_bytes(&facet_bytes)?;
+        let decoded: Colors = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -509,7 +509,7 @@ mod generic_enum_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MyResult<u32, String> = from_bytes(&facet_bytes)?;
+        let decoded: MyResult<u32, String> = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -522,7 +522,7 @@ mod generic_enum_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MyResult<u32, String> = from_bytes(&facet_bytes)?;
+        let decoded: MyResult<u32, String> = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }

--- a/facet-postcard/tests/primitives.rs
+++ b/facet-postcard/tests/primitives.rs
@@ -2,8 +2,8 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_postcard::{from_bytes, to_vec};
-use postcard::from_bytes as postcard_from_bytes;
+use facet_postcard::{from_slice, to_vec};
+use postcard::from_bytes as postcard_from_slice;
 use postcard::to_allocvec as postcard_to_vec;
 use serde::{Deserialize, Serialize};
 
@@ -40,7 +40,7 @@ macro_rules! test_primitive {
                 for &value in &$values {
                     let wrapper = Wrapper { value };
                     let bytes = to_vec(&wrapper)?;
-                    let decoded: Wrapper = from_bytes(&bytes)?;
+                    let decoded: Wrapper = from_slice(&bytes)?;
                     assert_eq!(wrapper, decoded, "Roundtrip failed for value {:?}", value);
                 }
                 Ok(())
@@ -54,12 +54,12 @@ macro_rules! test_primitive {
 
                     // facet -> postcard
                     let facet_bytes = to_vec(&wrapper)?;
-                    let decoded: Wrapper = postcard_from_bytes(&facet_bytes)?;
+                    let decoded: Wrapper = postcard_from_slice(&facet_bytes)?;
                     assert_eq!(wrapper, decoded, "facet->postcard failed for {:?}", value);
 
                     // postcard -> facet
                     let postcard_bytes = postcard_to_vec(&wrapper)?;
-                    let decoded: Wrapper = from_bytes(&postcard_bytes)?;
+                    let decoded: Wrapper = from_slice(&postcard_bytes)?;
                     assert_eq!(wrapper, decoded, "postcard->facet failed for {:?}", value);
                 }
                 Ok(())
@@ -266,7 +266,7 @@ mod unit_tests {
         facet_testhelpers::setup();
         let wrapper = UnitWrapper { value: () };
         let bytes = to_vec(&wrapper)?;
-        let decoded: UnitWrapper = from_bytes(&bytes)?;
+        let decoded: UnitWrapper = from_slice(&bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -296,7 +296,7 @@ mod special_floats {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: F32Wrapper = from_bytes(&facet_bytes)?;
+        let decoded: F32Wrapper = from_slice(&facet_bytes)?;
         assert!(decoded.value.is_infinite() && decoded.value.is_sign_positive());
         Ok(())
     }
@@ -311,7 +311,7 @@ mod special_floats {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: F32Wrapper = from_bytes(&facet_bytes)?;
+        let decoded: F32Wrapper = from_slice(&facet_bytes)?;
         assert!(decoded.value.is_infinite() && decoded.value.is_sign_negative());
         Ok(())
     }
@@ -324,7 +324,7 @@ mod special_floats {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: F32Wrapper = from_bytes(&facet_bytes)?;
+        let decoded: F32Wrapper = from_slice(&facet_bytes)?;
         assert!(decoded.value.is_nan());
         Ok(())
     }
@@ -339,7 +339,7 @@ mod special_floats {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: F64Wrapper = from_bytes(&facet_bytes)?;
+        let decoded: F64Wrapper = from_slice(&facet_bytes)?;
         assert!(decoded.value.is_infinite() && decoded.value.is_sign_positive());
         Ok(())
     }
@@ -354,7 +354,7 @@ mod special_floats {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: F64Wrapper = from_bytes(&facet_bytes)?;
+        let decoded: F64Wrapper = from_slice(&facet_bytes)?;
         assert!(decoded.value.is_infinite() && decoded.value.is_sign_negative());
         Ok(())
     }
@@ -367,7 +367,7 @@ mod special_floats {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: F64Wrapper = from_bytes(&facet_bytes)?;
+        let decoded: F64Wrapper = from_slice(&facet_bytes)?;
         assert!(decoded.value.is_nan());
         Ok(())
     }

--- a/facet-postcard/tests/smart_pointers.rs
+++ b/facet-postcard/tests/smart_pointers.rs
@@ -7,7 +7,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_postcard::{from_bytes, to_vec};
+use facet_postcard::{from_slice, to_vec};
 use postcard::to_allocvec as postcard_to_vec;
 use serde::{Deserialize, Serialize};
 use std::rc::Rc;
@@ -35,7 +35,7 @@ mod box_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: BoxedU32 = from_bytes(&facet_bytes)?;
+        let decoded: BoxedU32 = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -55,7 +55,7 @@ mod box_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: BoxedString = from_bytes(&facet_bytes)?;
+        let decoded: BoxedString = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -75,7 +75,7 @@ mod box_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: BoxedVec = from_bytes(&facet_bytes)?;
+        let decoded: BoxedVec = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -95,7 +95,7 @@ mod box_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NestedBoxes = from_bytes(&facet_bytes)?;
+        let decoded: NestedBoxes = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -115,7 +115,7 @@ mod box_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: BoxedOption = from_bytes(&facet_bytes)?;
+        let decoded: BoxedOption = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -130,7 +130,7 @@ mod box_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: BoxedOption = from_bytes(&facet_bytes)?;
+        let decoded: BoxedOption = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -150,7 +150,7 @@ mod box_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: OptionBoxed = from_bytes(&facet_bytes)?;
+        let decoded: OptionBoxed = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -163,7 +163,7 @@ mod box_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: OptionBoxed = from_bytes(&facet_bytes)?;
+        let decoded: OptionBoxed = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -215,7 +215,7 @@ mod rc_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: RcU32 = from_bytes(&facet_bytes)?;
+        let decoded: RcU32 = from_slice(&facet_bytes)?;
         assert_eq!(*value.value, *decoded.value);
         Ok(())
     }
@@ -243,7 +243,7 @@ mod arc_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: ArcU32 = from_bytes(&facet_bytes)?;
+        let decoded: ArcU32 = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -263,7 +263,7 @@ mod arc_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: ArcString = from_bytes(&facet_bytes)?;
+        let decoded: ArcString = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -283,7 +283,7 @@ mod arc_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: ArcVec = from_bytes(&facet_bytes)?;
+        let decoded: ArcVec = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -303,7 +303,7 @@ mod arc_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NestedArcs = from_bytes(&facet_bytes)?;
+        let decoded: NestedArcs = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -335,7 +335,7 @@ mod mixed_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MixedPointers = from_bytes(&facet_bytes)?;
+        let decoded: MixedPointers = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }

--- a/facet-postcard/tests/strings.rs
+++ b/facet-postcard/tests/strings.rs
@@ -2,7 +2,7 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_postcard::{from_bytes, to_vec};
+use facet_postcard::{from_slice, to_vec};
 use postcard::to_allocvec as postcard_to_vec;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -22,7 +22,7 @@ fn test_empty_string() -> Result<()> {
     let postcard_bytes = postcard_to_vec(&wrapper)?;
     assert_eq!(facet_bytes, postcard_bytes);
 
-    let decoded: StringWrapper = from_bytes(&facet_bytes)?;
+    let decoded: StringWrapper = from_slice(&facet_bytes)?;
     assert_eq!(wrapper, decoded);
     Ok(())
 }
@@ -37,7 +37,7 @@ fn test_ascii_string() -> Result<()> {
     let postcard_bytes = postcard_to_vec(&wrapper)?;
     assert_eq!(facet_bytes, postcard_bytes);
 
-    let decoded: StringWrapper = from_bytes(&facet_bytes)?;
+    let decoded: StringWrapper = from_slice(&facet_bytes)?;
     assert_eq!(wrapper, decoded);
     Ok(())
 }
@@ -52,7 +52,7 @@ fn test_unicode_string() -> Result<()> {
     let postcard_bytes = postcard_to_vec(&wrapper)?;
     assert_eq!(facet_bytes, postcard_bytes);
 
-    let decoded: StringWrapper = from_bytes(&facet_bytes)?;
+    let decoded: StringWrapper = from_slice(&facet_bytes)?;
     assert_eq!(wrapper, decoded);
     Ok(())
 }
@@ -67,7 +67,7 @@ fn test_string_with_null() -> Result<()> {
     let postcard_bytes = postcard_to_vec(&wrapper)?;
     assert_eq!(facet_bytes, postcard_bytes);
 
-    let decoded: StringWrapper = from_bytes(&facet_bytes)?;
+    let decoded: StringWrapper = from_slice(&facet_bytes)?;
     assert_eq!(wrapper, decoded);
     Ok(())
 }
@@ -82,7 +82,7 @@ fn test_string_with_escapes() -> Result<()> {
     let postcard_bytes = postcard_to_vec(&wrapper)?;
     assert_eq!(facet_bytes, postcard_bytes);
 
-    let decoded: StringWrapper = from_bytes(&facet_bytes)?;
+    let decoded: StringWrapper = from_slice(&facet_bytes)?;
     assert_eq!(wrapper, decoded);
     Ok(())
 }
@@ -98,7 +98,7 @@ fn test_long_string() -> Result<()> {
     let postcard_bytes = postcard_to_vec(&wrapper)?;
     assert_eq!(facet_bytes, postcard_bytes);
 
-    let decoded: StringWrapper = from_bytes(&facet_bytes)?;
+    let decoded: StringWrapper = from_slice(&facet_bytes)?;
     assert_eq!(wrapper, decoded);
     Ok(())
 }
@@ -114,7 +114,7 @@ fn test_very_long_string() -> Result<()> {
     let postcard_bytes = postcard_to_vec(&wrapper)?;
     assert_eq!(facet_bytes, postcard_bytes);
 
-    let decoded: StringWrapper = from_bytes(&facet_bytes)?;
+    let decoded: StringWrapper = from_slice(&facet_bytes)?;
     assert_eq!(wrapper, decoded);
     Ok(())
 }
@@ -139,7 +139,7 @@ mod cow_str_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: CowWrapper<'static> = from_bytes(&facet_bytes)?;
+        let decoded: CowWrapper<'static> = from_slice(&facet_bytes)?;
         assert_eq!(wrapper.value, decoded.value);
         Ok(())
     }
@@ -181,7 +181,7 @@ mod multi_string_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MultiString = from_bytes(&facet_bytes)?;
+        let decoded: MultiString = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -198,7 +198,7 @@ mod multi_string_tests {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MultiString = from_bytes(&facet_bytes)?;
+        let decoded: MultiString = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -218,7 +218,7 @@ mod edge_cases {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: StringWrapper = from_bytes(&facet_bytes)?;
+        let decoded: StringWrapper = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -234,7 +234,7 @@ mod edge_cases {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: StringWrapper = from_bytes(&facet_bytes)?;
+        let decoded: StringWrapper = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -250,7 +250,7 @@ mod edge_cases {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: StringWrapper = from_bytes(&facet_bytes)?;
+        let decoded: StringWrapper = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }
@@ -266,7 +266,7 @@ mod edge_cases {
         let postcard_bytes = postcard_to_vec(&wrapper)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: StringWrapper = from_bytes(&facet_bytes)?;
+        let decoded: StringWrapper = from_slice(&facet_bytes)?;
         assert_eq!(wrapper, decoded);
         Ok(())
     }

--- a/facet-postcard/tests/structs.rs
+++ b/facet-postcard/tests/structs.rs
@@ -2,8 +2,8 @@
 
 use eyre::Result;
 use facet::Facet;
-use facet_postcard::{from_bytes, to_vec};
-use postcard::from_bytes as postcard_from_bytes;
+use facet_postcard::{from_slice, to_vec};
+use postcard::from_bytes as postcard_from_slice;
 use postcard::to_allocvec as postcard_to_vec;
 use serde::{Deserialize, Serialize};
 
@@ -25,7 +25,7 @@ mod unit_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: UnitStruct = from_bytes(&facet_bytes)?;
+        let decoded: UnitStruct = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -47,7 +47,7 @@ mod unit_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: WrapperWithUnit = from_bytes(&facet_bytes)?;
+        let decoded: WrapperWithUnit = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -72,7 +72,7 @@ mod tuple_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NewtypeU32 = from_bytes(&facet_bytes)?;
+        let decoded: NewtypeU32 = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -88,7 +88,7 @@ mod tuple_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NewtypeString = from_bytes(&facet_bytes)?;
+        let decoded: NewtypeString = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -104,7 +104,7 @@ mod tuple_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NewtypeVec = from_bytes(&facet_bytes)?;
+        let decoded: NewtypeVec = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -121,7 +121,7 @@ mod tuple_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: TupleStruct2 = from_bytes(&facet_bytes)?;
+        let decoded: TupleStruct2 = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -137,7 +137,7 @@ mod tuple_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: TupleStruct3 = from_bytes(&facet_bytes)?;
+        let decoded: TupleStruct3 = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -154,7 +154,7 @@ mod tuple_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NestedNewtype = from_bytes(&facet_bytes)?;
+        let decoded: NestedNewtype = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -180,7 +180,7 @@ mod named_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: SingleField = from_bytes(&facet_bytes)?;
+        let decoded: SingleField = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -206,7 +206,7 @@ mod named_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: MultipleFields = from_bytes(&facet_bytes)?;
+        let decoded: MultipleFields = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -228,7 +228,7 @@ mod named_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: NestedStruct = from_bytes(&facet_bytes)?;
+        let decoded: NestedStruct = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -253,7 +253,7 @@ mod named_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: DeeplyNested = from_bytes(&facet_bytes)?;
+        let decoded: DeeplyNested = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -277,7 +277,7 @@ mod named_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: WithOptions = from_bytes(&facet_bytes)?;
+        let decoded: WithOptions = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -294,7 +294,7 @@ mod named_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: WithOptions = from_bytes(&facet_bytes)?;
+        let decoded: WithOptions = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -343,7 +343,7 @@ mod named_struct_tests {
         let postcard_bytes = postcard_to_vec(&value)?;
         assert_eq!(facet_bytes, postcard_bytes);
 
-        let decoded: KitchenSink = from_bytes(&facet_bytes)?;
+        let decoded: KitchenSink = from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -373,7 +373,7 @@ mod cross_compatibility {
         };
 
         let facet_bytes = to_vec(&value)?;
-        let decoded: TestStruct = postcard_from_bytes(&facet_bytes)?;
+        let decoded: TestStruct = postcard_from_slice(&facet_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }
@@ -388,7 +388,7 @@ mod cross_compatibility {
         };
 
         let postcard_bytes = postcard_to_vec(&value)?;
-        let decoded: TestStruct = from_bytes(&postcard_bytes)?;
+        let decoded: TestStruct = from_slice(&postcard_bytes)?;
         assert_eq!(value, decoded);
         Ok(())
     }

--- a/facet-shapelike/src/shape_like.rs
+++ b/facet-shapelike/src/shape_like.rs
@@ -88,7 +88,7 @@ impl From<&Attr> for AttrLike {
 
 impl AttrLike {
     pub fn parse_data<T: Facet<'static>>(&self) -> Result<T, facet_postcard::DeserializeError> {
-        facet_postcard::from_bytes(&self.data)
+        facet_postcard::from_slice(&self.data)
     }
 }
 


### PR DESCRIPTION
## Summary

Renames deserialization functions in facet-postcard for consistency with API conventions:
- `from_bytes` → `from_slice`
- `take_from_bytes` → `take_from_slice`

## Motivation

The postcard crate uses `from_bytes`, but Rust convention typically uses `from_slice` for deserialization from a byte slice (e.g., `serde_json::from_slice`). This also makes the API symmetric with our existing `to_slice` function.

Current facet-postcard exports:
```rust
pub fn from_slice<T: Facet<'static>>(data: &[u8]) -> Result<T, DeserializeError>
pub fn take_from_slice<T: Facet<'static>>(data: &[u8]) -> Result<(T, &[u8]), DeserializeError>
pub fn to_vec<T: Facet<'static>>(value: &T) -> Result<Vec<u8>, SerializeError>
pub fn to_slice<T: Facet<'static>>(value: &T, buffer: &mut [u8]) -> Result<usize, SerializeError>
```

Now `from_slice`/`to_slice` form a symmetric pair.

## Test plan

- [x] All 225 facet-postcard tests pass

Closes #1194