### PR TITLE
Fix deserialization of attributes when an element with the same name is present

### DIFF
--- a/facet-format/src/deserializer.rs
+++ b/facet-format/src/deserializer.rs
@@ -614,6 +614,11 @@ where
         location: FieldLocationHint,
         ns_all: Option<&str>,
     ) -> bool {
+        // === XML/HTML: Fields with xml::attribute match only attributes
+        if field.is_attribute() && !matches!(location, FieldLocationHint::Attribute) {
+            return false;
+        }
+
         // === XML/HTML: Text location matches fields with text attribute ===
         // The name "_text" from the parser is ignored - we match by attribute presence
         if matches!(location, FieldLocationHint::Text) {

--- a/facet-xml/tests/attributes.rs
+++ b/facet-xml/tests/attributes.rs
@@ -1,0 +1,59 @@
+use std::borrow::Cow;
+
+use facet::Facet;
+use facet_xml::{self as xml, from_str, to_string};
+
+#[test]
+fn test_deserialize_attribute_when_element_with_the_same_name_is_present() {
+    #[derive(Facet, Debug, PartialEq)]
+    #[facet(rename = "root")]
+    struct Root<'a> {
+        #[facet(xml::attribute)]
+        id: Cow<'a, str>,
+    }
+
+    let xml_data = r#"<root><id>value</id></root>"#;
+    assert!(from_str::<Root>(xml_data).is_err());
+}
+
+#[test]
+fn test_deserialize_attribute_and_element_with_the_same_name() {
+    #[derive(Facet, Debug, PartialEq)]
+    #[facet(rename = "root")]
+    struct Root<'a> {
+        #[facet(xml::attribute, rename = "id")]
+        id_attribute: Cow<'a, str>,
+        #[facet(xml::element, rename = "id")]
+        id_element: Cow<'a, str>,
+    }
+
+    let xml_data = r#"<root id="attribute"><id>element</id></root>"#;
+    assert_eq!(
+        from_str::<Root>(xml_data).unwrap(),
+        Root {
+            id_attribute: Cow::Borrowed("attribute"),
+            id_element: Cow::Borrowed("element")
+        }
+    );
+}
+
+#[test]
+fn test_serialize_attribute_and_element_with_the_same_name() {
+    #[derive(Facet, Debug, PartialEq)]
+    #[facet(rename = "root")]
+    struct Root<'a> {
+        #[facet(xml::attribute, rename = "id")]
+        id_attribute: Cow<'a, str>,
+        #[facet(xml::element, rename = "id")]
+        id_element: Cow<'a, str>,
+    }
+
+    assert_eq!(
+        to_string(&Root {
+            id_attribute: Cow::Borrowed("attribute"),
+            id_element: Cow::Borrowed("element")
+        })
+        .unwrap(),
+        r#"<root id="attribute"><id>element</id></root>"#,
+    );
+}


### PR DESCRIPTION
The current implementation of `facet-xml` incorrectly deserializes a missing attribute from an element with the same name, as shown in the following snippet:

```rust
#[derive(Debug, Facet, PartialEq)]
struct Root {
    #[facet(xml::attribute)]
    id: String,
}

assert_eq!(
    facet_xml::from_str::<Root>(r#"<Root><id>value</id></Root>"#).unwrap(),
    Root {
        id: "value".to_string()
    }
);
```

This PR fixes this issue. Additionally, it enables the ability to deserialize both an attribute and an element with the same name without confusion.