### PR TITLE
Fix facet-format-postcard deserialization signatures

### DIFF
--- a/facet-format-postcard/tests/issue_1474.rs
+++ b/facet-format-postcard/tests/issue_1474.rs
@@ -6,7 +6,7 @@
 #![cfg(feature = "jit")]
 
 use facet::Facet;
-use facet_format_postcard::{from_slice, to_vec};
+use facet_format_postcard::{from_slice, from_slice_borrowed, to_vec};
 use std::borrow::Cow;
 
 /// Test Cow<'a, str> deserialization
@@ -50,7 +50,9 @@ fn test_bytes_slice() {
     let bytes = to_vec(&original).expect("serialization should succeed");
     eprintln!("Serialized bytes: {:?}", bytes);
 
-    let decoded: BytesOnly<'_> = from_slice(&bytes).expect("deserialization should succeed");
+    // &[u8] requires from_slice_borrowed since it cannot be owned
+    let decoded: BytesOnly<'_> =
+        from_slice_borrowed(&bytes).expect("deserialization should succeed");
     assert_eq!(decoded.data, b"hello");
     assert_eq!(decoded.count, 42);
 }
@@ -139,7 +141,9 @@ fn test_bytes_slice_zero_copy() {
     };
     let bytes = to_vec(&original).expect("serialization should succeed");
 
-    let decoded: BytesOnly<'_> = from_slice(&bytes).expect("deserialization should succeed");
+    // &[u8] requires from_slice_borrowed for zero-copy deserialization
+    let decoded: BytesOnly<'_> =
+        from_slice_borrowed(&bytes).expect("deserialization should succeed");
     assert_eq!(decoded.data, b"zero-copy bytes");
     assert_eq!(decoded.count, 2);
 }

--- a/facet-format-postcard/tests/multi_tier.rs
+++ b/facet-format-postcard/tests/multi_tier.rs
@@ -45,10 +45,10 @@ mod tier_helpers {
         }
     }
 
-    /// Deserialize using Tier-2 (format JIT - direct byte parsing)
-    pub fn deserialize_tier2<'de, T>(input: &'de [u8]) -> Result<T, DeserializeError<PostcardError>>
+    /// Deserialize using Tier-2 (format JIT - direct byte parsing) into owned types.
+    pub fn deserialize_tier2<T>(input: &[u8]) -> Result<T, DeserializeError<PostcardError>>
     where
-        T: Facet<'de>,
+        T: Facet<'static>,
     {
         from_slice(input)
     }


### PR DESCRIPTION
## Summary

Fix the `facet-format-postcard` deserialization interface to match `facet-format-json` by splitting into separate owned and borrowed variants.

## Changes

- Replace single `from_slice<'de, T: Facet<'de>>` with two variants:
  - `from_slice<T: Facet<'static>>` for deserializing into owned types (recommended for most use cases)
  - `from_slice_borrowed<'input, 'facet, T: Facet<'facet>>` for zero-copy deserialization

- Remove `#[cfg(feature = "jit")]` split from public API (tier selection now happens internally in `FormatDeserializer`)

- Update module-level docs and tests

## Rationale

The old signature conflated input lifetime with facet lifetime, preventing deserialization of temporary buffers into owned values. This design now follows Rust conventions and matches `facet-format-json`.