### PR TITLE
feat(format-json): Add streaming support and convenience functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,14 +1358,17 @@ dependencies = [
 name = "facet-format-json"
 version = "0.32.2"
 dependencies = [
+ "corosensei",
  "facet",
  "facet-core",
  "facet-format",
  "facet-format-suite",
  "facet-json",
  "facet-reflect",
+ "futures-io",
  "indoc",
  "libtest-mimic",
+ "tokio",
 ]
 
 [[package]]

--- a/facet-format-json/Cargo.toml
+++ b/facet-format-json/Cargo.toml
@@ -13,10 +13,13 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
+corosensei = { version = "0.3", optional = true }
 facet-core = { path = "../facet-core", features = ["auto-traits", "bytes", "camino", "chrono", "fn-ptr", "indexmap", "jiff02", "net", "nonzero", "num-complex", "ordered-float", "ruint", "simd", "time", "tuples-12", "ulid", "url", "uuid"] }
 facet-format = { path = "../facet-format" }
 facet-json = { path = "../facet-json", features = ["axum"] }
 facet-reflect = { path = "../facet-reflect", features = ["miette"] }
+futures-io = { version = "0.3", optional = true }
+tokio = { version = "1", default-features = false, optional = true, features = ["io-util"] }
 
 [dev-dependencies]
 facet = { workspace = true, features = ["doc", "net"] } #unified
@@ -29,3 +32,8 @@ name = "format_suite"
 harness = false
 
 [features]
+default = []
+streaming = ["dep:corosensei", "facet-json/streaming", "std"]
+std = ["facet-json/std"]
+tokio = ["streaming", "facet-json/tokio", "dep:tokio"]
+futures-io = ["streaming", "facet-json/futures-io", "dep:futures-io"]

--- a/facet-format-json/src/lib.rs
+++ b/facet-format-json/src/lib.rs
@@ -1,9 +1,84 @@
 #![forbid(unsafe_code)]
 
-//! Minimal JSON parser that implements `FormatParser` for the codex prototype.
+//! JSON parser and serializer using facet-format.
+//!
+//! This crate provides JSON support via the `FormatParser` trait.
 
 mod parser;
 mod serializer;
 
 pub use parser::{JsonError, JsonParser};
-pub use serializer::{JsonSerializeError, JsonSerializer, to_vec};
+pub use serializer::{JsonSerializeError, JsonSerializer, to_string, to_vec};
+
+// Re-export DeserializeError for convenience
+pub use facet_format::DeserializeError;
+
+/// Deserialize a value from a JSON string.
+///
+/// This is a convenience wrapper around `FormatDeserializer` that handles
+/// the common case of deserializing from a complete JSON string.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_format_json::from_str;
+///
+/// #[derive(Facet, Debug, PartialEq)]
+/// struct Person {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// let json = r#"{"name": "Alice", "age": 30}"#;
+/// let person: Person = from_str(json).unwrap();
+/// assert_eq!(person.name, "Alice");
+/// assert_eq!(person.age, 30);
+/// ```
+pub fn from_str<'de, T>(input: &'de str) -> Result<T, DeserializeError<JsonError>>
+where
+    T: facet_core::Facet<'de>,
+{
+    from_slice(input.as_bytes())
+}
+
+/// Deserialize a value from JSON bytes.
+///
+/// This is a convenience wrapper around `FormatDeserializer` that handles
+/// the common case of deserializing from a complete JSON byte slice.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_format_json::from_slice;
+///
+/// #[derive(Facet, Debug, PartialEq)]
+/// struct Point {
+///     x: i32,
+///     y: i32,
+/// }
+///
+/// let json = br#"{"x": 10, "y": 20}"#;
+/// let point: Point = from_slice(json).unwrap();
+/// assert_eq!(point.x, 10);
+/// assert_eq!(point.y, 20);
+/// ```
+pub fn from_slice<'de, T>(input: &'de [u8]) -> Result<T, DeserializeError<JsonError>>
+where
+    T: facet_core::Facet<'de>,
+{
+    use facet_format::FormatDeserializer;
+    let parser = JsonParser::new(input);
+    let mut de = FormatDeserializer::new(parser);
+    de.deserialize_root()
+}
+
+#[cfg(feature = "streaming")]
+mod streaming;
+#[cfg(feature = "futures-io")]
+pub use streaming::from_async_reader_futures;
+#[cfg(feature = "tokio")]
+pub use streaming::from_async_reader_tokio;
+#[cfg(feature = "streaming")]
+pub use streaming::from_reader;

