### PR TITLE
fix: remove Box::leak in facet-value PathSegment conversion

### DIFF
--- a/facet-pretty/examples/span_demo.rs
+++ b/facet-pretty/examples/span_demo.rs
@@ -2,6 +2,8 @@
 //!
 //! Run with: cargo run -p facet-pretty --example span_demo
 
+use std::borrow::Cow;
+
 use facet::Facet;
 use facet_pretty::{FormattedShape, PathSegment, format_shape_colored, format_shape_with_spans};
 use owo_colors::OwoColorize;
@@ -82,7 +84,7 @@ fn demo_error_highlight() {
     let result = format_shape_with_spans(Config::SHAPE);
 
     // Simulate an error at max_retries field
-    let error_path = vec![PathSegment::Field("max_retries")];
+    let error_path = vec![PathSegment::Field(Cow::Borrowed("max_retries"))];
 
     if let Some(field_span) = result.spans.get(&error_path) {
         let (start, end) = field_span.value;

--- a/facet-pretty/examples/spans_showcase.rs
+++ b/facet-pretty/examples/spans_showcase.rs
@@ -2,6 +2,10 @@
 //!
 //! Run with: cargo run -p facet-pretty --example spans_showcase
 
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt;
+
 use facet::Facet;
 use facet_pretty::{FieldSpan, PathSegment, format_shape_colored, format_shape_with_spans};
 use facet_showcase::{OutputMode, ShowcaseRunner, ansi_to_html};
@@ -9,8 +13,6 @@ use miette::{
     Diagnostic, GraphicalReportHandler, GraphicalTheme, LabeledSpan, NamedSource, Severity,
 };
 use owo_colors::OwoColorize;
-use std::collections::HashMap;
-use std::fmt;
 
 // ============================================================================
 // Test Types
@@ -153,7 +155,7 @@ fn demo_highlight_key(runner: &mut ShowcaseRunner) {
         "Highlight Field Name",
         "Point to the field name when it's unknown or unexpected.",
         Config::SHAPE,
-        &[PathSegment::Field("max_retries")],
+        &[PathSegment::Field(Cow::Borrowed("max_retries"))],
         HighlightMode::Key,
         "unknown field `max_retries`",
         "not expected here",
@@ -166,7 +168,7 @@ fn demo_highlight_value(runner: &mut ShowcaseRunner) {
         "Highlight Type",
         "Point to the type when the value doesn't match.",
         Config::SHAPE,
-        &[PathSegment::Field("max_retries")],
+        &[PathSegment::Field(Cow::Borrowed("max_retries"))],
         HighlightMode::Value,
         "value 1000 is out of range for u8",
         "expected 0..255",
@@ -179,7 +181,7 @@ fn demo_highlight_both(runner: &mut ShowcaseRunner) {
         "Highlight Entire Field",
         "Point to both name and type for context.",
         Config::SHAPE,
-        &[PathSegment::Field("timeout_ms")],
+        &[PathSegment::Field(Cow::Borrowed("timeout_ms"))],
         HighlightMode::Both,
         "missing required field",
         "this field is required",
@@ -192,7 +194,7 @@ fn demo_nested_struct(runner: &mut ShowcaseRunner) {
         "Nested Struct Field",
         "Highlight a field inside a nested struct.",
         Employee::SHAPE,
-        &[PathSegment::Field("person")],
+        &[PathSegment::Field(Cow::Borrowed("person"))],
         HighlightMode::Value,
         "invalid person data",
         "expected valid Person",
@@ -205,7 +207,7 @@ fn demo_nested_field(runner: &mut ShowcaseRunner) {
         "Deeply Nested Field",
         "Highlight a deeply nested field path.",
         Employee::SHAPE,
-        &[PathSegment::Field("address")],
+        &[PathSegment::Field(Cow::Borrowed("address"))],
         HighlightMode::Both,
         "address validation failed",
         "city is required",
@@ -218,7 +220,7 @@ fn demo_unit_variant(runner: &mut ShowcaseRunner) {
         "Unit Variant",
         "Highlight an enum variant name.",
         Status::SHAPE,
-        &[PathSegment::Variant("Active")],
+        &[PathSegment::Variant(Cow::Borrowed("Active"))],
         HighlightMode::Value,
         "invalid variant",
         "not allowed in this context",
@@ -231,7 +233,7 @@ fn demo_tuple_variant(runner: &mut ShowcaseRunner) {
         "Tuple Variant",
         "Highlight a tuple variant.",
         Message::SHAPE,
-        &[PathSegment::Variant("Text")],
+        &[PathSegment::Variant(Cow::Borrowed("Text"))],
         HighlightMode::Value,
         "type mismatch",
         "expected Number, got Text",
@@ -244,7 +246,10 @@ fn demo_struct_variant(runner: &mut ShowcaseRunner) {
         "Struct Variant Field",
         "Highlight a field inside a struct variant.",
         Status::SHAPE,
-        &[PathSegment::Variant("Error"), PathSegment::Field("code")],
+        &[
+            PathSegment::Variant(Cow::Borrowed("Error")),
+            PathSegment::Field(Cow::Borrowed("code")),
+        ],
         HighlightMode::Value,
         "error code out of range",
         "must be positive",
@@ -257,7 +262,7 @@ fn demo_vec_field(runner: &mut ShowcaseRunner) {
         "Vec Field",
         "Highlight a Vec field type.",
         Employee::SHAPE,
-        &[PathSegment::Field("tags")],
+        &[PathSegment::Field(Cow::Borrowed("tags"))],
         HighlightMode::Value,
         "invalid tags",
         "expected array of strings",
@@ -270,7 +275,7 @@ fn demo_option_field(runner: &mut ShowcaseRunner) {
         "Option Field",
         "Highlight an Option field.",
         Person::SHAPE,
-        &[PathSegment::Field("email")],
+        &[PathSegment::Field(Cow::Borrowed("email"))],
         HighlightMode::Both,
         "invalid email format",
         "must be a valid email address",
@@ -283,7 +288,7 @@ fn demo_hashmap_field(runner: &mut ShowcaseRunner) {
         "HashMap Field",
         "Highlight a HashMap field.",
         Employee::SHAPE,
-        &[PathSegment::Field("metadata")],
+        &[PathSegment::Field(Cow::Borrowed("metadata"))],
         HighlightMode::Value,
         "invalid metadata",
         "keys must be alphanumeric",

--- a/facet-value/src/deserialize.rs
+++ b/facet-value/src/deserialize.rs
@@ -42,6 +42,8 @@ use facet_reflect::{Partial, ReflectError};
 use crate::{VNumber, Value, ValueType};
 
 #[cfg(feature = "diagnostics")]
+use alloc::borrow::Cow;
+#[cfg(feature = "diagnostics")]
 use facet_pretty::{PathSegment as ShapePathSegment, format_shape_with_spans};
 
 /// A segment in a deserialization path
@@ -282,12 +284,10 @@ impl ValueErrorReport {
                     .iter()
                     .filter_map(|seg| match seg {
                         PathSegment::Field(name) => {
-                            let leaked: &'static str = Box::leak(name.clone().into_boxed_str());
-                            Some(ShapePathSegment::Field(leaked))
+                            Some(ShapePathSegment::Field(Cow::Owned(name.clone())))
                         }
                         PathSegment::Variant(name) => {
-                            let leaked: &'static str = Box::leak(name.clone().into_boxed_str());
-                            Some(ShapePathSegment::Variant(leaked))
+                            Some(ShapePathSegment::Variant(Cow::Owned(name.clone())))
                         }
                         PathSegment::Index(_) => None,
                     })


### PR DESCRIPTION
## Summary

Fixes a memory leak where every deserialization error diagnostic leaked memory via `Box::leak`.

## Changes

Changed `PathSegment` in facet-pretty to use `Cow<'static, str>` instead of `&'static str`:

```rust
// Before
pub enum PathSegment {
    Field(&'static str),
    Variant(&'static str),
}

// After
pub enum PathSegment {
    Field(Cow<'static, str>),
    Variant(Cow<'static, str>),
}
```

This allows:
- Static strings from Shape metadata (common case) to remain zero-cost with `Cow::Borrowed`
- Owned strings from deserialization errors to work without memory leaks using `Cow::Owned`

## Root Cause

facet-value's `PathSegment` uses owned `String` (from dynamic deserialization), but facet-pretty's `PathSegment` expected `&'static str` (for static type metadata). Converting between them required `Box::leak`, causing memory to leak on every error diagnostic.

## Test plan

- [x] All 169 tests in facet-pretty and facet-value pass

Closes #1178