### PR TITLE
Add `facet_no_doc` cfg for global doc string stripping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,11 @@ ulid = "^1.2.1"
 unsynn = "^0.3.0"
 uuid = "^1.19.0"
 
+# Allow the facet_no_doc cfg in generated code
+# See: https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(facet_no_doc)"] }
+
 # Fuzzing profile for cargo-bolero
 [profile.fuzz]
 inherits = "dev"

--- a/cinereus/Cargo.toml
+++ b/cinereus/Cargo.toml
@@ -17,3 +17,6 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 indextree = { workspace = true }
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/docs/content/guide/getting-started.md
+++ b/docs/content/guide/getting-started.md
@@ -33,7 +33,7 @@ If you also need YAML/TOML/KDL/etc., add `facet-yaml`, `facet-toml`, `facet-kdl`
 
 ### Optional feature flags
 - Time/UUID: enable the matching features on the format crate (check the crate docs).
-- `doc`: include doc comments in generated shapes (needed for CLI help text with facet-args).
+- `doc`: include doc comments in generated shapes (needed for CLI help text with facet-args). To strip docs in release builds while keeping them in debug, add `--cfg facet_no_doc` to your release rustflags.
 - `no_std`: use `facet-core` with `alloc`; most format crates require `std`.
 
 ## Derive `Facet` on your types

--- a/facet-args/Cargo.toml
+++ b/facet-args/Cargo.toml
@@ -38,3 +38,6 @@ default = ["rich-diagnostics"]
 rich-diagnostics = []
 # Include doc comments in help generation (enables facet/doc)
 doc = ["facet/doc"]
+
+[lints]
+workspace = true

--- a/facet-asn1/Cargo.toml
+++ b/facet-asn1/Cargo.toml
@@ -32,3 +32,6 @@ libtest-mimic = "0.8"
 [[test]]
 name = "format_suite"
 harness = false
+
+[lints]
+workspace = true

