### PR TITLE
fix: improve XML diff rendering for wrapper elements and proxy types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,6 +1370,7 @@ dependencies = [
  "facet-showcase",
  "facet-testhelpers",
  "facet-value",
+ "facet-xml",
  "insta",
  "log",
  "owo-colors",

--- a/facet-assert/src/lib.rs
+++ b/facet-assert/src/lib.rs
@@ -9,12 +9,13 @@
 
 mod same;
 
+pub use facet_diff::DiffReport;
 pub use facet_diff_core::layout::{
     AnsiBackend, BuildOptions, ColorBackend, DiffFlavor, JsonFlavor, PlainBackend, RenderOptions,
     RustFlavor, XmlFlavor,
 };
 pub use same::{
-    DiffReport, SameOptions, SameReport, Sameness, check_same, check_same_report, check_same_with,
+    SameOptions, SameReport, Sameness, check_same, check_same_report, check_same_with,
     check_same_with_report,
 };
 
@@ -260,7 +261,8 @@ mod tests {
         assert!(json.contains("\"name\""));
 
         let xml = report.render_plain_xml();
-        assert!(xml.contains("<Person"));
+        // Person is a proxy type (struct without xml:: attributes), so it gets @ prefix
+        assert!(xml.contains("<@Person"));
     }
 
     #[test]

--- a/facet-diff-core/src/layout/flavor.rs
+++ b/facet-diff-core/src/layout/flavor.rs
@@ -372,11 +372,13 @@ impl DiffFlavor for XmlFlavor {
     }
 
     fn seq_open(&self) -> Cow<'static, str> {
-        Cow::Borrowed("<items>")
+        // XML sequences don't need wrapper elements - items render as siblings
+        Cow::Borrowed("")
     }
 
     fn seq_close(&self) -> Cow<'static, str> {
-        Cow::Borrowed("</items>")
+        // XML sequences don't need wrapper elements - items render as siblings
+        Cow::Borrowed("")
     }
 
     fn item_separator(&self) -> &'static str {
@@ -423,14 +425,15 @@ impl DiffFlavor for XmlFlavor {
         ""
     }
 
-    fn format_seq_field_open(&self, field_name: &str) -> String {
-        // XML: sequence field becomes a wrapper element, not an attribute
-        format!("<{}>", field_name)
+    fn format_seq_field_open(&self, _field_name: &str) -> String {
+        // XML: sequences render items directly without wrapper elements
+        // The items are children of the parent element
+        String::new()
     }
 
-    fn format_seq_field_close(&self, field_name: &str) -> Cow<'static, str> {
-        // XML: close the wrapper element
-        Cow::Owned(format!("</{}>", field_name))
+    fn format_seq_field_close(&self, _field_name: &str) -> Cow<'static, str> {
+        // XML: sequences render items directly without wrapper elements
+        Cow::Borrowed("")
     }
 }
 
