### PR TITLE
Extract metrics TUI from xtask to tools/metrics-tui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,6 +2714,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "metrics-tui"
+version = "0.32.3"
+dependencies = [
+ "crossterm",
+ "facet",
+ "facet-json",
+ "ratatui",
+]
+
+[[package]]
 name = "micromap"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4693,12 +4703,10 @@ name = "xtask"
 version = "0.32.3"
 dependencies = [
  "benchmark-defs",
- "crossterm",
  "facet",
  "facet-args",
  "facet-json",
  "miette",
- "ratatui",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,10 @@ members = [
     # dev tooling
     "facet-bloatbench",
     "xtask",
+    "tools/benchmark-defs",
     "tools/benchmark-generator",
     "tools/benchmark-analyzer",
+    "tools/metrics-tui",
     "tools/perf-index-generator",
 
     "facet-shapelike",

--- a/tools/metrics-tui/Cargo.toml
+++ b/tools/metrics-tui/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "metrics-tui"
+version = "0.32.3"
+edition = "2024"
+rust-version = "1.89.0"
+publish = false
+
+[package.metadata."docs.rs"]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[[bin]]
+name = "metrics-tui"
+path = "src/main.rs"
+
+[dependencies]
+crossterm = { version = "0.29", default-features = false }
+facet = { path = "../../facet" }
+facet-json = { path = "../../facet-json" }
+ratatui = { version = "0.30.0-beta.0", default-features = false, features = ["crossterm"] }

--- a/tools/metrics-tui/arborium-header.html
+++ b/tools/metrics-tui/arborium-header.html
@@ -1,0 +1,2 @@
+<!-- Rustdoc doesn't highlight some languages natively -- let's do it ourselves: https://github.com/bearcove/arborium -->
+<script defer src="https://cdn.jsdelivr.net/npm/@arborium/arborium@1/dist/arborium.iife.js"></script>

--- a/tools/metrics-tui/src/main.rs
+++ b/tools/metrics-tui/src/main.rs
@@ -315,7 +315,7 @@ fn workspace_root() -> PathBuf {
         .to_path_buf()
 }
 
-pub fn run() -> io::Result<()> {
+fn main() -> io::Result<()> {
     let workspace = workspace_root();
     let reports_dir = workspace.join("reports");
     let metrics = load_metrics(&reports_dir);

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,9 +12,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
 benchmark-defs = { path = "../tools/benchmark-defs", version = "0.32.3" }
-crossterm = { version = "0.29", default-features = false }
 facet = { workspace = true, features = ["bytes", "camino", "chrono", "doc", "jiff02", "net", "nonzero", "ordered-float", "time", "ulid", "uuid"] } #unified
 facet-args = { path = "../facet-args", version = "0.32.3" }
 facet-json = { path = "../facet-json", version = "0.32.3", features = ["axum"] }
 miette = { workspace = true }
-ratatui = { version = "0.30.0-beta.0", default-features = false, features = ["crossterm"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,8 +14,6 @@ use facet_args as args;
 use facet_json::to_string;
 use miette::Report;
 
-mod metrics_tui_impl;
-
 /// xtask commands for the facet workspace.
 #[derive(Facet, Debug)]
 struct XtaskArgs {
@@ -99,7 +97,7 @@ fn main() {
             json,
         } => schema_build(target, release, toolchain, timings_format, also_json, json),
         XtaskCommand::Measure { name } => measure(&name),
-        XtaskCommand::Metrics => metrics_tui_impl::run().expect("TUI failed"),
+        XtaskCommand::Metrics => metrics_tui(),
         XtaskCommand::GenBenchmarks => gen_benchmarks(),
         XtaskCommand::Bench(args) => bench_report(args),
     }
@@ -113,6 +111,21 @@ fn gen_benchmarks() {
         .stderr(Stdio::inherit())
         .status()
         .expect("Failed to run benchmark-generator");
+
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}
+
+fn metrics_tui() {
+    // Delegate to the metrics-tui binary
+    let status = Command::new("cargo")
+        .args(["run", "-p", "metrics-tui", "--release", "--"])
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .stdin(Stdio::inherit())
+        .status()
+        .expect("Failed to run metrics-tui");
 
     if !status.success() {
         std::process::exit(status.code().unwrap_or(1));


### PR DESCRIPTION
## Summary

Moves the ratatui/crossterm TUI dependencies out of xtask into a separate `tools/metrics-tui` crate. This speeds up xtask compilation for users who just want to run simple commands like `cargo xtask bench` or `cargo xtask schema`.

## Changes

- Created `tools/metrics-tui/` crate with ratatui/crossterm dependencies
- Moved TUI logic from `xtask/src/metrics_tui_impl.rs` to `tools/metrics-tui/src/main.rs`
- Updated `cargo xtask metrics` to delegate to `cargo run -p metrics-tui --release`
- Removed ratatui/crossterm from xtask's dependencies
- Added `tools/metrics-tui` and `tools/benchmark-defs` to workspace members

## Before/After xtask deps

**Before:**
```
xtask v0.32.3
├── benchmark-defs
├── crossterm v0.29.0      ← TUI only
├── facet
├── facet-args
├── facet-json
├── miette
└── ratatui v0.30.0-beta.0  ← TUI only
```

**After:**
```
xtask v0.32.3
├── benchmark-defs
├── facet
├── facet-args
├── facet-json
└── miette
```

## Test plan

- [x] `cargo check -p xtask -p metrics-tui` passes
- [x] Verified xtask no longer has ratatui/crossterm as direct deps via `cargo tree -p xtask`
- [x] Verified metrics-tui has the TUI deps via `cargo tree -p metrics-tui`

Fixes #1329