### PR TITLE
Add ScalarValue::Char variant for proper char serialization

### DIFF
--- a/facet-asn1/src/serializer.rs
+++ b/facet-asn1/src/serializer.rs
@@ -274,6 +274,10 @@ impl FormatSerializer for Asn1Serializer {
         match scalar {
             ScalarValue::Null => self.write_null(),
             ScalarValue::Bool(v) => self.write_bool(v),
+            ScalarValue::Char(c) => {
+                let mut buf = [0u8; 4];
+                self.write_str(c.encode_utf8(&mut buf));
+            }
             ScalarValue::U64(n) => self.write_u64(n),
             ScalarValue::I64(n) => self.write_i64(n),
             ScalarValue::U128(n) => {

--- a/facet-csv/src/serializer.rs
+++ b/facet-csv/src/serializer.rs
@@ -129,6 +129,10 @@ impl FormatSerializer for CsvSerializer {
                     self.out.extend_from_slice(b"false");
                 }
             }
+            ScalarValue::Char(c) => {
+                let mut buf = [0u8; 4];
+                self.write_csv_escaped(c.encode_utf8(&mut buf));
+            }
             ScalarValue::I64(v) => {
                 #[cfg(feature = "fast")]
                 self.out

--- a/facet-format/src/deserializer.rs
+++ b/facet-format/src/deserializer.rs
@@ -3953,6 +3953,7 @@ where
 
         match scalar {
             ScalarValue::Bool(_) => matches!(scalar_type, ScalarType::Bool),
+            ScalarValue::Char(_) => matches!(scalar_type, ScalarType::Char),
             ScalarValue::I64(val) => {
                 // I64 matches signed types directly
                 if matches!(
@@ -4409,6 +4410,9 @@ where
             }
             ScalarValue::Bool(b) => {
                 wip = wip.set(b).map_err(&reflect_err)?;
+            }
+            ScalarValue::Char(c) => {
+                wip = wip.set(c).map_err(&reflect_err)?;
             }
             ScalarValue::I64(n) => {
                 // Handle signed types

--- a/facet-format/src/event.rs
+++ b/facet-format/src/event.rs
@@ -110,6 +110,8 @@ pub enum ScalarValue<'de> {
     Null,
     /// Boolean literal.
     Bool(bool),
+    /// Character literal.
+    Char(char),
     /// Signed integer literal (fits in i64).
     I64(i64),
     /// Unsigned integer literal (fits in u64).

--- a/facet-format/src/jit/helpers.rs
+++ b/facet-format/src/jit/helpers.rs
@@ -88,6 +88,8 @@ pub struct FieldNamePayload {
 pub union ScalarPayload {
     /// Boolean value
     pub bool_val: bool,
+    /// Character value
+    pub char_val: char,
     /// i64 value (also used for smaller signed integers)
     pub i64_val: i64,
     /// u64 value (also used for smaller unsigned integers)
@@ -155,6 +157,8 @@ pub enum ScalarTag {
     I128 = 8,
     /// Unsigned 128-bit integer
     U128 = 9,
+    /// Character value
+    Char = 10,
 }
 
 impl ScalarTag {
@@ -171,6 +175,7 @@ impl ScalarTag {
             7 => ScalarTag::Bytes,
             8 => ScalarTag::I128,
             9 => ScalarTag::U128,
+            10 => ScalarTag::Char,
             _ => ScalarTag::None,
         }
     }
@@ -463,6 +468,12 @@ fn convert_event_to_raw(event: ParseEvent<'_>) -> RawEvent {
                     ScalarTag::Bool,
                     EventPayload {
                         scalar: ScalarPayload { bool_val: b },
+                    },
+                ),
+                ScalarValue::Char(c) => (
+                    ScalarTag::Char,
+                    EventPayload {
+                        scalar: ScalarPayload { char_val: c },
                     },
                 ),
                 ScalarValue::I64(n) => (

--- a/facet-format/src/serializer.rs
+++ b/facet-format/src/serializer.rs
@@ -249,11 +249,7 @@ pub trait FormatSerializer {
         let scalar = match scalar_type {
             ScalarType::Unit => ScalarValue::Null,
             ScalarType::Bool => ScalarValue::Bool(*value.get::<bool>().unwrap()),
-            ScalarType::Char => {
-                let c = *value.get::<char>().unwrap();
-                let mut buf = [0u8; 4];
-                ScalarValue::Str(Cow::Owned(c.encode_utf8(&mut buf).to_string()))
-            }
+            ScalarType::Char => ScalarValue::Char(*value.get::<char>().unwrap()),
             ScalarType::Str | ScalarType::String | ScalarType::CowStr => {
                 ScalarValue::Str(Cow::Borrowed(value.as_str().unwrap()))
             }

--- a/facet-html/src/serializer.rs
+++ b/facet-html/src/serializer.rs
@@ -860,6 +860,10 @@ impl FormatSerializer for HtmlSerializer {
 
                 self.write_scalar_string(if v { "true" } else { "false" })
             }
+            ScalarValue::Char(c) => {
+                let mut buf = [0u8; 4];
+                self.write_scalar_string(c.encode_utf8(&mut buf))
+            }
             ScalarValue::I64(v) => self.write_scalar_string(&v.to_string()),
             ScalarValue::U64(v) => self.write_scalar_string(&v.to_string()),
             ScalarValue::F64(v) => {

--- a/facet-json/src/serializer.rs
+++ b/facet-json/src/serializer.rs
@@ -323,6 +323,11 @@ impl FormatSerializer for JsonSerializer {
                     self.out.extend_from_slice(b"false")
                 }
             }
+            ScalarValue::Char(c) => {
+                self.out.push(b'"');
+                self.write_json_escaped_char(c);
+                self.out.push(b'"');
+            }
             ScalarValue::I64(v) => {
                 #[cfg(feature = "fast")]
                 self.out

--- a/facet-json/tests/format_suite.rs
+++ b/facet-json/tests/format_suite.rs
@@ -394,8 +394,7 @@ impl FormatSuite for JsonSlice {
     }
 
     fn flatten_optional_some() -> CaseSpec {
-        // TODO: flatten with Option<T> not yet fully supported
-        CaseSpec::skip("flatten with Option<T> not yet implemented")
+        CaseSpec::from_str(r#"{"name":"test","version":1,"author":"alice"}"#)
     }
 
     fn flatten_optional_none() -> CaseSpec {
@@ -610,7 +609,6 @@ impl FormatSuite for JsonSlice {
 
     fn char_scalar() -> CaseSpec {
         CaseSpec::from_str(r#"{"letter":"A","emoji":"🦀"}"#)
-            .without_roundtrip("char serialization not yet supported")
     }
 
     // ── HashSet cases ──
@@ -753,35 +751,33 @@ impl FormatSuite for JsonSlice {
     }
 
     // ── Dynamic value cases ──
-    // NOTE: facet_value::Value uses DynamicValue def which requires specialized handling
-    // in the deserializer. The format deserializer doesn't support this yet.
 
     fn value_null() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("null")
     }
 
     fn value_bool() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("true")
     }
 
     fn value_integer() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("42")
     }
 
     fn value_float() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("2.5")
     }
 
     fn value_string() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str(r#""hello world""#)
     }
 
     fn value_array() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("[1, 2, 3]")
     }
 
     fn value_object() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str(r#"{"name": "test", "count": 42}"#)
     }
 }
 

--- a/facet-kdl/src/serializer.rs
+++ b/facet-kdl/src/serializer.rs
@@ -92,6 +92,13 @@ impl KdlSerializer {
             ScalarValue::Null => "#null".to_string(),
             ScalarValue::Bool(true) => "#true".to_string(),
             ScalarValue::Bool(false) => "#false".to_string(),
+            ScalarValue::Char(c) => {
+                let mut result = String::with_capacity(3);
+                result.push('"');
+                result.push(*c);
+                result.push('"');
+                result
+            }
             ScalarValue::I64(n) => {
                 #[cfg(feature = "fast")]
                 return itoa::Buffer::new().format(*n).to_string();

--- a/facet-msgpack/src/serializer.rs
+++ b/facet-msgpack/src/serializer.rs
@@ -320,6 +320,10 @@ impl FormatSerializer for MsgPackSerializer {
         match scalar {
             ScalarValue::Null => self.write_nil(),
             ScalarValue::Bool(v) => self.write_bool(v),
+            ScalarValue::Char(c) => {
+                let mut buf = [0u8; 4];
+                self.write_str(c.encode_utf8(&mut buf));
+            }
             ScalarValue::U64(n) => self.write_u64(n),
             ScalarValue::I64(n) => self.write_i64(n),
             ScalarValue::U128(n) => {

--- a/facet-postcard/src/serialize.rs
+++ b/facet-postcard/src/serialize.rs
@@ -274,6 +274,12 @@ impl<W: Writer> FormatSerializer for PostcardSerializer<'_, W> {
         match scalar {
             facet_format::ScalarValue::Null => Ok(()),
             facet_format::ScalarValue::Bool(v) => self.writer.write_byte(if v { 1 } else { 0 }),
+            facet_format::ScalarValue::Char(c) => {
+                // Postcard encodes char as UTF-8
+                let mut buf = [0u8; 4];
+                let s = c.encode_utf8(&mut buf);
+                self.write_str(s)
+            }
             facet_format::ScalarValue::I64(n) => write_varint_signed(n, self.writer),
             facet_format::ScalarValue::U64(n) => write_varint(n, self.writer),
             facet_format::ScalarValue::I128(n) => write_varint_signed_i128(n, self.writer),

--- a/facet-toml/src/serializer.rs
+++ b/facet-toml/src/serializer.rs
@@ -255,6 +255,9 @@ impl FormatSerializer for TomlSerializer {
             ScalarValue::Bool(v) => {
                 self.out.push_str(if v { "true" } else { "false" });
             }
+            ScalarValue::Char(c) => {
+                self.write_toml_string(&c.to_string());
+            }
             ScalarValue::I64(v) => {
                 #[cfg(feature = "fast")]
                 self.out.push_str(itoa::Buffer::new().format(v));

--- a/facet-xdr/src/serializer.rs
+++ b/facet-xdr/src/serializer.rs
@@ -195,6 +195,10 @@ impl FormatSerializer for XdrSerializer {
                 self.write_u32(0);
             }
             ScalarValue::Bool(v) => self.write_bool(v),
+            ScalarValue::Char(c) => {
+                let mut buf = [0u8; 4];
+                self.write_string(c.encode_utf8(&mut buf));
+            }
             ScalarValue::U64(n) => {
                 // Determine size based on value
                 if n <= u32::MAX as u64 {

--- a/facet-xml/src/serializer.rs
+++ b/facet-xml/src/serializer.rs
@@ -846,6 +846,7 @@ impl FormatSerializer for XmlSerializer {
             let value = match scalar {
                 ScalarValue::Null => "null".to_string(),
                 ScalarValue::Bool(v) => if v { "true" } else { "false" }.to_string(),
+                ScalarValue::Char(c) => c.to_string(),
                 ScalarValue::I64(v) => v.to_string(),
                 ScalarValue::U64(v) => v.to_string(),
                 ScalarValue::I128(v) => v.to_string(),
@@ -879,6 +880,10 @@ impl FormatSerializer for XmlSerializer {
             match scalar {
                 ScalarValue::Null => self.write_text_escaped("null"),
                 ScalarValue::Bool(v) => self.write_text_escaped(if v { "true" } else { "false" }),
+                ScalarValue::Char(c) => {
+                    let mut buf = [0u8; 4];
+                    self.write_text_escaped(c.encode_utf8(&mut buf));
+                }
                 ScalarValue::I64(v) => self.write_text_escaped(&v.to_string()),
                 ScalarValue::U64(v) => self.write_text_escaped(&v.to_string()),
                 ScalarValue::I128(v) => self.write_text_escaped(&v.to_string()),
@@ -906,6 +911,10 @@ impl FormatSerializer for XmlSerializer {
                 self.write_text_escaped("null");
             }
             ScalarValue::Bool(v) => self.write_text_escaped(if v { "true" } else { "false" }),
+            ScalarValue::Char(c) => {
+                let mut buf = [0u8; 4];
+                self.write_text_escaped(c.encode_utf8(&mut buf));
+            }
             ScalarValue::I64(v) => self.write_text_escaped(&v.to_string()),
             ScalarValue::U64(v) => self.write_text_escaped(&v.to_string()),
             ScalarValue::I128(v) => self.write_text_escaped(&v.to_string()),

--- a/facet-xml/tests/format_suite.rs
+++ b/facet-xml/tests/format_suite.rs
@@ -419,8 +419,9 @@ impl FormatSuite for XmlSlice {
     }
 
     fn flatten_optional_some() -> CaseSpec {
-        // TODO: flatten with Option<T> not yet fully supported
-        CaseSpec::skip("flatten with Option<T> not yet implemented")
+        CaseSpec::from_str(
+            r#"<record><name>test</name><version>1</version><author>alice</author></record>"#,
+        )
     }
 
     fn flatten_optional_none() -> CaseSpec {
@@ -641,7 +642,6 @@ impl FormatSuite for XmlSlice {
 
     fn char_scalar() -> CaseSpec {
         CaseSpec::from_str(r#"<record><letter>A</letter><emoji>🦀</emoji></record>"#)
-            .without_roundtrip("char serialization not yet supported")
     }
 
     // ── HashSet cases ──
@@ -796,47 +796,46 @@ impl FormatSuite for XmlSlice {
     }
 
     // ── Dynamic value cases ──
-    // NOTE: facet_value::Value uses DynamicValue def which requires specialized handling
-    // in the deserializer. The format deserializer doesn't support this yet.
 
     fn value_null() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("<value>null</value>")
     }
 
     fn value_bool() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("<value>true</value>")
     }
 
     fn value_integer() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("<value>42</value>")
     }
 
     fn value_float() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        // XML element text is always a string - no way to distinguish "2.5" from 2.5
+        CaseSpec::skip("XML cannot distinguish string from number in element text")
     }
 
     fn value_string() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("<value>hello world</value>")
     }
 
     fn value_array() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("<array><item>1</item><item>2</item><item>3</item></array>")
     }
 
     fn value_object() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("<object><name>test</name><count>42</count></object>")
     }
 
     fn numeric_enum() -> CaseSpec {
-        CaseSpec::skip("Numeric not yet supported in format deserializer")
+        CaseSpec::from_str("<value>1</value>")
     }
 
     fn signed_numeric_enum() -> CaseSpec {
-        CaseSpec::skip("Numeric not yet supported in format deserializer")
+        CaseSpec::from_str("<value>-1</value>")
     }
 
     fn inferred_numeric_enum() -> CaseSpec {
-        CaseSpec::skip("Numeric not yet supported in format deserializer")
+        CaseSpec::from_str("<value>0</value>")
     }
 }
 

--- a/facet-yaml/src/serializer.rs
+++ b/facet-yaml/src/serializer.rs
@@ -433,6 +433,10 @@ impl FormatSerializer for YamlSerializer {
                     self.out.extend_from_slice(b"false")
                 }
             }
+            ScalarValue::Char(c) => {
+                let mut buf = [0u8; 4];
+                self.write_string(c.encode_utf8(&mut buf));
+            }
             ScalarValue::I64(v) => {
                 #[cfg(feature = "fast")]
                 self.out

--- a/facet-yaml/tests/format_suite.rs
+++ b/facet-yaml/tests/format_suite.rs
@@ -344,8 +344,7 @@ impl FormatSuite for YamlSlice {
     }
 
     fn flatten_optional_some() -> CaseSpec {
-        // TODO: flatten with Option<T> not yet fully supported
-        CaseSpec::skip("flatten with Option<T> not yet implemented")
+        CaseSpec::from_str("name: test\nversion: 1\nauthor: alice")
     }
 
     fn flatten_optional_none() -> CaseSpec {
@@ -544,7 +543,6 @@ impl FormatSuite for YamlSlice {
 
     fn char_scalar() -> CaseSpec {
         CaseSpec::from_str("letter: A\nemoji: \"\u{1F980}\"")
-            .without_roundtrip("char serialization not yet supported")
     }
 
     // -- HashSet cases --
@@ -690,43 +688,43 @@ impl FormatSuite for YamlSlice {
     // -- Dynamic value cases --
 
     fn value_null() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("null")
     }
 
     fn value_bool() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("true")
     }
 
     fn value_integer() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("42")
     }
 
     fn value_float() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("2.5")
     }
 
     fn value_string() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("hello world")
     }
 
     fn value_array() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("- 1\n- 2\n- 3")
     }
 
     fn value_object() -> CaseSpec {
-        CaseSpec::skip("DynamicValue not yet supported in format deserializer")
+        CaseSpec::from_str("name: test\ncount: 42")
     }
 
     fn numeric_enum() -> CaseSpec {
-        CaseSpec::skip("Numeric not yet supported in format deserializer")
+        CaseSpec::from_str("1")
     }
 
     fn signed_numeric_enum() -> CaseSpec {
-        CaseSpec::skip("Numeric not yet supported in format deserializer")
+        CaseSpec::from_str("-1")
     }
 
     fn inferred_numeric_enum() -> CaseSpec {
-        CaseSpec::skip("Numeric not yet supported in format deserializer")
+        CaseSpec::from_str("'0'")
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a dedicated `Char(char)` variant to `ScalarValue` so formats can serialize/deserialize character types properly. Previously, chars were converted to single-character strings which prevented proper roundtrip in some formats.

This brings **facet-json to 100% format suite coverage**.

## Changes

- Add `Char(char)` variant to `ScalarValue` enum in facet-format
- Update facet-format serializer to emit `ScalarValue::Char` for char types
- Add `ScalarTag::Char` and `char_val` to JIT helpers for FFI support  
- Handle `ScalarValue::Char` in format deserializer
- Update all 11 format serializers (JSON, YAML, XML, TOML, KDL, MsgPack, ASN.1, XDR, HTML, Postcard, CSV)
- Enable full roundtrip char tests in YAML and XML (previously partial)

## Test plan

- [x] All format suite tests pass
- [x] facet-json: 118/118 tests (100% coverage)
- [x] facet-yaml: 104/118 tests (88% coverage)
- [x] facet-xml: 107/118 tests (91% coverage)
- [x] Pre-push checks pass (clippy, tests, doctests, cargo-shear)

Relates to #1613