### PR TITLE
feat: re-export simd feature flag from facet crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,7 @@ dependencies = [
 name = "facet"
 version = "0.31.8"
 dependencies = [
+ "autocfg",
  "cargo-husky",
  "eyre",
  "facet-core",

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -62,11 +62,18 @@ tuples-12 = ["facet-core/tuples-12"]
 # Provide Facet trait implementations for function pointers.
 fn-ptr = ["facet-core/fn-ptr"]
 
+# Provide Facet trait implementations for portable SIMD types (requires nightly).
+# This adds 84 type implementations which increases compile time.
+simd = ["facet-core/simd"]
+
 # Include doc comments in generated Shape/Field/Variant definitions
 doc = ["facet-macros/doc"]
 
 # Enable typo suggestions for unknown attributes/fields (uses strsim)
 helpful-derive = ["facet-macros/helpful-derive"]
+
+[build-dependencies]
+autocfg = "1.3"
 
 [dependencies]
 facet-core = { path = "../facet-core", version = "=0.31.8", default-features = false }

--- a/facet/build.rs
+++ b/facet/build.rs
@@ -1,0 +1,20 @@
+fn main() {
+    // Emit a cfg flag when portable_simd is available (nightly only for now).
+    println!("cargo::rustc-check-cfg=cfg(has_portable_simd)");
+
+    let ac = autocfg::new();
+    // Probe for portable_simd feature support (requires nightly).
+    if ac
+        .probe_raw(
+            r#"
+            #![feature(portable_simd)]
+            fn _test() { let _: core::simd::Simd<f32, 4>; }
+            "#,
+        )
+        .is_ok()
+    {
+        println!("cargo::rustc-cfg=has_portable_simd");
+    }
+
+    println!("cargo::rerun-if-changed=build.rs");
+}

--- a/facet/tests/simd.rs
+++ b/facet/tests/simd.rs
@@ -1,0 +1,30 @@
+// Only run these tests when the simd feature is enabled AND portable_simd is available
+#![cfg(all(feature = "simd", has_portable_simd))]
+#![feature(portable_simd)]
+
+use core::simd::Simd;
+use facet::{Def, Facet, Type, UserType};
+
+#[test]
+fn simd_f32x4_shape() {
+    let shape = <Simd<f32, 4> as Facet>::SHAPE;
+    assert_eq!(shape.type_identifier, "f32x4");
+    assert!(matches!(shape.ty, Type::User(UserType::Opaque)));
+    assert!(matches!(shape.def, Def::Scalar));
+}
+
+#[test]
+fn simd_f64x8_shape() {
+    let shape = <Simd<f64, 8> as Facet>::SHAPE;
+    assert_eq!(shape.type_identifier, "f64x8");
+    assert!(matches!(shape.ty, Type::User(UserType::Opaque)));
+    assert!(matches!(shape.def, Def::Scalar));
+}
+
+#[test]
+fn simd_f32x16_shape() {
+    let shape = <Simd<f32, 16> as Facet>::SHAPE;
+    assert_eq!(shape.type_identifier, "f32x16");
+    assert!(matches!(shape.ty, Type::User(UserType::Opaque)));
+    assert!(matches!(shape.def, Def::Scalar));
+}


### PR DESCRIPTION
## Summary

- Re-export the `simd` feature flag from the main `facet` crate to `facet-core`
- Add `build.rs` to detect nightly `portable_simd` feature availability for tests
- Add usage tests to verify SIMD types can be used via the `facet` crate

This allows users to enable SIMD support via `facet = { features = ["simd"] }` instead of needing to depend directly on `facet-core`.

## Test plan

- [x] `cargo check -p facet --features simd` compiles successfully
- [x] `cargo nextest run -p facet --features simd` passes all tests
- [x] `cargo +nightly nextest run -p facet --features simd simd` runs the new SIMD tests on nightly
- [x] `cargo nextest run --workspace` passes all 2193 tests

Fixes #1223