### PR TITLE
Split perf benchmarks into parallel jobs with serialized publish

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,20 +95,31 @@ jobs:
         run: |
           just valgrind-facet-json
 
-  benchmarks:
+  perf-divan:
     runs-on: depot-ubuntu-24.04-32
-
-    permissions:
-      contents: write  # For pushing to perf.facet.rs
-
-    concurrency:
-      group: perf-${{ github.ref }}
-      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v5
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: ✨ Run divan benchmarks
+        run: |
+          cd facet-json
+          cargo bench --bench unified_benchmarks_divan --features cranelift --features jit | tee divan-output.txt
+
+      - name: Upload divan results
+        uses: actions/upload-artifact@v4
         with:
-          fetch-depth: 0  # Need full git history
+          name: divan-results
+          path: facet-json/divan-output.txt
+          retention-days: 1
+
+  perf-gungraun:
+    runs-on: depot-ubuntu-24.04-32
+
+    steps:
+      - uses: actions/checkout@v5
 
       - name: Install valgrind (required by gungraun)
         run: sudo apt-get update && sudo apt-get install -y valgrind
@@ -117,6 +128,54 @@ jobs:
 
       - name: Install gungraun-runner
         run: cargo install gungraun-runner@0.17.0
+
+      - name: ✨ Run gungraun benchmarks
+        run: |
+          cd facet-json
+          cargo bench --bench unified_benchmarks_gungraun --features cranelift --features jit | tee gungraun-output.txt
+
+      - name: Upload gungraun results
+        uses: actions/upload-artifact@v4
+        with:
+          name: gungraun-results
+          path: facet-json/gungraun-output.txt
+          retention-days: 1
+
+  perf-publish:
+    runs-on: depot-ubuntu-24.04-32
+    needs: [perf-divan, perf-gungraun]
+
+    permissions:
+      contents: write  # For pushing to perf.facet.rs
+
+    concurrency:
+      group: perf-push  # Global concurrency - only one push at a time
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Need full git history
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Download divan results
+        uses: actions/download-artifact@v4
+        with:
+          name: divan-results
+          path: bench-reports
+
+      - name: Download gungraun results
+        uses: actions/download-artifact@v4
+        with:
+          name: gungraun-results
+          path: bench-reports
+
+      - name: Rename benchmark files
+        run: |
+          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+          mv bench-reports/divan-output.txt bench-reports/divan-${TIMESTAMP}.txt
+          mv bench-reports/gungraun-output.txt bench-reports/gungraun-${TIMESTAMP}.txt
 
       - name: Set up SSH deploy key
         shell: bash
@@ -127,11 +186,12 @@ jobs:
           echo "$DEPLOY_KEY" > ~/.ssh/perf_deploy_key
           chmod 600 ~/.ssh/perf_deploy_key
           ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config --global core.sshCommand "ssh -i ~/.ssh/perf_deploy_key -o IdentitiesOnly=yes"
 
-      - name: ✨ Run benchmarks, generate index, and publish
+      - name: ✨ Generate index and publish
         shell: bash
         env:
+          # SSH deploy key for pushing to perf.facet.rs (env var inherited by subprocesses)
+          GIT_SSH_COMMAND: "ssh -i ~/.ssh/perf_deploy_key -o IdentitiesOnly=yes"
           # Pass metadata to benchmark-analyzer for correct PR handling
           # All potentially unsafe inputs are passed via env vars (safe pattern)
           BRANCH_ORIGINAL: ${{ github.head_ref || github.ref_name }}
@@ -151,7 +211,7 @@ jobs:
             export COMMIT_SHORT="$(git rev-parse --short HEAD)"
             export COMMIT_MESSAGE="$HEAD_COMMIT_MESSAGE"
           fi
-          cargo xtask bench --index --push
+          cargo xtask bench --no-run --index --push
 
   nightly:
     runs-on: depot-ubuntu-24.04-32

