### PR TITLE
Fix #1575: facet-html crashes on <li> with parentheses

### DIFF
--- a/facet-html/src/elements.rs
+++ b/facet-html/src/elements.rs
@@ -593,7 +593,7 @@ pub struct Ol {
     #[facet(default)]
     pub reversed: Option<String>,
     /// List items.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub li: Vec<Li>,
 }
 
@@ -605,7 +605,7 @@ pub struct Ul {
     #[facet(flatten, default)]
     pub attrs: GlobalAttrs,
     /// List items.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub li: Vec<Li>,
 }
 
@@ -633,10 +633,10 @@ pub struct Dl {
     #[facet(flatten, default)]
     pub attrs: GlobalAttrs,
     /// Terms and descriptions (mixed dt/dd).
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub dt: Vec<Dt>,
     /// Descriptions.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub dd: Vec<Dd>,
 }
 
@@ -1228,10 +1228,10 @@ pub struct Video {
     #[facet(default)]
     pub crossorigin: Option<String>,
     /// Source elements.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub source: Vec<Source>,
     /// Track elements.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub track: Vec<Track>,
 }
 
@@ -1264,7 +1264,7 @@ pub struct Audio {
     #[facet(default)]
     pub crossorigin: Option<String>,
     /// Source elements.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub source: Vec<Source>,
 }
 
