### PR TITLE
Fix #1404: Support untagged enums with nested renamed enum variants

### DIFF
--- a/facet-format-toml/tests/issue_1404.rs
+++ b/facet-format-toml/tests/issue_1404.rs
@@ -1,0 +1,57 @@
+//! Regression test for issue #1404: facet-format-toml untagged enums fail to parse nested renamed enum variants
+
+use facet::Facet;
+
+#[test]
+fn test_untagged_enum_with_renamed_nested_enum() {
+    #[derive(Facet, Debug, PartialEq)]
+    #[repr(u8)]
+    pub enum Edition {
+        #[facet(rename = "2021")]
+        E2021,
+        #[facet(rename = "2024")]
+        E2024,
+    }
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct WorkspaceRef {
+        workspace: bool,
+    }
+
+    #[derive(Facet, Debug, PartialEq)]
+    #[repr(u8)]
+    #[facet(untagged)]
+    pub enum EditionOrWorkspace {
+        Edition(Edition),
+        Workspace(WorkspaceRef),
+    }
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct Config {
+        edition: EditionOrWorkspace,
+    }
+
+    // This should work - struct variant
+    let toml1 = r#"edition = { workspace = true }"#;
+    let config1: Config = facet_format_toml::from_str(toml1).unwrap();
+    assert!(matches!(
+        config1.edition,
+        EditionOrWorkspace::Workspace(WorkspaceRef { workspace: true })
+    ));
+
+    // This should also work - enum variant with renamed value
+    let toml2 = r#"edition = "2024""#;
+    let config2: Config = facet_format_toml::from_str(toml2).unwrap();
+    assert!(matches!(
+        config2.edition,
+        EditionOrWorkspace::Edition(Edition::E2024)
+    ));
+
+    // And this should work too
+    let toml3 = r#"edition = "2021""#;
+    let config3: Config = facet_format_toml::from_str(toml3).unwrap();
+    assert!(matches!(
+        config3.edition,
+        EditionOrWorkspace::Edition(Edition::E2021)
+    ));
+}


### PR DESCRIPTION
## Summary

Fixes #1404 

When deserializing untagged enums from scalar values, facet-format-toml was only trying variants where the inner type matched primitive scalar types (String, i32, bool, etc.). This failed for newtype variants wrapping enums with `#[facet(rename)]` attributes.

## Changes

- **facet-format/src/deserializer.rs**: Enhanced `deserialize_enum_untagged` to try non-primitive scalar variants after trying primitive ones
- **facet-format-toml/tests/issue_1404.rs**: Added regression test for the fix

## Example that now works

```rust
#[derive(Facet)]
#[repr(u8)]
pub enum Edition {
    #[facet(rename = "2021")]
    E2021,
    #[facet(rename = "2024")]
    E2024,
}

#[derive(Facet)]
#[facet(untagged)]
pub enum EditionOrWorkspace {
    Edition(Edition),          // Now correctly deserializes from "2024"
    Workspace(WorkspaceRef),
}
```

TOML:
```toml
edition = "2024"  # ✅ Now works
edition = { workspace = true }  # ✅ Already worked
```

## Test plan

- [x] Added regression test `test_untagged_enum_with_renamed_nested_enum`
- [x] All existing facet-format-toml tests pass
- [x] All existing facet-format-json and facet-toml tests pass
- [x] Pre-push checks (clippy, nextest, doc tests, docs build, cargo-shear) all passed