### PR TITLE
feat(format-json): Make facet-format-json self-contained

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,11 +1363,13 @@ dependencies = [
  "facet-core",
  "facet-format",
  "facet-format-suite",
- "facet-json",
  "facet-reflect",
  "futures-io",
  "indoc",
+ "lexical-parse-float",
+ "lexical-parse-integer",
  "libtest-mimic",
+ "miette",
  "tokio",
 ]
 

--- a/facet-format-json/Cargo.toml
+++ b/facet-format-json/Cargo.toml
@@ -16,9 +16,11 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 corosensei = { version = "0.3", optional = true }
 facet-core = { path = "../facet-core", features = ["auto-traits", "bytes", "camino", "chrono", "fn-ptr", "indexmap", "jiff02", "net", "nonzero", "num-complex", "ordered-float", "ruint", "simd", "time", "tuples-12", "ulid", "url", "uuid"] }
 facet-format = { path = "../facet-format" }
-facet-json = { path = "../facet-json", features = ["axum"] }
 facet-reflect = { path = "../facet-reflect", features = ["miette"] }
 futures-io = { version = "0.3", optional = true }
+lexical-parse-float = { version = "1.0.5", optional = true }
+lexical-parse-integer = { version = "1.0.5", optional = true }
+miette = { workspace = true }
 tokio = { version = "1", default-features = false, optional = true, features = ["io-util"] }
 
 [dev-dependencies]
@@ -34,7 +36,9 @@ harness = false
 
 [features]
 default = []
-streaming = ["dep:corosensei", "facet-json/streaming", "std"]
-std = ["facet-json/std"]
-tokio = ["streaming", "facet-json/tokio", "dep:tokio"]
-futures-io = ["streaming", "facet-json/futures-io", "dep:futures-io"]
+fast = ["lexical-parse"]
+lexical-parse = ["dep:lexical-parse-float", "dep:lexical-parse-integer"]
+streaming = ["dep:corosensei", "std"]
+std = []
+tokio = ["streaming", "dep:tokio"]
+futures-io = ["streaming", "dep:futures-io"]

