### PR TITLE
feat(facet-reflect): add Poke type for mutation through reflection

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -108,7 +108,7 @@ miri *args:
     export MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-env-forward=NEXTEST"
     rustup toolchain install "${RUSTUP_TOOLCHAIN}"
     rustup "+${RUSTUP_TOOLCHAIN}" component add miri rust-src
-    cargo "+${RUSTUP_TOOLCHAIN}" miri nextest run --target-dir target/miri -p facet-reflect -p facet-core -p facet-value --lib {{args}}
+    cargo "+${RUSTUP_TOOLCHAIN}" miri nextest run --target-dir target/miri -p facet-reflect -p facet-core -p facet-value {{args}}
 
 miri-ci *args:
     #!/usr/bin/env -S bash -euxo pipefail
@@ -117,7 +117,7 @@ miri-ci *args:
 
     export CARGO_TARGET_DIR=target/miri
     export MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-env-forward=NEXTEST"
-    cmd_group "cargo miri nextest run -p facet-reflect -p facet-core -p facet-value --lib {{args}}"
+    cmd_group "cargo miri nextest run -p facet-reflect -p facet-core -p facet-value {{args}}"
 
 absolve:
     ./facet-dev/absolve.sh

--- a/facet-reflect/src/error.rs
+++ b/facet-reflect/src/error.rs
@@ -100,6 +100,16 @@ pub enum ReflectError {
         field_error: FieldError,
     },
 
