### PR TITLE
Fix #1415: Support dotted keys with array values in facet-format-toml

### DIFF
--- a/facet-format-toml/tests/issue_1415.rs
+++ b/facet-format-toml/tests/issue_1415.rs
@@ -1,0 +1,95 @@
+// Test for issue #1415: facet-format-toml fails to parse dotted keys with array values
+use facet::Facet;
+
+#[derive(Facet, Debug)]
+struct Workspace {
+    members: Vec<String>,
+    metadata: Option<facet_value::Value>,
+}
+
+#[derive(Facet, Debug)]
+struct Manifest {
+    workspace: Option<Workspace>,
+}
+
+#[test]
+fn test_dotted_key_with_string_value() {
+    // ✓ This should work - dotted key with string value
+    let toml = r#"
+[workspace]
+members = []
+
+[workspace.metadata.typos]
+default.simple = "value"
+"#;
+
+    let result = facet_format_toml::from_str::<Manifest>(toml);
+    match &result {
+        Ok(manifest) => {
+            assert!(manifest.workspace.is_some());
+            let workspace = manifest.workspace.as_ref().unwrap();
+            assert!(workspace.metadata.is_some());
+        }
+        Err(e) => {
+            panic!("Failed to parse dotted key with string value: {:?}", e);
+        }
+    }
+}
+
+#[test]
+fn test_dotted_key_with_array_value() {
+    // This currently fails - dotted key with array value
+    let toml = r#"
+[workspace]
+members = []
+
+[workspace.metadata.typos]
+default.extend-ignore-re = ["clonable"]
+"#;
+
+    let result = facet_format_toml::from_str::<Manifest>(toml);
+    match &result {
+        Ok(manifest) => {
+            assert!(manifest.workspace.is_some());
+            let workspace = manifest.workspace.as_ref().unwrap();
+            assert!(workspace.metadata.is_some());
+
+            // Verify the structure is correct
+            let metadata = workspace.metadata.as_ref().unwrap();
+            assert!(metadata.is_object());
+            let obj = metadata.as_object().unwrap();
+            assert!(obj.contains_key("typos"));
+        }
+        Err(e) => {
+            panic!("Failed to parse dotted key with array value: {:?}", e);
+        }
+    }
+}
+
+#[test]
+fn test_dotted_key_with_various_types() {
+    // Test multiple value types with dotted keys
+    let toml = r#"
+[workspace]
+members = []
+
+[workspace.metadata.test]
+a.string = "value"
+b.integer = 42
+c.boolean = true
+d.array = [1, 2, 3]
+e.inline-table = { key = "value" }
+"#;
+
+    let result = facet_format_toml::from_str::<Manifest>(toml);
+    match &result {
+        Ok(manifest) => {
+            assert!(manifest.workspace.is_some());
+            let workspace = manifest.workspace.as_ref().unwrap();
+            assert!(workspace.metadata.is_some());
+        }
+        Err(e) => {
+            panic!("Failed to parse dotted keys with various types: {:?}", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1415: facet-format-toml now correctly parses dotted keys with array values.

Previously, parsing would fail with "type mismatch: expected scalar, sequence, or struct, got StructEnd" when using dotted keys with arrays or inline tables, e.g.:

```toml
[workspace.metadata.typos]
default.extend-ignore-re = ["clonable"]
```

## Root Cause

The parser was emitting `StructEnd` events immediately after encountering an array or inline table in a dotted key expression, before the inline container finished parsing. This caused the event stream to be malformed.

For `default.extend-ignore-re = ["clonable"]`, the parser would emit:
```
FieldKey("default")
StructStart         <- Open struct for "default"
FieldKey("extend-ignore-re")
SequenceStart       <- Open array
StructEnd           <- ❌ WRONG! Closes "default" before array ends
Scalar("clonable")
SequenceEnd
```

## Solution

Modified the parser to defer `StructEnd` events until after inline containers close:

1. Changed `inline_stack` from `Vec<bool>` to `Vec<(bool, usize)>` to track both:
   - Container type (inline table vs. array)
   - Number of deferred `StructEnd` events

2. When parsing a dotted key value:
   - Track the inline stack depth before parsing
   - If we entered an inline container, increment the deferred counter instead of immediately emitting `StructEnd`
   - For scalar values, emit `StructEnd` immediately (existing behavior)

3. When closing an inline container (`InlineTableClose` or `ArrayClose`):
   - Emit the container's closing event (`StructEnd` or `SequenceEnd`)
   - Then emit all deferred `StructEnd` events

This ensures the event stream is well-formed and matches TOML semantics.

## Test Coverage

Added comprehensive regression tests in `facet-format-toml/tests/issue_1415.rs`:
- Dotted keys with string values (baseline)
- Dotted keys with array values (the bug case)
- Dotted keys with various types (strings, integers, booleans, arrays, inline tables)

All existing tests continue to pass.