--- a/facet-format-json/src/adapter.rs
+++ b/facet-format-json/src/adapter.rs
@@ -1,0 +1,858 @@
+//! Token adapter that bridges Scanner to the deserializer.
+//!
+//! The adapter provides two methods:
+//! - `next_token()` - returns decoded token content
+//! - `skip()` - skips a value without allocation, returns span
+//!
+//! This design allows the deserializer to avoid allocations when:
+//! - Skipping unknown fields
+//! - Capturing RawJson (just need span)
+
+use alloc::borrow::Cow;
+
+use facet_reflect::Span;
+
+use crate::scanner::{self, ParsedNumber, ScanError, ScanErrorKind, Scanner, Token as ScanToken};
+
+/// Token with decoded content, ready for deserialization.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Token<'input> {
+    /// `{`
+    ObjectStart,
+    /// `}`
+    ObjectEnd,
+    /// `[`
+    ArrayStart,
+    /// `]`
+    ArrayEnd,
+    /// `:`
+    Colon,
+    /// `,`
+    Comma,
+    /// `null`
+    Null,
+    /// `true`
+    True,
+    /// `false`
+    False,
+    /// String value (decoded)
+    String(Cow<'input, str>),
+    /// Unsigned 64-bit integer
+    U64(u64),
+    /// Signed 64-bit integer
+    I64(i64),
+    /// Unsigned 128-bit integer
+    U128(u128),
+    /// Signed 128-bit integer
+    I128(i128),
+    /// 64-bit float
+    F64(f64),
+    /// End of input
+    Eof,
+}
+
+/// Spanned token with location information.
+#[derive(Debug, Clone)]
+pub struct SpannedAdapterToken<'input> {
+    /// The token
+    pub token: Token<'input>,
+    /// Source span
+    pub span: Span,
+}
+
+/// Adapter error (wraps scanner errors).
+#[derive(Debug, Clone)]
+pub struct AdapterError {
+    /// The error kind
+    pub kind: AdapterErrorKind,
+    /// Source span
+    pub span: Span,
+}
+
+/// Types of adapter errors.
+#[derive(Debug, Clone)]
+pub enum AdapterErrorKind {
+    /// Scanner error
+    Scan(ScanErrorKind),
+    /// Need more data (for streaming)
+    NeedMore,
+}
+
+impl From<ScanError> for AdapterError {
+    fn from(e: ScanError) -> Self {
+        AdapterError {
+            kind: AdapterErrorKind::Scan(e.kind),
+            span: e.span,
+        }
+    }
+}
+
+/// Default chunk size for windowed scanning (small for testing boundary conditions)
+pub const DEFAULT_CHUNK_SIZE: usize = 4;
+
+/// Token adapter for slice-based parsing with fixed-size windowing.
+///
+/// Uses a sliding window approach:
+/// - Scanner sees only `chunk_size` bytes at a time
+/// - On `NeedMore`, window grows (extends end) to include more bytes
+/// - On token complete, window slides (moves start) past consumed bytes
+/// - No data is copied - window is just a view into the original slice
+///
+/// The const generic `BORROW` controls string handling:
+/// - `BORROW=true`: strings without escapes are borrowed (`Cow::Borrowed`)
+/// - `BORROW=false`: all strings are owned (`Cow::Owned`)
+pub struct SliceAdapter<'input, const BORROW: bool> {
+    /// Full original input (for borrowing strings)
+    input: &'input [u8],
+    /// Start of current window in input
+    window_start: usize,
+    /// End of current window in input
+    window_end: usize,
+    /// Chunk size for window growth
+    chunk_size: usize,
+    /// The scanner
+    scanner: Scanner,
+}
+
+impl<'input, const BORROW: bool> SliceAdapter<'input, BORROW> {
+    /// Create a new adapter with the default chunk size (4 bytes).
+    pub fn new(input: &'input [u8]) -> Self {
+        Self::with_chunk_size(input, DEFAULT_CHUNK_SIZE)
+    }
+
+    /// Create a new adapter with a custom chunk size.
+    pub fn with_chunk_size(input: &'input [u8], chunk_size: usize) -> Self {
+        let initial_end = chunk_size.min(input.len());
+        Self {
+            input,
+            window_start: 0,
+            window_end: initial_end,
+            chunk_size,
+            scanner: Scanner::new(),
+        }
+    }
+
+    /// Get the current window into the input.
+    #[inline]
+    fn current_window(&self) -> &'input [u8] {
+        &self.input[self.window_start..self.window_end]
+    }
+
+    /// Grow the window by one chunk (or to end of input).
+    #[inline]
+    fn grow_window(&mut self) {
+        self.window_end = (self.window_end + self.chunk_size).min(self.input.len());
+    }
+
+    /// Slide the window forward past consumed bytes, reset scanner.
+    #[inline]
+    fn slide_window(&mut self, consumed_in_window: usize) {
+        self.window_start += consumed_in_window;
+        self.window_end = (self.window_start + self.chunk_size).min(self.input.len());
+        self.scanner.set_pos(0);
+    }
+
+    /// Check if we've reached the end of input.
+    #[inline]
+    fn at_end_of_input(&self) -> bool {
+        self.window_end >= self.input.len()
+    }
+
+    /// Get the next token with decoded content.
+    ///
+    /// Strings are decoded (escapes processed) and returned as `Cow<str>`.
+    /// Numbers are parsed into appropriate numeric types.
+    ///
+    /// Uses windowed scanning: on `NeedMore`, grows the window and retries.
+    /// Spans are absolute positions in the original input.
+    pub fn next_token(&mut self) -> Result<SpannedAdapterToken<'input>, AdapterError> {
+        loop {
+            let window = self.current_window();
+            let spanned = match self.scanner.next_token(window) {
+                Ok(s) => s,
+                Err(e) => {
+                    // Translate error span to absolute position
+                    return Err(AdapterError {
+                        kind: AdapterErrorKind::Scan(e.kind),
+                        span: Span::new(self.window_start + e.span.offset, e.span.len),
+                    });
+                }
+            };
+
+            match spanned.token {
+                ScanToken::NeedMore { .. } => {
+                    // Need more data - grow window if possible
+                    if self.at_end_of_input() {
+                        // True EOF - try to finalize any pending token (e.g., number at EOF)
+                        let window = self.current_window();
+                        let finalized = match self.scanner.finalize_at_eof(window) {
+                            Ok(f) => f,
+                            Err(e) => {
+                                return Err(AdapterError {
+                                    kind: AdapterErrorKind::Scan(e.kind),
+                                    span: Span::new(self.window_start + e.span.offset, e.span.len),
+                                });
+                            }
+                        };
+
+                        // Handle the finalized token
+                        let consumed = self.scanner.pos();
+                        let absolute_span = Span::new(
+                            self.window_start + finalized.span.offset,
+                            finalized.span.len,
+                        );
+
+                        let token = self.materialize_token(&finalized)?;
+                        self.slide_window(consumed);
+
+                        return Ok(SpannedAdapterToken {
+                            token,
+                            span: absolute_span,
+                        });
+                    }
+                    self.grow_window();
+                    continue;
+                }
+                ScanToken::Eof => {
+                    // Scanner hit end of window
+                    if self.at_end_of_input() {
+                        // True EOF
+                        return Ok(SpannedAdapterToken {
+                            token: Token::Eof,
+                            span: Span::new(self.window_start + spanned.span.offset, 0),
+                        });
+                    }
+                    // End of window but more input available - slide forward
+                    self.slide_window(self.scanner.pos());
+                    continue;
+                }
+                _ => {
+                    // Complete token - materialize and return
+                    let consumed = self.scanner.pos();
+                    let absolute_span =
+                        Span::new(self.window_start + spanned.span.offset, spanned.span.len);
+
+                    let token = self.materialize_token(&spanned)?;
+
+                    // Slide window past this token for next call
+                    self.slide_window(consumed);
+
+                    return Ok(SpannedAdapterToken {
+                        token,
+                        span: absolute_span,
+                    });
+                }
+            }
+        }
+    }
+
+    /// Materialize a scanned token into a decoded token.
+    ///
+    /// Positions in `spanned` are relative to current window.
+    /// We borrow/decode from the original input slice using absolute positions.
+    fn materialize_token(
+        &self,
+        spanned: &scanner::SpannedToken,
+    ) -> Result<Token<'input>, AdapterError> {
+        match &spanned.token {
+            ScanToken::ObjectStart => Ok(Token::ObjectStart),
+            ScanToken::ObjectEnd => Ok(Token::ObjectEnd),
+            ScanToken::ArrayStart => Ok(Token::ArrayStart),
+            ScanToken::ArrayEnd => Ok(Token::ArrayEnd),
+            ScanToken::Colon => Ok(Token::Colon),
+            ScanToken::Comma => Ok(Token::Comma),
+            ScanToken::Null => Ok(Token::Null),
+            ScanToken::True => Ok(Token::True),
+            ScanToken::False => Ok(Token::False),
+            ScanToken::String {
+                start,
+                end,
+                has_escapes,
+            } => {
+                // Convert to absolute positions in original input
+                let abs_start = self.window_start + start;
+                let abs_end = self.window_start + end;
+
+                let s = if BORROW && !*has_escapes {
+                    // Borrow directly from original input (zero-copy)
+                    scanner::decode_string(self.input, abs_start, abs_end, false)?
+                } else {
+                    // Must produce owned string (has escapes or BORROW=false)
+                    Cow::Owned(scanner::decode_string_owned(
+                        self.input, abs_start, abs_end,
+                    )?)
+                };
+                Ok(Token::String(s))
+            }
+            ScanToken::Number { start, end, hint } => {
+                // Convert to absolute positions
+                let abs_start = self.window_start + start;
+                let abs_end = self.window_start + end;
+
+                let parsed = scanner::parse_number(self.input, abs_start, abs_end, *hint)?;
+                Ok(match parsed {
+                    ParsedNumber::U64(n) => Token::U64(n),
+                    ParsedNumber::I64(n) => Token::I64(n),
+                    ParsedNumber::U128(n) => Token::U128(n),
+                    ParsedNumber::I128(n) => Token::I128(n),
+                    ParsedNumber::F64(n) => Token::F64(n),
+                })
+            }
+            ScanToken::Eof | ScanToken::NeedMore { .. } => {
+                unreachable!("Eof and NeedMore handled in next_token loop")
+            }
+        }
+    }
+
+    /// Skip a JSON value without decoding.
+    ///
+    /// Returns the span of the skipped value (absolute positions).
+    /// No string allocations occur.
+    pub fn skip(&mut self) -> Result<Span, AdapterError> {
+        // Get the first token using windowing
+        let first_token = self.next_token_for_skip()?;
+        let abs_start = first_token.span.offset;
+
+        match first_token.token {
+            SkipToken::ObjectStart => {
+                // Skip until matching ObjectEnd
+                let mut depth = 1;
+                let mut abs_end = first_token.span.offset + first_token.span.len;
+                while depth > 0 {
+                    let t = self.next_token_for_skip()?;
+                    abs_end = t.span.offset + t.span.len;
+                    match t.token {
+                        SkipToken::ObjectStart => depth += 1,
+                        SkipToken::ObjectEnd => depth -= 1,
+                        _ => {}
+                    }
+                }
+                Ok(Span::new(abs_start, abs_end - abs_start))
+            }
+            SkipToken::ArrayStart => {
+                // Skip until matching ArrayEnd
+                let mut depth = 1;
+                let mut abs_end = first_token.span.offset + first_token.span.len;
+                while depth > 0 {
+                    let t = self.next_token_for_skip()?;
+                    abs_end = t.span.offset + t.span.len;
+                    match t.token {
+                        SkipToken::ArrayStart => depth += 1,
+                        SkipToken::ArrayEnd => depth -= 1,
+                        _ => {}
+                    }
+                }
+                Ok(Span::new(abs_start, abs_end - abs_start))
+            }
+            // Scalars: just return their span
+            SkipToken::Scalar => Ok(first_token.span),
+            SkipToken::Eof => Err(AdapterError {
+                kind: AdapterErrorKind::Scan(ScanErrorKind::UnexpectedEof("expected value")),
+                span: first_token.span,
+            }),
+            // These shouldn't appear as first token when skipping a value
+            SkipToken::ObjectEnd | SkipToken::ArrayEnd => Err(AdapterError {
+                kind: AdapterErrorKind::Scan(ScanErrorKind::UnexpectedChar('}')),
+                span: first_token.span,
+            }),
+        }
+    }
+
+    /// Internal: get next token for skip operation (handles windowing).
+    fn next_token_for_skip(&mut self) -> Result<SpannedSkipToken, AdapterError> {
+        loop {
+            let window = self.current_window();
+            let spanned = match self.scanner.next_token(window) {
+                Ok(s) => s,
+                Err(e) => {
+                    return Err(AdapterError {
+                        kind: AdapterErrorKind::Scan(e.kind),
+                        span: Span::new(self.window_start + e.span.offset, e.span.len),
+                    });
+                }
+            };
+
+            match spanned.token {
+                ScanToken::NeedMore { .. } => {
+                    if self.at_end_of_input() {
+                        // True EOF - try to finalize any pending token
+                        let window = self.current_window();
+                        let finalized = match self.scanner.finalize_at_eof(window) {
+                            Ok(f) => f,
+                            Err(e) => {
+                                return Err(AdapterError {
+                                    kind: AdapterErrorKind::Scan(e.kind),
+                                    span: Span::new(self.window_start + e.span.offset, e.span.len),
+                                });
+                            }
+                        };
+
+                        let consumed = self.scanner.pos();
+                        let abs_span = Span::new(
+                            self.window_start + finalized.span.offset,
+                            finalized.span.len,
+                        );
+
+                        let skip_token = match finalized.token {
+                            ScanToken::ObjectStart => SkipToken::ObjectStart,
+                            ScanToken::ObjectEnd => SkipToken::ObjectEnd,
+                            ScanToken::ArrayStart => SkipToken::ArrayStart,
+                            ScanToken::ArrayEnd => SkipToken::ArrayEnd,
+                            ScanToken::String { .. }
+                            | ScanToken::Number { .. }
+                            | ScanToken::True
+                            | ScanToken::False
+                            | ScanToken::Null
+                            | ScanToken::Colon
+                            | ScanToken::Comma => SkipToken::Scalar,
+                            ScanToken::Eof => SkipToken::Eof,
+                            ScanToken::NeedMore { .. } => unreachable!(),
+                        };
+
+                        self.slide_window(consumed);
+                        return Ok(SpannedSkipToken {
+                            token: skip_token,
+                            span: abs_span,
+                        });
+                    }
+                    self.grow_window();
+                    continue;
+                }
+                ScanToken::Eof => {
+                    if self.at_end_of_input() {
+                        return Ok(SpannedSkipToken {
+                            token: SkipToken::Eof,
+                            span: Span::new(self.window_start + spanned.span.offset, 0),
+                        });
+                    }
+                    self.slide_window(self.scanner.pos());
+                    continue;
+                }
+                _ => {
+                    let consumed = self.scanner.pos();
+                    let abs_span =
+                        Span::new(self.window_start + spanned.span.offset, spanned.span.len);
+
+                    let skip_token = match spanned.token {
+                        ScanToken::ObjectStart => SkipToken::ObjectStart,
+                        ScanToken::ObjectEnd => SkipToken::ObjectEnd,
+                        ScanToken::ArrayStart => SkipToken::ArrayStart,
+                        ScanToken::ArrayEnd => SkipToken::ArrayEnd,
+                        ScanToken::String { .. }
+                        | ScanToken::Number { .. }
+                        | ScanToken::True
+                        | ScanToken::False
+                        | ScanToken::Null
+                        | ScanToken::Colon
+                        | ScanToken::Comma => SkipToken::Scalar,
+                        ScanToken::Eof | ScanToken::NeedMore { .. } => unreachable!(),
+                    };
+
+                    self.slide_window(consumed);
+                    return Ok(SpannedSkipToken {
+                        token: skip_token,
+                        span: abs_span,
+                    });
+                }
+            }
+        }
+    }
+
+    /// Get the current absolute position in the input.
+    #[allow(dead_code)]
+    pub fn position(&self) -> usize {
+        self.window_start + self.scanner.pos()
+    }
+
+    /// Get the underlying input slice.
+    #[allow(dead_code)]
+    pub fn input(&self) -> &'input [u8] {
+        self.input
+    }
+}
+
+/// Simplified token type for skip operations (no need to decode content).
+#[derive(Debug, Clone, Copy)]
+enum SkipToken {
+    ObjectStart,
+    ObjectEnd,
+    ArrayStart,
+    ArrayEnd,
+    Scalar, // String, Number, true, false, null, colon, comma
+    Eof,
+}
+
+/// Spanned skip token.
+#[derive(Debug)]
+struct SpannedSkipToken {
+    token: SkipToken,
+    span: Span,
+}
+
+// ============================================================================
+// TokenSource trait - unifies slice and streaming adapters
+// ============================================================================
+
+use crate::error::{JsonError, JsonErrorKind};
+
+/// Trait for token sources that can be used by the deserializer.
+///
+/// This trait abstracts over both:
+/// - `SliceAdapter<'input>` implements `TokenSource<'input>` - can borrow from input
+/// - `StreamingAdapter` implements `TokenSource<'static>` - always owned
+///
+/// The lifetime parameter `'input` is the lifetime of the input data,
+/// NOT the lifetime of `self`. This is why we don't need GATs.
+pub trait TokenSource<'input> {
+    /// Get the next token.
+    fn next_token(&mut self) -> Result<SpannedAdapterToken<'input>, JsonError>;
+
+    /// Skip a JSON value without fully decoding it.
+    /// Returns the span of the skipped value.
+    fn skip(&mut self) -> Result<Span, JsonError>;
+
+    /// Get the raw input bytes, if available.
+    ///
+    /// Returns `Some` for slice-based adapters, `None` for streaming.
+    /// Used for features that need direct input access (RawJson, flatten replay).
+    #[allow(dead_code)]
+    fn input_bytes(&self) -> Option<&'input [u8]> {
+        None
+    }
+
+    /// Create a new adapter starting from the given offset in the input.
+    ///
+    /// Returns `Some` for slice-based adapters, `None` for streaming.
+    /// Used for flatten replay.
+    #[allow(dead_code)]
+    fn at_offset(&self, offset: usize) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        let _ = offset;
+        None
+    }
+}
+
+impl<'input, const BORROW: bool> TokenSource<'input> for SliceAdapter<'input, BORROW> {
+    fn next_token(&mut self) -> Result<SpannedAdapterToken<'input>, JsonError> {
+        SliceAdapter::next_token(self).map_err(|e| JsonError {
+            kind: JsonErrorKind::Scan(match e.kind {
+                AdapterErrorKind::Scan(s) => s,
+                AdapterErrorKind::NeedMore => {
+                    crate::scanner::ScanErrorKind::UnexpectedEof("need more data")
+                }
+            }),
+            span: Some(e.span),
+            source_code: None,
+        })
+    }
+
+    fn skip(&mut self) -> Result<Span, JsonError> {
+        SliceAdapter::skip(self).map_err(|e| JsonError {
+            kind: JsonErrorKind::Scan(match e.kind {
+                AdapterErrorKind::Scan(s) => s,
+                AdapterErrorKind::NeedMore => {
+                    crate::scanner::ScanErrorKind::UnexpectedEof("need more data")
+                }
+            }),
+            span: Some(e.span),
+            source_code: None,
+        })
+    }
+
+    fn input_bytes(&self) -> Option<&'input [u8]> {
+        Some(self.input)
+    }
+
+    fn at_offset(&self, offset: usize) -> Option<Self> {
+        Some(SliceAdapter::new(&self.input[offset..]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_next_simple() {
+        let json = br#"{"name": "test", "value": 42}"#;
+        let mut adapter = SliceAdapter::<true>::new(json);
+
+        // {
+        let t = adapter.next_token().unwrap();
+        assert!(matches!(t.token, Token::ObjectStart));
+
+        // "name"
+        let t = adapter.next_token().unwrap();
+        assert_eq!(t.token, Token::String(Cow::Borrowed("name")));
+
+        // :
+        let t = adapter.next_token().unwrap();
+        assert!(matches!(t.token, Token::Colon));
+
+        // "test"
+        let t = adapter.next_token().unwrap();
+        assert_eq!(t.token, Token::String(Cow::Borrowed("test")));
+
+        // ,
+        let t = adapter.next_token().unwrap();
+        assert!(matches!(t.token, Token::Comma));
+
+        // "value"
+        let t = adapter.next_token().unwrap();
+        assert_eq!(t.token, Token::String(Cow::Borrowed("value")));
+
+        // :
+        let t = adapter.next_token().unwrap();
+        assert!(matches!(t.token, Token::Colon));
+
+        // 42
+        let t = adapter.next_token().unwrap();
+        assert_eq!(t.token, Token::U64(42));
+
+        // }
+        let t = adapter.next_token().unwrap();
+        assert!(matches!(t.token, Token::ObjectEnd));
+
+        // EOF
+        let t = adapter.next_token().unwrap();
+        assert!(matches!(t.token, Token::Eof));
+    }
+
+    #[test]
+    fn test_next_with_escapes() {
+        let json = br#""hello\nworld""#;
+        let mut adapter = SliceAdapter::<true>::new(json);
+
+        let t = adapter.next_token().unwrap();
+        // Has escapes, so it's Owned
+        assert_eq!(
+            t.token,
+            Token::String(Cow::Owned("hello\nworld".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_skip_scalar() {
+        let json = br#"{"skip": 12345, "keep": "value"}"#;
+        let mut adapter = SliceAdapter::<true>::new(json);
+
+        // {
+        adapter.next_token().unwrap();
+        // "skip"
+        adapter.next_token().unwrap();
+        // :
+        adapter.next_token().unwrap();
+
+        // Skip the number - no allocation!
+        let span = adapter.skip().unwrap();
+        assert_eq!(&json[span.offset..span.offset + span.len], b"12345");
+
+        // ,
+        let t = adapter.next_token().unwrap();
+        assert!(matches!(t.token, Token::Comma));
+
+        // Continue with "keep"
+        let t = adapter.next_token().unwrap();
+        assert_eq!(t.token, Token::String(Cow::Borrowed("keep")));
+    }
+
+    #[test]
+    fn test_skip_object() {
+        let json = br#"{"skip": {"nested": {"deep": true}}, "keep": 1}"#;
+        let mut adapter = SliceAdapter::<true>::new(json);
+
+        // {
+        adapter.next_token().unwrap();
+        // "skip"
+        adapter.next_token().unwrap();
+        // :
+        adapter.next_token().unwrap();
+
+        // Skip the entire nested object
+        let span = adapter.skip().unwrap();
+        assert_eq!(
+            &json[span.offset..span.offset + span.len],
+            br#"{"nested": {"deep": true}}"#
+        );
+
+        // ,
+        let t = adapter.next_token().unwrap();
+        assert!(matches!(t.token, Token::Comma));
+
+        // "keep"
+        let t = adapter.next_token().unwrap();
+        assert_eq!(t.token, Token::String(Cow::Borrowed("keep")));
+    }
+
+    #[test]
+    fn test_skip_array() {
+        let json = br#"{"skip": [1, [2, 3], 4], "keep": true}"#;
+        let mut adapter = SliceAdapter::<true>::new(json);
+
+        // {
+        adapter.next_token().unwrap();
+        // "skip"
+        adapter.next_token().unwrap();
+        // :
+        adapter.next_token().unwrap();
+
+        // Skip the entire array
+        let span = adapter.skip().unwrap();
+        assert_eq!(
+            &json[span.offset..span.offset + span.len],
+            br#"[1, [2, 3], 4]"#
+        );
+
+        // ,
+        adapter.next_token().unwrap();
+
+        // "keep"
+        let t = adapter.next_token().unwrap();
+        assert_eq!(t.token, Token::String(Cow::Borrowed("keep")));
+
+        // :
+        adapter.next_token().unwrap();
+
+        // true
+        let t = adapter.next_token().unwrap();
+        assert!(matches!(t.token, Token::True));
+    }
+
+    #[test]
+    fn test_skip_string_no_allocation() {
+        // When skipping a string, even one with escapes, we shouldn't allocate
+        let json = br#"{"skip": "hello\nworld\twith\rescapes", "keep": 1}"#;
+        let mut adapter = SliceAdapter::<true>::new(json);
+
+        // {
+        adapter.next_token().unwrap();
+        // "skip"
+        adapter.next_token().unwrap();
+        // :
+        adapter.next_token().unwrap();
+
+        // Skip the string - the span covers the whole string including quotes
+        let span = adapter.skip().unwrap();
+        assert_eq!(
+            &json[span.offset..span.offset + span.len],
+            br#""hello\nworld\twith\rescapes""#
+        );
+    }
+
+    #[test]
+    fn test_borrow_false_always_owned() {
+        let json = br#""no escapes here""#;
+        let mut adapter = SliceAdapter::<false>::new(json);
+
+        let t = adapter.next_token().unwrap();
+        // Even without escapes, BORROW=false means Owned
+        assert!(matches!(t.token, Token::String(Cow::Owned(_))));
+    }
+
+    #[test]
+    fn test_borrow_true_borrows_when_possible() {
+        let json = br#""no escapes here""#;
+        let mut adapter = SliceAdapter::<true>::new(json);
+
+        let t = adapter.next_token().unwrap();
+        // No escapes + BORROW=true means Borrowed
+        assert!(matches!(t.token, Token::String(Cow::Borrowed(_))));
+    }
+
+    #[test]
+    fn test_windowed_parsing_long_string() {
+        // Test that strings longer than the chunk size (4 bytes) work correctly
+        // This exercises the NeedMore handling
+        let json = br#""hello world""#; // 13 bytes, much longer than chunk_size=4
+        let mut adapter = SliceAdapter::<true>::new(json);
+
+        let t = adapter.next_token().unwrap();
+        assert_eq!(t.token, Token::String(Cow::Borrowed("hello world")));
+        // Span should cover the entire string including quotes
+        assert_eq!(t.span.offset, 0);
+        assert_eq!(t.span.len, 13);
+    }
+
+    #[test]
+    fn test_windowed_parsing_number_at_eof() {
+        // Test that numbers at EOF are finalized correctly
+        let json = b"-123"; // 4 bytes, exactly chunk_size
+        let mut adapter = SliceAdapter::<true>::new(json);
+
+        let t = adapter.next_token().unwrap();
+        assert_eq!(t.token, Token::I64(-123));
+    }
+
+    #[test]
+    fn test_windowed_parsing_complex_object() {
+        // Test a complex object that spans many chunks
+        let json = br#"{"name": "hello world", "value": 12345, "nested": {"a": 1}}"#;
+        let mut adapter = SliceAdapter::<true>::new(json);
+
+        // {
+        assert!(matches!(
+            adapter.next_token().unwrap().token,
+            Token::ObjectStart
+        ));
+        // "name"
+        assert_eq!(
+            adapter.next_token().unwrap().token,
+            Token::String(Cow::Borrowed("name"))
+        );
+        // :
+        assert!(matches!(adapter.next_token().unwrap().token, Token::Colon));
+        // "hello world"
+        assert_eq!(
+            adapter.next_token().unwrap().token,
+            Token::String(Cow::Borrowed("hello world"))
+        );
+        // ,
+        assert!(matches!(adapter.next_token().unwrap().token, Token::Comma));
+        // "value"
+        assert_eq!(
+            adapter.next_token().unwrap().token,
+            Token::String(Cow::Borrowed("value"))
+        );
+        // :
+        assert!(matches!(adapter.next_token().unwrap().token, Token::Colon));
+        // 12345
+        assert_eq!(adapter.next_token().unwrap().token, Token::U64(12345));
+        // ,
+        assert!(matches!(adapter.next_token().unwrap().token, Token::Comma));
+        // "nested"
+        assert_eq!(
+            adapter.next_token().unwrap().token,
+            Token::String(Cow::Borrowed("nested"))
+        );
+        // :
+        assert!(matches!(adapter.next_token().unwrap().token, Token::Colon));
+        // {
+        assert!(matches!(
+            adapter.next_token().unwrap().token,
+            Token::ObjectStart
+        ));
+        // "a"
+        assert_eq!(
+            adapter.next_token().unwrap().token,
+            Token::String(Cow::Borrowed("a"))
+        );
+        // :
+        assert!(matches!(adapter.next_token().unwrap().token, Token::Colon));
+        // 1
+        assert_eq!(adapter.next_token().unwrap().token, Token::U64(1));
+        // }
+        assert!(matches!(
+            adapter.next_token().unwrap().token,
+            Token::ObjectEnd
+        ));
+        // }
+        assert!(matches!(
+            adapter.next_token().unwrap().token,
+            Token::ObjectEnd
+        ));
+        // EOF
+        assert!(matches!(adapter.next_token().unwrap().token, Token::Eof));
+    }
+}

--- a/facet-format-json/src/error.rs
+++ b/facet-format-json/src/error.rs
@@ -1,0 +1,333 @@
+//! Error types for JSON deserialization.
+
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt::{self, Display};
+
+use facet_reflect::{ReflectError, Span};
+
+use crate::adapter::{AdapterError, AdapterErrorKind};
+use crate::scanner::ScanErrorKind;
+
+/// Error type for JSON deserialization.
+#[derive(Debug)]
+pub struct JsonError {
+    /// The specific kind of error
+    pub kind: JsonErrorKind,
+    /// Source span where the error occurred
+    pub span: Option<Span>,
+    /// The source input (for diagnostics)
+    pub source_code: Option<String>,
+}
+
+impl Display for JsonError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.kind)
+    }
+}
+
+impl std::error::Error for JsonError {}
+
+impl miette::Diagnostic for JsonError {
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        Some(Box::new(self.kind.code()))
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        self.source_code
+            .as_ref()
+            .map(|s| s as &dyn miette::SourceCode)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        // Handle MissingField with multiple spans
+        if let JsonErrorKind::MissingField {
+            field,
+            object_start,
+            object_end,
+        } = &self.kind
+        {
+            let mut labels = Vec::new();
+            if let Some(start) = object_start {
+                labels.push(miette::LabeledSpan::new(
+                    Some("object started here".into()),
+                    start.offset,
+                    start.len,
+                ));
+            }
+            if let Some(end) = object_end {
+                labels.push(miette::LabeledSpan::new(
+                    Some(format!("object ended without field `{field}`")),
+                    end.offset,
+                    end.len,
+                ));
+            }
+            if labels.is_empty() {
+                return None;
+            }
+            return Some(Box::new(labels.into_iter()));
+        }
+
+        // Default: single span with label
+        let span = self.span?;
+        Some(Box::new(core::iter::once(miette::LabeledSpan::new(
+            Some(self.kind.label()),
+            span.offset,
+            span.len,
+        ))))
+    }
+}
+
+impl JsonError {
+    /// Create a new error with span information
+    pub fn new(kind: JsonErrorKind, span: Span) -> Self {
+        JsonError {
+            kind,
+            span: Some(span),
+            source_code: None,
+        }
+    }
+
+    /// Create an error without span information
+    pub fn without_span(kind: JsonErrorKind) -> Self {
+        JsonError {
+            kind,
+            span: None,
+            source_code: None,
+        }
+    }
+
+    /// Attach source code for rich diagnostics
+    pub fn with_source(mut self, source: &str) -> Self {
+        self.source_code = Some(source.to_string());
+        self
+    }
+}
+
+/// Specific error kinds for JSON deserialization
+#[derive(Debug)]
+pub enum JsonErrorKind {
+    /// Scanner/adapter error
+    Scan(ScanErrorKind),
+    /// Scanner error with type context (what type was being parsed)
+    ScanWithContext {
+        /// The underlying scan error
+        error: ScanErrorKind,
+        /// The type that was being parsed
+        expected_type: &'static str,
+    },
+    /// Unexpected token
+    UnexpectedToken {
+        /// The token that was found
+        got: String,
+        /// What was expected instead
+        expected: &'static str,
+    },
+    /// Unexpected end of input
+    UnexpectedEof {
+        /// What was expected before EOF
+        expected: &'static str,
+    },
+    /// Type mismatch
+    TypeMismatch {
+        /// The expected type
+        expected: &'static str,
+        /// The actual type found
+        got: &'static str,
+    },
+    /// Unknown field in struct
+    UnknownField {
+        /// The unknown field name
+        field: String,
+        /// List of valid field names
+        expected: Vec<&'static str>,
+        /// Suggested field name (if similar to an expected field)
+        suggestion: Option<&'static str>,
+    },
+    /// Missing required field
+    MissingField {
+        /// The name of the missing field
+        field: &'static str,
+        /// Span of the object start (opening brace)
+        object_start: Option<Span>,
+        /// Span of the object end (closing brace)
+        object_end: Option<Span>,
+    },
+    /// Invalid value for type
+    InvalidValue {
+        /// Description of why the value is invalid
+        message: String,
+    },
+    /// Reflection error from facet-reflect
+    Reflect(ReflectError),
+    /// Number out of range
+    NumberOutOfRange {
+        /// The numeric value that was out of range
+        value: String,
+        /// The target type that couldn't hold the value
+        target_type: &'static str,
+    },
+    /// Duplicate key in object
+    DuplicateKey {
+        /// The key that appeared more than once
+        key: String,
+    },
+    /// Invalid UTF-8 in string
+    InvalidUtf8,
+    /// Solver error (for flattened types)
+    Solver(String),
+    /// I/O error (for streaming deserialization)
+    Io(String),
+}
+
+impl Display for JsonErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            JsonErrorKind::Scan(e) => write!(f, "{e:?}"),
+            JsonErrorKind::ScanWithContext {
+                error,
+                expected_type,
+            } => {
+                write!(f, "{error:?} (while parsing {expected_type})")
+            }
+            JsonErrorKind::UnexpectedToken { got, expected } => {
+                write!(f, "unexpected token: got {got}, expected {expected}")
+            }
+            JsonErrorKind::UnexpectedEof { expected } => {
+                write!(f, "unexpected end of input, expected {expected}")
+            }
+            JsonErrorKind::TypeMismatch { expected, got } => {
+                write!(f, "type mismatch: expected {expected}, got {got}")
+            }
+            JsonErrorKind::UnknownField {
+                field,
+                expected,
+                suggestion,
+            } => {
+                write!(f, "unknown field `{field}`, expected one of: {expected:?}")?;
+                if let Some(suggested) = suggestion {
+                    write!(f, " (did you mean `{suggested}`?)")?;
+                }
+                Ok(())
+            }
+            JsonErrorKind::MissingField { field, .. } => {
+                write!(f, "missing required field `{field}`")
+            }
+            JsonErrorKind::InvalidValue { message } => {
+                write!(f, "invalid value: {message}")
+            }
+            JsonErrorKind::Reflect(e) => write!(f, "reflection error: {e}"),
+            JsonErrorKind::NumberOutOfRange { value, target_type } => {
+                write!(f, "number `{value}` out of range for {target_type}")
+            }
+            JsonErrorKind::DuplicateKey { key } => {
+                write!(f, "duplicate key `{key}`")
+            }
+            JsonErrorKind::InvalidUtf8 => write!(f, "invalid UTF-8 sequence"),
+            JsonErrorKind::Solver(msg) => write!(f, "solver error: {msg}"),
+            JsonErrorKind::Io(msg) => write!(f, "I/O error: {msg}"),
+        }
+    }
+}
+
+impl JsonErrorKind {
+    /// Get an error code for this kind of error.
+    pub fn code(&self) -> &'static str {
+        match self {
+            JsonErrorKind::Scan(_) => "json::scan",
+            JsonErrorKind::ScanWithContext { .. } => "json::scan",
+            JsonErrorKind::UnexpectedToken { .. } => "json::unexpected_token",
+            JsonErrorKind::UnexpectedEof { .. } => "json::unexpected_eof",
+            JsonErrorKind::TypeMismatch { .. } => "json::type_mismatch",
+            JsonErrorKind::UnknownField { .. } => "json::unknown_field",
+            JsonErrorKind::MissingField { .. } => "json::missing_field",
+            JsonErrorKind::InvalidValue { .. } => "json::invalid_value",
+            JsonErrorKind::Reflect(_) => "json::reflect",
+            JsonErrorKind::NumberOutOfRange { .. } => "json::number_out_of_range",
+            JsonErrorKind::DuplicateKey { .. } => "json::duplicate_key",
+            JsonErrorKind::InvalidUtf8 => "json::invalid_utf8",
+            JsonErrorKind::Solver(_) => "json::solver",
+            JsonErrorKind::Io(_) => "json::io",
+        }
+    }
+
+    /// Get a label describing where/what the error points to.
+    pub fn label(&self) -> String {
+        match self {
+            JsonErrorKind::Scan(e) => match e {
+                ScanErrorKind::UnexpectedChar(c) => format!("unexpected '{c}'"),
+                ScanErrorKind::UnexpectedEof(ctx) => format!("unexpected end of input {ctx}"),
+                ScanErrorKind::InvalidUtf8 => "invalid UTF-8 here".into(),
+            },
+            JsonErrorKind::ScanWithContext {
+                error,
+                expected_type,
+            } => match error {
+                ScanErrorKind::UnexpectedChar(c) => {
+                    format!("unexpected '{c}', expected {expected_type}")
+                }
+                ScanErrorKind::UnexpectedEof(_) => {
+                    format!("unexpected end of input, expected {expected_type}")
+                }
+                ScanErrorKind::InvalidUtf8 => "invalid UTF-8 here".into(),
+            },
+            JsonErrorKind::UnexpectedToken { got, expected } => {
+                format!("expected {expected}, got '{got}'")
+            }
+            JsonErrorKind::UnexpectedEof { expected } => format!("expected {expected}"),
+            JsonErrorKind::TypeMismatch { expected, got } => {
+                format!("expected {expected}, got {got}")
+            }
+            JsonErrorKind::UnknownField {
+                field, suggestion, ..
+            } => {
+                if let Some(suggested) = suggestion {
+                    format!("unknown field '{field}' - did you mean '{suggested}'?")
+                } else {
+                    format!("unknown field '{field}'")
+                }
+            }
+            JsonErrorKind::MissingField { field, .. } => format!("missing field '{field}'"),
+            JsonErrorKind::InvalidValue { .. } => "invalid value".into(),
+            JsonErrorKind::Reflect(_) => "reflection error".into(),
+            JsonErrorKind::NumberOutOfRange { target_type, .. } => {
+                format!("out of range for {target_type}")
+            }
+            JsonErrorKind::DuplicateKey { key } => format!("duplicate key '{key}'"),
+            JsonErrorKind::InvalidUtf8 => "invalid UTF-8".into(),
+            JsonErrorKind::Solver(_) => "solver error".into(),
+            JsonErrorKind::Io(_) => "I/O error".into(),
+        }
+    }
+}
+
+impl From<AdapterError> for JsonError {
+    fn from(err: AdapterError) -> Self {
+        let kind = match err.kind {
+            AdapterErrorKind::Scan(scan_err) => JsonErrorKind::Scan(scan_err),
+            AdapterErrorKind::NeedMore => JsonErrorKind::UnexpectedEof {
+                expected: "more data",
+            },
+        };
+        JsonError {
+            kind,
+            span: Some(err.span),
+            source_code: None,
+        }
+    }
+}
+
+impl From<ReflectError> for JsonError {
+    fn from(err: ReflectError) -> Self {
+        JsonError {
+            kind: JsonErrorKind::Reflect(err),
+            span: None,
+            source_code: None,
+        }
+    }
+}
+
+/// Result type for JSON deserialization
+#[allow(dead_code)]
+pub type Result<T> = core::result::Result<T, JsonError>;