@@ -752,8 +755,9 @@ mod tests {
         assert_eq!(rust.seq_close(), "]");
         assert_eq!(json.seq_open(), "[");
         assert_eq!(json.seq_close(), "]");
-        assert_eq!(xml.seq_open(), "<items>");
-        assert_eq!(xml.seq_close(), "</items>");
+        // XML sequences render items as siblings without wrapper elements
+        assert_eq!(xml.seq_open(), "");
+        assert_eq!(xml.seq_close(), "");
 
         // comment
         assert_eq!(rust.comment("5 more"), "/* 5 more */");

--- a/facet-diff/Cargo.toml
+++ b/facet-diff/Cargo.toml
@@ -28,6 +28,7 @@ owo-colors = "4"
 
 [dev-dependencies]
 boxen = { workspace = true } #unified
+facet-xml = { path = "../facet-xml", version = "0.32.2", features = ["diff"] }
 facet-showcase = { path = "../facet-showcase", version = "0.32.2" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 facet-value = { path = "../facet-value" }

--- a/facet-diff/src/lib.rs
+++ b/facet-diff/src/lib.rs
@@ -3,6 +3,7 @@
 #![doc = include_str!("../README.md")]
 
 mod diff;
+mod report;
 mod sequences;
 mod tree;
 
@@ -11,6 +12,7 @@ pub use diff::{
     diff_new_peek, diff_new_peek_with_options, format_diff, format_diff_compact,
     format_diff_compact_plain, format_diff_default,
 };
+pub use report::DiffReport;
 pub use tree::{
     EditOp, FacetTree, NodeKind, NodeLabel, SimilarityResult, build_tree,
     compute_element_similarity, elements_are_similar, tree_diff,
@@ -23,6 +25,12 @@ pub use cinereus::{Matching, MatchingConfig};
 pub use facet_diff_core::{
     ChangeKind, Diff, DiffSymbols, DiffTheme, Interspersed, Path, PathSegment, ReplaceGroup,
     Updates, UpdatesGroup, Value,
+};
+
+// Re-export layout types for custom rendering
+pub use facet_diff_core::layout::{
+    AnsiBackend, BuildOptions, ColorBackend, DiffFlavor, JsonFlavor, PlainBackend, RenderOptions,
+    RustFlavor, XmlFlavor, build_layout, render_to_string,
 };
 
 #[cfg(test)]

--- a/facet-diff/src/report.rs
+++ b/facet-diff/src/report.rs
@@ -1,0 +1,172 @@
+//! Diff report with multi-format rendering capabilities.
+//!
+//! This module provides [`DiffReport`], which holds a computed diff along with
+//! references to the original values, enabling rendering in multiple output formats
+//! (Rust, JSON, XML) with or without ANSI colors.
+
+use crate::Diff;
+use facet_diff_core::layout::{
+    AnsiBackend, BuildOptions, ColorBackend, DiffFlavor, JsonFlavor, RenderOptions, RustFlavor,
+    XmlFlavor, build_layout, render_to_string,
+};
+use facet_reflect::Peek;
+
+/// A reusable diff plus its original inputs, allowing rendering in different output styles.
+///
+/// `DiffReport` holds a computed [`Diff`] along with [`Peek`] references to the original
+/// left and right values. This allows rendering the same diff in multiple formats without
+/// recomputing the diff tree.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_diff::{DiffReport, diff_new_peek};
+/// use facet_reflect::Peek;
+///
+/// #[derive(Facet)]
+/// struct Point { x: i32, y: i32 }
+///
+/// let old = Point { x: 10, y: 20 };
+/// let new = Point { x: 10, y: 30 };
+///
+/// let left = Peek::new(&old);
+/// let right = Peek::new(&new);
+/// let diff = diff_new_peek(left, right);
+///
+/// let report = DiffReport::new(diff, left, right);
+///
+/// // Render in different formats
+/// println!("Rust format:\n{}", report.render_plain_rust());
+/// println!("JSON format:\n{}", report.render_plain_json());
+/// println!("XML format:\n{}", report.render_plain_xml());
+/// ```
+pub struct DiffReport<'mem, 'facet> {
+    diff: Diff<'mem, 'facet>,
+    left: Peek<'mem, 'facet>,
+    right: Peek<'mem, 'facet>,
+    /// Float tolerance used during comparison, stored to compute display precision.
+    float_tolerance: Option<f64>,
+}
+
+impl<'mem, 'facet> DiffReport<'mem, 'facet> {
+    /// Create a new diff report from a computed diff and the original values.
+    pub fn new(
+        diff: Diff<'mem, 'facet>,
+        left: Peek<'mem, 'facet>,
+        right: Peek<'mem, 'facet>,
+    ) -> Self {
+        Self {
+            diff,
+            left,
+            right,
+            float_tolerance: None,
+        }
+    }
+
+    /// Create a new diff report with float tolerance information.
+    ///
+    /// The tolerance is used to determine appropriate decimal precision when rendering
+    /// floating-point values in the diff output.
+    pub fn with_float_tolerance(mut self, tolerance: f64) -> Self {
+        self.float_tolerance = Some(tolerance);
+        self
+    }
+
+    /// Access the raw diff tree.
+    pub fn diff(&self) -> &Diff<'mem, 'facet> {
+        &self.diff
+    }
+
+    /// Peek into the left-hand value.
+    pub fn left(&self) -> Peek<'mem, 'facet> {
+        self.left
+    }
+
+    /// Peek into the right-hand value.
+    pub fn right(&self) -> Peek<'mem, 'facet> {
+        self.right
+    }
+
+    /// Format the diff using the legacy tree display (same output as `Display` impl).
+    pub fn legacy_string(&self) -> String {
+        format!("{}", self.diff)
+    }
+
+    /// Compute float precision from tolerance.
+    ///
+    /// If tolerance is 0.002, we need ~3 decimal places to see differences at that scale.
+    /// Formula: ceil(-log10(tolerance))
+    fn float_precision_from_tolerance(&self) -> Option<usize> {
+        self.float_tolerance.map(|tol| {
+            if tol <= 0.0 {
+                6 // fallback to reasonable precision
+            } else {
+                (-tol.log10()).ceil() as usize
+            }
+        })
+    }
+
+    /// Build options with float precision derived from tolerance.
+    fn build_opts_with_precision(&self) -> BuildOptions {
+        BuildOptions {
+            float_precision: self.float_precision_from_tolerance(),
+            ..Default::default()
+        }
+    }
+
+    /// Render the diff with a custom flavor and render/build options.
+    pub fn render_with_options<B: ColorBackend, F: DiffFlavor>(
+        &self,
+        flavor: &F,
+        build_opts: &BuildOptions,
+        render_opts: &RenderOptions<B>,
+    ) -> String {
+        let layout = build_layout(&self.diff, self.left, self.right, build_opts, flavor);
+        render_to_string(&layout, render_opts, flavor)
+    }
+
+    /// Render using ANSI colors with the provided flavor.
+    pub fn render_ansi_with<F: DiffFlavor>(&self, flavor: &F) -> String {
+        let build_opts = self.build_opts_with_precision();
+        let render_opts = RenderOptions::<AnsiBackend>::default();
+        self.render_with_options(flavor, &build_opts, &render_opts)
+    }
+
+    /// Render without colors using the provided flavor.
+    pub fn render_plain_with<F: DiffFlavor>(&self, flavor: &F) -> String {
+        let build_opts = self.build_opts_with_precision();
+        let render_opts = RenderOptions::plain();
+        self.render_with_options(flavor, &build_opts, &render_opts)
+    }
+
+    /// Render using the Rust flavor with ANSI colors.
+    pub fn render_ansi_rust(&self) -> String {
+        self.render_ansi_with(&RustFlavor)
+    }
+
+    /// Render using the Rust flavor without colors.
+    pub fn render_plain_rust(&self) -> String {
+        self.render_plain_with(&RustFlavor)
+    }
+
+    /// Render using the JSON flavor with ANSI colors.
+    pub fn render_ansi_json(&self) -> String {
+        self.render_ansi_with(&JsonFlavor)
+    }
+
+    /// Render using the JSON flavor without colors.
+    pub fn render_plain_json(&self) -> String {
+        self.render_plain_with(&JsonFlavor)
+    }
+
+    /// Render using the XML flavor with ANSI colors.
+    pub fn render_ansi_xml(&self) -> String {
+        self.render_ansi_with(&XmlFlavor)
+    }
+
+    /// Render using the XML flavor without colors.
+    pub fn render_plain_xml(&self) -> String {
+        self.render_plain_with(&XmlFlavor)
+    }
+}

--- a/facet-diff/tests/svg_diff_issues.rs
+++ b/facet-diff/tests/svg_diff_issues.rs
@@ -1,0 +1,378 @@
+//! Tests for SVG-like XML diff rendering issues.
+//!
+//! These tests reproduce issues found when diffing SVG structures:
+//! 1. Wrapper elements like `<children>`, `<PathData>`, `<commands>` appearing in output
+//! 2. Empty placeholder (`∅`) behavior for missing attribute values
+
+use facet::Facet;
+use facet_diff::{DiffOptions, DiffReport, diff_new_peek_with_options};
+use facet_reflect::Peek;
+use facet_testhelpers::test;
+use facet_xml as xml;
+
+// =============================================================================
+// Types that reproduce the wrapper element issue
+// =============================================================================
+
+/// A path command similar to SVG's path commands
+#[derive(Facet, Debug, Clone, PartialEq)]
+#[repr(u8)]
+pub enum PathCommand {
+    MoveTo { x: f64, y: f64 },
+    LineTo { x: f64, y: f64 },
+    Arc { rx: f64, ry: f64, x: f64, y: f64 },
+    ClosePath,
+}
+
+/// Structured path data - a sequence of commands
+#[derive(Facet, Debug, Clone, PartialEq, Default)]
+pub struct PathData {
+    /// This field does NOT have xml::elements, so it will render
+    /// as a wrapper `<commands>` element in XML diff output
+    pub commands: Vec<PathCommand>,
+}
+
+/// A path element with the PathData
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(xml::ns_all = "http://www.w3.org/2000/svg", rename = "path")]
+pub struct Path {
+    #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
+    pub fill: Option<String>,
+    /// The `d` attribute in SVG - this is a complex nested type
+    pub d: Option<PathData>,
+}
+
+/// SVG node enum (newtype variants)
+#[derive(Facet, Debug, Clone)]
+#[facet(xml::ns_all = "http://www.w3.org/2000/svg")]
+#[repr(u8)]
+pub enum SvgNode {
+    #[facet(rename = "path")]
+    Path(Path),
+    #[facet(rename = "circle")]
+    Circle(Circle),
+}
+
+/// A circle element
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(xml::ns_all = "http://www.w3.org/2000/svg", rename = "circle")]
+pub struct Circle {
+    #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
+    pub cx: Option<f64>,
+    #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
+    pub cy: Option<f64>,
+    #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
+    pub r: Option<f64>,
+}
+
+/// SVG root element
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(xml::ns_all = "http://www.w3.org/2000/svg", rename = "svg")]
+pub struct Svg {
+    #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
+    pub view_box: Option<String>,
+    /// This has xml::elements, so children should be rendered properly
+    #[facet(xml::elements)]
+    pub children: Vec<SvgNode>,
+}
+
+/// Helper to compute diff and render as plain XML
+fn diff_to_xml<'f, T: facet_core::Facet<'f>>(from: &T, to: &T, float_tolerance: f64) -> String {
+    let left = Peek::new(from);
+    let right = Peek::new(to);
+
+    let options = DiffOptions::new()
+        .with_float_tolerance(float_tolerance)
+        .with_similarity_threshold(0.5);
+    let diff = diff_new_peek_with_options(left, right, &options);
+
+    let report = DiffReport::new(diff, left, right).with_float_tolerance(float_tolerance);
+    report.render_plain_xml()
+}
+
+// =============================================================================
+// Issue 1: Wrapper elements in diff output
+// =============================================================================
+
+/// Test that PathData.commands doesn't render with a <commands> wrapper
+#[test]
+fn test_path_data_commands_no_wrapper() {
+    let from = PathData {
+        commands: vec![
+            PathCommand::MoveTo { x: 10.0, y: 20.0 },
+            PathCommand::LineTo { x: 30.0, y: 40.0 },
+            PathCommand::ClosePath,
+        ],
+    };
+
+    let to = PathData {
+        commands: vec![
+            PathCommand::MoveTo { x: 10.0, y: 20.0 },
+            PathCommand::LineTo { x: 50.0, y: 60.0 }, // changed
+            PathCommand::ClosePath,
+        ],
+    };
+
+    let xml_output = diff_to_xml(&from, &to, 0.002);
+    println!("=== PathData diff (XML) ===\n{}", xml_output);
+
+    // The output should NOT contain <commands> wrapper
+    // It should show the path commands directly
+    assert!(
+        !xml_output.contains("<commands>"),
+        "Output should NOT have <commands> wrapper:\n{}",
+        xml_output
+    );
+}
+
+/// Test that Svg.children with xml::elements doesn't render with a <children> wrapper
+#[test]
+fn test_svg_children_no_wrapper() {
+    let from = Svg {
+        view_box: Some("0 0 100 100".to_string()),
+        children: vec![SvgNode::Circle(Circle {
+            cx: Some(50.0),
+            cy: Some(50.0),
+            r: Some(25.0),
+        })],
+    };
+
+    let to = Svg {
+        view_box: Some("0 0 100 100".to_string()),
+        children: vec![SvgNode::Circle(Circle {
+            cx: Some(50.0),
+            cy: Some(50.0),
+            r: Some(30.0), // changed
+        })],
+    };
+
+    let xml_output = diff_to_xml(&from, &to, 0.002);
+    println!("=== Svg.children diff (XML) ===\n{}", xml_output);
+
+    // The output should NOT contain <children> wrapper since we have xml::elements
+    assert!(
+        !xml_output.contains("<children>"),
+        "Output should NOT have <children> wrapper:\n{}",
+        xml_output
+    );
+}
+
+/// Test that PathData doesn't render as a <PathData> element when nested
+#[test]
+fn test_nested_path_data_no_wrapper() {
+    let from = Path {
+        fill: Some("red".to_string()),
+        d: Some(PathData {
+            commands: vec![
+                PathCommand::MoveTo { x: 10.0, y: 20.0 },
+                PathCommand::LineTo { x: 30.0, y: 40.0 },
+            ],
+        }),
+    };
+
+    let to = Path {
+        fill: Some("red".to_string()),
+        d: Some(PathData {
+            commands: vec![
+                PathCommand::MoveTo { x: 10.0, y: 20.0 },
+                PathCommand::LineTo { x: 50.0, y: 60.0 }, // changed
+            ],
+        }),
+    };
+
+    let xml_output = diff_to_xml(&from, &to, 0.002);
+    println!("=== Nested PathData diff (XML) ===\n{}", xml_output);
+
+    // The output should NOT contain <PathData> as a wrapper element
+    assert!(
+        !xml_output.contains("<PathData>"),
+        "Output should NOT have <PathData> wrapper:\n{}",
+        xml_output
+    );
+}
+
+// =============================================================================
+// Issue 2: Empty placeholder (∅) behavior
+// =============================================================================
+
+/// Test when comparing LineTo commands where one has values and one doesn't
+/// This reproduces the strange:
+///   ← <LineTo ∅           ∅           />
+///   → <LineTo x="106.589" y="348.771" />
+#[test]
+fn test_lineto_empty_placeholder() {
+    // Scenario: One list has a LineTo, the other doesn't (or has different commands)
+    let from = PathData {
+        commands: vec![
+            PathCommand::MoveTo { x: 100.0, y: 200.0 },
+            // No LineTo here - this will show as "deleted"
+            PathCommand::ClosePath,
+        ],
+    };
+
+    let to = PathData {
+        commands: vec![
+            PathCommand::MoveTo { x: 100.0, y: 200.0 },
+            PathCommand::LineTo { x: 100.0, y: 200.0 }, // Added
+            PathCommand::ClosePath,
+        ],
+    };
+
+    let xml_output = diff_to_xml(&from, &to, 0.002);
+    println!("=== LineTo insertion diff (XML) ===\n{}", xml_output);
+
+    // This should show LineTo as inserted with + prefix, not as a modification
+    // with ∅ placeholders
+    assert!(
+        !xml_output.contains("∅"),
+        "Output should NOT contain empty placeholder ∅:\n{}",
+        xml_output
+    );
+}
+
+/// Test when comparing two LineTo commands where values differ
+/// This should show a proper inline diff, not ∅ placeholders
+#[test]
+fn test_lineto_value_change_no_empty_placeholder() {
+    let from = PathData {
+        commands: vec![
+            PathCommand::MoveTo { x: 100.0, y: 200.0 },
+            PathCommand::LineTo { x: 30.0, y: 40.0 },
+            PathCommand::ClosePath,
+        ],
+    };
+
+    let to = PathData {
+        commands: vec![
+            PathCommand::MoveTo { x: 100.0, y: 200.0 },
+            PathCommand::LineTo { x: 50.0, y: 60.0 }, // Changed values
+            PathCommand::ClosePath,
+        ],
+    };
+
+    let xml_output = diff_to_xml(&from, &to, 0.002);
+    println!("=== LineTo value change diff (XML) ===\n{}", xml_output);
+
+    // Should show the old and new values, not ∅
+    assert!(
+        !xml_output.contains("∅"),
+        "Output should NOT contain empty placeholder ∅:\n{}",
+        xml_output
+    );
+
+    // Should contain both old and new x/y values
+    assert!(xml_output.contains("30"), "Should contain old x value");
+    assert!(xml_output.contains("40"), "Should contain old y value");
+    assert!(xml_output.contains("50"), "Should contain new x value");
+    assert!(xml_output.contains("60"), "Should contain new y value");
+}
+
+/// Test when comparing variant change (MoveTo to LineTo) - this should properly
+/// show as deleted/inserted, not as a modification with empty placeholders
+#[test]
+fn test_variant_change_no_empty_placeholder() {
+    let from = PathData {
+        commands: vec![PathCommand::MoveTo { x: 100.0, y: 200.0 }],
+    };
+
+    let to = PathData {
+        commands: vec![PathCommand::LineTo { x: 100.0, y: 200.0 }],
+    };
+
+    let xml_output = diff_to_xml(&from, &to, 0.002);
+    println!("=== Variant change diff (XML) ===\n{}", xml_output);
+
+    // Should show MoveTo as deleted and LineTo as inserted
+    // Not as a modification with ∅ placeholders
+    assert!(
+        !xml_output.contains("∅"),
+        "Output should NOT contain empty placeholder ∅:\n{}",
+        xml_output
+    );
+}
+
+// =============================================================================
+// Combined tests - full SVG structure
+// =============================================================================
+
+/// Test a full SVG structure diff
+#[test]
+fn test_full_svg_diff_no_wrappers() {
+    let from = Svg {
+        view_box: Some("0 0 200 200".to_string()),
+        children: vec![
+            SvgNode::Path(Path {
+                fill: Some("red".to_string()),
+                d: Some(PathData {
+                    commands: vec![
+                        PathCommand::MoveTo { x: 10.0, y: 20.0 },
+                        PathCommand::LineTo { x: 30.0, y: 40.0 },
+                        PathCommand::Arc {
+                            rx: 5.0,
+                            ry: 5.0,
+                            x: 50.0,
+                            y: 60.0,
+                        },
+                        PathCommand::ClosePath,
+                    ],
+                }),
+            }),
+            SvgNode::Circle(Circle {
+                cx: Some(100.0),
+                cy: Some(100.0),
+                r: Some(50.0),
+            }),
+        ],
+    };
+
+    let to = Svg {
+        view_box: Some("0 0 200 200".to_string()),
+        children: vec![
+            SvgNode::Path(Path {
+                fill: Some("blue".to_string()), // changed
+                d: Some(PathData {
+                    commands: vec![
+                        PathCommand::MoveTo { x: 10.0, y: 20.0 },
+                        PathCommand::LineTo { x: 35.0, y: 45.0 }, // changed
+                        PathCommand::Arc {
+                            rx: 5.0,
+                            ry: 5.0,
+                            x: 50.0,
+                            y: 60.0,
+                        },
+                        PathCommand::ClosePath,
+                    ],
+                }),
+            }),
+            SvgNode::Circle(Circle {
+                cx: Some(100.0),
+                cy: Some(100.0),
+                r: Some(60.0), // changed
+            }),
+        ],
+    };
+
+    let xml_output = diff_to_xml(&from, &to, 0.002);
+    println!("=== Full SVG diff (XML) ===\n{}", xml_output);
+
+    // Should NOT have wrapper elements for sequences
+    assert!(
+        !xml_output.contains("<children>"),
+        "Output should NOT have <children> wrapper:\n{}",
+        xml_output
+    );
+    assert!(
+        !xml_output.contains("<commands>"),
+        "Output should NOT have <commands> wrapper:\n{}",
+        xml_output
+    );
+    // NOTE: <PathData> still appears because it's a type name, not a sequence wrapper.
+    // Removing type wrappers would require explicit #[facet(xml::transparent)] support.
+
+    // Should NOT have empty placeholders
+    assert!(
+        !xml_output.contains("∅"),
+        "Output should NOT contain empty placeholder ∅:\n{}",
+        xml_output
+    );
+}

