### PR TITLE
feat(format): Add solver-based flatten for complex enum/nested cases

### DIFF
--- a/facet-format-json/tests/format_suite.rs
+++ b/facet-format-json/tests/format_suite.rs
@@ -357,6 +357,19 @@ impl FormatSuite for JsonSlice {
         )
     }
 
+    fn flatten_multilevel() -> CaseSpec {
+        // All fields from 3 levels should be flattened to top level
+        CaseSpec::from_str(r#"{"top_field":"top","mid_field":42,"deep_field":100}"#)
+    }
+
+    fn flatten_multiple_enums() -> CaseSpec {
+        // Two different enums (auth + transport) flattened into same struct
+        CaseSpec::from_str(
+            r#"{"name":"service","Password":{"password":"secret"},"Tcp":{"port":8080}}"#,
+        )
+        .without_roundtrip("serialization of flattened enums not yet supported")
+    }
+
     // ── Scalar cases ──
 
     fn scalar_bool() -> CaseSpec {
@@ -412,6 +425,11 @@ impl FormatSuite for JsonSlice {
 
     fn enum_untagged() -> CaseSpec {
         CaseSpec::from_str(r#"{"x":10,"y":20}"#)
+    }
+
+    fn enum_variant_rename() -> CaseSpec {
+        // Variant "Active" is renamed to "enabled" in the input
+        CaseSpec::from_str(r#""enabled""#)
     }
 
     fn untagged_with_null() -> CaseSpec {
@@ -641,6 +659,11 @@ impl FormatSuite for JsonSlice {
 
     fn chrono_naive_time() -> CaseSpec {
         CaseSpec::from_str(r#"{"alarm_time":"12:34:56"}"#)
+            .without_roundtrip("opaque type serialization not yet supported")
+    }
+
+    fn chrono_in_vec() -> CaseSpec {
+        CaseSpec::from_str(r#"{"timestamps":["2023-01-01T00:00:00Z","2023-06-15T12:30:00Z"]}"#)
             .without_roundtrip("opaque type serialization not yet supported")
     }
 

--- a/facet-format-xml/tests/format_suite.rs
+++ b/facet-format-xml/tests/format_suite.rs
@@ -377,6 +377,16 @@ impl FormatSuite for XmlSlice {
         )
     }
 
+    fn flatten_multilevel() -> CaseSpec {
+        // TODO: multilevel nested flatten not yet supported in FormatDeserializer
+        CaseSpec::skip("multilevel nested flatten not yet implemented in format layer")
+    }
+
+    fn flatten_multiple_enums() -> CaseSpec {
+        // TODO: multiple flattened enums not yet supported in FormatDeserializer
+        CaseSpec::skip("multiple flattened enums not yet implemented in format layer")
+    }
+
     // ── Scalar cases ──
 
     fn scalar_bool() -> CaseSpec {
@@ -437,6 +447,11 @@ impl FormatSuite for XmlSlice {
 
     fn enum_untagged() -> CaseSpec {
         CaseSpec::from_str(r#"<value><x>10</x><y>20</y></value>"#)
+    }
+
+    fn enum_variant_rename() -> CaseSpec {
+        // Variant "Active" is renamed to "enabled" in the input
+        CaseSpec::from_str(r#"<value>enabled</value>"#)
     }
 
     fn untagged_with_null() -> CaseSpec {
@@ -689,6 +704,13 @@ impl FormatSuite for XmlSlice {
     fn chrono_naive_time() -> CaseSpec {
         CaseSpec::from_str(r#"<record><alarm_time>12:34:56</alarm_time></record>"#)
             .without_roundtrip("opaque type serialization not yet supported")
+    }
+
+    fn chrono_in_vec() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"<record><timestamps><item>2023-01-01T00:00:00Z</item><item>2023-06-15T12:30:00Z</item></timestamps></record>"#,
+        )
+        .without_roundtrip("opaque type serialization not yet supported")
     }
 
     // ── Bytes crate cases ──

--- a/facet-json/src/serialize.rs
+++ b/facet-json/src/serialize.rs
@@ -352,7 +352,10 @@ impl<W: std::io::Write> crate::JsonWrite for &mut StdWriteAdapter<W> {
 pub enum SerializeError {}
 
 fn variant_is_newtype_like(variant: &facet_core::Variant) -> bool {
-    variant.data.kind == StructKind::Tuple && variant.data.fields.len() == 1
+    matches!(
+        variant.data.kind,
+        StructKind::Tuple | StructKind::TupleStruct
+    ) && variant.data.fields.len() == 1
 }
 
 /// Write indentation for pretty printing

--- a/facet-macros-impl/src/process_enum.rs
+++ b/facet-macros-impl/src/process_enum.rs
@@ -474,7 +474,7 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                                 )
                             })
                             .collect();
-                        let kind = quote! { 𝟋Sk::Tuple };
+                        let kind = quote! { 𝟋Sk::TupleStruct };
                         let variant = gen_variant(
                             &name_token,
                             &discriminant_ts,
@@ -683,7 +683,7 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                                 )
                             })
                             .collect();
-                        let kind = quote! { 𝟋Sk::Tuple };
+                        let kind = quote! { 𝟋Sk::TupleStruct };
                         let variant = gen_variant(
                             &name_token,
                             &discriminant_ts,


### PR DESCRIPTION
- Fix StructKind for enum tuple variants: use TupleStruct instead of Tuple in derive macro for correct newtype variant classification
- Add three-way dispatch in FormatDeserializer:
  - deserialize_struct_simple: no flatten fields
  - deserialize_struct_single_flatten: simple Option<T> flatten
  - deserialize_struct_with_flatten: solver-based for nested/enum flatten
- Update variant_is_newtype_like() to handle both Tuple and TupleStruct
- Add format suite tests for multilevel flatten and multiple flattened enums