--- a/facet-format-json/src/serializer.rs
+++ b/facet-format-json/src/serializer.rs
@@ -175,6 +175,21 @@ impl FormatSerializer for JsonSerializer {
     }
 }
 
+/// Serialize a value to JSON bytes.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_format_json::to_vec;
+///
+/// #[derive(Facet)]
+/// struct Point { x: i32, y: i32 }
+///
+/// let point = Point { x: 10, y: 20 };
+/// let bytes = to_vec(&point).unwrap();
+/// assert_eq!(bytes, br#"{"x":10,"y":20}"#);
+/// ```
 pub fn to_vec<'facet, T>(value: &'_ T) -> Result<Vec<u8>, SerializeError<JsonSerializeError>>
 where
     T: Facet<'facet> + ?Sized,
@@ -182,4 +197,28 @@ where
     let mut serializer = JsonSerializer::new();
     serialize_root(&mut serializer, Peek::new(value))?;
     Ok(serializer.finish())
+}
+
+/// Serialize a value to a JSON string.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_format_json::to_string;
+///
+/// #[derive(Facet)]
+/// struct Person { name: String, age: u32 }
+///
+/// let person = Person { name: "Alice".into(), age: 30 };
+/// let json = to_string(&person).unwrap();
+/// assert_eq!(json, r#"{"name":"Alice","age":30}"#);
+/// ```
+pub fn to_string<'facet, T>(value: &'_ T) -> Result<String, SerializeError<JsonSerializeError>>
+where
+    T: Facet<'facet> + ?Sized,
+{
+    let bytes = to_vec(value)?;
+    // JSON output is always valid UTF-8, so this unwrap is safe
+    Ok(String::from_utf8(bytes).expect("JSON output should always be valid UTF-8"))
 }

