### PR TITLE
feat: add #[facet(pod)] attribute for Plain Old Data types

### DIFF
--- a/facet-core/src/types/shape/shape_builder.rs
+++ b/facet-core/src/types/shape/shape_builder.rs
@@ -321,6 +321,16 @@ impl ShapeBuilder {
         self.flags(ShapeFlags::NUMERIC)
     }
 
+    /// Mark this type as Plain Old Data.
+    ///
+    /// POD types have no invariants - any combination of valid field values
+    /// produces a valid instance. This enables safe mutation through reflection.
+    #[inline]
+    pub const fn pod(mut self) -> Self {
+        self.shape.flags = self.shape.flags.union(ShapeFlags::POD);
+        self
+    }
+
     /// Build the Shape.
     ///
     /// If `ty` was not explicitly set (still `Type::Undefined`), it will be

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -136,6 +136,15 @@ pub mod builtin {
             /// Usage: `#[facet(is_numeric)]`
             IsNumeric,
 
+            /// Marks a type as Plain Old Data.
+            ///
+            /// POD types have no invariants - any combination of valid field values
+            /// produces a valid instance. This enables safe mutation through reflection
+            /// (poke operations).
+            ///
+            /// Usage: `#[facet(pod)]`
+            Pod,
+
             /// Renames a field or variant during serialization/deserialization.
             ///
             /// Usage: `#[facet(rename = "new_name")]`

--- a/facet/tests/derive.rs
+++ b/facet/tests/derive.rs
@@ -893,3 +893,73 @@ fn metadata_field_structural_hash() {
         "Values with different data should have different structural hash"
     );
 }
+
+// ============================================================================
+// POD (Plain Old Data) attribute tests
+// ============================================================================
+
+#[test]
+fn pod_struct_basic() {
+    #[derive(Debug, Facet)]
+    #[facet(pod)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    let shape = Point::SHAPE;
+    assert!(shape.is_pod(), "Point should be marked as POD");
+}
+
+#[test]
+fn pod_tuple_struct() {
+    #[derive(Debug, Facet)]
+    #[facet(pod)]
+    struct Pair(i32, i32);
+
+    let shape = Pair::SHAPE;
+    assert!(shape.is_pod(), "Pair should be marked as POD");
+}
+
+#[test]
+fn pod_enum() {
+    #[derive(Debug, Facet)]
+    #[repr(u8)]
+    #[facet(pod)]
+    #[allow(dead_code)]
+    enum Color {
+        Red,
+        Green,
+        Blue,
+    }
+
+    let shape = Color::SHAPE;
+    assert!(shape.is_pod(), "Color enum should be marked as POD");
+}
+
+#[test]
+fn non_pod_struct() {
+    #[derive(Debug, Facet)]
+    struct NotPod {
+        x: i32,
+    }
+
+    let shape = NotPod::SHAPE;
+    assert!(!shape.is_pod(), "NotPod should not be marked as POD");
+}
+
+#[test]
+fn primitives_are_pod() {
+    assert!(u8::SHAPE.is_pod(), "u8 should be POD");
+    assert!(u16::SHAPE.is_pod(), "u16 should be POD");
+    assert!(u32::SHAPE.is_pod(), "u32 should be POD");
+    assert!(u64::SHAPE.is_pod(), "u64 should be POD");
+    assert!(i8::SHAPE.is_pod(), "i8 should be POD");
+    assert!(i16::SHAPE.is_pod(), "i16 should be POD");
+    assert!(i32::SHAPE.is_pod(), "i32 should be POD");
+    assert!(i64::SHAPE.is_pod(), "i64 should be POD");
+    assert!(f32::SHAPE.is_pod(), "f32 should be POD");
+    assert!(f64::SHAPE.is_pod(), "f64 should be POD");
+    assert!(bool::SHAPE.is_pod(), "bool should be POD");
+    assert!(char::SHAPE.is_pod(), "char should be POD");
+}


### PR DESCRIPTION
## Summary

Add support for marking types as POD (Plain Old Data), enabling safe mutation through reflection. POD types assert they have no invariants - any combination of valid field values produces a valid instance.

## Changes

- Add `POD` flag to `ShapeFlags` and `is_pod()` method on `Shape`
- Add `.pod()` builder method to `ShapeBuilder`
- Add `Pod` variant to builtin attribute grammar
- Handle `pod` attribute in struct and enum derive macros
- Add compile-time validation: `pod` and `invariants` are mutually exclusive
- Primitives are implicitly POD (any value is valid)
- Add comprehensive documentation in `docs/content/guide/attributes.md`
- Add tests for POD functionality

## Design Decisions

- **POD is explicit, not inferred**: A struct with all POD fields is NOT automatically POD. The author must explicitly mark it to assert no semantic invariants exist.
- **Primitives are implicitly POD**: All primitive types return `true` from `is_pod()` since any value is valid.
- **Containers don't need POD**: `Vec<T>`, `Option<T>`, etc. are manipulated through vtables. The element type's POD-ness matters for element mutation, not container mutation.
- **Mutual exclusivity with invariants**: Compile-time error if both `pod` and `invariants` are specified, since they're contradictory.

## Example Usage

```rust
#[derive(Facet)]
#[facet(pod)]
struct Point {
    x: i32,
    y: i32,
}

let shape = Point::SHAPE;
assert!(shape.is_pod()); // true - can be safely mutated through reflection
```