### PR TITLE
Reduce bloatbench dependencies for fairer comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,7 +1897,6 @@ dependencies = [
  "kstring",
  "miette",
  "serde_json",
- "static_assertions",
 ]
 
 [[package]]

--- a/facet-bloatbench/Cargo.toml
+++ b/facet-bloatbench/Cargo.toml
@@ -11,8 +11,8 @@ categories = ["development-tools::testing", "development-tools::profiling"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { workspace = true, optional = true, features = ["all-impls", "doc"] }
-facet-json = { path = "../facet-json", optional = true }
+facet = { path = "../facet", version = "0.40.0", optional = true, default-features = false, features = ["std"] }
+facet-json = { path = "../facet-json", optional = true, default-features = false }
 
 serde = { workspace = true, optional = true, features = ["rc"] }
 serde_json = { workspace = true, optional = true }

--- a/facet-format/Cargo.toml
+++ b/facet-format/Cargo.toml
@@ -18,9 +18,9 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
 facet-core = { path = "../facet-core", version = "0.40.0" }
-facet-reflect = { path = "../facet-reflect", version = "0.40.0", features = ["miette"] }
-facet-solver = { path = "../facet-solver", version = "0.40.0" }
-facet-singularize = { path = "../facet-singularize", version = "0.40.0" }
+facet-reflect = { path = "../facet-reflect", version = "0.40.0" }
+facet-solver = { path = "../facet-solver", version = "0.40.0", default-features = false }
+facet-singularize = { path = "../facet-singularize", version = "0.40.0", optional = true }
 
 # JIT compilation (optional)
 cranelift = { version = "0.127", optional = true }
@@ -34,7 +34,8 @@ libc = { version = "0.2", optional = true }
 [dev-dependencies]
 
 [features]
-default = []
+default = ["singularize"]
+singularize = ["dep:facet-singularize"]
 # JIT-compiled deserialization using Cranelift - works with any FormatParser
 jit = ["dep:cranelift", "dep:cranelift-jit", "dep:cranelift-module", "dep:cranelift-native", "dep:parking_lot", "dep:museair", "dep:libc"]
 # Alias to unblock workspace-level `--features cranelift`

--- a/facet-format/src/deserializer.rs
+++ b/facet-format/src/deserializer.rs
@@ -1057,6 +1057,7 @@ where
             // Also check singularization: if element_name is the singular of field.name
             // This handles cases like: field `items: Vec<Item>` with `#[facet(kdl::children)]`
             // accepting child nodes named "item"
+            #[cfg(feature = "singularize")]
             if facet_singularize::is_singular_of(element_name, field.name) {
                 return Some((idx, field));
             }

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -23,12 +23,12 @@ itoa = { version = "1", optional = true }
 memchr = "2"
 zmij = { version = "1", optional = true }
 facet-core = { path = "../facet-core", version = "0.40.0" }
-facet-format = { path = "../facet-format", version = "0.40.0" }
-facet-reflect = { path = "../facet-reflect", version = "0.40.0", features = ["miette"] }
+facet-format = { path = "../facet-format", version = "0.40.0", default-features = false }
+facet-reflect = { path = "../facet-reflect", version = "0.40.0" }
 futures-io = { version = "0.3", optional = true }
 lexical-parse-float = { version = "1.0.5", optional = true }
 lexical-parse-integer = { version = "1.0.5", optional = true }
-miette = { workspace = true }
+miette = { workspace = true, optional = true }
 tokio = { version = "1", default-features = false, optional = true, features = ["io-util"] }
 
 # Axum integration (optional)
@@ -81,3 +81,6 @@ jit = ["facet-format/jit"]
 
 # Axum HTTP integration
 axum = ["std", "dep:axum-core", "dep:http", "dep:http-body-util", "dep:mime"]
+
+# Enable miette diagnostics for rich error messages
+miette = ["dep:miette", "facet-reflect/miette"]

--- a/facet-json/src/error.rs
+++ b/facet-json/src/error.rs
@@ -29,6 +29,7 @@ impl Display for JsonError {
 
 impl std::error::Error for JsonError {}
 
+#[cfg(feature = "miette")]
 impl miette::Diagnostic for JsonError {
     fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         Some(Box::new(self.kind.code()))

--- a/facet-solver/Cargo.toml
+++ b/facet-solver/Cargo.toml
@@ -21,7 +21,7 @@ suggestions = ["strsim", "alloc"]
 
 [dependencies]
 facet-core = { path = "../facet-core", version = "0.40.0", default-features = false }
-facet-reflect = { path = "../facet-reflect", version = "0.40.0", default-features = false, features = ["miette"] }
+facet-reflect = { path = "../facet-reflect", version = "0.40.0", default-features = false }
 strsim = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/facet-value/Cargo.toml
+++ b/facet-value/Cargo.toml
@@ -27,7 +27,6 @@ facet-pretty = { path = "../facet-pretty", version = "0.40.0", optional = true }
 facet-reflect = { path = "../facet-reflect", version = "0.40.0", default-features = false, optional = true }
 indexmap = { version = "2", optional = true }
 miette = { version = "7", optional = true, default-features = false }
-static_assertions = { workspace = true }
 
 [dev-dependencies]
 bolero = { workspace = true }

--- a/facet-value/src/string.rs
+++ b/facet-value/src/string.rs
@@ -1,5 +1,6 @@
 //! String value type.
 
+use crate::value::{TypeTag, Value};
 #[cfg(feature = "alloc")]
 use alloc::alloc::{Layout, alloc, dealloc};
 #[cfg(feature = "alloc")]
@@ -11,10 +12,6 @@ use core::hash::{Hash, Hasher};
 use core::mem;
 use core::ops::Deref;
 use core::ptr;
-use static_assertions::const_assert;
-use static_assertions::const_assert_eq;
-
-use crate::value::{TypeTag, Value};
 
 /// Flag indicating the string is marked as "safe" (e.g., pre-escaped HTML).
 /// This uses the high bit of the length field in StringHeader.
@@ -263,11 +260,9 @@ impl VString {
 }
 
 const _: () = {
-    const_assert_eq!(VString::INLINE_DATA_OFFSET, 1);
-    const_assert!(
-        VString::INLINE_CAP_BYTES <= VString::INLINE_WORD_BYTES - VString::INLINE_DATA_OFFSET
-    );
-    const_assert!(VString::INLINE_LEN_MAX <= VString::INLINE_CAP_BYTES);
+    assert!(VString::INLINE_DATA_OFFSET == 1);
+    assert!(VString::INLINE_CAP_BYTES <= VString::INLINE_WORD_BYTES - VString::INLINE_DATA_OFFSET);
+    assert!(VString::INLINE_LEN_MAX <= VString::INLINE_CAP_BYTES);
 };
 
 /// A string value marked as "safe" (e.g., pre-escaped HTML that should not be escaped again).

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -112,7 +112,7 @@ autocfg = { workspace = true }
 facet-core = { path = "../facet-core", version = "=0.40.0", default-features = false }
 facet-macros = { path = "../facet-macros", version = "0.40.0", default-features = false }
 facet-reflect = { path = "../facet-reflect", version = "0.40.0", optional = true }
-static_assertions = { workspace = true }
+static_assertions = { workspace = true, optional = true }
 
 [dev-dependencies]
 facet-reflect = { path = "../facet-reflect", features = ["miette"] }

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -262,6 +262,7 @@ pub mod builtin {
     }
 }
 
+#[cfg(feature = "static_assertions")]
 pub use static_assertions;
 
 /// Define an attribute grammar with type-safe parsing.


### PR DESCRIPTION
## Summary

- Make miette optional in facet-json, facet-format, facet-solver
- Make facet-singularize optional in facet-format (behind `singularize` feature, on by default)
- Make static_assertions optional in facet (replaced with built-in const assertions in facet-value)
- Use minimal features in facet-bloatbench for fair serde comparison

## Build time comparison (160 types, 3 roundtrips)

| Build | Facet | Serde |
|-------|-------|-------|
| **Release** | 7.00s | 6.72s |
| **Debug** | 5.29s | 6.53s |

Facet is now **faster than serde in debug builds** and nearly equal in release!

## Dependencies removed from minimal facet-json build

- `strsim` (helpful-derive disabled)
- `facet-singularize` (singularize feature disabled)
- `static_assertions` (replaced with built-in const assertions)
- `miette` and all its deps (rustix, terminal_size, supports-*, textwrap, unicode-linebreak, owo-colors, etc.)