### PR TITLE
fix(facet-assert): fix type inference in assert_same! macro

### DIFF
--- a/facet-assert/README.md
+++ b/facet-assert/README.md
@@ -27,10 +27,19 @@ assert_same!(a, b); // Requires: Facet (that's it!)
 
 This works because Facet gives us full introspection into any type's structure.
 
-### Structural sameness, not type identity
+### Type inference works naturally
 
-Two values are "same" if they have **the same structure and values** — even if
-they have different type names:
+Unlike some reflection-based comparison macros, `assert_same!` supports full
+type inference:
+
+```ignore
+let x: Option<Option<i32>> = Some(None);
+assert_same!(x, Some(None)); // Type of Some(None) inferred from x
+```
+
+### Cross-type comparison with `assert_sameish!`
+
+Need to compare values of different types? Use `assert_sameish!`:
 
 ```ignore
 #[derive(Facet)]
@@ -42,7 +51,7 @@ struct PersonV2 { name: String, age: u32 }
 let a = PersonV1 { name: "Alice".into(), age: 30 };
 let b = PersonV2 { name: "Alice".into(), age: 30 };
 
-assert_same!(a, b); // Passes! Same structure, same values.
+assert_sameish!(a, b); // Passes! Same structure, same values.
 ```
 
 This is useful for:
