### PR TITLE
Fix soundness issue: Attr can contain non-Sync data

### DIFF
--- a/facet-core/src/types/attr.rs
+++ b/facet-core/src/types/attr.rs
@@ -21,7 +21,8 @@ pub struct Attr {
     pub data: OxRef<'static>,
 }
 
-// SAFETY: Attr only holds static data, which is inherently Send + Sync
+// SAFETY: Attr only holds `&'static T` where `T: Sync` (enforced by `Attr::new`),
+// so the data can be safely accessed from any thread.
 unsafe impl Send for Attr {}
 unsafe impl Sync for Attr {}
 
@@ -30,8 +31,10 @@ impl Attr {
     ///
     /// The data must be a static reference to a sized value that implements `Facet`.
     /// The `Sized` bound is required to allow const construction.
+    /// The `Sync` bound is required because `Attr` is `Sync`, so the data must be
+    /// safely accessible from any thread.
     #[inline]
-    pub const fn new<T: Facet<'static> + Sized>(
+    pub const fn new<T: Facet<'static> + Sized + Sync>(
         ns: Option<&'static str>,
         key: &'static str,
         data: &'static T,

--- a/facet-reflect/tests/attr/compile_tests/non_sync_data.rs
+++ b/facet-reflect/tests/attr/compile_tests/non_sync_data.rs
@@ -1,0 +1,16 @@
+//! Soundness test for GitHub issue #1573
+//!
+//! Before the fix, Attr could store non-Sync data like Rc<T>, but Attr itself
+//! was Sync, allowing data races when accessed from multiple threads.
+//!
+//! After the fix, Attr::new requires T: Sync, so this code should fail to compile.
+
+use std::rc::Rc;
+
+use facet::Attr;
+
+fn main() {
+    // Rc is not Sync, so this should fail to compile
+    let rc: &'static Rc<i32> = Box::leak(Box::new(Rc::new(0)));
+    let _attr = Attr::new(None, "test", rc);
+}

--- a/facet-reflect/tests/compile_tests.rs
+++ b/facet-reflect/tests/compile_tests.rs
@@ -356,3 +356,23 @@ fn test_poke_opaque_borrowed_non_facet() {
 
     run_compilation_test(&test);
 }
+
+/// Soundness test for GitHub issue #1573
+///
+/// Before the fix, Attr could store non-Sync data like Rc<T>, but Attr itself
+/// was Sync, allowing data races when accessed from multiple threads.
+///
+/// After the fix, Attr::new requires T: Sync, so this code should fail to compile.
+///
+/// See: https://github.com/facet-rs/facet/issues/1573
+#[test]
+#[cfg(not(miri))]
+fn test_attr_non_sync_data() {
+    let test = CompilationTest {
+        name: "attr_non_sync_data",
+        source: include_str!("attr/compile_tests/non_sync_data.rs"),
+        expected_errors: &["Rc<i32>` cannot be shared between threads safely"],
+    };
+
+    run_compilation_test(&test);
+}


### PR DESCRIPTION
## Summary

Fixes a soundness issue where `Attr` could store non-thread-safe types like `Rc<T>`, but since `Attr` is `Sync`, this could lead to data races when accessed from multiple threads.

The fix adds a `T: Sync` bound to `Attr::new()` so that only thread-safe types can be stored.

## Changes

- Add `T: Sync` bound to `Attr::new()` in `facet-core/src/types/attr.rs`
- Update SAFETY comment to correctly explain why `Send`/`Sync` are safe
- Add compile-fail regression test to ensure non-Sync types are rejected

## Test plan

- [x] `cargo check` passes
- [x] All tests pass
- [x] New compile-fail test verifies `Rc<i32>` is rejected

Fixes #1573