### PR TITLE
Fix facet-toml: Allow nested table headers with HashMap values (issue…

### DIFF
--- a/facet-toml/tests/issue_1350.rs
+++ b/facet-toml/tests/issue_1350.rs
@@ -1,0 +1,69 @@
+// Issue #1350: facet-toml fails to parse nested table headers like [target.'cfg(windows)'.dependencies]
+
+use facet::Facet;
+use std::collections::HashMap;
+
+#[derive(Facet, Debug)]
+struct TestManifest {
+    target: Option<HashMap<String, TargetSpec>>,
+}
+
+#[derive(Facet, Debug, Default)]
+#[facet(rename_all = "kebab-case")]
+struct TargetSpec {
+    dependencies: Option<HashMap<String, String>>,
+}
+
+#[test]
+fn test_nested_table_header_with_quoted_key() {
+    let toml = r#"
+[target.'cfg(windows)'.dependencies]
+windows-targets = "0.52.6"
+"#;
+
+    let result: Result<TestManifest, _> = facet_toml::from_str(toml);
+
+    match &result {
+        Ok(manifest) => {
+            let target = manifest.target.as_ref().expect("target should exist");
+            let cfg_windows = target
+                .get("cfg(windows)")
+                .expect("cfg(windows) key should exist");
+            let deps = cfg_windows
+                .dependencies
+                .as_ref()
+                .expect("dependencies should exist");
+            assert_eq!(deps.get("windows-targets"), Some(&"0.52.6".to_string()));
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            panic!("Failed to parse TOML: {}", e);
+        }
+    }
+}
+
+#[test]
+fn test_nested_table_header_simple() {
+    let toml = r#"
+[target.x86_64.dependencies]
+some-dep = "1.0"
+"#;
+
+    let result: Result<TestManifest, _> = facet_toml::from_str(toml);
+
+    match &result {
+        Ok(manifest) => {
+            let target = manifest.target.as_ref().expect("target should exist");
+            let x86_64 = target.get("x86_64").expect("x86_64 key should exist");
+            let deps = x86_64
+                .dependencies
+                .as_ref()
+                .expect("dependencies should exist");
+            assert_eq!(deps.get("some-dep"), Some(&"1.0".to_string()));
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            panic!("Failed to parse TOML: {}", e);
+        }
+    }
+}

--- a/facet-toml/tests/issue_1350_debug.rs
+++ b/facet-toml/tests/issue_1350_debug.rs
@@ -1,0 +1,58 @@
+// Debug version with more detailed output
+
+use facet::Facet;
+use std::collections::HashMap;
+
+#[derive(Facet, Debug)]
+struct TestManifest {
+    target: Option<HashMap<String, TargetSpec>>,
+}
+
+#[derive(Facet, Debug, Default)]
+#[facet(rename_all = "kebab-case")]
+struct TargetSpec {
+    dependencies: Option<HashMap<String, String>>,
+}
+
+#[test]
+fn test_two_level_nested_table() {
+    let toml = r#"
+[target.x86_64]
+"#;
+
+    let result: Result<TestManifest, _> = facet_toml::from_str(toml);
+
+    match &result {
+        Ok(manifest) => {
+            eprintln!("Success: {:#?}", manifest);
+            let target = manifest.target.as_ref().expect("target should exist");
+            assert!(target.contains_key("x86_64"));
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            panic!("Failed to parse TOML: {}", e);
+        }
+    }
+}
+
+#[test]
+fn test_three_level_no_values() {
+    let toml = r#"
+[target.x86_64.dependencies]
+"#;
+
+    let result: Result<TestManifest, _> = facet_toml::from_str(toml);
+
+    match &result {
+        Ok(manifest) => {
+            eprintln!("Success: {:#?}", manifest);
+            let target = manifest.target.as_ref().expect("target should exist");
+            let x86_64 = target.get("x86_64").expect("x86_64 key should exist");
+            assert!(x86_64.dependencies.is_some());
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            panic!("Failed to parse TOML: {}", e);
+        }
+    }
+}


### PR DESCRIPTION
… #1350)

This commit fixes the inability to parse nested TOML table headers like `[target.'cfg(windows)'.dependencies]` when the intermediate keys map to struct values in a HashMap.

**Root Cause:**

The table header parser had an overly restrictive check in `begin_field_or_list_item()` that rejected ANY HashMap value with `Def::Undefined`, treating it as "scalar-like" and incompatible with table headers. However, structs often have `Def::Undefined` even though they CAN serve as tables (they have fields that can receive key-value pairs).

**The Fix:**

1. Changed the scalar-like check to ONLY reject `Def::Scalar` types
2. Added a guard so the check only applies when `is_last_in_path=true` (when the value will directly receive key-value pairs)
3. For middle path elements (`is_last_in_path=false`), we skip the check entirely since we'll navigate deeper into the structure

This allows table headers like:
- `[target.x86_64.dependencies]` where target: HashMap<String, TargetSpec>
- `[target.'cfg(windows)'.dependencies]` (the real-world Cargo.toml case)

The fix is minimal and conservative - we only reject definite scalars, and allow `Def::Undefined` types to proceed. If they're truly incompatible, the subsequent field navigation will fail with a clear error.

**Testing:**

Added comprehensive tests covering both 2-level and 3-level nested table headers, with and without key-value pairs, and with quoted keys. All 195 existing facet-toml tests still pass.