### PR TITLE
feat(format-json): Add peek_to_string serialization functions

### DIFF
--- a/facet-format-json/src/lib.rs
+++ b/facet-format-json/src/lib.rs
@@ -9,8 +9,9 @@ mod serializer;
 
 pub use parser::{JsonError, JsonParser};
 pub use serializer::{
-    JsonSerializeError, JsonSerializer, SerializeOptions, to_string, to_string_pretty,
-    to_string_with_options, to_vec, to_vec_pretty, to_vec_with_options,
+    JsonSerializeError, JsonSerializer, SerializeOptions, peek_to_string, peek_to_string_pretty,
+    peek_to_string_with_options, to_string, to_string_pretty, to_string_with_options, to_vec,
+    to_vec_pretty, to_vec_with_options,
 };
 
 // Re-export DeserializeError for convenience


### PR DESCRIPTION
## Summary

- Add `peek_to_string`: serialize `Peek` to compact JSON string
- Add `peek_to_string_pretty`: serialize `Peek` to pretty-printed JSON  
- Add `peek_to_string_with_options`: serialize `Peek` with custom `SerializeOptions`

These are useful when you already have a `Peek` from reflection operations and want to serialize without going through `&T`.

## Test plan

- [x] Doc tests pass for all three new functions
- [x] Pre-push hooks pass (clippy, nextest, doc tests, docs build)