@@ -125,9 +134,18 @@ fn test_config_parsing() {
 
 ## Macros
 
+### Same-type comparison (the common case)
+
 - `assert_same!(a, b)` — panics if `a` and `b` are not structurally same
 - `assert_same!(a, b, "message {}", x)` — with custom message
+- `assert_same_with!(a, b, options)` — with custom comparison options
 - `debug_assert_same!(...)` — only in debug builds
+
+### Cross-type comparison (for migrations, etc.)
+
+- `assert_sameish!(a, b)` — compare values of different types
+- `assert_sameish_with!(a, b, options)` — with custom comparison options
+- `debug_assert_sameish!(...)` — only in debug builds
 
 ## Sponsors
 

--- a/facet-assert/README.md.in
+++ b/facet-assert/README.md.in
@@ -18,10 +18,19 @@ assert_same!(a, b); // Requires: Facet (that's it!)
 
 This works because Facet gives us full introspection into any type's structure.
 
-### Structural sameness, not type identity
+### Type inference works naturally
 
-Two values are "same" if they have **the same structure and values** — even if
-they have different type names:
+Unlike some reflection-based comparison macros, `assert_same!` supports full
+type inference:
+
+```ignore
+let x: Option<Option<i32>> = Some(None);
+assert_same!(x, Some(None)); // Type of Some(None) inferred from x
+```
+
+### Cross-type comparison with `assert_sameish!`
+
+Need to compare values of different types? Use `assert_sameish!`:
 
 ```ignore
 #[derive(Facet)]
@@ -33,7 +42,7 @@ struct PersonV2 { name: String, age: u32 }
 let a = PersonV1 { name: "Alice".into(), age: 30 };
 let b = PersonV2 { name: "Alice".into(), age: 30 };
 
-assert_same!(a, b); // Passes! Same structure, same values.
+assert_sameish!(a, b); // Passes! Same structure, same values.
 ```
 
 This is useful for:
@@ -116,6 +125,15 @@ fn test_config_parsing() {
 
 ## Macros
 
+### Same-type comparison (the common case)
+
 - `assert_same!(a, b)` — panics if `a` and `b` are not structurally same
 - `assert_same!(a, b, "message {}", x)` — with custom message
+- `assert_same_with!(a, b, options)` — with custom comparison options
 - `debug_assert_same!(...)` — only in debug builds
+
+### Cross-type comparison (for migrations, etc.)
+
+- `assert_sameish!(a, b)` — compare values of different types
+- `assert_sameish_with!(a, b, options)` — with custom comparison options
+- `debug_assert_sameish!(...)` — only in debug builds

--- a/facet-assert/examples/assert_showcase.rs
+++ b/facet-assert/examples/assert_showcase.rs
@@ -5,7 +5,7 @@
 //! Run with: cargo run -p facet-assert --example assert_showcase
 
 use facet::Facet;
-use facet_assert::{SameReport, assert_same, check_same_report};
+use facet_assert::{SameReport, assert_same, assert_sameish, check_same_report};
 use facet_showcase::{Language, OutputMode, ShowcaseRunner, ansi_to_html};
 use owo_colors::OwoColorize;
 
@@ -107,7 +107,7 @@ fn scenario_cross_type(runner: &mut ShowcaseRunner, _mode: OutputMode) {
     };
 
     // This passes! Different types, same structure.
-    assert_same!(v1, v2);
+    assert_sameish!(v1, v2);
 
     let mut scenario = runner.scenario("Cross-Type Comparison");
     scenario = scenario.description(

--- a/facet-value/tests/assert_diff_pretty.rs
+++ b/facet-value/tests/assert_diff_pretty.rs
@@ -1,6 +1,6 @@
 //! Tests for facet-assert, facet-diff, and facet-pretty support for Value
 
-use facet_assert::{Sameness, assert_same, check_same};
+use facet_assert::{Sameness, assert_same, assert_sameish, check_same, check_sameish};
 use facet_diff::FacetDiff;
 use facet_pretty::FacetPretty;
 use facet_value::value;
@@ -31,21 +31,21 @@ fn test_value_vs_value_different() {
 fn test_value_array_vs_vec_same() {
     let v = value!([1, 2, 3]);
     let vec: Vec<i64> = vec![1, 2, 3];
-    assert_same!(v, vec);
+    assert_sameish!(v, vec);
 }
 
 #[test]
 fn test_vec_vs_value_array_same() {
     let vec: Vec<i64> = vec![1, 2, 3];
     let v = value!([1, 2, 3]);
-    assert_same!(vec, v);
+    assert_sameish!(vec, v);
 }
 
 #[test]
 fn test_value_array_vs_vec_different_length() {
     let v = value!([1, 2, 3, 4]);
     let vec: Vec<i64> = vec![1, 2, 3];
-    match check_same(&v, &vec) {
+    match check_sameish(&v, &vec) {
         Sameness::Different(_) => {} // expected
         Sameness::Same => panic!("expected Different, got Same"),
         Sameness::Opaque { type_name } => panic!("expected Different, got Opaque: {type_name}"),
@@ -56,7 +56,7 @@ fn test_value_array_vs_vec_different_length() {
 fn test_value_array_vs_vec_different_content() {
     let v = value!([1, 2, 99]);
     let vec: Vec<i64> = vec![1, 2, 3];
-    match check_same(&v, &vec) {
+    match check_sameish(&v, &vec) {
         Sameness::Different(_) => {} // expected
         Sameness::Same => panic!("expected Different, got Same"),
         Sameness::Opaque { type_name } => panic!("expected Different, got Opaque: {type_name}"),
@@ -67,14 +67,14 @@ fn test_value_array_vs_vec_different_content() {
 fn test_value_string_vs_string_same() {
     let v = value!("hello");
     let s = String::from("hello");
-    assert_same!(v, s);
+    assert_sameish!(v, s);
 }
 
 #[test]
 fn test_value_string_vs_string_different() {
     let v = value!("hello");
     let s = String::from("world");
-    match check_same(&v, &s) {
+    match check_sameish(&v, &s) {
         Sameness::Different(_) => {} // expected
         Sameness::Same => panic!("expected Different, got Same"),
         Sameness::Opaque { type_name } => panic!("expected Different, got Opaque: {type_name}"),
@@ -85,14 +85,14 @@ fn test_value_string_vs_string_different() {
 fn test_value_number_vs_i64_same() {
     let v = value!(42);
     let n: i64 = 42;
-    assert_same!(v, n);
+    assert_sameish!(v, n);
 }
 
 #[test]
 fn test_value_number_vs_i64_different() {
     let v = value!(42);
     let n: i64 = 43;
-    match check_same(&v, &n) {
+    match check_sameish(&v, &n) {
         Sameness::Different(_) => {} // expected
         Sameness::Same => panic!("expected Different, got Same"),
         Sameness::Opaque { type_name } => panic!("expected Different, got Opaque: {type_name}"),
@@ -103,14 +103,14 @@ fn test_value_number_vs_i64_different() {
 fn test_value_bool_vs_bool_same() {
     let v = value!(true);
     let b = true;
-    assert_same!(v, b);
+    assert_sameish!(v, b);
 }
 
 #[test]
 fn test_value_bool_vs_bool_different() {
     let v = value!(true);
     let b = false;
-    match check_same(&v, &b) {
+    match check_sameish(&v, &b) {
         Sameness::Different(_) => {} // expected
         Sameness::Same => panic!("expected Different, got Same"),
         Sameness::Opaque { type_name } => panic!("expected Different, got Opaque: {type_name}"),
@@ -122,7 +122,7 @@ fn test_nested_value_vs_nested_vec() {
     // Nested arrays
     let v = value!([[1, 2], [3, 4]]);
     let vec: Vec<Vec<i64>> = vec![vec![1, 2], vec![3, 4]];
-    assert_same!(v, vec);
+    assert_sameish!(v, vec);
 }
 
 #[test]


### PR DESCRIPTION
Fixes type inference for the `assert_same!` macro by restructuring comparison functions with same-type and cross-type variants. The `check_same()` function now requires both arguments to have the same type `T`, enabling proper type inference where the second argument's type can be inferred from the first.

This change makes the assertion API more ergonomic for typical use cases while maintaining support for cross-type comparisons via the new `check_sameish()` variant. Includes comprehensive documentation updates and examples.