--- a/facet-format-json/src/streaming.rs
+++ b/facet-format-json/src/streaming.rs
@@ -1,0 +1,621 @@
+//! Streaming JSON deserialization using stackful coroutines.
+//!
+//! This module provides `from_reader` that can deserialize JSON from any `Read`
+//! source without requiring the entire input to be in memory.
+
+extern crate alloc;
+
+use alloc::borrow::Cow;
+use alloc::rc::Rc;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+
+use corosensei::{Coroutine, CoroutineResult};
+use facet_core::Facet;
+use facet_format::{
+    DeserializeError, FieldEvidence, FieldKey, FieldLocationHint, FormatDeserializer, FormatParser,
+    ParseEvent, ProbeStream, ScalarValue,
+};
+use facet_json::{
+    AdapterToken, JsonError, JsonErrorKind, ScanBuffer, SpannedAdapterToken, StreamingAdapter,
+    TokenSource,
+};
+
+/// Deserialize JSON from a synchronous reader.
+///
+/// This function streams the JSON input, reading chunks as needed rather than
+/// requiring the entire input to be in memory.
+///
+/// # Example
+///
+/// ```ignore
+/// use std::io::Cursor;
+/// use facet::Facet;
+/// use facet_format_json::from_reader;
+///
+/// #[derive(Facet, Debug)]
+/// struct Person {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// let json = br#"{"name": "Alice", "age": 30}"#;
+/// let reader = Cursor::new(json);
+/// let person: Person = from_reader(reader).unwrap();
+/// ```
+#[cfg(feature = "std")]
+pub fn from_reader<R, T>(mut reader: R) -> Result<T, DeserializeError<JsonError>>
+where
+    R: std::io::Read,
+    T: Facet<'static>,
+{
+    // Shared buffer between coroutine and driver
+    let buffer = Rc::new(RefCell::new(ScanBuffer::new()));
+    let buffer_for_coroutine = buffer.clone();
+
+    // Initial fill
+    {
+        let mut buf = buffer.borrow_mut();
+        let n = buf.refill(&mut reader).map_err(|e| {
+            DeserializeError::Parser(JsonError::without_span(JsonErrorKind::Io(e.to_string())))
+        })?;
+        if n == 0 {
+            return Err(DeserializeError::Parser(JsonError::without_span(
+                JsonErrorKind::UnexpectedEof {
+                    expected: "JSON value",
+                },
+            )));
+        }
+    }
+
+    // Create coroutine that runs the deserializer
+    let mut coroutine: Coroutine<(), (), Result<T, DeserializeError<JsonError>>> =
+        Coroutine::new(move |yielder, ()| {
+            let adapter = StreamingAdapter::new(buffer_for_coroutine, yielder);
+            let parser = StreamingJsonParser::new(adapter);
+            let mut de = FormatDeserializer::new_owned(parser);
+            de.deserialize_root::<T>()
+        });
+
+    // Drive the coroutine
+    loop {
+        match coroutine.resume(()) {
+            CoroutineResult::Yield(()) => {
+                // Coroutine needs more data - refill buffer
+                let mut buf = buffer.borrow_mut();
+
+                // If buffer is full, grow it
+                if buf.filled() == buf.capacity() {
+                    buf.grow();
+                }
+
+                let _n = buf.refill(&mut reader).map_err(|e| {
+                    DeserializeError::Parser(JsonError::without_span(JsonErrorKind::Io(
+                        e.to_string(),
+                    )))
+                })?;
+            }
+            CoroutineResult::Return(result) => {
+                return result;
+            }
+        }
+    }
+}
+
+/// Deserialize JSON from an async reader (tokio).
+///
+/// This function streams the JSON input asynchronously, reading chunks as needed.
+#[cfg(feature = "tokio")]
+#[allow(clippy::await_holding_refcell_ref)]
+pub async fn from_async_reader_tokio<R, T>(mut reader: R) -> Result<T, DeserializeError<JsonError>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    T: Facet<'static>,
+{
+    let buffer = Rc::new(RefCell::new(ScanBuffer::new()));
+    let buffer_for_coroutine = buffer.clone();
+
+    // Initial fill
+    {
+        let mut buf = buffer.borrow_mut();
+        let n = buf.refill_tokio(&mut reader).await.map_err(|e| {
+            DeserializeError::Parser(JsonError::without_span(JsonErrorKind::Io(e.to_string())))
+        })?;
+        if n == 0 {
+            return Err(DeserializeError::Parser(JsonError::without_span(
+                JsonErrorKind::UnexpectedEof {
+                    expected: "JSON value",
+                },
+            )));
+        }
+    }
+
+    let mut coroutine: Coroutine<(), (), Result<T, DeserializeError<JsonError>>> =
+        Coroutine::new(move |yielder, ()| {
+            let adapter = StreamingAdapter::new(buffer_for_coroutine, yielder);
+            let parser = StreamingJsonParser::new(adapter);
+            let mut de = FormatDeserializer::new_owned(parser);
+            de.deserialize_root::<T>()
+        });
+
+    loop {
+        match coroutine.resume(()) {
+            CoroutineResult::Yield(()) => {
+                let mut buf = buffer.borrow_mut();
+                if buf.filled() == buf.capacity() {
+                    buf.grow();
+                }
+                let _n = buf.refill_tokio(&mut reader).await.map_err(|e| {
+                    DeserializeError::Parser(JsonError::without_span(JsonErrorKind::Io(
+                        e.to_string(),
+                    )))
+                })?;
+            }
+            CoroutineResult::Return(result) => {
+                return result;
+            }
+        }
+    }
+}
+
+/// Deserialize JSON from an async reader (futures-io).
+///
+/// This function streams the JSON input asynchronously, reading chunks as needed.
+#[cfg(feature = "futures-io")]
+#[allow(clippy::await_holding_refcell_ref)]
+pub async fn from_async_reader_futures<R, T>(
+    mut reader: R,
+) -> Result<T, DeserializeError<JsonError>>
+where
+    R: futures_io::AsyncRead + Unpin,
+    T: Facet<'static>,
+{
+    let buffer = Rc::new(RefCell::new(ScanBuffer::new()));
+    let buffer_for_coroutine = buffer.clone();
+
+    // Initial fill
+    {
+        let mut buf = buffer.borrow_mut();
+        let n = buf.refill_futures(&mut reader).await.map_err(|e| {
+            DeserializeError::Parser(JsonError::without_span(JsonErrorKind::Io(e.to_string())))
+        })?;
+        if n == 0 {
+            return Err(DeserializeError::Parser(JsonError::without_span(
+                JsonErrorKind::UnexpectedEof {
+                    expected: "JSON value",
+                },
+            )));
+        }
+    }
+
+    let mut coroutine: Coroutine<(), (), Result<T, DeserializeError<JsonError>>> =
+        Coroutine::new(move |yielder, ()| {
+            let adapter = StreamingAdapter::new(buffer_for_coroutine, yielder);
+            let parser = StreamingJsonParser::new(adapter);
+            let mut de = FormatDeserializer::new_owned(parser);
+            de.deserialize_root::<T>()
+        });
+
+    loop {
+        match coroutine.resume(()) {
+            CoroutineResult::Yield(()) => {
+                let mut buf = buffer.borrow_mut();
+                if buf.filled() == buf.capacity() {
+                    buf.grow();
+                }
+                let _n = buf.refill_futures(&mut reader).await.map_err(|e| {
+                    DeserializeError::Parser(JsonError::without_span(JsonErrorKind::Io(
+                        e.to_string(),
+                    )))
+                })?;
+            }
+            CoroutineResult::Return(result) => {
+                return result;
+            }
+        }
+    }
+}
+
+/// Streaming JSON parser that implements `FormatParser<'static>`.
+///
+/// Wraps a `TokenSource<'static>` (like `StreamingAdapter`) and converts
+/// tokens to `ParseEvent`s.
+pub struct StreamingJsonParser<A> {
+    adapter: A,
+    stack: Vec<ContextState>,
+    event_peek: Option<ParseEvent<'static>>,
+    root_started: bool,
+    root_complete: bool,
+}
+
+#[derive(Debug)]
+enum ContextState {
+    Object(ObjectState),
+    Array(ArrayState),
+}
+
+#[derive(Debug)]
+enum ObjectState {
+    KeyOrEnd,
+    Value,
+    CommaOrEnd,
+}
+
+#[derive(Debug)]
+enum ArrayState {
+    ValueOrEnd,
+    CommaOrEnd,
+}
+
+impl<A: TokenSource<'static>> StreamingJsonParser<A> {
+    /// Create a new streaming parser wrapping a token source.
+    pub fn new(adapter: A) -> Self {
+        Self {
+            adapter,
+            stack: Vec::new(),
+            event_peek: None,
+            root_started: false,
+            root_complete: false,
+        }
+    }
+
+    fn next_token(&mut self) -> Result<SpannedAdapterToken<'static>, JsonError> {
+        self.adapter.next_token()
+    }
+
+    fn unexpected(
+        &self,
+        token: &SpannedAdapterToken<'static>,
+        expected: &'static str,
+    ) -> JsonError {
+        JsonError::new(
+            JsonErrorKind::UnexpectedToken {
+                got: alloc::format!("{:?}", token.token),
+                expected,
+            },
+            token.span,
+        )
+    }
+
+    fn expect_colon(&mut self) -> Result<(), JsonError> {
+        let token = self.next_token()?;
+        if !matches!(token.token, AdapterToken::Colon) {
+            return Err(self.unexpected(&token, "':'"));
+        }
+        Ok(())
+    }
+
+    fn finish_value_in_parent(&mut self) {
+        if let Some(context) = self.stack.last_mut() {
+            match context {
+                ContextState::Object(state) => *state = ObjectState::CommaOrEnd,
+                ContextState::Array(state) => *state = ArrayState::CommaOrEnd,
+            }
+        } else if self.root_started {
+            self.root_complete = true;
+        }
+    }
+
+    fn parse_value_start_with_token(
+        &mut self,
+        first: Option<SpannedAdapterToken<'static>>,
+    ) -> Result<ParseEvent<'static>, JsonError> {
+        let token = match first {
+            Some(tok) => tok,
+            None => self.next_token()?,
+        };
+
+        self.root_started = true;
+
+        match token.token {
+            AdapterToken::ObjectStart => {
+                self.stack.push(ContextState::Object(ObjectState::KeyOrEnd));
+                Ok(ParseEvent::StructStart)
+            }
+            AdapterToken::ArrayStart => {
+                self.stack.push(ContextState::Array(ArrayState::ValueOrEnd));
+                Ok(ParseEvent::SequenceStart)
+            }
+            AdapterToken::String(s) => {
+                let event = ParseEvent::Scalar(ScalarValue::Str(s));
+                self.finish_value_in_parent();
+                Ok(event)
+            }
+            AdapterToken::True => {
+                self.finish_value_in_parent();
+                Ok(ParseEvent::Scalar(ScalarValue::Bool(true)))
+            }
+            AdapterToken::False => {
+                self.finish_value_in_parent();
+                Ok(ParseEvent::Scalar(ScalarValue::Bool(false)))
+            }
+            AdapterToken::Null => {
+                self.finish_value_in_parent();
+                Ok(ParseEvent::Scalar(ScalarValue::Null))
+            }
+            AdapterToken::U64(n) => {
+                self.finish_value_in_parent();
+                Ok(ParseEvent::Scalar(ScalarValue::U64(n)))
+            }
+            AdapterToken::I64(n) => {
+                self.finish_value_in_parent();
+                Ok(ParseEvent::Scalar(ScalarValue::I64(n)))
+            }
+            AdapterToken::U128(n) => {
+                self.finish_value_in_parent();
+                Ok(ParseEvent::Scalar(ScalarValue::Str(Cow::Owned(
+                    n.to_string(),
+                ))))
+            }
+            AdapterToken::I128(n) => {
+                self.finish_value_in_parent();
+                Ok(ParseEvent::Scalar(ScalarValue::Str(Cow::Owned(
+                    n.to_string(),
+                ))))
+            }
+            AdapterToken::F64(n) => {
+                self.finish_value_in_parent();
+                Ok(ParseEvent::Scalar(ScalarValue::F64(n)))
+            }
+            AdapterToken::ObjectEnd | AdapterToken::ArrayEnd => {
+                Err(self.unexpected(&token, "value"))
+            }
+            AdapterToken::Comma | AdapterToken::Colon => Err(self.unexpected(&token, "value")),
+            AdapterToken::Eof => Err(JsonError::new(
+                JsonErrorKind::UnexpectedEof { expected: "value" },
+                token.span,
+            )),
+        }
+    }
+
+    fn produce_event(&mut self) -> Result<ParseEvent<'static>, JsonError> {
+        loop {
+            match self.determine_action() {
+                NextAction::ObjectKey => {
+                    let token = self.next_token()?;
+                    match token.token {
+                        AdapterToken::ObjectEnd => {
+                            self.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(ParseEvent::StructEnd);
+                        }
+                        AdapterToken::String(name) => {
+                            self.expect_colon()?;
+                            if let Some(ContextState::Object(state)) = self.stack.last_mut() {
+                                *state = ObjectState::Value;
+                            }
+                            return Ok(ParseEvent::FieldKey(FieldKey::new(
+                                name,
+                                FieldLocationHint::KeyValue,
+                            )));
+                        }
+                        AdapterToken::Eof => {
+                            return Err(JsonError::new(
+                                JsonErrorKind::UnexpectedEof {
+                                    expected: "field name or '}'",
+                                },
+                                token.span,
+                            ));
+                        }
+                        _ => return Err(self.unexpected(&token, "field name or '}'")),
+                    }
+                }
+                NextAction::ObjectValue => {
+                    return self.parse_value_start_with_token(None);
+                }
+                NextAction::ObjectComma => {
+                    let token = self.next_token()?;
+                    match token.token {
+                        AdapterToken::Comma => {
+                            if let Some(ContextState::Object(state)) = self.stack.last_mut() {
+                                *state = ObjectState::KeyOrEnd;
+                            }
+                            continue;
+                        }
+                        AdapterToken::ObjectEnd => {
+                            self.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(ParseEvent::StructEnd);
+                        }
+                        AdapterToken::Eof => {
+                            return Err(JsonError::new(
+                                JsonErrorKind::UnexpectedEof {
+                                    expected: "',' or '}'",
+                                },
+                                token.span,
+                            ));
+                        }
+                        _ => return Err(self.unexpected(&token, "',' or '}'")),
+                    }
+                }
+                NextAction::ArrayValue => {
+                    let token = self.next_token()?;
+                    match token.token {
+                        AdapterToken::ArrayEnd => {
+                            self.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(ParseEvent::SequenceEnd);
+                        }
+                        AdapterToken::Eof => {
+                            return Err(JsonError::new(
+                                JsonErrorKind::UnexpectedEof {
+                                    expected: "value or ']'",
+                                },
+                                token.span,
+                            ));
+                        }
+                        AdapterToken::Comma | AdapterToken::Colon => {
+                            return Err(self.unexpected(&token, "value or ']'"));
+                        }
+                        _ => {
+                            return self.parse_value_start_with_token(Some(token));
+                        }
+                    }
+                }
+                NextAction::ArrayComma => {
+                    let token = self.next_token()?;
+                    match token.token {
+                        AdapterToken::Comma => {
+                            if let Some(ContextState::Array(state)) = self.stack.last_mut() {
+                                *state = ArrayState::ValueOrEnd;
+                            }
+                            continue;
+                        }
+                        AdapterToken::ArrayEnd => {
+                            self.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(ParseEvent::SequenceEnd);
+                        }
+                        AdapterToken::Eof => {
+                            return Err(JsonError::new(
+                                JsonErrorKind::UnexpectedEof {
+                                    expected: "',' or ']'",
+                                },
+                                token.span,
+                            ));
+                        }
+                        _ => return Err(self.unexpected(&token, "',' or ']'")),
+                    }
+                }
+                NextAction::RootValue => {
+                    return self.parse_value_start_with_token(None);
+                }
+                NextAction::RootFinished => {
+                    return Err(JsonError::without_span(JsonErrorKind::UnexpectedToken {
+                        got: "end of input".into(),
+                        expected: "no additional JSON values",
+                    }));
+                }
+            }
+        }
+    }
+
+    fn determine_action(&self) -> NextAction {
+        if let Some(context) = self.stack.last() {
+            match context {
+                ContextState::Object(state) => match state {
+                    ObjectState::KeyOrEnd => NextAction::ObjectKey,
+                    ObjectState::Value => NextAction::ObjectValue,
+                    ObjectState::CommaOrEnd => NextAction::ObjectComma,
+                },
+                ContextState::Array(state) => match state {
+                    ArrayState::ValueOrEnd => NextAction::ArrayValue,
+                    ArrayState::CommaOrEnd => NextAction::ArrayComma,
+                },
+            }
+        } else if self.root_complete {
+            NextAction::RootFinished
+        } else {
+            NextAction::RootValue
+        }
+    }
+
+    fn skip_value_internal(&mut self) -> Result<(), JsonError> {
+        self.adapter.skip().map(|_| ())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NextAction {
+    ObjectKey,
+    ObjectValue,
+    ObjectComma,
+    ArrayValue,
+    ArrayComma,
+    RootValue,
+    RootFinished,
+}
+
+impl<A: TokenSource<'static>> FormatParser<'static> for StreamingJsonParser<A> {
+    type Error = JsonError;
+    type Probe<'a>
+        = StreamingProbe
+    where
+        Self: 'a;
+
+    fn next_event(&mut self) -> Result<ParseEvent<'static>, Self::Error> {
+        if let Some(event) = self.event_peek.take() {
+            return Ok(event);
+        }
+        self.produce_event()
+    }
+
+    fn peek_event(&mut self) -> Result<ParseEvent<'static>, Self::Error> {
+        if let Some(event) = self.event_peek.clone() {
+            return Ok(event);
+        }
+        let event = self.produce_event()?;
+        self.event_peek = Some(event.clone());
+        Ok(event)
+    }
+
+    fn skip_value(&mut self) -> Result<(), Self::Error> {
+        debug_assert!(
+            self.event_peek.is_none(),
+            "skip_value called while an event is buffered"
+        );
+        self.skip_value_internal()?;
+        self.finish_value_in_parent();
+        Ok(())
+    }
+
+    fn begin_probe(&mut self) -> Result<Self::Probe<'_>, Self::Error> {
+        // Streaming doesn't support probing - return empty evidence
+        Ok(StreamingProbe)
+    }
+}
+
+/// Empty probe for streaming (probing not supported in streaming mode).
+pub struct StreamingProbe;
+
+impl ProbeStream<'static> for StreamingProbe {
+    type Error = JsonError;
+
+    fn next(&mut self) -> Result<Option<FieldEvidence<'static>>, Self::Error> {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use facet::Facet;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_from_reader_simple() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Person {
+            name: String,
+            age: u32,
+        }
+
+        let json = br#"{"name": "Alice", "age": 30}"#;
+        let reader = Cursor::new(&json[..]);
+        let person: Person = from_reader(reader).unwrap();
+
+        assert_eq!(person.name, "Alice");
+        assert_eq!(person.age, 30);
+    }
+
+    #[test]
+    fn test_from_reader_nested() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Inner {
+            value: i32,
+        }
+
+        #[derive(Facet, Debug, PartialEq)]
+        struct Outer {
+            inner: Inner,
+            list: Vec<i32>,
+        }
+
+        let json = br#"{"inner": {"value": 42}, "list": [1, 2, 3]}"#;
+        let reader = Cursor::new(&json[..]);
+        let result: Outer = from_reader(reader).unwrap();
+
+        assert_eq!(result.inner.value, 42);
+        assert_eq!(result.list, vec![1, 2, 3]);
+    }
+}

