### PR TITLE
Fix #1453: Use positional struct deserializer in list/map compilers

### DIFF
--- a/facet-format-postcard/tests/issue_1453.rs
+++ b/facet-format-postcard/tests/issue_1453.rs
@@ -1,0 +1,68 @@
+//! Regression test for issue #1453: JIT deserialization fails for Vec<Struct>
+//! with multiple String fields.
+
+#![cfg(feature = "jit")]
+
+use facet::Facet;
+use facet_format_postcard::{from_slice, to_vec};
+
+#[derive(Debug, Clone, PartialEq, Facet)]
+struct Field {
+    name: String,
+    value: String,
+}
+
+#[test]
+fn test_single_struct() {
+    // ✅ This should work - single struct with multiple strings
+    let field = Field {
+        name: "test".to_string(),
+        value: "data".to_string(),
+    };
+    let bytes = to_vec(&field).unwrap();
+    let decoded: Field = from_slice(&bytes).unwrap();
+    assert_eq!(decoded, field);
+}
+
+#[test]
+fn test_vec_of_structs() {
+    // ❌ This was failing before the fix
+    let fields = vec![
+        Field {
+            name: "user".to_string(),
+            value: "bob".to_string(),
+        },
+        Field {
+            name: "count".to_string(),
+            value: "42".to_string(),
+        },
+    ];
+    let bytes = to_vec(&fields).unwrap();
+
+    // Was failing with: Parser(PostcardError { code: -100, pos: 3, message: "unexpected end of input" })
+    let decoded: Vec<Field> = from_slice(&bytes).unwrap();
+    assert_eq!(decoded, fields);
+}
+
+#[test]
+fn test_vec_of_structs_roundtrip() {
+    // More comprehensive test
+    let fields = vec![
+        Field {
+            name: "a".to_string(),
+            value: "b".to_string(),
+        },
+        Field {
+            name: "longer_name".to_string(),
+            value: "longer_value".to_string(),
+        },
+        Field {
+            name: "".to_string(),
+            value: "".to_string(),
+        },
+    ];
+
+    let encoded = to_vec(&fields).expect("should serialize");
+    let decoded: Vec<Field> = from_slice(&encoded).expect("should deserialize");
+    assert_eq!(decoded, fields);
+}


### PR DESCRIPTION
## Summary

Fixes #1453 by making the JIT list and map deserializers dispatch to the correct struct compiler based on the format's `STRUCT_ENCODING` setting.

## Problem

The list and map deserializers were always calling `compile_struct_format_deserializer` (the map-based compiler) even for formats like postcard that use positional encoding. This caused JIT-compiled code to expect:
- A field count varint prefix
- Field keys for dispatch

But positional formats encode structs as just fields in declaration order without keys or count.

### Failure Mode

For `Vec<Field>` where `Field { name: String, value: String }`:

```
[0]: 0x02        ← Vec length
[1]: 0x04        ← First struct's "name" field length (4 bytes)
[2-5]: "user"    ← "name" field data
[6]: 0x03        ← "value" field length
[7-9]: "bob"     ← "value" field data
...
```

The map-based compiler would:
1. Read byte [0] as vec length ✓
2. Start parsing first struct at pos=1
3. Read byte [1] (0x04) thinking it's the *struct field count*
4. Try to read a field key but find string data instead
5. Fail with `code=-100, pos=3, message="unexpected end of input"`

## Solution

Both `list_format_deserializer.rs` and `map_format_deserializer.rs` now check `F::STRUCT_ENCODING` and dispatch appropriately:

```rust
let struct_func_id = match F::STRUCT_ENCODING {
    StructEncoding::Map => 
        compile_struct_format_deserializer::<F>(module, struct_shape, memo)?,
    StructEncoding::Positional => 
        compile_struct_positional_deserializer::<F>(module, struct_shape, memo)?,
};
```

This matches the existing dispatch logic in the top-level `try_compile_format_module`.

## Test Plan

- ✅ New regression test `issue_1453.rs` with `Vec<Struct>` containing multiple String fields
- ✅ All 399 existing `facet-format-postcard` JIT tests pass
- ✅ Pre-push checks (clippy, tests, docs, shear) all pass

## Impact

This enables the [rapace-tracing-over-rapace demo](https://github.com/bearcove/rapace/tree/main/demos/tracing-over-rapace) to work correctly, which sends vectors of field data over RPC using postcard serialization.