### PR TITLE
facet-xml: check if attribute is namespace definition before namespace resolution

### DIFF
--- a/facet-xml/tests/namespace.rs
+++ b/facet-xml/tests/namespace.rs
@@ -1006,3 +1006,17 @@ fn test_namespace_with_deny_unknown_fields() {
 
     assert_eq!(doc, deserialized);
 }
+
+#[test]
+fn test_namespace_with_prefix_is_ignored() {
+    #[derive(Facet, Debug, PartialEq)]
+    #[facet(deny_unknown_fields, rename = "root")]
+    struct Root {
+        #[facet(xml::element)]
+        item: String,
+    }
+
+    let xml = r#"<root xmlns:gml="http://www.opengis.net/gml"><gml:item>test</gml:item></root>"#;
+    let deserialized: Root = xml::from_str(xml).unwrap();
+    assert_eq!(deserialized.item, "test");
+}


### PR DESCRIPTION
This pull request fix how XML namespace definitions are handled during XML deserialization:

* Moved the check for ignoring XML namespace definitions before namespace resolution.
* Updated the `is_xml_namespace_attribute` function to work with `quick_xml::name::QName`.
* Added a new test to verify that attributes with namespace prefixes are properly ignored.