### PR TITLE
feat: add facet-format-svg crate and fix XML skip_value bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,6 +1601,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-format-svg"
+version = "0.35.0"
+dependencies = [
+ "datatest-stable",
+ "facet",
+ "facet-assert",
+ "facet-format",
+ "facet-format-xml",
+]
+
+[[package]]
 name = "facet-format-toml"
 version = "0.35.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ members = [
     "facet-format-postcard",
     "facet-format-msgpack",
     "facet-format-xml",
+    "facet-format-svg",
     "facet-format-toml",
     "facet-format-suite",
 ]

--- a/facet-format-svg/Cargo.toml
+++ b/facet-format-svg/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "facet-format-svg"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "SVG (Scalable Vector Graphics) serialization for Facet types using facet-format-xml"
+keywords = ["svg", "serialization", "facet", "graphics", "vector"]
+categories = ["encoding", "parsing", "graphics"]
+homepage = "https://facet.rs"
+
+[package.metadata."docs.rs"]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[dependencies]
+facet = { workspace = true }
+facet-format = { path = "../facet-format", version = "0.35.0" }
+facet-format-xml = { path = "../facet-format-xml", version = "0.35.0" }
+
+[dev-dependencies]
+datatest-stable = "0.3"
+facet-assert = { path = "../facet-assert" }
+facet-format = { path = "../facet-format" }
+facet-format-xml = { path = "../facet-format-xml" }
+
+[[test]]
+name = "roundtrip"
+harness = false

