### PR TITLE
feat(format-json): Add RawJson support and to_writer_std functions

### DIFF
--- a/facet-format-json/Cargo.toml
+++ b/facet-format-json/Cargo.toml
@@ -14,6 +14,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
 corosensei = { version = "0.3", optional = true }
+facet = { path = "../facet", default-features = false }
 facet-core = { path = "../facet-core", features = ["auto-traits", "bytes", "camino", "chrono", "fn-ptr", "indexmap", "jiff02", "net", "nonzero", "num-complex", "ordered-float", "ruint", "simd", "time", "tuples-12", "ulid", "url", "uuid"] }
 facet-format = { path = "../facet-format" }
 facet-reflect = { path = "../facet-reflect", features = ["miette"] }

--- a/facet-format-json/src/lib.rs
+++ b/facet-format-json/src/lib.rs
@@ -9,6 +9,7 @@ extern crate alloc;
 mod adapter;
 mod error;
 mod parser;
+mod raw_json;
 mod scan_buffer;
 mod scanner;
 mod serializer;
@@ -17,10 +18,13 @@ mod serializer;
 mod streaming_adapter;
 
 pub use parser::{JsonError, JsonParser};
+pub use raw_json::RawJson;
 pub use serializer::{
     JsonSerializeError, JsonSerializer, SerializeOptions, peek_to_string, peek_to_string_pretty,
-    peek_to_string_with_options, to_string, to_string_pretty, to_string_with_options, to_vec,
-    to_vec_pretty, to_vec_with_options,
+    peek_to_string_with_options, peek_to_writer_std, peek_to_writer_std_pretty,
+    peek_to_writer_std_with_options, to_string, to_string_pretty, to_string_with_options, to_vec,
+    to_vec_pretty, to_vec_with_options, to_writer_std, to_writer_std_pretty,
+    to_writer_std_with_options,
 };
 
 // Re-export DeserializeError for convenience

--- a/facet-format-json/src/raw_json.rs
+++ b/facet-format-json/src/raw_json.rs
@@ -1,0 +1,98 @@
+//! Raw JSON value that defers parsing.
+//!
+//! [`RawJson`] captures unparsed JSON text, allowing you to delay or skip
+//! deserialization of parts of a JSON document.
+
+use alloc::borrow::Cow;
+use alloc::string::String;
+use core::fmt;
+use facet::Facet;
+
+/// A raw JSON value that has not been parsed.
+///
+/// This type captures the raw JSON text for a value, deferring parsing until
+/// you're ready (or skipping it entirely if you just need to pass it through).
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_format_json::RawJson;
+///
+/// #[derive(Facet, Debug)]
+/// struct Response<'a> {
+///     status: u32,
+///     // We don't know what shape `data` has, so defer parsing
+///     data: RawJson<'a>,
+/// }
+///
+/// let json = r#"{"status": 200, "data": {"nested": [1, 2, 3], "complex": true}}"#;
+/// let response: Response = facet_format_json::from_str_borrowed(json).unwrap();
+///
+/// assert_eq!(response.status, 200);
+/// assert_eq!(response.data.as_str(), r#"{"nested": [1, 2, 3], "complex": true}"#);
+/// ```
+#[derive(Clone, PartialEq, Eq, Hash, Facet)]
+pub struct RawJson<'a>(pub Cow<'a, str>);
+
+impl<'a> RawJson<'a> {
+    /// Create a new `RawJson` from a string slice.
+    #[inline]
+    pub fn new(s: &'a str) -> Self {
+        RawJson(Cow::Borrowed(s))
+    }
+
+    /// Create a new `RawJson` from an owned string.
+    #[inline]
+    pub fn from_owned(s: String) -> Self {
+        RawJson(Cow::Owned(s))
+    }
+
+    /// Get the raw JSON as a string slice.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Convert into an owned `RawJson<'static>`.
+    #[inline]
+    pub fn into_owned(self) -> RawJson<'static> {
+        RawJson(Cow::Owned(self.0.into_owned()))
+    }
+}
+
+impl fmt::Debug for RawJson<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("RawJson").field(&self.0).finish()
+    }
+}
+
+impl fmt::Display for RawJson<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<'a> From<&'a str> for RawJson<'a> {
+    fn from(s: &'a str) -> Self {
+        RawJson::new(s)
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for RawJson<'a> {
+    fn from(s: Cow<'a, str>) -> Self {
+        RawJson(s)
+    }
+}
+
+impl From<String> for RawJson<'static> {
+    fn from(s: String) -> Self {
+        RawJson::from_owned(s)
+    }
+}
+
+impl<'a> AsRef<str> for RawJson<'a> {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}

