### PR TITLE
Propagate span information through facet-format for reflection errors

### DIFF
--- a/facet-format-toml/src/error.rs
+++ b/facet-format-toml/src/error.rs
@@ -8,7 +8,7 @@ use core::fmt::{self, Display};
 use facet_reflect::{ReflectError, Span};
 
 /// Error type for TOML operations.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TomlError {
     /// The specific kind of error
     pub kind: TomlErrorKind,
@@ -103,7 +103,7 @@ impl TomlError {
 }
 
 /// Specific error kinds for TOML operations
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TomlErrorKind {
     /// Parse error from toml_parser
     Parse(String),

--- a/facet-format-toml/tests/issue_1443.rs
+++ b/facet-format-toml/tests/issue_1443.rs
@@ -1,0 +1,118 @@
+/// Test for issue #1443: Reflection errors don't preserve span info for diagnostics
+///
+/// When facet-format-toml encounters a reflection error (e.g., type mismatch),
+/// it should preserve span information for nice miette-style diagnostics.
+use facet::Facet;
+use facet_format_toml as toml;
+
+#[derive(Facet, Debug)]
+struct PackageMetadata {
+    name: String,
+    version: String,
+    /// README can be either a string path or a workspace-inherited value
+    readme: ReadmeValue,
+}
+
+#[derive(Facet, Debug)]
+#[repr(u8)]
+#[facet(untagged)]
+enum ReadmeValue {
+    /// Simple path to README file
+    Path(String),
+    /// Workspace-inherited value
+    Workspace { workspace: bool },
+}
+
+#[test]
+fn test_type_mismatch_preserves_span() {
+    // This TOML has a boolean value for readme, but we expect String or {workspace = true}
+    let toml_str = r#"
+[package]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+readme = false
+"#;
+
+    #[derive(Facet, Debug)]
+    struct CargoManifest {
+        package: PackageMetadata,
+    }
+
+    let result: Result<CargoManifest, _> = toml::from_str(toml_str);
+
+    match result {
+        Ok(_) => panic!("Should have failed with type mismatch error"),
+        Err(e) => {
+            // Print the error using miette's diagnostic formatting
+            let error_msg = format!("{}", e);
+            eprintln!("Simple error: {}", error_msg);
+
+            // Print with miette formatting
+            eprintln!("Miette report:\n{:?}", miette::Report::new(e.clone()));
+
+            // Check that it's a reflection error about wrong shape
+            assert!(
+                error_msg.contains("reflection error") || error_msg.contains("Wrong shape"),
+                "Error should mention reflection/shape issue: {}",
+                error_msg
+            );
+
+            // Check that the error has source code attached
+            assert!(
+                e.source_code.is_some(),
+                "Error should have source code attached"
+            );
+
+            // Check that the error has span information (we use heuristic search for "false")
+            assert!(e.span.is_some(), "Error should have span information");
+
+            // Verify the span points to the problematic value
+            if let Some(span) = e.span {
+                let span_text = &toml_str[span.offset..span.offset + span.len];
+                assert_eq!(span_text, "false", "Span should point to the 'false' value");
+            }
+        }
+    }
+}
+
+#[test]
+fn test_valid_readme_string() {
+    let toml_str = r#"
+[package]
+name = "test"
+version = "1.0.0"
+readme = "README.md"
+"#;
+
+    #[derive(Facet, Debug)]
+    struct CargoManifest {
+        package: PackageMetadata,
+    }
+
+    let result: CargoManifest = toml::from_str(toml_str).expect("should parse string variant");
+    match result.package.readme {
+        ReadmeValue::Path(path) => assert_eq!(path, "README.md"),
+        _ => panic!("Expected Path variant"),
+    }
+}
+
+#[test]
+fn test_valid_readme_workspace() {
+    let toml_str = r#"
+[package]
+name = "test"
+version = "1.0.0"
+readme = { workspace = true }
+"#;
+
+    #[derive(Facet, Debug)]
+    struct CargoManifest {
+        package: PackageMetadata,
+    }
+
+    let result: CargoManifest = toml::from_str(toml_str).expect("should parse workspace variant");
+    match result.package.readme {
+        ReadmeValue::Workspace { workspace } => assert!(workspace),
+        _ => panic!("Expected Workspace variant"),
+    }
+}

--- a/facet-format/src/jit/helpers.rs
+++ b/facet-format/src/jit/helpers.rs
@@ -763,7 +763,7 @@ pub unsafe extern "C" fn jit_write_error_string(
     // This works for any `DeserializeError<E>` since Reflect variant doesn't depend on E
     // Using InvariantViolation since duplicate variant keys are an invariant violation
     let error: DeserializeError<()> =
-        DeserializeError::Reflect(ReflectError::InvariantViolation { invariant: msg_str });
+        DeserializeError::reflect(ReflectError::InvariantViolation { invariant: msg_str });
 
     unsafe {
         // Transmute to write as `DeserializeError<E>` where E is the actual parser error type

--- a/facet-format/src/parser.rs
+++ b/facet-format/src/parser.rs
@@ -1,4 +1,5 @@
 use crate::FieldEvidence;
+use facet_reflect::Span;
 
 /// Streaming cursor that yields serialized fields for solver probing.
 pub trait ProbeStream<'de> {
@@ -132,6 +133,17 @@ pub trait FormatParser<'de> {
     /// in the wire format).
     fn hint_enum(&mut self, _variants: &[EnumVariantHint]) {
         // Default: ignore (self-describing formats don't need this)
+    }
+
+    /// Returns the source span of the most recently consumed event.
+    ///
+    /// This is used for error reporting - when a deserialization error occurs,
+    /// the span of the last consumed event helps locate the problem in the input.
+    ///
+    /// Parsers that track source positions should override this to return
+    /// meaningful span information. The default implementation returns `None`.
+    fn current_span(&self) -> Option<Span> {
+        None
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `current_span()` method to `FormatParser` trait for parsers to report source location
- Change `DeserializeError::Reflect` to struct variant with optional span field
- Track spans in `FormatDeserializer` after consuming events
- Implement `current_span()` in `TomlParser` to return scalar spans

This replaces the hacky `find_scalar_span()` approach that did string matching on input text (e.g., `input.find("= false")`). Now spans flow properly from `toml_parser::Event` through the facet-format layer to the final error.

## Test plan
- [x] All existing tests pass (233 tests across facet-format, facet-format-toml, facet-format-json)
- [x] `issue_1443` test verifies span preservation in reflection errors