### PR TITLE
fix(facet-format-postcard): gate miette impls behind pretty-errors feature

### DIFF
--- a/facet-format-postcard/Cargo.toml
+++ b/facet-format-postcard/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 facet-core = { path = "../facet-core", version = "0.34.0", default-features = false }
 facet-format = { path = "../facet-format", version = "0.34.0" }
 facet-path = { path = "../facet-path", version = "0.34.0", default-features = false, features = ["alloc"] }
-facet-reflect = { path = "../facet-reflect", version = "0.34.0", default-features = false, features = ["miette"] }
+facet-reflect = { path = "../facet-reflect", version = "0.34.0", default-features = false }
 miette = { workspace = true, optional = true }
 
 # Axum integration (optional)
@@ -64,7 +64,7 @@ harness = false
 default = ["std", "pretty-errors"]
 std = ["alloc", "facet-core/std", "facet-reflect/std", "facet-path/std"]
 alloc = ["facet-core/alloc", "facet-reflect/alloc", "facet-path/alloc"]
-pretty-errors = ["facet-path/pretty", "dep:miette"]
+pretty-errors = ["facet-path/pretty", "facet-reflect/miette", "dep:miette"]
 jit = ["facet-format/jit"]
 
 # Axum HTTP integration

--- a/facet-format-postcard/src/error.rs
+++ b/facet-format-postcard/src/error.rs
@@ -24,6 +24,7 @@ impl fmt::Display for PostcardError {
 
 impl std::error::Error for PostcardError {}
 
+#[cfg(feature = "pretty-errors")]
 impl miette::Diagnostic for PostcardError {
     fn code<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
         Some(Box::new(format!("postcard::error::{}", self.code)))
@@ -94,4 +95,5 @@ impl fmt::Display for SerializeError {
 
 impl std::error::Error for SerializeError {}
 
+#[cfg(feature = "pretty-errors")]
 impl miette::Diagnostic for SerializeError {}


### PR DESCRIPTION
## Summary

- Gate `miette::Diagnostic` impls behind the `pretty-errors` feature in `facet-format-postcard`
- Fix WASM builds that use `default-features = false`

## Changes

- Add `#[cfg(feature = "pretty-errors")]` to `impl miette::Diagnostic for PostcardError`
- Add `#[cfg(feature = "pretty-errors")]` to `impl miette::Diagnostic for SerializeError`
- Remove unconditional `features = ["miette"]` from `facet-reflect` dependency
- Add `facet-reflect/miette` to the `pretty-errors` feature activation

## Test Plan

- [x] `cargo check -p facet-format-postcard --no-default-features` compiles without miette
- [x] `cargo check -p facet-format-postcard --no-default-features --features alloc` compiles
- [x] `cargo check -p facet-format-postcard` (default features) still works with miette
- [x] `cargo nextest run -p facet-format-postcard` all tests pass
- [x] `cargo check --workspace` succeeds
- [x] `just nostd-ci` succeeds

Closes #1476
