### PR TITLE
Introduce the concept of truthiness

### DIFF
--- a/docs/content/extend/shape.md
+++ b/docs/content/extend/shape.md
@@ -4,11 +4,110 @@ weight = 3
 insert_anchor_links = "heading"
 +++
 
-What you can get from `Shape` (to be expanded):
+## What you can get from `Shape`
 
-- Identity: `ConstTypeId`, `type_identifier`, generics metadata.
-- Layout: size/alignment, owned vs borrowed.
-- Structure: `Type`/`Def` with structs/enums/collections, fields/variants, docstrings, attributes.
-- VTables: operations available (`clone_into`, `debug`, `parse`, marker traits via `Characteristic`).
-- Safety notes: why `Facet` is `unsafe`, invariants you must respect when consuming `Shape`.
-- Examples: listing fields, checking marker traits, rendering type names.
+### Identity
+
+- `ConstTypeId` — A stable, hashable identifier for the type
+- `type_identifier()` — Human-readable name (e.g., "MyStruct", "Vec<i32>")
+- Generics metadata — Information about generic type parameters
+
+### Layout
+
+- `size()` — Size in bytes
+- `alignment()` — Alignment requirement
+- `owned` vs `borrowed` — Whether the type owns or borrows its data
+
+### Structure
+
+`Shape` contains:
+- `Type` — Structural classification (Struct, Enum, Primitive, Pointer, etc.)
+- `Def` — Semantic definition (Scalar, List, Map, Struct, Enum, etc.)
+- Fields/variants/docstrings — For aggregate types
+- Attributes — Including `skip_unless_truthy`, `sensitive`, custom extension attributes
+
+Access fields through `Peek` or `Partial` for safe, ergonomic inspection and mutation.
+
+### VTables
+
+Operations available on this type via function pointers:
+- `clone_into` — Runtime cloning without Clone bound
+- `display` / `debug` — Formatting
+- `parse` — Parsing from strings
+- `hash` — Computing hashes
+- `partial_eq` — Equality comparison
+- `truthiness_fn()` — Checking if a value is truthy (when available)
+
+Use `Characteristic` to query support for these operations:
+
+```rust,noexec
+if shape.is(Characteristic::Clone) {
+    // Safe to call clone_into from the vtable
+}
+```
+
+### Truthiness
+
+Types can register a **truthiness predicate** — a function that determines if a value is "truthy" or "falsy". This is used by `#[facet(skip_unless_truthy)]` to conditionally skip serialization.
+
+Call `shape.truthiness_fn()` to get the predicate, if available:
+
+```rust,noexec
+if let Some(truthy) = shape.truthiness_fn() {
+    let is_truthy = unsafe { truthy(ptr) };
+    // Use is_truthy to decide whether to serialize
+}
+```
+
+**Built-in truthiness rules:**
+- **bool**: `true` is truthy
+- **Numbers**: non-zero is truthy (floats also exclude NaN)
+- **Collections** (Vec, String, slice, etc.): non-empty is truthy
+- **Option**: `Some(_)` is truthy, `None` is falsy
+- **Arrays**: non-zero-length arrays are truthy
+- **Custom types**: Can register a custom truthiness function via `#[facet(truthy = path::to::fn)]`
+
+### Safety
+
+Why `Facet` is `unsafe`:
+- Facet requires you to ensure layout matches between Rust and the shape
+- Pointers in the shape (vtable, type_ops) must be valid
+- When implementing custom Facet, you're responsible for correctness
+
+Invariants you must respect when consuming `Shape`:
+- Don't call vtable functions with mismatched pointer types
+- Don't assume a type has a characteristic it doesn't claim
+- Truthiness predicates assume well-formed values
+
+### Examples
+
+**Listing fields:**
+```rust,noexec
+use facet::Peek;
+
+let value = MyStruct { /* ... */ };
+let peek = Peek::new(&value);
+
+for field in peek.fields() {
+    println!("Field: {}", field.name());
+}
+```
+
+**Checking marker traits:**
+```rust,noexec
+if shape.is(Characteristic::Clone) {
+    // This type is Clone
+}
+```
+
+**Rendering type names:**
+```rust,noexec
+println!("Type: {}", shape.type_identifier());
+```
+
+**Checking truthiness support:**
+```rust,noexec
+if let Some(truthy) = shape.truthiness_fn() {
+    let is_truthy = unsafe { truthy(ptr) };
+}
+```

