### PR TITLE
Fix Clippy linting warnings

### DIFF
--- a/facet-diff-core/src/layout/attrs.rs
+++ b/facet-diff-core/src/layout/attrs.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use super::Span;
 
 /// Type of a formatted value for color selection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ValueType {
     /// String type (green-based colors)
     String,
@@ -16,13 +16,8 @@ pub enum ValueType {
     /// Null/None type (cyan-based colors)
     Null,
     /// Other/unknown types (use accent color)
+    #[default]
     Other,
-}
-
-impl Default for ValueType {
-    fn default() -> Self {
-        Self::Other
-    }
 }
 
 /// A pre-formatted value with its measurements.

--- a/facet-diff/src/diff.rs
+++ b/facet-diff/src/diff.rs
@@ -609,17 +609,6 @@ fn deref_if_pointer<'mem, 'facet>(peek: Peek<'mem, 'facet>) -> Peek<'mem, 'facet
     peek
 }
 
-pub(crate) fn diff_closeness(diff: &Diff<'_, '_>) -> usize {
-    match diff {
-        Diff::Equal { .. } => 1, // This does not actually matter for flattening sequence diffs, because all diffs there are non-equal
-        Diff::Replace { .. } => 0,
-        Diff::Sequence { updates, .. } => updates.closeness(),
-        Diff::User {
-            from, to, value, ..
-        } => value.closeness() + (from == to) as usize,
-    }
-}
-
 /// Collect all leaf-level changes with their paths.
 ///
 /// This walks the diff tree recursively and collects every terminal change

--- a/facet-diff/src/sequences.rs
+++ b/facet-diff/src/sequences.rs
@@ -4,7 +4,7 @@ use facet_diff_core::Updates;
 use facet_reflect::Peek;
 use log::trace;
 
-use crate::diff::{diff_closeness, diff_new_peek};
+use crate::diff::diff_new_peek;
 
 /// Maximum size for sequences to use Myers' algorithm.
 /// Larger sequences fall back to simple element-by-element comparison

--- a/facet-diff/tests/deep_nesting.rs
+++ b/facet-diff/tests/deep_nesting.rs
@@ -93,12 +93,11 @@ fn test_single_difference_in_deep_tree() {
     let mut b = a.clone();
 
     // Change just one value deep in the tree
-    if let Some(level1) = b.children.get_mut(0) {
-        if let Some(level2) = level1.children.get_mut(0) {
-            if let Some(level3) = level2.children.get_mut(0) {
-                level3.value = 999;
-            }
-        }
+    if let Some(level1) = b.children.get_mut(0)
+        && let Some(level2) = level1.children.get_mut(0)
+        && let Some(level3) = level2.children.get_mut(0)
+    {
+        level3.value = 999;
     }
 
     let _diff = a.diff(&b);


### PR DESCRIPTION
Address derivable_impls, unused_imports, dead_code, and collapsible_if warnings across facet-diff-core and facet-diff crates. All Clippy checks now pass cleanly.