### PR TITLE
fix: benchmark report improvements

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -293,9 +293,8 @@ function BranchOverview({ data }) {
   // Get baseline state
   const baseline = getBaselineState(data);
 
-  // Get all branches except main
+  // Get all branches (including main)
   const branches = Object.keys(data.branches)
-    .filter(name => name !== 'main')
     .map(name => ({
       name,
       commits: data.branches[name]

--- a/tools/benchmark-analyzer/src/report.rs
+++ b/tools/benchmark-analyzer/src/report.rs
@@ -571,6 +571,12 @@ tr.baseline td { border-top: 1px solid var(--border2); }
   font-size: 12px;
 }
 
+/* Observable Plot legend (color swatches) */
+.summary-chart-wrapper figure[class*="plot"],
+.summary-chart-wrapper [class*="swatches"] {
+  font-family: var(--mono);
+  font-size: 12px;
+}
 
 /* Footer */
 footer {


### PR DESCRIPTION
## Summary

Multiple fixes for the benchmark report generation and perf.facet.rs index:

## Changes

- **Fix chart axis labels**: Changed from "Time (µs)" to "Instructions (K)" since we're tracking instruction counts, not time
- **Fix field naming**: Renamed `time` field to `value` in chart data structures to avoid confusion
- **Export all targets**: `perf-data.json` now exports all benchmark targets (facet_format_jit, serde_json, etc.) instead of just facet_format_jit, enabling ratio computation on the frontend
- **Show main in branch list**: Removed filter that excluded main from the branch overview on perf.facet.rs
- **Fix legend font**: Added CSS to force Iosevka font on Observable Plot legends

## Test plan

- [ ] Verify charts show "Instructions (K)" on x-axis
- [ ] Check perf-data.json contains all targets after benchmark run
- [ ] Confirm main appears in perf.facet.rs branch list
- [ ] Verify chart legends use Iosevka font