### PR TITLE
fix: support --help flag for subcommands

### DIFF
--- a/facet-args/src/format.rs
+++ b/facet-args/src/format.rs
@@ -640,6 +640,17 @@ impl<'input> Context<'input> {
 
         self.index += 1;
 
+        // Check if the next argument (if it exists) is a help flag for this subcommand
+        if self.index < self.args.len() && is_help_flag(self.args[self.index]) {
+            // Generate help for this specific subcommand variant
+            let help_text = crate::help::generate_subcommand_help(
+                variant,
+                "command", // This would ideally be the program name, but we don't have it in Context
+                &HelpConfig::default(),
+            );
+            return Err(ArgsErrorKind::HelpRequested { help_text });
+        }
+
         if is_optional {
             // Set Option to Some(variant)
             p = p.begin_some()?;

--- a/facet-args/tests/help.rs
+++ b/facet-args/tests/help.rs
@@ -205,3 +205,37 @@ fn test_help_not_triggered_with_other_args() {
     let err = result.unwrap_err();
     assert!(!err.is_help_request());
 }
+
+#[test]
+fn test_subcommand_help_long_flag() {
+    // Test --help after a subcommand
+    let result = facet_args::from_slice::<GitArgs>(&["clone", "--help"]);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.is_help_request());
+    let help = err.help_text().unwrap();
+    // Should show help for the clone subcommand
+    assert!(help.contains("clone"));
+}
+
+#[test]
+fn test_subcommand_help_short_flag() {
+    // Test -h after a subcommand
+    let result = facet_args::from_slice::<GitArgs>(&["log", "-h"]);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.is_help_request());
+    let help = err.help_text().unwrap();
+    assert!(help.contains("log"));
+}
+
+#[test]
+fn test_nested_subcommand_help() {
+    // Test --help for nested subcommands
+    let result = facet_args::from_slice::<GitArgs>(&["remote", "add", "--help"]);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.is_help_request());
+    let help = err.help_text().unwrap();
+    assert!(help.contains("add"));
+}


### PR DESCRIPTION
## Summary

- Fixed issue #1324 where `--help` flags weren't recognized when used with subcommands
- Added help flag detection to the subcommand parsing workflow in `handle_subcommand_field()`
- When a help flag (--help, -h, -help, /?) is detected after a subcommand, the parser now generates and displays subcommand-specific help

## Test plan

- Added 3 new tests for subcommand help functionality:
  - `test_subcommand_help_long_flag` - Tests `--help` with a subcommand
  - `test_subcommand_help_short_flag` - Tests `-h` with a subcommand  
  - `test_nested_subcommand_help` - Tests help for nested subcommands
- All 90 existing facet-args tests continue to pass
- No_std compatibility verified with `just nostd-ci`

## Usage Examples

Now users can run:
- `cargo xtask bench --help` - Shows help for the bench subcommand
- `cargo xtask remote add -h` - Shows help for the nested 'add' subcommand