### PR TITLE
Extend Tier-0 deserialization with hint_option and hint_enum support

### DIFF
--- a/facet-format-postcard/src/error.rs
+++ b/facet-format-postcard/src/error.rs
@@ -39,6 +39,10 @@ pub mod codes {
     pub const SEQ_UNDERFLOW: i32 = -103;
     /// Invalid UTF-8 in string
     pub const INVALID_UTF8: i32 = -104;
+    /// Invalid Option discriminant (not 0x00 or 0x01)
+    pub const INVALID_OPTION_DISCRIMINANT: i32 = -105;
+    /// Invalid enum variant discriminant (out of range)
+    pub const INVALID_ENUM_DISCRIMINANT: i32 = -106;
     /// Unsupported operation (triggers fallback)
     pub const UNSUPPORTED: i32 = -1;
 }
@@ -52,6 +56,10 @@ impl PostcardError {
             codes::VARINT_OVERFLOW => "varint overflow".to_string(),
             codes::SEQ_UNDERFLOW => "sequence underflow (internal error)".to_string(),
             codes::INVALID_UTF8 => "invalid UTF-8 in string".to_string(),
+            codes::INVALID_OPTION_DISCRIMINANT => {
+                "invalid Option discriminant (expected 0x00 or 0x01)".to_string()
+            }
+            codes::INVALID_ENUM_DISCRIMINANT => "invalid enum variant discriminant".to_string(),
             codes::UNSUPPORTED => "unsupported operation".to_string(),
             _ => format!("unknown error code {}", code),
         };

