### PR TITLE
facet-format-postcard: external types, axum integration, diagnostic improvements

### DIFF
--- a/facet-format-postcard/src/axum.rs
+++ b/facet-format-postcard/src/axum.rs
@@ -1,0 +1,213 @@
+//! Axum integration for postcard format.
+//!
+//! This module provides the `Postcard<T>` extractor and response type for axum.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use axum::{Router, routing::post};
+//! use facet::Facet;
+//! use facet_format_postcard::Postcard;
+//!
+//! #[derive(Facet)]
+//! struct CreateUser {
+//!     name: String,
+//!     email: String,
+//! }
+//!
+//! #[derive(Facet)]
+//! struct User {
+//!     id: u64,
+//!     name: String,
+//!     email: String,
+//! }
+//!
+//! async fn create_user(Postcard(payload): Postcard<CreateUser>) -> Postcard<User> {
+//!     let user = User {
+//!         id: 1,
+//!         name: payload.name,
+//!         email: payload.email,
+//!     };
+//!     Postcard(user)
+//! }
+//!
+//! let app = Router::new().route("/users", post(create_user));
+//! ```
+
+use axum_core::{
+    body::Body,
+    extract::{FromRequest, Request},
+    response::{IntoResponse, Response},
+};
+use core::fmt;
+use core::ops::{Deref, DerefMut};
+use facet_core::Facet;
+use http::{HeaderValue, StatusCode, header};
+use http_body_util::BodyExt;
+
+use crate::{DeserializeError, PostcardError, SerializeError};
+
+/// A wrapper type for postcard-encoded request/response bodies.
+///
+/// This type implements `FromRequest` for extracting postcard-encoded data from
+/// request bodies, and `IntoResponse` for serializing data as postcard in responses.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Postcard<T>(pub T);
+
+impl<T> Postcard<T> {
+    /// Consume the wrapper and return the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> Deref for Postcard<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Postcard<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> From<T> for Postcard<T> {
+    fn from(inner: T) -> Self {
+        Self(inner)
+    }
+}
+
+/// Rejection type for Postcard extraction errors.
+#[derive(Debug)]
+pub struct PostcardRejection {
+    kind: PostcardRejectionKind,
+}
+
+#[derive(Debug)]
+enum PostcardRejectionKind {
+    /// Failed to read the request body.
+    Body(axum_core::Error),
+    /// Failed to deserialize the postcard data.
+    Deserialize(DeserializeError<PostcardError>),
+}
+
+impl PostcardRejection {
+    /// Returns the HTTP status code for this rejection.
+    pub fn status(&self) -> StatusCode {
+        match &self.kind {
+            PostcardRejectionKind::Body(_) => StatusCode::BAD_REQUEST,
+            PostcardRejectionKind::Deserialize(_) => StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
+
+    /// Returns true if this is a body reading error.
+    pub fn is_body_error(&self) -> bool {
+        matches!(&self.kind, PostcardRejectionKind::Body(_))
+    }
+
+    /// Returns true if this is a deserialization error.
+    pub fn is_deserialize_error(&self) -> bool {
+        matches!(&self.kind, PostcardRejectionKind::Deserialize(_))
+    }
+}
+
+impl fmt::Display for PostcardRejection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            PostcardRejectionKind::Body(err) => {
+                write!(f, "Failed to read request body: {err}")
+            }
+            PostcardRejectionKind::Deserialize(err) => {
+                write!(f, "Failed to deserialize Postcard: {err}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PostcardRejection {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            PostcardRejectionKind::Body(err) => Some(err),
+            PostcardRejectionKind::Deserialize(err) => Some(err),
+        }
+    }
+}
+
+impl IntoResponse for PostcardRejection {
+    fn into_response(self) -> Response {
+        (self.status(), self.to_string()).into_response()
+    }
+}
+
+impl<T, S> FromRequest<S> for Postcard<T>
+where
+    T: for<'de> Facet<'de>,
+    S: Send + Sync,
+{
+    type Rejection = PostcardRejection;
+
+    async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
+        let bytes = req
+            .into_body()
+            .collect()
+            .await
+            .map_err(|e| PostcardRejection {
+                kind: PostcardRejectionKind::Body(axum_core::Error::new(e)),
+            })?
+            .to_bytes();
+
+        let value: T = crate::from_slice(&bytes).map_err(|e| PostcardRejection {
+            kind: PostcardRejectionKind::Deserialize(e),
+        })?;
+
+        Ok(Postcard(value))
+    }
+}
+
+impl<T> IntoResponse for Postcard<T>
+where
+    T: for<'de> Facet<'de>,
+{
+    fn into_response(self) -> Response {
+        match crate::to_vec(&self.0) {
+            Ok(bytes) => {
+                let mut res = Response::new(Body::from(bytes));
+                res.headers_mut().insert(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/octet-stream"),
+                );
+                res
+            }
+            Err(err) => {
+                let body = format!("Failed to serialize response: {err}");
+                (StatusCode::INTERNAL_SERVER_ERROR, body).into_response()
+            }
+        }
+    }
+}
+
+/// Rejection type for Postcard serialization errors in responses.
+#[derive(Debug)]
+pub struct PostcardSerializeRejection(pub SerializeError);
+
+impl fmt::Display for PostcardSerializeRejection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Failed to serialize Postcard response: {}", self.0)
+    }
+}
+
+impl std::error::Error for PostcardSerializeRejection {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl IntoResponse for PostcardSerializeRejection {
+    fn into_response(self) -> Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
+    }
+}

--- a/facet-format-postcard/src/lib.rs
+++ b/facet-format-postcard/src/lib.rs
@@ -46,6 +46,11 @@ mod serialize;
 #[cfg(feature = "jit")]
 pub mod jit;
 
+#[cfg(feature = "axum")]
+mod axum;
+
+#[cfg(feature = "axum")]
+pub use axum::{Postcard, PostcardRejection, PostcardSerializeRejection};
 pub use error::{PostcardError, SerializeError};
 #[cfg(feature = "jit")]
 pub use jit::PostcardJitFormat;

