### PR TITLE
Fix string-like types as map keys (#1614)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,6 +1820,7 @@ version = "0.41.0"
 dependencies = [
  "axum-core",
  "brotli",
+ "compact_str",
  "corosensei",
  "facet",
  "facet-core",

--- a/facet-format/Cargo.toml
+++ b/facet-format/Cargo.toml
@@ -51,6 +51,8 @@ validate = ["dep:facet-validate"]
 jit = ["dep:cranelift", "dep:cranelift-jit", "dep:cranelift-module", "dep:cranelift-native", "dep:parking_lot", "dep:museair", "dep:libc"]
 # Alias to unblock workspace-level `--features cranelift`
 cranelift = ["jit"]
+# compact_str support
+compact_str = ["facet-core/compact_str"]
 
 [lints]
 workspace = true

--- a/facet-format/src/serializer.rs
+++ b/facet-format/src/serializer.rs
@@ -558,8 +558,8 @@ where
                     let key_str = if let Some(s) = key.as_str() {
                         Cow::Borrowed(s)
                     } else {
-                        // For non-string keys, use debug format
-                        Cow::Owned(alloc::format!("{:?}", key))
+                        // For non-string keys, use Display format (not Debug, which adds quotes)
+                        Cow::Owned(alloc::format!("{}", key))
                     };
                     serializer
                         .field_key(&key_str)

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -39,7 +39,8 @@ mime = { version = "0.3", optional = true }
 
 [dev-dependencies]
 brotli = "7"
-facet = { workspace = true, features = ["doc", "net"] }
+compact_str = { workspace = true }
+facet = { workspace = true, features = ["doc", "net", "compact_str"] }
 facet-format = { path = "../facet-format", features = ["jit"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -78,6 +79,9 @@ miette = ["dep:miette", "facet-reflect/miette"]
 
 # Field validation during deserialization
 validate = ["facet-format/validate"]
+
+# compact_str support
+compact_str = ["facet/compact_str", "facet-format/compact_str"]
 
 [lints]
 workspace = true

--- a/facet-json/tests/string_like_map_keys.rs
+++ b/facet-json/tests/string_like_map_keys.rs
@@ -1,0 +1,49 @@
+//! Tests for string-like types as map keys.
+//!
+//! Issue #1614: Box<str>, Arc<str>, CompactString, etc. should serialize correctly
+//! as map keys, not using debug format.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use compact_str::CompactString;
+use facet_json::to_string;
+
+/// Test Box<str> as map key - should serialize as `{"key":true}` not `{"⟨Box<str>⟩":true}`
+#[test]
+fn box_str_map_key() {
+    let map = HashMap::from([(Box::<str>::from("key"), true)]);
+    let json = to_string(&map).unwrap();
+    assert_eq!(json, r#"{"key":true}"#);
+}
+
+/// Test Arc<str> as map key - should serialize as `{"key":true}` not `{"⟨Arc<str>⟩":true}`
+#[test]
+fn arc_str_map_key() {
+    let map = HashMap::from([(Arc::<str>::from("key"), true)]);
+    let json = to_string(&map).unwrap();
+    assert_eq!(json, r#"{"key":true}"#);
+}
+
+/// Test CompactString as map key - should serialize as `{"key":true}` not `{"\"key\"":true}`
+#[test]
+fn compact_string_map_key() {
+    let map = HashMap::from([(CompactString::from("key"), true)]);
+    let json = to_string(&map).unwrap();
+    assert_eq!(json, r#"{"key":true}"#);
+}
+
+/// Test multiple string-like keys in the same map
+#[test]
+fn box_str_multiple_keys() {
+    let map = HashMap::from([
+        (Box::<str>::from("alpha"), 1),
+        (Box::<str>::from("beta"), 2),
+    ]);
+    let json = to_string(&map).unwrap();
+    // HashMap ordering is not guaranteed, so check both possibilities
+    assert!(
+        json == r#"{"alpha":1,"beta":2}"# || json == r#"{"beta":2,"alpha":1}"#,
+        "unexpected json: {json}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1614. `Box<str>`, `Arc<str>`, and `CompactString` weren't serialized correctly when used as map keys - they were hitting the debug representation instead of being serialized as strings.

## Changes

- Extended `as_str()` in `facet-reflect` to handle smart pointer types (`Box<str>`, `Arc<str>`, `Rc<str>`) by using their `borrow_fn` to get the inner `&str`
- Changed serializer fallback in `facet-format` from Debug to Display format for non-string map keys (fixes `CompactString` showing `"\"key\""` instead of `"key"`)
- Added `compact_str` feature to `facet-format` and `facet-json`
- Added tests for `Box<str>`, `Arc<str>`, and `CompactString` as map keys

## Test plan

- [x] New tests pass: `cargo test -p facet-json --test string_like_map_keys`
- [x] All existing tests pass (2572 tests)
- [x] Clippy passes