### PR TITLE
Disable tracing default features to remove syn dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4543,19 +4543,7 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ strsim = "0.11"
 tempfile = "^3.23.0"
 time = { version = "^0.3.44", features = ["formatting", "macros", "parsing"] }
 tokio = { version = "^1.48.0", default-features = false, features = ["macros"] }
-tracing = "^0.1.43"
+tracing = { version = "^0.1.43", default-features = false, features = ["std"] }
 ulid = "^1.2.1"
 unsynn = "^0.3.0"
 uuid = "^1.19.0"


### PR DESCRIPTION
## Summary
- Disabled default features for workspace `tracing` dependency
- Enabled only `std` feature, removing `attributes` feature
- Eliminates `syn` dependency from `facet-args` and `facet-solver`

## Changes
Modified `Cargo.toml` workspace dependencies:
```toml
tracing = { version = "^0.1.43", default-features = false, features = ["std"] }
```

## Impact
- ✅ Removes `syn` from dependency tree (verified with `cargo tree`)
- ✅ Faster compile times
- ✅ All tests pass (`cargo nextest run -p facet-args -p facet-solver`)
- ✅ Entire workspace builds (`cargo check --workspace`)
- ⚠️ `#[instrument]` macro no longer available (not used in codebase)
- ✅ Manual `span!` and `event!` macros still work

Closes #1458