--- a/facet-format-postcard/tests/cross_compat.rs
+++ b/facet-format-postcard/tests/cross_compat.rs
@@ -1,0 +1,727 @@
+//! Cross-compatibility tests between facet-format-postcard and serde postcard.
+//!
+//! These tests verify:
+//! 1. Byte-for-byte equality between facet and serde postcard serialization
+//! 2. Facet-serialized data can be deserialized by serde postcard
+//! 3. Serde postcard-serialized data can be deserialized by facet
+//!
+//! This is critical for ensuring interoperability in mixed codebases.
+
+#![cfg(feature = "jit")]
+
+use facet::Facet;
+use facet_format_postcard::{from_slice, to_vec};
+use postcard::from_bytes as postcard_from_slice;
+use postcard::to_allocvec as postcard_to_vec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Helper macro to test cross-compatibility for a type.
+///
+/// Creates tests that verify:
+/// 1. Serialization produces identical bytes
+/// 2. Facet can deserialize serde's output
+/// 3. Serde can deserialize facet's output
+macro_rules! test_cross_compat {
+    ($name:ident, $facet_ty:ty, $serde_ty:ty, $values:expr) => {
+        mod $name {
+            use super::*;
+
+            #[test]
+            fn serialization_matches() {
+                facet_testhelpers::setup();
+                for value in $values {
+                    let facet_bytes = to_vec(&value).expect("facet serialization failed");
+                    let postcard_bytes =
+                        postcard_to_vec(&value).expect("postcard serialization failed");
+                    assert_eq!(
+                        facet_bytes, postcard_bytes,
+                        "Serialization mismatch for value {:?}",
+                        value
+                    );
+                }
+            }
+
+            #[test]
+            fn facet_to_serde() {
+                facet_testhelpers::setup();
+                for value in $values {
+                    let facet_bytes = to_vec(&value).expect("facet serialization failed");
+                    let decoded: $serde_ty = postcard_from_slice(&facet_bytes)
+                        .expect("serde deserialization of facet bytes failed");
+                    assert_eq!(
+                        value, decoded,
+                        "facet->serde roundtrip failed for {:?}",
+                        value
+                    );
+                }
+            }
+
+            #[test]
+            fn serde_to_facet() {
+                facet_testhelpers::setup();
+                for value in $values {
+                    let postcard_bytes =
+                        postcard_to_vec(&value).expect("postcard serialization failed");
+                    let decoded: $facet_ty = from_slice(&postcard_bytes)
+                        .expect("facet deserialization of serde bytes failed");
+                    assert_eq!(
+                        value, decoded,
+                        "serde->facet roundtrip failed for {:?}",
+                        value
+                    );
+                }
+            }
+        }
+    };
+}
+
+/// Helper macro for types where Facet and Serde types are the same
+macro_rules! test_cross_compat_same {
+    ($name:ident, $ty:ty, $values:expr) => {
+        test_cross_compat!($name, $ty, $ty, $values);
+    };
+}
+
+// =============================================================================
+// Primitive Types
+// =============================================================================
+
+mod primitives {
+    use super::*;
+
+    // Wrapper struct for primitives (needed for both Facet and Serde derives)
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct Wrap<T> {
+        value: T,
+    }
+
+    fn wrap<T: Clone>(values: &[T]) -> Vec<Wrap<T>> {
+        values.iter().map(|v| Wrap { value: v.clone() }).collect()
+    }
+
+    test_cross_compat_same!(u8_values, Wrap<u8>, wrap(&[0u8, 1, 127, 128, 255]));
+
+    test_cross_compat_same!(
+        u16_values,
+        Wrap<u16>,
+        wrap(&[0u16, 1, 127, 128, 255, 256, 1000, 65535])
+    );
+
+    test_cross_compat_same!(
+        u32_values,
+        Wrap<u32>,
+        wrap(&[
+            0u32,
+            1,
+            127,
+            128,
+            255,
+            256,
+            65535,
+            65536,
+            100_000,
+            1_000_000,
+            u32::MAX
+        ])
+    );
+
+    test_cross_compat_same!(
+        u64_values,
+        Wrap<u64>,
+        wrap(&[
+            0u64,
+            1,
+            127,
+            128,
+            255,
+            256,
+            u32::MAX as u64,
+            u32::MAX as u64 + 1,
+            u64::MAX
+        ])
+    );
+
+    test_cross_compat_same!(i8_values, Wrap<i8>, wrap(&[0i8, 1, -1, 127, -128]));
+
+    test_cross_compat_same!(
+        i16_values,
+        Wrap<i16>,
+        wrap(&[0i16, 1, -1, 127, -128, 1000, -1000, i16::MIN, i16::MAX])
+    );
+
+    test_cross_compat_same!(
+        i32_values,
+        Wrap<i32>,
+        wrap(&[
+            0i32,
+            1,
+            -1,
+            127,
+            -128,
+            1000,
+            -1000,
+            100_000,
+            -100_000,
+            i32::MIN,
+            i32::MAX
+        ])
+    );
+
+    test_cross_compat_same!(
+        i64_values,
+        Wrap<i64>,
+        wrap(&[
+            0i64,
+            1,
+            -1,
+            i32::MIN as i64,
+            i32::MAX as i64,
+            i64::MIN,
+            i64::MAX
+        ])
+    );
+
+    test_cross_compat_same!(
+        f32_values,
+        Wrap<f32>,
+        wrap(&[
+            0.0f32,
+            1.0,
+            -1.0,
+            1.5,
+            -2.5,
+            f32::MIN,
+            f32::MAX,
+            f32::EPSILON
+        ])
+    );
+
+    test_cross_compat_same!(
+        f64_values,
+        Wrap<f64>,
+        wrap(&[
+            0.0f64,
+            1.0,
+            -1.0,
+            1.23456789012345,
+            f64::MIN,
+            f64::MAX,
+            f64::EPSILON
+        ])
+    );
+
+    test_cross_compat_same!(bool_values, Wrap<bool>, wrap(&[true, false]));
+}
+
+// =============================================================================
+// String Types
+// =============================================================================
+
+mod strings {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct StringWrapper {
+        value: String,
+    }
+
+    test_cross_compat_same!(
+        string_values,
+        StringWrapper,
+        [
+            StringWrapper {
+                value: String::new()
+            },
+            StringWrapper {
+                value: "hello".to_string()
+            },
+            StringWrapper {
+                value: "Hello, World!".to_string()
+            },
+            StringWrapper {
+                value: "こんにちは世界".to_string()
+            },
+            StringWrapper {
+                value: "🦀 Rust 🚀".to_string()
+            },
+            StringWrapper {
+                value: "a".repeat(1000)
+            }
+        ]
+    );
+}
+
+// =============================================================================
+// Collection Types
+// =============================================================================
+
+mod collections {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct VecU32 {
+        values: Vec<u32>,
+    }
+
+    test_cross_compat_same!(
+        vec_u32,
+        VecU32,
+        [
+            VecU32 { values: vec![] },
+            VecU32 { values: vec![42] },
+            VecU32 {
+                values: vec![1, 2, 3, 4, 5]
+            },
+            VecU32 {
+                values: (0..100).collect()
+            }
+        ]
+    );
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct VecString {
+        values: Vec<String>,
+    }
+
+    test_cross_compat_same!(
+        vec_string,
+        VecString,
+        [
+            VecString { values: vec![] },
+            VecString {
+                values: vec!["hello".to_string()]
+            },
+            VecString {
+                values: vec!["a".to_string(), "b".to_string(), "c".to_string()]
+            }
+        ]
+    );
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct VecBytes {
+        values: Vec<u8>,
+    }
+
+    test_cross_compat_same!(
+        vec_bytes,
+        VecBytes,
+        [
+            VecBytes { values: vec![] },
+            VecBytes {
+                values: vec![0, 1, 2, 3]
+            },
+            VecBytes {
+                values: (0..=255).collect()
+            }
+        ]
+    );
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct NestedVec {
+        values: Vec<Vec<u32>>,
+    }
+
+    test_cross_compat_same!(
+        nested_vec,
+        NestedVec,
+        [
+            NestedVec { values: vec![] },
+            NestedVec {
+                values: vec![vec![1, 2], vec![3, 4, 5], vec![]]
+            }
+        ]
+    );
+
+    // Note: HashMap order is not guaranteed, so we use BTreeMap for deterministic tests
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct BTreeMapWrapper {
+        map: BTreeMap<String, u32>,
+    }
+
+    test_cross_compat_same!(
+        btreemap,
+        BTreeMapWrapper,
+        [
+            BTreeMapWrapper {
+                map: BTreeMap::new()
+            },
+            BTreeMapWrapper {
+                map: [("key".to_string(), 42)].into_iter().collect()
+            },
+            BTreeMapWrapper {
+                map: [
+                    ("alpha".to_string(), 1),
+                    ("beta".to_string(), 2),
+                    ("gamma".to_string(), 3),
+                ]
+                .into_iter()
+                .collect()
+            }
+        ]
+    );
+}
+
+// =============================================================================
+// Option Types
+// =============================================================================
+
+mod options {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct OptionU32 {
+        value: Option<u32>,
+    }
+
+    test_cross_compat_same!(
+        option_u32,
+        OptionU32,
+        [
+            OptionU32 { value: None },
+            OptionU32 { value: Some(0) },
+            OptionU32 { value: Some(42) },
+            OptionU32 {
+                value: Some(u32::MAX)
+            }
+        ]
+    );
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct OptionString {
+        value: Option<String>,
+    }
+
+    test_cross_compat_same!(
+        option_string,
+        OptionString,
+        [
+            OptionString { value: None },
+            OptionString {
+                value: Some(String::new())
+            },
+            OptionString {
+                value: Some("hello".to_string())
+            }
+        ]
+    );
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct NestedOption {
+        value: Option<Option<u32>>,
+    }
+
+    test_cross_compat_same!(
+        nested_option,
+        NestedOption,
+        [
+            NestedOption { value: None },
+            NestedOption { value: Some(None) },
+            NestedOption {
+                value: Some(Some(42))
+            }
+        ]
+    );
+}
+
+// =============================================================================
+// Result Types
+// =============================================================================
+
+mod results {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct ResultWrapper {
+        value: Result<u32, String>,
+    }
+
+    test_cross_compat_same!(
+        result_u32_string,
+        ResultWrapper,
+        [
+            ResultWrapper { value: Ok(42) },
+            ResultWrapper { value: Ok(0) },
+            ResultWrapper {
+                value: Err("error".to_string())
+            },
+            ResultWrapper {
+                value: Err(String::new())
+            }
+        ]
+    );
+}
+
+// =============================================================================
+// Struct Types
+// =============================================================================
+
+mod structs {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct UnitStruct;
+
+    test_cross_compat_same!(unit_struct, UnitStruct, [UnitStruct]);
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    test_cross_compat_same!(
+        point,
+        Point,
+        [
+            Point { x: 0, y: 0 },
+            Point { x: 10, y: -20 },
+            Point {
+                x: i32::MIN,
+                y: i32::MAX
+            }
+        ]
+    );
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct Person {
+        name: String,
+        age: u32,
+        active: bool,
+    }
+
+    test_cross_compat_same!(
+        person,
+        Person,
+        [
+            Person {
+                name: "Alice".to_string(),
+                age: 30,
+                active: true
+            },
+            Person {
+                name: "Bob".to_string(),
+                age: 0,
+                active: false
+            },
+            Person {
+                name: "".to_string(),
+                age: u32::MAX,
+                active: true
+            }
+        ]
+    );
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct TupleStruct(u32, String);
+
+    test_cross_compat_same!(
+        tuple_struct,
+        TupleStruct,
+        [
+            TupleStruct(0, String::new()),
+            TupleStruct(42, "hello".to_string())
+        ]
+    );
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct Newtype(u64);
+
+    test_cross_compat_same!(
+        newtype,
+        Newtype,
+        [Newtype(0), Newtype(42), Newtype(u64::MAX)]
+    );
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct Nested {
+        name: String,
+        point: Point,
+    }
+
+    test_cross_compat_same!(
+        nested,
+        Nested,
+        [
+            Nested {
+                name: "origin".to_string(),
+                point: Point { x: 0, y: 0 }
+            },
+            Nested {
+                name: "test".to_string(),
+                point: Point { x: 100, y: -50 }
+            }
+        ]
+    );
+}
+
+// =============================================================================
+// Enum Types
+// =============================================================================
+
+mod enums {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    #[repr(u8)]
+    enum Color {
+        Red,
+        Green,
+        Blue,
+    }
+
+    test_cross_compat_same!(unit_enum, Color, [Color::Red, Color::Green, Color::Blue]);
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    #[repr(u8)]
+    enum Message {
+        Quit,
+        Text(String),
+        Number(u32),
+    }
+
+    test_cross_compat_same!(
+        newtype_enum,
+        Message,
+        [
+            Message::Quit,
+            Message::Text("hello".to_string()),
+            Message::Number(42)
+        ]
+    );
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    #[repr(u8)]
+    enum TupleEnum {
+        Empty,
+        Pair(u32, String),
+    }
+
+    test_cross_compat_same!(
+        tuple_enum,
+        TupleEnum,
+        [TupleEnum::Empty, TupleEnum::Pair(42, "test".to_string())]
+    );
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    #[repr(u8)]
+    enum StructEnum {
+        Unit,
+        Point { x: i32, y: i32 },
+    }
+
+    test_cross_compat_same!(
+        struct_enum,
+        StructEnum,
+        [StructEnum::Unit, StructEnum::Point { x: 10, y: -20 }]
+    );
+}
+
+// =============================================================================
+// Tuple Types
+// =============================================================================
+
+mod tuples {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct WrapPair {
+        value: (u32, String),
+    }
+
+    test_cross_compat_same!(
+        pair,
+        WrapPair,
+        [
+            WrapPair {
+                value: (0, String::new())
+            },
+            WrapPair {
+                value: (42, "hello".to_string())
+            }
+        ]
+    );
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct WrapTriple {
+        value: (u32, String, bool),
+    }
+
+    test_cross_compat_same!(
+        triple,
+        WrapTriple,
+        [
+            WrapTriple {
+                value: (0, String::new(), false)
+            },
+            WrapTriple {
+                value: (42, "test".to_string(), true)
+            }
+        ]
+    );
+}
+
+// =============================================================================
+// Complex Types (Kitchen Sink)
+// =============================================================================
+
+mod complex {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Clone, Facet, Serialize, Deserialize)]
+    struct KitchenSink {
+        u8_field: u8,
+        u16_field: u16,
+        u32_field: u32,
+        u64_field: u64,
+        i8_field: i8,
+        i16_field: i16,
+        i32_field: i32,
+        i64_field: i64,
+        f32_field: f32,
+        f64_field: f64,
+        bool_field: bool,
+        string_field: String,
+        vec_field: Vec<u32>,
+        option_field: Option<u32>,
+    }
+
+    test_cross_compat_same!(
+        kitchen_sink,
+        KitchenSink,
+        [
+            KitchenSink {
+                u8_field: 255,
+                u16_field: 65535,
+                u32_field: u32::MAX,
+                u64_field: u64::MAX,
+                i8_field: -128,
+                i16_field: -32768,
+                i32_field: i32::MIN,
+                i64_field: i64::MIN,
+                f32_field: std::f32::consts::PI,
+                f64_field: std::f64::consts::E,
+                bool_field: true,
+                string_field: "Hello, World!".to_string(),
+                vec_field: vec![1, 2, 3, 4, 5],
+                option_field: Some(42),
+            },
+            KitchenSink {
+                u8_field: 0,
+                u16_field: 0,
+                u32_field: 0,
+                u64_field: 0,
+                i8_field: 0,
+                i16_field: 0,
+                i32_field: 0,
+                i64_field: 0,
+                f32_field: 0.0,
+                f64_field: 0.0,
+                bool_field: false,
+                string_field: String::new(),
+                vec_field: vec![],
+                option_field: None,
+            }
+        ]
+    );
+}

