### PR TITLE
Expand format suite with serialization fixes and new test cases

### DIFF
--- a/facet-core/src/impls/core/nonzero.rs
+++ b/facet-core/src/impls/core/nonzero.rs
@@ -65,6 +65,17 @@ macro_rules! impl_facet_for_nonzero {
                         }
                         try_from
                     }],
+                    // try_borrow_inner borrows the inner value for serialization
+                    // NonZero<T> has transparent repr, so the inner T is at the same address
+                    [try_borrow_inner = {
+                        /// # Safety
+                        /// `ptr` must point to a valid NonZero<$type>
+                        unsafe fn try_borrow_inner(ptr: *const NonZero<$type>) -> Result<crate::PtrMut, alloc::string::String> {
+                            // NonZero<T> is repr(transparent), so we can just cast the pointer
+                            Ok(crate::PtrMut::new(ptr as *mut ()))
+                        }
+                        try_borrow_inner
+                    }],
                 );
 
                 ShapeBuilder::for_sized::<NonZero<$type>>("NonZero")

--- a/facet-format-json/tests/format_suite.rs
+++ b/facet-format-json/tests/format_suite.rs
@@ -231,7 +231,89 @@ impl FormatSuite for JsonSlice {
     fn proxy_container() -> CaseSpec {
         // ProxyInt deserializes from a string "42" via IntAsString proxy
         CaseSpec::from_str(r#""42""#)
-            .without_roundtrip("facet-format serializer doesn't support proxy yet")
+    }
+
+    // ── Scalar cases ──
+
+    fn scalar_bool() -> CaseSpec {
+        CaseSpec::from_str(r#"{"yes":true,"no":false}"#)
+    }
+
+    fn scalar_integers() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"{"signed_8":-128,"unsigned_8":255,"signed_32":-2147483648,"unsigned_32":4294967295,"signed_64":-9223372036854775808,"unsigned_64":18446744073709551615}"#,
+        )
+    }
+
+    fn scalar_floats() -> CaseSpec {
+        CaseSpec::from_str(r#"{"float_32":1.5,"float_64":2.25}"#)
+    }
+
+    // ── Collection cases ──
+
+    fn map_string_keys() -> CaseSpec {
+        CaseSpec::from_str(r#"{"data":{"alpha":1,"beta":2}}"#)
+    }
+
+    fn tuple_simple() -> CaseSpec {
+        CaseSpec::from_str(r#"{"triple":["hello",42,true]}"#)
+    }
+
+    // ── Enum variant cases ──
+
+    fn enum_unit_variant() -> CaseSpec {
+        CaseSpec::from_str(r#""Active""#)
+    }
+
+    fn enum_untagged() -> CaseSpec {
+        CaseSpec::from_str(r#"{"x":10,"y":20}"#)
+    }
+
+    // ── Smart pointer cases ──
+
+    fn box_wrapper() -> CaseSpec {
+        CaseSpec::from_str(r#"{"inner":42}"#)
+    }
+
+    fn arc_wrapper() -> CaseSpec {
+        CaseSpec::from_str(r#"{"inner":42}"#)
+    }
+
+    fn rc_wrapper() -> CaseSpec {
+        CaseSpec::from_str(r#"{"inner":42}"#)
+    }
+
+    // ── Set cases ──
+
+    fn set_btree() -> CaseSpec {
+        CaseSpec::from_str(r#"{"items":["alpha","beta","gamma"]}"#)
+    }
+
+    // ── Extended numeric cases ──
+
+    fn scalar_integers_16() -> CaseSpec {
+        CaseSpec::from_str(r#"{"signed_16":-32768,"unsigned_16":65535}"#)
+    }
+
+    fn scalar_integers_128() -> CaseSpec {
+        CaseSpec::from_str(r#"{"signed_128":-170141183460469231731687303715884105728,"unsigned_128":340282366920938463463374607431768211455}"#)
+            .without_roundtrip("i128/u128 serialization not supported yet")
+    }
+
+    fn scalar_integers_size() -> CaseSpec {
+        CaseSpec::from_str(r#"{"signed_size":-1000,"unsigned_size":2000}"#)
+    }
+
+    // ── NonZero cases ──
+
+    fn nonzero_integers() -> CaseSpec {
+        CaseSpec::from_str(r#"{"nz_u32":42,"nz_i64":-100}"#)
+    }
+
+    // ── Borrowed string cases ──
+
+    fn cow_str() -> CaseSpec {
+        CaseSpec::from_str(r#"{"owned":"hello world","message":"borrowed"}"#)
     }
 }
 

--- a/facet-format-suite/Cargo.toml
+++ b/facet-format-suite/Cargo.toml
@@ -13,7 +13,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { path = "../facet" }
+facet = { path = "../facet", features = ["nonzero"] }
 facet-assert = { path = "../facet-assert" }
 facet-pretty = { path = "../facet-pretty" }
 arborium = { version = "1.1.5", default-features = false, features = ["lang-json", "lang-xml"] }

--- a/facet-format-xml/tests/format_suite.rs
+++ b/facet-format-xml/tests/format_suite.rs
@@ -246,7 +246,99 @@ impl FormatSuite for XmlSlice {
     fn proxy_container() -> CaseSpec {
         // ProxyInt deserializes from a string "42" via IntAsString proxy
         CaseSpec::from_str(r#"<value>42</value>"#)
-            .without_roundtrip("facet-format serializer doesn't support proxy yet")
+    }
+
+    // ── Scalar cases ──
+
+    fn scalar_bool() -> CaseSpec {
+        CaseSpec::from_str(r#"<record><yes>true</yes><no>false</no></record>"#)
+    }
+
+    fn scalar_integers() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"<record><signed_8>-128</signed_8><unsigned_8>255</unsigned_8><signed_32>-2147483648</signed_32><unsigned_32>4294967295</unsigned_32><signed_64>-9223372036854775808</signed_64><unsigned_64>18446744073709551615</unsigned_64></record>"#,
+        )
+    }
+
+    fn scalar_floats() -> CaseSpec {
+        CaseSpec::from_str(r#"<record><float_32>1.5</float_32><float_64>2.25</float_64></record>"#)
+    }
+
+    // ── Collection cases ──
+
+    fn map_string_keys() -> CaseSpec {
+        CaseSpec::from_str(r#"<record><data><alpha>1</alpha><beta>2</beta></data></record>"#)
+    }
+
+    fn tuple_simple() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"<record><triple><item>hello</item><item>42</item><item>true</item></triple></record>"#,
+        )
+    }
+
+    // ── Enum variant cases ──
+
+    fn enum_unit_variant() -> CaseSpec {
+        CaseSpec::from_str(r#"<value>Active</value>"#)
+    }
+
+    fn enum_untagged() -> CaseSpec {
+        CaseSpec::from_str(r#"<value><x>10</x><y>20</y></value>"#)
+    }
+
+    // ── Smart pointer cases ──
+
+    fn box_wrapper() -> CaseSpec {
+        CaseSpec::from_str(r#"<record><inner>42</inner></record>"#)
+    }
+
+    fn arc_wrapper() -> CaseSpec {
+        CaseSpec::from_str(r#"<record><inner>42</inner></record>"#)
+    }
+
+    fn rc_wrapper() -> CaseSpec {
+        CaseSpec::from_str(r#"<record><inner>42</inner></record>"#)
+    }
+
+    // ── Set cases ──
+
+    fn set_btree() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"<record><items><item>alpha</item><item>beta</item><item>gamma</item></items></record>"#,
+        )
+    }
+
+    // ── Extended numeric cases ──
+
+    fn scalar_integers_16() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"<record><signed_16>-32768</signed_16><unsigned_16>65535</unsigned_16></record>"#,
+        )
+    }
+
+    fn scalar_integers_128() -> CaseSpec {
+        // Skip: VNumber can't hold values outside i64/u64 range, so deserialization fails
+        CaseSpec::skip("i128/u128 values exceed VNumber range")
+    }
+
+    fn scalar_integers_size() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"<record><signed_size>-1000</signed_size><unsigned_size>2000</unsigned_size></record>"#,
+        )
+    }
+
+    // ── NonZero cases ──
+
+    fn nonzero_integers() -> CaseSpec {
+        CaseSpec::from_str(r#"<record><nz_u32>42</nz_u32><nz_i64>-100</nz_i64></record>"#)
+    }
+
+    // ── Borrowed string cases ──
+
+    fn cow_str() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"<record><owned>hello world</owned><message>borrowed</message></record>"#,
+        )
     }
 }
 

--- a/facet-format/src/lib.rs
+++ b/facet-format/src/lib.rs
@@ -1,4 +1,4 @@
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
 //! Prototype types for the format codex deserializer.

--- a/facet-value/src/deserialize.rs
+++ b/facet-value/src/deserialize.rs
@@ -37,7 +37,7 @@ use alloc::vec::Vec;
 use alloc::boxed::Box;
 
 use facet_core::{
-    Def, Facet, NumericType, PrimitiveType, Shape, StructKind, Type, UserType, Variant,
+    Def, Facet, NumericType, PrimitiveType, Shape, StructKind, TextualType, Type, UserType, Variant,
 };
 use facet_reflect::{Partial, ReflectError};
 
@@ -617,41 +617,51 @@ fn set_number<'p>(num: &VNumber, partial: Partial<'p>, shape: &Shape) -> Result<
                     message: "value cannot be represented as i64".into(),
                 })
             })?;
-            match size {
-                1 => {
-                    let v = i8::try_from(val).map_err(|_| {
-                        ValueError::new(ValueErrorKind::NumberOutOfRange {
-                            message: format!("{val} out of range for i8"),
-                        })
-                    })?;
-                    partial = partial.set(v)?;
-                }
-                2 => {
-                    let v = i16::try_from(val).map_err(|_| {
-                        ValueError::new(ValueErrorKind::NumberOutOfRange {
-                            message: format!("{val} out of range for i16"),
-                        })
-                    })?;
-                    partial = partial.set(v)?;
-                }
-                4 => {
-                    let v = i32::try_from(val).map_err(|_| {
-                        ValueError::new(ValueErrorKind::NumberOutOfRange {
-                            message: format!("{val} out of range for i32"),
-                        })
-                    })?;
-                    partial = partial.set(v)?;
-                }
-                8 => {
-                    partial = partial.set(val)?;
-                }
-                16 => {
-                    partial = partial.set(val as i128)?;
-                }
-                _ => {
-                    return Err(ValueError::new(ValueErrorKind::Unsupported {
-                        message: format!("unexpected integer size: {size}"),
-                    }));
+            // Check type_identifier to distinguish i64 from isize (both 8 bytes on 64-bit)
+            if shape.type_identifier == "isize" {
+                let v = isize::try_from(val).map_err(|_| {
+                    ValueError::new(ValueErrorKind::NumberOutOfRange {
+                        message: format!("{val} out of range for isize"),
+                    })
+                })?;
+                partial = partial.set(v)?;
+            } else {
+                match size {
+                    1 => {
+                        let v = i8::try_from(val).map_err(|_| {
+                            ValueError::new(ValueErrorKind::NumberOutOfRange {
+                                message: format!("{val} out of range for i8"),
+                            })
+                        })?;
+                        partial = partial.set(v)?;
+                    }
+                    2 => {
+                        let v = i16::try_from(val).map_err(|_| {
+                            ValueError::new(ValueErrorKind::NumberOutOfRange {
+                                message: format!("{val} out of range for i16"),
+                            })
+                        })?;
+                        partial = partial.set(v)?;
+                    }
+                    4 => {
+                        let v = i32::try_from(val).map_err(|_| {
+                            ValueError::new(ValueErrorKind::NumberOutOfRange {
+                                message: format!("{val} out of range for i32"),
+                            })
+                        })?;
+                        partial = partial.set(v)?;
+                    }
+                    8 => {
+                        partial = partial.set(val)?;
+                    }
+                    16 => {
+                        partial = partial.set(val as i128)?;
+                    }
+                    _ => {
+                        return Err(ValueError::new(ValueErrorKind::Unsupported {
+                            message: format!("unexpected integer size: {size}"),
+                        }));
+                    }
                 }
             }
         }
@@ -661,41 +671,51 @@ fn set_number<'p>(num: &VNumber, partial: Partial<'p>, shape: &Shape) -> Result<
                     message: "value cannot be represented as u64".into(),
                 })
             })?;
-            match size {
-                1 => {
-                    let v = u8::try_from(val).map_err(|_| {
-                        ValueError::new(ValueErrorKind::NumberOutOfRange {
-                            message: format!("{val} out of range for u8"),
-                        })
-                    })?;
-                    partial = partial.set(v)?;
-                }
-                2 => {
-                    let v = u16::try_from(val).map_err(|_| {
-                        ValueError::new(ValueErrorKind::NumberOutOfRange {
-                            message: format!("{val} out of range for u16"),
-                        })
-                    })?;
-                    partial = partial.set(v)?;
-                }
-                4 => {
-                    let v = u32::try_from(val).map_err(|_| {
-                        ValueError::new(ValueErrorKind::NumberOutOfRange {
-                            message: format!("{val} out of range for u32"),
-                        })
-                    })?;
-                    partial = partial.set(v)?;
-                }
-                8 => {
-                    partial = partial.set(val)?;
-                }
-                16 => {
-                    partial = partial.set(val as u128)?;
-                }
-                _ => {
-                    return Err(ValueError::new(ValueErrorKind::Unsupported {
-                        message: format!("unexpected integer size: {size}"),
-                    }));
+            // Check type_identifier to distinguish u64 from usize (both 8 bytes on 64-bit)
+            if shape.type_identifier == "usize" {
+                let v = usize::try_from(val).map_err(|_| {
+                    ValueError::new(ValueErrorKind::NumberOutOfRange {
+                        message: format!("{val} out of range for usize"),
+                    })
+                })?;
+                partial = partial.set(v)?;
+            } else {
+                match size {
+                    1 => {
+                        let v = u8::try_from(val).map_err(|_| {
+                            ValueError::new(ValueErrorKind::NumberOutOfRange {
+                                message: format!("{val} out of range for u8"),
+                            })
+                        })?;
+                        partial = partial.set(v)?;
+                    }
+                    2 => {
+                        let v = u16::try_from(val).map_err(|_| {
+                            ValueError::new(ValueErrorKind::NumberOutOfRange {
+                                message: format!("{val} out of range for u16"),
+                            })
+                        })?;
+                        partial = partial.set(v)?;
+                    }
+                    4 => {
+                        let v = u32::try_from(val).map_err(|_| {
+                            ValueError::new(ValueErrorKind::NumberOutOfRange {
+                                message: format!("{val} out of range for u32"),
+                            })
+                        })?;
+                        partial = partial.set(v)?;
+                    }
+                    8 => {
+                        partial = partial.set(val)?;
+                    }
+                    16 => {
+                        partial = partial.set(val as u128)?;
+                    }
+                    _ => {
+                        return Err(ValueError::new(ValueErrorKind::Unsupported {
+                            message: format!("unexpected integer size: {size}"),
+                        }));
+                    }
                 }
             }
         }
@@ -1403,25 +1423,27 @@ fn deserialize_option<'p>(value: &Value, partial: Partial<'p>) -> Result<Partial
     Ok(partial)
 }
 
-/// Deserialize a smart pointer (Box, Arc, Rc) from a Value.
+/// Deserialize a smart pointer (Box, Arc, Rc) or Cow from a Value.
 fn deserialize_pointer<'p>(value: &Value, partial: Partial<'p>) -> Result<Partial<'p>> {
     use facet_core::{KnownPointer, SequenceType};
 
     let mut partial = partial;
-    let (is_slice_pointer, is_reference) = if let Def::Pointer(ptr_def) = partial.shape().def {
-        let is_slice = if let Some(pointee) = ptr_def.pointee() {
-            matches!(pointee.ty, Type::Sequence(SequenceType::Slice(_)))
+    let (is_slice_pointer, is_reference, is_cow) =
+        if let Def::Pointer(ptr_def) = partial.shape().def {
+            let is_slice = if let Some(pointee) = ptr_def.pointee() {
+                matches!(pointee.ty, Type::Sequence(SequenceType::Slice(_)))
+            } else {
+                false
+            };
+            let is_ref = matches!(
+                ptr_def.known,
+                Some(KnownPointer::SharedReference | KnownPointer::ExclusiveReference)
+            );
+            let is_cow = matches!(ptr_def.known, Some(KnownPointer::Cow));
+            (is_slice, is_ref, is_cow)
         } else {
-            false
+            (false, false, false)
         };
-        let is_ref = matches!(
-            ptr_def.known,
-            Some(KnownPointer::SharedReference | KnownPointer::ExclusiveReference)
-        );
-        (is_slice, is_ref)
-    } else {
-        (false, false)
-    };
 
     // References can't be deserialized (need existing data to borrow from)
     if is_reference {
@@ -1431,6 +1453,37 @@ fn deserialize_pointer<'p>(value: &Value, partial: Partial<'p>) -> Result<Partia
                 partial.shape().type_identifier
             ),
         }));