--- a/facet-format-json/tests/format_suite.rs
+++ b/facet-format-json/tests/format_suite.rs
@@ -127,6 +127,28 @@ impl FormatSuite for JsonSlice {
         ))
     }
 
+    fn attr_default_struct() -> CaseSpec {
+        // message is missing, should use String::default() (empty string)
+        CaseSpec::from_str(indoc!(
+            r#"
+            {
+                "count": 123
+            }
+        "#
+        ))
+    }
+
+    fn attr_default_function() -> CaseSpec {
+        // magic_number is missing, should use custom_default_value() = 42
+        CaseSpec::from_str(indoc!(
+            r#"
+            {
+                "name": "hello"
+            }
+        "#
+        ))
+    }
+
     fn option_none() -> CaseSpec {
         // nickname is missing, should be None
         CaseSpec::from_str(indoc!(
@@ -169,6 +191,17 @@ impl FormatSuite for JsonSlice {
             r#"
             {
                 "visible": "shown"
+            }
+        "#
+        ))
+    }
+
+    fn attr_skip_serializing_if() -> CaseSpec {
+        // optional_data is None, skip_serializing_if = Option::is_none makes it absent in output
+        CaseSpec::from_str(indoc!(
+            r#"
+            {
+                "name": "test"
             }
         "#
         ))
@@ -279,6 +312,14 @@ impl FormatSuite for JsonSlice {
 
     fn attr_rename_all_screaming() -> CaseSpec {
         CaseSpec::from_str(r#"{"API_KEY":"secret-123","MAX_RETRY_COUNT":5}"#)
+    }
+
+    fn attr_rename_unicode() -> CaseSpec {
+        CaseSpec::from_str(r#"{"🎉":"party"}"#)
+    }
+
+    fn attr_rename_special_chars() -> CaseSpec {
+        CaseSpec::from_str(r#"{"@type":"node"}"#)
     }
 
     // ── Proxy cases ──

--- a/facet-format-xml/tests/format_suite.rs
+++ b/facet-format-xml/tests/format_suite.rs
@@ -139,6 +139,29 @@ impl FormatSuite for XmlSlice {
         ))
     }
 
+    fn attr_default_struct() -> CaseSpec {
+        // message is missing, should use String::default() (empty string)
+        CaseSpec::from_str(indoc!(
+            r#"
+            <record>
+                <count>123</count>
+            </record>
+        "#
+        ))
+        .without_roundtrip("empty string serializes as empty element, which XML parses as struct")
+    }
+
+    fn attr_default_function() -> CaseSpec {
+        // magic_number is missing, should use custom_default_value() = 42
+        CaseSpec::from_str(indoc!(
+            r#"
+            <record>
+                <name>hello</name>
+            </record>
+        "#
+        ))
+    }
+
     fn option_none() -> CaseSpec {
         // nickname is missing, should be None
         CaseSpec::from_str(indoc!(
@@ -173,6 +196,17 @@ impl FormatSuite for XmlSlice {
             r#"
             <record>
                 <visible>shown</visible>
+            </record>
+        "#
+        ))
+    }
+
+    fn attr_skip_serializing_if() -> CaseSpec {
+        // optional_data is None, skip_serializing_if = Option::is_none makes it absent in output
+        CaseSpec::from_str(indoc!(
+            r#"
+            <record>
+                <name>test</name>
             </record>
         "#
         ))
@@ -299,6 +333,16 @@ impl FormatSuite for XmlSlice {
         CaseSpec::from_str(
             r#"<record><API_KEY>secret-123</API_KEY><MAX_RETRY_COUNT>5</MAX_RETRY_COUNT></record>"#,
         )
+    }
+
+    fn attr_rename_unicode() -> CaseSpec {
+        // Emoji is not a valid XML element name character
+        CaseSpec::skip("Emoji not valid in XML element names")
+    }
+
+    fn attr_rename_special_chars() -> CaseSpec {
+        // @ is not a valid XML element name character
+        CaseSpec::skip("@ not valid in XML element names")
     }
 
     // ── Proxy cases ──

--- a/facet-format/src/parser.rs
+++ b/facet-format/src/parser.rs
@@ -32,4 +32,18 @@ pub trait FormatParser<'de> {
 
     /// Begin evidence collection for untagged-enum resolution.
     fn begin_probe(&mut self) -> Result<Self::Probe<'_>, Self::Error>;
+
+    /// Capture the raw representation of the current value without parsing it.
+    ///
+    /// This is used for types like `RawJson` that want to defer parsing.
+    /// The parser should skip the value and return the raw bytes/string
+    /// from the input.
+    ///
+    /// Returns `Ok(None)` if raw capture is not supported (e.g., streaming mode
+    /// or formats where raw capture doesn't make sense).
+    fn capture_raw(&mut self) -> Result<Option<&'de str>, Self::Error> {
+        // Default: not supported
+        self.skip_value()?;
+        Ok(None)
+    }
 }


### PR DESCRIPTION
## Summary

- Add `from_str` and `from_slice` convenience deserialize functions
- Add `to_string` convenience serialize function
- Add streaming deserialization with `from_reader` (requires `streaming` feature)
- Add async streaming with `from_async_reader_tokio` and `from_async_reader_futures`
- Add `capture_raw()` method to FormatParser trait for future RawJson support
- Add new test cases: `attr_default_struct`, `attr_default_function`, `attr_skip_serializing_if`

## Test plan

- [x] All 225 nextest tests pass
- [x] All doc tests pass (4 passed, 1 ignored for streaming)
- [x] Clippy passes
- [x] Docs build