### PR TITLE
Enable doc feature by default (fixes #1352)

### DIFF
--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -11,14 +11,14 @@ categories = ["development-tools", "encoding", "rust-patterns"]
 homepage = "https://facet.rs"
 
 [package.metadata.docs.rs]
-features = ["std", "reflect", "camino", "ordered-float"]
+features = ["std", "reflect", "camino", "ordered-float", "doc"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [package.metadata."docs.rs"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [features]
-default = ["std", "helpful-derive"]
+default = ["std", "helpful-derive", "doc"]
 auto-traits = ["facet-core/auto-traits"]
 function = ["facet-macros/function"] # Enable function shape introspection
 reflect = ["dep:facet-reflect"] # Enable reflection via Peek and Poke types


### PR DESCRIPTION
## Summary
Fixes #1352 by enabling the `doc` feature by default.

## Problem
Doc comments in `SHAPE.doc` were returning empty arrays because the `doc` feature was not enabled by default. This was a regression introduced in v0.32.1 (commit 3971cf5e8) when doc comment generation was gated behind a feature flag as part of bloat reduction efforts.

In v0.31.8 and earlier, doc comments were always generated unconditionally.

## Solution
- Added `doc` to the default feature set in `facet/Cargo.toml`
- Added `doc` to the docs.rs feature list to ensure documentation on docs.rs includes doc comments

## Test Plan
- [x] Verified that doc comments are now captured without explicitly enabling the feature
- [x] All existing tests pass (129 tests in facet crate)
- [x] Tested with standalone example that previously showed empty doc array
- [x] Pre-push checks passed (clippy, nextest, doc tests, docs build, cargo-shear)

## Backwards Compatibility
This change restores the behavior from v0.31.8 and earlier, making doc comments available by default again. Users who want to opt out of doc comment generation (for bloat reduction) can use `default-features = false` and selectively enable only the features they need.