--- a/tools/benchmark-analyzer/src/main.rs
+++ b/tools/benchmark-analyzer/src/main.rs
@@ -197,7 +197,7 @@ fn export_run_json(
             .unwrap_or(&default_label);
         let benches = benchmarks_by_section
             .get(group_id)
-            .map(|v| v.clone())
+            .cloned()
             .unwrap_or_default();
         groups.insert(
             group_id.clone(),

--- a/tools/benchmark-analyzer/src/run_types.rs
+++ b/tools/benchmark-analyzer/src/run_types.rs
@@ -107,16 +107,19 @@ pub struct RunMeta {
 
 impl RunMeta {
     /// Get the commit SHA (handles both old and new schema)
+    #[allow(dead_code)]
     pub fn get_sha(&self) -> Option<&str> {
         self.sha.as_deref().or(self.commit.as_deref())
     }
 
     /// Get the short commit SHA (handles both old and new schema)
+    #[allow(dead_code)]
     pub fn get_short(&self) -> Option<&str> {
         self.short.as_deref().or(self.commit_short.as_deref())
     }
 
     /// Get the timestamp (handles both old and new schema)
+    #[allow(dead_code)]
     pub fn get_timestamp(&self) -> Option<&str> {
         self.timestamp.as_deref().or(self.generated_at.as_deref())
     }

--- a/tools/perf-index-generator/src/main.rs
+++ b/tools/perf-index-generator/src/main.rs
@@ -366,22 +366,20 @@ fn extract_metrics(json_str: &str) -> ExtractedMetrics {
             .deserialize
             .get("serde_json")
             .and_then(|o| o.as_ref())
+            && let Some(instructions) = serde_metrics.instructions
         {
-            if let Some(instructions) = serde_metrics.instructions {
-                metrics.serde_instructions = instructions;
-                result.serde_sum += instructions;
-            }
+            metrics.serde_instructions = instructions;
+            result.serde_sum += instructions;
         }
 
         if let Some(facet_metrics) = bench_ops
             .deserialize
             .get("facet_format_jit")
             .and_then(|o| o.as_ref())
+            && let Some(instructions) = facet_metrics.instructions
         {
-            if let Some(instructions) = facet_metrics.instructions {
-                metrics.facet_instructions = instructions;
-                result.facet_sum += instructions;
-            }
+            metrics.facet_instructions = instructions;
+            result.facet_sum += instructions;
         }
 
         // Only add if we got at least one metric
@@ -646,13 +644,13 @@ fn generate_index_v2(runs: &[RunInfo]) -> String {
 
     // Find baseline (latest main commit) with per-benchmark data for highlights
     let baseline = branches.get("main").and_then(|main| {
-        main.commits.first().and_then(|c| {
+        main.commits.first().map(|c| {
             // Get benchmarks from the commits data
             let benchmarks = commits
                 .get(&c.sha)
                 .map(|cd| cd.benchmarks.clone())
                 .unwrap_or_default();
-            Some(BaselineData {
+            BaselineData {
                 name: "main tip".to_string(),
                 branch_key: "main".to_string(),
                 commit_sha: c.sha.clone(),
@@ -661,7 +659,7 @@ fn generate_index_v2(runs: &[RunInfo]) -> String {
                 serde_sum: c.serde_sum,
                 facet_sum: c.facet_sum,
                 benchmarks,
-            })
+            }
         })
     });
 
@@ -1142,7 +1140,7 @@ fn compute_ratio(metrics: &BenchmarkMetrics) -> Option<f64> {
 }
 
 /// Compute highlights (regressions/improvements) comparing commit to baseline
-/// Returns (regressions, improvements) as sorted Vec<DiffItem>
+/// Returns (regressions, improvements) as sorted `Vec<DiffItem>`
 fn compute_highlights(
     commit_benchmarks: &IndexMap<String, BenchmarkMetrics>,
     baseline_benchmarks: &IndexMap<String, BenchmarkMetrics>,


### PR DESCRIPTION
## Summary
- Split single `benchmarks` job into three parallel jobs:
  - `perf-divan`: runs divan wall-clock benchmarks
  - `perf-gungraun`: runs gungraun instruction-count benchmarks
  - `perf-publish`: downloads artifacts from both, generates index, pushes to perf.facet.rs
- The publish job uses global concurrency (`group: perf-push`) to prevent race conditions when multiple workflow runs try to push to gh-pages simultaneously
- Switched from `git config core.sshCommand` to `GIT_SSH_COMMAND` env var for reliable SSH key inheritance in cargo subprocesses

## Test plan
- [ ] CI runs successfully with the new job structure
- [ ] perf-divan and perf-gungraun run in parallel
- [ ] perf-publish waits for both and successfully pushes to perf.facet.rs
- [ ] No more lost commits from concurrent pushes