+    /// Attempted to mutate struct fields on a type that is not POD (Plain Old Data).
+    ///
+    /// Field mutation through reflection requires the parent struct to be POD
+    /// (have no invariants). Mark the struct with `#[facet(pod)]` to enable
+    /// field mutation. Wholesale replacement via `Poke::set()` is always allowed.
+    NotPod {
+        /// The shape of the struct that is not POD.
+        shape: &'static Shape,
+    },
+
     /// Indicates that we try to access a field on an `Arc<T>`, for example, and the field might exist
     /// on the T, but you need to do begin_smart_ptr first when using the WIP API.
     MissingPushPointee {
@@ -268,6 +278,14 @@ impl core::fmt::Display for ReflectError {
             }
             ReflectError::FieldError { shape, field_error } => {
                 write!(f, "Field error for shape {shape}: {field_error}")
+            }
+            ReflectError::NotPod { shape } => {
+                write!(
+                    f,
+                    "Cannot mutate fields of '{shape}' - it is not POD (Plain Old Data). \
+                     Add #[facet(pod)] to the struct to enable field mutation. \
+                     (Wholesale replacement via Poke::set() is always allowed.)"
+                )
             }
             ReflectError::MissingPushPointee { shape } => {
                 write!(

--- a/facet-reflect/src/lib.rs
+++ b/facet-reflect/src/lib.rs
@@ -25,6 +25,9 @@ pub use resolution::*;
 mod peek;
 pub use peek::*;
 
+mod poke;
+pub use poke::*;
+
 mod scalar;
 pub use scalar::*;
 

--- a/facet-reflect/src/poke/mod.rs
+++ b/facet-reflect/src/poke/mod.rs
@@ -1,0 +1,21 @@
+//! Allows mutating values through reflection.
+//!
+//! This module provides the [`Poke`] type for mutating values at runtime.
+//! Unlike [`Peek`](crate::Peek) which provides read-only access, `Poke` allows
+//! modifying struct fields, enum variant data, and collection elements.
+//!
+//! # Safety
+//!
+//! Mutation through reflection is only safe for Plain Old Data (POD) types -
+//! types that have no invariants. A type is POD if:
+//!
+//! - It's a primitive (`u32`, `bool`, `char`, etc.), OR
+//! - It's marked with `#[facet(pod)]`
+//!
+//! Attempting to create a `Poke` for a non-POD type will fail.
+
+mod value;
+pub use value::*;
+
+mod struct_;
+pub use struct_::*;

--- a/facet-reflect/src/poke/struct_.rs
+++ b/facet-reflect/src/poke/struct_.rs
@@ -1,0 +1,177 @@
+use facet_core::{Facet, FieldError, StructType};
+
+use crate::ReflectError;
+
+use super::Poke;
+
+/// Lets you mutate a struct's fields.
+pub struct PokeStruct<'mem, 'facet> {
+    /// The underlying value
+    pub(crate) value: Poke<'mem, 'facet>,
+
+    /// The definition of the struct
+    pub(crate) ty: StructType,
+}
+
+impl core::fmt::Debug for PokeStruct<'_, '_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PokeStruct").finish_non_exhaustive()
+    }
+}
+
+impl<'mem, 'facet> PokeStruct<'mem, 'facet> {
+    /// Returns the struct definition.
+    #[inline(always)]
+    pub fn ty(&self) -> &StructType {
+        &self.ty
+    }
+
+    /// Returns the number of fields in this struct.
+    #[inline(always)]
+    pub fn field_count(&self) -> usize {
+        self.ty.fields.len()
+    }
+
+    /// Returns a `Poke` for the field at the given index.
+    ///
+    /// This always succeeds (for valid indices). The POD check happens when
+    /// you try to mutate via [`Poke::set`] on the returned field poke, or
+    /// when calling [`PokeStruct::set_field`] which checks the parent struct.
+    pub fn field(&mut self, index: usize) -> Result<Poke<'_, 'facet>, ReflectError> {
+        let field = self.ty.fields.get(index).ok_or(ReflectError::FieldError {
+            shape: self.value.shape,
+            field_error: FieldError::IndexOutOfBounds {
+                index,
+                bound: self.ty.fields.len(),
+            },
+        })?;
+
+        let field_data = unsafe { self.value.data.field(field.offset) };
+        let field_shape = field.shape();
+
+        Ok(unsafe { Poke::from_raw_parts(field_data, field_shape) })
+    }
+
+    /// Returns a `Poke` for the field with the given name.
+    ///
+    /// Returns an error if the field is not found.
+    pub fn field_by_name(&mut self, name: &str) -> Result<Poke<'_, 'facet>, ReflectError> {
+        for (i, field) in self.ty.fields.iter().enumerate() {
+            if field.name == name {
+                return self.field(i);
+            }
+        }
+        Err(ReflectError::FieldError {
+            shape: self.value.shape,
+            field_error: FieldError::NoSuchField,
+        })
+    }
+
+    /// Sets the value of a field by index.
+    ///
+    /// The value type must match the field's type.
+    ///
+    /// Returns an error if the parent struct is not POD. Field mutation could
+    /// violate struct-level invariants, so the struct must be marked with
+    /// `#[facet(pod)]` to allow this.
+    pub fn set_field<T: Facet<'facet>>(
+        &mut self,
+        index: usize,
+        value: T,
+    ) -> Result<(), ReflectError> {
+        // Check that the parent struct is POD before allowing field mutation
+        if !self.value.shape.is_pod() {
+            return Err(ReflectError::NotPod {
+                shape: self.value.shape,
+            });
+        }
+
+        let field = self.ty.fields.get(index).ok_or(ReflectError::FieldError {
+            shape: self.value.shape,
+            field_error: FieldError::IndexOutOfBounds {
+                index,
+                bound: self.ty.fields.len(),
+            },
+        })?;
+
+        let field_shape = field.shape();
+        if field_shape != T::SHAPE {
+            return Err(ReflectError::WrongShape {
+                expected: field_shape,
+                actual: T::SHAPE,
+            });
+        }
+
+        unsafe {
+            let field_ptr = self.value.data.field(field.offset);
+            // Drop the old value and write the new one
+            field_shape.call_drop_in_place(field_ptr);
+            core::ptr::write(field_ptr.as_mut_byte_ptr() as *mut T, value);
+        }
+
+        Ok(())
+    }
+
+    /// Sets the value of a field by name.
+    ///
+    /// The value type must match the field's type.
+    pub fn set_field_by_name<T: Facet<'facet>>(
+        &mut self,
+        name: &str,
+        value: T,
+    ) -> Result<(), ReflectError> {
+        for (i, field) in self.ty.fields.iter().enumerate() {
+            if field.name == name {
+                return self.set_field(i, value);
+            }
+        }
+        Err(ReflectError::FieldError {
+            shape: self.value.shape,
+            field_error: FieldError::NoSuchField,
+        })
+    }
+
+    /// Gets a read-only view of a field by index.
+    pub fn peek_field(&self, index: usize) -> Result<crate::Peek<'_, 'facet>, FieldError> {
+        let field = self
+            .ty
+            .fields
+            .get(index)
+            .ok_or(FieldError::IndexOutOfBounds {
+                index,
+                bound: self.ty.fields.len(),
+            })?;
+
+        let field_data = unsafe { self.value.data.as_const().field(field.offset) };
+        Ok(unsafe { crate::Peek::unchecked_new(field_data, field.shape()) })
+    }
+
+    /// Gets a read-only view of a field by name.
+    pub fn peek_field_by_name(&self, name: &str) -> Result<crate::Peek<'_, 'facet>, FieldError> {
+        for (i, field) in self.ty.fields.iter().enumerate() {
+            if field.name == name {
+                return self.peek_field(i);
+            }
+        }
+        Err(FieldError::NoSuchField)
+    }
+
+    /// Converts this back into the underlying `Poke`.
+    #[inline]
+    pub fn into_inner(self) -> Poke<'mem, 'facet> {
+        self.value
+    }
+
+    /// Returns a read-only `PeekStruct` view.
+    #[inline]
+    pub fn as_peek_struct(&self) -> crate::PeekStruct<'_, 'facet> {
+        crate::PeekStruct {
+            value: self.value.as_peek(),
+            ty: self.ty,
+        }
+    }
+}
+
+// Note: PokeStruct tests require custom structs with #[derive(Facet)] which can't be done
+// in inline tests within facet-reflect. All PokeStruct tests are in the integration tests:
+// facet-reflect/tests/poke/struct_.rs

