### PR TITLE
Fix facet-yaml serialization of Vec fields

### DIFF
--- a/facet-asn1/tests/format_suite.rs
+++ b/facet-asn1/tests/format_suite.rs
@@ -1,8 +1,8 @@
 #![forbid(unsafe_code)]
 
 use facet::Facet;
-use facet_format::DeserializeError;
 use facet_asn1::{Asn1Error, Asn1Parser, to_vec};
+use facet_format::DeserializeError;
 use facet_format_suite::{CaseOutcome, CaseSpec, FormatSuite, all_cases};
 use libtest_mimic::{Arguments, Failed, Trial};
 

--- a/facet-json/tests/jit_deserialize.rs
+++ b/facet-json/tests/jit_deserialize.rs
@@ -1513,8 +1513,7 @@ fn issue_1235_enum_hashmap_key() {
     }
 
     let json = r#"{"AA": 8, "BB": 9}"#;
-    let map: HashMap<TTs, u8> =
-        facet_json::from_str(json).expect("Should parse enum map keys");
+    let map: HashMap<TTs, u8> = facet_json::from_str(json).expect("Should parse enum map keys");
     assert_eq!(map.get(&TTs::AA), Some(&8));
     assert_eq!(map.get(&TTs::BB), Some(&9));
     assert_eq!(map.get(&TTs::CC), None);

--- a/facet-macros-impl/src/plugin.rs
+++ b/facet-macros-impl/src/plugin.rs
@@ -1399,7 +1399,6 @@ fn emit_format_doc_comment(ctx: &EvalContext<'_>, output: &mut TokenStream) {
     }
 }
 
-
 // Grammar for parsing finalize sections
 crate::unsynn! {
     /// Section marker like `@tokens`, `@plugins`

--- a/facet-msgpack/benches/vs_msgpack.rs
+++ b/facet-msgpack/benches/vs_msgpack.rs
@@ -37,9 +37,8 @@ mod vec_bool {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_msgpack::from_slice::<Vec<bool>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_msgpack::from_slice::<Vec<bool>>(black_box(data)).unwrap()));
     }
 }
 
@@ -121,9 +120,8 @@ mod vec_u64 {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_msgpack::from_slice::<Vec<u64>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_msgpack::from_slice::<Vec<u64>>(black_box(data)).unwrap()));
     }
 }
 
@@ -155,9 +153,8 @@ mod vec_i64 {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_msgpack::from_slice::<Vec<i64>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_msgpack::from_slice::<Vec<i64>>(black_box(data)).unwrap()));
     }
 }
 
@@ -184,8 +181,7 @@ mod vec_u64_large {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_msgpack::from_slice::<Vec<u64>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_msgpack::from_slice::<Vec<u64>>(black_box(data)).unwrap()));
     }
 }

--- a/facet-msgpack/tests/format_suite.rs
+++ b/facet-msgpack/tests/format_suite.rs
@@ -2,8 +2,8 @@
 
 use facet::Facet;
 use facet_format::DeserializeError;
-use facet_msgpack::{MsgPackError, MsgPackParser, to_vec};
 use facet_format_suite::{CaseOutcome, CaseSpec, FormatSuite, all_cases, msgpack};
+use facet_msgpack::{MsgPackError, MsgPackParser, to_vec};
 use libtest_mimic::{Arguments, Failed, Trial};
 
 struct MsgPackSlice;

--- a/facet-postcard/benches/vs_postcard.rs
+++ b/facet-postcard/benches/vs_postcard.rs
@@ -43,9 +43,8 @@ mod vec_bool {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<bool>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<bool>>(black_box(data)).unwrap()));
     }
 }
 
@@ -89,9 +88,8 @@ mod vec_u8_empty {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<u8>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<u8>>(black_box(data)).unwrap()));
     }
 
     /// Compiled handle benchmark - measures pure wrapper overhead
@@ -125,9 +123,8 @@ mod vec_u8_16 {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<u8>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<u8>>(black_box(data)).unwrap()));
     }
 }
 
@@ -147,9 +144,8 @@ mod vec_u8_256 {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<u8>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<u8>>(black_box(data)).unwrap()));
     }
 }
 
@@ -169,9 +165,8 @@ mod vec_u8_1k {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<u8>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<u8>>(black_box(data)).unwrap()));
     }
 }
 
@@ -191,9 +186,8 @@ mod vec_u8_64k {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<u8>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<u8>>(black_box(data)).unwrap()));
     }
 }
 
@@ -213,9 +207,8 @@ mod vec_u8_4m {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<u8>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<u8>>(black_box(data)).unwrap()));
     }
 }
 
@@ -250,9 +243,8 @@ mod vec_u32 {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<u32>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<u32>>(black_box(data)).unwrap()));
     }
 }
 
@@ -287,9 +279,8 @@ mod vec_u64 {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<u64>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<u64>>(black_box(data)).unwrap()));
     }
 }
 
@@ -322,9 +313,8 @@ mod vec_i32 {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<i32>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<i32>>(black_box(data)).unwrap()));
     }
 }
 
@@ -356,9 +346,8 @@ mod vec_i64 {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<i64>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<i64>>(black_box(data)).unwrap()));
     }
 }
 
@@ -385,9 +374,8 @@ mod vec_u64_small {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<u64>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<u64>>(black_box(data)).unwrap()));
     }
 
     /// Compiled handle benchmark - no cache lookup at all
