### PR TITLE
fix(docs): mark non-runnable code samples as noexec

### DIFF
--- a/docs/content/contribute/adding-types.md
+++ b/docs/content/contribute/adding-types.md
@@ -30,7 +30,7 @@ So we implement `Facet` for third-party types from the facet side, using optiona
 2. Create `facet-core/src/impls_my_crate.rs`
 
 3. Add to `facet-core/src/lib.rs`:
-   ```rust
+   ```rust,noexec
    #[cfg(feature = "my-crate")]
    mod impls_my_crate;
    ```
@@ -45,7 +45,7 @@ So we implement `Facet` for third-party types from the facet side, using optiona
 
 Most third-party types are scalars (atomic values like UUIDs, timestamps, paths):
 
-```rust
+```rust,noexec
 unsafe impl Facet<'_> for my_crate::MyType {
     const SHAPE: &'static Shape = &Shape {
         id: Shape::id_of::<Self>(),
@@ -75,7 +75,7 @@ Look at existing implementations in `facet-core/src/impls_*` for patterns:
 
 Collections need vtable functions for their operations (push, get, len, etc.):
 
-```rust
+```rust,noexec
 unsafe impl<T: Facet<'static>> Facet<'_> for MyVec<T> {
     const SHAPE: &'static Shape = &Shape {
         id: Shape::id_of::<Self>(),

--- a/docs/content/contribute/core-concepts.md
+++ b/docs/content/contribute/core-concepts.md
@@ -50,7 +50,7 @@ This lets you clone a value at runtime without a `Clone` bound — you check `sh
 
 `Characteristic` lets you query whether a shape supports certain operations:
 
-```rust
+```rust,noexec
 if shape.is(Characteristic::Clone) {
     // Safe to call clone_into from the vtable
 }

--- a/docs/content/extend/extension-attributes.md
+++ b/docs/content/extend/extension-attributes.md
@@ -10,7 +10,7 @@ For the full guide on creating extension attributes, see this page; for a quick 
 
 ## Using extension attributes
 
-```rust
+```rust,noexec
 use facet::Facet;
 use facet_kdl as kdl;
 
