### PR TITLE
facet-reflect: replace explicit Box::leak

### DIFF
--- a/facet-reflect/src/error.rs
+++ b/facet-reflect/src/error.rs
@@ -189,6 +189,15 @@ pub enum ReflectError {
     },
 
     #[cfg(feature = "alloc")]
+    /// A user-defined invariant check failed during build
+    UserInvariantFailed {
+        /// The error message from the invariant check
+        message: alloc::string::String,
+        /// The shape of the value that failed the invariant check
+        shape: &'static Shape,
+    },
+
+    #[cfg(feature = "alloc")]
     /// Error during custom serialization
     CustomSerializationError {
         /// Error message provided by the serialize_with method
@@ -334,6 +343,10 @@ impl core::fmt::Display for ReflectError {
                     f,
                     "Custom serialization of shape '{src_shape}' into '{dst_shape}' failed: {message}"
                 )
+            }
+            #[cfg(feature = "alloc")]
+            ReflectError::UserInvariantFailed { message, shape } => {
+                write!(f, "Invariant check failed for '{shape}': {message}")
             }
         }
     }

--- a/facet-reflect/src/partial/partial_api/build.rs
+++ b/facet-reflect/src/partial/partial_api/build.rs
@@ -29,14 +29,11 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 Ok(()) => {
                     // Invariants passed
                 }
-                Err(msg) => {
+                Err(message) => {
                     // Put the frame back so Drop can handle cleanup properly
+                    let shape = frame.shape;
                     self.frames_mut().push(frame);
-                    // Leak the string to get a 'static lifetime for the error
-                    let static_msg: &'static str = Box::leak(msg.into_boxed_str());
-                    return Err(ReflectError::InvariantViolation {
-                        invariant: static_msg,
-                    });
+                    return Err(ReflectError::UserInvariantFailed { message, shape });
                 }
             }
         }


### PR DESCRIPTION
This addresses one of the Miri failures from #1376 by introducing a new `ReflectError` variant with an owned message instead of `Box::leak`ing the message to fit it into a `&'static str`.