--- a/facet-format-json/src/lib.rs
+++ b/facet-format-json/src/lib.rs
@@ -4,8 +4,17 @@
 //!
 //! This crate provides JSON support via the `FormatParser` trait.
 
+extern crate alloc;
+
+mod adapter;
+mod error;
 mod parser;
+mod scan_buffer;
+mod scanner;
 mod serializer;
+
+#[cfg(feature = "streaming")]
+mod streaming_adapter;
 
 pub use parser::{JsonError, JsonParser};
 pub use serializer::{

--- a/facet-format-json/src/parser.rs
+++ b/facet-format-json/src/parser.rs
@@ -6,8 +6,10 @@ use facet_format::{
     ContainerKind, FieldEvidence, FieldKey, FieldLocationHint, FormatParser, ParseEvent,
     ProbeStream, ScalarValue,
 };
-pub use facet_json::JsonError;
-use facet_json::{AdapterToken, JsonErrorKind, SliceAdapter, SpannedAdapterToken};
+
+use crate::adapter::{SliceAdapter, SpannedAdapterToken, Token as AdapterToken};
+pub use crate::error::JsonError;
+use crate::error::JsonErrorKind;
 
 /// Streaming JSON parser backed by `facet-json`'s `SliceAdapter`.
 pub struct JsonParser<'de> {

--- a/facet-format-json/src/scan_buffer.rs
+++ b/facet-format-json/src/scan_buffer.rs
@@ -1,0 +1,259 @@
+//! Buffer management for streaming JSON scanning.
+//!
+//! # Design: No Compaction Needed
+//!
+//! This buffer uses a grow-only strategy that never requires compacting
+//! (shifting data to the left). This is possible because:
+//!
+//! 1. When the scanner returns a complete token, we materialize it immediately.
+//!    The raw bytes are no longer needed.
+//!
+//! 2. When the scanner returns `Eof` (end of buffer, not real EOF), all tokens
+//!    in the buffer have been processed. We can **reset** and read fresh data.
+//!
+//! 3. When the scanner returns `NeedMore` (mid-token), we **grow** the buffer
+//!    and read more data into the new space. Indices remain valid.
+//!
+//! This avoids all data copying, which is both simpler and more efficient.
+
+use alloc::vec::Vec;
+
+/// Default buffer capacity (8KB)
+pub const DEFAULT_CAPACITY: usize = 8 * 1024;
+
+/// A refillable buffer for streaming JSON parsing.
+///
+/// Uses a grow-only strategy: we either reset (when all data processed)
+/// or grow (when mid-token). Never compacts/shifts data.
+#[derive(Debug)]
+pub struct ScanBuffer {
+    /// The underlying buffer
+    data: Vec<u8>,
+    /// How many bytes are valid (filled with data)
+    filled: usize,
+    /// Whether EOF has been reached on the underlying reader
+    eof: bool,
+}
+
+impl ScanBuffer {
+    /// Create a new buffer with the default capacity.
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    /// Create a new buffer with a specific capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            data: vec![0u8; capacity],
+            filled: 0,
+            eof: false,
+        }
+    }
+
+    /// Create a buffer from an existing slice (for slice-based parsing).
+    #[allow(dead_code)]
+    pub fn from_slice(slice: &[u8]) -> Self {
+        let mut data = Vec::with_capacity(slice.len());
+        data.extend_from_slice(slice);
+        Self {
+            filled: data.len(),
+            data,
+            eof: true, // No more data to read
+        }
+    }
+
+    /// Get the current buffer contents.
+    #[inline]
+    pub fn data(&self) -> &[u8] {
+        &self.data[..self.filled]
+    }
+
+    /// Whether the underlying reader has reached EOF.
+    #[inline]
+    pub fn is_eof(&self) -> bool {
+        self.eof
+    }
+
+    /// How many bytes are filled.
+    #[inline]
+    pub fn filled(&self) -> usize {
+        self.filled
+    }
+
+    /// Get the buffer's total capacity.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Reset the buffer for fresh data.
+    ///
+    /// Called when all data has been processed (scanner returned Eof but reader has more).
+    /// This is NOT compaction - we're simply starting fresh because everything was consumed.
+    pub fn reset(&mut self) {
+        self.filled = 0;
+        // Note: we don't reset eof here - that's determined by the reader
+    }
+
+    /// Grow the buffer to make room for more data.
+    ///
+    /// Called when mid-token (NeedMore) and buffer is full.
+    /// We grow rather than compact because:
+    /// - No data copying needed
+    /// - Scanner indices remain valid
+    /// - Simpler logic
+    pub fn grow(&mut self) {
+        let new_capacity = self.data.len() * 2;
+        self.data.resize(new_capacity, 0);
+    }
+
+    /// Refill the buffer from a synchronous reader.
+    ///
+    /// Reads more data into the unfilled portion of the buffer.
+    /// Returns the number of bytes read, or 0 if EOF.
+    #[cfg(feature = "std")]
+    pub fn refill<R: std::io::Read>(&mut self, reader: &mut R) -> std::io::Result<usize> {
+        if self.eof {
+            return Ok(0);
+        }
+
+        let read_buf = &mut self.data[self.filled..];
+        if read_buf.is_empty() {
+            // Buffer is full - caller should grow() first if needed
+            return Ok(0);
+        }
+
+        let n = reader.read(read_buf)?;
+        self.filled += n;
+
+        if n == 0 {
+            self.eof = true;
+        }
+
+        Ok(n)
+    }
+
+    /// Refill the buffer from an async reader (tokio).
+    #[cfg(feature = "tokio")]
+    pub async fn refill_tokio<R>(&mut self, reader: &mut R) -> std::io::Result<usize>
+    where
+        R: tokio::io::AsyncRead + Unpin,
+    {
+        use tokio::io::AsyncReadExt;
+
+        if self.eof {
+            return Ok(0);
+        }
+
+        let read_buf = &mut self.data[self.filled..];
+        if read_buf.is_empty() {
+            return Ok(0);
+        }
+
+        let n = reader.read(read_buf).await?;
+        self.filled += n;
+
+        if n == 0 {
+            self.eof = true;
+        }
+
+        Ok(n)
+    }
+
+    /// Refill the buffer from an async reader (futures-io).
+    #[cfg(feature = "futures-io")]
+    pub async fn refill_futures<R>(&mut self, reader: &mut R) -> std::io::Result<usize>
+    where
+        R: futures_io::AsyncRead + Unpin,
+    {
+        use core::pin::Pin;
+        use core::task::Context;
+
+        if self.eof {
+            return Ok(0);
+        }
+
+        let read_buf = &mut self.data[self.filled..];
+        if read_buf.is_empty() {
+            return Ok(0);
+        }
+
+        let n = core::future::poll_fn(|cx: &mut Context<'_>| {
+            Pin::new(&mut *reader).poll_read(cx, read_buf)
+        })
+        .await?;
+        self.filled += n;
+
+        if n == 0 {
+            self.eof = true;
+        }
+
+        Ok(n)
+    }
+}
+
+impl Default for ScanBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_slice() {
+        let buf = ScanBuffer::from_slice(b"hello world");
+        assert_eq!(buf.data(), b"hello world");
+        assert_eq!(buf.filled(), 11);
+        assert!(buf.is_eof());
+    }
+
+    #[test]
+    fn test_reset() {
+        let mut buf = ScanBuffer::from_slice(b"hello");
+        assert_eq!(buf.filled(), 5);
+        buf.reset();
+        assert_eq!(buf.filled(), 0);
+        assert_eq!(buf.data(), b"");
+    }
+
+    #[test]
+    fn test_grow() {
+        let mut buf = ScanBuffer::with_capacity(4);
+        assert_eq!(buf.capacity(), 4);
+        buf.grow();
+        assert_eq!(buf.capacity(), 8);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_refill_from_reader() {
+        use std::io::Cursor;
+
+        let mut reader = Cursor::new(b"hello world");
+        let mut buf = ScanBuffer::with_capacity(8);
+
+        // First read
+        let n = buf.refill(&mut reader).unwrap();
+        assert_eq!(n, 8);
+        assert_eq!(buf.data(), b"hello wo");
+
+        // Buffer full, refill returns 0
+        let n = buf.refill(&mut reader).unwrap();
+        assert_eq!(n, 0);
+
+        // Grow and refill
+        buf.grow();
+        let n = buf.refill(&mut reader).unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(buf.data(), b"hello world");
+        assert!(!buf.is_eof()); // Not EOF yet - we got 3 bytes
+
+        // One more refill to confirm EOF
+        let n = buf.refill(&mut reader).unwrap();
+        assert_eq!(n, 0);
+        assert!(buf.is_eof());
+    }
+}

