### PR TITLE
Fix #1409: Add DynamicValue support to facet-format deserializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,6 +1637,7 @@ dependencies = [
  "facet-core",
  "facet-format",
  "facet-reflect",
+ "facet-value",
  "miette",
  "toml_parser",
  "toml_writer",

--- a/facet-format-toml/Cargo.toml
+++ b/facet-format-toml/Cargo.toml
@@ -29,6 +29,7 @@ toml_writer = { version = "1.0.4", default-features = false, optional = true }
 [dev-dependencies]
 facet = { workspace = true, features = ["doc", "net"] }
 facet-format = { path = "../facet-format", version = "0.34.0", features = ["jit"] }
+facet-value = { path = "../facet-value", version = "0.34.0" }
 
 [features]
 default = []

--- a/facet-format-toml/tests/issue_1409.rs
+++ b/facet-format-toml/tests/issue_1409.rs
@@ -1,0 +1,113 @@
+//! Test for issue #1409: facet-format-toml doesn't support deserializing into facet_value::Value
+
+use facet::Facet;
+use facet_value::{Value, value};
+
+#[derive(Facet, Debug)]
+struct Package {
+    name: String,
+    version: String,
+    metadata: Option<Value>,
+}
+
+#[derive(Facet, Debug)]
+struct Manifest {
+    package: Package,
+}
+
+#[test]
+fn test_deserialize_value_metadata() {
+    let toml = r#"
+[package]
+name = "test"
+version = "0.1.0"
+
+[package.metadata.custom]
+foo = "bar"
+numbers = [1, 2, 3]
+nested = { key = "value" }
+"#;
+
+    // This should work - deserialize arbitrary TOML into facet_value::Value
+    let manifest: Manifest = facet_format_toml::from_str(toml).unwrap();
+
+    assert_eq!(manifest.package.name, "test");
+    assert_eq!(manifest.package.version, "0.1.0");
+
+    let metadata = manifest
+        .package
+        .metadata
+        .expect("metadata should be present");
+
+    // Use the value! macro to construct the expected structure
+    let expected = value!({
+        "custom": {
+            "foo": "bar",
+            "numbers": [1, 2, 3],
+            "nested": {
+                "key": "value"
+            }
+        }
+    });
+
+    assert_eq!(metadata, expected);
+}
+
+#[test]
+fn test_value_with_various_toml_types() {
+    #[derive(Facet, Debug)]
+    struct Config {
+        data: Value,
+    }
+
+    let toml = r#"
+[data]
+string = "hello"
+integer = 42
+float = 3.14
+boolean = true
+array = [1, 2, 3]
+
+[data.nested]
+key = "value"
+"#;
+
+    let config: Config = facet_format_toml::from_str(toml).unwrap();
+
+    // Verify it's an object with the right fields
+    let obj = config.data.as_object().expect("data should be an object");
+
+    // Check string field
+    let string_val = obj.get("string").expect("should have string field");
+    assert_eq!(string_val.as_string().map(|s| s.as_str()), Some("hello"));
+
+    // Check integer field
+    let int_val = obj.get("integer").expect("should have integer field");
+    assert_eq!(int_val.as_number().and_then(|n| n.to_i64()), Some(42));
+
+    // Check float field
+    let float_val = obj.get("float").expect("should have float field");
+    let f = float_val
+        .as_number()
+        .and_then(|n| n.to_f64())
+        .expect("should be float");
+    #[allow(clippy::approx_constant)]
+    {
+        assert!((f - 3.14).abs() < 0.001);
+    }
+
+    // Check boolean field
+    let bool_val = obj.get("boolean").expect("should have boolean field");
+    assert_eq!(bool_val.as_bool(), Some(true));
+
+    // Check array field
+    let array_val = obj.get("array").expect("should have array field");
+    let array = array_val.as_array().expect("should be array");
+    assert_eq!(array.len(), 3);
+
+    // Check nested object
+    let nested_val = obj.get("nested").expect("should have nested field");
+    let nested = nested_val.as_object().expect("should be object");
+    let key_val = nested.get("key").expect("should have key field");
+    assert_eq!(key_val.as_string().map(|s| s.as_str()), Some("value"));
+}

--- a/facet-format/src/deserializer.rs
+++ b/facet-format/src/deserializer.rs
@@ -251,6 +251,7 @@ where
             Def::Map(_) => self.deserialize_map(wip),
             Def::Array(_) => self.deserialize_array(wip),
             Def::Set(_) => self.deserialize_set(wip),