--- a/facet-format-svg/README.md
+++ b/facet-format-svg/README.md
@@ -1,0 +1,125 @@
+# facet-format-svg
+
+[![codecov](https://codecov.io/gh/facet-rs/facet/graph/badge.svg)](https://codecov.io/gh/facet-rs/facet)
+[![crates.io](https://img.shields.io/crates/v/facet-format-svg.svg)](https://crates.io/crates/facet-format-svg)
+[![documentation](https://docs.rs/facet-format-svg/badge.svg)](https://docs.rs/facet-format-svg)
+[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/facet-format-svg.svg)](./LICENSE)
+[![Discord](https://img.shields.io/discord/1379550208551026748?logo=discord&label=discord)](https://discord.gg/JhD7CwCJ8F)
+
+
+Provides strongly-typed SVG parsing for Facet types using facet-format-xml.
+
+## Why facet-format-svg?
+
+SVG is ubiquitous in diagram generation—tools like **pikchr**, **Graphviz**, **Mermaid**, and countless design applications output SVG as their primary format. However, SVG parsing in Rust typically requires either:
+
+- **Generic XML libraries** that lose type information and require error-prone casting
+- **Special-purpose SVG libraries** that add heavyweight dependencies and force you into their abstractions
+- **Manual string parsing** that's fragile and doesn't scale
+
+facet-format-svg solves this by providing **strongly-typed, compile-time-safe SVG structures** derived from Facet's reflection system. You get:
+
+- **Type Safety**: The Rust compiler catches mismatches between your SVG structure and actual data
+- **Zero Dependencies**: Built on facet-format-xml, which uses only quick-xml for parsing
+- **Graceful Degradation**: Unknown elements are safely ignored, so SVGs from any tool work without modification
+- **Structured Access**: Navigate SVG geometry programmatically with full IDE support and type checking
+
+This makes facet-format-svg ideal for:
+- Processing SVG output from diagram tools in build pipelines
+- Extracting geometric data (paths, shapes, text) for analysis or transformation
+- Building Rust applications that need to consume or validate SVGs at compile time
+
+## Difference from facet-svg
+
+This crate uses `facet-format-xml` instead of `facet-xml`. The `facet-format-*` crates are the
+next-generation format infrastructure for Facet, featuring a unified parser/serializer architecture.
+
+## Supported Elements
+
+The following SVG elements are fully supported for parsing and type-safe access:
+
+- **Shapes**: `<rect>`, `<circle>`, `<ellipse>`, `<line>`, `<path>`, `<polygon>`, `<polyline>`
+- **Text**: `<text>` with styling attributes
+- **Grouping**: `<g>` with transform support, `<defs>`, `<style>`, `<symbol>`
+- **References**: `<use>` for referencing defined elements
+- **Media**: `<image>` for embedded or linked images
+- **Metadata**: `<title>`, `<desc>` for accessibility and documentation
+
+Unsupported elements (such as `<filter>`, `<marker>`, `<tspan>`, and specialized SVG filters) are gracefully ignored during parsing, allowing real-world SVG files to be processed without errors.
+
+## Basic Usage
+
+```rust
+use facet_format_svg::Svg;
+
+let svg_str = r#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+</svg>"#;
+
+let svg: Svg = facet_format_svg::from_str(svg_str)?;
+assert_eq!(svg.width, Some("100".to_string()));
+```
+
+## Features
+
+- **Type-safe parsing**: Strongly-typed SVG structures via Facet's derive macro
+- **Attribute support**: Full attribute parsing for colors, dimensions, transforms, and styling
+- **Namespace handling**: Proper SVG namespace support
+- **Graceful degradation**: Unknown elements are safely ignored
+- **Path parsing**: Complex SVG path data with multiple commands
+
+## Use Cases
+
+- Parsing SVG output from diagram tools (like pikchr, Graphviz)
+- Extracting geometric data from SVG files
+- Type-safe SVG manipulation in Rust applications
+
+## Sponsors
+
+Thanks to all individual sponsors:
+
+<p> <a href="https://github.com/sponsors/fasterthanlime">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-light.svg" height="40" alt="GitHub Sponsors">
+</picture>
+</a> <a href="https://patreon.com/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-light.svg" height="40" alt="Patreon">
+    </picture>
+</a> </p>
+
+...along with corporate sponsors:
+
+<p> <a href="https://aws.amazon.com">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-light.svg" height="40" alt="AWS">
+</picture>
+</a> <a href="https://zed.dev">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-light.svg" height="40" alt="Zed">
+</picture>
+</a> <a href="https://depot.dev?utm_source=facet">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-light.svg" height="40" alt="Depot">
+</picture>
+</a> </p>
+
+...without whom this work could not exist.
+
+## Special thanks
+
+The facet logo was drawn by [Misiasart](https://misiasart.com/).
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/facet-rs/facet/blob/main/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/facet-rs/facet/blob/main/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/facet-format-svg/README.md.in
+++ b/facet-format-svg/README.md.in
@@ -1,0 +1,66 @@
+Provides strongly-typed SVG parsing for Facet types using facet-format-xml.
+
+## Why facet-format-svg?
+
+SVG is ubiquitous in diagram generation—tools like **pikchr**, **Graphviz**, **Mermaid**, and countless design applications output SVG as their primary format. However, SVG parsing in Rust typically requires either:
+
+- **Generic XML libraries** that lose type information and require error-prone casting
+- **Special-purpose SVG libraries** that add heavyweight dependencies and force you into their abstractions
+- **Manual string parsing** that's fragile and doesn't scale
+
+facet-format-svg solves this by providing **strongly-typed, compile-time-safe SVG structures** derived from Facet's reflection system. You get:
+
+- **Type Safety**: The Rust compiler catches mismatches between your SVG structure and actual data
+- **Zero Dependencies**: Built on facet-format-xml, which uses only quick-xml for parsing
+- **Graceful Degradation**: Unknown elements are safely ignored, so SVGs from any tool work without modification
+- **Structured Access**: Navigate SVG geometry programmatically with full IDE support and type checking
+
+This makes facet-format-svg ideal for:
+- Processing SVG output from diagram tools in build pipelines
+- Extracting geometric data (paths, shapes, text) for analysis or transformation
+- Building Rust applications that need to consume or validate SVGs at compile time
+
+## Difference from facet-svg
+
+This crate uses `facet-format-xml` instead of `facet-xml`. The `facet-format-*` crates are the
+next-generation format infrastructure for Facet, featuring a unified parser/serializer architecture.
+
+## Supported Elements
+
+The following SVG elements are fully supported for parsing and type-safe access:
+
+- **Shapes**: `<rect>`, `<circle>`, `<ellipse>`, `<line>`, `<path>`, `<polygon>`, `<polyline>`
+- **Text**: `<text>` with styling attributes
+- **Grouping**: `<g>` with transform support, `<defs>`, `<style>`, `<symbol>`
+- **References**: `<use>` for referencing defined elements
+- **Media**: `<image>` for embedded or linked images
+- **Metadata**: `<title>`, `<desc>` for accessibility and documentation
+
+Unsupported elements (such as `<filter>`, `<marker>`, `<tspan>`, and specialized SVG filters) are gracefully ignored during parsing, allowing real-world SVG files to be processed without errors.
+
+## Basic Usage
+
+```rust
+use facet_format_svg::Svg;
+
+let svg_str = r#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <rect x="10" y="10" width="80" height="80" fill="blue"/>
+</svg>"#;
+
+let svg: Svg = facet_format_svg::from_str(svg_str)?;
+assert_eq!(svg.width, Some("100".to_string()));
+```
+
+## Features
+
+- **Type-safe parsing**: Strongly-typed SVG structures via Facet's derive macro
+- **Attribute support**: Full attribute parsing for colors, dimensions, transforms, and styling
+- **Namespace handling**: Proper SVG namespace support
+- **Graceful degradation**: Unknown elements are safely ignored
+- **Path parsing**: Complex SVG path data with multiple commands
+
+## Use Cases
+
+- Parsing SVG output from diagram tools (like pikchr, Graphviz)
+- Extracting geometric data from SVG files
+- Type-safe SVG manipulation in Rust applications

--- a/facet-format-svg/arborium-header.html
+++ b/facet-format-svg/arborium-header.html
@@ -1,0 +1,2 @@
+<!-- Rustdoc doesn't highlight some languages natively -- let's do it ourselves: https://github.com/bearcove/arborium -->
+<script defer src="https://cdn.jsdelivr.net/npm/@arborium/arborium@1/dist/arborium.iife.js"></script>

--- a/facet-format-svg/src/lib.rs
+++ b/facet-format-svg/src/lib.rs
@@ -1,0 +1,492 @@
+//! Facet-derived types for SVG parsing and serialization.
+//!
+//! This crate provides strongly-typed SVG elements that can be deserialized
+//! from XML using `facet-format-xml`.
+//!
+//! # Example
+//!
+//! ```rust
+//! use facet_format_svg::Svg;
+//!
+//! let svg_str = r#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+//!     <rect x="10" y="10" width="80" height="80" fill="blue"/>
+//! </svg>"#;
+//!
+//! let svg: Svg = facet_format_svg::from_str(svg_str).unwrap();
+//! ```
+
+use facet::Facet;
+use facet_format::FormatDeserializer;
+use facet_format_xml as xml;
+use facet_format_xml::{XmlParser, to_vec};
+
+mod path;
+mod points;
+
+pub use path::{PathCommand, PathData, PathDataProxy};
+pub use points::{Point, Points, PointsProxy};
+
+/// SVG namespace URI
+pub const SVG_NS: &str = "http://www.w3.org/2000/svg";
+
+/// Error type for SVG parsing
+pub type Error = facet_format::DeserializeError<facet_format_xml::XmlError>;
+
+/// Error type for SVG serialization
+pub type SerializeError = facet_format::SerializeError<facet_format_xml::XmlSerializeError>;
+
+/// Deserialize an SVG from a string.
+pub fn from_str<'input, T>(xml: &'input str) -> Result<T, Error>
+where
+    T: Facet<'input>,
+{
+    let parser = XmlParser::new(xml.as_bytes());
+    let mut de = FormatDeserializer::new(parser);
+    de.deserialize()
+}
+
+/// Serialize an SVG value to a string.
+pub fn to_string<'facet, T>(value: &T) -> Result<String, SerializeError>
+where
+    T: Facet<'facet> + ?Sized,
+{
+    let bytes = to_vec(value)?;
+    // SAFETY: XmlSerializer produces valid UTF-8
+    Ok(String::from_utf8(bytes).expect("XmlSerializer produces valid UTF-8"))
+}
+
+/// Root SVG element
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(
+    xml::ns_all = "http://www.w3.org/2000/svg",
+    rename = "svg",
+    rename_all = "camelCase",
+    skip_all_unless_truthy
+)]
+pub struct Svg {
+    // Note: xmlns is handled by ns_all, not as a separate field
+    #[facet(xml::attribute)]
+    pub width: Option<String>,
+    #[facet(xml::attribute)]
+    pub height: Option<String>,
+    #[facet(xml::attribute)]
+    pub view_box: Option<String>,
+    #[facet(xml::elements)]
+    pub children: Vec<SvgNode>,
+}
+
+/// Any SVG node we care about
+#[derive(Facet, Debug, Clone)]
+#[facet(xml::ns_all = "http://www.w3.org/2000/svg", rename_all = "lowercase")]
+#[repr(u8)]
+pub enum SvgNode {
+    G(Group),
+    Defs(Defs),
+    Style(Style),
+    Rect(Rect),
+    Circle(Circle),
+    Ellipse(Ellipse),
+    Line(Line),
+    Path(Path),
+    Polygon(Polygon),
+    Polyline(Polyline),
+    Text(Text),
+    Use(Use),
+    Image(Image),
+    Title(Title),
+    Desc(Desc),
+    Symbol(Symbol),
+}
+
+/// SVG group element (`<g>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(xml::ns_all = "http://www.w3.org/2000/svg", skip_all_unless_truthy)]
+pub struct Group {
+    #[facet(xml::attribute)]
+    pub id: Option<String>,
+    #[facet(xml::attribute)]
+    pub class: Option<String>,
+    #[facet(xml::attribute)]
+    pub transform: Option<String>,
+    #[facet(xml::elements)]
+    pub children: Vec<SvgNode>,
+}
+
+/// SVG defs element (`<defs>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(xml::ns_all = "http://www.w3.org/2000/svg")]
+pub struct Defs {
+    #[facet(xml::elements)]
+    pub children: Vec<SvgNode>,
+}
+
+/// SVG style element (`<style>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(skip_all_unless_truthy)]
+pub struct Style {
+    #[facet(xml::attribute, rename = "type")]
+    pub type_: Option<String>,
+    #[facet(xml::text)]
+    pub content: Option<String>,
+}
+
+/// SVG rect element (`<rect>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(
+    xml::ns_all = "http://www.w3.org/2000/svg",
+    rename_all = "kebab-case",
+    skip_all_unless_truthy
+)]
+pub struct Rect {
+    #[facet(xml::attribute)]
+    pub x: Option<f64>,
+    #[facet(xml::attribute)]
+    pub y: Option<f64>,
+    #[facet(xml::attribute)]
+    pub width: Option<f64>,
+    #[facet(xml::attribute)]
+    pub height: Option<f64>,
+    #[facet(xml::attribute)]
+    pub rx: Option<f64>,
+    #[facet(xml::attribute)]
+    pub ry: Option<f64>,
+    #[facet(xml::attribute)]
+    pub fill: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_width: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_dasharray: Option<String>,
+    #[facet(xml::attribute)]
+    pub style: Option<String>,
+}
+
+/// SVG circle element (`<circle>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(
+    xml::ns_all = "http://www.w3.org/2000/svg",
+    rename_all = "kebab-case",
+    skip_all_unless_truthy
+)]
+pub struct Circle {
+    #[facet(xml::attribute)]
+    pub cx: Option<f64>,
+    #[facet(xml::attribute)]
+    pub cy: Option<f64>,
+    #[facet(xml::attribute)]
+    pub r: Option<f64>,
+    #[facet(xml::attribute)]
+    pub fill: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_width: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_dasharray: Option<String>,
+    #[facet(xml::attribute)]
+    pub style: Option<String>,
+}
+
+/// SVG ellipse element (`<ellipse>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(
+    xml::ns_all = "http://www.w3.org/2000/svg",
+    rename_all = "kebab-case",
+    skip_all_unless_truthy
+)]
+pub struct Ellipse {
+    #[facet(xml::attribute)]
+    pub cx: Option<f64>,
+    #[facet(xml::attribute)]
+    pub cy: Option<f64>,
+    #[facet(xml::attribute)]
+    pub rx: Option<f64>,
+    #[facet(xml::attribute)]
+    pub ry: Option<f64>,
+    #[facet(xml::attribute)]
+    pub fill: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_width: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_dasharray: Option<String>,
+    #[facet(xml::attribute)]
+    pub style: Option<String>,
+}
+
+/// SVG line element (`<line>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(
+    xml::ns_all = "http://www.w3.org/2000/svg",
+    rename_all = "kebab-case",
+    skip_all_unless_truthy
+)]
+pub struct Line {
+    #[facet(xml::attribute)]
+    pub x1: Option<f64>,
+    #[facet(xml::attribute)]
+    pub y1: Option<f64>,
+    #[facet(xml::attribute)]
+    pub x2: Option<f64>,
+    #[facet(xml::attribute)]
+    pub y2: Option<f64>,
+    #[facet(xml::attribute)]
+    pub fill: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_width: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_dasharray: Option<String>,
+    #[facet(xml::attribute)]
+    pub style: Option<String>,
+}
+
+/// SVG path element (`<path>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(
+    xml::ns_all = "http://www.w3.org/2000/svg",
+    rename_all = "kebab-case",
+    skip_all_unless_truthy
+)]
+pub struct Path {
+    #[facet(xml::attribute, proxy = PathDataProxy)]
+    pub d: Option<PathData>,
+    #[facet(xml::attribute)]
+    pub fill: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_width: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_dasharray: Option<String>,
+    #[facet(xml::attribute)]
+    pub style: Option<String>,
+}
+
+/// SVG polygon element (`<polygon>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(
+    xml::ns_all = "http://www.w3.org/2000/svg",
+    rename_all = "kebab-case",
+    skip_all_unless_truthy
+)]
+pub struct Polygon {
+    #[facet(xml::attribute, proxy = PointsProxy)]
+    pub points: Points,
+    #[facet(xml::attribute)]
+    pub fill: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_width: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_dasharray: Option<String>,
+    #[facet(xml::attribute)]
+    pub style: Option<String>,
+}
+
+/// SVG polyline element (`<polyline>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(
+    xml::ns_all = "http://www.w3.org/2000/svg",
+    rename_all = "kebab-case",
+    skip_all_unless_truthy
+)]
+pub struct Polyline {
+    #[facet(xml::attribute, proxy = PointsProxy)]
+    pub points: Points,
+    #[facet(xml::attribute)]
+    pub fill: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_width: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_dasharray: Option<String>,
+    #[facet(xml::attribute)]
+    pub style: Option<String>,
+}
+
+/// SVG text element (`<text>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(
+    xml::ns_all = "http://www.w3.org/2000/svg",
+    rename_all = "kebab-case",
+    skip_all_unless_truthy
+)]
+pub struct Text {
+    #[facet(xml::attribute)]
+    pub x: Option<f64>,
+    #[facet(xml::attribute)]
+    pub y: Option<f64>,
+    #[facet(xml::attribute)]
+    pub transform: Option<String>,
+    #[facet(xml::attribute)]
+    pub fill: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke: Option<String>,
+    #[facet(xml::attribute)]
+    pub stroke_width: Option<String>,
+    #[facet(xml::attribute)]
+    pub style: Option<String>,
+    #[facet(xml::attribute)]
+    pub font_family: Option<String>,
+    #[facet(xml::attribute)]
+    pub font_style: Option<String>,
+    #[facet(xml::attribute)]
+    pub font_weight: Option<String>,
+    #[facet(xml::attribute)]
+    pub font_size: Option<String>,
+    #[facet(xml::attribute)]
+    pub text_anchor: Option<String>,
+    #[facet(xml::attribute)]
+    pub dominant_baseline: Option<String>,
+    #[facet(xml::text)]
+    pub content: Option<String>,
+}
+
+/// SVG use element (`<use>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(xml::ns_all = "http://www.w3.org/2000/svg", skip_all_unless_truthy)]
+pub struct Use {
+    #[facet(xml::attribute)]
+    pub x: Option<f64>,
+    #[facet(xml::attribute)]
+    pub y: Option<f64>,
+    #[facet(xml::attribute)]
+    pub width: Option<f64>,
+    #[facet(xml::attribute)]
+    pub height: Option<f64>,
+    #[facet(xml::attribute, rename = "xlink:href")]
+    pub href: Option<String>,
+}
+
+/// SVG image element (`<image>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(xml::ns_all = "http://www.w3.org/2000/svg", skip_all_unless_truthy)]
+pub struct Image {
+    #[facet(xml::attribute)]
+    pub x: Option<f64>,
+    #[facet(xml::attribute)]
+    pub y: Option<f64>,
+    #[facet(xml::attribute)]
+    pub width: Option<f64>,
+    #[facet(xml::attribute)]
+    pub height: Option<f64>,
+    #[facet(xml::attribute)]
+    pub href: Option<String>,
+    #[facet(xml::attribute)]
+    pub style: Option<String>,
+}
+
+/// SVG title element (`<title>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(xml::ns_all = "http://www.w3.org/2000/svg")]
+pub struct Title {
+    #[facet(xml::text)]
+    pub content: Option<String>,
+}
+
+/// SVG description element (`<desc>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(xml::ns_all = "http://www.w3.org/2000/svg")]
+pub struct Desc {
+    #[facet(xml::text)]
+    pub content: Option<String>,
+}
+
+/// SVG symbol element (`<symbol>`)
+#[derive(Facet, Debug, Clone, Default)]
+#[facet(
+    xml::ns_all = "http://www.w3.org/2000/svg",
+    rename_all = "camelCase",
+    skip_all_unless_truthy
+)]
+pub struct Symbol {
+    #[facet(xml::attribute)]
+    pub id: Option<String>,
+    #[facet(xml::attribute)]
+    pub view_box: Option<String>,
+    #[facet(xml::attribute)]
+    pub width: Option<String>,
+    #[facet(xml::attribute)]
+    pub height: Option<String>,
+    #[facet(xml::elements)]
+    pub children: Vec<SvgNode>,
+}
+
+// Re-export XML utilities for convenience
+pub use facet_format_xml;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_attributes_are_parsed() {
+        let xml = r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <path d="M10,10L50,50" stroke="black"/>
+        </svg>"#;
+
+        let svg: Svg = from_str(xml).unwrap();
+
+        println!("Parsed SVG: {:?}", svg);
+
+        // These should NOT be None!
+        assert!(svg.view_box.is_some(), "viewBox should be parsed");
+
+        if let Some(SvgNode::Path(path)) = svg.children.first() {
+            println!("Parsed Path: {:?}", path);
+            assert!(path.d.is_some(), "path d attribute should be parsed");
+            assert!(
+                path.stroke.is_some(),
+                "path stroke attribute should be parsed"
+            );
+        } else {
+            panic!("Expected a Path element");
+        }
+    }
+
+    #[test]
+    fn test_svg_float_tolerance() {
+        use facet_assert::{SameOptions, SameReport, check_same_with_report};
+
+        // Simulate C vs Rust precision - C has 3 decimals, Rust has 10
+        // (Without style difference to isolate float tolerance test)
+        let c_svg = r#"<svg xmlns="http://www.w3.org/2000/svg">
+            <path d="M118.239,208.239L226.239,208.239Z"/>
+        </svg>"#;
+
+        let rust_svg = r#"<svg xmlns="http://www.w3.org/2000/svg">
+            <path d="M118.2387401575,208.2387401575L226.2387401575,208.2387401575Z"/>
+        </svg>"#;
+
+        let c: Svg = from_str(c_svg).unwrap();
+        let rust: Svg = from_str(rust_svg).unwrap();
+
+        eprintln!("C SVG: {:?}", c);
+        eprintln!("Rust SVG: {:?}", rust);
+
+        let tolerance = 0.002;
+        let options = SameOptions::new().float_tolerance(tolerance);
+
+        let result = check_same_with_report(&c, &rust, options);
+
+        match &result {
+            SameReport::Same => eprintln!("Result: Same"),
+            SameReport::Different(report) => {
+                eprintln!("Result: Different");
+                eprintln!("XML diff:\n{}", report.render_ansi_xml());
+            }
+            SameReport::Opaque { type_name } => eprintln!("Result: Opaque({})", type_name),
+        }
+
+        assert!(
+            matches!(result, SameReport::Same),
+            "SVG values within float tolerance should be considered Same"
+        );
+    }
+}

