### PR TITLE
feat(format): Add i128/u128 support to ScalarValue and VNumber

### DIFF
--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -76,7 +76,7 @@ time = { version = "0.3.41", optional = true, features = [
     "parsing",
     "formatting",
 ] }
-chrono = { version = "0.4", optional = true, default-features = false, features = [
+chrono = { version = "0.4.35", optional = true, default-features = false, features = [
     "alloc",
     "clock",
 ] }

--- a/facet-format-json/src/serializer.rs
+++ b/facet-format-json/src/serializer.rs
@@ -163,6 +163,8 @@ impl FormatSerializer for JsonSerializer {
             }
             ScalarValue::I64(v) => self.out.extend_from_slice(v.to_string().as_bytes()),
             ScalarValue::U64(v) => self.out.extend_from_slice(v.to_string().as_bytes()),
+            ScalarValue::I128(v) => self.out.extend_from_slice(v.to_string().as_bytes()),
+            ScalarValue::U128(v) => self.out.extend_from_slice(v.to_string().as_bytes()),
             ScalarValue::F64(v) => self.out.extend_from_slice(v.to_string().as_bytes()),
             ScalarValue::Str(s) => self.write_json_string(&s),
             ScalarValue::Bytes(_) => {

--- a/facet-format-suite/Cargo.toml
+++ b/facet-format-suite/Cargo.toml
@@ -26,7 +26,7 @@ camino = { version = "1", optional = true }
 ordered-float = { version = "5.0.0", optional = true, default-features = false }
 time = { version = "0.3", optional = true, features = ["macros"] }
 jiff = { version = "0.2", optional = true }
-chrono = { version = "0.4", optional = true, default-features = false }
+chrono = { version = "0.4.35", optional = true, default-features = false }
 
 [dev-dependencies]
 

--- a/facet-format-suite/src/lib.rs
+++ b/facet-format-suite/src/lib.rs
@@ -10,6 +10,9 @@ use facet_assert::assert_same;
 use facet_pretty::{FacetPretty, PrettyPrinter};
 use indoc::formatdoc;
 
+#[cfg(feature = "chrono")]
+use chrono::TimeZone;
+
 /// Trait every format variant implements to participate in the suite.
 ///
 /// Each method returning a [`CaseSpec`] corresponds to a canonical test case.
@@ -1760,7 +1763,8 @@ const CASE_CHRONO_DATETIME_UTC: CaseDescriptor<ChronoDateTimeUtcWrapper> = CaseD
     id: "third_party::chrono_datetime_utc",
     description: "chrono::DateTime<Utc> type",
     expected: || ChronoDateTimeUtcWrapper {
-        created_at: chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2023, 1, 15, 12, 34, 56)
+        created_at: chrono::Utc
+            .with_ymd_and_hms(2023, 1, 15, 12, 34, 56)
             .unwrap(),
     },
 };

--- a/facet-format-xml/src/parser.rs
+++ b/facet-format-xml/src/parser.rs
@@ -322,6 +322,8 @@ enum XmlValue {
     Bool(bool),
     I64(i64),
     U64(u64),
+    I128(i128),
+    U128(u128),
     F64(f64),
     String(String),
     Array(Vec<XmlValue>),
@@ -545,6 +547,13 @@ fn parse_scalar(text: &str) -> XmlValue {
     if let Ok(u) = text.parse::<u64>() {
         return XmlValue::U64(u);
     }
+    // Try 128-bit integers for values outside i64/u64 range
+    if let Ok(i) = text.parse::<i128>() {
+        return XmlValue::I128(i);
+    }
+    if let Ok(u) = text.parse::<u128>() {
+        return XmlValue::U128(u);
+    }
     if let Ok(f) = text.parse::<f64>() {
         return XmlValue::F64(f);
     }
@@ -557,6 +566,8 @@ fn emit_value_events<'de>(value: &XmlValue, events: &mut Vec<ParseEvent<'de>>) {
         XmlValue::Bool(b) => events.push(ParseEvent::Scalar(ScalarValue::Bool(*b))),
         XmlValue::I64(n) => events.push(ParseEvent::Scalar(ScalarValue::I64(*n))),
         XmlValue::U64(n) => events.push(ParseEvent::Scalar(ScalarValue::U64(*n))),
+        XmlValue::I128(n) => events.push(ParseEvent::Scalar(ScalarValue::I128(*n))),
+        XmlValue::U128(n) => events.push(ParseEvent::Scalar(ScalarValue::U128(*n))),
         XmlValue::F64(n) => events.push(ParseEvent::Scalar(ScalarValue::F64(*n))),
         XmlValue::String(s) => {
             events.push(ParseEvent::Scalar(ScalarValue::Str(Cow::Owned(s.clone()))))

--- a/facet-format-xml/src/serializer.rs
+++ b/facet-format-xml/src/serializer.rs
@@ -439,6 +439,8 @@ impl FormatSerializer for XmlSerializer {
                 ScalarValue::Bool(v) => if v { "true" } else { "false" }.to_string(),
                 ScalarValue::I64(v) => v.to_string(),
                 ScalarValue::U64(v) => v.to_string(),
+                ScalarValue::I128(v) => v.to_string(),
+                ScalarValue::U128(v) => v.to_string(),
                 ScalarValue::F64(v) => v.to_string(),
                 ScalarValue::Str(s) => s.into_owned(),
                 ScalarValue::Bytes(_) => {
@@ -464,6 +466,8 @@ impl FormatSerializer for XmlSerializer {
             ScalarValue::Bool(v) => self.write_text_escaped(if v { "true" } else { "false" }),
             ScalarValue::I64(v) => self.write_text_escaped(&v.to_string()),
             ScalarValue::U64(v) => self.write_text_escaped(&v.to_string()),
+            ScalarValue::I128(v) => self.write_text_escaped(&v.to_string()),
+            ScalarValue::U128(v) => self.write_text_escaped(&v.to_string()),
             ScalarValue::F64(v) => self.write_text_escaped(&v.to_string()),
             ScalarValue::Str(s) => self.write_text_escaped(&s),
             ScalarValue::Bytes(_) => {

--- a/facet-format-xml/tests/format_suite.rs
+++ b/facet-format-xml/tests/format_suite.rs
@@ -340,8 +340,9 @@ impl FormatSuite for XmlSlice {
     }
 
     fn scalar_integers_128() -> CaseSpec {
-        // Skip: VNumber can't hold values outside i64/u64 range, so deserialization fails
-        CaseSpec::skip("i128/u128 values exceed VNumber range")
+        CaseSpec::from_str(
+            r#"<record><signed_128>-170141183460469231731687303715884105728</signed_128><unsigned_128>340282366920938463463374607431768211455</unsigned_128></record>"#,
+        )
     }
 
     fn scalar_integers_size() -> CaseSpec {
@@ -498,8 +499,9 @@ impl FormatSuite for XmlSlice {
     // ── Extended NonZero cases ──
 
     fn nonzero_integers_extended() -> CaseSpec {
-        // Skip: i128/u128 values exceed VNumber range
-        CaseSpec::skip("i128/u128 values exceed VNumber range")
+        CaseSpec::from_str(
+            r#"<record><nz_u8>255</nz_u8><nz_i8>-128</nz_i8><nz_u16>65535</nz_u16><nz_i16>-32768</nz_i16><nz_u128>1</nz_u128><nz_i128>-1</nz_i128><nz_usize>1000</nz_usize><nz_isize>-500</nz_isize></record>"#,
+        )
     }
 
     // ── DateTime type cases ──

--- a/facet-format/src/deserializer.rs
+++ b/facet-format/src/deserializer.rs
@@ -1221,6 +1221,24 @@ where
                     | ScalarType::U128
                     | ScalarType::USize
             ),
+            ScalarValue::I128(_) => matches!(
+                scalar_type,
+                ScalarType::I8
+                    | ScalarType::I16
+                    | ScalarType::I32
+                    | ScalarType::I64
+                    | ScalarType::I128
+                    | ScalarType::ISize
+            ),
+            ScalarValue::U128(_) => matches!(
+                scalar_type,
+                ScalarType::U8
+                    | ScalarType::U16
+                    | ScalarType::U32
+                    | ScalarType::U64
+                    | ScalarType::U128
+                    | ScalarType::USize
+            ),
             ScalarValue::F64(_) => matches!(scalar_type, ScalarType::F32 | ScalarType::F64),
             ScalarValue::Str(_) => matches!(
                 scalar_type,
@@ -1478,6 +1496,82 @@ where
                 } else if shape.type_identifier == "f64" {
                     wip = wip.set(n as f64).map_err(DeserializeError::Reflect)?;
                 // Handle String - stringify the number
+                } else if shape.type_identifier == "String" {
+                    wip = wip
+                        .set(alloc::string::ToString::to_string(&n))
+                        .map_err(DeserializeError::Reflect)?;
+                } else {
+                    wip = wip.set(n).map_err(DeserializeError::Reflect)?;
+                }
+            }
+            ScalarValue::I128(n) => {
+                // Handle 128-bit signed integer
+                if shape.type_identifier == "i128" {
+                    wip = wip.set(n).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "i64" {
+                    wip = wip.set(n as i64).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "i32" {
+                    wip = wip.set(n as i32).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "i16" {
+                    wip = wip.set(n as i16).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "i8" {
+                    wip = wip.set(n as i8).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "isize" {
+                    wip = wip.set(n as isize).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "u128" {
+                    wip = wip.set(n as u128).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "u64" {
+                    wip = wip.set(n as u64).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "u32" {
+                    wip = wip.set(n as u32).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "u16" {
+                    wip = wip.set(n as u16).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "u8" {
+                    wip = wip.set(n as u8).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "usize" {
+                    wip = wip.set(n as usize).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "f64" {
+                    wip = wip.set(n as f64).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "f32" {
+                    wip = wip.set(n as f32).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "String" {
+                    wip = wip
+                        .set(alloc::string::ToString::to_string(&n))
+                        .map_err(DeserializeError::Reflect)?;
+                } else {
+                    wip = wip.set(n).map_err(DeserializeError::Reflect)?;
+                }
+            }
+            ScalarValue::U128(n) => {
+                // Handle 128-bit unsigned integer
+                if shape.type_identifier == "u128" {
+                    wip = wip.set(n).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "u64" {
+                    wip = wip.set(n as u64).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "u32" {
+                    wip = wip.set(n as u32).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "u16" {
+                    wip = wip.set(n as u16).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "u8" {
+                    wip = wip.set(n as u8).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "usize" {
+                    wip = wip.set(n as usize).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "i128" {
+                    wip = wip.set(n as i128).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "i64" {
+                    wip = wip.set(n as i64).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "i32" {
+                    wip = wip.set(n as i32).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "i16" {
+                    wip = wip.set(n as i16).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "i8" {
+                    wip = wip.set(n as i8).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "isize" {
+                    wip = wip.set(n as isize).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "f64" {
+                    wip = wip.set(n as f64).map_err(DeserializeError::Reflect)?;
+                } else if shape.type_identifier == "f32" {
+                    wip = wip.set(n as f32).map_err(DeserializeError::Reflect)?;
                 } else if shape.type_identifier == "String" {
                     wip = wip
                         .set(alloc::string::ToString::to_string(&n))

--- a/facet-format/src/event.rs
+++ b/facet-format/src/event.rs
@@ -78,6 +78,10 @@ pub enum ScalarValue<'de> {
     I64(i64),
     /// Unsigned integer literal.
     U64(u64),
+    /// Signed 128-bit integer literal.
+    I128(i128),
+    /// Unsigned 128-bit integer literal.
+    U128(u128),
     /// Floating-point literal.
     F64(f64),
     /// UTF-8 string literal.

--- a/facet-format/src/serializer.rs
+++ b/facet-format/src/serializer.rs
@@ -592,9 +592,7 @@ fn scalar_from_peek<'mem, 'facet, E: Debug>(
         }
         ScalarType::U64 => ScalarValue::U64(*value.get::<u64>().map_err(SerializeError::Reflect)?),
         ScalarType::U128 => {
-            return Err(SerializeError::Unsupported(
-                "u128 scalar serialization is not supported yet",
-            ));
+            ScalarValue::U128(*value.get::<u128>().map_err(SerializeError::Reflect)?)
         }
         ScalarType::USize => {
             ScalarValue::U64(*value.get::<usize>().map_err(SerializeError::Reflect)? as u64)
@@ -610,9 +608,7 @@ fn scalar_from_peek<'mem, 'facet, E: Debug>(
         }
         ScalarType::I64 => ScalarValue::I64(*value.get::<i64>().map_err(SerializeError::Reflect)?),
         ScalarType::I128 => {
-            return Err(SerializeError::Unsupported(
-                "i128 scalar serialization is not supported yet",
-            ));
+            ScalarValue::I128(*value.get::<i128>().map_err(SerializeError::Reflect)?)
         }
         ScalarType::ISize => {
             ScalarValue::I64(*value.get::<isize>().map_err(SerializeError::Reflect)? as i64)

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -91,7 +91,7 @@ facet-showcase = { path = "../facet-showcase" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 insta = "1.43.1"
 time = { version = "0.3.41", features = ["macros"] }
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4.35", default-features = false }
 ulid = { version = "1.2.1" }
 uuid = { version = "1.17.0" }
 jiff = "0.2.15"


### PR DESCRIPTION
## Summary
- Add I128/U128 variants to `ScalarValue` in facet-format
- Add i128/u128 support to `VNumber` in facet-value (with `from_i128`, `from_u128`, `to_i128`, `to_u128` methods)
- Update serializers and deserializers in facet-format, facet-format-xml, and facet-format-json to handle 128-bit integers
- Enable previously skipped format-suite tests for 128-bit integers

Closes #1277

## Test plan
- [x] All facet-format-xml format suite tests pass (56 passed)
- [x] All facet-format-json format suite tests pass (57 passed)
- [x] All facet-value tests pass (140 passed)
- [x] Workspace compiles cleanly