### PR TITLE
Expose diff reports and showcase XML/JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ dependencies = [
  "facet",
  "facet-core",
  "facet-diff",
+ "facet-diff-core",
  "facet-reflect",
  "facet-showcase",
  "owo-colors",

--- a/docs/content/guide/showcases/assert.md
+++ b/docs/content/guide/showcases/assert.md
@@ -32,10 +32,7 @@ title = "Assertions"
   <span style="color:rgb(115,218,202)">host</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">localhost</span>"<span style="opacity:0.7">,</span>
   <span style="color:rgb(115,218,202)">port</span><span style="opacity:0.7">: </span><span style="color:rgb(224,186,81)">8080</span><span style="opacity:0.7">,</span>
   <span style="color:rgb(115,218,202)">debug</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">tags</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;String&gt;</span><span style="opacity:0.7"> [</span>
-    "<span style="color:rgb(158,206,106)">prod</span>"<span style="opacity:0.7">,</span>
-    "<span style="color:rgb(158,206,106)">api</span>"<span style="opacity:0.7">,</span>
-  <span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">tags</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;String&gt;</span><span style="opacity:0.7"> [</span>"<span style="color:rgb(158,206,106)">prod</span>"<span style="opacity:0.7">,</span> "<span style="color:rgb(158,206,106)">api</span>"<span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
@@ -65,9 +62,7 @@ title = "Assertions"
   <span style="color:rgb(115,218,202)">host</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">localhost</span>"<span style="opacity:0.7">,</span>
   <span style="color:rgb(115,218,202)">port</span><span style="opacity:0.7">: </span><span style="color:rgb(224,186,81)">8080</span><span style="opacity:0.7">,</span>
   <span style="color:rgb(115,218,202)">debug</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">tags</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;String&gt;</span><span style="opacity:0.7"> [</span>
-    "<span style="color:rgb(158,206,106)">prod</span>"<span style="opacity:0.7">,</span>
-  <span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">tags</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;String&gt;</span><span style="opacity:0.7"> [</span>"<span style="color:rgb(158,206,106)">prod</span>"<span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
@@ -112,20 +107,37 @@ title = "Assertions"
 ## Structural Diff
 
 <section class="scenario">
-<p class="description">When values differ, you get a precise structural diff showing exactly which fields changed and at what path — not just a wall of red/green text.</p>
+<p class="description">When values differ, you get a precise structural diff showing exactly which fields changed and at what path — then render it as Rust, JSON, or XML for whichever toolchain you need.</p>
 <div class="diff-output">
-<h4>Diff Output</h4>
-<pre><code><span style="font-weight:bold">.host</span>:
-  <span style="color:#e06c75">- "localhost"</span>
-  <span style="color:#98c379">+ "prod.example.com"</span>
-<span style="font-weight:bold">.port</span>:
-  <span style="color:#e06c75">- 8080</span>
-  <span style="color:#98c379">+ 443</span>
-<span style="font-weight:bold">.debug</span>:
-  <span style="color:#e06c75">- true</span>
-  <span style="color:#98c379">+ false</span>
-<span style="font-weight:bold">.tags[1]</span> (only in left):
-  <span style="color:#e06c75">- "api"</span>
+<h4>Rust Diff Output</h4>
+<pre><code><span style="color:rgb(86,95,137)">{</span>
+    <span style="color:rgb(115,218,202)">debug</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(247,118,142)">true</span> → <span style="color:rgb(115,218,202)">false</span>
+    <span style="color:rgb(115,218,202)">host</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(247,118,142)">"localhost"</span> → <span style="color:rgb(115,218,202)">"prod.example.com"</span>
+    <span style="color:rgb(115,218,202)">port</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(247,118,142)">8080</span> → <span style="color:rgb(115,218,202)">443</span>
+    <span style="color:rgb(115,218,202)">tags</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(86,95,137)">[</span>
+        <span style="color:rgb(86,95,137)">.. 1 unchanged item</span>
+        <span style="color:rgb(247,118,142)">- "api"</span>
+    <span style="color:rgb(86,95,137)">]</span>
+<span style="color:rgb(86,95,137)">}</span></code></pre>
+</div>
+<div class="diff-output">
+<h4>JSON Diff Output</h4>
+<pre><code>    <span style="color:rgb(220,220,220)">{</span> <span style="color:rgb(100,100,100)">/* Config */</span>
+      <span style="color:rgb(229,192,123);opacity:0.7">←</span> <span style="color:rgb(255,234,162);opacity:0.7">"debug": </span><span style="color:rgb(255,234,162);opacity:0.7">true</span><span style="color:rgb(224,209,189);opacity:0.7"></span> , <span style="color:rgb(255,234,162);opacity:0.7">"host": </span><span style="color:rgb(229,192,123);opacity:0.7">"localhost"</span><span style="color:rgb(224,209,189);opacity:0.7"></span>       , <span style="color:rgb(255,234,162);opacity:0.7">"port": </span><span style="color:rgb(255,234,162);opacity:0.7">8080</span><span style="color:rgb(224,209,189);opacity:0.7"></span>
+      <span style="color:rgb(97,175,239);opacity:0.7">→</span> <span style="color:rgb(142,216,255);opacity:0.7">"debug": </span><span style="color:rgb(142,216,255);opacity:0.7">false</span><span style="color:rgb(184,204,228);opacity:0.7"></span>, <span style="color:rgb(142,216,255);opacity:0.7">"host": </span><span style="color:rgb(97,175,239);opacity:0.7">"prod.example.com"</span><span style="color:rgb(184,204,228);opacity:0.7"></span>, <span style="color:rgb(142,216,255);opacity:0.7">"port": </span><span style="color:rgb(142,216,255);opacity:0.7">443</span><span style="color:rgb(184,204,228);opacity:0.7"></span>
+    <span style="color:rgb(220,220,220)"></span>
+        <span style="color:rgb(220,220,220)">"tags": [</span><span style="color:rgb(220,220,220)">]</span><span style="color:rgb(100,100,100)">,</span>
+    <span style="color:rgb(220,220,220)">}</span>
+</code></pre>
+</div>
+<div class="diff-output">
+<h4>XML Diff Output</h4>
+<pre><code>    <span style="color:rgb(220,220,220)">&lt;Config</span>
+      <span style="color:rgb(229,192,123);opacity:0.7">←</span> <span style="color:rgb(255,234,162);opacity:0.7">debug="</span><span style="color:rgb(255,234,162);opacity:0.7">true</span><span style="color:rgb(224,209,189);opacity:0.7">"</span>  <span style="color:rgb(255,234,162);opacity:0.7">host="</span><span style="color:rgb(229,192,123);opacity:0.7">localhost</span><span style="color:rgb(224,209,189);opacity:0.7">"</span>        <span style="color:rgb(255,234,162);opacity:0.7">port="</span><span style="color:rgb(255,234,162);opacity:0.7">8080</span><span style="color:rgb(224,209,189);opacity:0.7">"</span>
+      <span style="color:rgb(97,175,239);opacity:0.7">→</span> <span style="color:rgb(142,216,255);opacity:0.7">debug="</span><span style="color:rgb(142,216,255);opacity:0.7">false</span><span style="color:rgb(184,204,228);opacity:0.7">"</span> <span style="color:rgb(142,216,255);opacity:0.7">host="</span><span style="color:rgb(97,175,239);opacity:0.7">prod.example.com</span><span style="color:rgb(184,204,228);opacity:0.7">"</span> <span style="color:rgb(142,216,255);opacity:0.7">port="</span><span style="color:rgb(142,216,255);opacity:0.7">443</span><span style="color:rgb(184,204,228);opacity:0.7">"</span>
+    <span style="color:rgb(220,220,220)">&gt;</span>
+        <span style="color:rgb(220,220,220)">&lt;tags&gt;</span><span style="color:rgb(220,220,220)">&lt;/tags&gt;</span><span style="color:rgb(100,100,100)"></span>
+    <span style="color:rgb(220,220,220)">&lt;/Config&gt;</span>
 </code></pre>
 </div>
 </section>