--- a/facet-format-json/src/scanner.rs
+++ b/facet-format-json/src/scanner.rs
@@ -1,0 +1,1220 @@
+//! Low-level JSON scanner that finds token boundaries without materializing strings.
+//!
+//! The scanner's job is to identify where tokens are in a buffer, not to interpret them.
+//! String content is returned as indices + a `has_escapes` flag. The deserializer
+//! decides whether to decode escapes based on the target type.
+//!
+//! This design enables:
+//! - Zero-copy borrowed strings (when no escapes)
+//! - Streaming from `std::io::Read` with buffer refills
+//! - Skipping values without allocation (RawJson, unknown fields)
+
+use core::str;
+
+use facet_reflect::Span;
+
+/// Token kinds with minimal data - strings/numbers are just indices into the buffer.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Token {
+    /// `{`
+    ObjectStart,
+    /// `}`
+    ObjectEnd,
+    /// `[`
+    ArrayStart,
+    /// `]`
+    ArrayEnd,
+    /// `:`
+    Colon,
+    /// `,`
+    Comma,
+    /// `null`
+    Null,
+    /// `true`
+    True,
+    /// `false`
+    False,
+    /// A string literal - indices point to content (excluding quotes)
+    String {
+        /// Start index of string content (after opening quote)
+        start: usize,
+        /// End index of string content (before closing quote)
+        end: usize,
+        /// True if the string contains escape sequences that need processing
+        has_escapes: bool,
+    },
+    /// A number literal - indices point to the raw number text
+    Number {
+        /// Start index of number
+        start: usize,
+        /// End index of number
+        end: usize,
+        /// Hint about number format
+        hint: NumberHint,
+    },
+    /// End of input reached
+    Eof,
+    /// Buffer exhausted mid-token - need refill for streaming
+    NeedMore {
+        /// How many bytes were consumed before hitting the boundary
+        consumed: usize,
+    },
+}
+
+/// Hint about number format to guide parsing
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NumberHint {
+    /// Unsigned integer (no sign, no decimal, no exponent)
+    Unsigned,
+    /// Signed integer (has `-` prefix, no decimal, no exponent)
+    Signed,
+    /// Floating point (has `.` or `e`/`E`)
+    Float,
+}
+
+/// Spanned token with location information
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpannedToken {
+    /// The token
+    pub token: Token,
+    /// Source span
+    pub span: Span,
+}
+
+/// Scanner error
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScanError {
+    /// The error kind
+    pub kind: ScanErrorKind,
+    /// Source span
+    pub span: Span,
+}
+
+/// Types of scanner errors
+#[derive(Debug, Clone, PartialEq)]
+pub enum ScanErrorKind {
+    /// Unexpected character
+    UnexpectedChar(char),
+    /// Unexpected end of input (with context)
+    UnexpectedEof(&'static str),
+    /// Invalid UTF-8
+    InvalidUtf8,
+}
+
+/// Result type for scanner operations
+pub type ScanResult = Result<SpannedToken, ScanError>;
+
+/// JSON scanner state machine.
+///
+/// The scanner operates on a byte buffer and tracks position. For streaming,
+/// the buffer can be refilled when `Token::NeedMore` is returned.
+pub struct Scanner {
+    /// Current position in the buffer
+    pos: usize,
+    /// State for resuming after NeedMore (for streaming)
+    state: ScanState,
+}
+
+/// Internal state for resuming mid-token after buffer refill
+#[derive(Debug, Clone, Default)]
+enum ScanState {
+    #[default]
+    Ready,
+    /// In the middle of scanning a string
+    InString {
+        start: usize,
+        has_escapes: bool,
+        escape_next: bool,
+    },
+    /// In the middle of scanning a number
+    InNumber { start: usize, hint: NumberHint },
+    /// In the middle of scanning a literal (true/false/null)
+    InLiteral {
+        start: usize,
+        expected: &'static [u8],
+        matched: usize,
+    },
+}
+
+impl Scanner {
+    /// Create a new scanner starting at position 0
+    pub fn new() -> Self {
+        Self {
+            pos: 0,
+            state: ScanState::Ready,
+        }
+    }
+
+    /// Create a scanner starting at a specific position
+    #[allow(dead_code)]
+    pub fn at_position(pos: usize) -> Self {
+        Self {
+            pos,
+            state: ScanState::Ready,
+        }
+    }
+
+    /// Current position in the buffer
+    pub fn pos(&self) -> usize {
+        self.pos
+    }
+
+    /// Set position (used after buffer operations)
+    pub fn set_pos(&mut self, pos: usize) {
+        self.pos = pos;
+    }
+
+    /// Finalize any pending token at true EOF.
+    ///
+    /// Call this when the scanner returned `NeedMore` but no more data is available.
+    /// Returns the completed token if one is pending (e.g., a number at EOF),
+    /// or an error if the token is incomplete (e.g., unterminated string).
+    pub fn finalize_at_eof(&mut self, buf: &[u8]) -> ScanResult {
+        match core::mem::take(&mut self.state) {
+            ScanState::Ready => {
+                // Nothing pending
+                Ok(SpannedToken {
+                    token: Token::Eof,
+                    span: Span::new(self.pos, 0),
+                })
+            }
+            ScanState::InNumber { start, hint } => {
+                // Number is complete at EOF (numbers don't need closing delimiter)
+                let end = self.pos;
+                if end == start || (end == start + 1 && buf.get(start) == Some(&b'-')) {
+                    return Err(ScanError {
+                        kind: ScanErrorKind::UnexpectedEof("in number"),
+                        span: Span::new(start, end - start),
+                    });
+                }
+                Ok(SpannedToken {
+                    token: Token::Number { start, end, hint },
+                    span: Span::new(start, end - start),
+                })
+            }
+            ScanState::InString { start, .. } => {
+                // Unterminated string
+                Err(ScanError {
+                    kind: ScanErrorKind::UnexpectedEof("in string"),
+                    span: Span::new(start, self.pos - start),
+                })
+            }
+            ScanState::InLiteral {
+                start,
+                expected,
+                matched,
+            } => {
+                // Check if the literal is complete
+                if matched == expected.len() {
+                    let token = match expected {
+                        b"true" => Token::True,
+                        b"false" => Token::False,
+                        b"null" => Token::Null,
+                        _ => unreachable!(),
+                    };
+                    Ok(SpannedToken {
+                        token,
+                        span: Span::new(start, expected.len()),
+                    })
+                } else {
+                    Err(ScanError {
+                        kind: ScanErrorKind::UnexpectedEof("in literal"),
+                        span: Span::new(start, self.pos - start),
+                    })
+                }
+            }
+        }
+    }
+
+    /// Scan the next token from the buffer.
+    ///
+    /// Returns `Token::NeedMore` if the buffer is exhausted mid-token,
+    /// allowing the caller to refill and retry.
+    pub fn next_token(&mut self, buf: &[u8]) -> ScanResult {
+        // If we have pending state from a previous NeedMore, resume
+        match core::mem::take(&mut self.state) {
+            ScanState::Ready => {}
+            ScanState::InString {
+                start,
+                has_escapes,
+                escape_next,
+            } => {
+                return self.resume_string(buf, start, has_escapes, escape_next);
+            }
+            ScanState::InNumber { start, hint } => {
+                return self.resume_number(buf, start, hint);
+            }
+            ScanState::InLiteral {
+                start,
+                expected,
+                matched,
+            } => {
+                return self.resume_literal(buf, start, expected, matched);
+            }
+        }
+
+        self.skip_whitespace(buf);
+
+        let start = self.pos;
+        let Some(&byte) = buf.get(self.pos) else {
+            return Ok(SpannedToken {
+                token: Token::Eof,
+                span: Span::new(self.pos, 0),
+            });
+        };
+
+        match byte {
+            b'{' => {
+                self.pos += 1;
+                Ok(SpannedToken {
+                    token: Token::ObjectStart,
+                    span: Span::new(start, 1),
+                })
+            }
+            b'}' => {
+                self.pos += 1;
+                Ok(SpannedToken {
+                    token: Token::ObjectEnd,
+                    span: Span::new(start, 1),
+                })
+            }
+            b'[' => {
+                self.pos += 1;
+                Ok(SpannedToken {
+                    token: Token::ArrayStart,
+                    span: Span::new(start, 1),
+                })
+            }
+            b']' => {
+                self.pos += 1;
+                Ok(SpannedToken {
+                    token: Token::ArrayEnd,
+                    span: Span::new(start, 1),
+                })
+            }
+            b':' => {
+                self.pos += 1;
+                Ok(SpannedToken {
+                    token: Token::Colon,
+                    span: Span::new(start, 1),
+                })
+            }
+            b',' => {
+                self.pos += 1;
+                Ok(SpannedToken {
+                    token: Token::Comma,
+                    span: Span::new(start, 1),
+                })
+            }
+            b'"' => self.scan_string(buf, start),
+            b'-' | b'0'..=b'9' => self.scan_number(buf, start),
+            b't' => self.scan_literal(buf, start, b"true", Token::True),
+            b'f' => self.scan_literal(buf, start, b"false", Token::False),
+            b'n' => self.scan_literal(buf, start, b"null", Token::Null),
+            _ => Err(ScanError {
+                kind: ScanErrorKind::UnexpectedChar(byte as char),
+                span: Span::new(start, 1),
+            }),
+        }
+    }
+
+    fn skip_whitespace(&mut self, buf: &[u8]) {
+        while let Some(&b) = buf.get(self.pos) {
+            match b {
+                b' ' | b'\t' | b'\n' | b'\r' => self.pos += 1,
+                _ => break,
+            }
+        }
+    }
+
+    /// Scan a string, finding its boundaries and noting if it has escapes.
+    fn scan_string(&mut self, buf: &[u8], start: usize) -> ScanResult {
+        // Skip opening quote
+        self.pos += 1;
+        let content_start = self.pos;
+
+        self.scan_string_content(buf, start, content_start, false, false)
+    }
+
+    fn resume_string(
+        &mut self,
+        buf: &[u8],
+        start: usize,
+        has_escapes: bool,
+        escape_next: bool,
+    ) -> ScanResult {
+        let content_start = start + 1; // After opening quote
+        self.scan_string_content(buf, start, content_start, has_escapes, escape_next)
+    }
+
+    fn scan_string_content(
+        &mut self,
+        buf: &[u8],
+        start: usize,
+        content_start: usize,
+        mut has_escapes: bool,
+        mut escape_next: bool,
+    ) -> ScanResult {
+        // SIMD-friendly fast path: scan 16 bytes at a time looking for quotes/backslashes
+        const STEP_SIZE: usize = 16;
+        type Window = u128;
+        type Chunk = [u8; STEP_SIZE];
+
+        // SIMD fast path: only if we're not in escape mode
+        if !escape_next {
+            loop {
+                if let Some(Ok(chunk)) = buf
+                    .get(self.pos..)
+                    .and_then(|s| s.get(..STEP_SIZE))
+                    .map(Chunk::try_from)
+                {
+                    let window = Window::from_ne_bytes(chunk);
+                    let has_quote = contains_byte(window, b'"');
+                    let has_backslash = contains_byte(window, b'\\');
+
+                    if !has_quote && !has_backslash {
+                        // Fast path: no special chars in this chunk
+                        self.pos += STEP_SIZE;
+                        continue;
+                    }
+                }
+                // Fall through to byte-by-byte scanning
+                break;
+            }
+        }
+
+        // Byte-by-byte scanning
+        while let Some(&byte) = buf.get(self.pos) {
+            if escape_next {
+                // Previous char was backslash, skip this char
+                escape_next = false;
+                self.pos += 1;
+
+                // Handle \uXXXX - need to skip 4 more hex digits
+                if byte == b'u' {
+                    // Check if we have 4 more bytes
+                    if self.pos + 4 > buf.len() {
+                        // Need more data
+                        self.state = ScanState::InString {
+                            start,
+                            has_escapes: true,
+                            escape_next: false,
+                        };
+                        return Ok(SpannedToken {
+                            token: Token::NeedMore { consumed: start },
+                            span: Span::new(start, self.pos - start),
+                        });
+                    }
+                    self.pos += 4;
+
+                    // Check for surrogate pair (\uXXXX\uXXXX)
+                    if self.pos + 2 <= buf.len()
+                        && buf.get(self.pos) == Some(&b'\\')
+                        && buf.get(self.pos + 1) == Some(&b'u')
+                    {
+                        if self.pos + 6 > buf.len() {
+                            // Need more data for second surrogate
+                            self.state = ScanState::InString {
+                                start,
+                                has_escapes: true,
+                                escape_next: false,
+                            };
+                            return Ok(SpannedToken {
+                                token: Token::NeedMore { consumed: start },
+                                span: Span::new(start, self.pos - start),
+                            });
+                        }
+                        // Skip \uXXXX
+                        self.pos += 6;
+                    }
+                }
+                continue;
+            }
+
+            match byte {
+                b'"' => {
+                    // Found closing quote
+                    let content_end = self.pos;
+                    self.pos += 1; // Skip closing quote
+
+                    return Ok(SpannedToken {
+                        token: Token::String {
+                            start: content_start,
+                            end: content_end,
+                            has_escapes,
+                        },
+                        span: Span::new(start, self.pos - start),
+                    });
+                }
+                b'\\' => {
+                    has_escapes = true;
+                    escape_next = true;
+                    self.pos += 1;
+                }
+                _ => {
+                    self.pos += 1;
+                }
+            }
+        }
+
+        // Reached end of buffer without closing quote
+        if escape_next || self.pos > start {
+            // Mid-string, need more data
+            self.state = ScanState::InString {
+                start,
+                has_escapes,
+                escape_next,
+            };
+            Ok(SpannedToken {
+                token: Token::NeedMore { consumed: start },
+                span: Span::new(start, self.pos - start),
+            })
+        } else {
+            Err(ScanError {
+                kind: ScanErrorKind::UnexpectedEof("in string"),
+                span: Span::new(start, self.pos - start),
+            })
+        }
+    }
+
+    /// Scan a number, finding its boundaries and determining its type hint.
+    fn scan_number(&mut self, buf: &[u8], start: usize) -> ScanResult {
+        let mut hint = NumberHint::Unsigned;
+
+        if buf.get(self.pos) == Some(&b'-') {
+            hint = NumberHint::Signed;
+            self.pos += 1;
+        }
+
+        self.scan_number_content(buf, start, hint)
+    }
+
+    fn resume_number(&mut self, buf: &[u8], start: usize, hint: NumberHint) -> ScanResult {
+        self.scan_number_content(buf, start, hint)
+    }
+
+    fn scan_number_content(
+        &mut self,
+        buf: &[u8],
+        start: usize,
+        mut hint: NumberHint,
+    ) -> ScanResult {
+        // Integer part
+        while let Some(&b) = buf.get(self.pos) {
+            if b.is_ascii_digit() {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+
+        // Check for decimal part
+        if buf.get(self.pos) == Some(&b'.') {
+            hint = NumberHint::Float;
+            self.pos += 1;
+
+            // Fractional digits
+            while let Some(&b) = buf.get(self.pos) {
+                if b.is_ascii_digit() {
+                    self.pos += 1;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // Check for exponent
+        if matches!(buf.get(self.pos), Some(b'e') | Some(b'E')) {
+            hint = NumberHint::Float;
+            self.pos += 1;
+
+            // Optional sign
+            if matches!(buf.get(self.pos), Some(b'+') | Some(b'-')) {
+                self.pos += 1;
+            }
+
+            // Exponent digits
+            while let Some(&b) = buf.get(self.pos) {
+                if b.is_ascii_digit() {
+                    self.pos += 1;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // Check if we're at end of buffer - might need more data
+        // Numbers end at whitespace, punctuation, or true EOF
+        if self.pos == buf.len() {
+            // At end of buffer - need more data to see terminator
+            self.state = ScanState::InNumber { start, hint };
+            return Ok(SpannedToken {
+                token: Token::NeedMore { consumed: start },
+                span: Span::new(start, self.pos - start),
+            });
+        }
+
+        let end = self.pos;
+
+        // Validate we actually parsed something
+        if end == start || (end == start + 1 && buf.get(start) == Some(&b'-')) {
+            return Err(ScanError {
+                kind: ScanErrorKind::UnexpectedChar(
+                    buf.get(self.pos).map(|&b| b as char).unwrap_or('?'),
+                ),
+                span: Span::new(start, 1),
+            });
+        }
+
+        Ok(SpannedToken {
+            token: Token::Number { start, end, hint },
+            span: Span::new(start, end - start),
+        })
+    }
+
+    /// Scan a literal keyword (true, false, null)
+    fn scan_literal(
+        &mut self,
+        buf: &[u8],
+        start: usize,
+        expected: &'static [u8],
+        token: Token,
+    ) -> ScanResult {
+        self.scan_literal_content(buf, start, expected, 0, token)
+    }
+
+    fn resume_literal(
+        &mut self,
+        buf: &[u8],
+        start: usize,
+        expected: &'static [u8],
+        matched: usize,
+    ) -> ScanResult {
+        let token = match expected {
+            b"true" => Token::True,
+            b"false" => Token::False,
+            b"null" => Token::Null,
+            _ => unreachable!(),
+        };
+        self.scan_literal_content(buf, start, expected, matched, token)
+    }
+
+    fn scan_literal_content(
+        &mut self,
+        buf: &[u8],
+        start: usize,
+        expected: &'static [u8],
+        mut matched: usize,
+        token: Token,
+    ) -> ScanResult {
+        while matched < expected.len() {
+            match buf.get(self.pos) {
+                Some(&b) if b == expected[matched] => {
+                    self.pos += 1;
+                    matched += 1;
+                }
+                Some(&b) => {
+                    return Err(ScanError {
+                        kind: ScanErrorKind::UnexpectedChar(b as char),
+                        span: Span::new(self.pos, 1),
+                    });
+                }
+                None => {
+                    // Need more data
+                    self.state = ScanState::InLiteral {
+                        start,
+                        expected,
+                        matched,
+                    };
+                    return Ok(SpannedToken {
+                        token: Token::NeedMore { consumed: start },
+                        span: Span::new(start, self.pos - start),
+                    });
+                }
+            }
+        }
+
+        Ok(SpannedToken {
+            token,
+            span: Span::new(start, expected.len()),
+        })
+    }
+}
+
+impl Default for Scanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Check if a 128-bit window contains a specific byte (SIMD-friendly)
+#[inline]
+fn contains_byte(window: u128, byte: u8) -> bool {
+    let pattern = u128::from_ne_bytes([byte; 16]);
+    let xor = window ^ pattern;
+    let has_zero = (xor.wrapping_sub(0x01010101010101010101010101010101))
+        & !xor
+        & 0x80808080808080808080808080808080;
+    has_zero != 0
+}
+
+// =============================================================================
+// String decoding utilities (second pass)
+// =============================================================================
+
+/// Decode a JSON string from a buffer, handling escape sequences.
+///
+/// This is the "second pass" - only called when the deserializer actually needs
+/// the string content. For borrowed strings without escapes, use `decode_string_borrowed`.
+///
+/// # Arguments
+/// * `buf` - The buffer containing the string
+/// * `start` - Start index (after opening quote)
+/// * `end` - End index (before closing quote)
+///
+/// # Returns
+/// The decoded string, or an error if the string contains invalid escapes.
+pub fn decode_string_owned(
+    buf: &[u8],
+    start: usize,
+    end: usize,
+) -> Result<alloc::string::String, ScanError> {
+    use alloc::string::String;
+
+    let slice = &buf[start..end];
+    let mut result = String::with_capacity(end - start);
+    let mut i = 0;
+
+    while i < slice.len() {
+        let byte = slice[i];
+        if byte == b'\\' {
+            i += 1;
+            if i >= slice.len() {
+                return Err(ScanError {
+                    kind: ScanErrorKind::UnexpectedEof("in escape sequence"),
+                    span: Span::new(start + i - 1, 1),
+                });
+            }
+
+            match slice[i] {
+                b'"' => result.push('"'),
+                b'\\' => result.push('\\'),
+                b'/' => result.push('/'),
+                b'b' => result.push('\x08'),
+                b'f' => result.push('\x0c'),
+                b'n' => result.push('\n'),
+                b'r' => result.push('\r'),
+                b't' => result.push('\t'),
+                b'u' => {
+                    i += 1;
+                    if i + 4 > slice.len() {
+                        return Err(ScanError {
+                            kind: ScanErrorKind::UnexpectedEof("in unicode escape"),
+                            span: Span::new(start + i - 2, slice.len() - i + 2),
+                        });
+                    }
+
+                    let hex = &slice[i..i + 4];
+                    let hex_str = str::from_utf8(hex).map_err(|_| ScanError {
+                        kind: ScanErrorKind::InvalidUtf8,
+                        span: Span::new(start + i, 4),
+                    })?;
+
+                    let code_unit = u16::from_str_radix(hex_str, 16).map_err(|_| ScanError {
+                        kind: ScanErrorKind::UnexpectedChar('?'),
+                        span: Span::new(start + i, 4),
+                    })?;
+
+                    i += 4;
+
+                    // Check for surrogate pairs
+                    let code_point = if (0xD800..=0xDBFF).contains(&code_unit) {
+                        // High surrogate - expect \uXXXX to follow
+                        if i + 6 > slice.len() || slice[i] != b'\\' || slice[i + 1] != b'u' {
+                            return Err(ScanError {
+                                kind: ScanErrorKind::InvalidUtf8,
+                                span: Span::new(start + i - 6, 6),
+                            });
+                        }
+
+                        i += 2; // Skip \u
+                        let low_hex = &slice[i..i + 4];
+                        let low_hex_str = str::from_utf8(low_hex).map_err(|_| ScanError {
+                            kind: ScanErrorKind::InvalidUtf8,
+                            span: Span::new(start + i, 4),
+                        })?;
+
+                        let low_unit =
+                            u16::from_str_radix(low_hex_str, 16).map_err(|_| ScanError {
+                                kind: ScanErrorKind::UnexpectedChar('?'),
+                                span: Span::new(start + i, 4),
+                            })?;
+
+                        i += 4;
+
+                        if !(0xDC00..=0xDFFF).contains(&low_unit) {
+                            return Err(ScanError {
+                                kind: ScanErrorKind::InvalidUtf8,
+                                span: Span::new(start + i - 4, 4),
+                            });
+                        }
+
+                        // Combine surrogates
+                        let high = code_unit as u32;
+                        let low = low_unit as u32;
+                        0x10000 + ((high & 0x3FF) << 10) + (low & 0x3FF)
+                    } else if (0xDC00..=0xDFFF).contains(&code_unit) {
+                        // Lone low surrogate
+                        return Err(ScanError {
+                            kind: ScanErrorKind::InvalidUtf8,
+                            span: Span::new(start + i - 4, 4),
+                        });
+                    } else {
+                        code_unit as u32
+                    };
+
+                    let c = char::from_u32(code_point).ok_or_else(|| ScanError {
+                        kind: ScanErrorKind::InvalidUtf8,
+                        span: Span::new(start + i - 4, 4),
+                    })?;
+
+                    result.push(c);
+                    continue; // Don't increment i again
+                }
+                other => {
+                    // Unknown escape - just push the character
+                    result.push(other as char);
+                }
+            }
+            i += 1;
+        } else {
+            // Regular UTF-8 byte
+            // Fast path for ASCII
+            if byte < 0x80 {
+                result.push(byte as char);
+                i += 1;
+            } else {
+                // Multi-byte UTF-8 sequence - find the end of valid UTF-8
+                let remaining = &slice[i..];
+                match str::from_utf8(remaining) {
+                    Ok(s) => {
+                        result.push_str(s);
+                        break;
+                    }
+                    Err(e) => {
+                        // Partial valid UTF-8
+                        let valid_len = e.valid_up_to();
+                        if valid_len > 0 {
+                            // Re-validate the valid portion (safe, no unsafe)
+                            let valid = str::from_utf8(&remaining[..valid_len])
+                                .expect("valid_up_to guarantees valid UTF-8");
+                            result.push_str(valid);
+                            i += valid_len;
+                        } else {
+                            return Err(ScanError {
+                                kind: ScanErrorKind::InvalidUtf8,
+                                span: Span::new(start + i, 1),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Try to borrow a string directly from the buffer (zero-copy).
+///
+/// This only works for strings without escape sequences. Returns `None` if
+/// the string contains escapes or invalid UTF-8.
+///
+/// # Arguments
+/// * `buf` - The buffer containing the string
+/// * `start` - Start index (after opening quote)
+/// * `end` - End index (before closing quote)
+pub fn decode_string_borrowed(buf: &[u8], start: usize, end: usize) -> Option<&str> {
+    let slice = &buf[start..end];
+
+    // Quick check for backslashes
+    if slice.contains(&b'\\') {
+        return None;
+    }
+
+    str::from_utf8(slice).ok()
+}
+
+/// Decode a JSON string, returning either a borrowed or owned string.
+///
+/// Uses `Cow<str>` to avoid allocation when possible.
+pub fn decode_string<'a>(
+    buf: &'a [u8],
+    start: usize,
+    end: usize,
+    has_escapes: bool,
+) -> Result<alloc::borrow::Cow<'a, str>, ScanError> {
+    use alloc::borrow::Cow;
+
+    if has_escapes {
+        decode_string_owned(buf, start, end).map(Cow::Owned)
+    } else {
+        decode_string_borrowed(buf, start, end)
+            .map(Cow::Borrowed)
+            .ok_or_else(|| ScanError {
+                kind: ScanErrorKind::InvalidUtf8,
+                span: Span::new(start, end - start),
+            })
+    }
+}
+
+/// Parse a number from the buffer.
+///
+/// Returns the appropriate numeric type based on the hint and value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParsedNumber {
+    /// Unsigned 64-bit integer
+    U64(u64),
+    /// Signed 64-bit integer
+    I64(i64),
+    /// Unsigned 128-bit integer
+    U128(u128),
+    /// Signed 128-bit integer
+    I128(i128),
+    /// 64-bit floating point
+    F64(f64),
+}
+
+/// Parse a number from the buffer slice.
+#[cfg(feature = "lexical-parse")]
+pub fn parse_number(
+    buf: &[u8],
+    start: usize,
+    end: usize,
+    hint: NumberHint,
+) -> Result<ParsedNumber, ScanError> {
+    use lexical_parse_float::FromLexical as _;
+    use lexical_parse_integer::FromLexical as _;
+
+    let slice = &buf[start..end];
+
+    match hint {
+        NumberHint::Float => f64::from_lexical(slice)
+            .map(ParsedNumber::F64)
+            .map_err(|_| ScanError {
+                kind: ScanErrorKind::UnexpectedChar('?'),
+                span: Span::new(start, end - start),
+            }),
+        NumberHint::Signed => {
+            if let Ok(n) = i64::from_lexical(slice) {
+                Ok(ParsedNumber::I64(n))
+            } else if let Ok(n) = i128::from_lexical(slice) {
+                Ok(ParsedNumber::I128(n))
+            } else {
+                Err(ScanError {
+                    kind: ScanErrorKind::UnexpectedChar('?'),
+                    span: Span::new(start, end - start),
+                })
+            }
+        }
+        NumberHint::Unsigned => {
+            if let Ok(n) = u64::from_lexical(slice) {
+                Ok(ParsedNumber::U64(n))
+            } else if let Ok(n) = u128::from_lexical(slice) {
+                Ok(ParsedNumber::U128(n))
+            } else {
+                Err(ScanError {
+                    kind: ScanErrorKind::UnexpectedChar('?'),
+                    span: Span::new(start, end - start),
+                })
+            }
+        }
+    }
+}
+
+/// Parse a number from the buffer slice (std fallback).
+#[cfg(not(feature = "lexical-parse"))]
+pub fn parse_number(
+    buf: &[u8],
+    start: usize,
+    end: usize,
+    hint: NumberHint,
+) -> Result<ParsedNumber, ScanError> {
+    let slice = &buf[start..end];
+    let s = str::from_utf8(slice).map_err(|_| ScanError {
+        kind: ScanErrorKind::InvalidUtf8,
+        span: Span::new(start, end - start),
+    })?;
+
+    match hint {
+        NumberHint::Float => s
+            .parse::<f64>()
+            .map(ParsedNumber::F64)
+            .map_err(|_| ScanError {
+                kind: ScanErrorKind::UnexpectedChar('?'),
+                span: Span::new(start, end - start),
+            }),
+        NumberHint::Signed => {
+            if let Ok(n) = s.parse::<i64>() {
+                Ok(ParsedNumber::I64(n))
+            } else if let Ok(n) = s.parse::<i128>() {
+                Ok(ParsedNumber::I128(n))
+            } else {
+                Err(ScanError {
+                    kind: ScanErrorKind::UnexpectedChar('?'),
+                    span: Span::new(start, end - start),
+                })
+            }
+        }
+        NumberHint::Unsigned => {
+            if let Ok(n) = s.parse::<u64>() {
+                Ok(ParsedNumber::U64(n))
+            } else if let Ok(n) = s.parse::<u128>() {
+                Ok(ParsedNumber::U128(n))
+            } else {
+                Err(ScanError {
+                    kind: ScanErrorKind::UnexpectedChar('?'),
+                    span: Span::new(start, end - start),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_tokens() {
+        let input = b"{}[],:";
+        let mut scanner = Scanner::new();
+
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::ObjectStart
+        ));
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::ObjectEnd
+        ));
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::ArrayStart
+        ));
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::ArrayEnd
+        ));
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::Comma
+        ));
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::Colon
+        ));
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::Eof
+        ));
+    }
+
+    #[test]
+    fn test_string_no_escapes() {
+        let input = b"\"hello world\"";
+        let mut scanner = Scanner::new();
+
+        let result = scanner.next_token(input).unwrap();
+        assert!(matches!(
+            result.token,
+            Token::String {
+                start: 1,
+                end: 12,
+                has_escapes: false
+            }
+        ));
+    }
+
+    #[test]
+    fn test_string_with_escapes() {
+        let input = br#""hello\nworld""#;
+        let mut scanner = Scanner::new();
+
+        let result = scanner.next_token(input).unwrap();
+        assert!(matches!(
+            result.token,
+            Token::String {
+                start: 1,
+                end: 13,
+                has_escapes: true
+            }
+        ));
+    }
+
+    #[test]
+    fn test_numbers() {
+        let mut scanner = Scanner::new();
+
+        // Unsigned (with terminator so scanner knows number is complete)
+        let result = scanner.next_token(b"42,").unwrap();
+        assert!(matches!(
+            result.token,
+            Token::Number {
+                hint: NumberHint::Unsigned,
+                ..
+            }
+        ));
+
+        // Signed
+        scanner.set_pos(0);
+        let result = scanner.next_token(b"-42]").unwrap();
+        assert!(matches!(
+            result.token,
+            Token::Number {
+                hint: NumberHint::Signed,
+                ..
+            }
+        ));
+
+        // Float
+        scanner.set_pos(0);
+        let result = scanner.next_token(b"3.14}").unwrap();
+        assert!(matches!(
+            result.token,
+            Token::Number {
+                hint: NumberHint::Float,
+                ..
+            }
+        ));
+
+        // Exponent
+        scanner.set_pos(0);
+        let result = scanner.next_token(b"1e10 ").unwrap();
+        assert!(matches!(
+            result.token,
+            Token::Number {
+                hint: NumberHint::Float,
+                ..
+            }
+        ));
+
+        // Number at end of buffer returns NeedMore (streaming behavior)
+        scanner.set_pos(0);
+        let result = scanner.next_token(b"42").unwrap();
+        assert!(matches!(result.token, Token::NeedMore { .. }));
+    }
+
+    #[test]
+    fn test_literals() {
+        let mut scanner = Scanner::new();
+
+        // Literals need terminators too (scanner can't know if "truex" is coming)
+        let result = scanner.next_token(b"true,").unwrap();
+        assert!(matches!(result.token, Token::True));
+
+        scanner.set_pos(0);
+        let result = scanner.next_token(b"false]").unwrap();
+        assert!(matches!(result.token, Token::False));
+
+        scanner.set_pos(0);
+        let result = scanner.next_token(b"null}").unwrap();
+        assert!(matches!(result.token, Token::Null));
+    }
+
+    #[test]
+    fn test_whitespace_handling() {
+        let input = b"  {\n\t\"key\"  :  42  }  ";
+        let mut scanner = Scanner::new();
+
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::ObjectStart
+        ));
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::String { .. }
+        ));
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::Colon
+        ));
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::Number { .. }
+        ));
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::ObjectEnd
+        ));
+        assert!(matches!(
+            scanner.next_token(input).unwrap().token,
+            Token::Eof
+        ));
+    }
+
+    #[test]
+    fn test_decode_string_no_escapes() {
+        let input = b"hello world";
+        let result = decode_string_borrowed(input, 0, input.len());
+        assert_eq!(result, Some("hello world"));
+    }
+
+    #[test]
+    fn test_decode_string_with_escapes() {
+        let input = br#"hello\nworld"#;
+        let result = decode_string_owned(input, 0, input.len()).unwrap();
+        assert_eq!(result, "hello\nworld");
+    }
+
+    #[test]
+    fn test_decode_string_unicode() {
+        // \u0048 = 'H', \u0065 = 'e', \u006C = 'l', \u006C = 'l', \u006F = 'o'
+        let input = br#"\u0048\u0065\u006C\u006C\u006F"#;
+        let result = decode_string_owned(input, 0, input.len()).unwrap();
+        assert_eq!(result, "Hello");
+    }
+
+    #[test]
+    fn test_decode_string_surrogate_pair() {
+        // U+1F600 (grinning face) = \uD83D\uDE00
+        let input = br#"\uD83D\uDE00"#;
+        let result = decode_string_owned(input, 0, input.len()).unwrap();
+        assert_eq!(result, "😀");
+    }
+
+    #[test]
+    fn test_decode_cow_borrowed() {
+        let input = b"simple";
+        let result = decode_string(input, 0, input.len(), false).unwrap();
+        assert!(matches!(result, alloc::borrow::Cow::Borrowed(_)));
+        assert_eq!(&*result, "simple");
+    }
+
+    #[test]
+    fn test_decode_cow_owned() {
+        let input = br#"has\tescape"#;
+        let result = decode_string(input, 0, input.len(), true).unwrap();
+        assert!(matches!(result, alloc::borrow::Cow::Owned(_)));
+        assert_eq!(&*result, "has\tescape");
+    }
+
+    #[test]
+    fn test_parse_numbers() {
+        assert_eq!(
+            parse_number(b"42", 0, 2, NumberHint::Unsigned).unwrap(),
+            ParsedNumber::U64(42)
+        );
+        assert_eq!(
+            parse_number(b"-42", 0, 3, NumberHint::Signed).unwrap(),
+            ParsedNumber::I64(-42)
+        );
+        #[allow(clippy::approx_constant)]
+        {
+            assert_eq!(
+                parse_number(b"3.14", 0, 4, NumberHint::Float).unwrap(),
+                ParsedNumber::F64(3.14)
+            );
+        }
+    }
+}

