### PR TITLE
feat: add support for decoding floats in msgpack

### DIFF
--- a/facet-msgpack/src/errors.rs
+++ b/facet-msgpack/src/errors.rs
@@ -2,8 +2,9 @@ use core::fmt;
 
 use facet_reflect::ReflectError;
 
-#[derive(Debug)]
 /// Errors that can occur during MessagePack encoding/decoding operations
+#[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Encountered a MessagePack type that doesn't match the expected type
     UnexpectedType,
@@ -17,6 +18,8 @@ pub enum Error {
     MissingField(String),
     /// Integer value is too large for the target type
     IntegerOverflow,
+    /// Float value is too large for the target type
+    FloatOverflow,
     /// Shape is not supported for deserialization
     UnsupportedShape(String),
     /// Type is not supported for deserialization
@@ -44,6 +47,7 @@ impl fmt::Display for Error {
             Error::UnknownField(field) => write!(f, "Unknown field: {field}"),
             Error::MissingField(field) => write!(f, "Missing required field: {field}"),
             Error::IntegerOverflow => write!(f, "Integer value too large for target type"),
+            Error::FloatOverflow => write!(f, "Float value too large for target type"),
             Error::UnsupportedShape(shape) => {
                 write!(f, "Unsupported shape for deserialization: {shape}")
             }

--- a/facet-msgpack/tests/float.rs
+++ b/facet-msgpack/tests/float.rs
@@ -1,0 +1,76 @@
+use eyre::Result;
+use facet::Facet;
+use facet_msgpack::from_slice;
+
+#[test]
+fn msgpack_read_float() -> Result<()> {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FloatStruct {
+        foo: f32,
+        bar: f64,
+        baz: f32,
+    }
+
+    let data = [
+        0x83, // Map with 3 elements
+        0xa3, // Fixstr with length 3
+        0x66, 0x6f, 0x6f, // "foo"
+        0xca, // float32
+        0x3f, 0x80, 0x00, 0x00, // 1.0
+        0xa3, // Fixstr with length 3
+        0x62, 0x61, 0x72, // "bar"
+        0xcb, // float64
+        0x7f, 0xef, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // f64::MAX
+        0xa3, // Fixstr with length 3
+        0x62, 0x61, 0x7a, // "baz"
+        0xcb, // float64, but will be cast to f32
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 0
+    ];
+
+    let s: FloatStruct = from_slice(&data)?;
+    assert_eq!(
+        s,
+        FloatStruct {
+            foo: 1.,
+            bar: f64::MAX,
+            baz: 0.
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
+#[should_panic = "FloatOverflow"]
+fn msgpack_read_bad_floats() {
+    facet_testhelpers::setup();
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct FloatStruct {
+        foo: f64,
+        bar: f32,
+    }
+
+    let data = [
+        0x82, // Map with 2 elements
+        0xa3, // Fixstr with length 3
+        0x66, 0x6f, 0x6f, // "foo"
+        0xca, // float32, but will be cast to f64
+        0x3f, 0x80, 0x00, 0x00, // 1.0
+        0xa3, // Fixstr with length 3
+        0x62, 0x61, 0x72, // "bar"
+        0xcb, // float64, but will be cast to f32
+        0x7f, 0xef, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // f64::MAX
+    ];
+
+    let s: FloatStruct = from_slice(&data).unwrap();
+    assert_eq!(
+        s,
+        FloatStruct {
+            foo: 1.,
+            bar: f64::MAX as f32,
+        }
+    );
+}


### PR DESCRIPTION
There's the potential for nuance based on how floats are cast. I figured it was fine that f32 gets cast up to f64 when parsing, then back down to f32 when being placed into the partial. By IEEE 754 specification, there should be no issues - it's just moving bits around; the bits themselves aren't truncated in any way.

The odd case is when a type is f32, but it is decoded from an f64. In that case, edge cases like `f32::MAX != (f64::MAX as u32)` may occur, which may be reflected in msgpack structures generated by systems that only support double-precision floats.

In that case, there's two (acceptable) options: throw a type error, or parse a valid f32 and ensure the value being cast down to f32 and up to f64 does not change the value, in which case, the f32 variant may be safely returned. I went with theb est-attempt to parse a valid f32. Two tests have been added to reflect this behavior: successfully parsing a f32, and a FloatOverflow when a f64 can't be represented as an f32.

I noted that the errors from msgpack were not non_exhaustive, which didn't reflect errors from some other crates. I've added the attribute, but it is technically a breaking change.