@@ -136,12 +148,12 @@ title = "Assertions"
 <p class="description">Vector comparisons show exactly which indices differ, which elements were added, and which were removed.</p>
 <div class="diff-output">
 <h4>Diff Output</h4>
-<pre><code><span style="font-weight:bold">[2]</span>:
-  <span style="color:#e06c75">- 3</span>
-  <span style="color:#98c379">+ 99</span>
-<span style="font-weight:bold">[4]</span> (only in left):
-  <span style="color:#e06c75">- 5</span>
-</code></pre>
+<pre><code><span style="color:rgb(86,95,137)">[</span>
+    <span style="color:rgb(86,95,137)">.. 2 unchanged items</span>
+    <span style="color:rgb(247,118,142)">3</span> → <span style="color:rgb(115,218,202)">99</span>
+    <span style="color:rgb(86,95,137)">.. 1 unchanged item</span>
+    <span style="color:rgb(247,118,142)">- 5</span>
+<span style="color:rgb(86,95,137)">]</span></code></pre>
 </div>
 </section>
 

--- a/facet-assert/Cargo.toml
+++ b/facet-assert/Cargo.toml
@@ -15,6 +15,7 @@ ci = [] # CI feature
 [dependencies]
 facet-core = { path = "../facet-core" }
 facet-diff = { path = "../facet-diff" }
