### PR TITLE
Add transform field to text node in facet-svg

### DIFF
--- a/facet-svg/src/lib.rs
+++ b/facet-svg/src/lib.rs
@@ -279,6 +279,8 @@ pub struct Text {
     #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
     pub y: Option<f64>,
     #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
+    pub transform: Option<String>,
+    #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
     pub fill: Option<String>,
     #[facet(xml::attribute, default, skip_serializing_if = Option::is_none)]
     pub stroke: Option<String>,


### PR DESCRIPTION
A lot more are probably missing.