--- a/facet-format-svg/src/path.rs
+++ b/facet-format-svg/src/path.rs
@@ -1,0 +1,866 @@
+//! SVG path data parsing and structured representation.
+
+use facet::Facet;
+
+/// A single SVG path command
+#[derive(Debug, Clone, PartialEq, Facet)]
+#[repr(u8)]
+pub enum PathCommand {
+    /// Move to (absolute)
+    MoveTo { x: f64, y: f64 },
+    /// Move to (relative)
+    MoveToRel { dx: f64, dy: f64 },
+    /// Line to (absolute)
+    LineTo { x: f64, y: f64 },
+    /// Line to (relative)
+    LineToRel { dx: f64, dy: f64 },
+    /// Horizontal line to (absolute)
+    HorizontalLineTo { x: f64 },
+    /// Horizontal line to (relative)
+    HorizontalLineToRel { dx: f64 },
+    /// Vertical line to (absolute)
+    VerticalLineTo { y: f64 },
+    /// Vertical line to (relative)
+    VerticalLineToRel { dy: f64 },
+    /// Cubic Bezier curve (absolute)
+    CurveTo {
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        x: f64,
+        y: f64,
+    },
+    /// Cubic Bezier curve (relative)
+    CurveToRel {
+        dx1: f64,
+        dy1: f64,
+        dx2: f64,
+        dy2: f64,
+        dx: f64,
+        dy: f64,
+    },
+    /// Smooth cubic Bezier curve (absolute)
+    SmoothCurveTo { x2: f64, y2: f64, x: f64, y: f64 },
+    /// Smooth cubic Bezier curve (relative)
+    SmoothCurveToRel {
+        dx2: f64,
+        dy2: f64,
+        dx: f64,
+        dy: f64,
+    },
+    /// Quadratic Bezier curve (absolute)
+    QuadTo { x1: f64, y1: f64, x: f64, y: f64 },
+    /// Quadratic Bezier curve (relative)
+    QuadToRel {
+        dx1: f64,
+        dy1: f64,
+        dx: f64,
+        dy: f64,
+    },
+    /// Smooth quadratic Bezier curve (absolute)
+    SmoothQuadTo { x: f64, y: f64 },
+    /// Smooth quadratic Bezier curve (relative)
+    SmoothQuadToRel { dx: f64, dy: f64 },
+    /// Arc (absolute)
+    Arc {
+        rx: f64,
+        ry: f64,
+        x_rotation: f64,
+        large_arc: bool,
+        sweep: bool,
+        x: f64,
+        y: f64,
+    },
+    /// Arc (relative)
+    ArcRel {
+        rx: f64,
+        ry: f64,
+        x_rotation: f64,
+        large_arc: bool,
+        sweep: bool,
+        dx: f64,
+        dy: f64,
+    },
+    /// Close path
+    ClosePath,
+}
+
+/// Structured SVG path data
+#[derive(Debug, Clone, PartialEq, Default, Facet)]
+#[facet(traits(Default, Display))]
+pub struct PathData {
+    pub commands: Vec<PathCommand>,
+}
+
+impl PathData {
+    pub fn new() -> Self {
+        Self {
+            commands: Vec::new(),
+        }
+    }
+
+    /// Move to absolute position (M command)
+    pub fn m(mut self, x: f64, y: f64) -> Self {
+        self.commands.push(PathCommand::MoveTo { x, y });
+        self
+    }
+
+    /// Move to relative position (m command)
+    pub fn m_rel(mut self, dx: f64, dy: f64) -> Self {
+        self.commands.push(PathCommand::MoveToRel { dx, dy });
+        self
+    }
+
+    /// Line to absolute position (L command)
+    pub fn l(mut self, x: f64, y: f64) -> Self {
+        self.commands.push(PathCommand::LineTo { x, y });
+        self
+    }
+
+    /// Line to relative position (l command)
+    pub fn l_rel(mut self, dx: f64, dy: f64) -> Self {
+        self.commands.push(PathCommand::LineToRel { dx, dy });
+        self
+    }
+
+    /// Horizontal line to absolute x position (H command)
+    pub fn h(mut self, x: f64) -> Self {
+        self.commands.push(PathCommand::HorizontalLineTo { x });
+        self
+    }
+
+    /// Horizontal line to relative x position (h command)
+    pub fn h_rel(mut self, dx: f64) -> Self {
+        self.commands.push(PathCommand::HorizontalLineToRel { dx });
+        self
+    }
+
+    /// Vertical line to absolute y position (V command)
+    pub fn v(mut self, y: f64) -> Self {
+        self.commands.push(PathCommand::VerticalLineTo { y });
+        self
+    }
+
+    /// Vertical line to relative y position (v command)
+    pub fn v_rel(mut self, dy: f64) -> Self {
+        self.commands.push(PathCommand::VerticalLineToRel { dy });
+        self
+    }
+
+    /// Cubic Bezier curve to absolute position (C command)
+    pub fn c(mut self, x1: f64, y1: f64, x2: f64, y2: f64, x: f64, y: f64) -> Self {
+        self.commands.push(PathCommand::CurveTo {
+            x1,
+            y1,
+            x2,
+            y2,
+            x,
+            y,
+        });
+        self
+    }
+
+    /// Cubic Bezier curve to relative position (c command)
+    pub fn c_rel(mut self, dx1: f64, dy1: f64, dx2: f64, dy2: f64, dx: f64, dy: f64) -> Self {
+        self.commands.push(PathCommand::CurveToRel {
+            dx1,
+            dy1,
+            dx2,
+            dy2,
+            dx,
+            dy,
+        });
+        self
+    }
+
+    /// Smooth cubic Bezier curve to absolute position (S command)
+    pub fn s(mut self, x2: f64, y2: f64, x: f64, y: f64) -> Self {
+        self.commands
+            .push(PathCommand::SmoothCurveTo { x2, y2, x, y });
+        self
+    }
+
+    /// Smooth cubic Bezier curve to relative position (s command)
+    pub fn s_rel(mut self, dx2: f64, dy2: f64, dx: f64, dy: f64) -> Self {
+        self.commands
+            .push(PathCommand::SmoothCurveToRel { dx2, dy2, dx, dy });
+        self
+    }
+
+    /// Quadratic Bezier curve to absolute position (Q command)
+    pub fn q(mut self, x1: f64, y1: f64, x: f64, y: f64) -> Self {
+        self.commands.push(PathCommand::QuadTo { x1, y1, x, y });
+        self
+    }
+
+    /// Quadratic Bezier curve to relative position (q command)
+    pub fn q_rel(mut self, dx1: f64, dy1: f64, dx: f64, dy: f64) -> Self {
+        self.commands
+            .push(PathCommand::QuadToRel { dx1, dy1, dx, dy });
+        self
+    }
+
+    /// Smooth quadratic Bezier curve to absolute position (T command)
+    pub fn t(mut self, x: f64, y: f64) -> Self {
+        self.commands.push(PathCommand::SmoothQuadTo { x, y });
+        self
+    }
+
+    /// Smooth quadratic Bezier curve to relative position (t command)
+    pub fn t_rel(mut self, dx: f64, dy: f64) -> Self {
+        self.commands.push(PathCommand::SmoothQuadToRel { dx, dy });
+        self
+    }
+
+    /// Arc to absolute position (A command)
+    #[allow(clippy::too_many_arguments)]
+    pub fn a(
+        mut self,
+        rx: f64,
+        ry: f64,
+        x_rotation: f64,
+        large_arc: bool,
+        sweep: bool,
+        x: f64,
+        y: f64,
+    ) -> Self {
+        self.commands.push(PathCommand::Arc {
+            rx,
+            ry,
+            x_rotation,
+            large_arc,
+            sweep,
+            x,
+            y,
+        });
+        self
+    }
+
+    /// Arc to relative position (a command)
+    #[allow(clippy::too_many_arguments)]
+    pub fn a_rel(
+        mut self,
+        rx: f64,
+        ry: f64,
+        x_rotation: f64,
+        large_arc: bool,
+        sweep: bool,
+        dx: f64,
+        dy: f64,
+    ) -> Self {
+        self.commands.push(PathCommand::ArcRel {
+            rx,
+            ry,
+            x_rotation,
+            large_arc,
+            sweep,
+            dx,
+            dy,
+        });
+        self
+    }
+
+    /// Close path (Z command)
+    pub fn z(mut self) -> Self {
+        self.commands.push(PathCommand::ClosePath);
+        self
+    }
+
+    /// Parse path data from a string
+    pub fn parse(s: &str) -> Result<Self, PathParseError> {
+        let mut commands = Vec::new();
+        let mut chars = s.chars().peekable();
+
+        while let Some(&c) = chars.peek() {
+            // Skip whitespace and commas
+            if c.is_whitespace() || c == ',' {
+                chars.next();
+                continue;
+            }
+
+            // Parse command
+            let cmd = chars.next().unwrap();
+            match cmd {
+                'M' => {
+                    let (x, y) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::MoveTo { x, y });
+                    // Subsequent coordinate pairs are implicit LineTo
+                    while let Some((x, y)) = try_parse_coord_pair(&mut chars) {
+                        commands.push(PathCommand::LineTo { x, y });
+                    }
+                }
+                'm' => {
+                    let (dx, dy) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::MoveToRel { dx, dy });
+                    while let Some((dx, dy)) = try_parse_coord_pair(&mut chars) {
+                        commands.push(PathCommand::LineToRel { dx, dy });
+                    }
+                }
+                'L' => {
+                    let (x, y) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::LineTo { x, y });
+                    while let Some((x, y)) = try_parse_coord_pair(&mut chars) {
+                        commands.push(PathCommand::LineTo { x, y });
+                    }
+                }
+                'l' => {
+                    let (dx, dy) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::LineToRel { dx, dy });
+                    while let Some((dx, dy)) = try_parse_coord_pair(&mut chars) {
+                        commands.push(PathCommand::LineToRel { dx, dy });
+                    }
+                }
+                'H' => {
+                    let x = parse_number(&mut chars)?;
+                    commands.push(PathCommand::HorizontalLineTo { x });
+                    while let Some(x) = try_parse_number(&mut chars) {
+                        commands.push(PathCommand::HorizontalLineTo { x });
+                    }
+                }
+                'h' => {
+                    let dx = parse_number(&mut chars)?;
+                    commands.push(PathCommand::HorizontalLineToRel { dx });
+                    while let Some(dx) = try_parse_number(&mut chars) {
+                        commands.push(PathCommand::HorizontalLineToRel { dx });
+                    }
+                }
+                'V' => {
+                    let y = parse_number(&mut chars)?;
+                    commands.push(PathCommand::VerticalLineTo { y });
+                    while let Some(y) = try_parse_number(&mut chars) {
+                        commands.push(PathCommand::VerticalLineTo { y });
+                    }
+                }
+                'v' => {
+                    let dy = parse_number(&mut chars)?;
+                    commands.push(PathCommand::VerticalLineToRel { dy });
+                    while let Some(dy) = try_parse_number(&mut chars) {
+                        commands.push(PathCommand::VerticalLineToRel { dy });
+                    }
+                }
+                'C' => {
+                    let (x1, y1) = parse_coord_pair(&mut chars)?;
+                    let (x2, y2) = parse_coord_pair(&mut chars)?;
+                    let (x, y) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::CurveTo {
+                        x1,
+                        y1,
+                        x2,
+                        y2,
+                        x,
+                        y,
+                    });
+                }
+                'c' => {
+                    let (dx1, dy1) = parse_coord_pair(&mut chars)?;
+                    let (dx2, dy2) = parse_coord_pair(&mut chars)?;
+                    let (dx, dy) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::CurveToRel {
+                        dx1,
+                        dy1,
+                        dx2,
+                        dy2,
+                        dx,
+                        dy,
+                    });
+                }
+                'S' => {
+                    let (x2, y2) = parse_coord_pair(&mut chars)?;
+                    let (x, y) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::SmoothCurveTo { x2, y2, x, y });
+                }
+                's' => {
+                    let (dx2, dy2) = parse_coord_pair(&mut chars)?;
+                    let (dx, dy) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::SmoothCurveToRel { dx2, dy2, dx, dy });
+                }
+                'Q' => {
+                    let (x1, y1) = parse_coord_pair(&mut chars)?;
+                    let (x, y) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::QuadTo { x1, y1, x, y });
+                }
+                'q' => {
+                    let (dx1, dy1) = parse_coord_pair(&mut chars)?;
+                    let (dx, dy) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::QuadToRel { dx1, dy1, dx, dy });
+                }
+                'T' => {
+                    let (x, y) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::SmoothQuadTo { x, y });
+                }
+                't' => {
+                    let (dx, dy) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::SmoothQuadToRel { dx, dy });
+                }
+                'A' => {
+                    let rx = parse_number(&mut chars)?;
+                    let ry = parse_number(&mut chars)?;
+                    let x_rotation = parse_number(&mut chars)?;
+                    let large_arc = parse_flag(&mut chars)?;
+                    let sweep = parse_flag(&mut chars)?;
+                    let (x, y) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::Arc {
+                        rx,
+                        ry,
+                        x_rotation,
+                        large_arc,
+                        sweep,
+                        x,
+                        y,
+                    });
+                }
+                'a' => {
+                    let rx = parse_number(&mut chars)?;
+                    let ry = parse_number(&mut chars)?;
+                    let x_rotation = parse_number(&mut chars)?;
+                    let large_arc = parse_flag(&mut chars)?;
+                    let sweep = parse_flag(&mut chars)?;
+                    let (dx, dy) = parse_coord_pair(&mut chars)?;
+                    commands.push(PathCommand::ArcRel {
+                        rx,
+                        ry,
+                        x_rotation,
+                        large_arc,
+                        sweep,
+                        dx,
+                        dy,
+                    });
+                }
+                'Z' | 'z' => {
+                    commands.push(PathCommand::ClosePath);
+                }
+                _ => {
+                    return Err(PathParseError::UnknownCommand(cmd));
+                }
+            }
+        }
+
+        Ok(PathData { commands })
+    }
+
+    /// Serialize path data to a string
+    fn serialize(&self) -> String {
+        let mut result = String::new();
+        for cmd in &self.commands {
+            if !result.is_empty() {
+                // No separator needed - commands are self-delimiting
+            }
+            match cmd {
+                PathCommand::MoveTo { x, y } => {
+                    result.push_str(&format!("M{},{}", fmt_num(*x), fmt_num(*y)));
+                }
+                PathCommand::MoveToRel { dx, dy } => {
+                    result.push_str(&format!("m{},{}", fmt_num(*dx), fmt_num(*dy)));
+                }
+                PathCommand::LineTo { x, y } => {
+                    result.push_str(&format!("L{},{}", fmt_num(*x), fmt_num(*y)));
+                }
+                PathCommand::LineToRel { dx, dy } => {
+                    result.push_str(&format!("l{},{}", fmt_num(*dx), fmt_num(*dy)));
+                }
+                PathCommand::HorizontalLineTo { x } => {
+                    result.push_str(&format!("H{}", fmt_num(*x)));
+                }
+                PathCommand::HorizontalLineToRel { dx } => {
+                    result.push_str(&format!("h{}", fmt_num(*dx)));
+                }
+                PathCommand::VerticalLineTo { y } => {
+                    result.push_str(&format!("V{}", fmt_num(*y)));
+                }
+                PathCommand::VerticalLineToRel { dy } => {
+                    result.push_str(&format!("v{}", fmt_num(*dy)));
+                }
+                PathCommand::CurveTo {
+                    x1,
+                    y1,
+                    x2,
+                    y2,
+                    x,
+                    y,
+                } => {
+                    result.push_str(&format!(
+                        "C{},{} {},{} {},{}",
+                        fmt_num(*x1),
+                        fmt_num(*y1),
+                        fmt_num(*x2),
+                        fmt_num(*y2),
+                        fmt_num(*x),
+                        fmt_num(*y)
+                    ));
+                }
+                PathCommand::CurveToRel {
+                    dx1,
+                    dy1,
+                    dx2,
+                    dy2,
+                    dx,
+                    dy,
+                } => {
+                    result.push_str(&format!(
+                        "c{},{} {},{} {},{}",
+                        fmt_num(*dx1),
+                        fmt_num(*dy1),
+                        fmt_num(*dx2),
+                        fmt_num(*dy2),
+                        fmt_num(*dx),
+                        fmt_num(*dy)
+                    ));
+                }
+                PathCommand::SmoothCurveTo { x2, y2, x, y } => {
+                    result.push_str(&format!(
+                        "S{},{} {},{}",
+                        fmt_num(*x2),
+                        fmt_num(*y2),
+                        fmt_num(*x),
+                        fmt_num(*y)
+                    ));
+                }
+                PathCommand::SmoothCurveToRel { dx2, dy2, dx, dy } => {
+                    result.push_str(&format!(
+                        "s{},{} {},{}",
+                        fmt_num(*dx2),
+                        fmt_num(*dy2),
+                        fmt_num(*dx),
+                        fmt_num(*dy)
+                    ));
+                }
+                PathCommand::QuadTo { x1, y1, x, y } => {
+                    result.push_str(&format!(
+                        "Q{},{} {},{}",
+                        fmt_num(*x1),
+                        fmt_num(*y1),
+                        fmt_num(*x),
+                        fmt_num(*y)
+                    ));
+                }
+                PathCommand::QuadToRel { dx1, dy1, dx, dy } => {
+                    result.push_str(&format!(
+                        "q{},{} {},{}",
+                        fmt_num(*dx1),
+                        fmt_num(*dy1),
+                        fmt_num(*dx),
+                        fmt_num(*dy)
+                    ));
+                }
+                PathCommand::SmoothQuadTo { x, y } => {
+                    result.push_str(&format!("T{},{}", fmt_num(*x), fmt_num(*y)));
+                }
+                PathCommand::SmoothQuadToRel { dx, dy } => {
+                    result.push_str(&format!("t{},{}", fmt_num(*dx), fmt_num(*dy)));
+                }
+                PathCommand::Arc {
+                    rx,
+                    ry,
+                    x_rotation,
+                    large_arc,
+                    sweep,
+                    x,
+                    y,
+                } => {
+                    result.push_str(&format!(
+                        "A{},{} {} {} {} {},{}",
+                        fmt_num(*rx),
+                        fmt_num(*ry),
+                        fmt_num(*x_rotation),
+                        if *large_arc { 1 } else { 0 },
+                        if *sweep { 1 } else { 0 },
+                        fmt_num(*x),
+                        fmt_num(*y)
+                    ));
+                }
+                PathCommand::ArcRel {
+                    rx,
+                    ry,
+                    x_rotation,
+                    large_arc,
+                    sweep,
+                    dx,
+                    dy,
+                } => {
+                    result.push_str(&format!(
+                        "a{},{} {} {} {} {},{}",
+                        fmt_num(*rx),
+                        fmt_num(*ry),
+                        fmt_num(*x_rotation),
+                        if *large_arc { 1 } else { 0 },
+                        if *sweep { 1 } else { 0 },
+                        fmt_num(*dx),
+                        fmt_num(*dy)
+                    ));
+                }
+                PathCommand::ClosePath => {
+                    result.push('Z');
+                }
+            }
+        }
+        result
+    }
+}
+
+/// Format a number with up to 3 decimal places (sufficient for SVG coordinates).
+/// Trims trailing zeros and decimal point.
+fn fmt_num(v: f64) -> String {
+    let s = format!("{:.3}", v);
+    let s = s.trim_end_matches('0');
+    let s = s.trim_end_matches('.');
+    s.to_string()
+}
+
+/// Error parsing path data
+#[derive(Debug, Clone, PartialEq)]
+pub enum PathParseError {
+    UnknownCommand(char),
+    ExpectedNumber,
+    ExpectedFlag,
+    InvalidNumber(String),
+}
+
+impl std::fmt::Display for PathParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PathParseError::UnknownCommand(c) => write!(f, "unknown path command: {}", c),
+            PathParseError::ExpectedNumber => write!(f, "expected number"),
+            PathParseError::ExpectedFlag => write!(f, "expected flag (0 or 1)"),
+            PathParseError::InvalidNumber(s) => write!(f, "invalid number: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for PathParseError {}
+
+impl std::fmt::Display for PathData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.serialize())
+    }
+}
+
+/// Proxy type for PathData - serializes as a string
+#[derive(Facet, Clone, Debug)]
+#[facet(transparent)]
+pub struct PathDataProxy(pub String);
+
+impl TryFrom<PathDataProxy> for PathData {
+    type Error = PathParseError;
+    fn try_from(proxy: PathDataProxy) -> Result<Self, Self::Error> {
+        PathData::parse(&proxy.0)
+    }
+}
+
+#[allow(clippy::infallible_try_from)]
+impl TryFrom<&PathData> for PathDataProxy {
+    type Error = std::convert::Infallible;
+    fn try_from(v: &PathData) -> Result<Self, Self::Error> {
+        Ok(PathDataProxy(v.to_string()))
+    }
+}
+
+// Option impls for facet proxy support
+impl From<PathDataProxy> for Option<PathData> {
+    fn from(proxy: PathDataProxy) -> Self {
+        PathData::parse(&proxy.0).ok()
+    }
+}
+
+#[allow(clippy::infallible_try_from)]
+impl TryFrom<&Option<PathData>> for PathDataProxy {
+    type Error = std::convert::Infallible;
+    fn try_from(v: &Option<PathData>) -> Result<Self, Self::Error> {
+        match v {
+            Some(data) => Ok(PathDataProxy(data.to_string())),
+            None => Ok(PathDataProxy(String::new())),
+        }
+    }
+}
+
+// Helper parsing functions
+
+fn skip_wsp_comma(chars: &mut std::iter::Peekable<std::str::Chars>) {
+    while let Some(&c) = chars.peek() {
+        if c.is_whitespace() || c == ',' {
+            chars.next();
+        } else {
+            break;
+        }
+    }
+}
+
+fn parse_number(chars: &mut std::iter::Peekable<std::str::Chars>) -> Result<f64, PathParseError> {
+    skip_wsp_comma(chars);
+    let mut num_str = String::new();
+
+    // Handle optional sign
+    if let Some(&c) = chars.peek()
+        && (c == '-' || c == '+')
+    {
+        num_str.push(chars.next().unwrap());
+    }
+
+    // Parse digits and decimal point
+    let mut has_digits = false;
+    while let Some(&c) = chars.peek() {
+        if c.is_ascii_digit() || c == '.' {
+            num_str.push(chars.next().unwrap());
+            has_digits = true;
+        } else if c == 'e' || c == 'E' {
+            // Scientific notation
+            num_str.push(chars.next().unwrap());
+            if let Some(&sign) = chars.peek()
+                && (sign == '-' || sign == '+')
+            {
+                num_str.push(chars.next().unwrap());
+            }
+            while let Some(&d) = chars.peek() {
+                if d.is_ascii_digit() {
+                    num_str.push(chars.next().unwrap());
+                } else {
+                    break;
+                }
+            }
+            break;
+        } else {
+            break;
+        }
+    }
+
+    if !has_digits {
+        return Err(PathParseError::ExpectedNumber);
+    }
+
+    num_str
+        .parse()
+        .map_err(|_| PathParseError::InvalidNumber(num_str))
+}
+
+fn try_parse_number(chars: &mut std::iter::Peekable<std::str::Chars>) -> Option<f64> {
+    skip_wsp_comma(chars);
+    if let Some(&c) = chars.peek()
+        && (c.is_ascii_digit() || c == '-' || c == '+' || c == '.')
+    {
+        return parse_number(chars).ok();
+    }
+    None
+}
+
+fn parse_coord_pair(
+    chars: &mut std::iter::Peekable<std::str::Chars>,
+) -> Result<(f64, f64), PathParseError> {
+    let x = parse_number(chars)?;
+    let y = parse_number(chars)?;
+    Ok((x, y))
+}
+
+fn try_parse_coord_pair(chars: &mut std::iter::Peekable<std::str::Chars>) -> Option<(f64, f64)> {
+    skip_wsp_comma(chars);
+    if let Some(&c) = chars.peek()
+        && (c.is_ascii_digit() || c == '-' || c == '+' || c == '.')
+        && let Ok(pair) = parse_coord_pair(chars)
+    {
+        return Some(pair);
+    }
+    None
+}
+
+fn parse_flag(chars: &mut std::iter::Peekable<std::str::Chars>) -> Result<bool, PathParseError> {
+    skip_wsp_comma(chars);
+    match chars.next() {
+        Some('0') => Ok(false),
+        Some('1') => Ok(true),
+        _ => Err(PathParseError::ExpectedFlag),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_path() {
+        let path = PathData::parse("M10,20L30,40Z").unwrap();
+        assert_eq!(path.commands.len(), 3);
+        assert_eq!(path.commands[0], PathCommand::MoveTo { x: 10.0, y: 20.0 });
+        assert_eq!(path.commands[1], PathCommand::LineTo { x: 30.0, y: 40.0 });
+        assert_eq!(path.commands[2], PathCommand::ClosePath);
+    }
+
+    #[test]
+    fn test_parse_box_path() {
+        // C pikchr box format
+        let path =
+            PathData::parse("M118.239,208.239L226.239,208.239L226.239,136.239L118.239,136.239Z")
+                .unwrap();
+        assert_eq!(path.commands.len(), 5);
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let original = "M10,20L30,40Z";
+        let path = PathData::parse(original).unwrap();
+        let serialized = path.to_string();
+        let reparsed = PathData::parse(&serialized).unwrap();
+        assert_eq!(path.commands, reparsed.commands);
+    }
+
+    #[test]
+    fn test_arc() {
+        let path = PathData::parse("A10,10 0 0,1 20,20").unwrap();
+        assert_eq!(path.commands.len(), 1);
+        match &path.commands[0] {
+            PathCommand::Arc {
+                rx,
+                ry,
+                x_rotation,
+                large_arc,
+                sweep,
+                x,
+                y,
+            } => {
+                assert_eq!(*rx, 10.0);
+                assert_eq!(*ry, 10.0);
+                assert_eq!(*x_rotation, 0.0);
+                assert!(!*large_arc);
+                assert!(*sweep);
+                assert_eq!(*x, 20.0);
+                assert_eq!(*y, 20.0);
+            }
+            _ => panic!("expected Arc command"),
+        }
+    }
+
+    #[test]
+    fn test_float_tolerance_in_diff() {
+        use facet_assert::{SameOptions, SameReport, check_same_with_report};
+
+        // Simulate C vs Rust precision difference
+        // C: "118.239" parses to this f64
+        // Rust: "118.2387401575" parses to this f64
+        let c_path = PathData::parse("M118.239,208.239L226.239,208.239Z").unwrap();
+        let rust_path =
+            PathData::parse("M118.2387401575,208.2387401575L226.2387401575,208.2387401575Z")
+                .unwrap();
+
+        // The difference is about 0.0003, well under 0.002 tolerance
+        let tolerance = 0.002;
+        let options = SameOptions::new().float_tolerance(tolerance);
+
+        eprintln!("C path: {:?}", c_path);
+        eprintln!("Rust path: {:?}", rust_path);
+
+        // Check if they're the same within tolerance
+        let result = check_same_with_report(&c_path, &rust_path, options);
+
+        match &result {
+            SameReport::Same => eprintln!("Result: Same"),
+            SameReport::Different(report) => {
+                eprintln!("Result: Different");
+                eprintln!("XML diff:\n{}", report.render_ansi_xml());
+            }
+            SameReport::Opaque { type_name } => eprintln!("Result: Opaque({})", type_name),
+        }
+
+        assert!(
+            matches!(result, SameReport::Same),
+            "PathData values within float tolerance should be considered Same"
+        );
+    }
+}

--- a/facet-format-svg/src/points.rs
+++ b/facet-format-svg/src/points.rs
@@ -1,0 +1,246 @@
+//! SVG points attribute parsing and structured representation.
+//!
+//! Used for polygon and polyline elements.
+
+use facet::Facet;
+
+/// A single point in SVG coordinates
+#[derive(Debug, Clone, PartialEq, Facet)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+/// Structured SVG points list (for polygon/polyline)
+#[derive(Debug, Clone, PartialEq, Default, Facet)]
+#[facet(traits(Default, Display))]
+pub struct Points {
+    pub points: Vec<Point>,
+}
+
+impl Points {
+    pub fn new() -> Self {
+        Self { points: Vec::new() }
+    }
+
+    /// Add a point
+    pub fn push(mut self, x: f64, y: f64) -> Self {
+        self.points.push(Point { x, y });
+        self
+    }
+
+    /// Parse points from an SVG points attribute string
+    pub fn parse(s: &str) -> Result<Self, PointsParseError> {
+        let mut points = Vec::new();
+        let s = s.trim();
+        if s.is_empty() {
+            return Ok(Points { points });
+        }
+
+        // Points are space or comma separated pairs like "x1,y1 x2,y2 x3,y3"
+        // or "x1 y1 x2 y2 x3 y3" (all whitespace/comma separated)
+        let mut chars = s.chars().peekable();
+
+        loop {
+            skip_wsp_comma(&mut chars);
+            if chars.peek().is_none() {
+                break;
+            }
+
+            let x = parse_number(&mut chars)?;
+            skip_wsp_comma(&mut chars);
+            let y = parse_number(&mut chars)?;
+            points.push(Point { x, y });
+        }
+
+        Ok(Points { points })
+    }
+
+    /// Serialize points to an SVG points attribute string
+    fn serialize(&self) -> String {
+        self.points
+            .iter()
+            .map(|p| format!("{},{}", fmt_num(p.x), fmt_num(p.y)))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    /// Check if empty
+    pub fn is_empty(&self) -> bool {
+        self.points.is_empty()
+    }
+}
+
+/// Format a number with up to 3 decimal places (sufficient for SVG coordinates).
+/// Trims trailing zeros and decimal point.
+fn fmt_num(v: f64) -> String {
+    let s = format!("{:.3}", v);
+    let s = s.trim_end_matches('0');
+    let s = s.trim_end_matches('.');
+    s.to_string()
+}
+
+/// Error parsing points
+#[derive(Debug, Clone, PartialEq)]
+pub enum PointsParseError {
+    ExpectedNumber,
+    InvalidNumber(String),
+}
+
+impl std::fmt::Display for PointsParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PointsParseError::ExpectedNumber => write!(f, "expected number"),
+            PointsParseError::InvalidNumber(s) => write!(f, "invalid number: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for PointsParseError {}
+
+impl std::fmt::Display for Points {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.serialize())
+    }
+}
+
+/// Proxy type for Points - serializes as a string
+#[derive(Facet, Clone, Debug)]
+#[facet(transparent)]
+pub struct PointsProxy(pub String);
+
+impl TryFrom<PointsProxy> for Points {
+    type Error = PointsParseError;
+    fn try_from(proxy: PointsProxy) -> Result<Self, Self::Error> {
+        Points::parse(&proxy.0)
+    }
+}
+
+#[allow(clippy::infallible_try_from)]
+impl TryFrom<&Points> for PointsProxy {
+    type Error = std::convert::Infallible;
+    fn try_from(v: &Points) -> Result<Self, Self::Error> {
+        Ok(PointsProxy(v.to_string()))
+    }
+}
+
+// Option impls for facet proxy support
+impl From<PointsProxy> for Option<Points> {
+    fn from(proxy: PointsProxy) -> Self {
+        Points::parse(&proxy.0).ok()
+    }
+}
+
+#[allow(clippy::infallible_try_from)]
+impl TryFrom<&Option<Points>> for PointsProxy {
+    type Error = std::convert::Infallible;
+    fn try_from(v: &Option<Points>) -> Result<Self, Self::Error> {
+        match v {
+            Some(data) => Ok(PointsProxy(data.to_string())),
+            None => Ok(PointsProxy(String::new())),
+        }
+    }
+}
+
+// Helper parsing functions
+
+fn skip_wsp_comma(chars: &mut std::iter::Peekable<std::str::Chars>) {
+    while let Some(&c) = chars.peek() {
+        if c.is_whitespace() || c == ',' {
+            chars.next();
+        } else {
+            break;
+        }
+    }
+}
+
+fn parse_number(chars: &mut std::iter::Peekable<std::str::Chars>) -> Result<f64, PointsParseError> {
+    skip_wsp_comma(chars);
+    let mut num_str = String::new();
+
+    // Handle optional sign
+    if let Some(&c) = chars.peek()
+        && (c == '-' || c == '+')
+    {
+        num_str.push(chars.next().unwrap());
+    }
+
+    // Parse digits and decimal point
+    let mut has_digits = false;
+    while let Some(&c) = chars.peek() {
+        if c.is_ascii_digit() || c == '.' {
+            num_str.push(chars.next().unwrap());
+            has_digits = true;
+        } else if c == 'e' || c == 'E' {
+            // Scientific notation
+            num_str.push(chars.next().unwrap());
+            if let Some(&sign) = chars.peek()
+                && (sign == '-' || sign == '+')
+            {
+                num_str.push(chars.next().unwrap());
+            }
+            while let Some(&d) = chars.peek() {
+                if d.is_ascii_digit() {
+                    num_str.push(chars.next().unwrap());
+                } else {
+                    break;
+                }
+            }
+            break;
+        } else {
+            break;
+        }
+    }
+
+    if !has_digits {
+        return Err(PointsParseError::ExpectedNumber);
+    }
+
+    num_str
+        .parse()
+        .map_err(|_| PointsParseError::InvalidNumber(num_str))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple() {
+        let points = Points::parse("10,20 30,40 50,60").unwrap();
+        assert_eq!(points.points.len(), 3);
+        assert_eq!(points.points[0], Point { x: 10.0, y: 20.0 });
+        assert_eq!(points.points[1], Point { x: 30.0, y: 40.0 });
+        assert_eq!(points.points[2], Point { x: 50.0, y: 60.0 });
+    }
+
+    #[test]
+    fn test_parse_with_decimals() {
+        let points = Points::parse("402.528,63.6158 397.436,74.8164").unwrap();
+        assert_eq!(points.points.len(), 2);
+        assert!((points.points[0].x - 402.528).abs() < 0.0001);
+        assert!((points.points[0].y - 63.6158).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_serialize() {
+        let points = Points::new().push(10.0, 20.0).push(30.5, 40.0);
+        assert_eq!(points.to_string(), "10,20 30.5,40");
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let original = "10,20 30.5,40 50,60.123";
+        let points = Points::parse(original).unwrap();
+        let serialized = points.to_string();
+        let reparsed = Points::parse(&serialized).unwrap();
+        assert_eq!(points, reparsed);
+    }
+
+    #[test]
+    fn test_empty() {
+        let points = Points::parse("").unwrap();
+        assert!(points.is_empty());
+        assert_eq!(points.to_string(), "");
+    }
+}

--- a/facet-format-svg/tests/fixtures.rs
+++ b/facet-format-svg/tests/fixtures.rs
@@ -1,0 +1,311 @@
+use facet_format_svg::Svg;
+
+// Basic SVG Element Tests
+
+#[test]
+fn test_parse_simple_circle() {
+    let svg_str = include_str!("fixtures/basic/circle.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse circle SVG");
+
+    assert_eq!(svg.width, Some("100".to_string()));
+    assert_eq!(svg.height, Some("100".to_string()));
+    assert_eq!(svg.view_box, Some("0 0 100 100".to_string()));
+    assert_eq!(svg.children.len(), 1);
+}
+
+#[test]
+fn test_parse_multiple_shapes() {
+    let svg_str = include_str!("fixtures/basic/multiple_shapes.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse multi-shape SVG");
+
+    assert_eq!(svg.children.len(), 3);
+}
+
+#[test]
+fn test_parse_grouped_elements() {
+    let svg_str = include_str!("fixtures/basic/grouped_elements.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse grouped SVG");
+
+    assert_eq!(svg.children.len(), 1);
+}
+
+#[test]
+fn test_parse_text_elements() {
+    let svg_str = include_str!("fixtures/basic/text.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse text SVG");
+
+    assert_eq!(svg.children.len(), 1);
+}
+
+#[test]
+fn test_parse_path_element() {
+    let svg_str = include_str!("fixtures/basic/path.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse path SVG");
+
+    assert_eq!(svg.children.len(), 1);
+}
+
+#[test]
+fn test_parse_style_element() {
+    let svg_str = include_str!("fixtures/basic/style.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse style SVG");
+
+    assert!(!svg.children.is_empty());
+}
+
+#[test]
+fn test_parse_defs_element() {
+    let svg_str = include_str!("fixtures/basic/defs.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse defs SVG");
+
+    assert!(!svg.children.is_empty());
+}
+
+#[test]
+fn test_parse_polygon_and_polyline() {
+    let svg_str = include_str!("fixtures/basic/polygon_polyline.svg");
+    let svg: Svg =
+        facet_format_svg::from_str(svg_str).expect("Failed to parse polygon/polyline SVG");
+
+    assert_eq!(svg.children.len(), 2);
+}
+
+#[test]
+fn test_parse_ellipse() {
+    let svg_str = include_str!("fixtures/basic/ellipse.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse ellipse SVG");
+
+    assert_eq!(svg.children.len(), 1);
+}
+
+#[test]
+fn test_parse_minimal_svg() {
+    let svg_str = include_str!("fixtures/basic/minimal.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse minimal SVG");
+
+    assert_eq!(svg.children.len(), 1);
+}
+
+#[test]
+fn test_parse_dashed_lines() {
+    let svg_str = include_str!("fixtures/basic/dashed_lines.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse dashed SVG");
+
+    assert_eq!(svg.children.len(), 2);
+}
+
+#[test]
+fn test_parse_nested_groups() {
+    let svg_str = include_str!("fixtures/basic/nested_groups.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse nested groups SVG");
+
+    assert_eq!(svg.children.len(), 1);
+}
+
+// Pikchr-style Diagram Tests
+
+#[test]
+fn test_parse_pikchr_style_diagram() {
+    let svg_str = include_str!("fixtures/pikchr/diagram.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse pikchr-style SVG");
+
+    // Should have the main group
+    assert!(!svg.children.is_empty());
+}
+
+// Advanced SVG Element Tests
+
+#[test]
+fn test_bootstrap_icon() {
+    let svg_str = include_str!("fixtures/advanced/bootstrap_icon.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse Bootstrap icon SVG");
+    assert_eq!(svg.width, Some("16".to_string()));
+    assert_eq!(svg.height, Some("16".to_string()));
+}
+
+#[test]
+fn test_feather_icon_style() {
+    let svg_str = include_str!("fixtures/advanced/feather_icon.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse Feather icon SVG");
+    assert_eq!(svg.children.len(), 2); // circle and path
+}
+
+#[test]
+fn test_svg_with_use_element() {
+    let svg_str = include_str!("fixtures/advanced/use_element.svg");
+    match facet_format_svg::from_str::<Svg>(svg_str) {
+        Ok(svg) => {
+            println!("Use element parsed successfully");
+            println!("  Children: {}", svg.children.len());
+        }
+        Err(e) => {
+            println!("Use element failed to parse: {}", e);
+        }
+    }
+}
+
+#[test]
+fn test_svg_with_filters() {
+    let svg_str = include_str!("fixtures/advanced/filters.svg");
+    match facet_format_svg::from_str::<Svg>(svg_str) {
+        Ok(svg) => {
+            println!("Filter elements parsed successfully");
+            println!("  Children: {}", svg.children.len());
+        }
+        Err(e) => {
+            println!("Filter elements failed: {}", e);
+        }
+    }
+}
+
+#[test]
+fn test_svg_with_tspan() {
+    let svg_str = include_str!("fixtures/advanced/tspan.svg");
+    match facet_format_svg::from_str::<Svg>(svg_str) {
+        Ok(svg) => {
+            println!("Tspan elements parsed successfully");
+            println!("  Children: {}", svg.children.len());
+        }
+        Err(e) => {
+            println!("Tspan elements failed: {}", e);
+        }
+    }
+}
+
+#[test]
+fn test_svg_with_image_element() {
+    let svg_str = include_str!("fixtures/advanced/image.svg");
+    match facet_format_svg::from_str::<Svg>(svg_str) {
+        Ok(svg) => {
+            println!("Image elements parsed successfully");
+            println!("  Children: {}", svg.children.len());
+        }
+        Err(e) => {
+            println!("Image elements failed: {}", e);
+        }
+    }
+}
+
+#[test]
+fn test_svg_with_marker() {
+    let svg_str = include_str!("fixtures/advanced/marker.svg");
+    match facet_format_svg::from_str::<Svg>(svg_str) {
+        Ok(svg) => {
+            println!("Marker elements parsed successfully");
+            println!("  Children: {}", svg.children.len());
+        }
+        Err(e) => {
+            println!("Marker elements failed: {}", e);
+        }
+    }
+}
+
+#[test]
+fn test_svg_with_transform() {
+    let svg_str = include_str!("fixtures/advanced/transform.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse transform SVG");
+    assert_eq!(svg.children.len(), 1); // one group
+}
+
+#[test]
+fn test_svg_with_metadata() {
+    let svg_str = include_str!("fixtures/advanced/metadata.svg");
+    match facet_format_svg::from_str::<Svg>(svg_str) {
+        Ok(svg) => {
+            println!("Metadata elements parsed successfully");
+            println!("  Children: {}", svg.children.len());
+        }
+        Err(e) => {
+            println!("Metadata elements failed: {}", e);
+        }
+    }
+}
+
+#[test]
+fn test_svg_with_aspect_ratio() {
+    let svg_str = include_str!("fixtures/advanced/aspect_ratio.svg");
+    match facet_format_svg::from_str::<Svg>(svg_str) {
+        Ok(svg) => {
+            assert_eq!(svg.view_box, Some("0 0 100 100".to_string()));
+            println!("Successfully parsed viewBox and preserveAspectRatio");
+        }
+        Err(e) => {
+            println!("Failed to parse aspectRatio SVG: {}", e);
+        }
+    }
+}
+
+#[test]
+fn test_svg_with_opacity() {
+    let svg_str = include_str!("fixtures/advanced/opacity.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse opacity SVG");
+    assert_eq!(svg.children.len(), 1);
+}
+
+#[test]
+fn test_svg_use_element_supported() {
+    let svg_str = include_str!("fixtures/advanced/use_with_href.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse use element SVG");
+    assert_eq!(svg.children.len(), 2); // defs and use
+    if let Some(facet_format_svg::SvgNode::Use(use_elem)) = svg.children.last() {
+        assert_eq!(use_elem.x, Some(50.0));
+        assert_eq!(use_elem.y, Some(50.0));
+        println!(
+            "Use element fully parsed with x={:?}, y={:?}",
+            use_elem.x, use_elem.y
+        );
+    }
+}
+
+#[test]
+fn test_svg_image_element_supported() {
+    let svg_str = include_str!("fixtures/advanced/image_embedded.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse image element SVG");
+    assert_eq!(svg.children.len(), 1);
+    if let Some(facet_format_svg::SvgNode::Image(img)) = svg.children.first() {
+        assert_eq!(img.x, Some(10.0));
+        assert_eq!(img.y, Some(10.0));
+        assert_eq!(img.width, Some(100.0));
+        assert_eq!(img.height, Some(100.0));
+        println!("Image element fully parsed with dimensions");
+    }
+}
+
+#[test]
+fn test_svg_title_element_supported() {
+    let svg_str = include_str!("fixtures/advanced/title.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse title element SVG");
+    assert_eq!(svg.children.len(), 2); // title and rect
+    if let Some(facet_format_svg::SvgNode::Title(title)) = svg.children.first() {
+        assert_eq!(title.content, Some("My Diagram".to_string()));
+        println!("Title element fully parsed: {:?}", title.content);
+    }
+}
+
+#[test]
+fn test_svg_desc_element_supported() {
+    let svg_str = include_str!("fixtures/advanced/desc.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse desc element SVG");
+    assert_eq!(svg.children.len(), 2); // desc and rect
+    if let Some(facet_format_svg::SvgNode::Desc(desc)) = svg.children.first() {
+        assert_eq!(
+            desc.content,
+            Some("A simple diagram with one rectangle".to_string())
+        );
+        println!("Desc element fully parsed: {:?}", desc.content);
+    }
+}
+
+#[test]
+fn test_svg_symbol_element_supported() {
+    let svg_str = include_str!("fixtures/advanced/symbol.svg");
+    let svg: Svg = facet_format_svg::from_str(svg_str).expect("Failed to parse symbol element SVG");
+    assert!(!svg.children.is_empty());
+    if let Some(facet_format_svg::SvgNode::Defs(defs)) = svg.children.first()
+        && let Some(facet_format_svg::SvgNode::Symbol(sym)) = defs.children.first()
+    {
+        assert_eq!(sym.id, Some("star".to_string()));
+        assert_eq!(sym.view_box, Some("0 0 100 100".to_string()));
+        println!("Symbol element fully parsed with id and viewBox");
+    }
+}

--- a/facet-format-svg/tests/fixtures/advanced/aspect_ratio.svg
+++ b/facet-format-svg/tests/fixtures/advanced/aspect_ratio.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100" preserveAspectRatio="xMidYMid meet">
+  <rect x="10" y="10" width="80" height="80" fill="red"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/bootstrap_icon.svg
+++ b/facet-format-svg/tests/fixtures/advanced/bootstrap_icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check" viewBox="0 0 16 16">
+  <path d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.267.267 0 0 1 .02-.022z"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/desc.svg
+++ b/facet-format-svg/tests/fixtures/advanced/desc.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <desc>A simple diagram with one rectangle</desc>
+  <rect x="10" y="10" width="80" height="80" fill="green"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/feather_icon.svg
+++ b/facet-format-svg/tests/fixtures/advanced/feather_icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="1"></circle>
+  <path d="M12 1v6m0 6v6M4.22 4.22l4.24 4.24m5.08 5.08l4.24 4.24M1 12h6m6 0h6M4.22 19.78l4.24-4.24m5.08-5.08l4.24-4.24"></path>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/filters.svg
+++ b/facet-format-svg/tests/fixtures/advanced/filters.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <defs>
+    <filter id="blur">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="5" />
+    </filter>
+  </defs>
+  <rect x="10" y="10" width="80" height="80" fill="blue" filter="url(#blur)"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/image.svg
+++ b/facet-format-svg/tests/fixtures/advanced/image.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <image x="10" y="10" width="100" height="100" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Crect fill='red' width='100' height='100'/%3E%3C/svg%3E"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/image_embedded.svg
+++ b/facet-format-svg/tests/fixtures/advanced/image_embedded.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <image x="10" y="10" width="100" height="100" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Crect fill='red' width='100' height='100'/%3E%3C/svg%3E"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/marker.svg
+++ b/facet-format-svg/tests/fixtures/advanced/marker.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0 0, 10 3, 0 6" fill="black" />
+    </marker>
+  </defs>
+  <line x1="10" y1="50" x2="150" y2="50" stroke="black" stroke-width="2" />
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/metadata.svg
+++ b/facet-format-svg/tests/fixtures/advanced/metadata.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100" preserveAspectRatio="xMidYMid meet" version="1.1">
+  <title>Test SVG</title>
+  <desc>A test SVG document</desc>
+  <rect x="10" y="10" width="80" height="80" fill="red" opacity="0.8" stroke="black" stroke-width="2"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/opacity.svg
+++ b/facet-format-svg/tests/fixtures/advanced/opacity.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect x="10" y="10" width="80" height="80" fill="red" opacity="0.5"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/symbol.svg
+++ b/facet-format-svg/tests/fixtures/advanced/symbol.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <defs>
+    <symbol id="star" viewBox="0 0 100 100">
+      <polygon points="50,10 61,35 87,35 70,57 79,82 50,60 21,82 30,57 13,35 39,35" fill="gold"/>
+    </symbol>
+  </defs>
+  <use x="50" y="50" href="data:star"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/title.svg
+++ b/facet-format-svg/tests/fixtures/advanced/title.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <title>My Diagram</title>
+  <rect x="10" y="10" width="80" height="80" fill="blue"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/transform.svg
+++ b/facet-format-svg/tests/fixtures/advanced/transform.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <g transform="rotate(45 100 100) translate(10 20)">
+    <rect x="50" y="50" width="100" height="100" fill="green" opacity="0.5"/>
+  </g>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/tspan.svg
+++ b/facet-format-svg/tests/fixtures/advanced/tspan.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <text x="50" y="50">
+    <tspan x="50" dy="1.2em">First line</tspan>
+    <tspan x="50" dy="1.2em">Second line</tspan>
+  </text>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/use_element.svg
+++ b/facet-format-svg/tests/fixtures/advanced/use_element.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100" height="100" viewBox="0 0 100 100">
+  <defs>
+    <g id="myCircle">
+      <circle cx="0" cy="0" r="20" fill="red"/>
+    </g>
+  </defs>
+  <use x="50" y="50"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/advanced/use_with_href.svg
+++ b/facet-format-svg/tests/fixtures/advanced/use_with_href.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+  <defs>
+    <g id="myCircle">
+      <circle cx="0" cy="0" r="20" fill="red"/>
+    </g>
+  </defs>
+  <use x="50" y="50" href="data:myCircle"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/basic/circle.svg
+++ b/facet-format-svg/tests/fixtures/basic/circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+    <circle cx="50" cy="50" r="40" fill="blue" stroke="black" stroke-width="2"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/basic/dashed_lines.svg
+++ b/facet-format-svg/tests/fixtures/basic/dashed_lines.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="50">
+    <line x1="10" y1="25" x2="190" y2="25" stroke="black" stroke-width="2" stroke-dasharray="5,5"/>
+    <circle cx="100" cy="25" r="10" fill="none" stroke="blue" stroke-width="1" stroke-dasharray="2,3"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/basic/defs.svg
+++ b/facet-format-svg/tests/fixtures/basic/defs.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <defs>
+        <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1" />
+            <stop offset="100%" style="stop-color:rgb(255,0,0);stop-opacity:1" />
+        </linearGradient>
+    </defs>
+    <rect x="10" y="10" width="80" height="80" fill="url(#grad1)"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/basic/ellipse.svg
+++ b/facet-format-svg/tests/fixtures/basic/ellipse.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+    <ellipse cx="100" cy="50" rx="80" ry="30" fill="yellow" stroke="black" stroke-width="2"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/basic/grouped_elements.svg
+++ b/facet-format-svg/tests/fixtures/basic/grouped_elements.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+    <g id="main-group" transform="translate(10, 10)">
+        <rect x="0" y="0" width="50" height="50" fill="blue"/>
+        <circle cx="75" cy="25" r="20" fill="green"/>
+    </g>
+</svg>

--- a/facet-format-svg/tests/fixtures/basic/minimal.svg
+++ b/facet-format-svg/tests/fixtures/basic/minimal.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <rect width="100" height="100" fill="red"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/basic/multiple_shapes.svg
+++ b/facet-format-svg/tests/fixtures/basic/multiple_shapes.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+    <rect x="10" y="10" width="80" height="80" fill="red"/>
+    <circle cx="150" cy="50" r="30" fill="green"/>
+    <line x1="10" y1="150" x2="190" y2="150" stroke="black" stroke-width="2"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/basic/nested_groups.svg
+++ b/facet-format-svg/tests/fixtures/basic/nested_groups.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+    <g id="outer" transform="translate(10, 10)">
+        <rect x="0" y="0" width="100" height="100" fill="lightgray"/>
+        <g id="inner" transform="translate(20, 20)">
+            <circle cx="0" cy="0" r="20" fill="red"/>
+        </g>
+    </g>
+</svg>

--- a/facet-format-svg/tests/fixtures/basic/path.svg
+++ b/facet-format-svg/tests/fixtures/basic/path.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <path d="M 10 10 L 90 90 Q 50 50 10 90 Z" stroke="black" stroke-width="2" fill="none"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/basic/polygon_polyline.svg
+++ b/facet-format-svg/tests/fixtures/basic/polygon_polyline.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+    <polygon points="50,10 90,90 10,90" fill="lime" stroke="purple" stroke-width="2"/>
+    <polyline points="10,10 20,20 30,30 40,20 50,30" fill="none" stroke="red" stroke-width="2"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/basic/style.svg
+++ b/facet-format-svg/tests/fixtures/basic/style.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <style type="text/css">
+        .myclass { fill: red; stroke: blue; }
+    </style>
+    <rect class="myclass" x="10" y="10" width="80" height="80"/>
+</svg>

--- a/facet-format-svg/tests/fixtures/basic/text.svg
+++ b/facet-format-svg/tests/fixtures/basic/text.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+    <text x="10" y="20" fill="black" text-anchor="start" dominant-baseline="hanging">Hello SVG</text>
+</svg>

--- a/facet-format-svg/tests/fixtures/pikchr/diagram.svg
+++ b/facet-format-svg/tests/fixtures/pikchr/diagram.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
+    <g id="diagram">
+        <!-- Background -->
+        <rect x="0" y="0" width="300" height="200" fill="white" stroke="gray" stroke-width="1"/>
+
+        <!-- Boxes -->
+        <rect x="20" y="20" width="80" height="60" fill="lightblue" stroke="navy" stroke-width="2"/>
+        <text x="60" y="50" text-anchor="middle" dominant-baseline="middle" fill="navy">Start</text>
+
+        <rect x="200" y="20" width="80" height="60" fill="lightgreen" stroke="darkgreen" stroke-width="2"/>
+        <text x="240" y="50" text-anchor="middle" dominant-baseline="middle" fill="darkgreen">End</text>
+
+        <!-- Arrow -->
+        <path d="M 100 50 L 200 50" stroke="black" stroke-width="2" fill="none" marker-end="url(#arrowhead)"/>
+
+        <!-- Bottom annotation -->
+        <text x="150" y="150" text-anchor="middle" fill="gray">Process Flow</text>
+    </g>
+</svg>

--- a/facet-format-svg/tests/roundtrip.rs
+++ b/facet-format-svg/tests/roundtrip.rs
@@ -1,0 +1,41 @@
+use facet_format_svg::Svg;
+use std::path::Path;
+
+fn svg_roundtrip_test(path: &Path) -> datatest_stable::Result<()> {
+    let fixture_path = path;
+    let svg_str = std::fs::read_to_string(fixture_path)?;
+
+    // Load the original SVG
+    let svg1: Svg = facet_format_svg::from_str(&svg_str)
+        .map_err(|e| format!("Failed to parse SVG from {}: {}", fixture_path.display(), e))?;
+
+    // Serialize it back to XML
+    let serialized1 = facet_format_svg::to_string(&svg1)
+        .map_err(|e| format!("Failed to serialize SVG: {}", e))?;
+
+    println!("\n=== Serialized SVG for {} ===", fixture_path.display());
+    println!("{}", serialized1);
+    println!("=== End ===\n");
+
+    // Deserialize again
+    let svg2: Svg = facet_format_svg::from_str(&serialized1)
+        .map_err(|e| format!("Failed to re-parse serialized SVG: {}", e))?;
+
+    // Serialize the second one
+    let serialized2 = facet_format_svg::to_string(&svg2)
+        .map_err(|e| format!("Failed to serialize SVG again: {}", e))?;
+
+    // The two serializations should be identical - this verifies perfect roundtrip
+    assert_eq!(
+        serialized1,
+        serialized2,
+        "Serialized SVG should be identical after roundtrip for {}",
+        fixture_path.display()
+    );
+
+    Ok(())
+}
+
+datatest_stable::harness! {
+    { test = svg_roundtrip_test, root = "tests/fixtures", pattern = r".*\.svg$" },
+}

--- a/facet-format-xml/Cargo.toml
+++ b/facet-format-xml/Cargo.toml
@@ -17,6 +17,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
+facet = { workspace = true }
 facet-core = { path = "../facet-core", version = "0.35.0" }
 facet-format = { path = "../facet-format", version = "0.35.0" }
 facet-reflect = { path = "../facet-reflect", version = "0.35.0", features = ["miette"] }

--- a/facet-format-xml/src/lib.rs
+++ b/facet-format-xml/src/lib.rs
@@ -20,3 +20,51 @@ pub use streaming::from_reader;
 
 #[cfg(feature = "tokio")]
 pub use streaming::from_async_reader_tokio;
+
+// XML extension attributes for use with #[facet(xml::attr)] syntax.
+//
+// After importing `use facet_format_xml as xml;`, users can write:
+//   #[facet(xml::element)]
+//   #[facet(xml::elements)]
+//   #[facet(xml::attribute)]
+//   #[facet(xml::text)]
+//   #[facet(xml::element_name)]
+
+// Generate XML attribute grammar using the grammar DSL.
+// This generates:
+// - `Attr` enum with all XML attribute variants
+// - `__attr!` macro that dispatches to attribute handlers and returns ExtensionAttr
+// - `__parse_attr!` macro for parsing (internal use)
+facet::define_attr_grammar! {
+    ns "xml";
+    crate_path ::facet_format_xml;
+
+    /// XML attribute types for field and container configuration.
+    pub enum Attr {
+        /// Marks a field as a single XML child element
+        Element,
+        /// Marks a field as collecting multiple XML child elements
+        Elements,
+        /// Marks a field as an XML attribute (on the element tag)
+        Attribute,
+        /// Marks a field as the text content of the element
+        Text,
+        /// Marks a field as storing the XML element name dynamically
+        ElementName,
+        /// Specifies the XML namespace URI for this field.
+        ///
+        /// Usage: `#[facet(xml::ns = "http://example.com/ns")]`
+        ///
+        /// When deserializing, the field will only match elements/attributes
+        /// in the specified namespace. When serializing, the element/attribute
+        /// will be emitted with the appropriate namespace prefix.
+        Ns(&'static str),
+        /// Specifies the default XML namespace URI for all fields in this container.
+        ///
+        /// Usage: `#[facet(xml::ns_all = "http://example.com/ns")]`
+        ///
+        /// This sets the default namespace for all fields that don't have their own
+        /// `xml::ns` attribute. Individual fields can override this with `xml::ns`.
+        NsAll(&'static str),
+    }
+}

--- a/facet-format/src/serializer.rs
+++ b/facet-format/src/serializer.rs
@@ -377,8 +377,13 @@ where
             serializer
                 .begin_seq_with_len(fields.len())
                 .map_err(SerializeError::Backend)?;
-            for (_field_item, field_value) in fields {
-                shared_serialize(serializer, field_value)?;
+            for (field_item, field_value) in fields {
+                // Check for field-level proxy
+                if let Some(proxy_def) = field_item.field.proxy() {
+                    serialize_via_proxy(serializer, field_value, proxy_def)?;
+                } else {
+                    shared_serialize(serializer, field_value)?;
+                }
             }
             serializer.end_seq().map_err(SerializeError::Backend)?;
         } else {
@@ -399,7 +404,12 @@ where
                 serializer
                     .field_key(field_item.name)
                     .map_err(SerializeError::Backend)?;
-                shared_serialize(serializer, field_value)?;
+                // Check for field-level proxy
+                if let Some(proxy_def) = field_item.field.proxy() {
+                    serialize_via_proxy(serializer, field_value, proxy_def)?;
+                } else {
+                    shared_serialize(serializer, field_value)?;
+                }
             }
             serializer.end_struct().map_err(SerializeError::Backend)?;
         }
@@ -451,7 +461,12 @@ where
                             serializer
                                 .field_key(field_item.name)
                                 .map_err(SerializeError::Backend)?;
-                            shared_serialize(serializer, field_value)?;
+                            // Check for field-level proxy
+                            if let Some(proxy_def) = field_item.field.proxy() {
+                                serialize_via_proxy(serializer, field_value, proxy_def)?;
+                            } else {
+                                shared_serialize(serializer, field_value)?;
+                            }
                         }
                     }
                     StructKind::TupleStruct | StructKind::Tuple => {
@@ -492,7 +507,12 @@ where
                             serializer
                                 .field_key(field_item.name)
                                 .map_err(SerializeError::Backend)?;
-                            shared_serialize(serializer, field_value)?;
+                            // Check for field-level proxy
+                            if let Some(proxy_def) = field_item.field.proxy() {
+                                serialize_via_proxy(serializer, field_value, proxy_def)?;
+                            } else {
+                                shared_serialize(serializer, field_value)?;
+                            }
                         }
                         serializer.end_struct().map_err(SerializeError::Backend)?;
                     }
@@ -607,7 +627,12 @@ where
                     serializer
                         .field_key(field_item.name)
                         .map_err(SerializeError::Backend)?;
-                    shared_serialize(serializer, field_value)?;
+                    // Check for field-level proxy
+                    if let Some(proxy_def) = field_item.field.proxy() {
+                        serialize_via_proxy(serializer, field_value, proxy_def)?;
+                    } else {
+                        shared_serialize(serializer, field_value)?;
+                    }
                 }
                 serializer.end_struct().map_err(SerializeError::Backend)?;
 
