### PR TITLE
Silence dead_code warnings for input field in JIT parsers

### DIFF
--- a/facet-format-msgpack/src/parser.rs
+++ b/facet-format-msgpack/src/parser.rs
@@ -10,6 +10,7 @@ use facet_format::{FieldEvidence, FormatParser, ParseEvent, ProbeStream};
 ///
 /// This parser only supports JIT mode. Calling non-JIT methods will return errors.
 pub struct MsgPackParser<'de> {
+    #[cfg_attr(not(feature = "jit"), allow(dead_code))]
     input: &'de [u8],
     pos: usize,
 }

--- a/facet-format-postcard/src/parser.rs
+++ b/facet-format-postcard/src/parser.rs
@@ -10,6 +10,7 @@ use facet_format::{FieldEvidence, FormatParser, ParseEvent, ProbeStream};
 ///
 /// This parser only supports JIT mode. Calling non-JIT methods will return errors.
 pub struct PostcardParser<'de> {
+    #[cfg_attr(not(feature = "jit"), allow(dead_code))]
     input: &'de [u8],
     pos: usize,
 }


### PR DESCRIPTION
The `input` field in PostcardParser and MsgPackParser is only accessed via the `jit_input()` method, which is gated behind `#[cfg(feature = "jit")]`. When building without the jit feature, the field is stored but never read, causing dead_code warnings.

Added `#[cfg_attr(not(feature = "jit"), allow(dead_code))]` to conditionally allow the warning since these parsers are JIT-only and the field is intentionally unused without the feature.