### PR TITLE
Remove miette-derive dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,7 +3059,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
  "cfg-if",
- "miette-derive",
  "owo-colors",
  "supports-color",
  "supports-hyperlinks",
@@ -3080,17 +3079,6 @@ dependencies = [
  "arborium-theme",
  "miette",
  "owo-colors",
-]
-
-[[package]]
-name = "miette-derive"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ indoc = "^2.0.7"
 insta = "^1.44.3"
 jiff = "^0.2.16"
 log = { version = "^0.4.29", features = ["std"] }
-miette = { version = "^7.6.0", features = ["derive", "fancy-no-backtrace"] }
+miette = { version = "^7.6.0", default-features = false, features = ["fancy-no-backtrace"] }
 proc-macro2 = "1"
 quote = "1"
 serde = { version = "^1.0.228", default-features = false, features = ["alloc", "derive"] }

--- a/facet-args/Cargo.toml
+++ b/facet-args/Cargo.toml
@@ -31,7 +31,7 @@ facet = { workspace = true, features = ["bytes", "camino", "chrono", "jiff02", "
 facet-pretty = { path = "../facet-pretty" }
 facet-showcase = { path = "../facet-showcase" }
 insta = { workspace = true }
-miette = { workspace = true, features = ["derive", "fancy-no-backtrace"] }
+miette = { workspace = true }
 
 [features]
 default = ["rich-diagnostics"]

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -63,7 +63,7 @@ lexical-parse-float = "1.0.5"
 lexical-parse-integer = "1.0.5"
 log = { workspace = true }
 memchr = { version = "2.7", optional = true }
-miette = { workspace = true, features = ["derive", "fancy-no-backtrace"] }
+miette = { workspace = true }
 mime = { version = "0.3", default-features = false, optional = true }
 parking_lot = { version = "0.12", optional = true }
 ryu = "1"

--- a/facet-kdl/Cargo.toml
+++ b/facet-kdl/Cargo.toml
@@ -45,5 +45,5 @@ facet-core = { path = "../facet-core", version = "0.34.0" }
 facet-showcase = { path = "../facet-showcase", version = "0.34.0" }
 facet-testhelpers = { path = "../facet-testhelpers", version = "0.34.0" }
 indoc = { workspace = true }
-miette = { workspace = true, features = ["derive", "fancy-no-backtrace"] }
+miette = { workspace = true }
 tempfile = { workspace = true }

--- a/facet-pretty/Cargo.toml
+++ b/facet-pretty/Cargo.toml
@@ -34,4 +34,4 @@ facet = { workspace = true, features = ["bytes", "camino", "chrono", "jiff02", "
 facet-showcase = { path = "../facet-showcase" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 insta = { workspace = true }
-miette = { workspace = true, features = ["derive", "fancy-no-backtrace"] }
+miette = { workspace = true }

--- a/facet-reflect/Cargo.toml
+++ b/facet-reflect/Cargo.toml
@@ -54,7 +54,7 @@ miette = ["dep:miette"] # Enable Spanned<T> type for source span tracking
 camino = { workspace = true, optional = true }
 facet-core = { path = "../facet-core", version = "0.34.0", default-features = false }
 log = { version = "0.4.27", optional = true }
-miette = { workspace = true, optional = true, features = ["derive", "fancy-no-backtrace"] }
+miette = { workspace = true, optional = true }
 ulid = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 

--- a/facet-showcase/Cargo.toml
+++ b/facet-showcase/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 arborium = { workspace = true, features = ["lang-kdl", "lang-rust", "lang-xml", "lang-yaml"] }
 facet = { workspace = true, features = ["bytes", "camino", "chrono", "doc", "jiff02", "net", "nonzero", "ordered-float", "time", "ulid", "uuid"] }
 facet-pretty = { path = "../facet-pretty", version = "0.34.0" }
-miette = { workspace = true, features = ["derive"] }
+miette = { workspace = true }
 miette-arborium = "2.4.5"
 
 # Terminal colors

--- a/facet-value/Cargo.toml
+++ b/facet-value/Cargo.toml
@@ -41,7 +41,7 @@ facet-showcase = { path = "../facet-showcase" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 indexmap = { workspace = true }
 kstring = "2"
-miette = { workspace = true, features = ["derive", "fancy-no-backtrace"] }
+miette = { workspace = true }
 serde_json = { workspace = true }
 
 [[example]]

--- a/facet-xml/Cargo.toml
+++ b/facet-xml/Cargo.toml
@@ -47,7 +47,7 @@ facet = { workspace = true, features = ["bytes", "camino", "chrono", "doc", "jif
 facet-core = { path = "../facet-core" }
 facet-showcase = { path = "../facet-showcase" }
 facet-testhelpers = { path = "../facet-testhelpers" }
-miette = { workspace = true, features = ["derive", "fancy-no-backtrace"] }
+miette = { workspace = true }
 
 [[example]]
 name = "xml_showcase"

--- a/facet-yaml/Cargo.toml
+++ b/facet-yaml/Cargo.toml
@@ -36,7 +36,7 @@ facet-solver = { path = "../facet-solver", version = "0.34.0" }
 http = { workspace = true, optional = true }
 http-body-util = { version = "0.1", default-features = false, optional = true }
 log = { workspace = true }
-miette = { workspace = true, features = ["derive", "fancy-no-backtrace"] }
+miette = { workspace = true }
 saphyr-parser = "0.0.6"
 
 [dev-dependencies]


### PR DESCRIPTION
Remove the miette-derive feature and replace derive macro usage with manual Diagnostic trait implementations across crates. This reduces dependencies while maintaining equivalent functionality for error diagnostics.

Changes:
- Updated Cargo.toml files to remove miette derive feature
- Manually implemented Diagnostic trait for error types in facet-solver
- Updated Cargo.lock to reflect dependency changes