--- a/facet-format-json/tests/raw_json.rs
+++ b/facet-format-json/tests/raw_json.rs
@@ -1,0 +1,229 @@
+//! Tests for RawJson support in facet-format-json.
+
+use facet::Facet;
+use facet_format_json::{RawJson, from_str, from_str_borrowed, to_string};
+
+// ── Deserialization tests ──
+
+#[test]
+fn deserialize_raw_json_object() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Response<'a> {
+        status: u32,
+        data: RawJson<'a>,
+    }
+
+    let json = r#"{"status": 200, "data": {"nested": [1, 2, 3], "complex": true}}"#;
+    let response: Response = from_str_borrowed(json).unwrap();
+
+    assert_eq!(response.status, 200);
+    assert_eq!(
+        response.data.as_str(),
+        r#"{"nested": [1, 2, 3], "complex": true}"#
+    );
+}
+
+#[test]
+fn deserialize_raw_json_array() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Container<'a> {
+        items: RawJson<'a>,
+    }
+
+    let json = r#"{"items": [1, "two", null, true]}"#;
+    let container: Container = from_str_borrowed(json).unwrap();
+
+    assert_eq!(container.items.as_str(), r#"[1, "two", null, true]"#);
+}
+
+#[test]
+fn deserialize_raw_json_string() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Container<'a> {
+        value: RawJson<'a>,
+    }
+
+    let json = r#"{"value": "hello world"}"#;
+    let container: Container = from_str_borrowed(json).unwrap();
+
+    assert_eq!(container.value.as_str(), r#""hello world""#);
+}
+
+#[test]
+fn deserialize_raw_json_number() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Container<'a> {
+        value: RawJson<'a>,
+    }
+
+    let json = r#"{"value": 42}"#;
+    let container: Container = from_str_borrowed(json).unwrap();
+
+    assert_eq!(container.value.as_str(), "42");
+}
+
+#[test]
+fn deserialize_raw_json_boolean() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Container<'a> {
+        value: RawJson<'a>,
+    }
+
+    let json = r#"{"value": true}"#;
+    let container: Container = from_str_borrowed(json).unwrap();
+
+    assert_eq!(container.value.as_str(), "true");
+}
+
+#[test]
+fn deserialize_raw_json_null() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Container<'a> {
+        value: RawJson<'a>,
+    }
+
+    let json = r#"{"value": null}"#;
+    let container: Container = from_str_borrowed(json).unwrap();
+
+    assert_eq!(container.value.as_str(), "null");
+}
+
+#[test]
+fn deserialize_raw_json_owned() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Response {
+        status: u32,
+        data: RawJson<'static>,
+    }
+
+    let json = r#"{"status": 200, "data": {"nested": true}}"#;
+    let response: Response = from_str(json).unwrap();
+
+    assert_eq!(response.status, 200);
+    assert_eq!(response.data.as_str(), r#"{"nested": true}"#);
+}
+
+#[test]
+fn deserialize_multiple_raw_json_fields() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Multi<'a> {
+        first: RawJson<'a>,
+        second: RawJson<'a>,
+        third: RawJson<'a>,
+    }
+
+    let json = r#"{"first": [1, 2], "second": {"key": "value"}, "third": null}"#;
+    let multi: Multi = from_str_borrowed(json).unwrap();
+
+    assert_eq!(multi.first.as_str(), "[1, 2]");
+    assert_eq!(multi.second.as_str(), r#"{"key": "value"}"#);
+    assert_eq!(multi.third.as_str(), "null");
+}
+
+// ── Serialization tests ──
+
+#[test]
+fn serialize_raw_json_object() {
+    #[derive(Facet, Debug)]
+    struct Response<'a> {
+        status: u32,
+        data: RawJson<'a>,
+    }
+
+    let response = Response {
+        status: 200,
+        data: RawJson::new(r#"{"nested": true}"#),
+    };
+
+    let json = to_string(&response).unwrap();
+    assert_eq!(json, r#"{"status":200,"data":{"nested": true}}"#);
+}
+
+#[test]
+fn serialize_raw_json_array() {
+    #[derive(Facet, Debug)]
+    struct Container<'a> {
+        items: RawJson<'a>,
+    }
+
+    let container = Container {
+        items: RawJson::new(r#"[1, 2, 3]"#),
+    };
+
+    let json = to_string(&container).unwrap();
+    assert_eq!(json, r#"{"items":[1, 2, 3]}"#);
+}
+
+#[test]
+fn serialize_raw_json_number() {
+    #[derive(Facet, Debug)]
+    struct Container<'a> {
+        value: RawJson<'a>,
+    }
+
+    let container = Container {
+        value: RawJson::new("42"),
+    };
+
+    let json = to_string(&container).unwrap();
+    assert_eq!(json, r#"{"value":42}"#);
+}
+
+// ── Round-trip tests ──
+
+#[test]
+fn round_trip_raw_json_complex() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Wrapper<'a> {
+        raw: RawJson<'a>,
+    }
+
+    let original_json = r#"{"raw": {"a": [1, 2, 3], "b": {"nested": true}}}"#;
+    let parsed: Wrapper = from_str_borrowed(original_json).unwrap();
+
+    // Re-serialize
+    let re_serialized = to_string(&parsed).unwrap();
+
+    // Parse again
+    let reparsed: Wrapper = from_str_borrowed(&re_serialized).unwrap();
+
+    assert_eq!(parsed.raw.as_str(), reparsed.raw.as_str());
+}
+
+#[test]
+fn raw_json_into_owned() {
+    #[derive(Facet, Debug)]
+    struct Response<'a> {
+        data: RawJson<'a>,
+    }
+
+    let json = r#"{"data": {"key": "value"}}"#;
+    let response: Response = from_str_borrowed(json).unwrap();
+
+    // Convert to owned
+    let owned: RawJson<'static> = response.data.into_owned();
+    assert_eq!(owned.as_str(), r#"{"key": "value"}"#);
+}
+
+// ── Top-level RawJson tests ──
+
+#[test]
+fn deserialize_top_level_raw_json_object() {
+    let json = r#"{"key": "value", "nested": [1, 2, 3]}"#;
+    let raw: RawJson = from_str_borrowed(json).unwrap();
+    assert_eq!(raw.as_str(), json);
+}
+
+#[test]
+fn deserialize_top_level_raw_json_array() {
+    let json = r#"[1, 2, 3, "four"]"#;
+    let raw: RawJson = from_str_borrowed(json).unwrap();
+    assert_eq!(raw.as_str(), json);
+}
+
+#[test]
+fn serialize_top_level_raw_json() {
+    let raw = RawJson::new(r#"{"key": "value"}"#);
+    let json = to_string(&raw).unwrap();
+    assert_eq!(json, r#"{"key": "value"}"#);
+}

--- a/facet-format/src/parser.rs
+++ b/facet-format/src/parser.rs
@@ -46,4 +46,15 @@ pub trait FormatParser<'de> {
         self.skip_value()?;
         Ok(None)
     }
+
+    /// Returns the shape of the format's raw capture type (e.g., `RawJson::SHAPE`).
+    ///
+    /// When the deserializer encounters a shape that matches this, it will use
+    /// `capture_raw` to capture the raw representation and store it in a
+    /// `Cow<str>` (the raw type must be a newtype over `Cow<str>`).
+    ///
+    /// Returns `None` if this format doesn't support raw capture types.
+    fn raw_capture_shape(&self) -> Option<&'static facet_core::Shape> {
+        None
+    }
 }

--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -552,6 +552,10 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
         if let Some(ScalarType::String) = peek.scalar_type() {
             return unsafe { Some(peek.data.get::<alloc::string::String>().as_str()) };
         }
+        #[cfg(feature = "alloc")]
+        if let Some(ScalarType::CowStr) = peek.scalar_type() {
+            return unsafe { Some(peek.data.get::<alloc::borrow::Cow<'mem, str>>().as_ref()) };
+        }
 
         // Handle references, including nested references like &&str
         if let Type::Pointer(PointerType::Reference(vpt)) = peek.shape.ty {


### PR DESCRIPTION
- Add RawJson<'a> type for deferred JSON parsing (zero-copy capable)
- Add raw_capture_shape/raw_serialize_shape hooks to FormatParser/FormatSerializer traits
- Implement capture_raw in JsonParser for extracting raw JSON values
- Add to_writer_std, to_writer_std_pretty, to_writer_std_with_options functions
- Add peek_to_writer_std variants for Peek-based serialization
- Fix Peek::as_str() to handle Cow<str> (ScalarType::CowStr)
- Add 16 tests for RawJson deserialization, serialization, and round-tripping