--- a/facet-reflect/src/poke/value.rs
+++ b/facet-reflect/src/poke/value.rs
@@ -1,0 +1,244 @@
+use core::marker::PhantomData;
+
+use facet_core::{Def, Facet, PtrConst, PtrMut, Shape, Type, UserType};
+
+use crate::ReflectError;
+
+use super::PokeStruct;
+
+/// A mutable view into a value with runtime type information.
+///
+/// `Poke` provides reflection capabilities for mutating values at runtime.
+/// It is the mutable counterpart to [`Peek`](crate::Peek).
+///
+/// # Wholesale Replacement vs Field Mutation
+///
+/// `Poke` can be created for any type. Replacing a value wholesale with [`Poke::set`]
+/// is always safe - it just drops the old value and writes the new one.
+///
+/// However, mutating individual struct fields via [`PokeStruct::set_field`] requires
+/// the struct to be marked as POD (`#[facet(pod)]`). This is because field mutation
+/// could violate struct-level invariants.
+///
+/// # Lifetime Parameters
+///
+/// - `'mem`: The memory lifetime - how long the underlying data is valid
+/// - `'facet`: The type's lifetime parameter (for types like `&'a str`)
+///
+/// # Example
+///
+/// ```ignore
+/// // Wholesale replacement works on any type
+/// let mut s = String::from("hello");
+/// let mut poke = Poke::new(&mut s);
+/// poke.set(String::from("world")).unwrap();
+///
+/// // Field mutation requires #[facet(pod)]
+/// #[derive(Facet)]
+/// #[facet(pod)]
+/// struct Point { x: i32, y: i32 }
+///
+/// let mut point = Point { x: 1, y: 2 };
+/// let mut poke = Poke::new(&mut point);
+/// poke.into_struct().unwrap().set_field_by_name("x", 10i32).unwrap();
+/// assert_eq!(point.x, 10);
+/// ```
+pub struct Poke<'mem, 'facet> {
+    /// Underlying data (mutable)
+    pub(crate) data: PtrMut,
+
+    /// Shape of the value
+    pub(crate) shape: &'static Shape,
+
+    /// Invariant over 'facet (same reasoning as Peek)
+    /// Covariant over 'mem but with mutable access
+    #[allow(clippy::type_complexity)]
+    _marker: PhantomData<(&'mem mut (), fn(&'facet ()) -> &'facet ())>,
+}
+
+impl<'mem, 'facet> Poke<'mem, 'facet> {
+    /// Creates a mutable view over a `T` value.
+    ///
+    /// This always succeeds - wholesale replacement via [`Poke::set`] is safe for any type.
+    /// The POD check happens when you try to mutate individual struct fields.
+    pub fn new<T: Facet<'facet>>(t: &'mem mut T) -> Self {
+        Self {
+            data: PtrMut::new(t as *mut T as *mut u8),
+            shape: T::SHAPE,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Creates a mutable view from raw parts without any validation.
+    ///
+    /// # Safety
+    ///
+    /// - `data` must point to a valid, initialized value of the type described by `shape`
+    /// - `data` must be valid for the lifetime `'mem`
+    pub unsafe fn from_raw_parts(data: PtrMut, shape: &'static Shape) -> Self {
+        Self {
+            data,
+            shape,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns the shape of the value.
+    #[inline(always)]
+    pub fn shape(&self) -> &'static Shape {
+        self.shape
+    }
+
+    /// Returns a const pointer to the underlying data.
+    #[inline(always)]
+    pub fn data(&self) -> PtrConst {
+        self.data.as_const()
+    }
+
+    /// Returns a mutable pointer to the underlying data.
+    #[inline(always)]
+    pub fn data_mut(&mut self) -> PtrMut {
+        self.data
+    }
+
+    /// Returns true if this value is a struct.
+    #[inline]
+    pub fn is_struct(&self) -> bool {
+        matches!(self.shape.ty, Type::User(UserType::Struct(_)))
+    }
+
+    /// Returns true if this value is an enum.
+    #[inline]
+    pub fn is_enum(&self) -> bool {
+        matches!(self.shape.ty, Type::User(UserType::Enum(_)))
+    }
+
+    /// Returns true if this value is a scalar (primitive type).
+    #[inline]
+    pub fn is_scalar(&self) -> bool {
+        matches!(self.shape.def, Def::Scalar)
+    }
+
+    /// Converts this into a `PokeStruct` if the value is a struct.
+    pub fn into_struct(self) -> Result<PokeStruct<'mem, 'facet>, ReflectError> {
+        match self.shape.ty {
+            Type::User(UserType::Struct(struct_type)) => Ok(PokeStruct {
+                value: self,
+                ty: struct_type,
+            }),
+            _ => Err(ReflectError::WrongShape {
+                expected: self.shape,
+                actual: self.shape,
+            }),
+        }
+    }
+
+    /// Gets a reference to the underlying value.
+    ///
+    /// Returns an error if the shape doesn't match `T`.
+    pub fn get<T: Facet<'facet>>(&self) -> Result<&T, ReflectError> {
+        if self.shape != T::SHAPE {
+            return Err(ReflectError::WrongShape {
+                expected: self.shape,
+                actual: T::SHAPE,
+            });
+        }
+        Ok(unsafe { self.data.as_const().get::<T>() })
+    }
+
+    /// Gets a mutable reference to the underlying value.
+    ///
+    /// Returns an error if the shape doesn't match `T`.
+    pub fn get_mut<T: Facet<'facet>>(&mut self) -> Result<&mut T, ReflectError> {
+        if self.shape != T::SHAPE {
+            return Err(ReflectError::WrongShape {
+                expected: self.shape,
+                actual: T::SHAPE,
+            });
+        }
+        Ok(unsafe { self.data.as_mut::<T>() })
+    }
+
+    /// Sets the value to a new value.
+    ///
+    /// This replaces the entire value. The new value must have the same shape.
+    pub fn set<T: Facet<'facet>>(&mut self, value: T) -> Result<(), ReflectError> {
+        if self.shape != T::SHAPE {
+            return Err(ReflectError::WrongShape {
+                expected: self.shape,
+                actual: T::SHAPE,
+            });
+        }
+        unsafe {
+            // Drop the old value and write the new one
+            self.shape.call_drop_in_place(self.data);
+            core::ptr::write(self.data.as_mut_byte_ptr() as *mut T, value);
+        }
+        Ok(())
+    }
+
+    /// Converts this `Poke` into a read-only `Peek`.
+    #[inline]
+    pub fn as_peek(&self) -> crate::Peek<'_, 'facet> {
+        unsafe { crate::Peek::unchecked_new(self.data.as_const(), self.shape) }
+    }
+}
+
+impl core::fmt::Debug for Poke<'_, '_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Poke<{}>", self.shape)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poke_primitive_get_set() {
+        let mut x: i32 = 42;
+        let mut poke = Poke::new(&mut x);
+
+        assert_eq!(*poke.get::<i32>().unwrap(), 42);
+
+        poke.set(100i32).unwrap();
+        assert_eq!(x, 100);
+    }
+
+    #[test]
+    fn poke_primitive_get_mut() {
+        let mut x: i32 = 42;
+        let mut poke = Poke::new(&mut x);
+
+        *poke.get_mut::<i32>().unwrap() = 99;
+        assert_eq!(x, 99);
+    }
+
+    #[test]
+    fn poke_wrong_type_fails() {
+        let mut x: i32 = 42;
+        let poke = Poke::new(&mut x);
+
+        let result = poke.get::<u32>();
+        assert!(matches!(result, Err(ReflectError::WrongShape { .. })));
+    }
+
+    #[test]
+    fn poke_set_wrong_type_fails() {
+        let mut x: i32 = 42;
+        let mut poke = Poke::new(&mut x);
+
+        let result = poke.set(42u32);
+        assert!(matches!(result, Err(ReflectError::WrongShape { .. })));
+    }
+
+    #[test]
+    fn poke_string_drop_and_replace() {
+        // Wholesale replacement works on any type, including String
+        let mut s = String::from("hello");
+        let mut poke = Poke::new(&mut s);
+
+        poke.set(String::from("world")).unwrap();
+        assert_eq!(s, "world");
+    }
+}

