### PR TITLE
fix(core): Add partial_eq implementations for DateTime types

### DIFF
--- a/facet-core/src/impls/crates/chrono.rs
+++ b/facet-core/src/impls/crates/chrono.rs
@@ -64,10 +64,19 @@ unsafe fn parse_datetime_utc(s: &str, target: OxPtrMut) -> Option<Result<(), Par
     }
 }
 
+unsafe fn partial_eq_datetime_utc(a: OxPtrConst, b: OxPtrConst) -> Option<bool> {
+    unsafe {
+        let a = a.get::<DateTime<Utc>>();
+        let b = b.get::<DateTime<Utc>>();
+        Some(a == b)
+    }
+}
+
 const DATETIME_UTC_VTABLE: VTableIndirect = VTableIndirect {
     display: Some(display_datetime_utc),
     try_from: Some(try_from_datetime_utc),
     parse: Some(parse_datetime_utc),
+    partial_eq: Some(partial_eq_datetime_utc),
     ..VTableIndirect::EMPTY
 };
 
@@ -138,10 +147,19 @@ unsafe fn parse_datetime_fixed_offset(s: &str, target: OxPtrMut) -> Option<Resul
     }
 }
 
+unsafe fn partial_eq_datetime_fixed_offset(a: OxPtrConst, b: OxPtrConst) -> Option<bool> {
+    unsafe {
+        let a = a.get::<DateTime<FixedOffset>>();
+        let b = b.get::<DateTime<FixedOffset>>();
+        Some(a == b)
+    }
+}
+
 const DATETIME_FIXED_OFFSET_VTABLE: VTableIndirect = VTableIndirect {
     display: Some(display_datetime_fixed_offset),
     try_from: Some(try_from_datetime_fixed_offset),
     parse: Some(parse_datetime_fixed_offset),
+    partial_eq: Some(partial_eq_datetime_fixed_offset),
     ..VTableIndirect::EMPTY
 };
 
@@ -214,10 +232,19 @@ unsafe fn parse_datetime_local(s: &str, target: OxPtrMut) -> Option<Result<(), P
     }
 }
 
+unsafe fn partial_eq_datetime_local(a: OxPtrConst, b: OxPtrConst) -> Option<bool> {
+    unsafe {
+        let a = a.get::<DateTime<Local>>();
+        let b = b.get::<DateTime<Local>>();
+        Some(a == b)
+    }
+}
+
 const DATETIME_LOCAL_VTABLE: VTableIndirect = VTableIndirect {
     display: Some(display_datetime_local),
     try_from: Some(try_from_datetime_local),
     parse: Some(parse_datetime_local),
+    partial_eq: Some(partial_eq_datetime_local),
     ..VTableIndirect::EMPTY
 };
 
@@ -286,10 +313,19 @@ unsafe fn parse_naive_datetime(s: &str, target: OxPtrMut) -> Option<Result<(), P
     }
 }
 
+unsafe fn partial_eq_naive_datetime(a: OxPtrConst, b: OxPtrConst) -> Option<bool> {
+    unsafe {
+        let a = a.get::<NaiveDateTime>();
+        let b = b.get::<NaiveDateTime>();
+        Some(a == b)
+    }
+}
+
 const NAIVE_DATETIME_VTABLE: VTableIndirect = VTableIndirect {
     display: Some(display_naive_datetime),
     try_from: Some(try_from_naive_datetime),
     parse: Some(parse_naive_datetime),
+    partial_eq: Some(partial_eq_naive_datetime),
     ..VTableIndirect::EMPTY
 };
 
@@ -356,10 +392,19 @@ unsafe fn parse_naive_date(s: &str, target: OxPtrMut) -> Option<Result<(), Parse
     }
 }
 
+unsafe fn partial_eq_naive_date(a: OxPtrConst, b: OxPtrConst) -> Option<bool> {
+    unsafe {
+        let a = a.get::<NaiveDate>();
+        let b = b.get::<NaiveDate>();
+        Some(a == b)
+    }
+}
+
 const NAIVE_DATE_VTABLE: VTableIndirect = VTableIndirect {
     display: Some(display_naive_date),
     try_from: Some(try_from_naive_date),
     parse: Some(parse_naive_date),
+    partial_eq: Some(partial_eq_naive_date),
     ..VTableIndirect::EMPTY
 };
 
@@ -428,10 +473,19 @@ unsafe fn parse_naive_time(s: &str, target: OxPtrMut) -> Option<Result<(), Parse
     }
 }
 
