### PR TITLE
args: flatten tuple variant fields in help output

### DIFF
--- a/facet-args/tests/snapshots/help__tuple_variant_main_help.snap
+++ b/facet-args/tests/snapshots/help__tuple_variant_main_help.snap
@@ -1,0 +1,15 @@
+---
+source: facet-args/tests/help.rs
+assertion_line: 367
+expression: help
+---
+myapp
+
+[1m[33mUSAGE[39m[0m:
+    myapp <COMMAND>
+
+[1m[33mCOMMANDS[39m[0m:
+    [32mbuild[39m
+            Build the project
+    [32mtest[39m
+            Run tests

--- a/facet-args/tests/snapshots/help__tuple_variant_subcommand_help.snap
+++ b/facet-args/tests/snapshots/help__tuple_variant_subcommand_help.snap
@@ -1,0 +1,19 @@
+---
+source: facet-args/tests/help.rs
+assertion_line: 396
+expression: help
+---
+command build
+
+Build the project
+
+[1m[33mUSAGE[39m[0m:
+    command build [OPTIONS]
+
+[1m[33mOPTIONS[39m[0m:
+    [32m-r[39m, [32m--release[39m
+            Build in release mode
+        [32m--no-spawn[39m
+            Disable spawning processes
+        [32m--no-tui[39m
+            Disable TUI mode


### PR DESCRIPTION
## Summary

Fixes the help output for tuple variant subcommands to show flattened fields instead of `--0 <STRUCTNAME>`.

**Before:**
```
OPTIONS:
    --0 <BUILDARGS>
```

**After:**
```
OPTIONS:
    -r, --release
            Build in release mode
        --no-spawn
            Disable spawning processes
        --no-tui
            Disable TUI mode
```

## Changes

- Modified `generate_subcommand_help` in `help.rs` to detect tuple variants with a single struct field and flatten the inner struct's fields
- Added test case reproducing the issue
- Added snapshots for the corrected help output

## Technical Details

The fix mirrors the existing flattening logic in `format.rs:427-439` which already handles this case during parsing. This ensures help output matches the actual parsing behavior and clap's "automatic flattening" for tuple variants.

Closes #1468
