### PR TITLE
perf(jit): buffered direct-fill for Vec<Struct> deserialization

### DIFF
--- a/facet-json/examples/citm_hot.rs
+++ b/facet-json/examples/citm_hot.rs
@@ -118,11 +118,15 @@ fn main() {
     let mut json = Vec::new();
     brotli::BrotliDecompress(&mut std::io::Cursor::new(compressed), &mut json).unwrap();
 
-    // Warmup - trigger JIT compilation
-    let _: CitmCatalog =
-        format_jit::deserialize_with_format_jit_fallback(JsonParser::new(&json)).unwrap();
+    // Warmup - trigger JIT compilation (10 iterations to be sure)
+    for _ in 0..10 {
+        let result: CitmCatalog =
+            format_jit::deserialize_with_format_jit_fallback(JsonParser::new(black_box(&json)))
+                .unwrap();
+        black_box(result);
+    }
 
-    // Hot path - 100 iterations
+    // Hot path - 100 iterations (measured)
     for _ in 0..100 {
         let result: CitmCatalog =
             format_jit::deserialize_with_format_jit_fallback(JsonParser::new(black_box(&json)))


### PR DESCRIPTION
## Summary

Eliminates per-element copy when deserializing `Vec<Struct>`, matching serde_json performance on citm_catalog.

## Changes

- Add `use_buffered_direct_fill_struct` flag for struct element types in list deserializer
- Add `bfs_*` (buffered-fill-struct) block set for the new JIT code path
- Wrap push-based loop in conditional so it only runs when needed
- Move `nested_error_passthrough` block outside conditional for shared use

## How it works

**Before (push-based):**
1. Deserialize struct into stack slot
2. Call `vec.push()` to copy from stack to Vec buffer
3. Repeat for each element

**After (buffered direct-fill):**
1. Reserve capacity in the Vec
2. Get raw buffer pointer  
3. Deserialize each struct directly into `buffer[count * struct_size]`
4. Call `set_len(count)` at the end

## Benchmark Results (citm_catalog)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Instructions | 3.53B | 3.43B | -2.7% |
| Wall-clock (median) | ~1.85ms | ~1.72ms | -7% |
| vs serde_json | 9% slower | **tied** | 🎉 |

## Test Results

All 657 facet-json tests pass.