### PR TITLE
Add Tier-0 fallback for facet-format-postcard deserialization

### DIFF
--- a/facet-format-postcard/tests/nested_enum_repr.rs
+++ b/facet-format-postcard/tests/nested_enum_repr.rs
@@ -1,0 +1,70 @@
+//! Test for nested enum with #[repr] attribute - reproducer for issue #1430.
+//!
+//! This simulates the rapace ControlPayload enum which has nested struct variants
+//! that may not be Tier-2 compatible initially.
+
+#![cfg(feature = "jit")]
+
+use facet::Facet;
+use facet_format_postcard::from_slice;
+use postcard::to_allocvec as postcard_to_vec;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Facet, Serialize, Deserialize)]
+#[repr(u8)]
+#[allow(clippy::enum_variant_names)]
+enum CancelReason {
+    NoError,
+    ProtocolError,
+    InternalError,
+}
+
+#[derive(Debug, PartialEq, Facet, Serialize, Deserialize)]
+#[repr(u8)]
+enum ControlPayload {
+    CancelChannel {
+        channel_id: u32,
+        reason: CancelReason,
+    },
+    GrantCredits {
+        channel_id: u32,
+        bytes: u32,
+    },
+}
+
+#[test]
+fn test_control_payload_cancel() {
+    facet_testhelpers::setup();
+
+    let payload = ControlPayload::CancelChannel {
+        channel_id: 42,
+        reason: CancelReason::ProtocolError,
+    };
+
+    // Serialize with postcard
+    let bytes = postcard_to_vec(&payload).expect("postcard should encode");
+
+    // Deserialize with facet-format-postcard
+    // This should work even if Tier-2 doesn't support this type yet
+    let decoded: ControlPayload = from_slice(&bytes).expect("should deserialize");
+
+    assert_eq!(decoded, payload);
+}
+
+#[test]
+fn test_control_payload_grant() {
+    facet_testhelpers::setup();
+
+    let payload = ControlPayload::GrantCredits {
+        channel_id: 100,
+        bytes: 1024,
+    };
+
+    // Serialize with postcard
+    let bytes = postcard_to_vec(&payload).expect("postcard should encode");
+
+    // Deserialize with facet-format-postcard
+    let decoded: ControlPayload = from_slice(&bytes).expect("should deserialize");
+
+    assert_eq!(decoded, payload);
+}


### PR DESCRIPTION
## Summary

Adds a Tier-0 reflection-based fallback when Tier-2 JIT deserialization is unavailable, making `facet-format-postcard` a complete replacement for `facet-postcard`.

Previously, `from_slice()` would fail with "Unsupported" for types like nested enums that aren't Tier-2 compatible. Now it seamlessly falls back to Tier-0 reflection, ensuring all `Facet` types work.

## Test plan

- ✅ All 211 existing tests pass (Tier-0 and Tier-2)
- ✅ 2 new tests for nested enums with struct variants (the rapace `ControlPayload` pattern)
- ✅ All clippy and pre-push checks pass

Resolves #1430.