### PR TITLE
Fix meta charset parsing in facet-format-html

### DIFF
--- a/facet-format-html/src/elements.rs
+++ b/facet-format-html/src/elements.rs
@@ -19,9 +19,9 @@
 //! - **Scripting**: `Script`, `Noscript`, `Template`, `Canvas`
 
 use facet::Facet;
-// Note: We use xml::text here because Rust doesn't allow referencing macro-generated
-// attributes from the same crate. The deserializer's is_text() helper handles both
-// xml::text and xml::text equivalently.
+// Note: We use xml::elements here because Rust doesn't allow referencing macro-generated
+// attributes from the same crate (rust-lang/rust#52234). The deserializer's is_elements()
+// helper handles both xml::elements and html::elements equivalently.
 use facet_format_xml as xml;
 
 // =============================================================================
@@ -109,16 +109,16 @@ pub struct Head {
     #[facet(default)]
     pub base: Option<Base>,
     /// Linked resources (stylesheets, icons, etc.).
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub link: Vec<Link>,
     /// Metadata elements.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub meta: Vec<Meta>,
     /// Inline styles.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub style: Vec<Style>,
     /// Scripts.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub script: Vec<Script>,
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/facet-rs/facet/issues/1527

When parsing `<head><meta charset="utf-8">...</head>`, the deserializer was incorrectly trying to deserialize `Vec<Meta>` directly by looking for a sequence/array container. Instead, for XML/HTML, repeated child elements should be accumulated into the list.

**Two-part fix:**
1. Mark Vec fields in `Head` struct with `#[facet(xml::elements)]` to indicate repeated child elements should be accumulated
2. Exclude `is_elements()` fields from direct field matching in the deserializer so they're handled via the `xml::elements` accumulation path

## Test plan
- [x] Added regression test for `<meta charset="utf-8">` parsing
- [x] Added test for full HTML document parsing with meta charset
- [x] All 374 format tests pass (facet-format, facet-format-xml, facet-format-html, facet-format-json)
- [x] Pre-push checks pass (clippy, tests, doc tests, docs, cargo-shear)