### PR TITLE
Fix streaming JSON parser probing with event buffering

### DIFF
--- a/drafts/facet-format.md
+++ b/drafts/facet-format.md
@@ -28,7 +28,7 @@ Crates in this branch:
 |---------|--------|-------|
 | Direct Partial deserialization | ✅ | `ParseEvent` → `Partial<T>` → `HeapValue<T>` → `T` (no intermediate Value) |
 | Parser probing (JSON slice) | ✅ | `begin_probe` returns real `FieldEvidence` |
-| Parser probing (JSON streaming) | ❌ | Returns empty by design (can't rewind a stream) |
+| Parser probing (JSON streaming) | ✅ | Buffers events during probing and replays them |
 | Parser probing (XML) | ✅ | Scans ahead through pre-parsed events |
 | `FieldLocationHint` | ✅ | Full enum: KeyValue, Attribute, Text, Child, Property, Argument |
 | `BORROW` const generic | ✅ | `from_str`/`from_slice` borrow via `Facet<'de>` |


### PR DESCRIPTION
## Summary

Fixes #1452 by implementing event buffering for the streaming JSON parser's `begin_probe()` method.

Previously, `begin_probe()` returned empty evidence because streams cannot be rewound. This caused 4 async tests to fail for internally/adjacently tagged enums and complex flatten cases.

## Implementation

The fix introduces event buffering with state management:

- **Event Buffer**: Added `event_buffer` and `buffer_idx` fields to `StreamingJsonParser`
- **Buffered Probing**: `build_probe_buffered()` scans ahead, buffers events, extracts evidence, and saves/restores parser state
- **Event Replay**: Modified `next_event()` to replay buffered events before producing new ones
- **Buffered Skipping**: Implemented `skip_value_buffered()` to handle skipping within the buffer, avoiding `UnexpectedEof` errors
- **State Cloning**: Added `Clone` derives to `ContextState`, `ObjectState`, and `ArrayState` for state management

## Test Results

All 4 previously failing async tests now pass:
- `test_async_internally_tagged_enum`
- `test_async_adjacently_tagged_enum`
- `test_async_flatten_internally_tagged`
- `test_async_flatten_adjacently_tagged`

All sync and async tests continue to pass.

## Test Plan

- [x] Run all facet-format-json tests with `cargo nextest run -p facet-format-json`
- [x] Verify async probing tests pass
- [x] Verify sync tests still pass
- [x] Check clippy warnings resolved
- [x] Verify docs build successfully