+facet-diff-core = { path = "../facet-diff-core" }
 facet-reflect = { path = "../facet-reflect" }
 
 [dev-dependencies]

--- a/facet-assert/README.md
+++ b/facet-assert/README.md
@@ -67,6 +67,30 @@ comparison. We know which fields changed:
 
 Instead of a wall of red/green like traditional diff tools.
 
+### Render diffs in your format
+
+Want the diff in JSON or XML so another tool can consume it? Call
+`check_same_report` to get a `SameReport`. When values differ you receive a
+`DiffReport` that can render the change set in Rust, JSON, or XML layouts with
+or without ANSI colors.
+
+```ignore
+use facet_assert::{SameReport, check_same_report};
+
+let report = match check_same_report(&c_output, &rust_output) {
+    SameReport::Different(report) => report,
+    SameReport::Same => return,
+    SameReport::Opaque { type_name } => panic!("opaque type {type_name}"),
+};
+
+let rust_view = report.legacy_string();
+let json_view = report.render_plain_json();
+let xml_view = report.render_plain_xml();
+```
+
+For full control, use `render_with_options` and pass your own `BuildOptions`,
+`RenderOptions`, or even a custom `DiffFlavor` implementation.
+
 ### Opaque types fail clearly
 
 If a type cannot be inspected (opaque), the assertion fails with a clear message

--- a/facet-assert/README.md.in
+++ b/facet-assert/README.md.in
@@ -59,6 +59,30 @@ comparison. We know which fields changed:
 
 Instead of a wall of red/green like traditional diff tools.
 
+### Render diffs in your format
+
+Want the diff in JSON or XML so another tool can consume it? Call
+`check_same_report` to get a `SameReport`. When values differ you receive a
+`DiffReport` that can render the change set in Rust, JSON, or XML layouts with
+or without ANSI colors.
+
+```ignore
+use facet_assert::{SameReport, check_same_report};
+
+let report = match check_same_report(&c_output, &rust_output) {
+    SameReport::Different(report) => report,
+    SameReport::Same => return,
+    SameReport::Opaque { type_name } => panic!("opaque type {type_name}"),
+};
+
+let rust_view = report.legacy_string();
+let json_view = report.render_plain_json();
+let xml_view = report.render_plain_xml();
+```
+
+For full control, use `render_with_options` and pass your own `BuildOptions`,
+`RenderOptions`, or even a custom `DiffFlavor` implementation.
+
 ### Opaque types fail clearly
 
 If a type cannot be inspected (opaque), the assertion fails with a clear message

--- a/facet-assert/src/lib.rs
+++ b/facet-assert/src/lib.rs
@@ -9,7 +9,14 @@
 
 mod same;
 
-pub use same::{SameOptions, Sameness, check_same, check_same_with};
+pub use facet_diff_core::layout::{
+    AnsiBackend, BuildOptions, ColorBackend, DiffFlavor, JsonFlavor, PlainBackend, RenderOptions,
+    RustFlavor, XmlFlavor,
+};
+pub use same::{
+    DiffReport, SameOptions, SameReport, Sameness, check_same, check_same_report, check_same_with,
+    check_same_with_report,
+};
 
 /// Asserts that two values are structurally the same.
 ///
@@ -228,6 +235,32 @@ mod tests {
                 matches!(other, Sameness::Same)
             ),
         }