--- a/facet-svg/src/lib.rs
+++ b/facet-svg/src/lib.rs
@@ -287,6 +287,14 @@ pub struct Text {
     #[facet(xml::attribute, proxy = SvgStyleProxy, skip_serializing_if = is_empty_style)]
     pub style: SvgStyle,
     #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
+    pub font_family: Option<String>,
+    #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
+    pub font_style: Option<String>,
+    #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
+    pub font_weight: Option<String>,
+    #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
+    pub font_size: Option<String>,
+    #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
     pub text_anchor: Option<String>,
     #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
     pub dominant_baseline: Option<String>,


### PR DESCRIPTION
## Summary

- Remove wrapper elements (`<commands>`, `<children>`) from XML diff output by making `XmlFlavor` return empty strings for sequence wrappers
- Fix empty placeholder (`∅`) issue by detecting pure insertions/deletions and skipping inline `← →` rendering for them
- Add `@` prefix for proxy types (structs without XML namespace attributes) to indicate they're Rust representations of something different in actual XML
- Move `DiffReport` from facet-assert to facet-diff to avoid circular dependency
- Add comprehensive tests for XML diff rendering issues

## Test plan

- [x] All svg_diff_issues tests pass
- [x] All 357 tests in facet-assert, facet-diff, facet-diff-core, facet-svg pass
- [x] Clippy and doc tests pass