@@ -1330,7 +1330,7 @@ pub struct Picture {
     #[facet(flatten, default)]
     pub attrs: GlobalAttrs,
     /// Source elements.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub source: Vec<Source>,
     /// Fallback image.
     #[facet(default)]
@@ -1395,19 +1395,19 @@ pub struct Table {
     #[facet(default)]
     pub caption: Option<Caption>,
     /// Column groups.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub colgroup: Vec<Colgroup>,
     /// Table head.
     #[facet(default)]
     pub thead: Option<Thead>,
     /// Table body sections.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub tbody: Vec<Tbody>,
     /// Table foot.
     #[facet(default)]
     pub tfoot: Option<Tfoot>,
     /// Direct rows (when no thead/tbody/tfoot).
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub tr: Vec<Tr>,
 }
 
@@ -1435,7 +1435,7 @@ pub struct Colgroup {
     #[facet(default)]
     pub span: Option<String>,
     /// Column definitions.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub col: Vec<Col>,
 }
 
@@ -1459,7 +1459,7 @@ pub struct Thead {
     #[facet(flatten, default)]
     pub attrs: GlobalAttrs,
     /// Rows.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub tr: Vec<Tr>,
 }
 
@@ -1471,7 +1471,7 @@ pub struct Tbody {
     #[facet(flatten, default)]
     pub attrs: GlobalAttrs,
     /// Rows.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub tr: Vec<Tr>,
 }
 
@@ -1483,7 +1483,7 @@ pub struct Tfoot {
     #[facet(flatten, default)]
     pub attrs: GlobalAttrs,
     /// Rows.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub tr: Vec<Tr>,
 }
 
@@ -1495,10 +1495,10 @@ pub struct Tr {
     #[facet(flatten, default)]
     pub attrs: GlobalAttrs,
     /// Header cells.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub th: Vec<Th>,
     /// Data cells.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub td: Vec<Td>,
 }
 
@@ -1770,10 +1770,10 @@ pub struct Select {
     #[facet(default)]
     pub form: Option<String>,
     /// Options.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub option: Vec<OptionElement>,
     /// Option groups.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub optgroup: Vec<Optgroup>,
 }
 
@@ -1815,7 +1815,7 @@ pub struct Optgroup {
     #[facet(default)]
     pub disabled: Option<String>,
     /// Options.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub option: Vec<OptionElement>,
 }
 
@@ -1932,7 +1932,7 @@ pub struct Datalist {
     #[facet(flatten, default)]
     pub attrs: GlobalAttrs,
     /// Options.
-    #[facet(default)]
+    #[facet(xml::elements, default)]
     pub option: Vec<OptionElement>,
 }
 

--- a/facet-html/tests/minimal_repro.rs
+++ b/facet-html/tests/minimal_repro.rs
@@ -1,22 +1,78 @@
-// Minimal reproduction for issue #1568
+// Regression tests for GitHub issues
 // Run with: cargo +nightly miri test -p facet-html --test minimal_repro
 
 use facet_html::elements::Html;
 
+// Issue #1568: Crash during error cleanup
 #[test]
-fn minimal_html_parse_error_cleanup() {
+fn issue_1568_html_parse_error_cleanup() {
     // Simplified HTML that previously triggered a crash during error cleanup.
-    // The important thing is that it doesn't crash - whether it parses
-    // successfully or returns an error is secondary.
     let html = r#"<ul><li>text <code>code</code></li></ul>"#;
 
     // This should NOT crash during parsing or cleanup
     let result = facet_html::from_str::<Html>(html);
 
-    // Log the result for debugging
-    match &result {
-        Ok(_) => println!("Parsing succeeded"),
-        Err(e) => println!("Parsing returned error (acceptable): {}", e),
-    }
-    // The test passes as long as we didn't crash
+    // After the fix for #1575, this should parse successfully
+    assert!(result.is_ok(), "Parsing should succeed: {:?}", result.err());
+}
+
+// Issue #1575: facet-html crashes on <li> with parentheses
+// Root cause: Vec<Li> fields in Ul/Ol structs were missing #[facet(xml::elements)]
+// attribute, which is required to properly group repeated child elements into a Vec.
+#[test]
+fn issue_1575_li_with_parentheses() {
+    // This HTML previously crashed with SIGABRT when parsing
+    let html = r#"<!DOCTYPE html>
+<html>
+<head><title>Test</title></head>
+<body>
+<ul>
+<li><code>index.html</code> - renders the root section (<code>/</code>)</li>
+</ul>
+</body>
+</html>"#;
+
+    // This should parse successfully (not just not crash)
+    let result = facet_html::from_str::<Html>(html);
+    assert!(result.is_ok(), "Parsing should succeed: {:?}", result.err());
+}
+
+#[test]
+fn issue_1575_simple_li_with_parentheses() {
+    let html = r#"<ul><li>Some text (with parentheses)</li></ul>"#;
+
+    let result = facet_html::from_str::<Html>(html);
+    assert!(result.is_ok(), "Parsing should succeed: {:?}", result.err());
+}
+
+#[test]
+fn issue_1575_li_with_description_and_parentheses() {
+    let html = r#"<ul><li>Item - description (detail)</li></ul>"#;
+
+    let result = facet_html::from_str::<Html>(html);
+    assert!(result.is_ok(), "Parsing should succeed: {:?}", result.err());
+}
+
+#[test]
+fn issue_1575_li_with_mixed_content() {
+    use facet_html::elements::{FlowContent, Ul};
+
+    // Test that mixed content (text + elements) in <li> is preserved correctly
+    let html = r#"<ul><li><code>a</code> text (<code>b</code>)</li></ul>"#;
+
+    let result = facet_html::from_str::<Ul>(html).expect("should parse");
+    assert_eq!(result.li.len(), 1);
+
+    // Verify the mixed content is parsed correctly
+    let children = &result.li[0].children;
+    assert_eq!(children.len(), 4); // code, text, code, text
+
+    // First child should be code element
+    assert!(matches!(&children[0], FlowContent::Code(_)));
+    // Second child should be text
+    assert!(matches!(&children[1], FlowContent::Text(_)));
+    // Third child should be code element
+    assert!(matches!(&children[2], FlowContent::Code(_)));
+    // Fourth child should be text
+    assert!(matches!(&children[3], FlowContent::Text(_)));
 }


### PR DESCRIPTION
## Summary

Fixes the crash that occurred when parsing `<li>` elements containing text with parentheses. The root cause was that Vec fields for repeated child elements (like `li`, `tr`, `td`, etc.) were missing the `#[facet(xml::elements)]` attribute.

## Changes

Added `#[facet(xml::elements)]` to all Vec fields that represent repeated child elements in HTML:
- List elements: `Ul.li`, `Ol.li`, `Dl.dt`, `Dl.dd`
- Table elements: `Table.colgroup`, `Table.tbody`, `Table.tr`, `Thead.tr`, `Tbody.tr`, `Tfoot.tr`, `Tr.th`, `Tr.td`, `Colgroup.col`
- Media elements: `Video.source`, `Video.track`, `Audio.source`, `Picture.source`
- Form elements: `Select.option`, `Select.optgroup`, `Optgroup.option`, `Datalist.option`

Updated regression tests to verify successful parsing of the issue reproduction cases.

## Test plan

- [x] All existing tests pass
- [x] Issue reproduction cases now parse successfully
- [x] Tests pass under valgrind with no memory issues

Fixes #1575