### PR TITLE
Add Tier-0 postcard deserialization support for Vec, Option, and enums

### DIFF
--- a/facet-format/src/jit/helpers.rs
+++ b/facet-format/src/jit/helpers.rs
@@ -204,6 +204,10 @@ pub const ERR_LIST_UNSUPPORTED_ELEMENT: i32 = -204;
 /// Element type is unsized
 pub const ERR_LIST_UNSIZED_ELEMENT: i32 = -205;
 
+// Positional struct deserialization error codes (-30x range)
+/// Invalid Option discriminant (positional format expects 0 or 1)
+pub const ERR_INVALID_OPTION_DISCRIMINANT: i32 = -301;
+
 // =============================================================================
 // Parser VTable (for calling trait methods from JIT code)
 // =============================================================================

--- a/facet-format/src/jit/mod.rs
+++ b/facet-format/src/jit/mod.rs
@@ -267,7 +267,7 @@ use facet_core::{ConstTypeId, Facet};
 use crate::{DeserializeError, FormatDeserializer, FormatParser};
 
 pub use compiler::CompiledDeserializer;
-pub use format::{JitCursor, JitFormat, JitScratch, JitStringValue, NoFormatJit};
+pub use format::{JitCursor, JitFormat, JitScratch, JitStringValue, NoFormatJit, StructEncoding};
 pub use format_compiler::CompiledFormatDeserializer;
 
 // Re-export handle getter for performance-critical code


### PR DESCRIPTION
## Summary

Implements Tier-0 (Rust fallback) deserialization support for `Vec<T>`, `Option<T>`, and enum variants in the postcard format, completing the foundation for Tier-2 JIT compilation of these types.

This PR extends the facet-format-postcard parser with:
- **Vec deserialization**: LEB128-encoded length followed by element parsing
- **Option deserialization**: Single-byte discriminant (0x00 = None, 0x01 = Some)  
- **Enum variant deserialization**: LEB128 variant index, then unit/newtype/multi-field parsing
- **Positional struct encoding**: New JIT compilation path for formats that encode fields in order without keys

## Key Changes

### Postcard Parser (`facet-format-postcard/src/parser.rs`)
- Implement `hint_seq()` for Vec deserialization with varint length prefix
- Implement `hint_option()` for Option with byte discriminants
- Implement `hint_enum()` with variant index parsing and multi-field support
- Add comprehensive error handling for malformed input

### JIT Format Compiler (`facet-format/src/jit/format_compiler.rs`)
- Add `StructEncoding` enum (Map | Positional) to `JitFormat` trait
- Implement `compile_struct_positional_deserializer()` for straight-line field parsing
- Dispatch struct compilation based on format's encoding preference
- Support tuple structs, unit structs, and named structs in positional mode

### Postcard JIT Format (`facet-format-postcard/src/jit/format.rs`)
- Set `STRUCT_ENCODING = Positional` for field-order encoding
- Add `emit_parse_f32()` for IEEE 754 little-endian float parsing

### Tests (`facet-format-postcard/tests/multi_tier.rs`)
- Update multi-tier tests to validate Vec, Option, and enum support across Tier-0/Tier-2

## Architecture

**Map-based vs Positional Encoding:**
- JSON uses `StructEncoding::Map` (parses field names, supports reordering/flatten)
- Postcard uses `StructEncoding::Positional` (parses fields in order, no keys)

The positional compiler generates simpler, more efficient code for formats that guarantee field order.

## Test Plan

```bash
# Run postcard-specific tests
cargo nextest run -p facet-format-postcard

# Verify multi-tier deserialization works
cargo nextest run -p facet-format-postcard multi_tier

# Check for regressions across all format crates
cargo nextest run -p facet-format -p facet-format-json -p facet-format-msgpack
```

## Related Work

- Builds on TOML format crate addition (commit 587e2a6)
- Prepares foundation for Tier-2 JIT of complex postcard types
- Aligns with facet-format migration strategy (prefer `facet-format-*` over legacy `facet-json`)