--- a/facet-reflect/tests/integration_tests.rs
+++ b/facet-reflect/tests/integration_tests.rs
@@ -1,2 +1,3 @@
 mod partial;
 mod peek;
+mod poke;

--- a/facet-reflect/tests/poke/mod.rs
+++ b/facet-reflect/tests/poke/mod.rs
@@ -1,0 +1,2 @@
+mod struct_;
+mod value;

--- a/facet-reflect/tests/poke/struct_.rs
+++ b/facet-reflect/tests/poke/struct_.rs
@@ -1,0 +1,208 @@
+use facet::Facet;
+use facet_reflect::{Poke, ReflectError};
+
+#[test]
+fn poke_struct_field_by_name() {
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    let mut point = Point { x: 1, y: 2 };
+    let poke = Poke::new(&mut point);
+    let mut poke_struct = poke.into_struct().expect("Point is a struct");
+
+    // Modify x field
+    poke_struct.set_field_by_name("x", 100i32).unwrap();
+
+    assert_eq!(point.x, 100);
+    assert_eq!(point.y, 2);
+}
+
+#[test]
+fn poke_struct_field_by_index() {
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    let mut point = Point { x: 1, y: 2 };
+    let poke = Poke::new(&mut point);
+    let mut poke_struct = poke.into_struct().expect("Point is a struct");
+
+    // Modify y field (index 1)
+    poke_struct.set_field(1, 200i32).unwrap();
+
+    assert_eq!(point.x, 1);
+    assert_eq!(point.y, 200);
+}
+
+#[test]
+fn poke_struct_get_field_poke() {
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    let mut point = Point { x: 1, y: 2 };
+    {
+        let poke = Poke::new(&mut point);
+        let mut poke_struct = poke.into_struct().expect("Point is a struct");
+
+        // Get mutable access to x field
+        let mut field_poke = poke_struct.field_by_name("x").unwrap();
+        field_poke.set(42i32).unwrap();
+    }
+
+    assert_eq!(point.x, 42);
+}
+
+#[test]
+fn poke_struct_wrong_field_type() {
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    let mut point = Point { x: 1, y: 2 };
+    let poke = Poke::new(&mut point);
+    let mut poke_struct = poke.into_struct().expect("Point is a struct");
+
+    // Try to set i32 field with u32
+    let result = poke_struct.set_field_by_name("x", 100u32);
+    assert!(matches!(result, Err(ReflectError::WrongShape { .. })));
+}
+
+#[test]
+fn poke_struct_no_such_field() {
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    let mut point = Point { x: 1, y: 2 };
+    let poke = Poke::new(&mut point);
+    let mut poke_struct = poke.into_struct().expect("Point is a struct");
+
+    let result = poke_struct.set_field_by_name("z", 100i32);
+    assert!(matches!(result, Err(ReflectError::FieldError { .. })));
+}
+
+#[test]
+fn poke_struct_field_index_out_of_bounds() {
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    let mut point = Point { x: 1, y: 2 };
+    let poke = Poke::new(&mut point);
+    let mut poke_struct = poke.into_struct().expect("Point is a struct");
+
+    let result = poke_struct.set_field(99, 100i32);
+    assert!(matches!(result, Err(ReflectError::FieldError { .. })));
+}
+
+#[test]
+fn poke_struct_peek_field() {
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    let mut point = Point { x: 42, y: 99 };
+    let poke = Poke::new(&mut point);
+    let poke_struct = poke.into_struct().expect("Point is a struct");
+
+    // Get read-only view of field
+    let x_peek = poke_struct.peek_field_by_name("x").unwrap();
+    assert_eq!(*x_peek.get::<i32>().unwrap(), 42);
+}
+
+#[test]
+fn poke_struct_as_peek_struct() {
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    let mut point = Point { x: 10, y: 20 };
+    let poke = Poke::new(&mut point);
+    let poke_struct = poke.into_struct().expect("Point is a struct");
+
+    let peek_struct = poke_struct.as_peek_struct();
+    assert_eq!(peek_struct.field_count(), 2);
+}
+
+#[test]
+fn poke_struct_with_string_field() {
+    // POD struct can have non-POD fields like String
+    // The POD check is on the parent struct, not the field type
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct Person {
+        name: String,
+        age: u32,
+    }
+
+    let mut person = Person {
+        name: "Alice".to_string(),
+        age: 30,
+    };
+
+    let poke = Poke::new(&mut person);
+    let mut poke_struct = poke.into_struct().expect("Person is a struct");
+
+    poke_struct
+        .set_field_by_name("name", "Bob".to_string())
+        .unwrap();
+    poke_struct.set_field_by_name("age", 25u32).unwrap();
+
+    assert_eq!(person.name, "Bob");
+    assert_eq!(person.age, 25);
+}
+
+#[test]
+fn poke_struct_with_non_pod_field_in_pod_parent() {
+    // The field type doesn't need to be POD - only the parent struct
+    #[derive(Debug, Facet, PartialEq)]
+    struct Inner {
+        value: i32,
+    }
+
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct Outer {
+        inner: Inner,
+    }
+
+    let mut outer = Outer {
+        inner: Inner { value: 42 },
+    };
+
+    let poke = Poke::new(&mut outer);
+    let mut poke_struct = poke.into_struct().expect("Outer is a struct");
+
+    // Can replace the Inner field even though Inner is not POD
+    poke_struct
+        .set_field_by_name("inner", Inner { value: 100 })
+        .unwrap();
+
+    assert_eq!(outer.inner.value, 100);
+}

