### PR TITLE
feat(format): Add ContainerKind for better type mismatch errors

### DIFF
--- a/facet-format-json/src/parser.rs
+++ b/facet-format-json/src/parser.rs
@@ -3,7 +3,8 @@ extern crate alloc;
 use alloc::{borrow::Cow, vec::Vec};
 
 use facet_format::{
-    FieldEvidence, FieldKey, FieldLocationHint, FormatParser, ParseEvent, ProbeStream, ScalarValue,
+    ContainerKind, FieldEvidence, FieldKey, FieldLocationHint, FormatParser, ParseEvent,
+    ProbeStream, ScalarValue,
 };
 pub use facet_json::JsonError;
 use facet_json::{AdapterToken, JsonErrorKind, SliceAdapter, SpannedAdapterToken};
@@ -100,11 +101,11 @@ impl<'de> JsonParser<'de> {
         match token.token {
             AdapterToken::ObjectStart => {
                 self.stack.push(ContextState::Object(ObjectState::KeyOrEnd));
-                Ok(ParseEvent::StructStart)
+                Ok(ParseEvent::StructStart(ContainerKind::Object))
             }
             AdapterToken::ArrayStart => {
                 self.stack.push(ContextState::Array(ArrayState::ValueOrEnd));
-                Ok(ParseEvent::SequenceStart)
+                Ok(ParseEvent::SequenceStart(ContainerKind::Array))
             }
             AdapterToken::String(s) => {
                 let event = ParseEvent::Scalar(ScalarValue::Str(s));

--- a/facet-format-json/src/streaming.rs
+++ b/facet-format-json/src/streaming.rs
@@ -13,8 +13,8 @@ use core::cell::RefCell;
 use corosensei::{Coroutine, CoroutineResult};
 use facet_core::Facet;
 use facet_format::{
-    DeserializeError, FieldEvidence, FieldKey, FieldLocationHint, FormatDeserializer, FormatParser,
-    ParseEvent, ProbeStream, ScalarValue,
+    ContainerKind, DeserializeError, FieldEvidence, FieldKey, FieldLocationHint,
+    FormatDeserializer, FormatParser, ParseEvent, ProbeStream, ScalarValue,
 };
 use facet_json::{
     AdapterToken, JsonError, JsonErrorKind, ScanBuffer, SpannedAdapterToken, StreamingAdapter,
@@ -310,11 +310,11 @@ impl<A: TokenSource<'static>> StreamingJsonParser<A> {
         match token.token {
             AdapterToken::ObjectStart => {
                 self.stack.push(ContextState::Object(ObjectState::KeyOrEnd));
-                Ok(ParseEvent::StructStart)
+                Ok(ParseEvent::StructStart(ContainerKind::Object))
             }
             AdapterToken::ArrayStart => {
                 self.stack.push(ContextState::Array(ArrayState::ValueOrEnd));
-                Ok(ParseEvent::SequenceStart)
+                Ok(ParseEvent::SequenceStart(ContainerKind::Array))
             }
             AdapterToken::String(s) => {
                 let event = ParseEvent::Scalar(ScalarValue::Str(s));

--- a/facet-format-xml/tests/format_suite.rs
+++ b/facet-format-xml/tests/format_suite.rs
@@ -312,10 +312,12 @@ impl FormatSuite for XmlSlice {
 
     fn error_type_mismatch_object_to_array() -> CaseSpec {
         // Object (nested struct) provided where array expected
-        // Skip: XML elements are semantically ambiguous (could be struct or sequence),
-        // so we can't give a "type mismatch: expected array, got object" error.
-        // See: https://github.com/facet-rs/facet/issues/1301 for improved ParseEvent types
-        CaseSpec::skip("XML elements are ambiguous - error messages need ParseEvent enrichment")
+        // Skip: XML elements are semantically ambiguous (ContainerKind::Element),
+        // so they're accepted as potential sequences. JSON gives "type mismatch"
+        // errors because it uses unambiguous ContainerKind::Object.
+        CaseSpec::skip(
+            "XML elements are ambiguous (ContainerKind::Element) - no type mismatch possible",
+        )
     }
 
     fn error_missing_required_field() -> CaseSpec {

--- a/facet-format/src/lib.rs
+++ b/facet-format/src/lib.rs
@@ -12,7 +12,9 @@ mod solver;
 mod visitor;
 
 pub use deserializer::{DeserializeError, FormatDeserializer};
-pub use event::{FieldKey, FieldLocationHint, ParseEvent, ScalarValue, ValueTypeHint};
+pub use event::{
+    ContainerKind, FieldKey, FieldLocationHint, ParseEvent, ScalarValue, ValueTypeHint,
+};
 pub use evidence::FieldEvidence;
 pub use parser::{FormatParser, ProbeStream};
 pub use serializer::{FieldOrdering, FormatSerializer, SerializeError, serialize_root};

--- a/facet-format/src/parser.rs
+++ b/facet-format/src/parser.rs
@@ -46,17 +46,4 @@ pub trait FormatParser<'de> {
         self.skip_value()?;
         Ok(None)
     }
-
-    /// Whether this format treats struct-like containers as potentially being sequences.
-    ///
-    /// XML elements are semantically ambiguous - `<items><item>1</item></items>` could be
-    /// a struct with one field or a sequence of items. The deserializer uses the target
-    /// type to decide. For XML, this returns `true` so `StructStart` is accepted when
-    /// deserializing sequences.
-    ///
-    /// JSON objects are unambiguous - `{}` is always struct-like, `[]` is always a sequence.
-    /// For JSON-like formats, this returns `false` (the default).
-    fn elements_as_sequences(&self) -> bool {
-        false
-    }
 }


### PR DESCRIPTION
## Summary

Closes #1301

Adds `ContainerKind` to `ParseEvent::StructStart` and `ParseEvent::SequenceStart` to distinguish between format-specific container types:

- **`Object`**: JSON objects (unambiguous struct-like)
- **`Array`**: JSON arrays (unambiguous sequence-like)  
- **`Element`**: XML elements (ambiguous, could be struct or sequence)

## Benefits

- JSON now gives clear "type mismatch: expected array, got object" errors instead of confusing "Failed to parse string value" errors
- XML elements are still accepted as sequences when target type expects one (since XML elements are semantically ambiguous)
- Removes `elements_as_sequences()` method from `FormatParser` trait in favor of checking `ContainerKind::is_ambiguous()` directly

## Test Results

- JSON: 225 tests passed (including error message tests)
- XML: 225 tests passed, type mismatch test appropriately skipped (XML elements use `ContainerKind::Element` which is ambiguous)

## Example

Before (JSON object to Vec<i32>):
```
reflection error: Operation failed on shape i32: Failed to parse string value
```

After:
```
type mismatch: expected array, got object
```