### PR TITLE
Add support for untagged newtype tuple variants in JSON and YAML deserialization

### DIFF
--- a/facet-json/tests/enums.rs
+++ b/facet-json/tests/enums.rs
@@ -543,6 +543,21 @@ fn test_untagged_newtype_variants() {
 }
 
 #[test]
+fn test_untagged_newtype_tuple_variant_issue_1189() {
+    #[derive(Debug, Facet, PartialEq)]
+    #[repr(u8)]
+    #[facet(untagged)]
+    enum Counter {
+        Unit(String),
+        Weight((String, f64)),
+    }
+
+    let json = r#"["AGRICIBPAR", 1.0]"#;
+    let counter: Counter = facet_json::from_str(json).unwrap();
+    assert_eq!(counter, Counter::Weight(("AGRICIBPAR".to_string(), 1.0)));
+}
+
+#[test]
 fn test_untagged_struct_variants() {
     #[derive(Debug, Facet, PartialEq)]
     #[repr(C)]

--- a/facet-yaml/tests/deserialize/untagged.rs
+++ b/facet-yaml/tests/deserialize/untagged.rs
@@ -519,6 +519,32 @@ fn test_untagged_tuple_list() {
     assert_eq!(points[2], Point::XY(3, 4));
 }
 
+#[test]
+fn test_untagged_newtype_tuple_variant_issue_1189() {
+    // Regression test for tuple values nested inside a newtype variant
+    #[derive(Debug, Facet, PartialEq)]
+    #[repr(u8)]
+    #[facet(untagged)]
+    enum Counter {
+        Unit(String),
+        Weight((String, f64)),
+    }
+
+    let yaml = r#"
+- [AGRICIBPAR, 1.0]
+- [BARCLAYLDN, 2.5]
+"#;
+
+    let counters: Vec<Counter> = facet_yaml::from_str(yaml).unwrap();
+    assert_eq!(
+        counters,
+        vec![
+            Counter::Weight(("AGRICIBPAR".to_string(), 1.0)),
+            Counter::Weight(("BARCLAYLDN".to_string(), 2.5)),
+        ]
+    );
+}
+
 // ===========================================================================
 // Multiple String-Parseable Types (Trial Parsing)
 // ===========================================================================


### PR DESCRIPTION
## Summary
This PR fixes deserialization of untagged enums containing newtype variants that wrap tuple types. Previously, these variants were not handled correctly when deserializing from JSON and YAML.

## Changes
- **facet-json**: Added detection and special handling for newtype tuple variants that wrap single tuple fields
- **facet-yaml**: Similarly updated YAML deserialization to handle newtype tuple variants correctly  
- **facet-solver**: Introduced new `NewtypeTuple` variant format classification to distinguish tuple-wrapping newtypes from other newtype variants
- **Tests**: Added regression tests in both JSON and YAML test suites to prevent future regressions

## Technical Details
When an untagged enum contains a newtype variant like `Weight((String, f64))`, the deserializer now:
1. Recognizes that the newtype wraps a single tuple field
2. Deserializes the entire sequence/array directly into that inner tuple value
3. Properly validates arity matches between the sequence and the tuple

Fixes issue #1189