--- a/facet-reflect/tests/poke/value.rs
+++ b/facet-reflect/tests/poke/value.rs
@@ -1,0 +1,126 @@
+use facet::Facet;
+use facet_reflect::{Poke, ReflectError};
+
+#[test]
+fn poke_pod_struct() {
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    let mut point = Point { x: 1, y: 2 };
+    let poke = Poke::new(&mut point);
+
+    assert_eq!(poke.shape(), Point::SHAPE);
+}
+
+#[test]
+fn poke_non_pod_struct_can_be_created() {
+    // Poke::new() works on any type - it's set_field that requires POD
+    #[derive(Debug, Facet)]
+    struct NotPod {
+        x: i32,
+    }
+
+    let mut value = NotPod { x: 42 };
+    let poke = Poke::new(&mut value);
+
+    assert_eq!(poke.shape(), NotPod::SHAPE);
+}
+
+#[test]
+fn poke_non_pod_struct_set_field_fails() {
+    #[derive(Debug, Facet)]
+    struct NotPod {
+        x: i32,
+    }
+
+    let mut value = NotPod { x: 42 };
+    let poke = Poke::new(&mut value);
+    let mut poke_struct = poke.into_struct().unwrap();
+
+    // Setting a field on a non-POD struct should fail
+    let result = poke_struct.set_field_by_name("x", 100i32);
+    assert!(matches!(result, Err(ReflectError::NotPod { .. })));
+}
+
+#[test]
+fn poke_non_pod_struct_wholesale_replace_works() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct NotPod {
+        x: i32,
+    }
+
+    let mut value = NotPod { x: 42 };
+    let mut poke = Poke::new(&mut value);
+
+    // Wholesale replacement always works
+    poke.set(NotPod { x: 100 }).unwrap();
+    assert_eq!(value.x, 100);
+}
+
+#[test]
+fn poke_primitive() {
+    let mut x: i32 = 42;
+    let mut poke = Poke::new(&mut x);
+
+    assert_eq!(*poke.get::<i32>().unwrap(), 42);
+
+    poke.set(100i32).unwrap();
+    assert_eq!(x, 100);
+}
+
+#[test]
+fn poke_get_mut() {
+    let mut x: i32 = 42;
+    let mut poke = Poke::new(&mut x);
+
+    *poke.get_mut::<i32>().unwrap() = 99;
+    assert_eq!(x, 99);
+}
+
+#[test]
+fn poke_wrong_type_fails() {
+    let mut x: i32 = 42;
+    let poke = Poke::new(&mut x);
+
+    let result = poke.get::<u32>();
+    assert!(matches!(result, Err(ReflectError::WrongShape { .. })));
+}
+
+#[test]
+fn poke_set_wrong_type_fails() {
+    let mut x: i32 = 42;
+    let mut poke = Poke::new(&mut x);
+
+    let result = poke.set(42u32);
+    assert!(matches!(result, Err(ReflectError::WrongShape { .. })));
+}
+
+#[test]
+fn poke_string_wholesale_replace() {
+    // String is not POD, but wholesale replacement works
+    let mut s = String::from("hello");
+    let mut poke = Poke::new(&mut s);
+
+    poke.set(String::from("world")).unwrap();
+    assert_eq!(s, "world");
+}
+
+#[test]
+fn poke_as_peek() {
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    let mut point = Point { x: 10, y: 20 };
+    let poke = Poke::new(&mut point);
+
+    let peek = poke.as_peek();
+    assert_eq!(peek.shape(), Point::SHAPE);
+}


