### PR TITLE
Fix untagged enum deserialization for Vec and unit enum variants (fixes #1359)

### DIFF
--- a/facet-toml/tests/issue_1359.rs
+++ b/facet-toml/tests/issue_1359.rs
@@ -1,0 +1,250 @@
+//! Test for issue #1359: Regression - Untagged enums with Vec variants fail
+//!
+//! After PR #1358 fixed dotted key handling for untagged enums, Vec<T> variants
+//! in untagged enums stopped working with the error:
+//! "No tuple-accepting variants in untagged enum VecOrWorkspace"
+
+use facet::Facet;
+
+/// Test 1: Vec variant matching TOML array (BROKEN after PR #1358)
+#[test]
+fn test_untagged_enum_vec_variant() {
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    #[repr(u8)]
+    #[facet(untagged)]
+    pub enum VecOrWorkspace {
+        Values(Vec<String>),
+        Workspace(WorkspaceRef),
+    }
+
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct WorkspaceRef {
+        pub workspace: bool,
+    }
+
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    #[facet(rename_all = "kebab-case")]
+    pub struct Package {
+        pub authors: Option<VecOrWorkspace>,
+    }
+
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct Manifest {
+        pub package: Option<Package>,
+    }
+
+    // Test Vec variant with array
+    let toml = r#"
+[package]
+authors = ["Alice <alice@example.com>", "Bob <bob@example.com>"]
+"#;
+
+    let result = facet_toml::from_str::<Manifest>(toml);
+    if let Err(e) = &result {
+        eprintln!("Error: {e}");
+    }
+
+    assert!(
+        result.is_ok(),
+        "Should parse TOML array into Vec variant of untagged enum"
+    );
+
+    let parsed = result.unwrap();
+    assert_eq!(
+        parsed.package.as_ref().unwrap().authors,
+        Some(VecOrWorkspace::Values(vec![
+            "Alice <alice@example.com>".to_string(),
+            "Bob <bob@example.com>".to_string()
+        ]))
+    );
+
+    // Test Workspace variant with dotted key syntax
+    let toml2 = r#"
+[package]
+authors.workspace = true
+"#;
+
+    let result2 = facet_toml::from_str::<Manifest>(toml2);
+    if let Err(e) = &result2 {
+        eprintln!("Error: {e}");
+    }
+
+    assert!(
+        result2.is_ok(),
+        "Should parse dotted key syntax into Workspace variant"
+    );
+
+    let parsed2 = result2.unwrap();
+    assert_eq!(
+        parsed2.package.as_ref().unwrap().authors,
+        Some(VecOrWorkspace::Workspace(WorkspaceRef { workspace: true }))
+    );
+}
+
+/// Test 2: String variant matching TOML string (should still work)
+#[test]
+fn test_untagged_enum_string_variant() {
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    #[repr(u8)]
+    #[facet(untagged)]
+    pub enum StringOrWorkspace {
+        String(String),
+        Workspace(WorkspaceRef),
+    }
+
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct WorkspaceRef {
+        pub workspace: bool,
+    }
+
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct Package {
+        pub version: Option<StringOrWorkspace>,
+    }
+
+    // Test String variant
+    let toml = r#"
+version = "1.0.0"
+"#;
+
+    let result = facet_toml::from_str::<Package>(toml);
+    assert!(result.is_ok());
+
+    let parsed = result.unwrap();
+    assert_eq!(
+        parsed.version,
+        Some(StringOrWorkspace::String("1.0.0".to_string()))
+    );
+
+    // Test Workspace variant
+    let toml2 = r#"
+version.workspace = true
+"#;
+
+    let result2 = facet_toml::from_str::<Package>(toml2);
+    assert!(result2.is_ok());
+
+    let parsed2 = result2.unwrap();
+    assert_eq!(
+        parsed2.version,
+        Some(StringOrWorkspace::Workspace(WorkspaceRef {
+            workspace: true
+        }))
+    );
+}
+
+/// Test 3: Enum variant matching TOML string
+#[test]
+fn test_untagged_enum_enum_variant() {
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    #[repr(u8)]
+    #[facet(untagged)]
+    pub enum EditionOrWorkspace {
+        Workspace(WorkspaceRef),
+        Edition(Edition),
+    }
+
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct WorkspaceRef {
+        pub workspace: bool,
+    }
+
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    #[repr(u8)]
+    pub enum Edition {
+        #[facet(rename = "2015")]
+        E2015,
+        #[facet(rename = "2018")]
+        E2018,
+        #[facet(rename = "2021")]
+        E2021,
+        #[facet(rename = "2024")]
+        E2024,
+    }
+
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct Package {
+        pub edition: Option<EditionOrWorkspace>,
+    }
+
+    // Test Edition variant
+    let toml = r#"
+edition = "2024"
+"#;
+
+    let result = facet_toml::from_str::<Package>(toml);
+    if let Err(e) = &result {
+        eprintln!("Error: {e}");
+    }
+    assert!(result.is_ok());
+
+    let parsed = result.unwrap();
+    assert_eq!(
+        parsed.edition,
+        Some(EditionOrWorkspace::Edition(Edition::E2024))
+    );
+
+    // Test Workspace variant
+    let toml2 = r#"
+edition.workspace = true
+"#;
+
+    let result2 = facet_toml::from_str::<Package>(toml2);
+    assert!(result2.is_ok());
+
+    let parsed2 = result2.unwrap();
+    assert_eq!(
+        parsed2.edition,
+        Some(EditionOrWorkspace::Workspace(WorkspaceRef {
+            workspace: true
+        }))
+    );
+}
+
+/// Test 4: BoolOrVec pattern
+#[test]
+fn test_untagged_enum_bool_or_vec() {
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    #[repr(u8)]
+    #[facet(untagged)]
+    pub enum BoolOrVec {
+        Bool(bool),
+        Vec(Vec<String>),
+    }
+
+    #[derive(Facet, Debug, Clone, PartialEq)]
+    pub struct Package {
+        pub publish: Option<BoolOrVec>,
+    }
+
+    // Test Bool variant
+    let toml = r#"
+publish = false
+"#;
+
+    let result = facet_toml::from_str::<Package>(toml);
+    assert!(result.is_ok());
+
+    let parsed = result.unwrap();
+    assert_eq!(parsed.publish, Some(BoolOrVec::Bool(false)));
+
+    // Test Vec variant
+    let toml2 = r#"
+publish = ["crates-io", "my-registry"]
+"#;
+
+    let result2 = facet_toml::from_str::<Package>(toml2);
+    if let Err(e) = &result2 {
+        eprintln!("Error: {e}");
+    }
+    assert!(result2.is_ok());
+
+    let parsed2 = result2.unwrap();
+    assert_eq!(
+        parsed2.publish,
+        Some(BoolOrVec::Vec(vec![
+            "crates-io".to_string(),
+            "my-registry".to_string()
+        ]))
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1359 - a regression introduced in PR #1358 where untagged enums containing `Vec<T>` variants or unit enum variants failed to deserialize.

## Root Cause

The `VariantsByFormat` classification in `facet-solver` didn't recognize:
1. **Sequence types** (Vec, Array, Slice, Set) as sequence-expecting variants
2. **Unit-only enums** as scalar-like variants

When classifying newtype variants like `Values(Vec<String>)`, the code checked if the inner type was a scalar, tuple struct, or named struct. Since `Vec<T>` has `Def::List`, it fell into `NewtypeOther` and was placed in `other_variants` instead of `tuple_variants`, causing array deserialization to fail with:
```
TOML error: No tuple-accepting variants in untagged enum VecOrWorkspace
```

Similarly, unit enums like `Edition { E2015, E2018, E2021 }` serialize as strings but weren't recognized as scalar-like, causing:
```
TOML error: No scalar-accepting variants in untagged enum EditionOrWorkspace
```

## Changes

### facet-solver/src/lib.rs
1. Added `NewtypeSequence` variant format for Vec/List/Array/Slice/Set wrappers
2. Added `is_sequence_shape()` helper to detect sequence types
3. Added `is_unit_enum_shape()` helper to detect unit-only enums
4. Updated variant classification to:
   - Recognize sequences as `NewtypeSequence` → added to `tuple_variants`
   - Treat unit enums as scalar-like → added to `scalar_variants`
5. Updated `expects_sequence()` to include `NewtypeSequence` variants

### facet-toml/tests/issue_1359.rs
Added comprehensive tests covering all variant patterns mentioned in the issue:
- ✅ Vec variant matching TOML arrays
- ✅ String variant matching TOML strings  
- ✅ Unit enum variant matching TOML strings
- ✅ BoolOrVec pattern (bool or array)

## Test Results

All tests pass:
- ✅ New issue_1359 tests (4/4)
- ✅ Existing issue_1353 tests (4/4) - regression check
- ✅ Full facet-toml suite (206/206)
- ✅ Full facet-solver suite (56/56)

## Breaking Changes

None. This is a bug fix that restores expected behavior.