### PR TITLE
fix: skip static SHAPE declaration for generic types

### DIFF
--- a/facet-macros-impl/src/derive.rs
+++ b/facet-macros-impl/src/derive.rs
@@ -5,7 +5,17 @@ use crate::{LifetimeName, RenameRule, process_enum, process_struct};
 
 /// Generate a static declaration that pre-evaluates `<T as Facet>::SHAPE`.
 /// Only emitted in release builds to avoid slowing down debug compile times.
-pub(crate) fn generate_static_decl(type_name: &Ident, facet_crate: &TokenStream) -> TokenStream {
+/// Skipped for generic types since we can't create a static for an unmonomorphized type.
+pub(crate) fn generate_static_decl(
+    type_name: &Ident,
+    facet_crate: &TokenStream,
+    has_type_or_const_generics: bool,
+) -> TokenStream {
+    // Can't generate a static for generic types - the type parameters aren't concrete
+    if has_type_or_const_generics {
+        return quote! {};
+    }
+
     let type_name_str = type_name.to_string();
     let screaming_snake_name = RenameRule::ScreamingSnakeCase.apply(&type_name_str);
 

--- a/facet-macros-impl/src/process_enum.rs
+++ b/facet-macros-impl/src/process_enum.rs
@@ -867,7 +867,8 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
     };
 
     // Static declaration for release builds (pre-evaluates SHAPE)
-    let static_decl = crate::derive::generate_static_decl(enum_name, &facet_crate);
+    let static_decl =
+        crate::derive::generate_static_decl(enum_name, &facet_crate, has_type_or_const_generics);
 
     // Generate the impl
     quote! {

--- a/facet-macros-impl/src/process_struct.rs
+++ b/facet-macros-impl/src/process_struct.rs
@@ -1672,7 +1672,11 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
     };
 
     // Static declaration for release builds (pre-evaluates SHAPE)
-    let static_decl = crate::derive::generate_static_decl(&struct_name_ident, &facet_crate);
+    let static_decl = crate::derive::generate_static_decl(
+        &struct_name_ident,
+        &facet_crate,
+        has_type_or_const_generics,
+    );
 
     // Final quote block using refactored parts
     let result = quote! {


### PR DESCRIPTION
## Summary
- Skip generating the static `TYPE_SHAPE` declaration for types with type or const generics
- The static declaration was generating invalid code like `static MY_RESULT_SHAPE: &'static Shape = <MyResult as Facet>::SHAPE;` which is missing the generic arguments

## Test plan
- [x] `cargo nextest run --release -p facet-postcard --test enums generic_enum` passes (this was failing before the fix)
- [x] Full test suite passes in release mode: `cargo nextest run --release` (2196 tests)

Fixes #1225