### PR TITLE
Remove Box::leak from facet-diff-core and facet-format

### DIFF
--- a/facet-diff-core/src/layout/node.rs
+++ b/facet-diff-core/src/layout/node.rs
@@ -1,5 +1,7 @@
 //! Layout tree nodes.
 
+use std::borrow::Cow;
+
 use indextree::{Arena, NodeId};
 
 use super::{Attr, ChangedGroup, FormatArena, FormattedValue};
@@ -44,7 +46,7 @@ pub enum LayoutNode {
     /// An element/struct with attributes and children.
     Element {
         /// Element tag name
-        tag: &'static str,
+        tag: Cow<'static, str>,
         /// Field name if this element is a struct field (e.g., "point" for `point: Inner`)
         field_name: Option<&'static str>,
         /// All attributes (unchanged, changed, deleted, inserted)
@@ -96,9 +98,9 @@ pub enum LayoutNode {
 
 impl LayoutNode {
     /// Create an element node with no changes.
-    pub fn element(tag: &'static str) -> Self {
+    pub fn element(tag: impl Into<Cow<'static, str>>) -> Self {
         Self::Element {
-            tag,
+            tag: tag.into(),
             field_name: None,
             attrs: Vec::new(),
             changed_groups: Vec::new(),
@@ -107,9 +109,9 @@ impl LayoutNode {
     }
 
     /// Create an element node with a specific change type.
-    pub fn element_with_change(tag: &'static str, change: ElementChange) -> Self {
+    pub fn element_with_change(tag: impl Into<Cow<'static, str>>, change: ElementChange) -> Self {
         Self::Element {
-            tag,
+            tag: tag.into(),
             field_name: None,
             attrs: Vec::new(),
             changed_groups: Vec::new(),

--- a/facet-diff-core/src/layout/render.rs
+++ b/facet-diff-core/src/layout/render.rs
@@ -258,7 +258,7 @@ fn render_node<W: Write, B: ColorBackend, F: DiffFlavor>(
             changed_groups,
             change,
         } => {
-            let tag = *tag;
+            let tag = tag.as_ref();
             let field_name = *field_name;
             let change = *change;
             let attrs = attrs.clone();
@@ -1120,6 +1120,8 @@ fn write_indent_minus_prefix<W: Write, B: ColorBackend>(
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use indextree::Arena;
 
     use super::*;
@@ -1144,7 +1146,7 @@ mod tests {
         let changed_groups = super::super::group_changed_attrs(&attrs, 80, 0);
 
         let root = LayoutNode::Element {
-            tag: "rect",
+            tag: Cow::Borrowed("rect"),
             field_name: None,
             attrs,
             changed_groups,
@@ -1189,7 +1191,7 @@ mod tests {
 
         // Parent element
         let parent = tree.new_node(LayoutNode::Element {
-            tag: "svg",
+            tag: Cow::Borrowed("svg"),
             field_name: None,
             attrs: vec![],
             changed_groups: vec![],
@@ -1210,7 +1212,7 @@ mod tests {
         let changed_groups = super::super::group_changed_attrs(&attrs, 80, 0);
 
         let child = tree.new_node(LayoutNode::Element {
-            tag: "rect",
+            tag: Cow::Borrowed("rect"),
             field_name: None,
             attrs,
             changed_groups,


### PR DESCRIPTION
## Summary
- Replaced `Box::leak()` with `Cow<'static, str>` in facet-diff-core's LayoutNode::Element
- Changed SerializeError to use `Cow<'static, str>` for error messages
- Dynamic proxy conversion errors now use `Cow::Owned()` instead of leaking memory

## Test plan
- ✅ All facet-diff-core tests pass (33 tests)
- ✅ facet-format builds successfully
- ✅ Pre-push checks passed (clippy, nextest, doc tests, cargo-shear)