### PR TITLE
facet-xml: fix deserialization of elements when an attribute with the same name is present

### DIFF
--- a/facet-format/src/deserializer.rs
+++ b/facet-format/src/deserializer.rs
@@ -727,6 +727,14 @@ where
             return false;
         }
 
+        // === XML/HTML: Fields with xml::element/elements match only child elements
+        // === KDL: Fields with kdl::child/children match only child nodes
+        if (field.is_element() || field.is_elements())
+            && !matches!(location, FieldLocationHint::Child)
+        {
+            return false;
+        }
+
         // === XML/HTML: Text location matches fields with text attribute ===
         // The name "_text" from the parser is ignored - we match by attribute presence
         if matches!(location, FieldLocationHint::Text) {
@@ -771,17 +779,6 @@ where
 
         if !name_matches {
             return false;
-        }
-
-        // === KDL/XML/HTML: Child location matches fields with child/element attributes ===
-        if matches!(location, FieldLocationHint::Child) {
-            // If field has explicit child/element attribute, it can match Child location
-            // If field has NO child attribute, it can still match by name (backwards compat)
-            if field.is_element() || field.is_elements() {
-                // Has explicit child marker - allow match
-                // (name already matched above)
-            }
-            // Fall through to namespace check for XML
         }
 
         // === XML: Namespace matching ===

--- a/facet-xml/tests/attributes.rs
+++ b/facet-xml/tests/attributes.rs
@@ -17,6 +17,19 @@ fn test_deserialize_attribute_when_element_with_the_same_name_is_present() {
 }
 
 #[test]
+fn test_deserialize_element_when_attribute_with_the_same_name_is_present() {
+    #[derive(Facet, Debug, PartialEq)]
+    #[facet(rename = "root")]
+    struct Root<'a> {
+        #[facet(xml::element)]
+        id: Cow<'a, str>,
+    }
+
+    let xml_data = r#"<root id="value"/>"#;
+    assert!(from_str::<Root>(xml_data).is_err());
+}
+
+#[test]
 fn test_deserialize_attribute_and_element_with_the_same_name() {
     #[derive(Facet, Debug, PartialEq)]
     #[facet(rename = "root")]


### PR DESCRIPTION
The current implementation of `facet-xml` incorrectly deserializes a missing element from an attribute with the same name.

It looks like some work was not finished and this old code was removed because it is a no-op.