### PR DESCRIPTION
## Summary

Adds `Poke<'mem, 'facet>` as the mutable counterpart to `Peek`. This enables mutation of values through reflection.

## Key Design Decisions

- **`Poke::new()` always succeeds** - You can create a `Poke` for any type. Wholesale replacement via `poke.set(new_value)` is always safe (drop old, write new).

- **`into_struct()` always succeeds** - It's just a view transformation, no mutation happens here.

- **`set_field()` checks if the PARENT struct is POD** - Field mutation could violate struct-level invariants, so the struct must be marked `#[facet(pod)]`.

- **Field types don't need to be POD** - A `#[facet(pod)]` struct can contain `String` or other non-POD fields. The POD check is on the parent, not the field type.

## Example

```rust
// Wholesale replacement works on any type
let mut s = String::from("hello");
let mut poke = Poke::new(&mut s);
poke.set(String::from("world")).unwrap();

// Field mutation requires #[facet(pod)] on the parent struct
#[derive(Facet)]
#[facet(pod)]
struct Point { x: i32, y: i32 }

let mut point = Point { x: 1, y: 2 };
let mut poke = Poke::new(&mut point);
poke.into_struct().unwrap().set_field_by_name("x", 10i32).unwrap();
assert_eq!(point.x, 10);
```

## Other Changes

- Remove `--lib` flag from miri recipes in Justfile so integration tests run under miri
- Add `NotPod` error variant with clear error message