### PR TITLE
Add UUID, jiff, chrono, and time support to facet-tokio-postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,14 +2035,18 @@ dependencies = [
 name = "facet-tokio-postgres"
 version = "0.41.0"
 dependencies = [
+ "chrono",
  "facet",
  "facet-core",
  "facet-reflect",
+ "jiff",
  "postgres-types",
  "testcontainers",
  "testcontainers-modules",
+ "time",
  "tokio",
  "tokio-postgres",
+ "uuid",
 ]
 
 [[package]]

--- a/facet-tokio-postgres/Cargo.toml
+++ b/facet-tokio-postgres/Cargo.toml
@@ -26,12 +26,24 @@ facet = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 testcontainers = "0.23"
 testcontainers-modules = { version = "0.11", features = ["postgres"] }
+uuid = "1"
+jiff = "0.2"
+chrono = { workspace = true }
+time = { workspace = true }
 
 [features]
 default = ["std"]
 std = []
 # Enable integration tests (requires postgres via POSTGRES_HOST/PORT env vars, or docker for testcontainers)
 test-postgres = []
+# Enable UUID support
+uuid = ["facet-core/uuid"]
+# Enable jiff timestamp support
+jiff02 = ["facet-core/jiff02"]
+# Enable chrono timestamp support
+chrono = ["facet-core/chrono"]
+# Enable time crate support
+time = ["facet-core/time"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Adds optional feature flags for commonly used date/time and ID types to `facet-tokio-postgres`. These types work automatically via the existing `parse()` fallback mechanism - the crate retrieves columns as strings and parses them using facet-core's type implementations.

Fixes #1609

## New Feature Flags

- `uuid` - Support for `uuid::Uuid`
- `jiff02` - Support for `jiff::Timestamp` 
- `chrono` - Support for `chrono::DateTime<Utc>`, `NaiveDate`, `NaiveDateTime`, `NaiveTime`, etc.
- `time` - Support for `time::OffsetDateTime`, `UtcDateTime`

## Usage

Enable the features you need:

```toml
[dependencies]
facet-tokio-postgres = { version = "0.41", features = ["uuid", "jiff02"] }
```

Then use the types in your structs:

```rust
#[derive(Facet)]
struct Product {
    id: Uuid,
    title: String,
    created_at: jiff::Timestamp,
}
```

**Note:** For now, users must cast UUID/timestamp columns to text in SQL queries:

```sql
SELECT id::text, title, to_char(created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as created_at FROM products
```

## Test plan

- [x] Added integration tests for UUID (required and optional)
- [x] Added integration tests for jiff::Timestamp (required and optional)
- [x] Added integration tests for chrono::DateTime<Utc> and NaiveDate (required and optional)
- [x] Added integration tests for time::OffsetDateTime (required and optional)
- [x] All 17 tests pass with `--all-features`