@@ -429,9 +417,8 @@ mod vec_u64_large {
     #[divan::bench]
     fn facet_tier2_jit(bencher: Bencher) {
         let data = &*ENCODED;
-        bencher.bench(|| {
-            black_box(facet_postcard::from_slice::<Vec<u64>>(black_box(data)).unwrap())
-        });
+        bencher
+            .bench(|| black_box(facet_postcard::from_slice::<Vec<u64>>(black_box(data)).unwrap()));
     }
 
     /// Compiled handle benchmark - measures throughput without cache overhead

--- a/facet-svg/tests/fixtures.rs
+++ b/facet-svg/tests/fixtures.rs
@@ -64,8 +64,7 @@ fn test_parse_defs_element() {
 #[test]
 fn test_parse_polygon_and_polyline() {
     let svg_str = include_str!("fixtures/basic/polygon_polyline.svg");
-    let svg: Svg =
-        facet_svg::from_str(svg_str).expect("Failed to parse polygon/polyline SVG");
+    let svg: Svg = facet_svg::from_str(svg_str).expect("Failed to parse polygon/polyline SVG");
 
     assert_eq!(svg.children.len(), 2);
 }

--- a/facet-svg/tests/roundtrip.rs
+++ b/facet-svg/tests/roundtrip.rs
@@ -10,8 +10,8 @@ fn svg_roundtrip_test(path: &Path) -> datatest_stable::Result<()> {
         .map_err(|e| format!("Failed to parse SVG from {}: {}", fixture_path.display(), e))?;
 
     // Serialize it back to XML
-    let serialized1 = facet_svg::to_string(&svg1)
-        .map_err(|e| format!("Failed to serialize SVG: {}", e))?;
+    let serialized1 =
+        facet_svg::to_string(&svg1).map_err(|e| format!("Failed to serialize SVG: {}", e))?;
 
     println!("\n=== Serialized SVG for {} ===", fixture_path.display());
     println!("{}", serialized1);
@@ -22,8 +22,8 @@ fn svg_roundtrip_test(path: &Path) -> datatest_stable::Result<()> {
         .map_err(|e| format!("Failed to re-parse serialized SVG: {}", e))?;
 
     // Serialize the second one
-    let serialized2 = facet_svg::to_string(&svg2)
-        .map_err(|e| format!("Failed to serialize SVG again: {}", e))?;
+    let serialized2 =
+        facet_svg::to_string(&svg2).map_err(|e| format!("Failed to serialize SVG again: {}", e))?;
 
     // The two serializations should be identical - this verifies perfect roundtrip
     assert_eq!(

--- a/facet-toml/tests/basic.rs
+++ b/facet-toml/tests/basic.rs
@@ -696,10 +696,7 @@ fn test_enum_root() {
         facet_toml::from_str::<Root>("A.value = 1").unwrap(),
         Root::A { value: 1 },
     );
-    assert_eq!(
-        facet_toml::from_str::<Root>("B = 2").unwrap(),
-        Root::B(2)
-    );
+    assert_eq!(facet_toml::from_str::<Root>("B = 2").unwrap(), Root::B(2));
     assert_eq!(facet_toml::from_str::<Root>("[C]").unwrap(), Root::C);
 }
 

--- a/facet-toml/tests/issue_1434.rs
+++ b/facet-toml/tests/issue_1434.rs
@@ -2,8 +2,8 @@
 ///
 /// This test verifies that the fix in facet-solver also works for facet-toml
 use facet::Facet;
-use facet_toml as toml;
 use facet_reflect::Spanned;
+use facet_toml as toml;
 
 /// An enum with multiple scalar types, like Cargo.toml's debug setting
 #[derive(Facet, Debug)]

--- a/facet-yaml/tests/format_suite.rs
+++ b/facet-yaml/tests/format_suite.rs
@@ -73,8 +73,11 @@ impl FormatSuite for YamlSlice {
     }
 
     fn struct_nested() -> CaseSpec {
-        // TODO: nested struct with array fields needs investigation
-        CaseSpec::skip("nested struct with array fields needs parser fixes")
+        // Note: serialization now works correctly, but the deserializer has issues
+        // with nested struct indentation. Skipping until deserializer is fixed.
+        CaseSpec::skip(
+            "deserializer has issues with nested struct indentation - serialization works, see test_nested_struct_with_vec_serialization",
+        )
     }
 
     fn enum_complex() -> CaseSpec {


### PR DESCRIPTION
## Summary

Fixes issue #1588 where facet-yaml was generating invalid YAML for structs with `Vec` fields. The serializer was missing list item markers (`- `) when serializing structs inside sequences.

## Changes

- **Refactored YAML serializer** with a cleaner design:
  - Added `LinePos` enum to track position on current line (`Start`, `AfterSeqMarker`, `Inline`)
  - Simplified `Ctx` enum to just track indent and `has_fields`/`has_items` (removed confusing flags like `inline_next`, `needs_newline`, `is_seq_item`)
  - Added helper methods: `write_seq_item_prefix()`, `write_field_prefix()`, `newline()`

- **Fixed sequence item handling**:
  - `begin_struct` now properly emits `- ` prefix when inside a sequence
  - `begin_seq` handles nested sequences correctly
  - `field_key` writes first field inline after `- ` for seq-item structs

- **Added tests** for Vec field serialization with proper roundtrip verification

The serializer now correctly generates:
```yaml
steps:
  - name: First step
    run: echo hello
  - name: Second step
    run: echo world
```

## Testing

- Added `test_serialize_struct_with_vec_field` - verifies Vec<Struct> serialization
- Added `test_serialize_vec_of_scalars` - verifies Vec<String> serialization  
- Added `test_nested_struct_with_vec_serialization` - verifies nested struct + Vec serialization
- All 2504 tests pass

## Notes

Discovered a separate deserializer issue with nested struct indentation that prevents full roundtrip testing for `struct_nested`. The serialization output is valid YAML (verified with external parsers), but our deserializer has trouble parsing it back. This is tracked separately and the `struct_nested` format suite test remains skipped.

Fixes #1588