+    }
+
+    // Cow needs special handling
+    if is_cow {
+        // Check if this is Cow<str> - we can set it directly from a string value
+        if let Def::Pointer(ptr_def) = partial.shape().def
+            && let Some(pointee) = ptr_def.pointee()
+            && matches!(
+                pointee.ty,
+                Type::Primitive(PrimitiveType::Textual(TextualType::Str))
+            )
+        {
+            // This is Cow<str> - deserialize from string
+            if let Some(s) = value.as_string() {
+                // Set the owned string value - Cow<str> will store it as Owned
+                partial = partial.set(alloc::borrow::Cow::<'static, str>::Owned(
+                    s.as_str().to_string(),
+                ))?;
+                return Ok(partial);
+            } else {
+                return Err(ValueError::new(ValueErrorKind::TypeMismatch {
+                    expected: "string for Cow<str>",
+                    got: value.value_type(),
+                }));
+            }
+        }
+        // For other Cow types, use begin_inner
+        partial = partial.begin_inner()?;
+        partial = deserialize_value_into(value, partial)?;
+        partial = partial.end()?;
+        return Ok(partial);
     }
 
     partial = partial.begin_smart_ptr()?;


### PR DESCRIPTION
## Summary

- Add Set serialization support to facet-format serializer
- Fix isize/usize deserialization by checking `type_identifier` (both are 8 bytes on 64-bit, same as i64/u64)
- Add `Cow<str>` deserialization support in facet-value
- Add `try_borrow_inner` for NonZero types to enable serialization
- Add Set comparison support to facet-diff

New test cases (34 total, up from 18):
- `Arc<T>` / `Rc<T>` smart pointer wrappers
- `BTreeSet<T>` collection
- Extended numeric types (i16, u16, i128, u128, isize, usize)
- NonZero integer types (NonZeroU32, NonZeroI64)
- `Cow<'static, str>` string fields

## Test plan

- [x] `cargo test -p facet-format-json --test format_suite` - 34 passing
- [x] `cargo test -p facet-format-xml --test format_suite` - 34 passing