--- a/facet-format-postcard/tests/external_types.rs
+++ b/facet-format-postcard/tests/external_types.rs
@@ -1,0 +1,1041 @@
+//! Tests for external type support in facet-format-postcard.
+//!
+//! This module tests serialization/deserialization of types from external crates:
+//! - uuid: UUID v4 identifiers
+//! - ulid: Universally Unique Lexicographically Sortable Identifiers
+//! - chrono: Date/time types (DateTime, NaiveDate, etc.)
+//! - jiff: Modern date/time library
+//! - time: Alternative date/time library
+//! - bytes: Bytes and BytesMut
+//! - ordered-float: OrderedFloat and NotNan
+//! - net: IP addresses (std::net)
+
+#![cfg(feature = "jit")]
+
+use facet::Facet;
+use facet_format_postcard::{from_slice, to_vec};
+
+// =============================================================================
+// UUID Tests
+// =============================================================================
+
+#[cfg(feature = "uuid")]
+mod uuid_tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn uuid_v4_roundtrip() {
+        facet_testhelpers::setup();
+        let uuid = Uuid::new_v4();
+        let bytes = to_vec(&uuid).unwrap();
+        let decoded: Uuid = from_slice(&bytes).unwrap();
+        assert_eq!(uuid, decoded);
+    }
+
+    #[test]
+    fn uuid_nil() {
+        facet_testhelpers::setup();
+        let uuid = Uuid::nil();
+        let bytes = to_vec(&uuid).unwrap();
+        let decoded: Uuid = from_slice(&bytes).unwrap();
+        assert_eq!(uuid, decoded);
+    }
+
+    #[test]
+    fn uuid_max() {
+        facet_testhelpers::setup();
+        let uuid = Uuid::from_bytes([0xFF; 16]);
+        let bytes = to_vec(&uuid).unwrap();
+        let decoded: Uuid = from_slice(&bytes).unwrap();
+        assert_eq!(uuid, decoded);
+    }
+
+    #[test]
+    fn uuid_serialization_size() {
+        facet_testhelpers::setup();
+        let uuid = Uuid::new_v4();
+        let bytes = to_vec(&uuid).unwrap();
+        // UUID should be exactly 16 bytes (no length prefix for opaque scalar)
+        assert_eq!(bytes.len(), 16);
+    }
+
+    #[test]
+    fn uuid_in_struct() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct Record {
+            id: Uuid,
+            name: String,
+        }
+
+        let original = Record {
+            id: Uuid::new_v4(),
+            name: "test".to_string(),
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: Record = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn uuid_in_option() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithOptionalId {
+            id: Option<Uuid>,
+        }
+
+        // Test Some variant
+        let original = WithOptionalId {
+            id: Some(Uuid::new_v4()),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithOptionalId = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+
+        // Test None variant
+        let original = WithOptionalId { id: None };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithOptionalId = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn uuid_in_vec() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithIds {
+            ids: Vec<Uuid>,
+        }
+
+        let original = WithIds {
+            ids: vec![Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()],
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithIds = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+}
+
+// =============================================================================
+// ULID Tests
+// =============================================================================
+
+#[cfg(feature = "ulid")]
+mod ulid_tests {
+    use super::*;
+    use ulid::Ulid;
+
+    #[test]
+    fn ulid_roundtrip() {
+        facet_testhelpers::setup();
+        let ulid = Ulid::new();
+        let bytes = to_vec(&ulid).unwrap();
+        let decoded: Ulid = from_slice(&bytes).unwrap();
+        assert_eq!(ulid, decoded);
+    }
+
+    #[test]
+    fn ulid_nil() {
+        facet_testhelpers::setup();
+        let ulid = Ulid::nil();
+        let bytes = to_vec(&ulid).unwrap();
+        let decoded: Ulid = from_slice(&bytes).unwrap();
+        assert_eq!(ulid, decoded);
+    }
+
+    #[test]
+    fn ulid_serialization_size() {
+        facet_testhelpers::setup();
+        let ulid = Ulid::new();
+        let bytes = to_vec(&ulid).unwrap();
+        // ULID should be exactly 16 bytes
+        assert_eq!(bytes.len(), 16);
+    }
+
+    #[test]
+    fn ulid_in_struct() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct Event {
+            id: Ulid,
+            data: String,
+        }
+
+        let original = Event {
+            id: Ulid::new(),
+            data: "event data".to_string(),
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: Event = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn ulid_in_option() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithOptionalUlid {
+            ulid: Option<Ulid>,
+        }
+
+        // Test Some variant
+        let original = WithOptionalUlid {
+            ulid: Some(Ulid::new()),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithOptionalUlid = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+
+        // Test None variant
+        let original = WithOptionalUlid { ulid: None };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithOptionalUlid = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn ulid_ordering_preserved() {
+        facet_testhelpers::setup();
+
+        // ULIDs are lexicographically sortable by creation time
+        let ulid1 = Ulid::new();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let ulid2 = Ulid::new();
+
+        assert!(ulid1 < ulid2);
+
+        let bytes1 = to_vec(&ulid1).unwrap();
+        let bytes2 = to_vec(&ulid2).unwrap();
+
+        let decoded1: Ulid = from_slice(&bytes1).unwrap();
+        let decoded2: Ulid = from_slice(&bytes2).unwrap();
+
+        assert!(decoded1 < decoded2);
+    }
+}
+
+// =============================================================================
+// UUID + ULID Combined Tests
+// =============================================================================
+
+#[cfg(all(feature = "uuid", feature = "ulid"))]
+mod uuid_ulid_combined {
+    use super::*;
+    use ulid::Ulid;
+    use uuid::Uuid;
+
+    #[test]
+    fn uuid_and_ulid_together() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithBothIds {
+            uuid: Uuid,
+            ulid: Ulid,
+            count: u32,
+        }
+
+        let original = WithBothIds {
+            uuid: Uuid::new_v4(),
+            ulid: Ulid::new(),
+            count: 42,
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithBothIds = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+}
+
+// =============================================================================
+// Chrono Tests
+// =============================================================================
+
+#[cfg(feature = "chrono")]
+mod chrono_tests {
+    use super::*;
+    use chrono::{DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+
+    #[test]
+    fn datetime_utc_roundtrip() {
+        facet_testhelpers::setup();
+        let dt = Utc::now();
+        let bytes = to_vec(&dt).unwrap();
+        let decoded: DateTime<Utc> = from_slice(&bytes).unwrap();
+        assert_eq!(dt, decoded);
+    }
+
+    #[test]
+    fn datetime_utc_specific() {
+        facet_testhelpers::setup();
+        let dt: DateTime<Utc> = "2024-12-23T15:30:00Z".parse().unwrap();
+        let bytes = to_vec(&dt).unwrap();
+        let decoded: DateTime<Utc> = from_slice(&bytes).unwrap();
+        assert_eq!(dt, decoded);
+    }
+
+    #[test]
+    fn datetime_utc_in_struct() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct Event {
+            timestamp: DateTime<Utc>,
+            name: String,
+        }
+
+        let original = Event {
+            timestamp: Utc::now(),
+            name: "test event".to_string(),
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: Event = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn datetime_local_roundtrip() {
+        facet_testhelpers::setup();
+        let dt = Local::now();
+        let bytes = to_vec(&dt).unwrap();
+        let decoded: DateTime<Local> = from_slice(&bytes).unwrap();
+        assert_eq!(dt, decoded);
+    }
+
+    #[test]
+    fn datetime_fixed_offset_roundtrip() {
+        facet_testhelpers::setup();
+        let dt: DateTime<FixedOffset> = "2024-12-23T15:30:00-05:00".parse().unwrap();
+        let bytes = to_vec(&dt).unwrap();
+        let decoded: DateTime<FixedOffset> = from_slice(&bytes).unwrap();
+        assert_eq!(dt, decoded);
+    }
+
+    #[test]
+    fn naive_datetime_roundtrip() {
+        facet_testhelpers::setup();
+        let dt = NaiveDateTime::parse_from_str("2024-12-23 15:30:00", "%Y-%m-%d %H:%M:%S").unwrap();
+        let bytes = to_vec(&dt).unwrap();
+        let decoded: NaiveDateTime = from_slice(&bytes).unwrap();
+        assert_eq!(dt, decoded);
+    }
+
+    #[test]
+    fn naive_date_roundtrip() {
+        facet_testhelpers::setup();
+        let date: NaiveDate = "2024-12-23".parse().unwrap();
+        let bytes = to_vec(&date).unwrap();
+        let decoded: NaiveDate = from_slice(&bytes).unwrap();
+        assert_eq!(date, decoded);
+    }
+
+    #[test]
+    fn naive_time_roundtrip() {
+        facet_testhelpers::setup();
+        let time: NaiveTime = "15:30:00".parse().unwrap();
+        let bytes = to_vec(&time).unwrap();
+        let decoded: NaiveTime = from_slice(&bytes).unwrap();
+        assert_eq!(time, decoded);
+    }
+
+    #[test]
+    fn chrono_in_option() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithOptionalDateTime {
+            timestamp: Option<DateTime<Utc>>,
+        }
+
+        // Test Some variant
+        let original = WithOptionalDateTime {
+            timestamp: Some(Utc::now()),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithOptionalDateTime = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+
+        // Test None variant
+        let original = WithOptionalDateTime { timestamp: None };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithOptionalDateTime = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn chrono_in_vec() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct EventLog {
+            timestamps: Vec<DateTime<Utc>>,
+        }
+
+        let original = EventLog {
+            timestamps: vec![Utc::now(), Utc::now(), Utc::now()],
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: EventLog = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn multiple_chrono_types() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct TimeData {
+            utc: DateTime<Utc>,
+            date: NaiveDate,
+            time: NaiveTime,
+        }
+
+        let original = TimeData {
+            utc: Utc::now(),
+            date: "2024-12-23".parse().unwrap(),
+            time: "15:30:00".parse().unwrap(),
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: TimeData = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+}
+
+// =============================================================================
+// Jiff Tests
+// =============================================================================
+
+#[cfg(feature = "jiff02")]
+mod jiff_tests {
+    use super::*;
+    use jiff::{Timestamp, Zoned, civil::DateTime};
+
+    #[test]
+    fn timestamp_roundtrip() {
+        facet_testhelpers::setup();
+        let ts = Timestamp::now();
+        let bytes = to_vec(&ts).unwrap();
+        let decoded: Timestamp = from_slice(&bytes).unwrap();
+        assert_eq!(ts, decoded);
+    }
+
+    #[test]
+    fn datetime_roundtrip() {
+        facet_testhelpers::setup();
+        let dt: DateTime = "2024-12-23T15:30:00".parse().unwrap();
+        let bytes = to_vec(&dt).unwrap();
+        let decoded: DateTime = from_slice(&bytes).unwrap();
+        assert_eq!(dt, decoded);
+    }
+
+    #[test]
+    fn zoned_roundtrip() {
+        facet_testhelpers::setup();
+        let zoned: Zoned = "2024-12-23T15:30:00-05:00[America/New_York]"
+            .parse()
+            .unwrap();
+        let bytes = to_vec(&zoned).unwrap();
+        let decoded: Zoned = from_slice(&bytes).unwrap();
+        assert_eq!(zoned, decoded);
+    }
+
+    #[test]
+    fn jiff_in_struct() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct Event {
+            timestamp: Timestamp,
+            name: String,
+        }
+
+        let original = Event {
+            timestamp: Timestamp::now(),
+            name: "test event".to_string(),
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: Event = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn jiff_in_option() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithOptionalTimestamp {
+            timestamp: Option<Timestamp>,
+        }
+
+        // Test Some variant
+        let original = WithOptionalTimestamp {
+            timestamp: Some(Timestamp::now()),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithOptionalTimestamp = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+
+        // Test None variant
+        let original = WithOptionalTimestamp { timestamp: None };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithOptionalTimestamp = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+}
+
+// =============================================================================
+// Time Crate Tests
+// =============================================================================
+
+#[cfg(feature = "time")]
+mod time_tests {
+    use super::*;
+    use time::{OffsetDateTime, UtcDateTime};
+
+    #[test]
+    fn utc_datetime_roundtrip() {
+        facet_testhelpers::setup();
+        let dt = UtcDateTime::now();
+        let bytes = to_vec(&dt).unwrap();
+        let decoded: UtcDateTime = from_slice(&bytes).unwrap();
+        // Compare with second precision due to subsecond differences
+        assert_eq!(dt.unix_timestamp(), decoded.unix_timestamp());
+    }
+
+    #[test]
+    fn offset_datetime_roundtrip() {
+        facet_testhelpers::setup();
+        let dt = OffsetDateTime::now_utc();
+        let bytes = to_vec(&dt).unwrap();
+        let decoded: OffsetDateTime = from_slice(&bytes).unwrap();
+        // Compare with second precision due to subsecond differences
+        assert_eq!(dt.unix_timestamp(), decoded.unix_timestamp());
+    }
+
+    #[test]
+    fn time_in_struct() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct Event {
+            timestamp: UtcDateTime,
+            name: String,
+        }
+
+        let original = Event {
+            timestamp: UtcDateTime::now(),
+            name: "test event".to_string(),
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: Event = from_slice(&bytes).unwrap();
+        // Compare timestamp with second precision
+        assert_eq!(original.name, decoded.name);
+        assert_eq!(
+            original.timestamp.unix_timestamp(),
+            decoded.timestamp.unix_timestamp()
+        );
+    }
+}
+
+// =============================================================================
+// Bytes Crate Tests
+// =============================================================================
+
+#[cfg(feature = "bytes")]
+mod bytes_tests {
+    use super::*;
+    use bytes::{Bytes, BytesMut};
+
+    #[test]
+    fn bytes_roundtrip() {
+        facet_testhelpers::setup();
+        let original = Bytes::from_static(b"hello world");
+        let serialized = to_vec(&original).unwrap();
+        let decoded: Bytes = from_slice(&serialized).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn bytes_empty() {
+        facet_testhelpers::setup();
+        let original = Bytes::new();
+        let serialized = to_vec(&original).unwrap();
+        let decoded: Bytes = from_slice(&serialized).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn bytes_large() {
+        facet_testhelpers::setup();
+        let data: Vec<u8> = (0..1000).map(|i| (i % 256) as u8).collect();
+        let original = Bytes::from(data);
+        let serialized = to_vec(&original).unwrap();
+        let decoded: Bytes = from_slice(&serialized).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn bytesmut_roundtrip() {
+        facet_testhelpers::setup();
+        let original = BytesMut::from(&b"hello world"[..]);
+        let serialized = to_vec(&original).unwrap();
+        let decoded: BytesMut = from_slice(&serialized).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn bytes_in_struct() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct BinaryData {
+            name: String,
+            data: Bytes,
+        }
+
+        let original = BinaryData {
+            name: "test".to_string(),
+            data: Bytes::from_static(b"binary content"),
+        };
+
+        let serialized = to_vec(&original).unwrap();
+        let decoded: BinaryData = from_slice(&serialized).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn bytes_in_option() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithOptionalBytes {
+            data: Option<Bytes>,
+        }
+
+        // Test Some variant
+        let original = WithOptionalBytes {
+            data: Some(Bytes::from_static(b"data")),
+        };
+        let serialized = to_vec(&original).unwrap();
+        let decoded: WithOptionalBytes = from_slice(&serialized).unwrap();
+        assert_eq!(original, decoded);
+
+        // Test None variant
+        let original = WithOptionalBytes { data: None };
+        let serialized = to_vec(&original).unwrap();
+        let decoded: WithOptionalBytes = from_slice(&serialized).unwrap();
+        assert_eq!(original, decoded);
+    }
+}
+
+// =============================================================================
+// OrderedFloat Tests
+// =============================================================================
+
+#[cfg(feature = "ordered-float")]
+mod ordered_float_tests {
+    use super::*;
+    use ordered_float::{NotNan, OrderedFloat};
+
+    #[test]
+    fn ordered_float_f32_roundtrip() {
+        facet_testhelpers::setup();
+        let original = OrderedFloat(2.71f32);
+        let bytes = to_vec(&original).unwrap();
+        let decoded: OrderedFloat<f32> = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn ordered_float_f64_roundtrip() {
+        facet_testhelpers::setup();
+        let original = OrderedFloat(123.456789f64);
+        let bytes = to_vec(&original).unwrap();
+        let decoded: OrderedFloat<f64> = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn ordered_float_serialization_size() {
+        facet_testhelpers::setup();
+        let f32_val = OrderedFloat(1.0f32);
+        let f64_val = OrderedFloat(1.0f64);
+
+        let f32_bytes = to_vec(&f32_val).unwrap();
+        let f64_bytes = to_vec(&f64_val).unwrap();
+
+        assert_eq!(f32_bytes.len(), 4, "OrderedFloat<f32> should be 4 bytes");
+        assert_eq!(f64_bytes.len(), 8, "OrderedFloat<f64> should be 8 bytes");
+    }
+
+    #[test]
+    fn ordered_float_in_struct() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct Measurement {
+            value: OrderedFloat<f64>,
+            unit: String,
+        }
+
+        let original = Measurement {
+            value: OrderedFloat(42.5),
+            unit: "meters".to_string(),
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: Measurement = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn ordered_float_special_values() {
+        facet_testhelpers::setup();
+
+        // Test infinity
+        let inf = OrderedFloat(f64::INFINITY);
+        let bytes = to_vec(&inf).unwrap();
+        let decoded: OrderedFloat<f64> = from_slice(&bytes).unwrap();
+        assert_eq!(inf, decoded);
+
+        // Test negative infinity
+        let neg_inf = OrderedFloat(f64::NEG_INFINITY);
+        let bytes = to_vec(&neg_inf).unwrap();
+        let decoded: OrderedFloat<f64> = from_slice(&bytes).unwrap();
+        assert_eq!(neg_inf, decoded);
+
+        // Test NaN (OrderedFloat allows NaN comparison)
+        let nan = OrderedFloat(f64::NAN);
+        let bytes = to_vec(&nan).unwrap();
+        let decoded: OrderedFloat<f64> = from_slice(&bytes).unwrap();
+        assert!(decoded.is_nan());
+    }
+
+    #[test]
+    fn notnan_f32_roundtrip() {
+        facet_testhelpers::setup();
+        let original = NotNan::new(2.71f32).unwrap();
+        let bytes = to_vec(&original).unwrap();
+        let decoded: NotNan<f32> = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn notnan_f64_roundtrip() {
+        facet_testhelpers::setup();
+        let original = NotNan::new(123.456789f64).unwrap();
+        let bytes = to_vec(&original).unwrap();
+        let decoded: NotNan<f64> = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn notnan_in_struct() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct Score {
+            value: NotNan<f64>,
+            label: String,
+        }
+
+        let original = Score {
+            value: NotNan::new(95.5).unwrap(),
+            label: "test score".to_string(),
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: Score = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+}
+
+// =============================================================================
+// Network Types Tests
+// =============================================================================
+
+#[cfg(feature = "net")]
+mod net_tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+    #[test]
+    fn ipv4_addr_roundtrip() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithIpv4 {
+            addr: Ipv4Addr,
+        }
+
+        let original = WithIpv4 {
+            addr: Ipv4Addr::new(192, 168, 1, 1),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithIpv4 = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn ipv6_addr_roundtrip() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithIpv6 {
+            addr: Ipv6Addr,
+        }
+
+        let original = WithIpv6 {
+            addr: Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithIpv6 = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn ip_addr_v4_roundtrip() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithIpAddr {
+            addr: IpAddr,
+        }
+
+        let original = WithIpAddr {
+            addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithIpAddr = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn ip_addr_v6_roundtrip() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithIpAddr {
+            addr: IpAddr,
+        }
+
+        let original = WithIpAddr {
+            addr: IpAddr::V6(Ipv6Addr::LOCALHOST),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithIpAddr = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn socket_addr_v4_roundtrip() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithSocketAddrV4 {
+            addr: SocketAddrV4,
+        }
+
+        let original = WithSocketAddrV4 {
+            addr: SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithSocketAddrV4 = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn socket_addr_v6_roundtrip() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithSocketAddrV6 {
+            addr: SocketAddrV6,
+        }
+
+        let original = WithSocketAddrV6 {
+            addr: SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithSocketAddrV6 = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn socket_addr_roundtrip() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithSocketAddr {
+            addr: SocketAddr,
+        }
+
+        // V4
+        let original = WithSocketAddr {
+            addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 1, 1), 443)),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithSocketAddr = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+
+        // V6
+        let original = WithSocketAddr {
+            addr: SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0)),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithSocketAddr = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn ip_addrs_special_values() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct AddressTest {
+            addr: Ipv4Addr,
+        }
+
+        // Localhost
+        let original = AddressTest {
+            addr: Ipv4Addr::LOCALHOST,
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: AddressTest = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+
+        // Broadcast
+        let original = AddressTest {
+            addr: Ipv4Addr::BROADCAST,
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: AddressTest = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+
+        // Unspecified
+        let original = AddressTest {
+            addr: Ipv4Addr::UNSPECIFIED,
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: AddressTest = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+}
+
+// =============================================================================
+// Camino Path Tests
+// =============================================================================
+
+#[cfg(feature = "camino")]
+mod camino_tests {
+    use super::*;
+    use camino::Utf8PathBuf;
+
+    #[test]
+    fn utf8pathbuf_roundtrip() {
+        facet_testhelpers::setup();
+        let path = Utf8PathBuf::from("/path/to/file");
+        let bytes = to_vec(&path).unwrap();
+        let decoded: Utf8PathBuf = from_slice(&bytes).unwrap();
+        assert_eq!(path, decoded);
+    }
+
+    #[test]
+    fn utf8pathbuf_empty() {
+        facet_testhelpers::setup();
+        let path = Utf8PathBuf::new();
+        let bytes = to_vec(&path).unwrap();
+        let decoded: Utf8PathBuf = from_slice(&bytes).unwrap();
+        assert_eq!(path, decoded);
+    }
+
+    #[test]
+    fn utf8pathbuf_relative() {
+        facet_testhelpers::setup();
+        let path = Utf8PathBuf::from("relative/path/to/file.txt");
+        let bytes = to_vec(&path).unwrap();
+        let decoded: Utf8PathBuf = from_slice(&bytes).unwrap();
+        assert_eq!(path, decoded);
+    }
+
+    #[test]
+    fn utf8pathbuf_in_struct() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct FileInfo {
+            path: Utf8PathBuf,
+            size: u64,
+        }
+
+        let original = FileInfo {
+            path: Utf8PathBuf::from("/home/user/documents/file.txt"),
+            size: 1024,
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: FileInfo = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn utf8pathbuf_in_option() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct WithOptionalPath {
+            path: Option<Utf8PathBuf>,
+        }
+
+        // Test Some variant
+        let original = WithOptionalPath {
+            path: Some(Utf8PathBuf::from("/path")),
+        };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithOptionalPath = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+
+        // Test None variant
+        let original = WithOptionalPath { path: None };
+        let bytes = to_vec(&original).unwrap();
+        let decoded: WithOptionalPath = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn utf8pathbuf_in_vec() {
+        facet_testhelpers::setup();
+
+        #[derive(Facet, PartialEq, Debug)]
+        struct PathList {
+            paths: Vec<Utf8PathBuf>,
+        }
+
+        let original = PathList {
+            paths: vec![
+                Utf8PathBuf::from("/a"),
+                Utf8PathBuf::from("/b/c"),
+                Utf8PathBuf::from("/d/e/f"),
+            ],
+        };
+
+        let bytes = to_vec(&original).unwrap();
+        let decoded: PathList = from_slice(&bytes).unwrap();
+        assert_eq!(original, decoded);
+    }
+}


### PR DESCRIPTION
## Summary

Brings `facet-format-postcard` to feature parity with `facet-postcard` by adding comprehensive external type support (ordered-float, ULID, chrono, jiff, time, uuid, net types), axum integration with `Postcard<T>` extractor/response, and enhanced miette-based error diagnostics.

## Changes

- **External type support**: Added serialization/deserialization for ordered_float types (OrderedFloat, NotNan), ULID, chrono (DateTime, NaiveDate, NaiveDateTime, NaiveTime), jiff (Timestamp, Zoned, Date, Time, DateTime), time crate, uuid, and all std::net types (IpAddr, SocketAddr, etc.)
- **Core deserializer fixes**: Fixed opaque scalar handling in priority 3 path (ULID), added `begin_inner()/set()/end()` pattern for types with `try_from` (NotNan), added Display fallback for scalar serialization
- **Axum integration**: New `Postcard<T>` wrapper implementing `FromRequest` and `IntoResponse` with proper HRTB lifetime bounds
- **Error diagnostics**: Enhanced `PostcardError` with source bytes context, hex dump around error position, and semantic miette codes with help text
- **Test suites**: Added cross-compatibility tests (731 lines) and external type tests (1041 lines) with roundtrip verification

## Testing

All 593 tests pass with `--all-features`. Includes comprehensive roundtrip tests for all external types and cross-compatibility verification with the `postcard` crate via serde.