### PR TITLE
Fix #1629: Preserve custom HTML elements during parse/serialize roundtrip

### DIFF
--- a/facet-core/src/types/ty/enum_.rs
+++ b/facet-core/src/types/ty/enum_.rs
@@ -77,6 +77,17 @@ impl Variant {
     pub fn is_text(&self) -> bool {
         self.has_attr(Some("html"), "text") || self.has_attr(Some("xml"), "text")
     }
+
+    /// Returns true if this variant has the `#[facet(html::custom_element)]` or
+    /// `#[facet(xml::custom_element)]` attribute.
+    ///
+    /// When deserializing HTML/XML, variants marked as custom_element act as a catch-all
+    /// for unknown element names. The element's tag name is stored in the variant's `tag` field.
+    #[inline]
+    pub fn is_custom_element(&self) -> bool {
+        self.has_attr(Some("html"), "custom_element")
+            || self.has_attr(Some("xml"), "custom_element")
+    }
 }
 
 /// An attribute that can be set on an enum variant.

--- a/facet-core/src/types/ty/field.rs
+++ b/facet-core/src/types/ty/field.rs
@@ -234,6 +234,15 @@ impl Field {
         self.has_attr(Some("xml"), "attribute") || self.has_attr(Some("html"), "attribute")
     }
 
+    /// Returns true if this field captures the element's tag name (for XML/HTML custom elements).
+    ///
+    /// Checks for `xml::tag` or `html::tag` attributes.
+    /// Used by custom element types to store the element's tag name during deserialization.
+    #[inline]
+    pub fn is_tag(&self) -> bool {
+        self.has_attr(Some("xml"), "tag") || self.has_attr(Some("html"), "tag")
+    }
+
     /// Returns true if this field is a KDL argument (positional value).
     ///
     /// Checks for `kdl::argument` or `kdl::arguments` attributes.

--- a/facet-format/src/event.rs
+++ b/facet-format/src/event.rs
@@ -18,6 +18,8 @@ pub enum FieldLocationHint {
     Property,
     /// KDL positional argument.
     Argument,
+    /// Element tag name (for custom elements in XML/HTML).
+    Tag,
 }
 
 /// Field key with optional namespace (for XML).

--- a/facet-html-dom/src/lib.rs
+++ b/facet-html-dom/src/lib.rs
@@ -2147,6 +2147,62 @@ pub struct Slot {
 }
 
 // =============================================================================
+// Custom Elements
+// =============================================================================
+
+/// A custom HTML element with a dynamic tag name.
+///
+/// This type is used as a catch-all for unknown elements during HTML parsing.
+/// Custom elements (like `<a-k>`, `<a-f>` from arborium syntax highlighting)
+/// are preserved with their tag name, attributes, and children.
+///
+/// # Example
+///
+/// ```ignore
+/// // Input: <a-k>fn</a-k>
+/// // Parses as:
+/// CustomElement {
+///     tag: "a-k".to_string(),
+///     attrs: GlobalAttrs::default(),
+///     children: vec![FlowContent::Text("fn".to_string())],
+/// }
+/// ```
+#[derive(Default, Facet)]
+pub struct CustomElement {
+    /// The tag name of the custom element (e.g., "a-k", "my-component").
+    ///
+    /// This field is marked with `#[facet(html::tag)]` to indicate it should
+    /// receive the element's tag name during deserialization.
+    #[facet(html::tag, default)]
+    pub tag: String,
+    /// Global attributes.
+    #[facet(flatten, default)]
+    pub attrs: GlobalAttrs,
+    /// Child elements.
+    #[facet(html::elements, default)]
+    #[facet(recursive_type)]
+    pub children: Vec<FlowContent>,
+}
+
+/// A custom phrasing element with a dynamic tag name.
+///
+/// Similar to [`CustomElement`] but for inline/phrasing content contexts.
+/// This allows custom elements to appear inside paragraphs, spans, etc.
+#[derive(Default, Facet)]
+pub struct CustomPhrasingElement {
+    /// The tag name of the custom element.
+    #[facet(html::tag, default)]
+    pub tag: String,
+    /// Global attributes.
+    #[facet(flatten, default)]
+    pub attrs: GlobalAttrs,
+    /// Child elements.
+    #[facet(html::elements, default)]
+    #[facet(recursive_type)]
+    pub children: Vec<PhrasingContent>,
+}
+
+// =============================================================================
 // Content Categories (Enums for mixed content)
 // =============================================================================
 
@@ -2323,6 +2379,11 @@ pub enum FlowContent {
     /// Template element.
     #[facet(rename = "template")]
     Template(Template),
+
+    // Custom elements (catch-all for unknown elements)
+    /// Custom element (catch-all for unknown elements like `<a-k>`, `<my-component>`).
+    #[facet(html::custom_element)]
+    Custom(CustomElement),
 }
 
 /// Phrasing content - inline elements and text.
@@ -2441,4 +2502,9 @@ pub enum PhrasingContent {
     /// Script element.
     #[facet(rename = "script")]
     Script(Script),
+
+    // Custom elements (catch-all for unknown elements)
+    /// Custom element (catch-all for unknown elements like `<a-k>`, `<my-component>`).
+    #[facet(html::custom_element)]
+    Custom(CustomPhrasingElement),
 }

--- a/facet-html/src/lib.rs
+++ b/facet-html/src/lib.rs
@@ -119,6 +119,17 @@ facet::define_attr_grammar! {
         Attribute,
         /// Marks a field as the text content of the element
         Text,
+        /// Marks a field as storing the element's tag name (for custom elements).
+        ///
+        /// Used on a `String` field to capture the tag name of an unknown element
+        /// during deserialization. When serializing, this value becomes the element's tag.
+        Tag,
+        /// Marks an enum variant as a catch-all for unknown elements.
+        ///
+        /// When deserializing, if no other variant matches the element name,
+        /// this variant is selected. The variant's struct must have a field
+        /// marked with `#[facet(html::tag)]` to capture the element name.
+        CustomElement,
     }
 }
 


### PR DESCRIPTION
## Summary

Custom HTML elements (like `<a-k>`, `<a-f>` from arborium syntax highlighting) were being silently dropped during parsing. This fix introduces a catch-all mechanism that preserves unknown elements as `CustomElement` types, enabling full roundtrip fidelity.

## Changes

- **facet-html-dom**: Add `CustomElement` and `CustomPhrasingElement` structs with `Custom` variants in `FlowContent` and `PhrasingContent` enums
- **facet-html**: Add `#[facet(html::tag)]` and `#[facet(html::custom_element)]` attributes to the grammar
- **facet-html**: Update parser to emit `_tag` field for all elements
- **facet-html**: Update serializer to output custom elements with dynamic tag names
- **facet-format**: Update deserializer to fall back to custom_element variants for unknown elements
- **facet-format**: Add `FieldLocationHint::Tag` for tag name fields
- **facet-core**: Add `is_custom_element()` and `is_tag()` helper methods to `Variant` and `Field`

## Test plan

- [x] Added `issue_1629_debug` test to verify custom element parsing
- [x] Added `issue_1629_custom_elements_preserved` test to verify `<a-k>` and `<a-f>` elements are captured
- [x] Added `issue_1629_custom_elements_roundtrip` test for idempotent serialization
- [x] All 63 HTML tests pass
- [x] All 346 XML tests pass  
- [x] All 360 JSON/core/format tests pass
- [x] Clippy clean

Closes #1629