### PR TITLE
Add Facet implementation for smol_str::SmolStr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,6 +1445,7 @@ dependencies = [
  "ordered-float",
  "ruint",
  "smartstring",
+ "smol_str",
  "time",
  "ulid",
  "url",
@@ -1555,6 +1556,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "smartstring",
+ "smol_str",
  "time",
  "tokio",
  "ulid",
@@ -4019,6 +4021,12 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "smol_str"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3498b0a27f93ef1402f20eefacfaa1691272ac4eca1cdc8c596cb0a245d6cbf5"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ quote = "1"
 serde = { version = "^1.0.228", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "^1.0.145", features = ["alloc"] }
 smartstring = { version = "^1.0.1", default-features = false }
+smol_str = { version = "^0.3.4", default-features = false }
 static_assertions = "^1.1.0"
 strsim = "0.11"
 tempfile = "^3.23.0"

--- a/facet-asn1/tests/format_suite.rs
+++ b/facet-asn1/tests/format_suite.rs
@@ -479,6 +479,10 @@ impl FormatSuite for Asn1Slice {
         CaseSpec::skip("ASN.1 is a binary format, requires binary input not JSON strings")
     }
 
+    fn smol_str() -> CaseSpec {
+        CaseSpec::skip("ASN.1 is a binary format, requires binary input not JSON strings")
+    }
+
     fn value_null() -> CaseSpec {
         CaseSpec::skip("ASN.1 is a binary format, DynamicValue not supported")
     }

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -53,6 +53,8 @@ compact_str = ["alloc", "dep:compact_str"]
 num-complex = ["dep:num-complex"]
 # Provide Facet trait implementations for smartstring::SmartString
 smartstring = ["alloc", "dep:smartstring"]
+# Provide Facet trait implementations for smol_str::SmolStr
+smol_str = ["alloc", "dep:smol_str"]
 # Provide Facet trait implementations for ruint::Uint and ruint::Bits
 ruint = ["alloc", "dep:ruint", "ruint?/alloc"]
 # Provide Facet trait implementations for indexmap::IndexMap and indexmap::IndexSet
@@ -87,6 +89,7 @@ ruint = { version = "1.17.0", optional = true, default-features = false }
 time = { workspace = true, optional = true, features = ["macros"] }
 ulid = { workspace = true, optional = true }
 smartstring = { workspace = true, optional = true }
+smol_str = { workspace = true, optional = true }
 url = { version = "2.5.4", optional = true, default-features = false }
 uuid = { workspace = true, optional = true }
 

--- a/facet-core/src/impls/crates/mod.rs
+++ b/facet-core/src/impls/crates/mod.rs
@@ -9,6 +9,7 @@ mod num_complex;
 mod ordered_float;
 mod ruint;
 mod smartstring;
+mod smol_str;
 mod time;
 mod ulid;
 mod url;

--- a/facet-core/src/impls/crates/smol_str.rs
+++ b/facet-core/src/impls/crates/smol_str.rs
@@ -1,0 +1,60 @@
+#![cfg(feature = "smol_str")]
+
+use smol_str::SmolStr;
+
+use crate::{
+    Def, Facet, PtrConst, Shape, ShapeBuilder, Type, UserType, VTableDirect, vtable_direct,
+};
+
+/// Try to convert from &str or String to SmolStr
+///
+/// # Safety
+/// `dst` must be valid for writes, `src` must point to valid data of type described by `src_shape`
+unsafe fn smol_str_try_from(
+    dst: *mut SmolStr,
+    src_shape: &'static Shape,
+    src: PtrConst,
+) -> Result<(), alloc::string::String> {
+    // Check if source is &str
+    if src_shape.id == <&str as Facet>::SHAPE.id {
+        let str_ref: &str = unsafe { src.get::<&str>() };
+        unsafe { dst.write(SmolStr::from(str_ref)) };
+        return Ok(());
+    }
+
+    // Check if source is String
+    if src_shape.id == <alloc::string::String as Facet>::SHAPE.id {
+        let string: alloc::string::String = unsafe { src.read::<alloc::string::String>() };
+        unsafe { dst.write(SmolStr::from(string)) };
+        return Ok(());
+    }
+
+    Err(alloc::format!(
+        "cannot convert {} to SmolStr",
+        src_shape.type_identifier
+    ))
+}
+
+unsafe impl Facet<'_> for SmolStr {
+    const SHAPE: &'static Shape = &const {
+        const VTABLE: VTableDirect = vtable_direct!(SmolStr =>
+            Display,
+            Debug,
+            Hash,
+            PartialEq,
+            PartialOrd,
+            Ord,
+            FromStr,
+            [try_from = smol_str_try_from],
+        );
+
+        ShapeBuilder::for_sized::<SmolStr>("SmolStr")
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::Scalar)
+            .vtable_direct(&VTABLE)
+            .eq()
+            .send()
+            .sync()
+            .build()
+    };
+}