+unsafe fn partial_eq_naive_time(a: OxPtrConst, b: OxPtrConst) -> Option<bool> {
+    unsafe {
+        let a = a.get::<NaiveTime>();
+        let b = b.get::<NaiveTime>();
+        Some(a == b)
+    }
+}
+
 const NAIVE_TIME_VTABLE: VTableIndirect = VTableIndirect {
     display: Some(display_naive_time),
     try_from: Some(try_from_naive_time),
     parse: Some(parse_naive_time),
+    partial_eq: Some(partial_eq_naive_time),
     ..VTableIndirect::EMPTY
 };
 

--- a/facet-core/src/impls/crates/jiff.rs
+++ b/facet-core/src/impls/crates/jiff.rs
@@ -72,12 +72,21 @@ unsafe fn zoned_try_from(
     }
 }
 
+unsafe fn zoned_partial_eq(a: OxPtrConst, b: OxPtrConst) -> Option<bool> {
+    unsafe {
+        let a = a.get::<Zoned>();
+        let b = b.get::<Zoned>();
+        Some(a == b)
+    }
+}
+
 unsafe impl Facet<'_> for Zoned {
     const SHAPE: &'static Shape = &const {
         const VTABLE: VTableIndirect = VTableIndirect {
             display: Some(zoned_display),
             parse: Some(zoned_parse),
             try_from: Some(zoned_try_from),
+            partial_eq: Some(zoned_partial_eq),
             ..VTableIndirect::EMPTY
         };
 
@@ -151,12 +160,21 @@ unsafe fn timestamp_try_from(
     }
 }
 
+unsafe fn timestamp_partial_eq(a: OxPtrConst, b: OxPtrConst) -> Option<bool> {
+    unsafe {
+        let a = a.get::<Timestamp>();
+        let b = b.get::<Timestamp>();
+        Some(a == b)
+    }
+}
+
 unsafe impl Facet<'_> for Timestamp {
     const SHAPE: &'static Shape = &const {
         const VTABLE: VTableIndirect = VTableIndirect {
             display: Some(timestamp_display),
             parse: Some(timestamp_parse),
             try_from: Some(timestamp_try_from),
+            partial_eq: Some(timestamp_partial_eq),
             ..VTableIndirect::EMPTY
         };
 
@@ -230,12 +248,21 @@ unsafe fn datetime_try_from(
     }
 }
 
+unsafe fn datetime_partial_eq(a: OxPtrConst, b: OxPtrConst) -> Option<bool> {
+    unsafe {
+        let a = a.get::<DateTime>();
+        let b = b.get::<DateTime>();
+        Some(a == b)
+    }
+}
+
 unsafe impl Facet<'_> for DateTime {
     const SHAPE: &'static Shape = &const {
         const VTABLE: VTableIndirect = VTableIndirect {
             display: Some(datetime_display),
             parse: Some(datetime_parse),
             try_from: Some(datetime_try_from),
+            partial_eq: Some(datetime_partial_eq),
             ..VTableIndirect::EMPTY
         };
 

--- a/facet-core/src/impls/crates/time.rs
+++ b/facet-core/src/impls/crates/time.rs
@@ -69,10 +69,19 @@ unsafe fn utc_parse(s: &str, target: OxPtrMut) -> Option<Result<(), ParseError>>
     }
 }
 
+unsafe fn utc_partial_eq(a: OxPtrConst, b: OxPtrConst) -> Option<bool> {
+    unsafe {
+        let a = a.get::<UtcDateTime>();
+        let b = b.get::<UtcDateTime>();
+        Some(a == b)
+    }
+}
+
 const UTC_VTABLE: VTableIndirect = VTableIndirect {
     display: Some(utc_display),
     try_from: Some(utc_try_from),
     parse: Some(utc_parse),
+    partial_eq: Some(utc_partial_eq),
     ..VTableIndirect::EMPTY
 };
 
@@ -144,10 +153,19 @@ unsafe fn offset_parse(s: &str, target: OxPtrMut) -> Option<Result<(), ParseErro
     }
 }
 
+unsafe fn offset_partial_eq(a: OxPtrConst, b: OxPtrConst) -> Option<bool> {
+    unsafe {
+        let a = a.get::<OffsetDateTime>();
+        let b = b.get::<OffsetDateTime>();
+        Some(a == b)
+    }
+}
+
 const OFFSET_VTABLE: VTableIndirect = VTableIndirect {
     display: Some(offset_display),
     try_from: Some(offset_try_from),
     parse: Some(offset_parse),
+    partial_eq: Some(offset_partial_eq),
     ..VTableIndirect::EMPTY
 };
 

