### PR TITLE
facet-xml: attributes reserved to namespace definition are ignored while deserializing

### DIFF
--- a/facet-xml/src/deserialize.rs
+++ b/facet-xml/src/deserialize.rs
@@ -153,6 +153,11 @@ fn get_list_item_shape(shape: &facet_core::Shape) -> Option<&'static facet_core:
     }
 }
 
+/// Check if the attribute is reserved for XML namespace
+fn is_xml_namespace_attribute(name: &QName) -> bool {
+    name.matches_exact("xmlns", None) || name.namespace.as_deref() == Some("xmlns")
+}
+
 // ============================================================================
 // Public API
 // ============================================================================
@@ -715,6 +720,11 @@ impl<'input> EventCollector<'input> {
                 Some(uri) => QName::with_ns(uri, local),
                 None => QName::local(local),
             };
+
+            // Ignore attributes reserved for XML namespace declarations
+            if is_xml_namespace_attribute(&qname) {
+                continue;
+            }
 
             let value = attr
                 .unescape_value()

--- a/facet-xml/tests/namespace.rs
+++ b/facet-xml/tests/namespace.rs
@@ -978,3 +978,31 @@ fn test_svg_attributes_only() {
     let parsed: SimpleSvg = xml::from_str(&xml_output).unwrap();
     assert_eq!(parsed, svg);
 }
+
+// ============================================================================
+// Test namespace with deny_unknown_fields
+// ============================================================================
+
+#[test]
+fn test_namespace_with_deny_unknown_fields() {
+    /// Namespace definitions are ignored when deny_unknown_fields is enabled.
+    #[derive(Facet, Debug, PartialEq)]
+    #[facet(
+        deny_unknown_fields,
+        rename = "root",
+        xml::ns_all = "http://example.com/ns"
+    )]
+    struct NamespacedRoot {
+        #[facet(xml::element)]
+        item: String,
+    }
+
+    let doc = NamespacedRoot {
+        item: "value".to_string(),
+    };
+
+    let serialized = xml::to_string(&doc).unwrap();
+    let deserialized: NamespacedRoot = xml::from_str(&serialized).unwrap();
+
+    assert_eq!(doc, deserialized);
+}

--- a/facet-xml/tests/real_world.rs
+++ b/facet-xml/tests/real_world.rs
@@ -18,8 +18,6 @@ struct Svg {
     height: Option<String>,
     #[facet(default, xml::attribute)]
     view_box: Option<String>,
-    #[facet(default, xml::attribute)]
-    xmlns: Option<String>,
     #[facet(recursive_type, xml::elements)]
     children: Vec<SvgElement>,
 }
@@ -119,8 +117,6 @@ fn test_svg_with_groups() {
 #[derive(Facet, Debug, PartialEq)]
 #[facet(rename = "project", rename_all = "camelCase")]
 struct MavenPom {
-    #[facet(default, xml::attribute)]
-    xmlns: Option<String>,
     #[facet(default, xml::element)]
     model_version: Option<String>,
     #[facet(default, xml::element)]
@@ -334,8 +330,6 @@ fn test_android_manifest() {
 #[derive(Facet, Debug, PartialEq)]
 #[facet(rename = "feed")]
 struct AtomFeed {
-    #[facet(default, xml::attribute)]
-    xmlns: Option<String>,
     #[facet(default, xml::element)]
     title: String,
     #[facet(default, xml::element)]
@@ -461,8 +455,6 @@ fn test_odf_manifest() {
 #[facet(rename = "html")]
 struct XhtmlDocument {
     #[facet(default, xml::attribute)]
-    xmlns: Option<String>,
-    #[facet(default, xml::attribute)]
     lang: Option<String>,
     #[facet(default, xml::element)]
     head: XhtmlHead,
@@ -560,7 +552,6 @@ fn test_xhtml() {
     </html>"#;
 
     let doc: XhtmlDocument = xml::from_str(xhtml).unwrap();
-    assert_eq!(doc.xmlns, Some("http://www.w3.org/1999/xhtml".into()));
     assert_eq!(doc.lang, Some("en".into()));
     assert_eq!(doc.head.title, "Test Page");
     assert_eq!(doc.head.meta.len(), 2);
@@ -576,8 +567,6 @@ fn test_xhtml() {
 #[derive(Facet, Debug, PartialEq)]
 #[facet(rename = "urlset")]
 struct Sitemap {
-    #[facet(default, xml::attribute)]
-    xmlns: Option<String>,
     #[facet(xml::elements)]
     url: Vec<SitemapUrl>,
 }


### PR DESCRIPTION
XML namespace definitions are reported as unknown attributes if the attribute `deny_unknown_fields` is used. I think that the proper behavior is to use these attributes only for the namespace resolution and to skip them in the deserialization step.

Another issue of the current behavior is that structure defined like follow cannot be deserialized from the output generate from serializer:
```rust
#[derive(Facet)]
#[facet(deny_unknown_fields, xml::ns_all = "http://example.com/ns")]
struct NamespacedRoot {
    #[facet(xml::element)]
    item: String,
}
```

This pull request fix the current behavior, attributes reserved for namespace definition are ignored in deserialization step. A small test is defined to check the correctness of the implementation.