### PR TITLE
Fix inconsistent Shape hash (issue #1574)

### DIFF
--- a/facet-core/src/types/const_typeid.rs
+++ b/facet-core/src/types/const_typeid.rs
@@ -77,9 +77,11 @@ impl Ord for ConstTypeId {
 impl Hash for ConstTypeId {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        // Hash the function pointer directly - much faster than calling it
-        // to get TypeId. The function pointer is unique per type within a process.
-        (self.type_id_fn as usize).hash(state);
+        // Hash the actual TypeId, not the function pointer.
+        // In debug builds, different crates may have different function pointer
+        // addresses for the same type's `typeid::of::<T>`, but they return the
+        // same TypeId. Hash must be consistent with Eq.
+        self.get().hash(state);
     }
 }
 

--- a/facet-core/src/types/shape.rs
+++ b/facet-core/src/types/shape.rs
@@ -161,8 +161,9 @@ impl Eq for Shape {}
 
 impl core::hash::Hash for Shape {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        // Only hash id, consistent with PartialEq which only compares id.
+        // The Hash trait requires: if a == b then hash(a) == hash(b).
         self.id.hash(state);
-        self.layout.hash(state);
     }
 }
 

--- a/facet-core/tests/vtable.rs
+++ b/facet-core/tests/vtable.rs
@@ -295,3 +295,56 @@ fn test_option_nested_debug() {
     let ox_none_outer = OxRef::from_ref(&none_outer);
     assert_eq!(format!("{ox_none_outer:?}"), "None");
 }
+
+/// Test that Shape hash is consistent with equality.
+/// This is a regression test for https://github.com/facet-rs/facet/issues/1574
+#[test]
+fn test_shape_hash_consistent_with_eq() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    // Get Shape from multiple places - in the same crate they're definitely
+    // the same pointer, but the hash/eq must be consistent for HashSet to work.
+    let shape1 = <u8 as Facet>::SHAPE;
+    let shape2 = <u8 as Facet>::SHAPE;
+
+    // They should be equal
+    assert_eq!(shape1, shape2, "Same type's shapes should be equal");
+
+    // If a == b, then hash(a) == hash(b) (Hash trait requirement)
+    let mut h1 = DefaultHasher::new();
+    let mut h2 = DefaultHasher::new();
+    shape1.hash(&mut h1);
+    shape2.hash(&mut h2);
+    assert_eq!(
+        h1.finish(),
+        h2.finish(),
+        "Equal shapes must have equal hashes"
+    );
+}
+
+/// Test that ConstTypeId hash is consistent with equality.
+#[test]
+fn test_const_type_id_hash_consistent_with_eq() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    use facet_core::ConstTypeId;
+
+    let id1 = ConstTypeId::of::<u8>();
+    let id2 = ConstTypeId::of::<u8>();
+
+    // They should be equal
+    assert_eq!(id1, id2, "Same type's ConstTypeIds should be equal");
+
+    // If a == b, then hash(a) == hash(b) (Hash trait requirement)
+    let mut h1 = DefaultHasher::new();
+    let mut h2 = DefaultHasher::new();
+    id1.hash(&mut h1);
+    id2.hash(&mut h2);
+    assert_eq!(
+        h1.finish(),
+        h2.finish(),
+        "Equal ConstTypeIds must have equal hashes"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the Hash trait violation where equal `Shape` values could produce different hashes, causing `HashSet` to incorrectly treat them as distinct.

Fixes #1574

## Changes

- **ConstTypeId**: Changed `hash()` to hash the actual `TypeId` (via `self.get()`) instead of the function pointer address. In debug builds, different crates get different function pointer addresses for the same type's `typeid::of::<T>`, but `eq()` correctly compared the returned `TypeId` values.

- **Shape**: Changed `hash()` to only hash `id`, consistent with `eq()` which only compares `id`. Previously `hash()` also included `layout`.

## Test plan

- Added regression tests `test_shape_hash_consistent_with_eq` and `test_const_type_id_hash_consistent_with_eq` in `facet-core/tests/vtable.rs`
- All 2482 existing tests pass