### PR TITLE
Enable TOML table reopening via deferred mode

### DIFF
--- a/facet-toml/src/lib.rs
+++ b/facet-toml/src/lib.rs
@@ -83,7 +83,8 @@ where
     use facet_format::FormatDeserializer;
     let parser = TomlParser::new(input).map_err(DeserializeError::Parser)?;
     let mut de = FormatDeserializer::new_owned(parser);
-    de.deserialize()
+    // TOML requires deferred mode to handle table reopening
+    de.deserialize_deferred()
 }
 
 /// Deserialize a value from TOML bytes into an owned type.
@@ -163,7 +164,8 @@ where
     use facet_format::FormatDeserializer;
     let parser = TomlParser::new(input).map_err(DeserializeError::Parser)?;
     let mut de = FormatDeserializer::new(parser);
-    de.deserialize()
+    // TOML requires deferred mode to handle table reopening
+    de.deserialize_deferred()
 }
 
 /// Deserialize a value from TOML bytes, allowing zero-copy borrowing.

--- a/facet-toml/src/parser.rs
+++ b/facet-toml/src/parser.rs
@@ -1535,29 +1535,10 @@ version = "1.1.2"
         assert_eq!(config.foo.bar.baz, 42);
     }
 
-    // NOTE: Table reopening deserialization is a known limitation.
-    //
-    // TOML allows fields for the same struct to appear at different points in the document:
-    //
-    //   [foo.bar]
-    //   x = 1
-    //   [foo.baz]
-    //   z = 3
-    //   [foo.bar]  # reopening!
-    //   y = 2
-    //
-    // The parser correctly emits events with StructEnd as "navigation" (not finalization),
-    // but facet-format's deserializer validates structs at StructEnd and fails because
-    // 'y' hasn't been seen yet.
-    //
-    // Solutions require either:
-    // 1. Adding deferred validation to facet-format (don't validate until EOF)
-    // 2. Reordering events in the parser so each struct is contiguous
-    //
-    // The event stream test (test_table_reopening) passes because it only checks events,
-    // not the full deserialization pipeline.
+    // Table reopening: TOML allows fields for the same struct to appear at different
+    // points in the document. This works because facet-toml uses deferred mode, which
+    // stores frames when we navigate away and restores them when we re-enter.
     #[test]
-    #[ignore = "table reopening requires deferred validation in facet-format"]
     fn test_deserialize_table_reopening() {
         #[derive(Debug, PartialEq, facet::Facet)]
         struct Config {


### PR DESCRIPTION
## Summary

TOML allows table reopening where fields of a struct can appear at different points in the document. This was previously unsupported because facet-format validated structs at `StructEnd`, before all fields were seen.

This PR enables deferred mode for all TOML deserialization, which stores frames when navigating away and restores them when re-entering, deferring validation until the end.

## Changes

- Add `deserialize_deferred()` method to `FormatDeserializer` that wraps deserialization in deferred mode from the start
- Switch facet-toml to use `deserialize_deferred()` for all deserialization
- Skip struct field validation in `deserialize_struct_simple` when in deferred mode (validation happens in `finish_deferred()` instead)
- Fix DynamicValue flatten handling to always call `begin_map()` since frames may not be stored/restored inside collections in deferred mode
- Remove the `#[ignore]` from `test_deserialize_table_reopening` test

## Test plan

- [x] `test_deserialize_table_reopening` now passes
- [x] All existing TOML tests pass
- [x] Full test suite passes (2502 tests)

Fixes #1590