--- a/facet-format-json/tests/format_suite.rs
+++ b/facet-format-json/tests/format_suite.rs
@@ -475,36 +475,40 @@ impl FormatSuite for JsonSlice {
     }
 
     // ── DateTime type cases ──
-    // Note: These tests require careful handling of DateTime comparison
-    // which may differ based on internal representation vs string format.
-    // Skipping for now until we can verify the expected comparison behavior.
 
     fn time_offset_datetime() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"{"created_at":"2023-01-15T12:34:56Z"}"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn jiff_timestamp() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"{"created_at":"2023-12-31T11:30:00Z"}"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn jiff_civil_datetime() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"{"created_at":"2024-06-19T15:22:45"}"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn chrono_datetime_utc() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"{"created_at":"2023-01-15T12:34:56Z"}"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn chrono_naive_datetime() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"{"created_at":"2023-01-15T12:34:56"}"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn chrono_naive_date() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"{"birth_date":"2023-01-15"}"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn chrono_naive_time() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"{"alarm_time":"12:34:56"}"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 }
 

--- a/facet-format-xml/tests/format_suite.rs
+++ b/facet-format-xml/tests/format_suite.rs
@@ -505,36 +505,40 @@ impl FormatSuite for XmlSlice {
     }
 
     // ── DateTime type cases ──
-    // Note: These tests require careful handling of DateTime comparison
-    // which may differ based on internal representation vs string format.
-    // Skipping for now until we can verify the expected comparison behavior.
 
     fn time_offset_datetime() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"<record><created_at>2023-01-15T12:34:56Z</created_at></record>"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn jiff_timestamp() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"<record><created_at>2023-12-31T11:30:00Z</created_at></record>"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn jiff_civil_datetime() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"<record><created_at>2024-06-19T15:22:45</created_at></record>"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn chrono_datetime_utc() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"<record><created_at>2023-01-15T12:34:56Z</created_at></record>"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn chrono_naive_datetime() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"<record><created_at>2023-01-15T12:34:56</created_at></record>"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn chrono_naive_date() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"<record><birth_date>2023-01-15</birth_date></record>"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn chrono_naive_time() -> CaseSpec {
-        CaseSpec::skip("datetime comparison needs special handling")
+        CaseSpec::from_str(r#"<record><alarm_time>12:34:56</alarm_time></record>"#)
+            .without_roundtrip("opaque type serialization not yet supported")
     }
 }
 


### PR DESCRIPTION
Fixes #1276

## Summary

DateTime types from `time`, `jiff`, and `chrono` crates were failing `assert_same!` comparisons despite having identical display values. This was because their VTables were missing `partial_eq` function implementations.

## Changes

### Core implementations
- **time.rs**: Added `partial_eq` for `OffsetDateTime` and `UtcDateTime`
- **jiff.rs**: Added `partial_eq` for `Zoned`, `Timestamp`, and `civil::DateTime`
- **chrono.rs**: Added `partial_eq` for all 6 types:
  - `DateTime<Utc>`
  - `DateTime<FixedOffset>`
  - `DateTime<Local>`
  - `NaiveDateTime`
  - `NaiveDate`
  - `NaiveTime`

### Test suite updates
- Re-enabled all 7 skipped DateTime tests in `facet-format-json` test suite
- Re-enabled all 7 skipped DateTime tests in `facet-format-xml` test suite

## Testing

All tests now pass:
- ✅ **facet-format-json**: 64/64 tests passed (including all 7 DateTime tests)
- ✅ **facet-format-xml**: 63/63 tests passed (including all 7 DateTime tests)
- ✅ **facet-core**: All unit tests passing with nextest

The implementation follows the same pattern as the existing `uuid` and `ulid` types, simply delegating to the underlying type's `PartialEq` implementation.

## Example

Before this fix:
```rust
let parsed: TimeOffsetDateTimeWrapper = from_str(r#"{"created_at":"2023-01-15T12:34:56Z"}"#).unwrap();
let expected = TimeOffsetDateTimeWrapper {
    created_at: time::macros::datetime!(2023-01-15 12:34:56 UTC),
};
assert_same!(parsed, expected);  // ❌ FAILED despite identical values
```

After this fix:
```rust
assert_same!(parsed, expected);  // ✅ PASSES
```