+    }
+
+    #[test]
+    fn diff_report_renders_multiple_flavors() {
+        let a = Person {
+            name: "Alice".into(),
+            age: 30,
+        };
+        let b = Person {
+            name: "Bob".into(),
+            age: 45,
+        };
+
+        let report = match check_same_report(&a, &b) {
+            SameReport::Different(report) => report,
+            _ => panic!("expected Different"),
+        };
+
+        let rust = report.render_plain_rust();
+        assert!(rust.contains("Person"));
+
+        let json = report.render_plain_json();
+        assert!(json.contains("\"name\""));
+
+        let xml = report.render_plain_xml();
+        assert!(xml.contains("<Person"));
     }
 
     #[test]

--- a/facet-assert/src/same.rs
+++ b/facet-assert/src/same.rs
@@ -1,7 +1,11 @@
 //! Structural sameness checking for Facet types.
 
 use facet_core::Facet;
-use facet_diff::{DiffOptions, diff_new_peek_with_options};
+use facet_diff::{Diff, DiffOptions, diff_new_peek_with_options};
+use facet_diff_core::layout::{
+    AnsiBackend, BuildOptions, ColorBackend, DiffFlavor, JsonFlavor, RenderOptions, RustFlavor,
+    XmlFlavor, build_layout, render_to_string,
+};
 use facet_reflect::Peek;
 
 /// Options for customizing structural comparison behavior.
@@ -66,6 +70,127 @@ pub enum Sameness {
     },
 }
 
+/// Detailed comparison result that retains the computed diff.
+pub enum SameReport<'mem, 'facet> {
+    /// The values are structurally the same.
+    Same,
+    /// The values differ - includes a diff report that can be rendered in multiple formats.
+    Different(DiffReport<'mem, 'facet>),
+    /// Encountered an opaque type that cannot be compared.
+    Opaque {
+        /// The type name of the opaque type.
+        type_name: &'static str,
+    },
+}
+
+impl<'mem, 'facet> SameReport<'mem, 'facet> {
+    /// Returns `true` if the two values matched.
+    pub fn is_same(&self) -> bool {
+        matches!(self, Self::Same)
+    }
+
+    /// Convert this report into a [`Sameness`] summary, formatting diffs using the legacy display.
+    pub fn into_sameness(self) -> Sameness {
+        match self {
+            SameReport::Same => Sameness::Same,
+            SameReport::Different(report) => Sameness::Different(report.legacy_string()),
+            SameReport::Opaque { type_name } => Sameness::Opaque { type_name },
+        }
+    }
+
+    /// Get the diff report if the values were different.
+    pub fn diff(&self) -> Option<&DiffReport<'mem, 'facet>> {
+        match self {
+            SameReport::Different(report) => Some(report),
+            _ => None,
+        }
+    }
+}
+
+/// A reusable diff plus its original inputs, allowing rendering in different output styles.
+pub struct DiffReport<'mem, 'facet> {
+    diff: Diff<'mem, 'facet>,
+    left: Peek<'mem, 'facet>,
+    right: Peek<'mem, 'facet>,
+}
+
+impl<'mem, 'facet> DiffReport<'mem, 'facet> {
+    /// Access the raw diff tree.
+    pub fn diff(&self) -> &Diff<'mem, 'facet> {
+        &self.diff
+    }
+
+    /// Peek into the left-hand value.
+    pub fn left(&self) -> Peek<'mem, 'facet> {
+        self.left
+    }
+
+    /// Peek into the right-hand value.
+    pub fn right(&self) -> Peek<'mem, 'facet> {
+        self.right
+    }
+
+    /// Format the diff using the legacy tree display (same output as before).
+    pub fn legacy_string(&self) -> String {
+        format!("{}", self.diff)
+    }
+
+    /// Render the diff with a custom flavor and render/build options.
+    pub fn render_with_options<B: ColorBackend, F: DiffFlavor>(
+        &self,
+        flavor: &F,
+        build_opts: &BuildOptions,
+        render_opts: &RenderOptions<B>,
+    ) -> String {
+        let layout = build_layout(&self.diff, self.left, self.right, build_opts, flavor);
+        render_to_string(&layout, render_opts, flavor)
+    }
+
+    /// Render using ANSI colors with the provided flavor.
+    pub fn render_ansi_with<F: DiffFlavor>(&self, flavor: &F) -> String {
+        let build_opts = BuildOptions::default();
+        let render_opts = RenderOptions::<AnsiBackend>::default();
+        self.render_with_options(flavor, &build_opts, &render_opts)
+    }
+
+    /// Render without colors using the provided flavor.
+    pub fn render_plain_with<F: DiffFlavor>(&self, flavor: &F) -> String {
+        let build_opts = BuildOptions::default();
+        let render_opts = RenderOptions::plain();
+        self.render_with_options(flavor, &build_opts, &render_opts)
+    }
+
+    /// Render using the Rust flavor with ANSI colors.
+    pub fn render_ansi_rust(&self) -> String {
+        self.render_ansi_with(&RustFlavor)
+    }
+
+    /// Render using the Rust flavor without colors.
+    pub fn render_plain_rust(&self) -> String {
+        self.render_plain_with(&RustFlavor)
+    }
+
+    /// Render using the JSON flavor with ANSI colors.
+    pub fn render_ansi_json(&self) -> String {
+        self.render_ansi_with(&JsonFlavor)
+    }
+
+    /// Render using the JSON flavor without colors.
+    pub fn render_plain_json(&self) -> String {
+        self.render_plain_with(&JsonFlavor)
+    }
+
+    /// Render using the XML flavor with ANSI colors.
+    pub fn render_ansi_xml(&self) -> String {
+        self.render_ansi_with(&XmlFlavor)
+    }
+
+    /// Render using the XML flavor without colors.
+    pub fn render_plain_xml(&self) -> String {
+        self.render_plain_with(&XmlFlavor)
+    }
+}
+
 /// Check if two Facet values are structurally the same.
 ///
 /// This does NOT require `PartialEq` - it walks the structure via reflection.
