### PR TITLE
Update plugin POC to use current facet-macro-parse API

### DIFF
--- a/poc/plugin-poc-test/Cargo.lock
+++ b/poc/plugin-poc-test/Cargo.lock
@@ -4,17 +4,7 @@ version = 4
 
 [[package]]
 name = "facet-macro-parse"
-version = "0.1.0"
-dependencies = [
- "facet-macro-types",
- "proc-macro2",
- "quote",
- "unsynn",
-]
-
-[[package]]
-name = "facet-macro-template"
-version = "0.1.0"
+version = "0.34.0"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -23,10 +13,11 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-types"
-version = "0.1.0"
+version = "0.34.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "unsynn",
 ]
 
 [[package]]
@@ -34,7 +25,6 @@ name = "facet-plugin-poc"
 version = "0.1.0"
 dependencies = [
  "facet-macro-parse",
- "facet-macro-template",
  "facet-macro-types",
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

The plugin POC in `poc/plugin-poc` was written against an older facet-macro-parse API that no longer exists. This updates it to use the current types so the POC compiles and all tests pass.

This is groundwork for #1139 (facet-error: thiserror replacement) and addresses part of #1254 (plugin POC enablement).

## Changes

- Update `generate_display` to use current `PVariant`, `PVariantKind`, and `PStructField` APIs
- Import `PVariantKind` and `IdentOrLiteral` from facet-macro-parse
- Map old API calls to new equivalents:
  - `v.raw_ident()` → `v.name.raw` 
  - `v.doc()` → `v.attrs.doc.join(" ")`
  - `v.effective_name()` → `v.name.effective`
  - `v.kind.is_unit()/is_tuple()` → match on `PVariantKind` enum
  - `s.doc()` → `s.container.attrs.doc`

## Test plan

- [x] `cargo build` in poc/plugin-poc-test succeeds
- [x] `cargo test` - all 5 tests pass
- [x] `cargo run` - demo output shows doc-comment-based Display working with field interpolation

Relates to #1254 and #1139