### PR TITLE
Fix facet-args: Option<T> fields with args::named should be optional (issue #1348)

### DIFF
--- a/facet-args/src/format.rs
+++ b/facet-args/src/format.rs
@@ -816,6 +816,9 @@ impl<'input> Context<'input> {
             } else if field.shape().is_shape(bool::SHAPE) {
                 // bools are just set to false
                 p = p.set_nth_field(field_index, false)?;
+            } else if let Def::Option(_) = field.shape().def {
+                // Option<T> fields default to None
+                p = p.set_nth_field_to_default(field_index)?;
             } else {
                 return Err(ArgsErrorKind::MissingArgument { field });
             }
@@ -854,6 +857,9 @@ impl<'input> Context<'input> {
                 p = p.set_nth_field_to_default(field_index)?;
             } else if field.shape().is_shape(bool::SHAPE) {
                 p = p.set_nth_field(field_index, false)?;
+            } else if let Def::Option(_) = field.shape().def {
+                // Option<T> fields default to None
+                p = p.set_nth_field_to_default(field_index)?;
             } else {
                 return Err(ArgsErrorKind::MissingArgument { field });
             }


### PR DESCRIPTION
## Summary
- Fixes #1348: `Option<T>` fields with `#[facet(args::named)]` are now correctly treated as optional
- Added regression tests for both struct fields and enum variant fields

## Problem
Previously, `Option<T>` fields were only recognized as optional when they had the `args::subcommand` attribute. For regular named/positional fields, the parser incorrectly treated `Option<T>` as required, causing errors like:

```
missing required argument `--node`
```

even though the field was `Option<String>`.

## Solution
Added `Option<T>` checks in both `finalize_struct` and `finalize_variant_fields` functions. When a field is `Option<T>` and wasn't explicitly set, it now correctly defaults to `None` using `set_nth_field_to_default`.

## Test Plan
- [x] Added `test_option_named_struct` for struct fields with `Option<T>`
- [x] Added `test_option_named_enum_variant` for enum variant fields with `Option<T>`
- [x] All existing `facet-args` tests pass (95/95)
- [x] Pre-push checks pass (clippy, nextest, doc tests, docs build, cargo-shear)