### PR TITLE
Remove unconditional feature dependencies in facet-diff and facet-assert

### DIFF
--- a/facet-assert/Cargo.toml
+++ b/facet-assert/Cargo.toml
@@ -16,12 +16,12 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 [features]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.32.3", features = ["auto-traits", "bytes", "camino", "chrono", "fn-ptr", "indexmap", "jiff02", "net", "nonzero", "num-complex", "ordered-float", "ruint", "simd", "time", "tuples-12", "ulid", "url", "uuid"] }
+facet-core = { path = "../facet-core", version = "0.32.3" }
 facet-diff = { path = "../facet-diff", version = "0.32.3" }
 facet-diff-core = { path = "../facet-diff-core", version = "0.32.3" }
 facet-reflect = { path = "../facet-reflect", version = "0.32.3", features = ["miette"] }
 
 [dev-dependencies]
-facet = { workspace = true, features = ["bytes", "camino", "chrono", "doc", "jiff02", "net", "nonzero", "ordered-float", "time", "ulid", "uuid"] } #unified
+facet = { workspace = true }
 facet-showcase = { path = "../facet-showcase", version = "0.32.3" }
 owo-colors = "4"

--- a/facet-diff/Cargo.toml
+++ b/facet-diff/Cargo.toml
@@ -18,8 +18,8 @@ default = []
 
 [dependencies]
 cinereus = { path = "../cinereus", version = "0.32.3" }
-facet = { workspace = true, features = ["bytes", "camino", "chrono", "doc", "jiff02", "net", "nonzero", "ordered-float", "time", "ulid", "uuid"] } #unified
-facet-core = { path = "../facet-core", version = "0.32.3", features = ["auto-traits", "bytes", "camino", "chrono", "fn-ptr", "indexmap", "jiff02", "net", "nonzero", "num-complex", "ordered-float", "ruint", "simd", "time", "tuples-12", "ulid", "url", "uuid"] }
+facet = { workspace = true }
+facet-core = { path = "../facet-core", version = "0.32.3" }
 facet-diff-core = { path = "../facet-diff-core", version = "0.32.3" }
 facet-pretty = { path = "../facet-pretty", version = "0.32.3" }
 facet-reflect = { path = "../facet-reflect", version = "0.32.3", features = ["miette"] }


### PR DESCRIPTION
## Summary

Fixes #1339 by removing unconditional feature dependencies from `facet-diff` and `facet-assert`.

Both crates were unconditionally enabling many optional features on `facet` and `facet-core`:
- bytes, camino, chrono, jiff02, net, nonzero, ordered-float, time, ulid, uuid, etc.

Due to Cargo's workspace-level feature unification, this polluted the entire dependency tree - even unrelated crates would get all these features enabled.

## Changes

**facet-diff/Cargo.toml:**
- Removed feature list from `facet` dependency (was: 11 features)
- Removed feature list from `facet-core` dependency (was: 18 features)

**facet-assert/Cargo.toml:**
- Removed feature list from `facet-core` dependency (was: 18 features)  
- Removed feature list from `facet` dev-dependency (was: 11 features)

## Analysis

Investigation revealed that `facet-diff` only actively uses basic functionality:
- The `DynValueKind` enum variants (Bytes, Uuid, etc.) are always available regardless of features
- Features only control whether specific types can be **converted into** those variants
- Downstream crates can still diff values containing these types as long as the **producer** had the features enabled
- facet-diff itself doesn't need the features to **handle** those variant types

## Test plan

- ✅ All 243 tests pass (`cargo nextest run -p facet-diff -p facet-assert`)
- ✅ nostd compatibility maintained (`just nostd-ci`)
- ✅ Pre-push checks pass (clippy, nextest, doc tests, docs build, cargo-shear)
- ✅ No unused dependencies detected