### PR TITLE
Fix flatten with SmolStr map keys producing empty output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1840,6 +1840,7 @@ dependencies = [
  "mime",
  "serde",
  "serde_json",
+ "smol_str",
  "tokio",
  "zmij",
 ]

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -40,13 +40,14 @@ mime = { version = "0.3", optional = true }
 [dev-dependencies]
 brotli = "7"
 compact_str = { workspace = true }
-facet = { workspace = true, features = ["doc", "net", "compact_str"] }
+facet = { workspace = true, features = ["doc", "net", "compact_str", "smol_str"] }
 facet-format = { path = "../facet-format", features = ["jit"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 facet-format-suite = { path = "../facet-format-suite", features = ["third-party", "tokio"] }
 indoc = { workspace = true }
 libtest-mimic = "0.8.1"
+smol_str = { workspace = true }
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [[test]]

--- a/facet-json/tests/smolstr_flatten_map.rs
+++ b/facet-json/tests/smolstr_flatten_map.rs
@@ -1,0 +1,96 @@
+#![forbid(unsafe_code)]
+
+//! Test for issue #1627: flatten with SmolStr map keys produces empty output
+
+use std::collections::HashMap;
+
+use facet::Facet;
+use smol_str::SmolStr;
+
+#[derive(Facet, Debug)]
+struct Inner {
+    value: bool,
+}
+
+#[derive(Facet, Debug)]
+struct Wrapper {
+    #[facet(flatten)]
+    map: HashMap<SmolStr, Vec<Inner>>,
+}
+
+#[test]
+fn smolstr_flatten_map_serializes_correctly() {
+    let wrapper = Wrapper {
+        map: HashMap::from([(SmolStr::from("key"), vec![Inner { value: true }])]),
+    };
+
+    let json = facet_json::to_string(&wrapper).expect("should serialize");
+
+    // The output should include the flattened map entry
+    assert!(
+        json.contains("\"key\""),
+        "expected 'key' in output, got: {json}"
+    );
+    assert!(
+        json.contains("\"value\":true"),
+        "expected '\"value\":true' in output, got: {json}"
+    );
+}
+
+#[test]
+fn smolstr_flatten_map_with_multiple_keys() {
+    let wrapper = Wrapper {
+        map: HashMap::from([
+            (SmolStr::from("first"), vec![Inner { value: true }]),
+            (SmolStr::from("second"), vec![Inner { value: false }]),
+        ]),
+    };
+
+    let json = facet_json::to_string(&wrapper).expect("should serialize");
+
+    assert!(
+        json.contains("\"first\""),
+        "expected 'first' in output, got: {json}"
+    );
+    assert!(
+        json.contains("\"second\""),
+        "expected 'second' in output, got: {json}"
+    );
+}
+
+#[test]
+fn smolstr_flatten_map_empty() {
+    let wrapper = Wrapper {
+        map: HashMap::new(),
+    };
+
+    let json = facet_json::to_string(&wrapper).expect("should serialize");
+
+    // Empty map should produce empty object
+    assert_eq!(json, "{}", "expected empty object for empty map");
+}
+
+// Also test with String keys to make sure we didn't break anything
+#[derive(Facet, Debug)]
+struct WrapperWithString {
+    #[facet(flatten)]
+    map: HashMap<String, Vec<Inner>>,
+}
+
+#[test]
+fn string_flatten_map_still_works() {
+    let wrapper = WrapperWithString {
+        map: HashMap::from([("key".to_string(), vec![Inner { value: true }])]),
+    };
+
+    let json = facet_json::to_string(&wrapper).expect("should serialize");
+
+    assert!(
+        json.contains("\"key\""),
+        "expected 'key' in output, got: {json}"
+    );
+    assert!(
+        json.contains("\"value\":true"),
+        "expected '\"value\":true' in output, got: {json}"
+    );
+}

--- a/facet-reflect/src/peek/fields.rs
+++ b/facet-reflect/src/peek/fields.rs
@@ -229,12 +229,15 @@ impl<'mem, 'facet> Iterator for FieldsForSerializeIter<'mem, 'facet> {
                         // Push iterator back for more entries
                         self.stack
                             .push(FieldsForSerializeIterState::FlattenedMap { map_iter });
-                        // Get the key as a string
-                        if let Ok(key_str) = key_peek.get::<String>() {
-                            let field_item = FieldItem::flattened_map_entry(key_str.clone());
+                        // Get the key as a string using Display trait
+                        // This works for String, SmolStr, SmartString, CompactString, etc.
+                        if key_peek.shape().vtable.has_display() {
+                            use alloc::string::ToString;
+                            let key_str = key_peek.to_string();
+                            let field_item = FieldItem::flattened_map_entry(key_str);
                             return Some((field_item, value_peek));
                         }
-                        // Skip entries with non-string keys
+                        // Skip entries with non-string-like keys
                         continue;
                     }
                     // Map exhausted, continue to next state


### PR DESCRIPTION
## Summary

Fix `#[facet(flatten)]` with `SmolStr` map keys producing empty `{}` output instead of the expected flattened entries. The fix also works for other string-like types like `SmartString` and `CompactString`.

## Problem

When using `#[facet(flatten)]` on a `HashMap<SmolStr, T>`, serialization produced an empty object `{}`:

```rust
#[derive(Facet)]
struct Wrapper {
    #[facet(flatten)]
    map: HashMap<SmolStr, Vec<Inner>>,
}

// Expected: {"key":[{"value":true}]}
// Actual:   {}
```

## Root Cause

In `fields_for_serialize()`, flattened map entries were being converted to field names using `key_peek.get::<String>()`. This only works if the key is exactly a `String` type - `SmolStr` and other string-like types silently failed and their entries were skipped.

## Fix

Use the `Display` vtable to convert map keys to strings instead of checking for a specific type:

```rust
// Before: Only worked for String
if let Ok(key_str) = key_peek.get::<String>() {

// After: Works for any type with Display
if key_peek.shape().vtable.has_display() {
    let key_str = key_peek.to_string();
```

This is the same approach used elsewhere in the serialization code for opaque scalars.

## Test Plan

- Added `smolstr_flatten_map.rs` with tests for SmolStr keys
- All 2580 tests pass

Fixes #1627