--- a/facet-format-postcard/tests/multi_tier.rs
+++ b/facet-format-postcard/tests/multi_tier.rs
@@ -285,26 +285,26 @@ mod primitives {
 mod vecs {
     use super::*;
 
-    // Vec<bool>
-    test_tier2_only!(vec_bool_empty, Vec<bool>, vec![]);
-    test_tier2_only!(vec_bool_single, Vec<bool>, vec![true]);
-    test_tier2_only!(vec_bool_multiple, Vec<bool>, vec![true, false, true, false]);
+    // Vec<bool> - now Tier-0 supported with hint_sequence
+    test_all_tiers!(vec_bool_empty, Vec<bool>, vec![]);
+    test_all_tiers!(vec_bool_single, Vec<bool>, vec![true]);
+    test_all_tiers!(vec_bool_multiple, Vec<bool>, vec![true, false, true, false]);
 
-    // Vec<u8>
-    test_tier2_only!(vec_u8_empty, Vec<u8>, vec![]);
-    test_tier2_only!(vec_u8_single, Vec<u8>, vec![42]);
-    test_tier2_only!(vec_u8_multiple, Vec<u8>, vec![0, 128, 255]);
+    // Vec<u8> - now Tier-0 supported with hint_sequence
+    test_all_tiers!(vec_u8_empty, Vec<u8>, vec![]);
+    test_all_tiers!(vec_u8_single, Vec<u8>, vec![42]);
+    test_all_tiers!(vec_u8_multiple, Vec<u8>, vec![0, 128, 255]);
 
-    // Vec<u32>
-    test_tier2_only!(vec_u32_empty, Vec<u32>, vec![]);
-    test_tier2_only!(vec_u32_single, Vec<u32>, vec![42]);
-    test_tier2_only!(vec_u32_multiple, Vec<u32>, vec![1, 2, 3, 4, 5]);
-    test_tier2_only!(vec_u32_large, Vec<u32>, (0..100).collect::<Vec<_>>());
+    // Vec<u32> - now Tier-0 supported with hint_sequence
+    test_all_tiers!(vec_u32_empty, Vec<u32>, vec![]);
+    test_all_tiers!(vec_u32_single, Vec<u32>, vec![42]);
+    test_all_tiers!(vec_u32_multiple, Vec<u32>, vec![1, 2, 3, 4, 5]);
+    test_all_tiers!(vec_u32_large, Vec<u32>, (0..100).collect::<Vec<_>>());
 
-    // Vec<u64>
-    test_tier2_only!(vec_u64_empty, Vec<u64>, vec![]);
-    test_tier2_only!(vec_u64_single, Vec<u64>, vec![u64::MAX]);
-    test_tier2_only!(
+    // Vec<u64> - now Tier-0 supported with hint_sequence
+    test_all_tiers!(vec_u64_empty, Vec<u64>, vec![]);
+    test_all_tiers!(vec_u64_single, Vec<u64>, vec![u64::MAX]);
+    test_all_tiers!(
         vec_u64_multiple,
         Vec<u64>,
         vec![0, 1, u64::MAX / 2, u64::MAX]
@@ -425,7 +425,8 @@ mod structs {
             name: "outer".to_string()
         }
     );
-    test_tier2_only!(
+    // Structs with Option and Vec - now Tier-0 supported
+    test_all_tiers!(
         option_some,
         WithOption,
         WithOption {
@@ -433,7 +434,7 @@ mod structs {
             optional: Some("present".to_string())
         }
     );
-    test_tier2_only!(
+    test_all_tiers!(
         option_none,
         WithOption,
         WithOption {
@@ -441,7 +442,7 @@ mod structs {
             optional: None
         }
     );
-    test_tier2_only!(
+    test_all_tiers!(
         with_vec,
         WithVec,
         WithVec {
@@ -511,27 +512,28 @@ mod enums {
         Named { x: i32, y: i32 },
     }
 
-    test_tier2_only!(unit_enum_a, UnitEnum, UnitEnum::A);
-    test_tier2_only!(unit_enum_b, UnitEnum, UnitEnum::B);
-    test_tier2_only!(unit_enum_c, UnitEnum, UnitEnum::C);
+    // Enum types - now Tier-0 supported with hint_enum
+    test_all_tiers!(unit_enum_a, UnitEnum, UnitEnum::A);
+    test_all_tiers!(unit_enum_b, UnitEnum, UnitEnum::B);
+    test_all_tiers!(unit_enum_c, UnitEnum, UnitEnum::C);
 
-    test_tier2_only!(newtype_enum_unit, NewtypeEnum, NewtypeEnum::Unit);
-    test_tier2_only!(newtype_enum_number, NewtypeEnum, NewtypeEnum::Number(42));
-    test_tier2_only!(
+    test_all_tiers!(newtype_enum_unit, NewtypeEnum, NewtypeEnum::Unit);
+    test_all_tiers!(newtype_enum_number, NewtypeEnum, NewtypeEnum::Number(42));
+    test_all_tiers!(
         newtype_enum_text,
         NewtypeEnum,
         NewtypeEnum::Text("hello".to_string())
     );
 
-    test_tier2_only!(tuple_enum_unit, TupleEnum, TupleEnum::Unit);
-    test_tier2_only!(
+    test_all_tiers!(tuple_enum_unit, TupleEnum, TupleEnum::Unit);
+    test_all_tiers!(
         tuple_enum_pair,
         TupleEnum,
         TupleEnum::Pair(42, "hello".to_string())
     );
 
-    test_tier2_only!(struct_enum_unit, StructEnum, StructEnum::Unit);
-    test_tier2_only!(
+    test_all_tiers!(struct_enum_unit, StructEnum, StructEnum::Unit);
+    test_all_tiers!(
         struct_enum_named,
         StructEnum,
         StructEnum::Named { x: 10, y: -20 }
@@ -634,34 +636,35 @@ mod options {
         value: Option<Option<u32>>,
     }
 
-    test_tier2_only!(opt_u32_some, OptU32, OptU32 { value: Some(42) });
-    test_tier2_only!(opt_u32_none, OptU32, OptU32 { value: None });
+    // Option types - now Tier-0 supported with hint_option
+    test_all_tiers!(opt_u32_some, OptU32, OptU32 { value: Some(42) });
+    test_all_tiers!(opt_u32_none, OptU32, OptU32 { value: None });
 
-    test_tier2_only!(
+    test_all_tiers!(
         opt_string_some,
         OptString,
         OptString {
             value: Some("hello".to_string())
         }
     );
-    test_tier2_only!(opt_string_none, OptString, OptString { value: None });
+    test_all_tiers!(opt_string_none, OptString, OptString { value: None });
 
-    test_tier2_only!(
+    test_all_tiers!(
         opt_vec_some,
         OptVec,
         OptVec {
             value: Some(vec![1, 2, 3])
         }
     );
-    test_tier2_only!(opt_vec_none, OptVec, OptVec { value: None });
+    test_all_tiers!(opt_vec_none, OptVec, OptVec { value: None });
 
-    test_tier2_only!(nested_opt_none, NestedOpt, NestedOpt { value: None });
-    test_tier2_only!(
+    test_all_tiers!(nested_opt_none, NestedOpt, NestedOpt { value: None });
+    test_all_tiers!(
         nested_opt_some_none,
         NestedOpt,
         NestedOpt { value: Some(None) }
     );
-    test_tier2_only!(
+    test_all_tiers!(
         nested_opt_some_some,
         NestedOpt,
         NestedOpt {

--- a/facet-format/src/parser.rs
+++ b/facet-format/src/parser.rs
@@ -100,6 +100,33 @@ pub trait FormatParser<'de> {
     fn hint_sequence(&mut self) {
         // Default: ignore (self-describing formats don't need this)
     }
+
+    /// Hint to the parser that an `Option<T>` is expected.
+    ///
+    /// For non-self-describing formats (like postcard), this allows the parser
+    /// to read the discriminant byte and emit either:
+    /// - `Scalar(Null)` for None (discriminant 0x00)
+    /// - Set up state to parse the inner value for Some (discriminant 0x01)
+    ///
+    /// Self-describing formats can ignore this hint (they determine `Option`
+    /// presence from the wire format, e.g., null vs value in JSON).
+    fn hint_option(&mut self) {
+        // Default: ignore (self-describing formats don't need this)
+    }
+
+    /// Hint to the parser that an enum is expected, providing variant information.
+    ///
+    /// For non-self-describing formats (like postcard), this allows the parser
+    /// to read the variant discriminant (varint) and map it to the variant name.
+    ///
+    /// The `variant_names` slice contains the variant names in declaration order,
+    /// matching the indices used in the wire format.
+    ///
+    /// Self-describing formats can ignore this hint (they include variant names
+    /// in the wire format).
+    fn hint_enum(&mut self, _variant_names: &[&str]) {
+        // Default: ignore (self-describing formats don't need this)
+    }
 }
 
 /// Hint for what scalar type is expected next.


### PR DESCRIPTION
Adds error codes for invalid Option discriminants and enum variant indices, implements hint_option and hint_enum methods in the postcard parser, and expands test coverage to all tiers for Options, Sequences, and Unit enums now that they're fully supported in Tier-0. This extends the Tier-0 deserialization capability to handle non-self-describing format discriminants efficiently.