### PR TITLE
Fix facet_no_doc cfg warning in downstream crates

### DIFF
--- a/facet-macros-impl/src/lib.rs
+++ b/facet-macros-impl/src/lib.rs
@@ -27,6 +27,26 @@ pub mod function;
 mod process_enum;
 mod process_struct;
 
+// ============================================================================
+// DOC STRIPPING DETECTION
+// ============================================================================
+
+/// Returns true if doc strings should be stripped from generated shapes.
+///
+/// Controlled by `--cfg facet_no_doc`. Set via rustflags in .cargo/config.toml,
+/// Cargo.toml profile, or RUSTFLAGS env var. The cfg is evaluated when the
+/// proc-macro is compiled.
+#[cfg(all(feature = "doc", facet_no_doc))]
+pub const fn is_no_doc() -> bool {
+    true
+}
+
+/// Returns true if doc strings should be stripped from generated shapes.
+#[cfg(all(feature = "doc", not(facet_no_doc)))]
+pub const fn is_no_doc() -> bool {
+    false
+}
+
 mod derive;
 pub use derive::*;
 

--- a/facet-macros-impl/src/process_enum.rs
+++ b/facet-macros-impl/src/process_enum.rs
@@ -173,16 +173,11 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
 
     // Container-level docs - returns builder call only if there are doc comments and doc feature is enabled
     #[cfg(feature = "doc")]
-    let doc_call = match &pe.container.attrs.doc[..] {
-        [] => quote! {},
-        doc_lines => quote! {
-            .doc({
-                #[cfg(facet_no_doc)]
-                { &[] as &[&str] }
-                #[cfg(not(facet_no_doc))]
-                { &[#(#doc_lines),*] }
-            })
-        },
+    let doc_call = if pe.container.attrs.doc.is_empty() || crate::is_no_doc() {
+        quote! {}
+    } else {
+        let doc_lines = &pe.container.attrs.doc;
+        quote! { .doc(&[#(#doc_lines),*]) }
     };
     #[cfg(not(feature = "doc"))]
     let doc_call = quote! {};
@@ -451,17 +446,13 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                 };
 
                 #[cfg(feature = "doc")]
-                let variant_doc: Option<TokenStream> = match &pv.attrs.doc[..] {
-                    [] => None,
-                    doc_lines => Some(quote! {
-                        {
-                            #[cfg(facet_no_doc)]
-                            { &[] as &[&str] }
-                            #[cfg(not(facet_no_doc))]
-                            { &[#(#doc_lines),*] }
-                        }
-                    }),
-                };
+                let variant_doc: Option<TokenStream> =
+                    if pv.attrs.doc.is_empty() || crate::is_no_doc() {
+                        None
+                    } else {
+                        let doc_lines = &pv.attrs.doc;
+                        Some(quote! { &[#(#doc_lines),*] })
+                    };
                 #[cfg(not(feature = "doc"))]
                 let variant_doc: Option<TokenStream> = None;
 
@@ -673,17 +664,13 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                 };
 
                 #[cfg(feature = "doc")]
-                let variant_doc: Option<TokenStream> = match &pv.attrs.doc[..] {
-                    [] => None,
-                    doc_lines => Some(quote! {
-                        {
-                            #[cfg(facet_no_doc)]
-                            { &[] as &[&str] }
-                            #[cfg(not(facet_no_doc))]
-                            { &[#(#doc_lines),*] }
-                        }
-                    }),
-                };
+                let variant_doc: Option<TokenStream> =
+                    if pv.attrs.doc.is_empty() || crate::is_no_doc() {
+                        None
+                    } else {
+                        let doc_lines = &pv.attrs.doc;
+                        Some(quote! { &[#(#doc_lines),*] })
+                    };
                 #[cfg(not(feature = "doc"))]
                 let variant_doc: Option<TokenStream> = None;
 

--- a/facet-macros-impl/src/process_struct.rs
+++ b/facet-macros-impl/src/process_struct.rs
@@ -1040,17 +1040,10 @@ pub(crate) fn gen_field_from_pfield(
     };
 
     #[cfg(feature = "doc")]
-    let maybe_field_doc = if doc_lines.is_empty() {
+    let maybe_field_doc = if doc_lines.is_empty() || crate::is_no_doc() {
         quote! { &[] }
     } else {
-        quote! {
-            {
-                #[cfg(facet_no_doc)]
-                { &[] as &[&str] }
-                #[cfg(not(facet_no_doc))]
-                { &[#(#doc_lines),*] }
-            }
-        }
+        quote! { &[#(#doc_lines),*] }
     };
     #[cfg(not(feature = "doc"))]
     let maybe_field_doc = quote! { &[] };
@@ -1523,18 +1516,11 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
     // Doc comments from PStruct - returns value for struct literal
     // doc call - only emit if there are doc comments and doc feature is enabled
     #[cfg(feature = "doc")]
-    let doc_call = if ps.container.attrs.doc.is_empty() {
+    let doc_call = if ps.container.attrs.doc.is_empty() || crate::is_no_doc() {
         quote! {}
     } else {
         let doc_lines = ps.container.attrs.doc.iter().map(|s| quote!(#s));
-        quote! {
-            .doc({
-                #[cfg(facet_no_doc)]
-                { &[] as &[&str] }
-                #[cfg(not(facet_no_doc))]
-                { &[#(#doc_lines),*] }
-            })
-        }
+        quote! { .doc(&[#(#doc_lines),*]) }
     };
     #[cfg(not(feature = "doc"))]
     let doc_call = quote! {};


### PR DESCRIPTION
## Summary

Fixes the `unexpected cfg condition name: facet_no_doc` warning that downstream crates see when using facet. The proc-macro was emitting `#[cfg(facet_no_doc)]` in generated code, which gets evaluated in the user's crate context where the cfg isn't declared.

## Changes

- Added `is_no_doc()` function in `facet-macros-impl/src/lib.rs` with `#[cfg(facet_no_doc)]` on the proc-macro code itself
- Updated `process_struct.rs` and `process_enum.rs` to call `is_no_doc()` at expansion time instead of emitting cfg attributes
- No cfg attributes are emitted in generated code anymore

## How it works

The `--cfg facet_no_doc` flag flows through Rust's compilation naturally:
1. User sets rustflags (via `.cargo/config.toml`, profile, or `RUSTFLAGS`)
2. facet-macros gets recompiled with that cfg active
3. `is_no_doc()` returns `true`, proc-macro generates code without doc strings
4. Generated code has no cfg attributes → no warnings in downstream crates

## Test plan

- [x] All facet tests pass
- [x] Clippy passes
- [x] Manual verification that cfg flows through to proc-macro