### PR TITLE
feat(facet-testhelpers): make cargo-nextest optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,7 +1708,6 @@ dependencies = [
 name = "facet-testhelpers"
 version = "0.32.2"
 dependencies = [
- "boxen",
  "facet-testhelpers-macros",
  "log",
  "owo-colors",

--- a/facet-testhelpers/Cargo.toml
+++ b/facet-testhelpers/Cargo.toml
@@ -13,7 +13,6 @@ description = "A collection of testing helpers and utilities for facet"
 [features]
 
 [dependencies]
-boxen = { workspace = true } #unified
 facet-testhelpers-macros = { version = "0.32.2", path = "../facet-testhelpers-macros" }
 log = { workspace = true } #unified
 owo-colors = "4.2.2"

--- a/facet-testhelpers/README.md
+++ b/facet-testhelpers/README.md
@@ -10,6 +10,37 @@
 Lightweight test helpers: a log facade that always does tracing (with colors),
 and color-backtrace using the btparse backend.
 
+## Usage
+
+Add this to your test files:
+
+```rust
+#[facet_testhelpers::test]
+fn my_test() {
+    log::info!("This will be printed with color!");
+    // Your test code here
+}
+```
+
+The test macro sets up a simple logger that works with both `cargo test` and `cargo nextest run`.
+
+### Recommendation
+
+While this crate works with regular `cargo test`, we recommend using [`cargo-nextest`](https://nexte.st) for:
+- Process-per-test isolation
+- Faster parallel test execution
+- Better test output and reporting
+
+Install with:
+```bash
+cargo install cargo-nextest
+```
+
+Then run tests with:
+```bash
+cargo nextest run
+```
+
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-testhelpers/README.md.in
+++ b/facet-testhelpers/README.md.in
@@ -1,2 +1,33 @@
 Lightweight test helpers: a log facade that always does tracing (with colors),
 and color-backtrace using the btparse backend.
+
+## Usage
+
+Add this to your test files:
+
+```rust
+#[facet_testhelpers::test]
+fn my_test() {
+    log::info!("This will be printed with color!");
+    // Your test code here
+}
+```
+
+The test macro sets up a simple logger that works with both `cargo test` and `cargo nextest run`.
+
+### Recommendation
+
+While this crate works with regular `cargo test`, we recommend using [`cargo-nextest`](https://nexte.st) for:
+- Process-per-test isolation
+- Faster parallel test execution
+- Better test output and reporting
+
+Install with:
+```bash
+cargo install cargo-nextest
+```
+
+Then run tests with:
+```bash
+cargo nextest run
+```


### PR DESCRIPTION
## Summary

- Replaces hard requirement on cargo-nextest with LazyLock-based logger initialization
- Tests can now run with either `cargo test` or `cargo nextest run`
- Removes boxen dependency (no longer needed)
- Adds friendly tip message when not using nextest
- Updates documentation to reflect nextest is recommended but optional

## Implementation Details

The original implementation required nextest because `log::set_boxed_logger()` can only be called once per process. With regular `cargo test`, multiple tests may run in the same process, causing a panic on the second call.

Using `LazyLock` solves this elegantly by ensuring initialization happens exactly once, making nextest optional while still recommended for its benefits (process isolation, better output, faster execution).

## Test Plan

- [x] Tests pass with `cargo test`
- [x] Tests pass with `cargo nextest run`
- [x] Clippy passes
- [x] Documentation builds
- [x] All pre-push checks pass

Fixes #1320