### PR TITLE
Document XML annotations and add showcase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,6 +1851,7 @@ dependencies = [
  "facet-diff-core",
  "facet-pretty",
  "facet-reflect",
+ "facet-showcase",
  "facet-solver",
  "facet-testhelpers",
  "http",

--- a/facet-showcase/src/highlighter.rs
+++ b/facet-showcase/src/highlighter.rs
@@ -13,6 +13,8 @@ pub enum Language {
     Json,
     /// YAML format
     Yaml,
+    /// XML format
+    Xml,
     /// KDL format (requires custom syntax definition)
     Kdl,
     /// Rust code (for type definitions)
@@ -25,6 +27,7 @@ impl Language {
         match self {
             Language::Json => "json",
             Language::Yaml => "yaml",
+            Language::Xml => "xml",
             Language::Kdl => "kdl",
             Language::Rust => "rs",
         }
@@ -35,6 +38,7 @@ impl Language {
         match self {
             Language::Json => "JSON",
             Language::Yaml => "YAML",
+            Language::Xml => "XML",
             Language::Kdl => "KDL",
             Language::Rust => "Rust",
         }

--- a/facet-xml/Cargo.toml
+++ b/facet-xml/Cargo.toml
@@ -44,6 +44,11 @@ facet = { path = "../facet" }
 facet-core = { path = "../facet-core" }
 facet-pretty = { path = "../facet-pretty" }
 facet-testhelpers = { path = "../facet-testhelpers" }
+facet-showcase = { path = "../facet-showcase" }
 miette = { version = "7", default-features = false }
 indoc = "2"
 cargo-husky = { version = "1.5.0", default-features = false, features = ["user-hooks"] }
+
+[[example]]
+name = "xml_showcase"
+path = "examples/xml_showcase.rs"

--- a/facet-xml/README.md
+++ b/facet-xml/README.md
@@ -8,6 +8,10 @@
 
 Provides XML serialization and deserialization for Facet types.
 
+> **Important:** Every struct field must declare how it maps to XML using one of the
+> `#[facet(xml::…)]` attributes (or `#[facet(child)]`). Unannotated fields now produce
+> a descriptive error instead of being silently skipped.
+
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-xml/README.md.in
+++ b/facet-xml/README.md.in
@@ -1,1 +1,5 @@
 Provides XML serialization and deserialization for Facet types.
+
+> **Important:** Every struct field must declare how it maps to XML using one of the
+> `#[facet(xml::…)]` attributes (or `#[facet(child)]`). Unannotated fields now produce
+> a descriptive error instead of being silently skipped.

--- a/facet-xml/examples/xml_showcase.rs
+++ b/facet-xml/examples/xml_showcase.rs
@@ -1,0 +1,151 @@
+//! XML showcase demonstrating serialization, deserialization, and
+//! the explicit-annotation error added in #1244.
+//!
+//! Run with: `cargo run -p facet-xml --example xml_showcase`
+
+use facet::Facet;
+use facet_showcase::{Language, ShowcaseRunner};
+use facet_xml as xml;
+
+#[derive(Facet, Debug)]
+#[facet(xml::ns_all = "https://example.com/contacts")]
+struct ContactBook {
+    #[facet(xml::attribute)]
+    owner: String,
+    #[facet(xml::elements)]
+    contacts: Vec<Contact>,
+}
+
+#[derive(Facet, Debug)]
+struct Contact {
+    #[facet(xml::attribute)]
+    id: u32,
+    #[facet(xml::element)]
+    name: String,
+    #[facet(xml::element)]
+    email: Option<String>,
+}
+
+#[derive(Facet, Debug)]
+struct AlertFeed {
+    #[facet(xml::attribute)]
+    severity: String,
+    #[facet(xml::element)]
+    title: String,
+    #[facet(xml::elements)]
+    messages: Vec<AlertMessage>,
+}
+
+#[derive(Facet, Debug)]
+struct AlertMessage {
+    #[facet(xml::attribute)]
+    code: String,
+    #[facet(xml::text)]
+    body: String,
+}
+
+#[derive(Facet, Debug)]
+struct MissingXmlAnnotations {
+    // Intentionally missing `#[facet(xml::...)]`
+    title: String,
+    details: String,
+}
+
+fn main() {
+    let mut runner = ShowcaseRunner::new("XML")
+        .slug("xml")
+        .language(Language::Xml);
+
+    runner.header();
+    runner.intro(
+        "`facet-xml` maps Facet types to XML via explicit field annotations. \
+         This showcase highlights common serialization patterns and the new \
+         diagnostic you get when a field forgets to declare its XML role.",
+    );
+
+    runner.section("Serialization");
+    scenario_contacts(&mut runner);
+    scenario_alert_feed(&mut runner);
+
+    runner.section("Diagnostics");
+    scenario_missing_annotations(&mut runner);
+
+    runner.footer();
+}
+
+fn scenario_contacts(runner: &mut ShowcaseRunner) {
+    let book = ContactBook {
+        owner: "Operations".to_string(),
+        contacts: vec![
+            Contact {
+                id: 1,
+                name: "Alice".into(),
+                email: Some("alice@example.com".into()),
+            },
+            Contact {
+                id: 2,
+                name: "Bob".into(),
+                email: None,
+            },
+        ],
+    };
+
+    let xml_output = xml::to_string_pretty(&book).expect("XML serialization succeeds");
+
+    runner
+        .scenario("Attributes, elements, and Vec fields")
+        .description(
+            "Attributes live on the root `<ContactBook>` tag while \
+             `#[facet(xml::elements)]` turns a Vec into repeated `<contacts>` children.",
+        )
+        .target_type::<ContactBook>()
+        .input_value(&book)
+        .serialized_output(Language::Xml, &xml_output)
+        .finish();
+}
+
+fn scenario_alert_feed(runner: &mut ShowcaseRunner) {
+    let xml_input = r#"
+<AlertFeed severity="warning">
+  <title>System Notices</title>
+  <messages code="OPS-201">Deploying new release at 02:00 UTC</messages>
+  <messages code="DB-503">Database failover test scheduled</messages>
+</AlertFeed>
+"#
+    .trim();
+
+    let parsed: Result<AlertFeed, _> = xml::from_str(xml_input);
+
+    runner
+        .scenario("xml::text for content")
+        .description(
+            "`#[facet(xml::text)]` captures character data inside an element, \
+             while attributes remain on the tag. This scenario deserializes \
+             the feed and pretty-prints the resulting Facet value.",
+        )
+        .input(Language::Xml, xml_input)
+        .target_type::<AlertFeed>()
+        .result(&parsed)
+        .finish();
+}
+
+fn scenario_missing_annotations(runner: &mut ShowcaseRunner) {
+    let post = MissingXmlAnnotations {
+        title: "Weekly Report".into(),
+        details: "Compile-time errors per crate".into(),
+    };
+
+    let err = xml::to_string(&post).expect_err("fields without xml annotations now error");
+
+    runner
+        .scenario("Missing XML annotations")
+        .description(
+            "Every field must opt into XML via `#[facet(xml::attribute/element/...)]` \
+             (or `#[facet(child)]`). Leaving a field unannotated now produces a \
+             descriptive error before serialization begins.",
+        )
+        .target_type::<MissingXmlAnnotations>()
+        .input_value(&post)
+        .error(&err)
+        .finish();
+}

--- a/facet-xml/src/annotation.rs
+++ b/facet-xml/src/annotation.rs
@@ -1,0 +1,56 @@
+use facet_core::{Field, FieldFlags};
+
+/// Phase used when checking whether struct fields declare how they map to XML.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum XmlAnnotationPhase {
+    /// Validation performed before serialization.
+    Serialize,
+    /// Validation performed before deserialization.
+    Deserialize,
+}
+
+/// Return all fields that require an XML annotation but don't have one.
+pub(crate) fn fields_missing_xml_annotations<'a>(
+    fields: &'a [Field],
+    phase: XmlAnnotationPhase,
+) -> Vec<&'a Field> {
+    fields
+        .iter()
+        .filter(|field| field_requires_xml_annotation(field, phase))
+        .filter(|field| !field_has_xml_mapping(field))
+        .collect()
+}
+
+fn field_requires_xml_annotation(field: &Field, phase: XmlAnnotationPhase) -> bool {
+    if field.is_metadata() || field.is_flattened() {
+        return false;
+    }
+
+    if field.flags.contains(FieldFlags::SKIP) {
+        return false;
+    }
+
+    match phase {
+        XmlAnnotationPhase::Serialize => {
+            if field.flags.contains(FieldFlags::SKIP_SERIALIZING) {
+                return false;
+            }
+        }
+        XmlAnnotationPhase::Deserialize => {
+            if field.flags.contains(FieldFlags::SKIP_DESERIALIZING) {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+fn field_has_xml_mapping(field: &Field) -> bool {
+    field.has_attr(Some("xml"), "attribute")
+        || field.has_attr(Some("xml"), "text")
+        || field.has_attr(Some("xml"), "elements")
+        || field.has_attr(Some("xml"), "element")
+        || field.has_attr(Some("xml"), "element_name")
+        || field.is_child()
+}

--- a/facet-xml/src/lib.rs
+++ b/facet-xml/src/lib.rs
@@ -32,6 +32,13 @@
 //! }
 //! ```
 //!
+//! > **Important:** Every struct field must declare how it maps to XML. Add
+//! > `#[facet(xml::attribute)]`, `#[facet(xml::element)]`,
+//! > `#[facet(xml::elements)]`, `#[facet(xml::text)]`,
+//! > `#[facet(xml::element_name)]`, or `#[facet(child)]` to every field that
+//! > should appear in XML. Fields without an annotation now trigger an error
+//! > instead of being silently skipped.
+//!
 //! # Attribute Guide
 //!
 //! ## `#[facet(xml::element)]`
@@ -114,6 +121,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::result_large_err)]
 
+mod annotation;
 mod deserialize;
 mod error;
 mod serialize;

--- a/facet-xml/tests/error_cases.rs
+++ b/facet-xml/tests/error_cases.rs
@@ -161,6 +161,32 @@ fn test_missing_attribute_uses_default() {
     assert_eq!(result.name, "Test");
 }
 
+// ============================================================================
+// Missing XML annotations
+// ============================================================================
+
+#[derive(Facet, Debug)]
+struct UnannotatedField {
+    // Intentionally missing #[facet(xml::...)]
+    value: String,
+}
+
+#[test]
+fn test_deserialize_missing_xml_annotation_errors() {
+    let xml = r#"<UnannotatedField><value>hi</value></UnannotatedField>"#;
+    let result: Result<UnannotatedField, _> = xml::from_str(xml);
+    assert_err_kind!(result, XmlErrorKind::MissingXmlAnnotations { .. });
+}
+
+#[test]
+fn test_serialize_missing_xml_annotation_errors() {
+    let value = UnannotatedField {
+        value: "hi".to_string(),
+    };
+    let result = xml::to_string(&value);
+    assert_err_kind!(result, XmlErrorKind::MissingXmlAnnotations { .. });
+}
+
 #[test]
 fn test_missing_element_uses_default() {
     // Note: facet-xml uses default values for missing elements


### PR DESCRIPTION
Add XML syntax highlighting support to the showcase runner. Introduce a facet-xml showcase covering serialization, xml::text deserialization, and the missing-annotation error. Enforce explicit XML annotations at runtime with a dedicated error and update error messages/docs/tests accordingly. Tests: cargo run -p facet-xml --example xml_showcase.

Closes #1244 