### PR TITLE
Fix #1406: Use solve_variant for proper untagged enum struct matching

### DIFF
--- a/facet-format-toml/tests/issue_1406.rs
+++ b/facet-format-toml/tests/issue_1406.rs
@@ -1,0 +1,53 @@
+use facet::Facet;
+
+#[derive(Facet, Debug, Clone, PartialEq)]
+struct DetailedDep {
+    version: Option<String>,
+    features: Option<Vec<String>>,
+}
+
+#[derive(Facet, Debug, Clone, PartialEq)]
+struct WorkspaceDep {
+    workspace: bool,
+}
+
+#[derive(Facet, Debug, Clone, PartialEq)]
+#[repr(u8)]
+#[facet(untagged)]
+enum Dep {
+    Simple(String),
+    Workspace(WorkspaceDep),
+    Detailed(DetailedDep),
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Config {
+    dep: Dep,
+}
+
+#[test]
+fn test_untagged_enum_with_struct_variants() {
+    // Simple variant - works
+    let toml1 = r#"dep = "1.0""#;
+    let c1: Config = facet_format_toml::from_str(toml1).unwrap();
+    assert_eq!(c1.dep, Dep::Simple("1.0".to_string()));
+    println!("✓ Simple: {:?}", c1);
+
+    // Workspace variant - works
+    let toml2 = r#"dep = { workspace = true }"#;
+    let c2: Config = facet_format_toml::from_str(toml2).unwrap();
+    assert_eq!(c2.dep, Dep::Workspace(WorkspaceDep { workspace: true }));
+    println!("✓ Workspace: {:?}", c2);
+
+    // Detailed variant - FAILS (regression from PR #1405)
+    let toml3 = r#"dep = { version = "2.0", features = ["foo"] }"#;
+    let c3: Config = facet_format_toml::from_str(toml3).unwrap();
+    assert_eq!(
+        c3.dep,
+        Dep::Detailed(DetailedDep {
+            version: Some("2.0".to_string()),
+            features: Some(vec!["foo".to_string()])
+        })
+    );
+    println!("✓ Detailed: {:?}", c3);
+}


### PR DESCRIPTION
## Summary

Fixes #1406 - PR #1405 introduced a regression where untagged enums would only try the first struct variant instead of intelligently matching based on fields present in the input.

## The Problem

When deserializing untagged enums from struct input (e.g., `{ version = "1.0", features = [...] }`), the code was using a naive "try first variant" approach. This broke parsing of Cargo.toml dependencies and similar patterns where multiple struct variants need to be disambiguated.

**Example that was failing:**
```rust
#[facet(untagged)]
enum Dep {
    Simple(String),              // "1.0"
    Workspace(WorkspaceDep),     // { workspace = true }
    Detailed(DetailedDep),       // { version = "1.0", features = [...] }
}
```

When parsing `{ version = "1.0", features = ["foo"] }`:
- ❌ Old behavior: Tried `Workspace` first, failed on missing `workspace` field
- ✅ New behavior: Uses facet-solver to match based on actual fields present

## The Fix

Replaced the naive "try first variant" approach with `solve_variant()`, which uses constraint-based matching to select the correct variant based on the fields present in the input.

The `solve_variant()` function:
1. Builds a schema mapping fields to each possible variant
2. Probes the input to collect field names (without consuming it)
3. Eliminates incompatible variants as each field is seen
4. Returns as soon as a unique variant is identified

## Testing

- ✅ Added regression test `facet-format-toml/tests/issue_1406.rs`
- ✅ Verified fix for #1404 still works
- ✅ All facet-format-toml tests pass (23/23)
- ✅ Clippy clean