### PR TITLE
Fix YAML serialization for empty structs and sequences

### DIFF
--- a/facet-yaml/tests/basic.rs
+++ b/facet-yaml/tests/basic.rs
@@ -350,6 +350,70 @@ fn test_deserialize_null_to_option() {
 }
 
 // ============================================================================
+// Empty struct serialization
+// ============================================================================
+
+#[test]
+fn test_empty_struct_roundtrip() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct EmptyStruct {}
+
+    #[derive(Debug, Facet, PartialEq)]
+    struct ConfigWithEmpty {
+        name: String,
+        empty_field: Option<EmptyStruct>,
+    }
+
+    let config = ConfigWithEmpty {
+        name: "test".to_string(),
+        empty_field: Some(EmptyStruct {}),
+    };
+
+    let yaml = facet_yaml::to_string(&config).unwrap();
+
+    // The empty struct should be inline: `empty_field: {}`
+    // Not on a new line like:
+    // empty_field:
+    // {}
+    assert!(
+        yaml.contains("empty_field: {}"),
+        "Expected 'empty_field: {{}}' inline, got:\n{}",
+        yaml
+    );
+
+    // Should be able to parse it back
+    let parsed: ConfigWithEmpty = facet_yaml::from_str(&yaml).unwrap();
+    assert_eq!(parsed, config);
+}
+
+#[test]
+fn test_empty_seq_roundtrip() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct ConfigWithEmptySeq {
+        name: String,
+        items: Vec<String>,
+    }
+
+    let config = ConfigWithEmptySeq {
+        name: "test".to_string(),
+        items: vec![],
+    };
+
+    let yaml = facet_yaml::to_string(&config).unwrap();
+
+    // The empty sequence should be inline: `items: []`
+    assert!(
+        yaml.contains("items: []"),
+        "Expected 'items: []' inline, got:\n{}",
+        yaml
+    );
+
+    // Should be able to parse it back
+    let parsed: ConfigWithEmptySeq = facet_yaml::from_str(&yaml).unwrap();
+    assert_eq!(parsed, config);
+}
+
+// ============================================================================
 // YAML-specific features
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Fixes issue where `facet-yaml` generated invalid YAML for empty structs and sequences by placing `{}` or `[]` on a new line after the key, rather than inline.

**Before:**
```yaml
name: test
empty_field:
{}
```

**After:**
```yaml
name: test
empty_field: {}
```

## Changes

- Added `needs_newline` field to `Ctx::Struct` and `Ctx::Seq` to track deferred newline state
- Modified `begin_struct()`/`begin_seq()` to defer newline emission
- Modified `field_key()` and sequence item handling to emit deferred newlines only when content is added
- Added roundtrip tests for empty structs and sequences

## Testing

- Added `test_empty_struct_roundtrip` and `test_empty_seq_roundtrip` tests
- All 2501 existing tests pass

Fixes #1584