### PR TITLE
Fix #1402: facet-format-toml should ignore unknown fields by default

### DIFF
--- a/facet-format-toml/tests/issue_1402.rs
+++ b/facet-format-toml/tests/issue_1402.rs
@@ -1,0 +1,137 @@
+//! Regression test for issue #1402: facet-format-toml should ignore unknown fields by default
+
+use facet::Facet;
+
+#[test]
+fn test_ignore_unknown_fields_by_default() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Config {
+        version: Option<u32>,
+        package: Option<Vec<Package>>,
+        // Note: NO deny_unknown_fields attribute
+    }
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct Package {
+        name: String,
+    }
+
+    let toml = r#"
+version = 3
+
+[[package]]
+name = "foo"
+
+[metadata]
+"checksum foo" = "abc123"
+"#;
+
+    // This should succeed and ignore the [metadata] section
+    let config: Config = facet_format_toml::from_str(toml).unwrap();
+    assert_eq!(config.version, Some(3));
+    assert_eq!(config.package.as_ref().unwrap().len(), 1);
+    assert_eq!(config.package.as_ref().unwrap()[0].name, "foo");
+}
+
+#[test]
+fn test_deny_unknown_fields_when_explicitly_set() {
+    #[derive(Facet, Debug)]
+    #[facet(deny_unknown_fields)]
+    struct Config {
+        version: Option<u32>,
+        package: Option<Vec<Package>>,
+    }
+
+    #[derive(Facet, Debug)]
+    struct Package {
+        name: String,
+    }
+
+    let toml = r#"
+version = 3
+
+[metadata]
+"checksum foo" = "abc123"
+"#;
+
+    // This should error because deny_unknown_fields is set
+    let result: Result<Config, _> = facet_format_toml::from_str(toml);
+    assert!(
+        result.is_err(),
+        "Should error on unknown field with deny_unknown_fields"
+    );
+}
+
+#[test]
+fn test_ignore_unknown_table_with_nested_fields() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Config {
+        name: String,
+    }
+
+    let toml = r#"
+name = "test"
+
+[unknown_section]
+field1 = "value1"
+field2 = 42
+
+[unknown_section.nested]
+field3 = true
+"#;
+
+    // Should succeed and ignore all unknown sections
+    let config: Config = facet_format_toml::from_str(toml).unwrap();
+    assert_eq!(config.name, "test");
+}
+
+#[test]
+fn test_ignore_unknown_array_table() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Config {
+        version: u32,
+    }
+
+    let toml = r#"
+version = 1
+
+[[unknown_array]]
+name = "item1"
+
+[[unknown_array]]
+name = "item2"
+"#;
+
+    // Should succeed and ignore the unknown array table
+    let config: Config = facet_format_toml::from_str(toml).unwrap();
+    assert_eq!(config.version, 1);
+}
+
+#[test]
+fn test_mixed_known_and_unknown_fields() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Config {
+        app: App,
+    }
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct App {
+        name: String,
+        version: u32,
+    }
+
+    let toml = r#"
+[app]
+name = "myapp"
+version = 1
+unknown_field = "should be ignored"
+
+[completely_unknown]
+foo = "bar"
+"#;
+
+    // Should succeed and ignore unknown fields
+    let config: Config = facet_format_toml::from_str(toml).unwrap();
+    assert_eq!(config.app.name, "myapp");
+    assert_eq!(config.app.version, 1);
+}


### PR DESCRIPTION
## Summary

Fixed issue #1402 where `facet-format-toml` was erroring on unknown fields even when `#[facet(deny_unknown_fields)]` was not set. The default behavior is now to silently ignore unknown fields, matching serde and other deserializers.

## Problem

When parsing TOML like:
```toml
version = 3

[[package]]
name = "foo"

[metadata]
"checksum foo" = "abc123"
```

With a struct that doesn't include the `metadata` field:
```rust
#[derive(Facet)]
struct Config {
    version: Option<u32>,
    package: Option<Vec<Package>>,
    // No metadata field, and no deny_unknown_fields
}
```

The parser would fail with: `type mismatch: expected field key or struct end, got StructStart(Object)`

## Root Cause

The `skip_value()` function in the TOML parser was operating at the wrong abstraction level:

1. **Raw token level**: TOML syntax tokens like `StdTableOpen` (`[section]`), `KeyValSep` (`=`)
2. **Parse event level**: Abstract events like `StructStart`, `FieldKey`, `Scalar`

The old implementation checked for raw tokens (`InlineTableOpen`, `ArrayOpen`) but couldn't handle table sections like `[metadata]`. When the deserializer encountered an unknown field, it would:
- Consume `FieldKey("metadata")` (parse event)  
- Call `skip_value()` to skip the value
- `skip_value()` looked at raw tokens, found `StdTableOpen`, didn't handle it
- The deserializer then saw `StructStart(Object)` unexpectedly

## Solution

Rewrote `skip_value()` to operate at the parse event level:
- Uses `produce_event()` instead of `peek_raw()`
- Tracks depth for nested `StructStart`/`StructEnd` pairs
- Tracks depth for nested `SequenceStart`/`SequenceEnd` pairs  
- Properly skips entire table sections when they're unknown fields

Removed the now-unused `skip_inline_container()` function.

## Testing

Added comprehensive regression tests in `facet-format-toml/tests/issue_1402.rs`:
- ✅ Ignoring unknown table sections with nested fields
- ✅ Ignoring unknown array tables
- ✅ Mixed known and unknown fields
- ✅ Verifying `deny_unknown_fields` still works when explicitly set

All existing tests continue to pass (21 tests total).

## Related

This fixes the Cargo.lock parsing issue mentioned in the original bug report, where older lock files contain a `[metadata]` section that should be ignored.