@@ -74,7 +199,15 @@ pub enum Sameness {
 ///
 /// Returns [`Sameness::Opaque`] if either value contains an opaque type.
 pub fn check_same<'f, T: Facet<'f>, U: Facet<'f>>(left: &T, right: &U) -> Sameness {
-    check_same_with(left, right, SameOptions::default())
+    check_same_report(left, right).into_sameness()
+}
+
+/// Check if two Facet values are structurally the same, returning a detailed report.
+pub fn check_same_report<'f, 'mem, T: Facet<'f>, U: Facet<'f>>(
+    left: &'mem T,
+    right: &'mem U,
+) -> SameReport<'mem, 'f> {
+    check_same_with_report(left, right, SameOptions::default())
 }
 
 /// Check if two Facet values are structurally the same, with custom options.
@@ -98,21 +231,35 @@ pub fn check_same_with<'f, T: Facet<'f>, U: Facet<'f>>(
     right: &U,
     options: SameOptions,
 ) -> Sameness {
+    check_same_with_report(left, right, options).into_sameness()
+}
+
+/// Detailed comparison with custom options.
+pub fn check_same_with_report<'f, 'mem, T: Facet<'f>, U: Facet<'f>>(
+    left: &'mem T,
+    right: &'mem U,
+    options: SameOptions,
+) -> SameReport<'mem, 'f> {
+    let left_peek = Peek::new(left);
+    let right_peek = Peek::new(right);
+
     // Convert SameOptions to DiffOptions
-    let diff_options = DiffOptions::new();
     let diff_options = if let Some(tol) = options.float_tolerance {
-        diff_options.with_float_tolerance(tol)
+        DiffOptions::new().with_float_tolerance(tol)
     } else {
-        diff_options
+        DiffOptions::new()
     };
 
     // Compute diff with options applied during computation
-    let diff = diff_new_peek_with_options(Peek::new(left), Peek::new(right), &diff_options);
+    let diff = diff_new_peek_with_options(left_peek, right_peek, &diff_options);
 
     if diff.is_equal() {
-        Sameness::Same
+        SameReport::Same
     } else {
-        // Use facet-diff's native Display formatting
-        Sameness::Different(format!("{}", diff))
+        SameReport::Different(DiffReport {
+            diff,
+            left: left_peek,
+            right: right_peek,
+        })
     }
 }


### PR DESCRIPTION
## Summary
- add SameReport/DiffReport so consumers can render diffs in Rust/JSON/XML
- extend assert showcase and docs to display the new styles