### PR TITLE
Require 'static for Opaque<T> Facet impl

### DIFF
--- a/docs/content/guide/attributes.md
+++ b/docs/content/guide/attributes.md
@@ -120,6 +120,10 @@ struct Config {
 }
 ```
 
+**Note:** For now, field-level `#[facet(opaque)]` requires the field type to be `'static`
+(no borrowed references). This avoids unsound lifetime laundering through reflection.
+If you need to hide a borrowed type, use a proxy or a wrapper type that owns its data.
+
 **When `assert_same!` encounters an opaque type**, it returns `Sameness::Opaque` — you cannot structurally compare opaque values.
 
 ### `pod`

--- a/facet-core/src/impls/builtin.rs
+++ b/facet-core/src/impls/builtin.rs
@@ -1,8 +1,13 @@
-use crate::{Opaque, Shape};
+use crate::{Opaque, Shape, Variance};
 
 use crate::Facet;
 
-unsafe impl<'facet, T: 'facet> Facet<'facet> for Opaque<T> {
-    const SHAPE: &'static Shape =
-        &const { Shape::builder_for_sized::<Opaque<T>>("Opaque").build() };
+// Opaque<T> is a lifetime boundary; require 'static to prevent lifetime laundering
+// through reflection. See issue #1563 for details.
+unsafe impl<'facet, T: 'static> Facet<'facet> for Opaque<T> {
+    const SHAPE: &'static Shape = &const {
+        Shape::builder_for_sized::<Opaque<T>>("Opaque")
+            .variance(Variance::INVARIANT)
+            .build()
+    };
 }

--- a/facet-reflect/tests/compile_tests.rs
+++ b/facet-reflect/tests/compile_tests.rs
@@ -327,3 +327,32 @@ fn test_oxref_unsound_from_raw_ptr() {
 
     run_compilation_test(&test);
 }
+
+/// Soundness test for GitHub issue #1563
+///
+/// After the fix, Opaque<T> requires T: 'static, so borrowed references
+/// are rejected and lifetime laundering through Poke is prevented.
+#[test]
+#[cfg(not(miri))]
+fn test_poke_opaque_insufficient_lifetime() {
+    let test = CompilationTest {
+        name: "opaque_insufficient_lifetime",
+        source: include_str!("poke/compile_tests/opaque_insufficient_lifetime.rs"),
+        expected_errors: &["does not live long enough"],
+    };
+
+    run_compilation_test(&test);
+}
+
+/// Opaque fields currently require 'static.
+#[test]
+#[cfg(not(miri))]
+fn test_poke_opaque_borrowed_non_facet() {
+    let test = CompilationTest {
+        name: "opaque_borrowed_non_facet",
+        source: include_str!("poke/compile_tests/opaque_borrowed_non_facet.rs"),
+        expected_errors: &["lifetime may not live long enough"],
+    };
+
+    run_compilation_test(&test);
+}

--- a/facet-reflect/tests/poke/compile_tests/opaque_borrowed_non_facet.rs
+++ b/facet-reflect/tests/poke/compile_tests/opaque_borrowed_non_facet.rs
@@ -1,0 +1,19 @@
+//! Opaque fields require 'static for now.
+//!
+//! This should fail because `#[facet(opaque)]` on a borrowed reference
+//! produces `Opaque<&'a T>`, and Opaque<T> requires T: 'static.
+
+use facet::Facet;
+
+struct NotFacet;
+
+#[derive(Facet)]
+struct Wrap<'a> {
+    #[facet(opaque)]
+    inner: &'a NotFacet,
+}
+
+fn main() {
+    let value = NotFacet;
+    let _wrap = Wrap { inner: &value };
+}

--- a/facet-reflect/tests/poke/compile_tests/opaque_insufficient_lifetime.rs
+++ b/facet-reflect/tests/poke/compile_tests/opaque_insufficient_lifetime.rs
@@ -1,0 +1,22 @@
+//! Regression test for GitHub issue #1563
+//!
+//! This code was unsound before the fix because Opaque's Facet implementation
+//! was covariant, allowing unsafe lifetime coercion. The code creates an
+//! Opaque<&mut String> with a short lifetime, then uses Poke::get_mut to
+//! get an Opaque<&mut String> with a longer lifetime (by inference), and
+//! assigns a short-lived reference to it.
+//!
+//! After the fix, Opaque<T> requires T: 'static, preventing this code from compiling.
+
+use facet::Opaque;
+use facet_reflect::Poke;
+
+fn main() {
+    let mut s = String::new();
+    let mut t = Opaque(&mut s);
+    Poke::new(&mut t)
+        .get_mut::<Opaque<&mut String>>()
+        .unwrap()
+        .0 = &mut ".".repeat(200);
+    println!("{}", t.0);
+}


### PR DESCRIPTION
## Summary
Close the Opaque<T> lifetime laundering hole by requiring `T: 'static` for the `Facet` impl and documenting the temporary restriction.

## Changes
- Require `T: 'static` for `Opaque<T>: Facet` and add a brief rationale comment
- Add compile-fail coverage for the original exploit and for borrowed `#[facet(opaque)]`
- Document the current `'static` restriction and open follow-up issue #1565

## Test Plan
- `cargo nextest run -p facet-reflect --features slow-tests test_poke_opaque_insufficient_lifetime test_poke_opaque_borrowed_non_facet --no-capture --no-fail-fast`

Closes #1563
