### PR TITLE
Fix facet-toml array table deserialization regression (issue #1303)

### DIFF
--- a/facet-toml/tests/deserialize/vec_struct.rs
+++ b/facet-toml/tests/deserialize/vec_struct.rs
@@ -1,5 +1,7 @@
 //! Test for Vec<Struct> deserialization
 
+use std::collections::HashMap;
+
 use facet::Facet;
 use facet_testhelpers::test;
 
@@ -40,6 +42,143 @@ fn test_deserialize_vec_struct() {
                     age: 25,
                 },
             ],
+        }
+    );
+}
+
+// Issue #1303: regression tests for nested tables and default HashMap in array tables
+
+#[derive(Debug, Facet, PartialEq)]
+struct NestedInner {
+    tag: String,
+}
+
+#[derive(Debug, Facet, PartialEq)]
+struct NestedOuter {
+    name: String,
+    inner: NestedInner,
+}
+
+#[derive(Debug, Facet, PartialEq)]
+struct NestedRoot {
+    nested: Vec<NestedOuter>,
+}
+
+#[test]
+fn nested_inline() {
+    assert_eq!(
+        facet_toml::from_str::<NestedRoot>(
+            r#"
+            [[nested]]
+            name = "inline"
+            inner = { tag = "inline tag" }
+            "#
+        )
+        .unwrap(),
+        NestedRoot {
+            nested: vec![NestedOuter {
+                name: "inline".to_string(),
+                inner: NestedInner {
+                    tag: "inline tag".to_string(),
+                },
+            },],
+        }
+    );
+}
+
+#[test]
+fn nested_separate() {
+    assert_eq!(
+        facet_toml::from_str::<NestedRoot>(
+            r#"
+            [[nested]]
+            name = "separate"
+
+            [nested.inner]
+            tag = "not an inline tag"
+            "#
+        )
+        .unwrap(),
+        NestedRoot {
+            nested: vec![NestedOuter {
+                name: "separate".to_string(),
+                inner: NestedInner {
+                    tag: "not an inline tag".to_string(),
+                },
+            },],
+        }
+    );
+}
+
+#[derive(Debug, Facet, PartialEq)]
+struct Mapped {
+    name: String,
+    #[facet(default = HashMap::<String, String>::new())]
+    features: HashMap<String, String>,
+}
+
+#[derive(Debug, Facet, PartialEq)]
+struct MappedRoot {
+    items: Vec<Mapped>,
+}
+
+#[test]
+fn mapped_full() {
+    assert_eq!(
+        facet_toml::from_str::<MappedRoot>(
+            r#"
+            [[items]]
+            name = "full"
+            features = {"minimal" = "not at all"}
+            "#
+        )
+        .unwrap(),
+        MappedRoot {
+            items: vec![Mapped {
+                name: "full".to_string(),
+                features: [("minimal".to_string(), "not at all".to_string())].into(),
+            },],
+        }
+    );
+}
+
+#[test]
+fn mapped_separate() {
+    assert_eq!(
+        facet_toml::from_str::<MappedRoot>(
+            r#"
+            [[items]]
+            name = "separate"
+
+            [items.features]
+            separate = "below"
+            "#
+        )
+        .unwrap(),
+        MappedRoot {
+            items: vec![Mapped {
+                name: "separate".to_string(),
+                features: [("separate".to_string(), "below".to_string())].into(),
+            },],
+        }
+    );
+}
+
+#[test]
+fn mapped_minimal() {
+    assert_eq!(
+        facet_toml::from_str::<MappedRoot>(
+            r#"
+            [[items]]
+            name = "minimal"
+            "#
+        )
+        .unwrap(),
+        MappedRoot {
+            items: vec![Mapped {
+                name: "minimal".to_string(),
+                features: HashMap::new(),
+            },],
         }
     );
 }

--- a/facet-toml/tests/vec_with_optional_fields.rs
+++ b/facet-toml/tests/vec_with_optional_fields.rs
@@ -1,8 +1,7 @@
 //! Test that Vec<T> works with optional fields in T
 //!
-//! KNOWN ISSUE: Optional fields within array-of-tables items are not properly
-//! handled when missing. This is tracked as a separate issue and is not
-//! related to the Option<Vec<T>> bug fixed in issue #1341.
+//! This was previously a known issue but has been fixed as part of issue #1303.
+//! Optional fields within array-of-tables items are now properly handled when missing.
 
 use facet::Facet;
 
@@ -30,17 +29,17 @@ name = "second"
 
     let result = facet_toml::from_str::<Root>(toml);
 
-    // This is a known bug - optional fields within array-of-tables items
-    // are not properly handled when missing
+    // Optional fields within array-of-tables items should work now (fixed in #1303)
     assert!(
-        result.is_err(),
-        "Currently fails due to known bug with optional fields in array items"
+        result.is_ok(),
+        "Optional fields in array items should work, got error: {:?}",
+        result.err()
     );
 
-    let err = result.unwrap_err();
-    let err_str = err.to_string();
-    assert!(
-        err_str.contains("Field 'Item::desc' was not initialized"),
-        "Error should mention uninitialized field, got: {err_str}"
-    );
+    let root = result.unwrap();
+    assert_eq!(root.items.len(), 2);
+    assert_eq!(root.items[0].name, "first");
+    assert_eq!(root.items[0].desc, Some("has desc".to_string()));
+    assert_eq!(root.items[1].name, "second");
+    assert_eq!(root.items[1].desc, None);
 }


### PR DESCRIPTION
## Summary

Fixes three related issues in TOML array table deserialization that were reported in issue #1303:

1. ✅ **Nested tables within array table items** - Table headers like `[array.field]` following `[[array]]` now correctly navigate into the current array item instead of failing
2. ✅ **HashMap/Map fields using separate table syntax** - Separate table syntax for map fields in array tables (e.g., `[items.features]` where `features` is a HashMap) now works correctly  
3. ✅ **Default values in array table items** - Fields with `#[facet(default)]` in array table items are now properly initialized with their defaults when missing

## Technical Details

### Problem 1 & 2: Nested table navigation

**Root cause:** When encountering a table header like `[nested.inner]` after `[[nested]]`, the deserializer closed all frames and tried to navigate from root, failing because `nested` is now a list.

**Fix:** Track active array tables in `active_array_tables` map. When a non-array table header has a prefix matching an active array table, close frames only to the list item level and navigate the remaining path within that item.

**Location:** `facet-toml/src/deserialize/streaming.rs`

### Problem 3: Missing default values

**Root cause:** In deferred mode, list items must be fully initialized before insertion. The `end()` method in facet-reflect checked `require_full_initialization()` but didn't apply defaults first.

**Fix:** Call `fill_defaults()` before `require_full_initialization()` when in deferred mode and full initialization is required.

**Location:** `facet-reflect/src/partial/partial_api/misc.rs`

## Bonus Fix

This also fixes a related known bug with `Option<T>` fields in array table items (see `tests/vec_with_optional_fields.rs`).

## Test Coverage

- Added 5 new regression tests from the issue report
- All 3000 existing tests pass
- Fixed previously-failing test for optional fields in array tables

Closes #1303