### PR TITLE
Replace syntect highlighting with arborium

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,118 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arborium"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422145cf0f54cd490b195555f9f7422e9eac3a3974f65fb947b8bb1663bd307d"
+dependencies = [
+ "arborium-highlight",
+ "arborium-json",
+ "arborium-kdl",
+ "arborium-rust",
+ "arborium-theme",
+ "arborium-tree-sitter",
+ "arborium-xml",
+ "arborium-yaml",
+ "dlmalloc",
+]
+
+[[package]]
+name = "arborium-highlight"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c57286c01089223a480db80d72fc149a73d3cc4a3f7e6707e9244d03c87dd4"
+dependencies = [
+ "arborium-theme",
+ "arborium-tree-sitter",
+ "streaming-iterator",
+]
+
+[[package]]
+name = "arborium-json"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4e2e59ffa98215afcfc350b5f4adbf212e6b8892951ed8f096e95ced05373e8"
+dependencies = [
+ "arborium-sysroot",
+ "arborium-tree-sitter",
+ "cc",
+]
+
+[[package]]
+name = "arborium-kdl"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c78b764b66aeb27a8eee813dc1193157025f06e5c4475e6e8aea0a5cf31fe"
+dependencies = [
+ "arborium-sysroot",
+ "arborium-tree-sitter",
+ "cc",
+]
+
+[[package]]
+name = "arborium-rust"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b9f6f76d7a5fac718586c1ac60c5302f89601dc6104f9a801a8fbf334132f1"
+dependencies = [
+ "arborium-sysroot",
+ "arborium-tree-sitter",
+ "cc",
+]
+
+[[package]]
+name = "arborium-sysroot"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5942714de3eb1c3d0c5607e30284e314ddea3698a76a0cf3e7686274ac57802f"
+
+[[package]]
+name = "arborium-theme"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873f67c4f4257629ebac01292d5763e45abb1d4e505d37469f796ef3cd99ffab"
+dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "arborium-tree-sitter"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd185bbb2193ad1034d4d7620251f799c354daed95c7fa3583c4fc7ead4c2c62"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "regex",
+ "regex-syntax",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-xml"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34a7dbd8512d6a06a813197ad9d980069a0e1b1a47e3f831026a0d1596cc1a69"
+dependencies = [
+ "arborium-sysroot",
+ "arborium-tree-sitter",
+ "cc",
+]
+
+[[package]]
+name = "arborium-yaml"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c03b9c3dcdce8c2a0b090d15292aea9b874c098fafbbedfd530edee3bdaca6b"
+dependencies = [
+ "arborium-sysroot",
+ "arborium-tree-sitter",
+ "cc",
+]
+
+[[package]]
 name = "ariadne"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,15 +398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
 dependencies = [
  "simd-abstraction",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -943,15 +1046,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d039de901c8d928222b8128e1b9a9ab27b82a7445cb749a871c75d9cb25c57d"
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1311,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "dlmalloc"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1653,11 +1758,12 @@ dependencies = [
 name = "facet-showcase"
 version = "0.32.2"
 dependencies = [
+ "arborium",
  "facet",
  "facet-pretty",
  "miette",
+ "miette-arborium",
  "owo-colors",
- "syntect",
 ]
 
 [[package]]
@@ -1752,6 +1858,7 @@ dependencies = [
 name = "facet-value"
 version = "0.32.2"
 dependencies = [
+ "arborium",
  "bolero",
  "divan",
  "facet",
@@ -1765,10 +1872,8 @@ dependencies = [
  "indexmap",
  "kstring",
  "miette",
- "once_cell",
  "serde_json",
  "static_assertions",
- "syntect",
 ]
 
 [[package]]
@@ -1889,16 +1994,6 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "flate2"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -2653,12 +2748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2781,10 +2870,20 @@ dependencies = [
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "syntect",
  "terminal_size",
  "textwrap",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-arborium"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1f2b7390b6134bb94b9ceb3429b4a9cc1f74fcbe8cd58b07172ea365aadb98f"
+dependencies = [
+ "arborium",
+ "miette",
+ "owo-colors",
 ]
 
 [[package]]
@@ -2817,7 +2916,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -2990,28 +3088,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "onig"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
-dependencies = [
- "bitflags 2.10.0",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "ordered-float"
@@ -3249,25 +3325,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plist"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
-dependencies = [
- "base64",
- "indexmap",
- "quick-xml",
- "serde",
- "time",
-]
 
 [[package]]
 name = "portable-atomic"
@@ -3904,6 +3961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3981,12 +4047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4046,6 +4106,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -4132,27 +4198,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "syntect"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
-dependencies = [
- "bincode",
- "flate2",
- "fnv",
- "once_cell",
- "onig",
- "plist",
- "regex-syntax",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror 2.0.17",
- "walkdir",
- "yaml-rust",
 ]
 
 [[package]]
@@ -4398,6 +4443,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml-test-data"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4411,6 +4468,9 @@ name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -4419,6 +4479,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -4527,6 +4589,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae62f7eae5eb549c71b76658648b72cc6111f2d87d24a1e31fa907f4943e3ce"
 
 [[package]]
 name = "typenum"
@@ -5160,15 +5228,6 @@ dependencies = [
  "facet",
  "facet-json",
  "ratatui",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/facet-showcase/Cargo.toml
+++ b/facet-showcase/Cargo.toml
@@ -15,14 +15,15 @@ categories = ["development-tools"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-# Syntax highlighting
-syntect = "5.3"
+# Syntax highlighting (tree-sitter based)
+arborium = { version = "1.1.5", default-features = false, features = ["lang-json", "lang-yaml", "lang-xml", "lang-kdl", "lang-rust"] }
+miette-arborium = "1.1.5"
 
 # Terminal colors
 owo-colors = "4"
 
 # Error diagnostics
-miette = { version = "7", features = ["fancy", "syntect-highlighter"] }
+miette = { version = "7", features = ["fancy"] }
 
 # Facet integration
 facet = { version = "0.32", path = "../facet" }

--- a/facet-value/Cargo.toml
+++ b/facet-value/Cargo.toml
@@ -19,7 +19,7 @@ ci = [] # CI feature
 default = ["std"]
 std = ["alloc", "dep:indexmap"]
 alloc = ["facet-core/alloc", "facet-reflect/alloc", "dep:facet-reflect"]
-diagnostics = ["alloc", "dep:miette", "dep:facet-pretty", "dep:syntect", "dep:once_cell"]
+diagnostics = ["alloc", "dep:miette", "dep:facet-pretty", "dep:arborium"]
 bolero-inline-tests = ["alloc"]
 
 [dependencies]
@@ -27,8 +27,7 @@ facet-core = { path = "../facet-core", version = "0.32.2", default-features = fa
 facet-pretty = { path = "../facet-pretty", version = "0.32.2", optional = true }
 facet-reflect = { path = "../facet-reflect", version = "0.32.2", default-features = false, optional = true }
 miette = { version = "7", optional = true, default-features = false }
-syntect = { version = "5.3", optional = true }
-once_cell = { version = "1", optional = true }
+arborium = { version = "1.1.5", optional = true, default-features = false, features = ["lang-json", "lang-rust"] }
 indexmap = { version = "2", optional = true }
 static_assertions = "1.1"
 

--- a/facet-value/src/highlight.rs
+++ b/facet-value/src/highlight.rs
@@ -1,18 +1,16 @@
-//! Syntax highlighting with span position conversion.
+//! Syntax highlighting with span position conversion powered by arborium.
 //!
-//! This module provides functions to apply syntect syntax highlighting
-//! to text while converting span positions from plain text to highlighted text.
+//! These helpers convert diagnostics spans expressed in plain-text byte positions
+//! into offsets within ANSI-colored strings so `miette` can keep labels aligned.
 
 use alloc::string::String;
 use alloc::vec::Vec;
-use once_cell::sync::Lazy;
-use syntect::easy::HighlightLines;
-use syntect::highlighting::{Style, ThemeSet};
-use syntect::parsing::SyntaxSet;
-use syntect::util::as_24_bit_terminal_escaped;
-
-static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(SyntaxSet::load_defaults_newlines);
-static THEME_SET: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
+use arborium::highlights::{HIGHLIGHTS, tag_for_capture};
+use arborium::theme::{self, Theme};
+use arborium::{Grammar, GrammarProvider, HighlightConfig, Injection, Span, StaticProvider};
+use core::future::Future;
+use core::pin::pin;
+use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 /// Highlight text as JSON and convert span positions.
 ///
@@ -22,7 +20,7 @@ pub fn highlight_json_with_spans(
     plain_text: &str,
     spans: &[(usize, usize, String)],
 ) -> (String, Vec<(usize, usize, String)>) {
-    highlight_with_spans(plain_text, spans, "JSON")
+    highlight_with_language(plain_text, spans, "json")
 }
 
 /// Highlight text as Rust and convert span positions.
@@ -33,58 +31,25 @@ pub fn highlight_rust_with_spans(
     plain_text: &str,
     spans: &[(usize, usize, String)],
 ) -> (String, Vec<(usize, usize, String)>) {
-    highlight_with_spans(plain_text, spans, "Rust")
+    highlight_with_language(plain_text, spans, "rust")
 }
 
-fn highlight_with_spans(
+fn highlight_with_language(
     plain_text: &str,
     spans: &[(usize, usize, String)],
-    syntax_name: &str,
+    language: &str,
 ) -> (String, Vec<(usize, usize, String)>) {
-    let syntax = SYNTAX_SET
-        .find_syntax_by_name(syntax_name)
-        .or_else(|| SYNTAX_SET.find_syntax_by_extension(syntax_name.to_lowercase().as_str()))
-        .unwrap_or_else(|| SYNTAX_SET.find_syntax_plain_text());
+    let (highlighted, position_map) =
+        highlight_text(language, plain_text).unwrap_or_else(|| fallback_highlight(plain_text));
 
-    let theme = &THEME_SET.themes["base16-ocean.dark"];
-    let mut highlighter = HighlightLines::new(syntax, theme);
-
-    let mut highlighted = String::new();
-    // Map from plain text byte position to highlighted text byte position
-    let mut position_map: Vec<usize> = Vec::with_capacity(plain_text.len() + 1);
-
-    for line in plain_text.lines() {
-        let ranges: Vec<(Style, &str)> = highlighter
-            .highlight_line(line, &SYNTAX_SET)
-            .unwrap_or_default();
-
-        for (style, text) in ranges {
-            // Record the mapping for each byte in the plain text
-            for _ in 0..text.len() {
-                position_map.push(highlighted.len());
-            }
-            // Write the highlighted version
-            let escaped = as_24_bit_terminal_escaped(&[(style, text)], false);
-            highlighted.push_str(&escaped);
-        }
-        // Handle newline
-        position_map.push(highlighted.len());
-        highlighted.push('\n');
-    }
-    // Final position for end-of-string
-    position_map.push(highlighted.len());
-
-    // Remove trailing newline if original didn't have one
-    if !plain_text.ends_with('\n') && highlighted.ends_with('\n') {
-        highlighted.pop();
-    }
-
-    // Convert spans
-    let converted_spans: Vec<(usize, usize, String)> = spans
+    let converted_spans = spans
         .iter()
         .map(|(start, end, label)| {
-            let new_start = position_map.get(*start).copied().unwrap_or(*start);
-            let new_end = position_map.get(*end).copied().unwrap_or(*end);
+            let new_start = position_map
+                .get(*start)
+                .copied()
+                .unwrap_or(highlighted.len());
+            let new_end = position_map.get(*end).copied().unwrap_or(highlighted.len());
             (new_start, new_end, label.clone())
         })
         .collect();
@@ -92,29 +57,323 @@ fn highlight_with_spans(
     (highlighted, converted_spans)
 }
 
+fn fallback_highlight(plain_text: &str) -> (String, Vec<usize>) {
+    let mut map = Vec::with_capacity(plain_text.len() + 1);
+    for i in 0..plain_text.len() {
+        map.push(i);
+    }
+    map.push(plain_text.len());
+    (plain_text.to_string(), map)
+}
+
+fn highlight_text(language: &str, source: &str) -> Option<(String, Vec<usize>)> {
+    if source.is_empty() {
+        return Some((String::new(), vec![0]));
+    }
+
+    let mut engine = ArboriumEngine::new();
+    let spans = engine.collect_spans(language, source)?;
+    let segments = segments_from_spans(source, spans);
+    let theme = theme::builtin::tokyo_night().clone();
+    Some(render_segments_to_ansi(source, &segments, &theme))
+}
+
+struct ArboriumEngine {
+    provider: StaticProvider,
+    config: HighlightConfig,
+}
+
+impl ArboriumEngine {
+    fn new() -> Self {
+        Self {
+            provider: StaticProvider::new(),
+            config: HighlightConfig::default(),
+        }
+    }
+
+    fn collect_spans(&mut self, language: &str, source: &str) -> Option<Vec<Span>> {
+        let grammar = self.poll_provider(language)?;
+        let result = grammar.parse(source);
+        let mut spans = result.spans;
+        if !result.injections.is_empty() {
+            self.process_injections(
+                source,
+                result.injections,
+                0,
+                self.config.max_injection_depth,
+                &mut spans,
+            );
+        }
+        Some(spans)
+    }
+
+    fn process_injections(
+        &mut self,
+        source: &str,
+        injections: Vec<Injection>,
+        base_offset: u32,
+        remaining_depth: u32,
+        spans: &mut Vec<Span>,
+    ) {
+        if remaining_depth == 0 {
+            return;
+        }
+
+        for injection in injections {
+            let start = injection.start as usize;
+            let end = injection.end as usize;
+            if start >= end || end > source.len() {
+                continue;
+            }
+
+            let injected_text = &source[start..end];
+            let Some(grammar) = self.poll_provider(&injection.language) else {
+                continue;
+            };
+            let result = grammar.parse(injected_text);
+            spans.extend(result.spans.into_iter().map(|mut span| {
+                span.start += base_offset + injection.start;
+                span.end += base_offset + injection.start;
+                span
+            }));
+
+            if !result.injections.is_empty() {
+                self.process_injections(
+                    injected_text,
+                    result.injections,
+                    base_offset + injection.start,
+                    remaining_depth - 1,
+                    spans,
+                );
+            }
+        }
+    }
+
+    fn poll_provider(
+        &mut self,
+        language: &str,
+    ) -> Option<&mut <StaticProvider as arborium::GrammarProvider>::Grammar> {
+        let future = self.provider.get(language);
+        let mut future = pin!(future);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        match future.as_mut().poll(&mut cx) {
+            Poll::Ready(result) => result,
+            Poll::Pending => None,
+        }
+    }
+}
+
+struct Segment<'a> {
+    text: &'a str,
+    tag: Option<&'static str>,
+}
+
+fn render_segments_to_ansi<'a>(
+    source: &'a str,
+    segments: &[Segment<'a>],
+    theme: &Theme,
+) -> (String, Vec<usize>) {
+    let mut highlighted = String::new();
+    let mut position_map = Vec::with_capacity(source.len() + 1);
+    let mut active_code: Option<String> = None;
+
+    for segment in segments {
+        let target_code = segment
+            .tag
+            .and_then(|tag| ansi_for_tag(theme, tag))
+            .filter(|code| !code.is_empty());
+
+        if target_code != active_code {
+            highlighted.push_str(Theme::ANSI_RESET);
+            if let Some(code) = &target_code {
+                highlighted.push_str(code);
+            }
+            active_code = target_code;
+        }
+
+        for ch in segment.text.chars() {
+            for _ in 0..ch.len_utf8() {
+                position_map.push(highlighted.len());
+            }
+            highlighted.push(ch);
+        }
+    }
+
+    highlighted.push_str(Theme::ANSI_RESET);
+    position_map.push(highlighted.len());
+    (highlighted, position_map)
+}
+
+fn segments_from_spans<'a>(source: &'a str, spans: Vec<Span>) -> Vec<Segment<'a>> {
+    if source.is_empty() {
+        return vec![Segment {
+            text: "",
+            tag: None,
+        }];
+    }
+
+    let normalized = normalize_and_coalesce(dedup_spans(spans));
+    if normalized.is_empty() {
+        return vec![Segment {
+            text: source,
+            tag: None,
+        }];
+    }
+
+    let mut events: Vec<(u32, bool, usize)> = Vec::new();
+    for (idx, span) in normalized.iter().enumerate() {
+        events.push((span.start, true, idx));
+        events.push((span.end, false, idx));
+    }
+    events.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    let mut segments = Vec::new();
+    let mut last_pos = 0usize;
+    let mut stack: Vec<usize> = Vec::new();
+
+    for (pos, is_start, idx) in events {
+        let pos = pos as usize;
+        if pos > last_pos && pos <= source.len() {
+            let text = &source[last_pos..pos];
+            let tag = stack.last().map(|&active| normalized[active].tag);
+            segments.push(Segment { text, tag });
+            last_pos = pos;
+        }
+
+        if is_start {
+            stack.push(idx);
+        } else if let Some(position) = stack.iter().rposition(|&active| active == idx) {
+            stack.remove(position);
+        }
+    }
+
+    if last_pos < source.len() {
+        let tag = stack.last().map(|&active| normalized[active].tag);
+        segments.push(Segment {
+            text: &source[last_pos..],
+            tag,
+        });
+    }
+
+    segments
+}
+
+fn dedup_spans(mut spans: Vec<Span>) -> Vec<Span> {
+    spans.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| b.end.cmp(&a.end)));
+    let mut deduped: Vec<Span> = Vec::new();
+
+    for span in spans {
+        if let Some(existing) = deduped
+            .iter_mut()
+            .find(|existing| existing.start == span.start && existing.end == span.end)
+        {
+            let new_has_style = tag_for_capture(&span.capture).is_some();
+            let existing_has_style = tag_for_capture(&existing.capture).is_some();
+            if new_has_style || !existing_has_style {
+                *existing = span;
+            }
+        } else {
+            deduped.push(span);
+        }
+    }
+
+    deduped
+}
+
+struct NormalizedSpan {
+    start: u32,
+    end: u32,
+    tag: &'static str,
+}
+
+fn normalize_and_coalesce(spans: Vec<Span>) -> Vec<NormalizedSpan> {
+    let mut normalized: Vec<NormalizedSpan> = spans
+        .into_iter()
+        .filter_map(|span| {
+            let tag = tag_for_capture(&span.capture)?;
+            Some(NormalizedSpan {
+                start: span.start,
+                end: span.end,
+                tag,
+            })
+        })
+        .collect();
+
+    if normalized.is_empty() {
+        return normalized;
+    }
+
+    normalized.sort_by_key(|s| (s.start, s.end));
+    let mut coalesced: Vec<NormalizedSpan> = Vec::with_capacity(normalized.len());
+
+    for span in normalized {
+        if let Some(last) = coalesced.last_mut()
+            && span.tag == last.tag
+            && span.start <= last.end
+        {
+            last.end = last.end.max(span.end);
+            continue;
+        }
+        coalesced.push(span);
+    }
+
+    coalesced
+}
+
+fn ansi_for_tag(theme: &Theme, tag: &str) -> Option<String> {
+    let index = find_style_index(theme, tag)?;
+    let ansi = theme.ansi_style(index);
+    if ansi.is_empty() { None } else { Some(ansi) }
+}
+
+fn find_style_index(theme: &Theme, tag: &str) -> Option<usize> {
+    let mut current = tag.strip_prefix("a-").unwrap_or(tag);
+    loop {
+        let (idx, _) = HIGHLIGHTS
+            .iter()
+            .enumerate()
+            .find(|(_, highlight)| highlight.tag == current)?;
+        if theme
+            .style(idx)
+            .map(|style| !style.is_empty())
+            .unwrap_or(false)
+        {
+            return Some(idx);
+        }
+        let parent = HIGHLIGHTS[idx].parent_tag;
+        if parent.is_empty() {
+            return None;
+        }
+        current = parent;
+    }
+}
+
+fn noop_waker() -> Waker {
+    const VTABLE: RawWakerVTable = RawWakerVTable::new(|_| RAW_WAKER, |_| {}, |_| {}, |_| {});
+    const RAW_WAKER: RawWaker = RawWaker::new(core::ptr::null(), &VTABLE);
+    unsafe { Waker::from_raw(RAW_WAKER) }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_highlight_preserves_content() {
-        let plain = r#"{"name": "Alice"}"#;
-        let (highlighted, _) = highlight_json_with_spans(plain, &[]);
-        // The highlighted version should contain the same visible text
-        // (just with ANSI codes added)
+    fn highlight_preserves_bytes() {
+        let plain = r#"{"name":"Facet"}"#;
+        let (highlighted, spans) = highlight_json_with_spans(plain, &[]);
         assert!(highlighted.contains("name"));
-        assert!(highlighted.contains("Alice"));
+        assert!(spans.is_empty());
     }
 
     #[test]
-    fn test_span_conversion() {
-        let plain = "hello";
-        let spans = vec![(0, 5, "test".into())];
-        let (highlighted, converted) = highlight_rust_with_spans(plain, &spans);
-        // The span should still cover the whole content
-        assert_eq!(converted.len(), 1);
-        let (_start, end, _) = &converted[0];
-        // The highlighted span should encompass the content
+    fn span_conversion_stays_in_bounds() {
+        let plain = "fn main() {}";
+        let (highlighted, spans) = highlight_rust_with_spans(plain, &[(3, 7, "body".into())]);
+        assert_eq!(spans.len(), 1);
+        let (start, end, _) = &spans[0];
+        assert!(start <= end);
         assert!(*end <= highlighted.len());
     }
 }


### PR DESCRIPTION
This swaps facet-showcase and facet-value over to arborium for syntax highlighting, eliminating the syntect dependency chain called out in #1262. The showcase highlighter now renders terminal/HTML/miette output directly from arborium spans, and the diagnostics helper in facet-value follows the same engine for span conversion.