+            Def::DynamicValue(_) => self.deserialize_dynamic_value(wip),
             _ => Err(DeserializeError::Unsupported(format!(
                 "unsupported shape def: {:?}",
                 shape.def
@@ -2572,6 +2573,85 @@ where
 
         // Default: convert to owned String
         wip = wip.set(s.into_owned()).map_err(DeserializeError::Reflect)?;
+        Ok(wip)
+    }
+
+    /// Deserialize any value into a DynamicValue type (e.g., facet_value::Value).
+    ///
+    /// This handles all value types by inspecting the parse events and calling
+    /// the appropriate methods on the Partial, which delegates to the DynamicValue vtable.
+    fn deserialize_dynamic_value(
+        &mut self,
+        mut wip: Partial<'input, BORROW>,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
+        let event = self.expect_peek("value for dynamic value")?;
+
+        match event {
+            ParseEvent::Scalar(_) => {
+                // Consume the scalar
+                let event = self.expect_event("scalar")?;
+                if let ParseEvent::Scalar(scalar) = event {
+                    // Use set_scalar which already handles all scalar types
+                    wip = self.set_scalar(wip, scalar)?;
+                }
+            }
+            ParseEvent::SequenceStart(_) => {
+                // Array/list
+                self.expect_event("sequence start")?; // consume '['
+                wip = wip.begin_list().map_err(DeserializeError::Reflect)?;
+
+                loop {
+                    let event = self.expect_peek("value or end")?;
+                    if matches!(event, ParseEvent::SequenceEnd) {
+                        self.expect_event("sequence end")?;
+                        break;
+                    }
+
+                    wip = wip.begin_list_item().map_err(DeserializeError::Reflect)?;
+                    wip = self.deserialize_dynamic_value(wip)?;
+                    wip = wip.end().map_err(DeserializeError::Reflect)?;
+                }
+            }
+            ParseEvent::StructStart(_) => {
+                // Object/map/table
+                self.expect_event("struct start")?; // consume '{'
+                wip = wip.begin_map().map_err(DeserializeError::Reflect)?;
+
+                loop {
+                    let event = self.expect_peek("field key or end")?;
+                    if matches!(event, ParseEvent::StructEnd) {
+                        self.expect_event("struct end")?;
+                        break;
+                    }
+
+                    // Parse the key
+                    let key_event = self.expect_event("field key")?;
+                    let key = match key_event {
+                        ParseEvent::FieldKey(field_key) => field_key.name.into_owned(),
+                        _ => {
+                            return Err(DeserializeError::TypeMismatch {
+                                expected: "field key",
+                                got: format!("{:?}", key_event),
+                            });
+                        }
+                    };
+
+                    // Begin the object entry and deserialize the value
+                    wip = wip
+                        .begin_object_entry(&key)
+                        .map_err(DeserializeError::Reflect)?;
+                    wip = self.deserialize_dynamic_value(wip)?;
+                    wip = wip.end().map_err(DeserializeError::Reflect)?;
+                }
+            }
+            _ => {
+                return Err(DeserializeError::TypeMismatch {
+                    expected: "scalar, sequence, or struct",
+                    got: format!("{:?}", event),
+                });
+            }
+        }
+
         Ok(wip)
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1409 by adding support for deserializing into `facet_value::Value` in `facet-format-toml` and all other `facet-format-*` crates.

## Problem

`facet-format-toml` couldn't deserialize arbitrary TOML into `facet_value::Value`, giving the error "unsupported shape def: DynamicValue". This broke 124 out of 617 manifest tests in `facet-cargo-toml` because any Cargo.toml with `[package.metadata.*]` sections couldn't be parsed.

## Solution

Added `Def::DynamicValue(_)` support to the generic `FormatDeserializer` in `facet-format`:

1. Added a new `deserialize_dynamic_value()` method that:
   - Handles scalars by delegating to the existing `set_scalar()` method
   - Handles arrays by calling `begin_list()`, recursively deserializing items, and `end()`
   - Handles objects by calling `begin_map()`, parsing keys, calling `begin_object_entry()`, recursively deserializing values, and `end()`

2. Added the `Def::DynamicValue(_)` case to the match statement in `deserialize_into()`

## Benefits

- Works automatically for **all** `facet-format-*` crates (JSON, TOML, YAML, XML, etc.)
- Follows the same pattern as the old `facet-json` and `facet-toml` implementations
- Minimal code (~80 lines) thanks to the generic architecture
- Fully tested with two comprehensive test cases

## Test Plan

- ✅ New test `test_deserialize_value_metadata()` - matches the exact reproduction from the issue
- ✅ New test `test_value_with_various_toml_types()` - verifies all scalar and container types
- ✅ All existing `facet-format-toml` tests pass (25 tests)
- ✅ All existing `facet-format-json` tests pass (175 tests)
- ✅ Clippy, doc tests, and cargo-shear all pass