### PR TITLE
Add Result<T, E> deserialization support to facet-format-postcard

### DIFF
--- a/facet-format-postcard/tests/multi_tier.rs
+++ b/facet-format-postcard/tests/multi_tier.rs
@@ -674,6 +674,86 @@ mod options {
 }
 
 // =============================================================================
+// Result types
+// =============================================================================
+
+mod results {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Facet, Serialize, Deserialize)]
+    struct ResU32 {
+        value: Result<u32, String>,
+    }
+
+    #[derive(Debug, PartialEq, Facet, Serialize, Deserialize)]
+    struct ResString {
+        value: Result<String, u32>,
+    }
+
+    #[derive(Debug, PartialEq, Facet, Serialize, Deserialize)]
+    struct ResVec {
+        value: Result<Vec<u32>, String>,
+    }
+
+    #[derive(Debug, PartialEq, Facet, Serialize, Deserialize)]
+    struct CustomError {
+        code: u32,
+        message: String,
+    }
+
+    #[derive(Debug, PartialEq, Facet, Serialize, Deserialize)]
+    struct ResCustom {
+        value: Result<i32, CustomError>,
+    }
+
+    // Result types - should work with Tier-0 like Option does
+    test_all_tiers!(res_u32_ok, ResU32, ResU32 { value: Ok(42) });
+    test_all_tiers!(
+        res_u32_err,
+        ResU32,
+        ResU32 {
+            value: Err("error message".to_string())
+        }
+    );
+
+    test_all_tiers!(
+        res_string_ok,
+        ResString,
+        ResString {
+            value: Ok("success".to_string())
+        }
+    );
+    test_all_tiers!(res_string_err, ResString, ResString { value: Err(404) });
+
+    test_all_tiers!(
+        res_vec_ok,
+        ResVec,
+        ResVec {
+            value: Ok(vec![1, 2, 3])
+        }
+    );
+    test_all_tiers!(
+        res_vec_err,
+        ResVec,
+        ResVec {
+            value: Err("failed".to_string())
+        }
+    );
+
+    test_all_tiers!(res_custom_ok, ResCustom, ResCustom { value: Ok(42) });
+    test_all_tiers!(
+        res_custom_err,
+        ResCustom,
+        ResCustom {
+            value: Err(CustomError {
+                code: 500,
+                message: "Internal Server Error".to_string()
+            })
+        }
+    );
+}
+
+// =============================================================================
 // Kitchen sink test (complex nested type)
 // =============================================================================
 


### PR DESCRIPTION
## Summary
- Implements Result<T, E> serialization/deserialization for facet-format-postcard
- Treats Result as a 2-variant enum (Ok and Err) compatible with postcard encoding
- Works through both Tier-0 (reflection) and Tier-2 (JIT) deserialization paths

## Changes
- Added `deserialize_result_as_enum()` method in `facet-format/src/deserializer.rs`
- Added special case check for `Def::Result` in `deserialize_into()` dispatcher
- Added comprehensive test suite in `facet-format-postcard/tests/multi_tier.rs`:
  - Tests for Ok/Err variants with primitives (u32, String)
  - Tests for Result with Vec<T>
  - Tests for Result with custom error types
  - All 16 tests pass for both Tier-0 and Tier-2

## Test Results
All 180 tests in multi_tier.rs pass, including the 16 new Result tests.

## Context
Closes #1435

This enables Result types in RPC return values for frameworks like rapace (see bearcove/rapace#55). Result<T, E> is a fundamental Rust error handling pattern and should be supported as a first-class citizen.