@@ -25,7 +25,7 @@ struct Server {
 
 The namespace (`kdl`) comes from how you import the crate:
 
-```rust
+```rust,noexec
 use facet_kdl as kdl;  // Enables kdl:: prefix
 use facet_args as args;  // Enables args:: prefix
 ```
@@ -34,7 +34,7 @@ use facet_args as args;  // Enables args:: prefix
 
 Use the [`define_attr_grammar!`](https://docs.rs/facet/latest/facet/macro.define_attr_grammar.html) macro to declare your attribute grammar. Here's how [`facet-kdl`](https://docs.rs/facet-kdl) does it:
 
-```rust
+```rust,noexec
 facet::define_attr_grammar! {
     ns "kdl";
     crate_path ::facet_kdl;
@@ -77,7 +77,7 @@ This generates:
 
 Simple flags with no arguments:
 
-```rust
+```rust,noexec
 pub enum Attr {
     /// A marker attribute
     Child,
@@ -90,7 +90,7 @@ Usage: `#[facet(kdl::child)]`
 
 Attributes that take a string:
 
-```rust
+```rust,noexec
 pub enum Attr {
     /// Rename to a different name
     Rename(&'static str),
@@ -103,7 +103,7 @@ Usage: `#[facet(rename = "new_name")]`
 
 For single-character flags (like CLI short options):
 
-```rust
+```rust,noexec
 pub enum Attr {
     /// Short flag, optionally with a character
     Short(Option<char>),
@@ -116,7 +116,7 @@ Usage: `#[facet(args::short)]` or `#[facet(args::short = 'v')]`
 
 The built-in facet attributes use additional payload types not typically needed by extension crates. For reference:
 
-```rust
+```rust,noexec
 // Inside the facet crate itself:
 define_attr_grammar! {
     builtin;
@@ -151,7 +151,7 @@ These special payload types enable powerful features but are primarily for core 
 
 One of the major benefits of `define_attr_grammar!`: **typos are caught at compile time** with helpful suggestions.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Parent {
     #[facet(kdl::chld)]  // Typo!
@@ -174,7 +174,7 @@ The system uses string similarity to suggest corrections.
 
 When your format crate needs to check for attributes, use the `get_as` method on [`ExtensionAttr`](https://docs.rs/facet-core/latest/facet_core/struct.ExtensionAttr.html):
 
-```rust
+```rust,noexec
 use facet_core::{Field, FieldAttribute, Facet};
 use facet_kdl::Attr as KdlAttr;
 
@@ -200,7 +200,7 @@ fn process_field(field: &Field) {
 
 For built-in attributes:
 
-```rust
+```rust,noexec
 use facet::builtin::Attr as BuiltinAttr;
 
 for attr in field.attributes {
@@ -230,7 +230,7 @@ for attr in field.attributes {
 
 [`facet-args`](https://docs.rs/facet-args) provides CLI argument parsing:
 
-```rust
+```rust,noexec
 facet::define_attr_grammar! {
     ns "args";
     crate_path ::facet_args;
@@ -250,7 +250,7 @@ facet::define_attr_grammar! {
 
 Usage:
 
-```rust
+```rust,noexec
 use facet_args as args;
 
 #[derive(Facet)]
@@ -270,7 +270,7 @@ struct Cli {
 
 [`facet-yaml`](https://docs.rs/facet-yaml) provides serde-compatible names:
 
-```rust
+```rust,noexec
 pub mod serde {
     facet::define_attr_grammar! {
         ns "serde";
@@ -286,7 +286,7 @@ pub mod serde {
 
 Usage:
 
-```rust
+```rust,noexec
 use facet_yaml::serde;
 
 #[derive(Facet)]

--- a/docs/content/extend/partial.md
+++ b/docs/content/extend/partial.md
@@ -16,7 +16,7 @@ insert_anchor_links = "heading"
 
 ## API sketch
 
-```rust
+```rust,noexec
 use facet_reflect::{Partial, Resolution};
 use facet_solver::ResolutionBuilder; // or other way to obtain Resolution
 

--- a/docs/content/extend/solver.md
+++ b/docs/content/extend/solver.md
@@ -10,7 +10,7 @@ The **solver** helps format crates implement `#[facet(flatten)]` and `#[facet(un
 
 Consider a type with a flattened enum:
 
-```rust
+```rust,noexec
 use facet::Facet;
 
 #[derive(Facet)]
@@ -76,7 +76,7 @@ The solver pre-computes all valid "configurations" — unique combinations of fi
 
 ## Basic usage
 
-```rust
+```rust,noexec
 use facet_solver::{KeyResult, Schema, Solver};
 
 // Build schema once (can be cached per-type)
@@ -124,7 +124,7 @@ This is O(1) per key lookup and O(configs/64) for the bitwise AND — extremely 
 
 Sometimes top-level keys don't distinguish variants:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct TextPayload { content: String }
 
@@ -175,7 +175,7 @@ Disambiguation paths:
 
 The `ProbingSolver` handles nested disambiguation:
 
-```rust
+```rust,noexec
 use facet_solver::{ProbingSolver, ProbeResult, Schema};
 
 let schema = Schema::build(Wrapper::SHAPE).unwrap();
@@ -200,7 +200,7 @@ match solver.probe_key(&["inner"], "content") {
 
 Sometimes variants have **identical keys** but different value types:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct SmallPayload { value: u8 }   // max 255
 
@@ -235,7 +235,7 @@ Both have `payload.value`, but with different types. When the deserializer sees 
 └──────────────────────────────────────────────────────┘
 ```
 
-```rust
+```rust,noexec
 use facet_solver::{Solver, KeyResult, Schema};
 
 let schema = Schema::build(Container::SHAPE).unwrap();
@@ -325,7 +325,7 @@ Facet's approach:
 
 Here's how a format crate typically integrates the solver:
 
-```rust
+```rust,noexec
 use facet_solver::{Schema, Solver, KeyResult};
 
 fn deserialize_object<T: Facet>(input: &str) -> Result<T, Error> {
@@ -360,7 +360,7 @@ fn deserialize_object<T: Facet>(input: &str) -> Result<T, Error> {
 
 ### Schema
 
-```rust
+```rust,noexec
 impl Schema {
     /// Build a schema from a Shape (cacheable per-type)
     pub fn build(shape: &'static Shape) -> Result<Schema, SchemaError>;
@@ -372,7 +372,7 @@ impl Schema {
 
 ### Solver
 
-```rust
+```rust,noexec
 impl Solver<'_> {
     /// Create a new solver from a schema
     pub fn new(schema: &Schema) -> Solver;
@@ -396,7 +396,7 @@ impl Solver<'_> {
 
 ### KeyResult
 
-```rust
+```rust,noexec
 pub enum KeyResult<'a> {
     /// Only one configuration remains — solved!
     Solved(Configuration<'a>),

--- a/docs/content/guide/attributes.md
+++ b/docs/content/guide/attributes.md
@@ -14,7 +14,7 @@ These attributes apply to structs and enums.
 
 Produce an error when encountering unknown fields during deserialization. By default, unknown fields are silently ignored.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(deny_unknown_fields)]
 struct Config {
@@ -27,7 +27,7 @@ struct Config {
 
 Use the type's `Default` implementation for missing fields during deserialization.
 
-```rust
+```rust,noexec
 #[derive(Facet, Default)]
 #[facet(default)]
 struct Config {
@@ -40,7 +40,7 @@ struct Config {
 
 Rename all fields/variants using a case convention.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(rename_all = "camelCase")]
 struct Config {
@@ -61,7 +61,7 @@ struct Config {
 
 Forward serialization/deserialization to the inner type. Used for newtype patterns.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(transparent)]
 struct UserId(u64);  // Serialized as just the u64
@@ -75,7 +75,7 @@ Mark a type as opaque — its inner structure is hidden from facet. The type its
 - Types whose internal structure shouldn't be exposed
 - Wrapper types around FFI or unsafe internals
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(opaque)]
 struct InternalState {
@@ -86,7 +86,7 @@ struct InternalState {
 
 **Important:** Opaque types cannot be serialized or deserialized on their own — use them with `#[facet(proxy = ...)]` to provide a serializable representation:
 
-```rust
+```rust,noexec
 // A type that doesn't implement Facet
 struct SecretKey([u8; 32]);
 
@@ -126,7 +126,7 @@ struct Config {
 
 Add a type identifier for self-describing formats.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(type_tag = "com.example.User")]
 struct User {
@@ -138,7 +138,7 @@ struct User {
 
 Specify a custom path to the facet crate. This is primarily useful for crates that re-export facet and want users to derive `Facet` without adding facet as a direct dependency.
 
-```rust
+```rust,noexec
 // In a crate that re-exports facet
 use other_crate::facet;
 
@@ -151,7 +151,7 @@ struct MyStruct {
 
 This attribute can also be used with enums and all struct variants:
 
-```rust
+```rust,noexec
 use other_crate::facet;
 
 #[derive(other_crate::facet::Facet)]
@@ -174,7 +174,7 @@ These attributes control enum serialization format.
 
 Serialize enum variants without a discriminator tag. The deserializer tries each variant in order until one succeeds.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(untagged)]
 enum Value {
@@ -188,7 +188,7 @@ enum Value {
 
 Use internal tagging — the variant name becomes a field inside the object.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(tag = "type")]
 enum Message {
@@ -202,7 +202,7 @@ enum Message {
 
 Use adjacent tagging — separate fields for the tag and content.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(tag = "t", content = "c")]
 enum Message {
@@ -220,7 +220,7 @@ These attributes apply to struct fields.
 
 Rename a field during serialization/deserialization.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct User {
     #[facet(rename = "user_name")]
@@ -232,7 +232,7 @@ struct User {
 
 Use a default value when the field is missing during deserialization.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Config {
     name: String,
@@ -256,7 +256,7 @@ fn default_timeout() -> Duration {
 
 Skip this field entirely during both serialization and deserialization. The field must have a default value.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Session {
     id: String,
@@ -269,7 +269,7 @@ struct Session {
 
 Skip this field during serialization only.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct User {
     name: String,
@@ -282,7 +282,7 @@ struct User {
 
 Skip this field during deserialization (uses default value).
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Record {
     data: String,
@@ -295,7 +295,7 @@ struct Record {
 
 Conditionally skip serialization based on a predicate.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct User {
     name: String,
@@ -315,7 +315,7 @@ struct User {
 
 Mark a field as containing sensitive data. Tools like [`facet-pretty`](https://docs.rs/facet-pretty) will redact this field in debug output.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Config {
     name: String,
@@ -328,7 +328,7 @@ struct Config {
 
 Flatten a nested struct's fields into the parent.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Pagination {
     page: u32,
@@ -348,7 +348,7 @@ struct Query {
 
 Mark a field as a child node for hierarchical formats like KDL or XML.
 
-```rust
+```rust,noexec
 use facet_kdl as kdl;
 
 #[derive(Facet)]
@@ -363,7 +363,7 @@ struct Document {
 
 Validate type invariants after deserialization. The function takes `&self` and returns `bool` — returning `false` causes deserialization to fail.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(invariants = validate_port)]
 struct ServerConfig {
@@ -379,7 +379,7 @@ fn validate_port(config: &ServerConfig) -> bool {
 
 **Method syntax:** You can also use a method on the type itself:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(invariants = Point::is_valid)]
 struct Point {
@@ -397,7 +397,7 @@ impl Point {
 
 **Multi-field invariants:** This is where invariants really shine — validating relationships between fields:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(invariants = Range::is_valid)]
 struct Range {
@@ -414,7 +414,7 @@ impl Range {
 
 **With enums:** Enums themselves don't support invariants directly, but you can wrap them in a struct:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[repr(C)]
 enum RangeKind {
@@ -450,7 +450,7 @@ Use a proxy type for serialization/deserialization. The proxy type handles the f
 - `TryFrom<ProxyType> for FieldType` — for deserialization (proxy → actual)
 - `TryFrom<&FieldType> for ProxyType` — for serialization (actual → proxy)
 
-```rust
+```rust,noexec
 use facet::Facet;
 
 // Your domain type
@@ -506,7 +506,7 @@ assert_eq!(parsed.id.0, 12345);
 
 A common pattern is parsing string fields using a type's `FromStr` implementation. For example, parsing `"#ff00ff"` into a color struct:
 
-```rust
+```rust,noexec
 use facet::Facet;
 use std::str::FromStr;
 
@@ -585,7 +585,7 @@ The key insight: `#[facet(transparent)]` on the proxy makes it serialize as just
 
 **Example: Parse integers from hex strings:**
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(transparent)]
 struct HexU64(String);
@@ -623,7 +623,7 @@ assert_eq!(parsed.address, 0x7fff5fbff8c0);
 
 **Example: Nested proxy with opaque type:**
 
-```rust
+```rust,noexec
 // Arc<T> with a custom serialization
 #[derive(Facet)]
 struct ArcU64Proxy { val: u64 }
@@ -664,7 +664,7 @@ Format crates can define their own namespaced attributes. See the [Extend guide]
 
 ### KDL attributes
 
-```rust
+```rust,noexec
 use facet_kdl as kdl;
 
 #[derive(Facet)]
@@ -694,7 +694,7 @@ struct Config {
 
 ### Args attributes
 
-```rust
+```rust,noexec
 use facet_args as args;
 
 #[derive(Facet)]

--- a/docs/content/guide/dynamic-values.md
+++ b/docs/content/guide/dynamic-values.md
@@ -18,7 +18,7 @@ A common pattern is to deserialize into `Value` first, then convert to a concret
 - You want to inspect the data before choosing a target type
 - You're building configuration layers that merge multiple sources
 
-```rust
+```rust,noexec
 use facet::Facet;
 use facet_value::{Value, from_value};
 
@@ -44,7 +44,7 @@ println!("{:?}", config);
 
 You can also extract just part of a `Value` tree into a typed struct:
 
-```rust
+```rust,noexec
 use facet::Facet;
 use facet_value::{Value, from_value};
 
@@ -77,7 +77,7 @@ if let Some(db_value) = value.as_object().and_then(|o| o.get("database")) {
 
 This is incredibly useful for testing: verify that your JSON matches the expected typed structure without manually constructing the typed value:
 
-```rust
+```rust,noexec
 use facet::Facet;
 use facet_assert::assert_same;
 use facet_value::Value;
@@ -102,7 +102,7 @@ assert_same!(user, expected);
 
 Compare DTOs across API versions without implementing `PartialEq` between them:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct UserV1 { name: String, age: u32 }
 
@@ -139,7 +139,7 @@ assertion `assert_same!(left, right)` failed
 
 ### Basic usage
 
-```rust
+```rust,noexec
 use facet::Facet;
 use facet_json::RawJson;
 
@@ -162,7 +162,7 @@ assert_eq!(response.data.as_str(), r#"{"nested": [1, 2, 3], "complex": true}"#);
 
 When possible, `RawJson` borrows from the input string (zero allocation):
 
-```rust
+```rust,noexec
 use facet_json::RawJson;
 use std::borrow::Cow;
 
@@ -182,7 +182,7 @@ let envelope: Envelope = facet_json::from_str(json)?;
 
 If you need to outlive the input, convert to owned:
 
-```rust
+```rust,noexec
 let owned: RawJson<'static> = envelope.payload.into_owned();
 ```
 
@@ -190,7 +190,7 @@ let owned: RawJson<'static> = envelope.payload.into_owned();
 
 Parse the raw JSON when you're ready:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct ClickEvent {
     r#type: String,
@@ -205,7 +205,7 @@ let event: ClickEvent = facet_json::from_str(response.data.as_str())?;
 
 These features compose naturally:
 
-```rust
+```rust,noexec
 use facet::Facet;
 use facet_assert::assert_same;
 use facet_json::RawJson;

--- a/docs/content/guide/ecosystem.md
+++ b/docs/content/guide/ecosystem.md
@@ -32,7 +32,7 @@ facet = { version = "{{ data.versions.facet }}", features = ["uuid", "chrono"] }
 
 ### Example: uUIDs
 
-```rust
+```rust,noexec
 use facet::Facet;
 use uuid::Uuid;
 
@@ -48,7 +48,7 @@ let user: User = facet_json::from_str(json)?;
 
 ### Example: dateTime with chrono
 
-```rust
+```rust,noexec
 use facet::Facet;
 use chrono::{DateTime, Utc};
 
@@ -64,7 +64,7 @@ let event: Event = facet_json::from_str(json)?;
 
 ### Example: UTF-8 paths with camino
 
-```rust
+```rust,noexec
 use facet::Facet;
 use camino::Utf8PathBuf;
 
@@ -151,7 +151,7 @@ Beyond basic argument parsing, `facet-args` provides utilities for help generati
 
 Generate formatted help text from your type's structure and doc comments:
 
-```rust
+```rust,noexec
 use facet::Facet;
 use facet_args::{generate_help, HelpConfig};
 
@@ -182,7 +182,7 @@ fn main() {
 
 Generate completion scripts for bash, zsh, and fish:
 
-```rust
+```rust,noexec
 use facet_args::{generate_completions, Shell};
 
 // Generate bash completions
@@ -205,7 +205,7 @@ Install completions by writing to the appropriate location:
 
 For quick CLI tools:
 
-```rust
+```rust,noexec
 use facet_args::from_std_args;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -225,7 +225,7 @@ If you have a type that doesn't implement `Facet`, you have several options:
 
 If it's your type, just derive it:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct MyType {
     // ...
@@ -236,7 +236,7 @@ struct MyType {
 
 If your type contains fields that don't implement `Facet`, use `opaque` to hide them:
 
-```rust
+```rust,noexec
 use some_crate::ExternalType;  // Doesn't implement Facet
 
 #[derive(Facet)]
@@ -249,7 +249,7 @@ struct MyWrapper {
 
 Opaque fields can't be serialized on their own. If you need serialization, add a `proxy`:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(transparent)]
 struct ExternalTypeProxy(String);

--- a/docs/content/guide/errors.md
+++ b/docs/content/guide/errors.md
@@ -8,7 +8,7 @@ Facet format crates return errors that implement [`miette::Diagnostic`](https://
 
 ## Printing errors nicely
 
-```rust
+```rust,noexec
 use facet::Facet;
 use facet_json::from_str;
 use miette::{IntoDiagnostic, Result};

--- a/docs/content/guide/faq.md
+++ b/docs/content/guide/faq.md
@@ -55,7 +55,7 @@ the vtables that are included
 
 ### How do I deserialize from JSON?
 
-```rust
+```rust,noexec
 use facet::Facet;
 use facet_json::from_str;
 
@@ -70,7 +70,7 @@ let person: Person = from_str(r#"{"name": "Alice", "age": 30}"#)?;
 
 ### How do I serialize to JSON?
 
-```rust
+```rust,noexec
 use facet::Facet;
 use facet_json::to_string;
 
@@ -88,7 +88,7 @@ let json = to_string(&person);
 
 Use `Option<T>` and optionally `skip_serializing_if`:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct User {
     name: String,
@@ -101,7 +101,7 @@ struct User {
 
 Use `rename` for individual fields or `rename_all` for all fields:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(rename_all = "camelCase")]
 struct Config {
@@ -113,7 +113,7 @@ struct Config {
 
 ### How do I use a default value for missing fields?
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Config {
     name: String,
@@ -124,7 +124,7 @@ struct Config {
 
 ### How do I skip a field?
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct User {
     name: String,
@@ -135,7 +135,7 @@ struct User {
 
 ### How do I flatten nested structs?
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Inner {
     x: i32,
@@ -155,7 +155,7 @@ struct Outer {
 
 facet supports multiple enum representations:
 
-```rust
+```rust,noexec
 // Externally tagged (default)
 #[derive(Facet)]
 enum Message {
@@ -199,7 +199,7 @@ enum AnyValue {
 
 By default, facet ignores unknown fields. Add `deny_unknown_fields` to make them errors:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(deny_unknown_fields)]
 struct Config {
@@ -211,7 +211,7 @@ struct Config {
 
 facet's format crates produce rich diagnostics with source locations when possible. Errors implement [miette](https://docs.rs/miette)'s `Diagnostic` trait for pretty printing:
 
-```rust
+```rust,noexec
 use miette::Result;
 use facet_json::from_str;
 
@@ -225,7 +225,7 @@ fn main() -> Result<()> {
 
 Use the `invariants` attribute:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 #[facet(invariants = validate)]
 struct Port(u16);
@@ -241,7 +241,7 @@ fn validate(port: &Port) -> bool {
 
 Not directly. facet has its own derive macro and format crates. However, you can have both derives on a type:
 
-```rust
+```rust,noexec
 #[derive(Facet, serde::Serialize, serde::Deserialize)]
 struct MyType {
     // ...
@@ -275,7 +275,7 @@ Ensure the type either:
 
 Make sure you're using the derive macro:
 
-```rust
+```rust,noexec
 use facet::Facet;
 
 #[derive(Facet)]  // This enables #[facet(...)] attributes
@@ -286,7 +286,7 @@ struct MyType { ... }
 
 Extension attributes require importing the crate with an alias:
 
-```rust
+```rust,noexec
 use facet_kdl as kdl;  // Enables kdl:: prefix
 
 #[derive(Facet)]
@@ -302,7 +302,7 @@ Without the import, `kdl::property` is not recognized.
 Due to the current facet implementation you need to manually tag where we should introduce indirection,
 this is done with the `#[facet(recursive_type)]` attribute like so
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Node {
     #[facet(recursive_type)] 

--- a/docs/content/guide/getting-started.md
+++ b/docs/content/guide/getting-started.md
@@ -38,7 +38,7 @@ If you also need YAML/TOML/KDL/etc., add `facet-yaml`, `facet-toml`, `facet-kdl`
 
 ## Derive `Facet` on your types
 
-```rust
+```rust,noexec
 // src/main.rs
 use facet::Facet;
 use facet_json::{from_str, to_string};

--- a/docs/content/guide/migration/_index.md
+++ b/docs/content/guide/migration/_index.md
@@ -21,7 +21,7 @@ is to ignore field that are not known.
 <tr>
 <td>
 
-```rust
+```rust,noexec
 #[derive(facet::Facet)]
 #[facet(deny_unknown_fields)]
 struct MyStruct {
@@ -34,7 +34,7 @@ struct MyStruct {
 </td>
 <td>
 
-```rust
+```rust,noexec
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 struct MyStruct {
@@ -62,7 +62,7 @@ variant.
 <tr>
 <td>
 
-```rust
+```rust,noexec
 #[derive(facet::Facet)]
 #[facet(default)]
 struct MyStruct {
@@ -84,7 +84,7 @@ impl Default for MyStruct {
 </td>
 <td>
 
-```rust
+```rust,noexec
 #[derive(serde::Deserialize)]
 #[serde(default)]
 struct MyStruct {
@@ -125,7 +125,7 @@ Rename all fields at once using a casing convention. Supported values are
 <tr>
 <td>
 
-```rust
+```rust,noexec
 #[derive(facet::Facet)]
 #[facet(rename_all = "camelCase")]
 struct MyStruct {
@@ -136,7 +136,7 @@ struct MyStruct {
 </td>
 <td>
 
-```rust
+```rust,noexec
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct MyStruct {
@@ -162,7 +162,7 @@ Skip this field during serialization.
 <tr>
 <td>
 
-```rust
+```rust,noexec
 #[derive(facet::Facet)]
 struct MyStruct {
     field1: i32,
@@ -174,7 +174,7 @@ struct MyStruct {
 </td>
 <td>
 
-```rust
+```rust,noexec
 #[derive(serde::Serialize)]
 struct MyStruct {
     field1: i32,
@@ -201,7 +201,7 @@ want to omit the field entirely from serialized output when the value is `None`.
 <tr>
 <td>
 
-```rust
+```rust,noexec
 #[derive(facet::Facet)]
 struct MyStruct {
     #[facet(skip_serializing_if = |n| n % 2 == 0)]
@@ -214,7 +214,7 @@ struct MyStruct {
 </td>
 <td>
 
-```rust
+```rust,noexec
 #[derive(serde::Serialize)]
 struct MyStruct {
     #[serde(skip_serializing_if = is_even)]
@@ -246,7 +246,7 @@ expression producing the default value.
 <tr>
 <td>
 
-```rust
+```rust,noexec
 #[derive(facet::Facet)]
 struct MyStruct {
     field1: i32,
@@ -262,7 +262,7 @@ struct MyStruct {
 </td>
 <td>
 
-```rust
+```rust,noexec
 #[derive(serde::Deserialize)]
 struct MyStruct {
     field1: i32,

--- a/docs/content/guide/showcases/binary.md
+++ b/docs/content/guide/showcases/binary.md
@@ -10,7 +10,7 @@ Facet supports several binary serialization formats for compact, efficient data 
 
 [MessagePack](https://msgpack.org/) is a compact binary format that's "like JSON but fast and small."
 
-```rust
+```rust,noexec
 use facet::Facet;
 
 #[derive(Facet)]
@@ -51,7 +51,7 @@ let decoded: Message = facet_msgpack::from_slice(&bytes)?;
 
 [Postcard](https://postcard.jamesmunns.com/) is a `no_std`-friendly binary format designed for embedded systems and high-performance applications.
 
-```rust
+```rust,noexec
 use facet::Facet;
 
 #[derive(Facet)]
@@ -92,7 +92,7 @@ let decoded: SensorReading = facet_postcard::from_slice(&bytes)?;
 
 Postcard can serialize to fixed-size arrays:
 
-```rust
+```rust,noexec
 use facet_postcard::to_slice;
 
 let mut buf = [0u8; 64];

--- a/docs/content/guide/showcases/toml.md
+++ b/docs/content/guide/showcases/toml.md
@@ -8,7 +8,7 @@ insert_anchor_links = "heading"
 
 ## Basic usage
 
-```rust
+```rust,noexec
 use facet::Facet;
 
 #[derive(Facet)]
@@ -34,7 +34,7 @@ let output = facet_toml::to_string(&config)?;
 
 TOML tables map to nested structs:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Package {
     name: String,
@@ -70,7 +70,7 @@ let config: Config = facet_toml::from_str(toml)?;
 
 TOML arrays work with `Vec<T>`:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Dependency {
     name: String,
@@ -114,7 +114,7 @@ port = 8080
 
 Use `Option<T>` for optional configuration:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Database {
     host: String,
@@ -134,7 +134,7 @@ facet = { version = "{{ data.versions.facet }}", features = ["chrono"] }
 # or "time" or "jiff02"
 ```
 
-```rust
+```rust,noexec
 use chrono::{DateTime, Utc};
 
 #[derive(Facet)]
@@ -168,7 +168,7 @@ Error: missing field `port`
 
 ### Cargo.toml-style configs
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Manifest {
     package: Package,
@@ -198,7 +198,7 @@ enum Dependency {
 
 ### Environment-specific configs
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Config {
     #[facet(default)]
@@ -220,7 +220,7 @@ struct ServerConfig {
 
 Serialize to TOML:
 
-```rust
+```rust,noexec
 let config = Config {
     package: Package {
         name: "myapp".into(),

--- a/docs/content/guide/structstruck.md
+++ b/docs/content/guide/structstruck.md
@@ -8,7 +8,7 @@ insert_anchor_links = "heading"
 
 ## Without structstruck
 
-```rust
+```rust,noexec
 use facet::Facet;
 
 #[derive(Facet)]
@@ -34,7 +34,7 @@ struct Features {
 
 ## With structstruck
 
-```rust
+```rust,noexec
 structstruck::strike! {
     #[structstruck::each[derive(facet::Facet)]]
     struct Config {

--- a/docs/content/guide/variance.md
+++ b/docs/content/guide/variance.md
@@ -13,7 +13,7 @@ Variance determines whether you can substitute a type with a different lifetime:
 - **Contravariant**: A shorter lifetime can be used where a longer one is expected. `fn(&'a str)` can accept `fn(&'static str)`.
 - **Invariant**: No substitution allowed. The lifetime must match exactly.
 
-```rust
+```rust,noexec
 // Covariant: &'a T
 fn takes_ref<'a>(r: &'a str) {}
 let s: &'static str = "hello";
@@ -37,7 +37,7 @@ Facet's `Peek` type lets you read values at runtime. Without careful design, ref
 
 Consider a type that contains a function pointer:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct FnWrapper<'a> {
     f: fn(&'a str),  // Contravariant in 'a
@@ -54,7 +54,7 @@ If reflection allowed lifetime changes, you could:
 
 `Peek` is **invariant** over its `'facet` lifetime parameter. This means you cannot change the lifetime through reflection at all:
 
-```rust
+```rust,noexec
 // This is enforced at compile time
 fn launder<'a>(p: Peek<'_, 'static>) -> Peek<'_, 'a> {
     p  // ERROR: cannot coerce Peek<'_, 'static> to Peek<'_, 'a>
@@ -65,7 +65,7 @@ fn launder<'a>(p: Peek<'_, 'static>) -> Peek<'_, 'a> {
 
 Every `Shape` in facet has a `variance` field that records the type's variance:
 
-```rust
+```rust,noexec
 pub struct Shape {
     // ... other fields ...
 
@@ -95,7 +95,7 @@ When combining types, variance follows these rules:
 
 The `Variance::combine()` method implements these rules:
 
-```rust
+```rust,noexec
 let struct_variance = field1_variance.combine(field2_variance);
 ```
 

--- a/docs/content/guide/why.md
+++ b/docs/content/guide/why.md
@@ -5,7 +5,7 @@ weight = 1
 
 facet is a reflection library for Rust. You derive `Facet` once, and you get serialization, pretty-printing, diffing, CLI argument parsing, and more — all from the same type information.
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Config {
     name: String,
@@ -80,7 +80,7 @@ If you want to reduce binary size, you might use `#[cfg_attr(...)]` to condition
 
 With facet, you derive once:
 
-```rust
+```rust,noexec
 #[derive(Facet)]
 struct Args {
     #[facet(args::named, args::short = 'v')]
@@ -100,7 +100,7 @@ That type works with `facet-json` for config files, `facet-args` for CLI parsing
 
 Writing a proc-macro is hard. With facet, if you want custom attributes for your format crate, you call `define_attr_grammar!` and you're done:
 
-```rust
+```rust,noexec
 facet::define_attr_grammar! {
     ns "myformat";
     crate_path ::my_format_crate;

--- a/docs/content/reference/attributes/_index.md
+++ b/docs/content/reference/attributes/_index.md
@@ -11,7 +11,7 @@ For the full guide on creating extension attributes, see [Extend → Extension A
 
 ### Using extension attributes
 
-```rust
+```rust,noexec
 use facet::Facet;
 use facet_kdl as kdl;
 
@@ -27,7 +27,7 @@ struct Config {
 
 The namespace (`kdl`) comes from how you import the crate:
 
-```rust
+```rust,noexec
 use facet_kdl as kdl;  // Enables kdl:: prefix
 use facet_args as args;  // Enables args:: prefix
 ```
@@ -44,7 +44,7 @@ use facet_args as args;  // Enables args:: prefix
 
 Use [`define_attr_grammar!`](https://docs.rs/facet/latest/facet/macro.define_attr_grammar.html) in your crate:
 
-```rust
+```rust,noexec
 facet::define_attr_grammar! {
     ns "myformat";
     crate_path ::my_format_crate;

--- a/docs/sass/main.scss
+++ b/docs/sass/main.scss
@@ -413,7 +413,7 @@ p {
 
 a {
   color: var(--link-color);
-  text-decoration: none;
+  text-decoration: none !important;
 
   &:hover {
     color: var(--link-hover);


### PR DESCRIPTION
## Summary

- Mark non-runnable Rust code samples in documentation with `noexec` attribute
- Override Glade's base link underline styles with `!important`
- Fix clippy `collapsible_if` warnings in facet-args, facet-assert, facet-showcase

## Context

dodeca now executes Rust code samples in documentation. Many examples were illustrative snippets referencing undefined types/crates (like `Server`, `hex`, `other_crate`), causing the website build to fail with 81 compilation errors.

## Test plan

- [x] `ddc build` succeeds locally
- [x] `cargo clippy` passes