--- a/facet-format-json/src/streaming.rs
+++ b/facet-format-json/src/streaming.rs
@@ -16,10 +16,11 @@ use facet_format::{
     ContainerKind, DeserializeError, FieldEvidence, FieldKey, FieldLocationHint,
     FormatDeserializer, FormatParser, ParseEvent, ProbeStream, ScalarValue,
 };
-use facet_json::{
-    AdapterToken, JsonError, JsonErrorKind, ScanBuffer, SpannedAdapterToken, StreamingAdapter,
-    TokenSource,
-};
+
+use crate::adapter::{SpannedAdapterToken, Token as AdapterToken, TokenSource};
+use crate::error::{JsonError, JsonErrorKind};
+use crate::scan_buffer::ScanBuffer;
+use crate::streaming_adapter::StreamingAdapter;
 
 /// Deserialize JSON from a synchronous reader.
 ///

--- a/facet-format-json/src/streaming_adapter.rs
+++ b/facet-format-json/src/streaming_adapter.rs
@@ -1,0 +1,327 @@
+//! Streaming adapter that bridges buffer-based scanning to the token source trait.
+
+extern crate alloc;
+
+use alloc::borrow::Cow;
+use alloc::rc::Rc;
+use core::cell::RefCell;
+
+use facet_reflect::Span;
+
+use crate::adapter::{SpannedAdapterToken, Token, TokenSource};
+use crate::error::{JsonError, JsonErrorKind};
+use crate::scan_buffer::ScanBuffer;
+use crate::scanner::{ParsedNumber, ScanErrorKind, Scanner, Token as ScanToken};
+
+/// Spanned token for streaming deserialization.
+///
+/// Uses `Token<'static>` since streaming always produces owned strings
+/// (the underlying buffer may be refilled/modified between tokens).
+#[derive(Debug, Clone)]
+pub struct SpannedStreamingToken {
+    /// The token (always owned strings)
+    pub token: Token<'static>,
+    /// Source span (absolute position in input stream)
+    pub span: Span,
+}
+
+impl SpannedStreamingToken {
+    /// Convert to a SpannedAdapterToken (same type, just for clarity)
+    #[allow(dead_code)]
+    pub fn to_adapter_token(&self) -> SpannedAdapterToken<'static> {
+        SpannedAdapterToken {
+            token: self.token.clone(),
+            span: self.span,
+        }
+    }
+}
+
+/// Streaming adapter that wraps a shared buffer and can yield to the driver.
+///
+/// This adapter is used inside the coroutine. When it needs more data, it
+/// suspends the coroutine via the yielder, and the driver refills the buffer.
+pub struct StreamingAdapter<'y> {
+    /// Shared buffer (via `Rc<RefCell>`)
+    buffer: Rc<RefCell<ScanBuffer>>,
+    /// Yielder to suspend coroutine when more data needed
+    yielder: &'y corosensei::Yielder<(), ()>,
+    /// Scanner state
+    scanner: Scanner,
+    /// Total bytes processed (for absolute positions)
+    bytes_processed: usize,
+    /// Peeked token for lookahead
+    peeked: Option<SpannedStreamingToken>,
+}
+
+impl<'y> StreamingAdapter<'y> {
+    /// Create a new streaming adapter.
+    pub fn new(buffer: Rc<RefCell<ScanBuffer>>, yielder: &'y corosensei::Yielder<(), ()>) -> Self {
+        Self {
+            buffer,
+            yielder,
+            scanner: Scanner::new(),
+            bytes_processed: 0,
+            peeked: None,
+        }
+    }
+
+    /// Peek at the next token without consuming it.
+    #[allow(dead_code)]
+    pub fn peek(&mut self) -> Result<&SpannedStreamingToken, JsonError> {
+        if self.peeked.is_none() {
+            self.peeked = Some(self.next_token_internal()?);
+        }
+        Ok(self.peeked.as_ref().unwrap())
+    }
+
+    /// Consume and return the next token.
+    pub fn next_token(&mut self) -> Result<SpannedStreamingToken, JsonError> {
+        if let Some(token) = self.peeked.take() {
+            Ok(token)
+        } else {
+            self.next_token_internal()
+        }
+    }
+
+    /// Internal implementation of next_token, yielding to the driver if more data is needed.
+    fn next_token_internal(&mut self) -> Result<SpannedStreamingToken, JsonError> {
+        loop {
+            let buf = self.buffer.borrow();
+            let data = buf.data();
+            let is_eof = buf.is_eof();
+
+            match self.scanner.next_token(data) {
+                Ok(spanned) => match spanned.token {
+                    ScanToken::NeedMore { .. } => {
+                        drop(buf); // Release borrow before yielding
+
+                        if is_eof {
+                            // True EOF - try to finalize
+                            let buf = self.buffer.borrow();
+                            let finalized = self.scanner.finalize_at_eof(buf.data());
+                            drop(buf);
+
+                            match finalized {
+                                Ok(f) => {
+                                    let abs_span =
+                                        Span::new(self.bytes_processed + f.span.offset, f.span.len);
+                                    let token = self.materialize_token(&f.token, abs_span)?;
+                                    self.advance_past(f.span.offset + f.span.len);
+                                    return Ok(token);
+                                }
+                                Err(e) => {
+                                    return Err(JsonError {
+                                        kind: JsonErrorKind::Scan(e.kind),
+                                        span: Some(Span::new(
+                                            self.bytes_processed + e.span.offset,
+                                            e.span.len,
+                                        )),
+                                        source_code: None,
+                                    });
+                                }
+                            }
+                        }
+
+                        // Yield to driver to refill buffer
+                        self.yielder.suspend(());
+                        continue;
+                    }
+                    ScanToken::Eof => {
+                        let abs_span = Span::new(self.bytes_processed + spanned.span.offset, 0);
+                        drop(buf);
+
+                        if is_eof {
+                            return Ok(SpannedStreamingToken {
+                                token: Token::Eof,
+                                span: abs_span,
+                            });
+                        }
+
+                        // End of current buffer data, but not true EOF
+                        // Reset scanner and yield for more data
+                        self.advance_past(self.scanner.pos());
+                        self.scanner.set_pos(0);
+                        self.yielder.suspend(());
+                        continue;
+                    }
+                    _ => {
+                        // Complete token - compute absolute span
+                        let abs_span =
+                            Span::new(self.bytes_processed + spanned.span.offset, spanned.span.len);
+                        let token = self.materialize_token(&spanned.token, abs_span)?;
+                        let consumed = self.scanner.pos();
+                        drop(buf);
+
+                        self.advance_past(consumed);
+                        return Ok(token);
+                    }
+                },
+                Err(e) => {
+                    return Err(JsonError {
+                        kind: JsonErrorKind::Scan(e.kind),
+                        span: Some(Span::new(self.bytes_processed + e.span.offset, e.span.len)),
+                        source_code: None,
+                    });
+                }
+            }
+        }
+    }
+
+    /// Skip a JSON value without fully decoding it.
+    pub fn skip(&mut self) -> Result<Span, JsonError> {
+        let first = self.next_token()?;
+        let start_span = first.span;
+
+        match first.token {
+            Token::ObjectStart => {
+                let mut depth = 1;
+                while depth > 0 {
+                    let t = self.next_token()?;
+                    match t.token {
+                        Token::ObjectStart => depth += 1,
+                        Token::ObjectEnd => depth -= 1,
+                        Token::Eof => {
+                            return Err(JsonError {
+                                kind: JsonErrorKind::Scan(ScanErrorKind::UnexpectedEof(
+                                    "in object",
+                                )),
+                                span: None,
+                                source_code: None,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(start_span)
+            }
+            Token::ArrayStart => {
+                let mut depth = 1;
+                while depth > 0 {
+                    let t = self.next_token()?;
+                    match t.token {
+                        Token::ArrayStart => depth += 1,
+                        Token::ArrayEnd => depth -= 1,
+                        Token::Eof => {
+                            return Err(JsonError {
+                                kind: JsonErrorKind::Scan(ScanErrorKind::UnexpectedEof("in array")),
+                                span: None,
+                                source_code: None,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(start_span)
+            }
+            Token::Eof => Err(JsonError {
+                kind: JsonErrorKind::Scan(ScanErrorKind::UnexpectedEof("expected value")),
+                span: None,
+                source_code: None,
+            }),
+            // Scalars - already consumed
+            _ => Ok(start_span),
+        }
+    }
+
+    /// Materialize a scanner token into an owned token with span.
+    fn materialize_token(
+        &self,
+        token: &ScanToken,
+        span: Span,
+    ) -> Result<SpannedStreamingToken, JsonError> {
+        let buf = self.buffer.borrow();
+        let data = buf.data();
+
+        let owned_token = match token {
+            ScanToken::ObjectStart => Token::ObjectStart,
+            ScanToken::ObjectEnd => Token::ObjectEnd,
+            ScanToken::ArrayStart => Token::ArrayStart,
+            ScanToken::ArrayEnd => Token::ArrayEnd,
+            ScanToken::Colon => Token::Colon,
+            ScanToken::Comma => Token::Comma,
+            ScanToken::Null => Token::Null,
+            ScanToken::True => Token::True,
+            ScanToken::False => Token::False,
+            ScanToken::String {
+                start,
+                end,
+                has_escapes: _,
+            } => {
+                // Always decode to owned string (buffer may change)
+                let s = crate::scanner::decode_string_owned(data, *start, *end).map_err(|e| {
+                    JsonError {
+                        kind: JsonErrorKind::Scan(e.kind),
+                        span: Some(Span::new(self.bytes_processed + e.span.offset, e.span.len)),
+                        source_code: None,
+                    }
+                })?;
+                Token::String(Cow::Owned(s))
+            }
+            ScanToken::Number { start, end, hint } => {
+                let parsed =
+                    crate::scanner::parse_number(data, *start, *end, *hint).map_err(|e| {
+                        JsonError {
+                            kind: JsonErrorKind::Scan(e.kind),
+                            span: Some(Span::new(self.bytes_processed + e.span.offset, e.span.len)),
+                            source_code: None,
+                        }
+                    })?;
+                match parsed {
+                    ParsedNumber::U64(n) => Token::U64(n),
+                    ParsedNumber::I64(n) => Token::I64(n),
+                    ParsedNumber::U128(n) => Token::U128(n),
+                    ParsedNumber::I128(n) => Token::I128(n),
+                    ParsedNumber::F64(n) => Token::F64(n),
+                }
+            }
+            ScanToken::Eof => Token::Eof,
+            ScanToken::NeedMore { .. } => unreachable!("NeedMore handled in next_token loop"),
+        };
+
+        Ok(SpannedStreamingToken {
+            token: owned_token,
+            span,
+        })
+    }
+
+    /// Advance past consumed bytes, resetting buffer if all data consumed.
+    fn advance_past(&mut self, consumed: usize) {
+        self.bytes_processed += consumed;
+
+        let mut buf = self.buffer.borrow_mut();
+        if consumed >= buf.filled() {
+            // All data consumed - reset buffer for fresh data
+            buf.reset();
+            self.scanner.set_pos(0);
+        } else {
+            // Partial consumption - this shouldn't happen with our model
+            // since we process complete tokens, but handle it anyway
+            self.scanner.set_pos(consumed);
+        }
+    }
+
+    /// Get the current absolute position.
+    #[allow(dead_code)]
+    pub fn position(&self) -> usize {
+        self.bytes_processed + self.scanner.pos()
+    }
+}
+
+impl<'y> TokenSource<'static> for StreamingAdapter<'y> {
+    fn next_token(&mut self) -> Result<SpannedAdapterToken<'static>, JsonError> {
+        // StreamingAdapter already produces owned tokens (Token<'static>)
+        // Call the inherent method, not the trait method
+        let token = StreamingAdapter::next_token(self)?;
+        Ok(SpannedAdapterToken {
+            token: token.token,
+            span: token.span,
+        })
+    }
+
+    fn skip(&mut self) -> Result<Span, JsonError> {
+        // Call the inherent skip method
+        StreamingAdapter::skip(self)
+    }
+
+    // input_bytes() and at_offset() return None (default) for streaming
+}


### PR DESCRIPTION
## Summary
- Remove dependency on `facet-json` by internalizing scanner, adapter, and error types
- Add `lexical-parse` feature flag for fast number parsing (optional)
- Without `lexical-parse`, falls back to std's `str::parse()`
- Add `fast` meta-feature that enables `lexical-parse`

## New modules
- `scanner.rs`: Low-level JSON tokenizer with streaming support
- `adapter.rs`: Token adapter bridging scanner to deserializer
- `scan_buffer.rs`: Buffer management for streaming
- `streaming_adapter.rs`: Coroutine-based streaming adapter
- `error.rs`: JsonError and JsonErrorKind types

## Test plan
- [x] All existing tests pass (137 tests)
- [x] Doc tests pass
- [x] Clippy passes