@@ -701,7 +726,12 @@ where
                 serializer
                     .field_key(field_item.name)
                     .map_err(SerializeError::Backend)?;
-                shared_serialize(serializer, field_value)?;
+                // Check for field-level proxy
+                if let Some(proxy_def) = field_item.field.proxy() {
+                    serialize_via_proxy(serializer, field_value, proxy_def)?;
+                } else {
+                    shared_serialize(serializer, field_value)?;
+                }
             }
             serializer.end_struct().map_err(SerializeError::Backend)?;
             Ok(())


### PR DESCRIPTION
## Summary

- Add new `facet-format-svg` crate for SVG parsing using `facet-format-xml`
- Add XML attribute grammar to `facet-format-xml` (`xml::element`, `xml::elements`, `xml::attribute`, `xml::text`, `xml::ns`, `xml::ns_all`)
- Fix field-level proxy serialization in `facet-format`
- Fix critical bug in `XmlParser::skip_value()` that caused "Unexpected end of XML" errors

## Details

### New facet-format-svg crate
- SVG types: `Svg`, `SvgNode` enum with variants for common elements (G, Defs, Style, Rect, Circle, Ellipse, Line, Path, Polygon, Polyline, Text, Use, Image, Title, Desc, Symbol)
- `PathData` with `PathDataProxy` for parsing SVG path `d` attributes
- `Points` with `PointsProxy` for polygon/polyline points parsing
- 70 tests including roundtrip tests for various SVG fixtures

### XmlParser::skip_value() bug fix
The previous implementation incorrectly tracked depth for `FieldKey` events. When skipping unknown elements (like `<linearGradient>` inside `<defs>`), the depth counter would grow unbounded because:
1. `FieldKey` events incremented depth
2. `Scalar` events (field values) never decremented it
3. Eventually the parser consumed all events looking for a `StructEnd` that would bring depth back to 0

The fix properly distinguishes `struct_depth` (actual nested container depth) from `pending_field_value` (flag indicating we're waiting for a field's value).