### PR TITLE
Add contains_peek method to PeekSet

### DIFF
--- a/facet-reflect/src/peek/set.rs
+++ b/facet-reflect/src/peek/set.rs
@@ -1,4 +1,5 @@
 use super::Peek;
+use crate::ReflectError;
 use facet_core::{PtrMut, SetDef};
 
 /// Iterator over values in a `PeekSet`
@@ -67,6 +68,19 @@ impl<'mem, 'facet> PeekSet<'mem, 'facet> {
     #[inline]
     pub fn len(&self) -> usize {
         unsafe { (self.def.vtable.len)(self.value.data()) }
+    }
+
+    /// Check if the set contains a value
+    #[inline]
+    pub fn contains_peek(&self, value: Peek<'_, 'facet>) -> Result<bool, ReflectError> {
+        if self.def.t() == value.shape {
+            return Ok(unsafe { (self.def.vtable.contains)(self.value.data(), value.data()) });
+        }
+
+        Err(ReflectError::WrongShape {
+            expected: self.def.t(),
+            actual: value.shape,
+        })
     }
 
     /// Returns an iterator over the values in the set

--- a/facet-reflect/tests/peek/set.rs
+++ b/facet-reflect/tests/peek/set.rs
@@ -1,4 +1,4 @@
-use facet_reflect::Peek;
+use facet_reflect::{Peek, ReflectError};
 use facet_testhelpers::test;
 use std::collections::HashSet;
 
@@ -27,4 +27,42 @@ fn test_peek_set_iteration() {
     entries.sort();
 
     assert_eq!(entries, vec!["a", "b"]);
+}
+
+#[test]
+fn test_peek_set_contains_peek() {
+    let mut source = HashSet::new();
+    source.insert("a");
+    source.insert("b");
+    source.insert("c");
+
+    let peek_value = Peek::new(&source);
+    let peek_set = peek_value.into_set().unwrap();
+
+    // Test contains with values that exist
+    let a = "a";
+    assert_eq!(peek_set.contains_peek(Peek::new(&a)).unwrap(), true);
+
+    let b = "b";
+    assert_eq!(peek_set.contains_peek(Peek::new(&b)).unwrap(), true);
+
+    // Test contains with value that doesn't exist
+    let d = "d";
+    assert_eq!(peek_set.contains_peek(Peek::new(&d)).unwrap(), false);
+}
+
+#[test]
+fn test_peek_set_contains_peek_wrong_type() {
+    let mut source = HashSet::new();
+    source.insert("a");
+    source.insert("b");
+
+    let peek_value = Peek::new(&source);
+    let peek_set = peek_value.into_set().unwrap();
+
+    // Try to check for an integer in a string set
+    let wrong_type = 42;
+    let result = peek_set.contains_peek(Peek::new(&wrong_type));
+
+    assert!(matches!(result, Err(ReflectError::WrongShape { .. })));
 }


### PR DESCRIPTION
## Summary
- Adds `contains_peek` method to `PeekSet` in facet-reflect
- Exposes existing `SetVTable::contains` functionality for efficient membership testing
- Follows the same API pattern as `PeekMap::contains_key_peek`

## Implementation Details
The method validates that the value's type matches the set's element type before delegating to the underlying vtable function. This enables O(n) set comparisons instead of O(n²) nested iteration.

## Testing
- Added tests for membership checking (existing and non-existing values)
- Added test for type safety (wrong type returns `ReflectError::WrongShape`)
- All existing facet-reflect tests pass (359 tests)

Fixes #1373