### PR TITLE
Fix untagged enum parsing in facet-toml (issue #1346)

### DIFF
--- a/facet-toml/tests/issue_1346.rs
+++ b/facet-toml/tests/issue_1346.rs
@@ -1,0 +1,105 @@
+//! Test for issue #1346: Untagged enums fail to parse in facet-toml
+//!
+//! This test reproduces the bug where facet-toml fails to deserialize
+//! enums marked with `#[facet(untagged)]`, returning the error:
+//! "Operation failed on shape Dependency: No variant found with the given name"
+//!
+//! The use case is parsing Cargo.toml-style dependency declarations where
+//! a field can be either a simple version string or a table with options.
+
+use facet::Facet;
+
+#[derive(Facet, Debug, PartialEq)]
+#[repr(u8)]
+#[facet(untagged)]
+enum Dependency {
+    Version(String),
+    Table(DepTable),
+}
+
+#[derive(Facet, Debug, Default, PartialEq)]
+struct DepTable {
+    path: Option<String>,
+    version: Option<String>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Test1 {
+    dep: Dependency,
+}
+
+/// Test parsing a simple version string into an untagged enum
+#[test]
+fn test_untagged_enum_string_variant() {
+    let toml = r#"dep = "1.0""#;
+
+    let result = facet_toml::from_str::<Test1>(toml);
+    if let Err(e) = &result {
+        eprintln!("Error: {e}");
+    }
+
+    assert!(
+        result.is_ok(),
+        "Should parse string value into untagged enum Version variant"
+    );
+
+    let parsed = result.unwrap();
+    assert_eq!(parsed.dep, Dependency::Version("1.0".to_string()));
+}
+
+/// Test parsing a table into an untagged enum
+#[test]
+fn test_untagged_enum_table_variant() {
+    let toml = r#"
+[dep]
+path = "../util"
+"#;
+
+    let result = facet_toml::from_str::<Test1>(toml);
+    if let Err(e) = &result {
+        eprintln!("Error: {e}");
+    }
+
+    assert!(
+        result.is_ok(),
+        "Should parse table value into untagged enum Table variant"
+    );
+
+    let parsed = result.unwrap();
+    assert_eq!(
+        parsed.dep,
+        Dependency::Table(DepTable {
+            path: Some("../util".to_string()),
+            version: None,
+        })
+    );
+}
+
+/// Test parsing a table with version field
+#[test]
+fn test_untagged_enum_table_with_version() {
+    let toml = r#"
+[dep]
+version = "1.0"
+path = "../util"
+"#;
+
+    let result = facet_toml::from_str::<Test1>(toml);
+    if let Err(e) = &result {
+        eprintln!("Error: {e}");
+    }
+
+    assert!(
+        result.is_ok(),
+        "Should parse table with both fields into untagged enum Table variant"
+    );
+
+    let parsed = result.unwrap();
+    assert_eq!(
+        parsed.dep,
+        Dependency::Table(DepTable {
+            path: Some("../util".to_string()),
+            version: Some("1.0".to_string()),
+        })
+    );
+}


### PR DESCRIPTION
## Summary

This PR adds support for `#[facet(untagged)]` enums in facet-toml by using facet-solver's `VariantsByFormat` to classify variants and match them against TOML value types.

**Fixes #1346**

## What Changed

For untagged enums like:

```rust
#[facet(untagged)]
enum Dependency {
    Version(String),    // dep = "1.0"
    Table(DepTable),    // [dep]\npath = "..."
}
```

The deserializer now examines the TOML value type to select the appropriate variant:
- **Scalar values** (strings, numbers) → newtype variants wrapping scalars
- **Tables** (inline or standard headers) → struct variants or newtype variants wrapping structs  
- **Arrays** → tuple variants

Key changes:
- Modified `needs_variant_selection` to exclude untagged enums (they need type-based dispatch, not name-based)
- Added `deserialize_untagged_enum` using `VariantsByFormat` from facet-solver
- Added untagged enum detection in table header processing for `[dep]` syntax

## Test Plan

- [x] Added `issue_1346.rs` test file with repro cases from the issue
- [x] All 191 facet-toml tests pass
- [x] Pre-push checks (clippy, nextest, doc tests) pass