### PR TITLE
fix(facet-args): handle Option<T> positional arguments correctly

### DIFF
--- a/facet-args/src/format.rs
+++ b/facet-args/src/format.rs
@@ -147,6 +147,12 @@ impl<'input> Context<'input> {
                 p = p.parse_from_str(value)?;
                 p.end()?
             }
+            Def::Option(_) => {
+                // if it's an Option<T>, wrap the value in Some
+                let mut p = p.begin_some()?;
+                p = p.parse_from_str(value)?;
+                p.end()?
+            }
             _ => {
                 // TODO: this surely won't be enough eventually
                 p.parse_from_str(value)?

--- a/facet-args/tests/simple.rs
+++ b/facet-args/tests/simple.rs
@@ -146,3 +146,21 @@ fn test_bool_str_before() {
     assert!(args.foo);
     assert_eq!(args.hello, "world".to_string());
 }
+
+#[test]
+fn test_option_string_positional() {
+    // Repro case for Option<String> positional argument
+    #[derive(Facet, Debug)]
+    struct Args {
+        #[facet(args::positional, default)]
+        path: Option<String>,
+    }
+
+    // Test with a value
+    let args: Args = facet_args::from_slice(&["."]).unwrap();
+    assert_eq!(args.path, Some(".".to_string()));
+
+    // Test without a value (should default to None)
+    let args: Args = facet_args::from_slice(&[]).unwrap();
+    assert_eq!(args.path, None);
+}

--- a/facet-args/tests/snapshots/err__error_option_with_multiple_values.snap
+++ b/facet-args/tests/snapshots/err__error_option_with_multiple_values.snap
@@ -1,12 +1,15 @@
 ---
 source: facet-args/tests/err.rs
+assertion_line: 170
 expression: "$crate :: common :: DiagnosticDisplayWrapper(& err).to_string()"
 ---
-args::reflect_error
+args::unexpected_positional
 
   × Could not parse CLI arguments
    ╭────
  1 │ --maybe value1 value2 
-   ·         ───┬──
-   ·            ╰── `String` cannot be parsed from a string value
+   ·                ───┬──
+   ·                   ╰── unexpected positional argument
    ╰────
+  help: available options:
+              --maybe


### PR DESCRIPTION
## Summary
- Fix parsing of `Option<T>` positional arguments which previously failed with "Type does not support parsing from string"
- Add `Def::Option` case in `handle_value` that properly wraps parsed values in `Some`
- Add regression test for `Option<String>` positional argument

## Test plan
- [x] Added test `test_option_string_positional` that verifies both providing and omitting an optional positional arg
- [x] All existing facet-args tests pass (72 tests)
- [x] Updated snapshot for `test_error_option_with_multiple_values` (error message improved from "cannot be parsed" to "unexpected positional")