### PR TITLE
feat(format): Support i128/u128 serialization and remove XmlValue middleman

### DIFF
--- a/facet-format-json/tests/format_suite.rs
+++ b/facet-format-json/tests/format_suite.rs
@@ -326,7 +326,7 @@ impl FormatSuite for JsonSlice {
 
     fn scalar_integers_128() -> CaseSpec {
         CaseSpec::from_str(r#"{"signed_128":-170141183460469231731687303715884105728,"unsigned_128":340282366920938463463374607431768211455}"#)
-            .without_roundtrip("i128/u128 serialization not supported yet")
+            .without_roundtrip("i128/u128 serialize as strings, not native JSON numbers")
     }
 
     fn scalar_integers_size() -> CaseSpec {
@@ -471,7 +471,7 @@ impl FormatSuite for JsonSlice {
         CaseSpec::from_str(
             r#"{"nz_u8":255,"nz_i8":-128,"nz_u16":65535,"nz_i16":-32768,"nz_u128":1,"nz_i128":-1,"nz_usize":1000,"nz_isize":-500}"#,
         )
-        .without_roundtrip("i128/u128 serialization not supported yet")
+        .without_roundtrip("i128/u128 serialize as strings, not native JSON numbers")
     }
 
     // ── DateTime type cases ──

--- a/facet-format-xml/tests/format_suite.rs
+++ b/facet-format-xml/tests/format_suite.rs
@@ -340,8 +340,9 @@ impl FormatSuite for XmlSlice {
     }
 
     fn scalar_integers_128() -> CaseSpec {
-        // Skip: VNumber can't hold values outside i64/u64 range, so deserialization fails
-        CaseSpec::skip("i128/u128 values exceed VNumber range")
+        CaseSpec::from_str(
+            r#"<record><signed_128>-170141183460469231731687303715884105728</signed_128><unsigned_128>340282366920938463463374607431768211455</unsigned_128></record>"#,
+        )
     }
 
     fn scalar_integers_size() -> CaseSpec {
@@ -498,8 +499,9 @@ impl FormatSuite for XmlSlice {
     // ── Extended NonZero cases ──
 
     fn nonzero_integers_extended() -> CaseSpec {
-        // Skip: i128/u128 values exceed VNumber range
-        CaseSpec::skip("i128/u128 values exceed VNumber range")
+        CaseSpec::from_str(
+            r#"<record><nz_u8>255</nz_u8><nz_i8>-128</nz_i8><nz_u16>65535</nz_u16><nz_i16>-32768</nz_i16><nz_u128>1</nz_u128><nz_i128>-1</nz_i128><nz_usize>1000</nz_usize><nz_isize>-500</nz_isize></record>"#,
+        )
     }
 
     // ── DateTime type cases ──

--- a/facet-format/src/serializer.rs
+++ b/facet-format/src/serializer.rs
@@ -592,9 +592,8 @@ fn scalar_from_peek<'mem, 'facet, E: Debug>(
         }
         ScalarType::U64 => ScalarValue::U64(*value.get::<u64>().map_err(SerializeError::Reflect)?),
         ScalarType::U128 => {
-            return Err(SerializeError::Unsupported(
-                "u128 scalar serialization is not supported yet",
-            ));
+            let n = *value.get::<u128>().map_err(SerializeError::Reflect)?;
+            ScalarValue::Str(Cow::Owned(alloc::string::ToString::to_string(&n)))
         }
         ScalarType::USize => {
             ScalarValue::U64(*value.get::<usize>().map_err(SerializeError::Reflect)? as u64)
@@ -610,9 +609,8 @@ fn scalar_from_peek<'mem, 'facet, E: Debug>(
         }
         ScalarType::I64 => ScalarValue::I64(*value.get::<i64>().map_err(SerializeError::Reflect)?),
         ScalarType::I128 => {
-            return Err(SerializeError::Unsupported(
-                "i128 scalar serialization is not supported yet",
-            ));
+            let n = *value.get::<i128>().map_err(SerializeError::Reflect)?;
+            ScalarValue::Str(Cow::Owned(alloc::string::ToString::to_string(&n)))
         }
         ScalarType::ISize => {
             ScalarValue::I64(*value.get::<isize>().map_err(SerializeError::Reflect)? as i64)


### PR DESCRIPTION
## Summary

- Remove `XmlValue`/`XmlField` intermediate enums from XML parser - emit `ParseEvent`s directly from the `Element` tree
- Add i128/u128 parsing support in XML (emitted as strings to preserve precision)
- Enable i128/u128 serialization in `facet-format` (as string representation)
- Enable previously skipped `scalar_integers_128` and `nonzero_integers_extended` tests

## Test plan

- [x] All XML format suite tests pass (143 tests, 17 skipped for unrelated reasons)
- [x] All JSON format suite tests pass
- [x] Pre-push hooks pass (clippy, nextest, doc tests, docs build, cargo-shear)

Closes #1277