--- a/docs/content/guide/attributes.md
+++ b/docs/content/guide/attributes.md
@@ -122,6 +122,23 @@ struct Config {
 
 **When `assert_same!` encounters an opaque type**, it returns `Sameness::Opaque` — you cannot structurally compare opaque values.
 
+### `skip_all_unless_truthy`
+
+Applies `skip_unless_truthy` to every field in the container. This is a convenient shorthand when all or most fields should be omitted if they're falsy.
+
+```rust,noexec
+#[derive(Facet)]
+#[facet(skip_all_unless_truthy)]
+struct Config {
+    name: String,              // Omitted if empty
+    description: String,       // Omitted if empty
+    count: u32,                // Omitted if zero
+    enabled: bool,             // Omitted if false
+}
+```
+
+Individual fields can still override this with `#[facet(skip_serializing)]` or by not being marked for skipping.
+
 ### `type_tag`
 
 Add a type identifier for self-describing formats.
@@ -310,6 +327,35 @@ struct User {
     count: i32,
 }
 ```
+
+### `skip_unless_truthy`
+
+Conditionally skip serialization unless the value is truthy. Uses the type's registered truthiness predicate.
+
+Truthiness is evaluated based on the type:
+- **Booleans**: `true` is truthy, `false` is falsy
+- **Numbers**: non-zero is truthy (for floats, also excludes NaN)
+- **Collections** (Vec, String, slice, etc.): non-empty is truthy
+- **Option**: `Some(_)` is truthy, `None` is falsy
+- **Arrays**: non-zero-length arrays are truthy
+
+```rust,noexec
+#[derive(Facet)]
+struct User {
+    name: String,
+
+    #[facet(skip_unless_truthy)]
+    email: Option<String>,  // Omitted if None
+
+    #[facet(skip_unless_truthy)]
+    tags: Vec<String>,  // Omitted if empty
+
+    #[facet(skip_unless_truthy)]
+    bio: String,  // Omitted if empty
+}
+```
+
+This is more ergonomic than `skip_serializing_if` when the type already has a natural notion of truthiness.
 
 ### `sensitive`
 

--- a/facet-core/src/impls/alloc/arc.rs
+++ b/facet-core/src/impls/alloc/arc.rs
@@ -177,6 +177,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Arc<T> {
                         drop_in_place: arc_drop::<T>,
                         default_in_place: None,
                         clone_into: None,
+                        is_truthy: None,
                     }
                 },
             )
@@ -222,6 +223,7 @@ static ARC_STR_TYPE_OPS: TypeOpsIndirect = TypeOpsIndirect {
     drop_in_place: arc_str_drop,
     default_in_place: None,
     clone_into: None,
+    is_truthy: None,
 };
 
 unsafe impl<'a> Facet<'a> for Arc<str> {
@@ -309,6 +311,7 @@ unsafe impl<'a, U: Facet<'a>> Facet<'a> for Arc<[U]> {
                         drop_in_place: arc_slice_drop::<U>,
                         default_in_place: None,
                         clone_into: None,
+                        is_truthy: None,
                     }
                 },
             )
@@ -371,6 +374,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Weak<T> {
                         drop_in_place: weak_drop::<T>,
                         default_in_place: Some(weak_default::<T>),
                         clone_into: Some(weak_clone::<Weak<T>>),
+                        is_truthy: None,
                     }
                 },
             )
@@ -402,6 +406,7 @@ static WEAK_STR_TYPE_OPS: TypeOpsIndirect = TypeOpsIndirect {
     drop_in_place: weak_str_drop,
     default_in_place: None,
     clone_into: Some(weak_clone::<Weak<str>>),
+    is_truthy: None,
 };
 
 static WEAK_VTABLE: VTableIndirect = VTableIndirect {
@@ -507,6 +512,7 @@ unsafe impl<'a, U: Facet<'a>> Facet<'a> for Weak<[U]> {
                         drop_in_place: weak_slice_drop::<U>,
                         default_in_place: None,
                         clone_into: Some(weak_clone::<Weak<[U]>>),
+                        is_truthy: None,
                     }
                 },
             )

--- a/facet-core/src/impls/alloc/boxed.rs
+++ b/facet-core/src/impls/alloc/boxed.rs
@@ -79,6 +79,7 @@ unsafe impl<'a, T: ?Sized + Facet<'a>> Facet<'a> for Box<T> {
                         drop_in_place: drop_in_place::<T>,
                         default_in_place: None,
                         clone_into: None,
+                        is_truthy: None,
                     }
                 },
             )

--- a/facet-core/src/impls/alloc/btreeset.rs
+++ b/facet-core/src/impls/alloc/btreeset.rs
@@ -119,6 +119,7 @@ where
                         drop_in_place: btreeset_drop::<T>,
                         default_in_place: None,
                         clone_into: None,
+                        is_truthy: None,
                     }
                 },
             )

--- a/facet-core/src/impls/alloc/rc.rs
+++ b/facet-core/src/impls/alloc/rc.rs
@@ -123,6 +123,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Rc<T> {
                         drop_in_place: rc_drop::<T>,
                         default_in_place: None,
                         clone_into: None,
+                        is_truthy: None,
                     }
                 },
             )
@@ -210,6 +211,7 @@ unsafe impl<'a> Facet<'a> for Rc<str> {
             drop_in_place: rc_str_drop,
             default_in_place: None,
             clone_into: Some(rc_str_clone),
+            is_truthy: None,
         };
 
         ShapeBuilder::for_sized::<Rc<str>>("Rc")
@@ -392,6 +394,7 @@ unsafe impl<'a, U: Facet<'a>> Facet<'a> for Rc<[U]> {
                         drop_in_place: rc_slice_drop::<U>,
                         default_in_place: None,
                         clone_into: None,
+                        is_truthy: None,
                     }
                 },
             )
@@ -506,6 +509,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Weak<T> {
                         drop_in_place: weak_drop::<T>,
                         default_in_place: Some(weak_default::<T>),
                         clone_into: Some(weak_clone::<T>),
+                        is_truthy: None,
                     }
                 },
             )
@@ -574,6 +578,7 @@ unsafe impl<'a> Facet<'a> for Weak<str> {
             drop_in_place: weak_str_drop,
             default_in_place: None,
             clone_into: Some(weak_str_clone),
+            is_truthy: None,
         };
 
         ShapeBuilder::for_sized::<Weak<str>>("Weak")
@@ -697,6 +702,7 @@ unsafe impl<'a, U: Facet<'a>> Facet<'a> for Weak<[U]> {
                         drop_in_place: weak_slice_drop::<U>,
                         default_in_place: None,
                         clone_into: Some(weak_slice_clone::<U>),
+                        is_truthy: None,
                     }
                 },
             )

--- a/facet-core/src/impls/alloc/string.rs
+++ b/facet-core/src/impls/alloc/string.rs
@@ -3,8 +3,16 @@ use crate::{
     type_ops_direct, vtable_direct,
 };
 
+#[inline(always)]
+unsafe fn string_truthy(value: PtrConst) -> bool {
+    !unsafe { value.get::<alloc::string::String>() }.is_empty()
+}
+
 // TypeOps lifted out - shared static
-static STRING_TYPE_OPS: TypeOpsDirect = type_ops_direct!(alloc::string::String => Default, Clone);
+static STRING_TYPE_OPS: TypeOpsDirect = TypeOpsDirect {
+    is_truthy: Some(string_truthy),
+    ..type_ops_direct!(alloc::string::String => Default, Clone)
+};
 
 /// Try to convert from &str or String to String
 ///

--- a/facet-core/src/impls/alloc/vec.rs
+++ b/facet-core/src/impls/alloc/vec.rs
@@ -387,10 +387,15 @@ where
                     unsafe { ox.ptr().as_uninit().put(Vec::<T>::new()) };
                 }
 
+                unsafe fn truthy<T>(ptr: PtrConst) -> bool {
+                    !unsafe { ptr.get::<Vec<T>>() }.is_empty()
+                }
+
                 TypeOpsIndirect {
                     drop_in_place: drop_in_place::<T>,
                     default_in_place: Some(default_in_place::<T>),
                     clone_into: None,
+                    is_truthy: Some(truthy::<T>),
                 }
             })
             .build()

--- a/facet-core/src/impls/core/array.rs
+++ b/facet-core/src/impls/core/array.rs
@@ -268,10 +268,15 @@ where
             .vtable_indirect(&ARRAY_VTABLE)
             .type_ops_indirect(
                 &const {
+                    unsafe fn truthy<const N: usize>(_: PtrConst) -> bool {
+                        N != 0
+                    }
+
                     TypeOpsIndirect {
                         drop_in_place: array_drop,
                         default_in_place: Some(array_default),
                         clone_into: Some(array_clone),
+                        is_truthy: Some(truthy::<N>),
                     }
                 },
             )

--- a/facet-core/src/impls/core/char_str.rs
+++ b/facet-core/src/impls/core/char_str.rs
@@ -1,7 +1,7 @@
 use crate::Facet;
 use crate::{
-    Def, PrimitiveType, Shape, ShapeBuilder, TextualType, Type, TypeOpsDirect, VTableIndirect,
-    type_ops_direct, vtable_direct, vtable_indirect,
+    Def, OxPtrMut, PrimitiveType, PtrConst, Shape, ShapeBuilder, TextualType, Type, TypeOpsDirect,
+    TypeOpsIndirect, VTableIndirect, type_ops_direct, vtable_direct, vtable_indirect,
 };
 
 // TypeOps lifted out - shared static (char has Default but not Clone as Copy type)
@@ -32,6 +32,20 @@ unsafe impl Facet<'_> for char {
     };
 }
 
+#[inline(always)]
+unsafe fn str_truthy(value: PtrConst) -> bool {
+    !unsafe { value.get::<str>() }.is_empty()
+}
+
+unsafe fn str_drop(_: OxPtrMut) {}
+
+static STR_TYPE_OPS: TypeOpsIndirect = TypeOpsIndirect {
+    drop_in_place: str_drop,
+    default_in_place: None,
+    clone_into: None,
+    is_truthy: Some(str_truthy),
+};
+
 unsafe impl Facet<'_> for str {
     const SHAPE: &'static Shape = &const {
         const VTABLE: VTableIndirect = vtable_indirect!(str =>
@@ -47,6 +61,7 @@ unsafe impl Facet<'_> for str {
             .ty(Type::Primitive(PrimitiveType::Textual(TextualType::Str)))
             .def(Def::Scalar)
             .vtable_indirect(&VTABLE)
+            .type_ops_indirect(&STR_TYPE_OPS)
             .eq()
             .send()
             .sync()

--- a/facet-core/src/impls/core/ops.rs
+++ b/facet-core/src/impls/core/ops.rs
@@ -69,6 +69,7 @@ unsafe impl<'a, Idx: Facet<'a>> Facet<'a> for core::ops::Range<Idx> {
                 drop_in_place: range_drop::<Idx>,
                 default_in_place: None,
                 clone_into: None,
+                is_truthy: None,
             }
         }
 

--- a/facet-core/src/impls/core/option.rs
+++ b/facet-core/src/impls/core/option.rs
@@ -235,6 +235,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Option<T> {
                 drop_in_place: option_drop,
                 default_in_place: Some(option_default::<T>),
                 clone_into: None,
+                is_truthy: Some(option_is_some::<T>),
             }
         }
 

--- a/facet-core/src/impls/core/phantom.rs
+++ b/facet-core/src/impls/core/phantom.rs
@@ -31,6 +31,7 @@ static PHANTOM_TYPE_OPS: TypeOpsIndirect = TypeOpsIndirect {
     drop_in_place: phantom_drop,
     default_in_place: Some(phantom_default),
     clone_into: None,
+    is_truthy: None,
 };
 
 unsafe fn phantom_debug(

--- a/facet-core/src/impls/core/pointer.rs
+++ b/facet-core/src/impls/core/pointer.rs
@@ -142,6 +142,7 @@ unsafe impl<'a, T: Facet<'a> + ?Sized> Facet<'a> for *const T {
                 drop_in_place: const_ptr_drop::<T>,
                 default_in_place: None,
                 clone_into: Some(const_ptr_clone::<T>),
+                is_truthy: None,
             }
         }
 
@@ -193,6 +194,7 @@ unsafe impl<'a, T: Facet<'a> + ?Sized> Facet<'a> for *mut T {
                 drop_in_place: mut_ptr_drop::<T>,
                 default_in_place: None,
                 clone_into: Some(mut_ptr_clone::<T>),
+                is_truthy: None,
             }
         }
 

--- a/facet-core/src/impls/core/reference.rs
+++ b/facet-core/src/impls/core/reference.rs
@@ -183,6 +183,7 @@ static REF_TYPE_OPS: TypeOpsIndirect = TypeOpsIndirect {
     drop_in_place: ref_drop,
     default_in_place: None,
     clone_into: Some(ref_clone),
+    is_truthy: None,
 };
 
 // Vtable for &mut T (not Clone since &mut T is not Clone)
@@ -205,6 +206,7 @@ static REF_MUT_TYPE_OPS: TypeOpsIndirect = TypeOpsIndirect {
     drop_in_place: ref_drop,
     default_in_place: None,
     clone_into: None,
+    is_truthy: None,
 };
 
 /// Borrow function for &T - dereferences to get inner pointer

--- a/facet-core/src/impls/core/result.rs
+++ b/facet-core/src/impls/core/result.rs
@@ -177,6 +177,7 @@ static RESULT_TYPE_OPS: TypeOpsIndirect = TypeOpsIndirect {
     drop_in_place: result_drop,
     default_in_place: None,
     clone_into: None,
+    is_truthy: None,
 };
 
 /// Check if Result<T, E> is Ok

--- a/facet-core/src/impls/core/tuple.rs
+++ b/facet-core/src/impls/core/tuple.rs
@@ -156,6 +156,7 @@ static TUPLE_TYPE_OPS: TypeOpsIndirect = TypeOpsIndirect {
     drop_in_place: tuple_drop,
     default_in_place: None,
     clone_into: None,
+    is_truthy: None,
 };
 
 /// Type-erased type_name for tuples - reads field types from the shape

--- a/facet-core/src/impls/crates/indexmap.rs
+++ b/facet-core/src/impls/crates/indexmap.rs
@@ -166,6 +166,7 @@ where
                         drop_in_place: indexmap_drop::<K, V, S>,
                         default_in_place: None,
                         clone_into: None,
+                        is_truthy: None,
                     }
                 },
             )

--- a/facet-core/src/impls/crates/num_complex.rs
+++ b/facet-core/src/impls/crates/num_complex.rs
@@ -176,6 +176,7 @@ unsafe impl<'facet, T: Facet<'facet>> Facet<'facet> for Complex<T> {
                     None
                 },
                 clone_into: None,
+                is_truthy: None,
             }
         }
 

--- a/facet-core/src/impls/std/hashmap.rs
+++ b/facet-core/src/impls/std/hashmap.rs
@@ -163,6 +163,7 @@ where
                         drop_in_place: hashmap_drop::<K, V, S>,
                         default_in_place: None,
                         clone_into: None,
+                        is_truthy: None,
                     }
                 },
             )

--- a/facet-core/src/impls/std/hashset.rs
+++ b/facet-core/src/impls/std/hashset.rs
@@ -267,6 +267,7 @@ where
                         drop_in_place: hashset_drop::<T, S>,
                         default_in_place: None,
                         clone_into: None,
+                        is_truthy: None,
                     }
                 },
             )

--- a/facet-core/src/types/def/pointer.rs
+++ b/facet-core/src/types/def/pointer.rs
@@ -59,11 +59,11 @@ bitflags! {
         /// An empty set of flags
         const EMPTY = 0;
 
-        /// Whether the pointer is weak (like [`std::sync::Weak`])
+        /// Whether the pointer is weak (like `std::sync::Weak`)
         const WEAK = 1 << 0;
-        /// Whether the pointer is atomic (like [`std::sync::Arc`])
+        /// Whether the pointer is atomic (like `std::sync::Arc`)
         const ATOMIC = 1 << 1;
-        /// Whether the pointer is a lock (like [`std::sync::Mutex`])
+        /// Whether the pointer is a lock (like `std::sync::Mutex`)
         const LOCK = 1 << 2;
     }
 }

--- a/facet-core/src/types/shape.rs
+++ b/facet-core/src/types/shape.rs
@@ -9,8 +9,8 @@ pub use shape_builder::*;
 use core::alloc::Layout;
 
 use crate::{
-    Attr, ConstTypeId, Def, Facet, MAX_VARIANCE_DEPTH, MarkerTraits, Type, TypeOps, UserType,
-    VTableErased, Variance,
+    Attr, ConstTypeId, Def, Facet, MAX_VARIANCE_DEPTH, MarkerTraits, TruthyFn, Type, TypeOps,
+    UserType, VTableErased, Variance,
 };
 #[cfg(feature = "alloc")]
 use crate::{PtrMut, PtrUninit, UnsizedError};
@@ -764,5 +764,11 @@ impl Shape {
     #[inline]
     pub fn is_type<T: crate::Facet<'static>>(&self) -> bool {
         self.id == Self::id_of::<T>()
+    }
+
+    /// Returns the truthiness predicate stored on this shape, if any.
+    #[inline]
+    pub fn truthiness_fn(&self) -> Option<TruthyFn> {
+        self.type_ops.and_then(|ops| ops.truthiness_fn())
     }
 }

--- a/facet-reflect/src/spanned.rs
+++ b/facet-reflect/src/spanned.rs
@@ -169,6 +169,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Spanned<T> {
                         drop_in_place: drop_in_place::<T>,
                         default_in_place: None,
                         clone_into: None,
+                        is_truthy: None,
                     }
                 },
             )

--- a/facet-reflect/tests/peek/ndarray.rs
+++ b/facet-reflect/tests/peek/ndarray.rs
@@ -150,6 +150,7 @@ const fn build_type_ops<T>() -> facet_core::TypeOpsIndirect {
         drop_in_place: mat_drop::<T>,
         default_in_place: None,
         clone_into: None,
+        is_truthy: None,
     }
 }
 

--- a/facet-value/src/facet_impl.rs
+++ b/facet-value/src/facet_impl.rs
@@ -406,6 +406,7 @@ static VALUE_TYPE_OPS_INDIRECT: facet_core::TypeOpsIndirect = facet_core::TypeOp
     drop_in_place: value_drop_in_place,
     default_in_place: Some(value_default_in_place),
     clone_into: Some(value_clone_into),
+    is_truthy: None,
 };
 
 unsafe impl Facet<'_> for Value {

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -28,6 +28,7 @@ pub mod builtin {
     pub use crate::DefaultInPlaceFn;
     pub use crate::InvariantsFn;
     pub use crate::SkipSerializingIfFn;
+    pub use crate::TruthyFn;
 
     // Generate built-in attribute grammar.
     // Uses empty namespace "" for built-in facet attributes.
@@ -112,6 +113,12 @@ pub mod builtin {
             /// Usage: `#[facet(skip_serializing_if = is_empty)]`
             SkipSerializingIf(predicate SkipSerializingIfFn),
 
+            /// Skips serialization unless the value is truthy.
+            /// Uses the type's registered truthiness predicate when available.
+            ///
+            /// Usage: `#[facet(skip_unless_truthy)]`
+            SkipUnlessTruthy,
+
             /// Skips deserialization of this field (uses default value).
             ///
             /// Usage: `#[facet(skip_deserializing)]`
@@ -165,6 +172,17 @@ pub mod builtin {
             ///
             /// Usage: `#[facet(invariants = validate_fn)]`
             Invariants(predicate InvariantsFn),
+
+            /// Declares the truthiness predicate for this container type.
+            /// Stores a type-erased function pointer: `fn(PtrConst) -> bool`.
+            ///
+            /// Usage: `#[facet(truthy = Self::is_truthy)]`
+            Truthy(predicate TruthyFn),
+
+            /// Applies `skip_unless_truthy` to every field in the container.
+            ///
+            /// Usage: `#[facet(skip_all_unless_truthy)]`
+            SkipAllUnlessTruthy,
 
             /// Proxy type for serialization and deserialization.
             /// The proxy type must implement `TryFrom<ProxyType> for FieldType` (for deserialization)


### PR DESCRIPTION
This closes an issue I opened recently about the fact that it would be so convenient to be able to skip everything that doesn't matter. So if a list is empty, skip it. If a number is zero, skip it. If a boolean is false, skip it.

And for that, we need kind of a universal way to assert the truthiness of something. And that's not really something that Rust language gives you, unlike languages like Ruby or JavaScript or literally any dynamic language. In Rust, you have to explicitly turn T into a bool. Only then can you have false and true.

Therefore, this introduces a new VTable slot called isTruthy. And it allows you to determine if something is truthy. And it also introduces two new attributes that let you skip a field if it's not truthy. And skip every field of a structure unless they're truthy. 

Closes #https://github.com/facet-rs/facet/issues/1243