### PR TITLE
Replace eprintln! with tracing::debug! in facet-format-postcard JIT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "serde_bytes",
  "smartstring",
  "time",
+ "tracing",
  "ulid",
  "uuid",
 ]

--- a/facet-format-postcard/Cargo.toml
+++ b/facet-format-postcard/Cargo.toml
@@ -21,6 +21,7 @@ facet-format = { path = "../facet-format", version = "0.34.0" }
 facet-path = { path = "../facet-path", version = "0.34.0", default-features = false, features = ["alloc"] }
 facet-reflect = { path = "../facet-reflect", version = "0.34.0", default-features = false }
 miette = { workspace = true, optional = true }
+tracing = { workspace = true }
 
 # Axum integration (optional)
 axum-core = { version = "0.5", default-features = false, optional = true }

--- a/facet-format-postcard/src/jit/mod.rs
+++ b/facet-format-postcard/src/jit/mod.rs
@@ -6,15 +6,9 @@
 //! Postcard is a binary format with NO trivia (whitespace/comments), which
 //! makes it an excellent test case for the format-agnostic Tier-2 design.
 
-/// Debug print macro for JIT - only active in debug builds.
-#[cfg(debug_assertions)]
+/// Debug print macro for JIT - uses tracing::debug! in all builds.
 macro_rules! jit_debug {
-    ($($arg:tt)*) => { eprintln!($($arg)*) }
-}
-
-#[cfg(not(debug_assertions))]
-macro_rules! jit_debug {
-    ($($arg:tt)*) => {};
+    ($($arg:tt)*) => { tracing::debug!($($arg)*) }
 }
 
 pub(crate) use jit_debug;


### PR DESCRIPTION
## Summary

- Replace `eprintln!` with `tracing::debug!` in postcard JIT debug logging
- Add `tracing` dependency to `facet-format-postcard`
- Debug logs now work in both debug and production builds

## Changes

### Before
- Used `eprintln!` directly to stderr ❌
- Only active in debug builds via `#[cfg(debug_assertions)]`
- Completely disabled in release builds
- No integration with application logging infrastructure

### After
- Uses `tracing::debug!` properly ✅
- Active in both debug and production builds
- Respects application's tracing configuration
- Can be filtered/disabled via standard tracing filters

## Testing

All 508 tests pass:
- 22 unit tests in facet-format-postcard
- 486 roundtrip tests
- All doc tests pass