--- a/facet-assert/Cargo.toml
+++ b/facet-assert/Cargo.toml
@@ -25,3 +25,6 @@ facet-reflect = { path = "../facet-reflect", version = "0.41.0", features = ["mi
 facet = { workspace = true }
 facet-showcase = { path = "../facet-showcase", version = "0.41.0" }
 owo-colors = "4"
+
+[lints]
+workspace = true

--- a/facet-axum/Cargo.toml
+++ b/facet-axum/Cargo.toml
@@ -40,3 +40,6 @@ axum = { version = "0.8", default-features = false, features = ["http1", "tokio"
 facet = { workspace = true, features = ["all-impls", "doc"] }
 tokio = { workspace = true, features = ["io-util", "rt", "rt-multi-thread"] }
 tower = { version = "0.5", default-features = false, features = ["util"] }
+
+[lints]
+workspace = true

--- a/facet-bloatbench/Cargo.toml
+++ b/facet-bloatbench/Cargo.toml
@@ -25,3 +25,6 @@ serde = ["dep:serde", "dep:serde_json"]
 [[bin]]
 name = "facet-bloatbench"
 path = "src/main.rs"
+
+[lints]
+workspace = true

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -93,3 +93,6 @@ uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
 facet-testhelpers = { path = "../facet-testhelpers" }
+
+[lints]
+workspace = true

--- a/facet-csv/Cargo.toml
+++ b/facet-csv/Cargo.toml
@@ -38,3 +38,6 @@ facet = { workspace = true, features = ["doc", "net"] }
 [features]
 default = []
 fast = ["dep:zmij", "dep:itoa"]
+
+[lints]
+workspace = true

--- a/facet-default/Cargo.toml
+++ b/facet-default/Cargo.toml
@@ -19,3 +19,6 @@ facet = { path = "../facet", version = "0.41.0" }
 
 [dev-dependencies]
 facet = { path = "../facet", version = "0.41.0" }
+
+[lints]
+workspace = true

--- a/facet-diff-core/Cargo.toml
+++ b/facet-diff-core/Cargo.toml
@@ -29,3 +29,6 @@ facet = { workspace = true, features = ["all-impls", "doc"] }
 facet-diff = { path = "../facet-diff", version = "0.41.0" }
 facet-value = { path = "../facet-value", version = "0.41.0" }
 facet-xml = { path = "../facet-xml", version = "0.41.0" }
+
+[lints]
+workspace = true

--- a/facet-diff/Cargo.toml
+++ b/facet-diff/Cargo.toml
@@ -34,3 +34,6 @@ facet-testhelpers = { path = "../facet-testhelpers" }
 facet-value = { path = "../facet-value" }
 insta = { workspace = true }
 owo-colors = "4"
+
+[lints]
+workspace = true

--- a/facet-error/Cargo.toml
+++ b/facet-error/Cargo.toml
@@ -19,3 +19,6 @@ facet = { path = "../facet", version = "0.41.0" }
 
 [dev-dependencies]
 facet = { path = "../facet", version = "0.41.0" }
+
+[lints]
+workspace = true

--- a/facet-format-suite/Cargo.toml
+++ b/facet-format-suite/Cargo.toml
@@ -62,3 +62,6 @@ third-party = ["uuid", "ulid", "camino", "ordered-float", "time", "jiff02", "chr
 
 # Binary format reference implementations
 msgpack = ["dep:rmp-serde", "dep:serde"]
+
+[lints]
+workspace = true

--- a/facet-format/Cargo.toml
+++ b/facet-format/Cargo.toml
@@ -46,3 +46,6 @@ miette = ["dep:miette", "facet-reflect/miette"]
 jit = ["dep:cranelift", "dep:cranelift-jit", "dep:cranelift-module", "dep:cranelift-native", "dep:parking_lot", "dep:museair", "dep:libc"]
 # Alias to unblock workspace-level `--features cranelift`
 cranelift = ["jit"]
+
+[lints]
+workspace = true

--- a/facet-html-dom/Cargo.toml
+++ b/facet-html-dom/Cargo.toml
@@ -19,3 +19,6 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 [dependencies]
 facet = { workspace = true }
 facet-html = { path = "../facet-html", version = "0.41.0" }
+
+[lints]
+workspace = true

--- a/facet-html/Cargo.toml
+++ b/facet-html/Cargo.toml
@@ -42,3 +42,6 @@ harness = false
 [features]
 default = []
 fast = ["dep:zmij", "dep:itoa"]
+
+[lints]
+workspace = true

--- a/facet-json-schema/Cargo.toml
+++ b/facet-json-schema/Cargo.toml
@@ -23,3 +23,6 @@ facet-json = { path = "../facet-json", version = "0.41.0" }
 
 [dev-dependencies]
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -74,3 +74,6 @@ axum = ["std", "dep:axum-core", "dep:http", "dep:http-body-util", "dep:mime"]
 
 # Enable miette diagnostics for rich error messages
 miette = ["dep:miette", "facet-reflect/miette"]
+
+[lints]
+workspace = true

--- a/facet-kdl/Cargo.toml
+++ b/facet-kdl/Cargo.toml
@@ -43,3 +43,6 @@ fast = ["dep:zmij", "dep:itoa"]
 
 # Axum HTTP integration
 axum = ["std", "dep:axum-core", "dep:http", "dep:http-body-util"]
+
+[lints]
+workspace = true

--- a/facet-macro-parse/Cargo.toml
+++ b/facet-macro-parse/Cargo.toml
@@ -20,3 +20,6 @@ proc-macro2 = "1"
 quote = { workspace = true }
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/facet-macro-template/Cargo.toml
+++ b/facet-macro-template/Cargo.toml
@@ -17,3 +17,6 @@ proc-macro2 = "1"
 quote = "1"
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/facet-macro-types/Cargo.toml
+++ b/facet-macro-types/Cargo.toml
@@ -17,3 +17,6 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 proc-macro2 = "1"
 quote = { workspace = true }
 unsynn = { workspace = true }
+
+[lints]
+workspace = true

--- a/facet-macros-impl/Cargo.toml
+++ b/facet-macros-impl/Cargo.toml
@@ -38,3 +38,6 @@ strsim = { workspace = true, optional = true }
 unsynn = { workspace = true }
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/facet-macros-impl/src/process_enum.rs
+++ b/facet-macros-impl/src/process_enum.rs
@@ -175,7 +175,14 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
     #[cfg(feature = "doc")]
     let doc_call = match &pe.container.attrs.doc[..] {
         [] => quote! {},
-        doc_lines => quote! { .doc(&[#(#doc_lines),*]) },
+        doc_lines => quote! {
+            .doc({
+                #[cfg(facet_no_doc)]
+                { &[] as &[&str] }
+                #[cfg(not(facet_no_doc))]
+                { &[#(#doc_lines),*] }
+            })
+        },
     };
     #[cfg(not(feature = "doc"))]
     let doc_call = quote! {};
@@ -446,7 +453,14 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                 #[cfg(feature = "doc")]
                 let variant_doc: Option<TokenStream> = match &pv.attrs.doc[..] {
                     [] => None,
-                    doc_lines => Some(quote! { &[#(#doc_lines),*] }),
+                    doc_lines => Some(quote! {
+                        {
+                            #[cfg(facet_no_doc)]
+                            { &[] as &[&str] }
+                            #[cfg(not(facet_no_doc))]
+                            { &[#(#doc_lines),*] }
+                        }
+                    }),
                 };
                 #[cfg(not(feature = "doc"))]
                 let variant_doc: Option<TokenStream> = None;
@@ -661,7 +675,14 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                 #[cfg(feature = "doc")]
                 let variant_doc: Option<TokenStream> = match &pv.attrs.doc[..] {
                     [] => None,
-                    doc_lines => Some(quote! { &[#(#doc_lines),*] }),
+                    doc_lines => Some(quote! {
+                        {
+                            #[cfg(facet_no_doc)]
+                            { &[] as &[&str] }
+                            #[cfg(not(facet_no_doc))]
+                            { &[#(#doc_lines),*] }
+                        }
+                    }),
                 };
                 #[cfg(not(feature = "doc"))]
                 let variant_doc: Option<TokenStream> = None;

--- a/facet-macros/Cargo.toml
+++ b/facet-macros/Cargo.toml
@@ -35,3 +35,6 @@ facet-macros-impl = { version = "0.41.0", path = "../facet-macros-impl", default
 
 # cf. https://hachyderm.io/@epage/114141126315983016
 [target.'cfg(any())'.dependencies]
+
+[lints]
+workspace = true

--- a/facet-miette/Cargo.toml
+++ b/facet-miette/Cargo.toml
@@ -25,3 +25,6 @@ miette = { workspace = true }
 [dev-dependencies]
 facet = { path = "../facet", version = "0.41.0" }
 facet-error = { path = "../facet-error", version = "0.41.0" }
+
+[lints]
+workspace = true

--- a/facet-msgpack/Cargo.toml
+++ b/facet-msgpack/Cargo.toml
@@ -51,3 +51,6 @@ jit = ["facet-format/jit"]
 
 # Axum HTTP integration
 axum = ["std", "dep:axum-core", "dep:http", "dep:http-body-util"]
+
+[lints]
+workspace = true

--- a/facet-path/Cargo.toml
+++ b/facet-path/Cargo.toml
@@ -33,3 +33,6 @@ arborium = { workspace = true, features = ["lang-rust"], optional = true }
 facet = { path = "../facet" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/facet-perf-shootout/Cargo.toml
+++ b/facet-perf-shootout/Cargo.toml
@@ -50,3 +50,6 @@ name = "generated_tests"
 [features]
 default = []
 jit = ["dep:facet-format", "facet-format/jit", "facet-json/jit", "facet-postcard/jit"]
+
+[lints]
+workspace = true

--- a/facet-postcard/Cargo.toml
+++ b/facet-postcard/Cargo.toml
@@ -86,3 +86,6 @@ ordered-float = ["facet-core/ordered-float", "dep:ordered-float"]
 jiff02 = ["facet-core/jiff02", "dep:jiff"]
 time = ["facet-core/time", "dep:time"]
 chrono = ["facet-core/chrono", "dep:chrono"]
+
+[lints]
+workspace = true

--- a/facet-pretty/Cargo.toml
+++ b/facet-pretty/Cargo.toml
@@ -35,3 +35,6 @@ facet-showcase = { path = "../facet-showcase" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 insta = { workspace = true }
 miette = { workspace = true }
+
+[lints]
+workspace = true

--- a/facet-reflect/Cargo.toml
+++ b/facet-reflect/Cargo.toml
@@ -67,3 +67,6 @@ insta = { workspace = true }
 log = { workspace = true }
 proptest = "1.9"
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/facet-shapelike/Cargo.toml
+++ b/facet-shapelike/Cargo.toml
@@ -28,3 +28,6 @@ facet-json = { path = "../facet-json", version = "0.41.0" }
 facet-kdl = { path = "../facet-kdl", version = "0.41.0" }
 facet-xml = { path = "../facet-xml", version = "0.41.0" }
 facet-testhelpers = { path = "../facet-testhelpers" }
+
+[lints]
+workspace = true

--- a/facet-showcase/Cargo.toml
+++ b/facet-showcase/Cargo.toml
@@ -25,3 +25,6 @@ owo-colors = "4"
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/facet-singularize/Cargo.toml
+++ b/facet-singularize/Cargo.toml
@@ -24,3 +24,6 @@ divan = { workspace = true }
 [[bench]]
 name = "singularize"
 harness = false
+
+[lints]
+workspace = true

--- a/facet-solver/Cargo.toml
+++ b/facet-solver/Cargo.toml
@@ -36,3 +36,6 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["e
 [[bench]]
 name = "solver"
 harness = false
+
+[lints]
+workspace = true

--- a/facet-svg/Cargo.toml
+++ b/facet-svg/Cargo.toml
@@ -27,3 +27,6 @@ facet-xml = { path = "../facet-xml" }
 [[test]]
 name = "roundtrip"
 harness = false
+
+[lints]
+workspace = true

--- a/facet-testhelpers-macros/Cargo.toml
+++ b/facet-testhelpers-macros/Cargo.toml
@@ -18,3 +18,6 @@ proc-macro = true
 [dependencies]
 quote = { workspace = true }
 unsynn = { workspace = true }
+
+[lints]
+workspace = true

--- a/facet-testhelpers/Cargo.toml
+++ b/facet-testhelpers/Cargo.toml
@@ -16,3 +16,6 @@ description = "A collection of testing helpers and utilities for facet"
 facet-testhelpers-macros = { version = "0.41.0", path = "../facet-testhelpers-macros" }
 log = { workspace = true }
 owo-colors = "4.2.2"
+
+[lints]
+workspace = true

--- a/facet-toml/Cargo.toml
+++ b/facet-toml/Cargo.toml
@@ -48,3 +48,6 @@ fast = ["dep:zmij", "dep:itoa"]
 
 # Axum HTTP integration
 axum = ["std", "serialize", "dep:axum-core", "dep:http", "dep:http-body-util"]
+
+[lints]
+workspace = true

--- a/facet-typescript/Cargo.toml
+++ b/facet-typescript/Cargo.toml
@@ -22,3 +22,6 @@ facet-core = { path = "../facet-core", version = "0.41.0" }
 [dev-dependencies]
 facet = { workspace = true }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/facet-urlencoded/Cargo.toml
+++ b/facet-urlencoded/Cargo.toml
@@ -34,3 +34,6 @@ log = { workspace = true }
 [dev-dependencies]
 facet = { workspace = true, features = ["all-impls", "doc"] }
 facet-testhelpers = { path = "../facet-testhelpers" }
+
+[lints]
+workspace = true

--- a/facet-value/Cargo.toml
+++ b/facet-value/Cargo.toml
@@ -50,3 +50,6 @@ required-features = ["diagnostics"]
 [[bench]]
 name = "map_keys"
 harness = false
+
+[lints]
+workspace = true

--- a/facet-xdr/Cargo.toml
+++ b/facet-xdr/Cargo.toml
@@ -28,3 +28,6 @@ xdr-codec = "0.4"
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/facet-xml/Cargo.toml
+++ b/facet-xml/Cargo.toml
@@ -69,3 +69,6 @@ axum = ["std", "dep:axum-core", "dep:http", "dep:http-body-util"]
 
 # Diff-aware XML serialization
 diff = ["dep:facet-diff-core"]
+
+[lints]
+workspace = true

--- a/facet-yaml/Cargo.toml
+++ b/facet-yaml/Cargo.toml
@@ -49,3 +49,6 @@ fast = ["dep:zmij", "dep:itoa"]
 
 # Axum HTTP integration
 axum = ["std", "dep:axum-core", "dep:http", "dep:http-body-util"]
+
+[lints]
+workspace = true

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -96,7 +96,10 @@ fn-ptr = ["facet-core/fn-ptr"]
 # This adds 84 type implementations which increases compile time.
 simd = ["facet-core/simd"]
 
-# Include doc comments in generated Shape/Field/Variant definitions
+# Include doc comments in generated Shape/Field/Variant definitions.
+# To strip docs globally (e.g., in release builds), set `--cfg facet_no_doc` in rustflags:
+#   [profile.release]
+#   rustflags = ["--cfg", "facet_no_doc"]
 doc = ["facet-macros/doc"]
 
 # Enable typo suggestions for unknown attributes/fields (uses strsim)
@@ -120,3 +123,6 @@ facet-showcase = { path = "../facet-showcase" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 num-complex = "0.4.6"
 owo-colors = "4.2.2"
+
+[lints]
+workspace = true

--- a/proto-attr/crates/proto-attr-core/Cargo.toml
+++ b/proto-attr/crates/proto-attr-core/Cargo.toml
@@ -6,3 +6,6 @@ license.workspace = true
 description = "Core types for proto-attr grammar system"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/proto-attr/crates/proto-attr-macros/Cargo.toml
+++ b/proto-attr/crates/proto-attr-macros/Cargo.toml
@@ -17,3 +17,6 @@ proc-macro2.workspace = true
 quote.workspace = true
 unsynn = "0.3.0"
 strsim.workspace = true
+
+[lints]
+workspace = true

--- a/proto-attr/crates/proto-attr/Cargo.toml
+++ b/proto-attr/crates/proto-attr/Cargo.toml
@@ -12,3 +12,6 @@ nightly = ["proto-attr-macros/nightly"]
 [dependencies]
 proto-attr-core.workspace = true
 proto-attr-macros.workspace = true
+
+[lints]
+workspace = true

--- a/proto-attr/crates/proto-ext-gen/Cargo.toml
+++ b/proto-attr/crates/proto-ext-gen/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2024"
 [dependencies]
 proto-attr = { path = "../proto-attr" }
 proto-attr-macros = { path = "../proto-attr-macros" }
+
+[lints]
+workspace = true

--- a/proto-attr/crates/proto-ext/Cargo.toml
+++ b/proto-attr/crates/proto-ext/Cargo.toml
@@ -17,3 +17,6 @@ facet-showcase = { path = "../../../facet-showcase" }  # relative to proto-attr/
 default = []
 slow-tests = []
 nightly = ["proto-attr/nightly"]
+
+[lints]
+workspace = true

--- a/proto-attr/crates/proto-user/Cargo.toml
+++ b/proto-attr/crates/proto-user/Cargo.toml
@@ -8,3 +8,6 @@ description = "Test crate to validate cross-crate attribute usage"
 [dependencies]
 proto-attr.workspace = true
 proto-ext.workspace = true
+
+[lints]
+workspace = true

--- a/tools/benchmark-analyzer/Cargo.toml
+++ b/tools/benchmark-analyzer/Cargo.toml
@@ -46,3 +46,6 @@ if-addrs = "0.14"
 
 # For JSON Schema cleaning
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/tools/benchmark-defs/Cargo.toml
+++ b/tools/benchmark-defs/Cargo.toml
@@ -14,3 +14,6 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 facet = { workspace = true }
 facet-args = { path = "../../facet-args" }
 facet-kdl = { path = "../../facet-kdl" }
+
+[lints]
+workspace = true

--- a/tools/benchmark-generator/Cargo.toml
+++ b/tools/benchmark-generator/Cargo.toml
@@ -18,3 +18,6 @@ path = "src/main.rs"
 benchmark-defs = { path = "../benchmark-defs" }
 regex = "1.12.2"
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/tools/metrics-tui/Cargo.toml
+++ b/tools/metrics-tui/Cargo.toml
@@ -17,3 +17,6 @@ crossterm = { version = "0.29", default-features = false }
 facet = { path = "../../facet" }
 facet-json = { path = "../../facet-json" }
 ratatui = { version = "0.30.0-beta.0", default-features = false, features = ["crossterm"] }
+
+[lints]
+workspace = true

--- a/tools/perf-index-generator/Cargo.toml
+++ b/tools/perf-index-generator/Cargo.toml
@@ -25,3 +25,6 @@ benchmark-analyzer = { path = "../benchmark-analyzer" }
 maud = "0.27"
 chrono = "0.4"
 indexmap = "2"
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = { workspace = true }
 ureq = "2.12"
 wordfreq = "0.2.3"
 zip = "2.4"
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary

Adds a cfg-based mechanism to globally disable doc strings in facet reflection metadata, similar to tracing's `release_max_level_off` pattern. This allows users to strip docs from release builds without patching dependencies.

Fixes #1583

## Usage

Add to `.cargo/config.toml`:

```toml
[profile.release]
rustflags = ["--cfg", "facet_no_doc"]
```

## How it works

- Feature `doc` disabled → No docs (checked at proc-macro compile time)
- Feature `doc` enabled + `facet_no_doc` cfg → No docs (checked at user crate compile time)  
- Feature `doc` enabled + no cfg → Docs included (default behavior)

## Changes

- Modified `process_struct.rs` to emit conditional cfg blocks for field and container docs
- Modified `process_enum.rs` to emit conditional cfg blocks for container and variant docs

## Test plan

- [x] `cargo check --all-features --all-targets` passes
- [x] `cargo nextest run --all-features` passes (pre-existing XML failures unrelated)
- [x] `RUSTFLAGS='--cfg facet_no_doc' cargo nextest run -p facet struct_doc_comment` fails with `left: []` vs `right: [" yes"]` - confirming docs are stripped