### PR TITLE
Fix release-plz action version: v0.3 → v0.5

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,7 +25,7 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1
         id: crates-io-auth
       - name: Run release-plz
-        uses: release-plz/action@v0.3
+        uses: release-plz/action@v0.5
         with:
           command: release
         env:
@@ -50,7 +50,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
-        uses: release-plz/action@v0.3
+        uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:


### PR DESCRIPTION
## Summary
- Fix invalid release-plz action version tag (`v0.3` doesn't exist)
- Update to `v0.5` per [official docs](https://release-plz.dev/docs/github/quickstart)

## Test plan
- [x] Validated locally with `release-plz update` - config parses correctly
- [x] All packages pass semver compatibility checks