--- a/facet-format-suite/Cargo.toml
+++ b/facet-format-suite/Cargo.toml
@@ -33,6 +33,7 @@ ordered-float = { version = "5.0.0", optional = true, default-features = false }
 rmp-serde = { version = "1", optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 smartstring = { workspace = true, optional = true }
+smol_str = { workspace = true, optional = true }
 time = { workspace = true, optional = true, features = ["formatting", "parsing"] }
 tokio = { version = "1", features = ["rt"], optional = true }
 ulid = { workspace = true, optional = true }
@@ -56,9 +57,10 @@ bytes = ["dep:bytes", "facet/bytes"]
 bytestring = ["dep:bytestring", "facet/bytestring"]
 compact_str = ["dep:compact_str", "facet/compact_str"]
 smartstring = ["dep:smartstring", "facet/smartstring"]
+smol_str = ["dep:smol_str", "facet/smol_str"]
 facet-value = ["dep:facet-value"]
 # All third-party types
-third-party = ["uuid", "ulid", "camino", "ordered-float", "time", "jiff02", "chrono", "bytes", "bytestring", "compact_str", "smartstring", "facet-value"]
+third-party = ["uuid", "ulid", "camino", "ordered-float", "time", "jiff02", "chrono", "bytes", "bytestring", "compact_str", "smartstring", "smol_str", "facet-value"]
 
 # Binary format reference implementations
 msgpack = ["dep:rmp-serde", "dep:serde"]

--- a/facet-format-suite/src/lib.rs
+++ b/facet-format-suite/src/lib.rs
@@ -414,6 +414,10 @@ pub trait FormatSuite {
     #[cfg(feature = "smartstring")]
     fn smartstring() -> CaseSpec;
 
+    /// Case: `smol_str::SmolStr` type.
+    #[cfg(feature = "smol_str")]
+    fn smol_str() -> CaseSpec;
+
     // ── Dynamic value tests ──
 
     /// Case: `facet_value::Value` dynamic type - null.
@@ -716,6 +720,8 @@ pub fn all_cases<S: FormatSuite + 'static>() -> Vec<SuiteCase> {
         SuiteCase::new::<S, CompactStringWrapper>(&CASE_COMPACT_STRING, S::compact_string),
         #[cfg(feature = "smartstring")]
         SuiteCase::new::<S, SmartStringWrapper>(&CASE_SMARTSTRING, S::smartstring),
+        #[cfg(feature = "smol_str")]
+        SuiteCase::new::<S, SmolStrWrapper>(&CASE_SMOL_STR, S::smol_str),
         // Dynamic value cases
         #[cfg(feature = "facet-value")]
         SuiteCase::new::<S, facet_value::Value>(&CASE_VALUE_NULL, S::value_null),
@@ -3268,6 +3274,15 @@ const CASE_SMARTSTRING: CaseDescriptor<SmartStringWrapper> = CaseDescriptor {
     },
 };
 
+#[cfg(feature = "smol_str")]
+const CASE_SMOL_STR: CaseDescriptor<SmolStrWrapper> = CaseDescriptor {
+    id: "third_party::smol_str",
+    description: "smol_str::SmolStr type",
+    expected: || SmolStrWrapper {
+        value: smol_str::SmolStr::from("hello world"),
+    },
+};
+
 // ── Dynamic value case descriptors ──
 
 #[cfg(feature = "facet-value")]
@@ -3454,6 +3469,13 @@ pub struct CompactStringWrapper {
 #[derive(Facet, Debug, Clone, PartialEq)]
 pub struct SmartStringWrapper {
     pub value: smartstring::SmartString<smartstring::LazyCompact>,
+}
+
+/// Fixture for `smol_str::SmolStr` test.
+#[cfg(feature = "smol_str")]
+#[derive(Facet, Debug, Clone, PartialEq)]
+pub struct SmolStrWrapper {
+    pub value: smol_str::SmolStr,
 }
 
 fn emit_case_showcase<S, T>(

--- a/facet-json/tests/format_suite.rs
+++ b/facet-json/tests/format_suite.rs
@@ -752,17 +752,18 @@ impl FormatSuite for JsonSlice {
 
     fn bytestring() -> CaseSpec {
         CaseSpec::from_str(r#"{"value":"hello world"}"#)
-            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn compact_string() -> CaseSpec {
         CaseSpec::from_str(r#"{"value":"hello world"}"#)
-            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn smartstring() -> CaseSpec {
         CaseSpec::from_str(r#"{"value":"hello world"}"#)
-            .without_roundtrip("opaque type serialization not yet supported")
+    }
+
+    fn smol_str() -> CaseSpec {
+        CaseSpec::from_str(r#"{"value":"hello world"}"#)
     }
 
     // ── Dynamic value cases ──

--- a/facet-msgpack/tests/format_suite.rs
+++ b/facet-msgpack/tests/format_suite.rs
@@ -491,6 +491,10 @@ impl FormatSuite for MsgPackSlice {
         CaseSpec::skip("MsgPack is a binary format, requires binary input not JSON strings")
     }
 
+    fn smol_str() -> CaseSpec {
+        CaseSpec::skip("MsgPack is a binary format, requires binary input not JSON strings")
+    }
+
     fn value_null() -> CaseSpec {
         CaseSpec::skip("MsgPack is a binary format, DynamicValue not supported")
     }

--- a/facet-xml/tests/format_suite.rs
+++ b/facet-xml/tests/format_suite.rs
@@ -795,17 +795,18 @@ impl FormatSuite for XmlSlice {
 
     fn bytestring() -> CaseSpec {
         CaseSpec::from_str(r#"<record><value>hello world</value></record>"#)
-            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn compact_string() -> CaseSpec {
         CaseSpec::from_str(r#"<record><value>hello world</value></record>"#)
-            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn smartstring() -> CaseSpec {
         CaseSpec::from_str(r#"<record><value>hello world</value></record>"#)
-            .without_roundtrip("opaque type serialization not yet supported")
+    }
+
+    fn smol_str() -> CaseSpec {
+        CaseSpec::from_str(r#"<record><value>hello world</value></record>"#)
     }
 
     // ── Dynamic value cases ──

--- a/facet-yaml/tests/format_suite.rs
+++ b/facet-yaml/tests/format_suite.rs
@@ -685,17 +685,18 @@ impl FormatSuite for YamlSlice {
 
     fn bytestring() -> CaseSpec {
         CaseSpec::from_str("value: hello world")
-            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn compact_string() -> CaseSpec {
         CaseSpec::from_str("value: hello world")
-            .without_roundtrip("opaque type serialization not yet supported")
     }
 
     fn smartstring() -> CaseSpec {
         CaseSpec::from_str("value: hello world")
-            .without_roundtrip("opaque type serialization not yet supported")
+    }
+
+    fn smol_str() -> CaseSpec {
+        CaseSpec::from_str("value: hello world")
     }
 
     // -- Dynamic value cases --

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -41,6 +41,7 @@ all-impls = [
     "indexmap",
     "num-complex",
     "smartstring",
+    "smol_str",
 ] # Enable all optional Facet trait implementations for third-party types
 alloc = ["facet-core/alloc"] # Enable allocation support for no_std environments
 nonzero = ["facet-core/nonzero"] # Provide Facet trait implementations for NonZero<T> types
@@ -84,6 +85,9 @@ num-complex = [
 smartstring = [
     "facet-core/smartstring",
 ] # Provide Facet trait implementations for smartstring::SmartString
+smol_str = [
+    "facet-core/smol_str",
+] # Provide Facet trait implementations for smol_str::SmolStr
 
 # Provide Facet trait implementations for tuples up to size 12. Without it,
 # Facet is only implemented for tuples up to size 4.


### PR DESCRIPTION
## Summary

Adds Facet trait implementation for `smol_str::SmolStr` with full roundtrip serialization support across all format crates. Also fixes serialization for other string-like types (smartstring, compact_str, bytestring) by adding a Display-based fallback for `Def::Scalar` types in the serializer.

## Changes

- Add `smol_str` feature and dependency to facet-core
- Implement Facet for SmolStr with try_from support for &str and String
- Add test cases in facet-format-suite for smol_str across all formats
- Fix serialization for `Def::Scalar` types that have Display trait (benefits SmolStr, SmartString, CompactString)
- Enable roundtrip tests for bytestring, compact_str, and smartstring (previously skipped)

## Testing

All 2515 tests pass, including new smol_str tests across JSON, YAML, XML, msgpack, and ASN.1 formats.

Fixes #1571