### PR TITLE
Fix #1617: Improve HTML documentation and add showcase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,6 +1810,7 @@ dependencies = [
  "facet-format",
  "facet-html-dom",
  "facet-reflect",
+ "facet-showcase",
  "facet-xml",
  "html5gum",
  "itoa",

--- a/docs/content/guide/showcases/args.md
+++ b/docs/content/guide/showcases/args.md
@@ -16,41 +16,37 @@ title = "Args"
 <p class="description">Parse a struct with flags, options, and positional arguments.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A simple CLI tool for file processing.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Enable verbose output
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Input file to process
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    input</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Output file (defaults to stdout)
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    output</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple CLI tool for file processing.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Enable verbose output
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Input file to process
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>input</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-c>/// Output file (defaults to stdout)
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>output</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">-v</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">-j</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">4</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">input.txt</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">output.txt</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;-v&quot;</a-s><a-p>,</a-p> <a-s>&quot;-j&quot;</a-s><a-p>,</a-p> <a-s>&quot;4&quot;</a-s><a-p>,</a-p> <a-s>&quot;input.txt&quot;</a-s><a-p>,</a-p> <a-s>&quot;output.txt&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">SimpleArgs</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">verbose</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">jobs</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::Some(</span><span style="color:rgb(81,114,224)">4</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">input</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">input.txt</span>"<span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">output</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">output.txt</span>"<span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">SimpleArgs</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">verbose</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">jobs</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span><span style="color:rgb(81,114,224)">4</span><span style="color:inherit"></span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">input</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">input.txt</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">output</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">output.txt</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
@@ -61,41 +57,37 @@ title = "Args"
 <p class="description">Short flags can have their values attached directly without a space.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A simple CLI tool for file processing.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Enable verbose output
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Input file to process
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    input</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Output file (defaults to stdout)
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    output</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple CLI tool for file processing.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Enable verbose output
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Input file to process
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>input</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-c>/// Output file (defaults to stdout)
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>output</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">-j4</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">input.txt</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;-j4&quot;</a-s><a-p>,</a-p> <a-s>&quot;input.txt&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">SimpleArgs</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">verbose</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">false</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">jobs</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::Some(</span><span style="color:rgb(81,114,224)">4</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">input</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">input.txt</span>"<span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">output</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">SimpleArgs</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">verbose</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">false</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">jobs</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span><span style="color:rgb(81,114,224)">4</span><span style="color:inherit"></span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">input</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">input.txt</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">output</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
@@ -106,41 +98,37 @@ title = "Args"
 <p class="description">Boolean flags can be explicitly set to true or false using <code>=</code>.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A simple CLI tool for file processing.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Enable verbose output
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Input file to process
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    input</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Output file (defaults to stdout)
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    output</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple CLI tool for file processing.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Enable verbose output
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Input file to process
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>input</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-c>/// Output file (defaults to stdout)
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>output</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">--verbose=true</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">input.txt</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;--verbose=true&quot;</a-s><a-p>,</a-p> <a-s>&quot;input.txt&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">SimpleArgs</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">verbose</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">jobs</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">input</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">input.txt</span>"<span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">output</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">SimpleArgs</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">verbose</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">jobs</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">input</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">input.txt</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">output</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
@@ -151,105 +139,101 @@ title = "Args"
 <p class="description">Multiple boolean short flags can be combined: <code>-sb</code> is equivalent to <code>-s -b</code>.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// Git-like CLI with subcommands.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">GitLikeArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show version information
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    version</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Git command to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">subcommand)]
-</span><span style="color:#9abdf5;">    command</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> GitCommand,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Available commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">GitCommand </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Clone a repository into a new directory
-</span><span style="color:#9abdf5;">    </span><span style="color:#0db9d7;">Clone </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// The repository URL to clone
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Directory to clone into
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        directory</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Clone only the specified branch
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Create a shallow clone with limited history
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named)]
-</span><span style="color:#9abdf5;">        depth</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show the working tree status
-</span><span style="color:#9abdf5;">    Status {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show short-format output
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        short</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show the branch even in short-format
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Manage set of tracked repositories
-</span><span style="color:#9abdf5;">    Remote {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Remote action to perform
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::subcommand)]
-</span><span style="color:#9abdf5;">        action</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> RemoteAction</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Remote management commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">RemoteAction </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
-</span><span style="color:#9abdf5;">    Add {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// URL of the remote repository
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Remove the remote named &lt;name&gt;
-</span><span style="color:#9abdf5;">    rm {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote to remove
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// List all remotes
-</span><span style="color:#9abdf5;">    ls {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show remote URLs after names
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// Git-like CLI with subcommands.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>GitLikeArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Show version information
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>version</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Git command to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+    <a-pr>command</a-pr><a-p>:</a-p> <a-t>GitCommand</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Available commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>GitCommand</a-t> <a-p>{</a-p>
+    <a-c>/// Clone a repository into a new directory
+</a-c>    <a-cr>Clone</a-cr> <a-p>{</a-p>
+        <a-c>/// The repository URL to clone
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// Directory to clone into
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>directory</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Clone only the specified branch
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Create a shallow clone with limited history
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+        <a-pr>depth</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Show the working tree status
+</a-c>    <a-cr>Status</a-cr> <a-p>{</a-p>
+        <a-c>/// Show short-format output
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>short</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+        <a-c>/// Show the branch even in short-format
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Manage set of tracked repositories
+</a-c>    <a-cr>Remote</a-cr> <a-p>{</a-p>
+        <a-c>/// Remote action to perform
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+        <a-pr>action</a-pr><a-p>:</a-p> <a-t>RemoteAction</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Remote management commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>RemoteAction</a-t> <a-p>{</a-p>
+    <a-c>/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
+</a-c>    <a-cr>Add</a-cr> <a-p>{</a-p>
+        <a-c>/// Name of the remote
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// URL of the remote repository
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Remove the remote named &lt;name&gt;
+</a-c>    rm <a-p>{</a-p>
+        <a-c>/// Name of the remote to remove
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// List all remotes
+</a-c>    ls <a-p>{</a-p>
+        <a-c>/// Show remote URLs after names
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">status</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">-sb</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;status&quot;</a-s><a-p>,</a-p> <a-s>&quot;-sb&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">GitLikeArgs</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">version</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">false</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">command</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">GitCommand</span><span style="opacity:0.7">::</span><span style="font-weight:bold">Status</span><span style="opacity:0.7"> {</span>
-    <span style="color:rgb(115,218,202)">short</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">branch</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">GitLikeArgs</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">version</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">false</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">command</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">GitCommand</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">Status</span><span style="opacity:0.7"> {</span>
+    <span style="color:rgb(115,218,202)">short</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">branch</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
@@ -261,107 +245,103 @@ title = "Args"
 <p class="description">Parse a CLI with subcommands, each with their own arguments.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// Git-like CLI with subcommands.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">GitLikeArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show version information
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    version</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Git command to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">subcommand)]
-</span><span style="color:#9abdf5;">    command</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> GitCommand,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Available commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">GitCommand </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Clone a repository into a new directory
-</span><span style="color:#9abdf5;">    </span><span style="color:#0db9d7;">Clone </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// The repository URL to clone
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Directory to clone into
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        directory</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Clone only the specified branch
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Create a shallow clone with limited history
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named)]
-</span><span style="color:#9abdf5;">        depth</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show the working tree status
-</span><span style="color:#9abdf5;">    Status {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show short-format output
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        short</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show the branch even in short-format
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Manage set of tracked repositories
-</span><span style="color:#9abdf5;">    Remote {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Remote action to perform
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::subcommand)]
-</span><span style="color:#9abdf5;">        action</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> RemoteAction</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Remote management commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">RemoteAction </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
-</span><span style="color:#9abdf5;">    Add {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// URL of the remote repository
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Remove the remote named &lt;name&gt;
-</span><span style="color:#9abdf5;">    rm {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote to remove
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// List all remotes
-</span><span style="color:#9abdf5;">    ls {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show remote URLs after names
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// Git-like CLI with subcommands.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>GitLikeArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Show version information
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>version</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Git command to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+    <a-pr>command</a-pr><a-p>:</a-p> <a-t>GitCommand</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Available commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>GitCommand</a-t> <a-p>{</a-p>
+    <a-c>/// Clone a repository into a new directory
+</a-c>    <a-cr>Clone</a-cr> <a-p>{</a-p>
+        <a-c>/// The repository URL to clone
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// Directory to clone into
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>directory</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Clone only the specified branch
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Create a shallow clone with limited history
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+        <a-pr>depth</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Show the working tree status
+</a-c>    <a-cr>Status</a-cr> <a-p>{</a-p>
+        <a-c>/// Show short-format output
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>short</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+        <a-c>/// Show the branch even in short-format
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Manage set of tracked repositories
+</a-c>    <a-cr>Remote</a-cr> <a-p>{</a-p>
+        <a-c>/// Remote action to perform
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+        <a-pr>action</a-pr><a-p>:</a-p> <a-t>RemoteAction</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Remote management commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>RemoteAction</a-t> <a-p>{</a-p>
+    <a-c>/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
+</a-c>    <a-cr>Add</a-cr> <a-p>{</a-p>
+        <a-c>/// Name of the remote
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// URL of the remote repository
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Remove the remote named &lt;name&gt;
+</a-c>    rm <a-p>{</a-p>
+        <a-c>/// Name of the remote to remove
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// List all remotes
+</a-c>    ls <a-p>{</a-p>
+        <a-c>/// Show remote URLs after names
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">clone</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">--branch</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">main</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">https://github.com/user/repo</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;clone&quot;</a-s><a-p>,</a-p> <a-s>&quot;--branch&quot;</a-s><a-p>,</a-p> <a-s>&quot;main&quot;</a-s><a-p>,</a-p> <a-s>&quot;https://github.com/user/repo&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">GitLikeArgs</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">version</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">false</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">command</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">GitCommand</span><span style="opacity:0.7">::</span><span style="font-weight:bold">Clone</span><span style="opacity:0.7"> {</span>
-    <span style="color:rgb(115,218,202)">url</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">https://github.com/user/repo</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">directory</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">branch</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">main</span>"<span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">depth</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">GitLikeArgs</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">version</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">false</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">command</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">GitCommand</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">Clone</span><span style="opacity:0.7"> {</span>
+    <span style="color:rgb(115,218,202)">url</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">https://github.com/user/repo</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">directory</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">branch</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">main</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">depth</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
@@ -373,106 +353,102 @@ title = "Args"
 <p class="description">Parse deeply nested subcommands like <code>git remote add</code>.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// Git-like CLI with subcommands.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">GitLikeArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show version information
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    version</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Git command to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">subcommand)]
-</span><span style="color:#9abdf5;">    command</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> GitCommand,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Available commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">GitCommand </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Clone a repository into a new directory
-</span><span style="color:#9abdf5;">    </span><span style="color:#0db9d7;">Clone </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// The repository URL to clone
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Directory to clone into
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        directory</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Clone only the specified branch
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Create a shallow clone with limited history
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named)]
-</span><span style="color:#9abdf5;">        depth</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show the working tree status
-</span><span style="color:#9abdf5;">    Status {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show short-format output
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        short</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show the branch even in short-format
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Manage set of tracked repositories
-</span><span style="color:#9abdf5;">    Remote {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Remote action to perform
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::subcommand)]
-</span><span style="color:#9abdf5;">        action</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> RemoteAction</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Remote management commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">RemoteAction </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
-</span><span style="color:#9abdf5;">    Add {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// URL of the remote repository
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Remove the remote named &lt;name&gt;
-</span><span style="color:#9abdf5;">    rm {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote to remove
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// List all remotes
-</span><span style="color:#9abdf5;">    ls {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show remote URLs after names
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// Git-like CLI with subcommands.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>GitLikeArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Show version information
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>version</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Git command to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+    <a-pr>command</a-pr><a-p>:</a-p> <a-t>GitCommand</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Available commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>GitCommand</a-t> <a-p>{</a-p>
+    <a-c>/// Clone a repository into a new directory
+</a-c>    <a-cr>Clone</a-cr> <a-p>{</a-p>
+        <a-c>/// The repository URL to clone
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// Directory to clone into
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>directory</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Clone only the specified branch
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Create a shallow clone with limited history
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+        <a-pr>depth</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Show the working tree status
+</a-c>    <a-cr>Status</a-cr> <a-p>{</a-p>
+        <a-c>/// Show short-format output
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>short</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+        <a-c>/// Show the branch even in short-format
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Manage set of tracked repositories
+</a-c>    <a-cr>Remote</a-cr> <a-p>{</a-p>
+        <a-c>/// Remote action to perform
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+        <a-pr>action</a-pr><a-p>:</a-p> <a-t>RemoteAction</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Remote management commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>RemoteAction</a-t> <a-p>{</a-p>
+    <a-c>/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
+</a-c>    <a-cr>Add</a-cr> <a-p>{</a-p>
+        <a-c>/// Name of the remote
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// URL of the remote repository
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Remove the remote named &lt;name&gt;
+</a-c>    rm <a-p>{</a-p>
+        <a-c>/// Name of the remote to remove
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// List all remotes
+</a-c>    ls <a-p>{</a-p>
+        <a-c>/// Show remote URLs after names
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">remote</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">add</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">origin</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">https://github.com/user/repo</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;remote&quot;</a-s><a-p>,</a-p> <a-s>&quot;add&quot;</a-s><a-p>,</a-p> <a-s>&quot;origin&quot;</a-s><a-p>,</a-p> <a-s>&quot;https://github.com/user/repo&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">GitLikeArgs</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">version</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">false</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">command</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">GitCommand</span><span style="opacity:0.7">::</span><span style="font-weight:bold">Remote</span><span style="opacity:0.7"> {</span>
-    <span style="color:rgb(115,218,202)">action</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">RemoteAction</span><span style="opacity:0.7">::</span><span style="font-weight:bold">Add</span><span style="opacity:0.7"> {</span>
-      <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">origin</span>"<span style="opacity:0.7">,</span>
-      <span style="color:rgb(115,218,202)">url</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">https://github.com/user/repo</span>"<span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">GitLikeArgs</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">version</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">false</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">command</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">GitCommand</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">Remote</span><span style="opacity:0.7"> {</span>
+    <span style="color:rgb(115,218,202)">action</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">RemoteAction</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">Add</span><span style="opacity:0.7"> {</span>
+      <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">origin</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">url</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">https://github.com/user/repo</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
     <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
@@ -488,52 +464,48 @@ title = "Args"
 <p class="description">Auto-generated help text from struct definition and doc comments.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A simple CLI tool for file processing.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Enable verbose output
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Input file to process
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    input</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Output file (defaults to stdout)
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    output</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple CLI tool for file processing.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Enable verbose output
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Input file to process
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>input</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-c>/// Output file (defaults to stdout)
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>output</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="serialized-output">
 <h4>Rust Output</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#c0caf5;">mytool </span><span style="color:#ff9e64;">1.0</span><span style="color:#c0caf5;">.</span><span style="color:#ff9e64;">0
-</span><span style="color:#c0caf5;">
-</span><span style="color:#c0caf5;">A simple </span><span style="color:#e0af68;">CLI</span><span style="color:#c0caf5;"> tool </span><span style="color:#bb9af7;">for</span><span style="color:#c0caf5;"> file processing.
-</span><span style="color:#c0caf5;">
-</span><span style="color:#e0af68;">USAGE</span><span style="color:#89ddff;">:
-</span><span style="color:#c0caf5;">    mytool </span><span style="color:#9abdf5;">[</span><span style="color:#e0af68;">OPTIONS</span><span style="color:#9abdf5;">] </span><span style="color:#89ddff;">&lt;</span><span style="color:#e0af68;">INPUT</span><span style="color:#89ddff;">&gt; </span><span style="color:#9abdf5;">[</span><span style="color:#e0af68;">OUTPUT</span><span style="color:#9abdf5;">]
-</span><span style="color:#c0caf5;">
-</span><span style="color:#e0af68;">ARGUMENTS</span><span style="color:#89ddff;">:
-</span><span style="color:#c0caf5;">        </span><span style="color:#89ddff;">&lt;</span><span style="color:#c0caf5;">INPUT</span><span style="color:#89ddff;">&gt;
-</span><span style="color:#c0caf5;">            Input file to process
-</span><span style="color:#c0caf5;">        </span><span style="color:#89ddff;">&lt;</span><span style="color:#e0af68;">OUTPUT</span><span style="color:#89ddff;">&gt;
-</span><span style="color:#c0caf5;">            Output file </span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">defaults to stdout</span><span style="color:#9abdf5;">)
-</span><span style="color:#c0caf5;">
-</span><span style="color:#e0af68;">OPTIONS</span><span style="color:#89ddff;">:
-</span><span style="color:#c0caf5;">    </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">v</span><span style="color:#89ddff;">, --</span><span style="color:#c0caf5;">verbose
-</span><span style="color:#c0caf5;">            Enable verbose output
-</span><span style="color:#c0caf5;">    </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">j</span><span style="color:#89ddff;">, --</span><span style="color:#c0caf5;">jobs </span><span style="color:#89ddff;">&lt;</span><span style="color:#e0af68;">OPTION</span><span style="color:#89ddff;">&gt;
-</span><span style="color:#c0caf5;">            Number of parallel jobs to run
-</span><span style="color:#c0caf5;">
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>mytool <a-co>1</a-co><a-p>.</a-p><a-co>0</a-co><a-p>.</a-p><a-co>0</a-co>
 
+<a-cr>A</a-cr> simple <a-cr>CLI</a-cr> tool <a-k>for</a-k> file processing<a-p>.</a-p>
+
+<a-p>[</a-p><a-co>1</a-co>m<a-p>[</a-p><a-co>33</a-co>mUSAGE<a-p>[</a-p><a-co>39</a-co>m<a-p>[</a-p><a-co>0</a-co>m<a-p>:</a-p>
+    mytool <a-p>[</a-p><a-cr>OPTIONS</a-cr><a-p>]</a-p> &lt;<a-cr>INPUT</a-cr>&gt; <a-p>[</a-p><a-cr>OUTPUT</a-cr><a-p>]</a-p>
+
+<a-p>[</a-p><a-co>1</a-co>m<a-p>[</a-p><a-co>33</a-co>mARGUMENTS<a-p>[</a-p><a-co>39</a-co>m<a-p>[</a-p><a-co>0</a-co>m<a-p>:</a-p>
+        <a-p>[</a-p><a-co>32</a-co><a-t>m</a-t><a-p>&lt;</a-p><a-t>INPUT</a-t><a-p>&gt;</a-p><a-p>[</a-p><a-co>39</a-co>m
+            <a-cr>Input</a-cr> file to process
+        <a-p>[</a-p><a-co>32</a-co><a-t>m</a-t><a-p>&lt;</a-p><a-t>OUTPUT</a-t><a-p>&gt;</a-p><a-p>[</a-p><a-co>39</a-co>m
+            <a-cr>Output</a-cr> file <a-p>(</a-p>defaults to stdout<a-p>)</a-p>
+
+<a-p>[</a-p><a-co>1</a-co>m<a-p>[</a-p><a-co>33</a-co>mOPTIONS<a-p>[</a-p><a-co>39</a-co>m<a-p>[</a-p><a-co>0</a-co>m<a-p>:</a-p>
+    <a-p>[</a-p><a-co>32</a-co>m-v<a-p>[</a-p><a-co>39</a-co>m<a-p>,</a-p> <a-p>[</a-p><a-co>32</a-co>m--verbose<a-p>[</a-p><a-co>39</a-co>m
+            <a-cr>Enable</a-cr> verbose output
+    <a-p>[</a-p><a-co>32</a-co>m-j<a-p>[</a-p><a-co>39</a-co>m<a-p>,</a-p> <a-p>[</a-p><a-co>32</a-co>m--jobs<a-p>[</a-p><a-co>39</a-co><a-t>m</a-t> <a-p>&lt;</a-p><a-t>OPTION</a-t><a-p>&gt;</a-p>
+            <a-cr>Number</a-cr> of parallel jobs to run
+
+</code></pre>
 </div>
 </section>
 
@@ -543,63 +515,54 @@ title = "Args"
 <p class="description">When <code>-h</code>, <code>--help</code>, <code>-help</code>, or <code>/?</code> is the first argument, help is automatically generated and returned.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A simple CLI tool for file processing.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Enable verbose output
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Input file to process
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    input</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Output file (defaults to stdout)
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    output</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple CLI tool for file processing.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Enable verbose output
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Input file to process
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>input</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-c>/// Output file (defaults to stdout)
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>output</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">--help</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;--help&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
-<pre><code><span style="color:#e06c75">args::help</span>
+<pre><code><span style="color:#56b6c2">args::help</span>
 
-  <span style="color:#e06c75">×</span> target/debug/examples/args_showcase
-  <span style="color:#e06c75">│</span> 
-  <span style="color:#e06c75">│</span> A simple CLI tool for file processing.
-  <span style="color:#e06c75">│</span> 
-  <span style="color:#e06c75">│</span> USAGE:
-  <span style="color:#e06c75">│</span>     target/debug/examples/args_showcase [OPTIONS] &lt;INPUT&gt; [OUTPUT]
-  <span style="color:#e06c75">│</span> 
-  <span style="color:#e06c75">│</span> ARGUMENTS:
-  <span style="color:#e06c75">│</span>         &lt;INPUT&gt;
-  <span style="color:#e06c75">│</span>             Input file to process
-  <span style="color:#e06c75">│</span>         &lt;OUTPUT&gt;
-  <span style="color:#e06c75">│</span>             Output file (defaults to stdout)
-  <span style="color:#e06c75">│</span> 
-  <span style="color:#e06c75">│</span> OPTIONS:
-  <span style="color:#e06c75">│</span>     -v, --verbose
-  <span style="color:#e06c75">│</span>             Enable verbose output
-  <span style="color:#e06c75">│</span>     -j, --jobs &lt;OPTION&gt;
-  <span style="color:#e06c75">│</span>             Number of parallel jobs to run
-  <span style="color:#e06c75">│</span> 
-  <span style="color:#e06c75">│</span> 
-   ╭────
- <span style="opacity:0.7">1</span> │ --help
-   · <span style="color:#c678dd;font-weight:bold">───┬──</span>
-   ·    <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">help requested</span>
-   ╰────
+  <span style="color:#56b6c2">☞</span> target/debug/examples/args_showcase
+  <span style="color:#56b6c2">│</span> 
+  <span style="color:#56b6c2">│</span> A simple CLI tool for file processing.
+  <span style="color:#56b6c2">│</span> 
+  <span style="color:#56b6c2">│</span> <span style="font-weight:bold"></span><span style="color:#e5c07b">USAGE</span><span style="color:inherit"></span>:
+  <span style="color:#56b6c2">│</span>     target/debug/examples/args_showcase [OPTIONS] &lt;INPUT&gt; [OUTPUT]
+  <span style="color:#56b6c2">│</span> 
+  <span style="color:#56b6c2">│</span> <span style="font-weight:bold"></span><span style="color:#e5c07b">ARGUMENTS</span><span style="color:inherit"></span>:
+  <span style="color:#56b6c2">│</span>         <span style="color:#98c379">&lt;INPUT&gt;</span><span style="color:inherit">
+  </span><span style="color:#56b6c2">│</span>             Input file to process
+  <span style="color:#56b6c2">│</span>         <span style="color:#98c379">&lt;OUTPUT&gt;</span><span style="color:inherit">
+  </span><span style="color:#56b6c2">│</span>             Output file (defaults to stdout)
+  <span style="color:#56b6c2">│</span> 
+  <span style="color:#56b6c2">│</span> <span style="font-weight:bold"></span><span style="color:#e5c07b">OPTIONS</span><span style="color:inherit"></span>:
+  <span style="color:#56b6c2">│</span>     <span style="color:#98c379">-v</span><span style="color:inherit">, </span><span style="color:#98c379">--verbose</span><span style="color:inherit">
+  </span><span style="color:#56b6c2">│</span>             Enable verbose output
+  <span style="color:#56b6c2">│</span>     <span style="color:#98c379">-j</span><span style="color:inherit">, </span><span style="color:#98c379">--jobs</span><span style="color:inherit"> &lt;OPTION&gt;
+  </span><span style="color:#56b6c2">│</span>             Number of parallel jobs to run
+  <span style="color:#56b6c2">│</span> 
+  <span style="color:#56b6c2">│</span> 
 </code></pre>
 </div>
 </section>
@@ -610,116 +573,112 @@ title = "Args"
 <p class="description">Help text automatically lists available subcommands with descriptions.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// Git-like CLI with subcommands.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">GitLikeArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show version information
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    version</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Git command to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">subcommand)]
-</span><span style="color:#9abdf5;">    command</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> GitCommand,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Available commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">GitCommand </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Clone a repository into a new directory
-</span><span style="color:#9abdf5;">    </span><span style="color:#0db9d7;">Clone </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// The repository URL to clone
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Directory to clone into
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        directory</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Clone only the specified branch
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Create a shallow clone with limited history
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named)]
-</span><span style="color:#9abdf5;">        depth</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show the working tree status
-</span><span style="color:#9abdf5;">    Status {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show short-format output
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        short</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show the branch even in short-format
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Manage set of tracked repositories
-</span><span style="color:#9abdf5;">    Remote {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Remote action to perform
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::subcommand)]
-</span><span style="color:#9abdf5;">        action</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> RemoteAction</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Remote management commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">RemoteAction </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
-</span><span style="color:#9abdf5;">    Add {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// URL of the remote repository
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Remove the remote named &lt;name&gt;
-</span><span style="color:#9abdf5;">    rm {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote to remove
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// List all remotes
-</span><span style="color:#9abdf5;">    ls {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show remote URLs after names
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// Git-like CLI with subcommands.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>GitLikeArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Show version information
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>version</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Git command to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+    <a-pr>command</a-pr><a-p>:</a-p> <a-t>GitCommand</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Available commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>GitCommand</a-t> <a-p>{</a-p>
+    <a-c>/// Clone a repository into a new directory
+</a-c>    <a-cr>Clone</a-cr> <a-p>{</a-p>
+        <a-c>/// The repository URL to clone
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// Directory to clone into
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>directory</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Clone only the specified branch
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Create a shallow clone with limited history
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+        <a-pr>depth</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Show the working tree status
+</a-c>    <a-cr>Status</a-cr> <a-p>{</a-p>
+        <a-c>/// Show short-format output
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>short</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+        <a-c>/// Show the branch even in short-format
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Manage set of tracked repositories
+</a-c>    <a-cr>Remote</a-cr> <a-p>{</a-p>
+        <a-c>/// Remote action to perform
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+        <a-pr>action</a-pr><a-p>:</a-p> <a-t>RemoteAction</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Remote management commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>RemoteAction</a-t> <a-p>{</a-p>
+    <a-c>/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
+</a-c>    <a-cr>Add</a-cr> <a-p>{</a-p>
+        <a-c>/// Name of the remote
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// URL of the remote repository
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Remove the remote named &lt;name&gt;
+</a-c>    rm <a-p>{</a-p>
+        <a-c>/// Name of the remote to remove
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// List all remotes
+</a-c>    ls <a-p>{</a-p>
+        <a-c>/// Show remote URLs after names
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="serialized-output">
 <h4>Rust Output</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#c0caf5;">git </span><span style="color:#ff9e64;">2.40</span><span style="color:#c0caf5;">.</span><span style="color:#ff9e64;">0
-</span><span style="color:#c0caf5;">
-</span><span style="color:#c0caf5;">Git</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">like </span><span style="color:#e0af68;">CLI</span><span style="color:#c0caf5;"> with subcommands.
-</span><span style="color:#c0caf5;">
-</span><span style="color:#e0af68;">USAGE</span><span style="color:#89ddff;">:
-</span><span style="color:#c0caf5;">    git </span><span style="color:#9abdf5;">[</span><span style="color:#e0af68;">OPTIONS</span><span style="color:#9abdf5;">] </span><span style="color:#89ddff;">&lt;</span><span style="color:#e0af68;">COMMAND</span><span style="color:#89ddff;">&gt;
-</span><span style="color:#c0caf5;">
-</span><span style="color:#e0af68;">OPTIONS</span><span style="color:#89ddff;">:
-</span><span style="color:#c0caf5;">        </span><span style="color:#89ddff;">--</span><span style="color:#c0caf5;">version
-</span><span style="color:#c0caf5;">            Show version information
-</span><span style="color:#c0caf5;">
-</span><span style="color:#e0af68;">COMMANDS</span><span style="color:#89ddff;">:
-</span><span style="color:#c0caf5;">    clone
-</span><span style="color:#c0caf5;">            </span><span style="color:#0db9d7;">Clone</span><span style="color:#c0caf5;"> a repository into a new directory
-</span><span style="color:#c0caf5;">    status
-</span><span style="color:#c0caf5;">            Show the working tree status
-</span><span style="color:#c0caf5;">    remote
-</span><span style="color:#c0caf5;">            Manage set of tracked repositories
-</span><span style="color:#c0caf5;">
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>git <a-co>2</a-co><a-p>.</a-p><a-co>40</a-co><a-p>.</a-p><a-co>0</a-co>
 
+<a-pr>Git</a-pr>-like <a-cr>CLI</a-cr> with subcommands<a-p>.</a-p>
+
+<a-p>[</a-p><a-co>1</a-co><a-pr>m</a-pr><a-p>[</a-p><a-co>33</a-co>mUSAGE<a-p>[</a-p><a-co>39</a-co>m<a-p>[</a-p><a-co>0</a-co>m<a-p>:</a-p>
+    git <a-p>[</a-p><a-cr>OPTIONS</a-cr><a-p>]</a-p> &lt;<a-cr>COMMAND</a-cr>&gt;
+
+<a-p>[</a-p><a-co>1</a-co>m<a-p>[</a-p><a-co>33</a-co>mOPTIONS<a-p>[</a-p><a-co>39</a-co>m<a-p>[</a-p><a-co>0</a-co>m<a-p>:</a-p>
+        <a-p>[</a-p><a-co>32</a-co>m--version<a-p>[</a-p><a-co>39</a-co>m
+            <a-cr>Show</a-cr> version information
+
+<a-p>[</a-p><a-co>1</a-co>m<a-p>[</a-p><a-co>33</a-co>mCOMMANDS<a-p>[</a-p><a-co>39</a-co>m<a-p>[</a-p><a-co>0</a-co>m<a-p>:</a-p>
+    <a-p>[</a-p><a-co>32</a-co>mclone<a-p>[</a-p><a-co>39</a-co>m
+            <a-cr>Clone</a-cr> a repository into a new directory
+    <a-p>[</a-p><a-co>32</a-co>mstatus<a-p>[</a-p><a-co>39</a-co>m
+            <a-cr>Show</a-cr> the working tree status
+    <a-p>[</a-p><a-co>32</a-co>mremote<a-p>[</a-p><a-co>39</a-co>m
+            <a-cr>Manage</a-cr> set of tracked repositories
+
+</code></pre>
 </div>
 </section>
 
@@ -732,64 +691,60 @@ title = "Args"
 <p class="description">Generated Bash completion script for tab-completion support.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A build tool configuration
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">BuildArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Build in release mode with optimizations
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    release</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Package to build
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    package</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Build all packages in the workspace
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    workspace</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Space-separated list of features to enable
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    features</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Target triple to build for
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    target</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A build tool configuration
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>BuildArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Build in release mode with optimizations
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>release</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Package to build
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>package</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Build all packages in the workspace
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>workspace</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+    <a-c>/// Space-separated list of features to enable
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>features</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Target triple to build for
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>target</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="serialized-output">
 <h4>Rust Output</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#c0caf5;">_cargo</span><span style="color:#89ddff;">-</span><span style="color:#2ac3de;">build</span><span style="color:#9abdf5;">() {
-</span><span style="color:#9abdf5;">    local cur prev words cword
-</span><span style="color:#9abdf5;">    _init_completion </span><span style="color:#89ddff;">|| </span><span style="color:#bb9af7;">return
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    local commands</span><span style="color:#89ddff;">=&quot;&quot;
-</span><span style="color:#9abdf5;">    local flags</span><span style="color:#89ddff;">=&quot;&quot;
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    flags</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">--release -r --jobs -j --package -p --workspace --features -F --target</span><span style="color:#89ddff;">&quot;
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    case </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">$prev</span><span style="color:#89ddff;">&quot; in
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;"> Add cases </span><span style="color:#bb9af7;">for</span><span style="color:#9abdf5;"> flags that take values
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">*</span><span style="color:#9abdf5;">)
-</span><span style="color:#9abdf5;">            </span><span style="color:#89ddff;">;;
-</span><span style="color:#9abdf5;">    esac
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#bb9af7;">if </span><span style="color:#9abdf5;">[[ </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">$cur</span><span style="color:#89ddff;">&quot; == -* </span><span style="color:#9abdf5;">]]</span><span style="color:#89ddff;">;</span><span style="color:#9abdf5;"> then
-</span><span style="color:#9abdf5;">        </span><span style="color:#e0af68;">COMPREPLY</span><span style="color:#89ddff;">=</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">$</span><span style="color:#9abdf5;">(compgen </span><span style="color:#89ddff;">-</span><span style="color:#9abdf5;">W </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">$flags</span><span style="color:#89ddff;">&quot; -- &quot;</span><span style="color:#9ece6a;">$cur</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">))
-</span><span style="color:#9abdf5;">    elif [[ </span><span style="color:#89ddff;">-</span><span style="color:#9abdf5;">n </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">$commands</span><span style="color:#89ddff;">&quot; </span><span style="color:#9abdf5;">]]</span><span style="color:#89ddff;">;</span><span style="color:#9abdf5;"> then
-</span><span style="color:#9abdf5;">        </span><span style="color:#e0af68;">COMPREPLY</span><span style="color:#89ddff;">=</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">$</span><span style="color:#9abdf5;">(compgen </span><span style="color:#89ddff;">-</span><span style="color:#9abdf5;">W </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">$commands</span><span style="color:#89ddff;">&quot; -- &quot;</span><span style="color:#9ece6a;">$cur</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">))
-</span><span style="color:#9abdf5;">    fi
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#c0caf5;">complete </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">F _cargo</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">build cargo</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">build
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>_cargo-<a-f>build</a-f><a-p>()</a-p> <a-p>{</a-p>
+    local cur prev words cword
+    _init_completion || <a-k>return</a-k>
 
+    local commands=<a-s>&quot;&quot;</a-s>
+    local flags=<a-s>&quot;&quot;</a-s>
+
+    flags=<a-s>&quot;--release -r --jobs -j --package -p --workspace --features -F --target&quot;</a-s>
+
+    case &quot;$prev&quot; <a-k>in</a-k>
+        # <a-cr>Add</a-cr> cases <a-k>for</a-k> flags that take values
+        <a-o>*</a-o><a-p>)</a-p>
+            <a-p>;;</a-p>
+    esac
+
+    if <a-p>[[</a-p> <a-s>&quot;$cur&quot;</a-s> == -<a-o>*</a-o> <a-p>]];</a-p> then
+        <a-cr>COMPREPLY</a-cr>=<a-p>(</a-p>$<a-p>(</a-p>compgen -<a-cr>W</a-cr> <a-s>&quot;$flags&quot;</a-s> -- <a-s>&quot;$cur&quot;</a-s><a-p>))</a-p>
+    elif <a-p>[[</a-p> -n <a-s>&quot;$commands&quot;</a-s> <a-p>]];</a-p> then
+        <a-cr>COMPREPLY</a-cr>=<a-p>(</a-p>$<a-p>(</a-p>compgen -<a-cr>W</a-cr> <a-s>&quot;$commands&quot;</a-s> -- <a-s>&quot;$cur&quot;</a-s><a-p>))</a-p>
+    fi
+<a-p>}</a-p>
+
+complete -<a-cr>F</a-cr> _cargo-build cargo-build
+</code></pre>
 </div>
 </section>
 
@@ -799,64 +754,60 @@ title = "Args"
 <p class="description">Generated Zsh completion script with argument descriptions.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A build tool configuration
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">BuildArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Build in release mode with optimizations
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    release</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Package to build
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    package</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Build all packages in the workspace
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    workspace</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Space-separated list of features to enable
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    features</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Target triple to build for
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    target</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A build tool configuration
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>BuildArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Build in release mode with optimizations
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>release</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Package to build
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>package</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Build all packages in the workspace
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>workspace</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+    <a-c>/// Space-separated list of features to enable
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>features</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Target triple to build for
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>target</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="serialized-output">
 <h4>Rust Output</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#c0caf5;">compdef cargo</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">build
-</span><span style="color:#c0caf5;">
-</span><span style="color:#c0caf5;">_cargo</span><span style="color:#89ddff;">-</span><span style="color:#2ac3de;">build</span><span style="color:#9abdf5;">() {
-</span><span style="color:#9abdf5;">    local </span><span style="color:#89ddff;">-</span><span style="color:#9abdf5;">a commands
-</span><span style="color:#9abdf5;">    local </span><span style="color:#89ddff;">-</span><span style="color:#9abdf5;">a options
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    options</span><span style="color:#89ddff;">=</span><span style="color:#9abdf5;">(
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">&#39;-</span><span style="color:#9abdf5;">r[Build </span><span style="color:#89ddff;">in</span><span style="color:#9abdf5;"> release mode with optimizations]</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">&#39;--</span><span style="color:#9abdf5;">release[Build </span><span style="color:#89ddff;">in</span><span style="color:#9abdf5;"> release mode with optimizations]</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">&#39;-</span><span style="color:#9abdf5;">j[Number of parallel jobs]</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">&#39;--</span><span style="color:#9abdf5;">jobs[Number of parallel jobs]</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">&#39;-</span><span style="color:#9abdf5;">p[Package to build]</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">&#39;--</span><span style="color:#9abdf5;">package[Package to build]</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">&#39;--</span><span style="color:#9abdf5;">workspace[Build all packages </span><span style="color:#89ddff;">in</span><span style="color:#9abdf5;"> the workspace]</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">&#39;-</span><span style="color:#9abdf5;">F[Space</span><span style="color:#89ddff;">-</span><span style="color:#9abdf5;">separated list of features to enable]</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">&#39;--</span><span style="color:#9abdf5;">features[Space</span><span style="color:#89ddff;">-</span><span style="color:#9abdf5;">separated list of features to enable]</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">&#39;--</span><span style="color:#9abdf5;">target[Target triple to build </span><span style="color:#bb9af7;">for</span><span style="color:#9abdf5;">]</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#9abdf5;">    )
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    _arguments </span><span style="color:#c0caf5;">$options
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#c0caf5;">_cargo</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">build </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">$@</span><span style="color:#89ddff;">&quot;
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>#compdef cargo-build
 
+_cargo-<a-f>build</a-f><a-p>()</a-p> <a-p>{</a-p>
+    local -a commands
+    local -a options
+
+    options=<a-p>(</a-p>
+        <a-o>&#39;</a-o>-r<a-p>[</a-p><a-cr>Build</a-cr> in release mode with optimizations<a-p>]</a-p><a-o>&#39;</a-o>
+        <a-o>&#39;</a-o>--release<a-p>[</a-p><a-cr>Build</a-cr> in release mode with optimizations<a-p>]</a-p><a-o>&#39;</a-o>
+        <a-o>&#39;</a-o>-j<a-p>[</a-p><a-cr>Number</a-cr> of parallel jobs<a-p>]</a-p><a-o>&#39;</a-o>
+        <a-o>&#39;</a-o>--jobs<a-p>[</a-p><a-cr>Number</a-cr> of parallel jobs<a-p>]</a-p><a-o>&#39;</a-o>
+        <a-o>&#39;</a-o>-p<a-p>[</a-p><a-cr>Package</a-cr> to build<a-p>]</a-p><a-o>&#39;</a-o>
+        <a-o>&#39;</a-o>--package<a-p>[</a-p><a-cr>Package</a-cr> to build<a-p>]</a-p><a-o>&#39;</a-o>
+        <a-o>&#39;</a-o>--workspace<a-p>[</a-p><a-cr>Build</a-cr> all packages in the workspace<a-p>]</a-p><a-o>&#39;</a-o>
+        <a-o>&#39;</a-o>-<a-cr>F</a-cr><a-p>[</a-p><a-cr>Space</a-cr>-separated list of features to enable<a-p>]</a-p><a-o>&#39;</a-o>
+        <a-o>&#39;</a-o>--features<a-p>[</a-p><a-cr>Space</a-cr>-separated list of features to enable<a-p>]</a-p><a-o>&#39;</a-o>
+        <a-o>&#39;</a-o>--target<a-p>[</a-p><a-cr>Target</a-cr> triple to build <a-k>for</a-k><a-p>]</a-p><a-o>&#39;</a-o>
+    <a-p>)</a-p>
+
+    _arguments $options
+<a-p>}</a-p>
+
+_cargo-build <a-s>&quot;$@&quot;</a-s>
+</code></pre>
 </div>
 </section>
 
@@ -866,49 +817,45 @@ title = "Args"
 <p class="description">Generated Fish shell completion script.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A build tool configuration
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">BuildArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Build in release mode with optimizations
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    release</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Package to build
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    package</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Build all packages in the workspace
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    workspace</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Space-separated list of features to enable
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    features</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Target triple to build for
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    target</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A build tool configuration
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>BuildArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Build in release mode with optimizations
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>release</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Package to build
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>package</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Build all packages in the workspace
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>workspace</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+    <a-c>/// Space-separated list of features to enable
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>features</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Target triple to build for
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>target</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="serialized-output">
 <h4>Rust Output</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#c0caf5;"> Fish completion </span><span style="color:#bb9af7;">for</span><span style="color:#c0caf5;"> cargo</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">build
-</span><span style="color:#c0caf5;">
-</span><span style="color:#c0caf5;">complete </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">c cargo</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">build </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">s r </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">l release </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">d </span><span style="font-style:italic;color:#9d7cd8;">&#39;Build </span><span style="color:#89ddff;">in</span><span style="color:#c0caf5;"> release mode with optimizations</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#c0caf5;">complete </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">c cargo</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">build </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">s j </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">l jobs </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">d </span><span style="font-style:italic;color:#9d7cd8;">&#39;Number</span><span style="color:#c0caf5;"> of parallel jobs</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#c0caf5;">complete </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">c cargo</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">build </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">s p </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">l package </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">d </span><span style="font-style:italic;color:#9d7cd8;">&#39;Package</span><span style="color:#c0caf5;"> to build</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#c0caf5;">complete </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">c cargo</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">build </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">l workspace </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">d </span><span style="font-style:italic;color:#9d7cd8;">&#39;Build</span><span style="color:#c0caf5;"> all packages </span><span style="color:#89ddff;">in</span><span style="color:#c0caf5;"> the workspace</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#c0caf5;">complete </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">c cargo</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">build </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">s F </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">l features </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">d </span><span style="font-style:italic;color:#9d7cd8;">&#39;Space</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">separated list of features to enable</span><span style="color:#89ddff;">&#39;
-</span><span style="color:#c0caf5;">complete </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">c cargo</span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">build </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">l target </span><span style="color:#89ddff;">-</span><span style="color:#c0caf5;">d </span><span style="font-style:italic;color:#9d7cd8;">&#39;Target</span><span style="color:#c0caf5;"> triple to build </span><span style="color:#bb9af7;">for</span><span style="color:#89ddff;">&#39;
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code># <a-cr>Fish</a-cr> completion for cargo-build
 
+complete -c cargo-build -s r -l release -d <a-o>&#39;</a-o><a-cr>Build</a-cr> in release mode with optimizations<a-o>&#39;</a-o>
+complete -c cargo-build -s j -l jobs -d <a-o>&#39;</a-o><a-cr>Number</a-cr> of parallel jobs<a-o>&#39;</a-o>
+complete -c cargo-build -s p -l package -d <a-o>&#39;</a-o><a-cr>Package</a-cr> to build<a-o>&#39;</a-o>
+complete -c cargo-build -l workspace -d <a-o>&#39;</a-o><a-cr>Build</a-cr> all packages in the workspace<a-o>&#39;</a-o>
+complete -c cargo-build -s <a-cr>F</a-cr> -l features -d <a-o>&#39;</a-o><a-cr>Space</a-cr>-separated list of features to enable<a-o>&#39;</a-o>
+complete -c cargo-build -l target -d <a-o>&#39;</a-o><a-cr>Target</a-cr> triple to build <a-k>for</a-k><a-o>&#39;</a-o>
+</code></pre>
 </div>
 </section>
 
@@ -921,33 +868,29 @@ title = "Args"
 <p class="description">Error when an unrecognized flag is provided.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A simple CLI tool for file processing.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Enable verbose output
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Input file to process
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    input</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Output file (defaults to stdout)
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    output</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple CLI tool for file processing.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Enable verbose output
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Input file to process
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>input</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-c>/// Output file (defaults to stdout)
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>output</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">--verbos</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">input.txt</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;--verbos&quot;</a-s><a-p>,</a-p> <a-s>&quot;input.txt&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
@@ -970,41 +913,37 @@ title = "Args"
 <p class="description">When the flag name is close to a valid one, a suggestion is offered.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A build tool configuration
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">BuildArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Build in release mode with optimizations
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    release</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Package to build
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    package</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Build all packages in the workspace
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    workspace</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Space-separated list of features to enable
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    features</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Target triple to build for
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    target</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A build tool configuration
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>BuildArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Build in release mode with optimizations
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>release</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Package to build
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>package</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Build all packages in the workspace
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>workspace</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+    <a-c>/// Space-separated list of features to enable
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>features</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Target triple to build for
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>target</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">--releas</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;--releas&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
@@ -1027,33 +966,29 @@ title = "Args"
 <p class="description">When chaining short flags, an unknown flag is reported with available options.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A simple CLI tool for file processing.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Enable verbose output
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Input file to process
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    input</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Output file (defaults to stdout)
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    output</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple CLI tool for file processing.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Enable verbose output
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Input file to process
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>input</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-c>/// Output file (defaults to stdout)
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>output</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">-vxyz</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">input.txt</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;-vxyz&quot;</a-s><a-p>,</a-p> <a-s>&quot;input.txt&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
@@ -1080,33 +1015,29 @@ title = "Args"
 <p class="description">Flags with too many dashes are rejected.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A simple CLI tool for file processing.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Enable verbose output
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Input file to process
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    input</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Output file (defaults to stdout)
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    output</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple CLI tool for file processing.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Enable verbose output
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Input file to process
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>input</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-c>/// Output file (defaults to stdout)
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>output</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">---verbose</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">input.txt</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;---verbose&quot;</a-s><a-p>,</a-p> <a-s>&quot;input.txt&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
@@ -1133,33 +1064,29 @@ title = "Args"
 <p class="description">Long flag names require double dashes.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A simple CLI tool for file processing.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Enable verbose output
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Input file to process
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    input</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Output file (defaults to stdout)
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    output</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple CLI tool for file processing.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Enable verbose output
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Input file to process
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>input</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-c>/// Output file (defaults to stdout)
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>output</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">-verbose</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">input.txt</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;-verbose&quot;</a-s><a-p>,</a-p> <a-s>&quot;input.txt&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
@@ -1186,33 +1113,29 @@ title = "Args"
 <p class="description">Error when a flag that requires a value doesn't get one.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A simple CLI tool for file processing.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Enable verbose output
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Input file to process
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    input</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Output file (defaults to stdout)
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    output</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple CLI tool for file processing.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Enable verbose output
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Input file to process
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>input</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-c>/// Output file (defaults to stdout)
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>output</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">-j</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;-j&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
@@ -1235,33 +1158,29 @@ title = "Args"
 <p class="description">Error when a required positional argument is not provided.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A simple CLI tool for file processing.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Enable verbose output
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Input file to process
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    input</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Output file (defaults to stdout)
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    output</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple CLI tool for file processing.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Enable verbose output
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Input file to process
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>input</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-c>/// Output file (defaults to stdout)
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>output</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">-v</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;-v&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
@@ -1282,41 +1201,37 @@ title = "Args"
 <p class="description">Error when a positional argument is provided but not expected.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A build tool configuration
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">BuildArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Build in release mode with optimizations
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    release</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Package to build
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    package</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Build all packages in the workspace
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    workspace</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Space-separated list of features to enable
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    features</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Target triple to build for
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    target</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A build tool configuration
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>BuildArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Build in release mode with optimizations
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>release</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Package to build
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>package</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Build all packages in the workspace
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>workspace</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+    <a-c>/// Space-separated list of features to enable
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>features</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Target triple to build for
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>target</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">extra</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">--release</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;extra&quot;</a-s><a-p>,</a-p> <a-s>&quot;--release&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
@@ -1345,97 +1260,93 @@ title = "Args"
 <p class="description">Error when an unrecognized subcommand is provided, with available options listed.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// Git-like CLI with subcommands.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">GitLikeArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show version information
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    version</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Git command to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">subcommand)]
-</span><span style="color:#9abdf5;">    command</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> GitCommand,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Available commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">GitCommand </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Clone a repository into a new directory
-</span><span style="color:#9abdf5;">    </span><span style="color:#0db9d7;">Clone </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// The repository URL to clone
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Directory to clone into
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        directory</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Clone only the specified branch
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Create a shallow clone with limited history
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named)]
-</span><span style="color:#9abdf5;">        depth</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show the working tree status
-</span><span style="color:#9abdf5;">    Status {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show short-format output
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        short</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show the branch even in short-format
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Manage set of tracked repositories
-</span><span style="color:#9abdf5;">    Remote {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Remote action to perform
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::subcommand)]
-</span><span style="color:#9abdf5;">        action</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> RemoteAction</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Remote management commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">RemoteAction </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
-</span><span style="color:#9abdf5;">    Add {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// URL of the remote repository
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Remove the remote named &lt;name&gt;
-</span><span style="color:#9abdf5;">    rm {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote to remove
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// List all remotes
-</span><span style="color:#9abdf5;">    ls {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show remote URLs after names
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// Git-like CLI with subcommands.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>GitLikeArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Show version information
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>version</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Git command to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+    <a-pr>command</a-pr><a-p>:</a-p> <a-t>GitCommand</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Available commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>GitCommand</a-t> <a-p>{</a-p>
+    <a-c>/// Clone a repository into a new directory
+</a-c>    <a-cr>Clone</a-cr> <a-p>{</a-p>
+        <a-c>/// The repository URL to clone
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// Directory to clone into
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>directory</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Clone only the specified branch
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Create a shallow clone with limited history
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+        <a-pr>depth</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Show the working tree status
+</a-c>    <a-cr>Status</a-cr> <a-p>{</a-p>
+        <a-c>/// Show short-format output
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>short</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+        <a-c>/// Show the branch even in short-format
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Manage set of tracked repositories
+</a-c>    <a-cr>Remote</a-cr> <a-p>{</a-p>
+        <a-c>/// Remote action to perform
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+        <a-pr>action</a-pr><a-p>:</a-p> <a-t>RemoteAction</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Remote management commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>RemoteAction</a-t> <a-p>{</a-p>
+    <a-c>/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
+</a-c>    <a-cr>Add</a-cr> <a-p>{</a-p>
+        <a-c>/// Name of the remote
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// URL of the remote repository
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Remove the remote named &lt;name&gt;
+</a-c>    rm <a-p>{</a-p>
+        <a-c>/// Name of the remote to remove
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// List all remotes
+</a-c>    ls <a-p>{</a-p>
+        <a-c>/// Show remote URLs after names
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">clon</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">https://example.com</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;clon&quot;</a-s><a-p>,</a-p> <a-s>&quot;https://example.com&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
@@ -1458,97 +1369,93 @@ title = "Args"
 <p class="description">Error when a required subcommand is not provided.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// Git-like CLI with subcommands.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">GitLikeArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show version information
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    version</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Git command to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">subcommand)]
-</span><span style="color:#9abdf5;">    command</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> GitCommand,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Available commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">GitCommand </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Clone a repository into a new directory
-</span><span style="color:#9abdf5;">    </span><span style="color:#0db9d7;">Clone </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// The repository URL to clone
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Directory to clone into
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        directory</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Clone only the specified branch
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Create a shallow clone with limited history
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named)]
-</span><span style="color:#9abdf5;">        depth</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show the working tree status
-</span><span style="color:#9abdf5;">    Status {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show short-format output
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        short</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show the branch even in short-format
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Manage set of tracked repositories
-</span><span style="color:#9abdf5;">    Remote {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Remote action to perform
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::subcommand)]
-</span><span style="color:#9abdf5;">        action</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> RemoteAction</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Remote management commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">RemoteAction </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
-</span><span style="color:#9abdf5;">    Add {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// URL of the remote repository
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Remove the remote named &lt;name&gt;
-</span><span style="color:#9abdf5;">    rm {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote to remove
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// List all remotes
-</span><span style="color:#9abdf5;">    ls {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show remote URLs after names
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// Git-like CLI with subcommands.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>GitLikeArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Show version information
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>version</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Git command to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+    <a-pr>command</a-pr><a-p>:</a-p> <a-t>GitCommand</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Available commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>GitCommand</a-t> <a-p>{</a-p>
+    <a-c>/// Clone a repository into a new directory
+</a-c>    <a-cr>Clone</a-cr> <a-p>{</a-p>
+        <a-c>/// The repository URL to clone
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// Directory to clone into
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>directory</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Clone only the specified branch
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Create a shallow clone with limited history
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+        <a-pr>depth</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Show the working tree status
+</a-c>    <a-cr>Status</a-cr> <a-p>{</a-p>
+        <a-c>/// Show short-format output
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>short</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+        <a-c>/// Show the branch even in short-format
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Manage set of tracked repositories
+</a-c>    <a-cr>Remote</a-cr> <a-p>{</a-p>
+        <a-c>/// Remote action to perform
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+        <a-pr>action</a-pr><a-p>:</a-p> <a-t>RemoteAction</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Remote management commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>RemoteAction</a-t> <a-p>{</a-p>
+    <a-c>/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
+</a-c>    <a-cr>Add</a-cr> <a-p>{</a-p>
+        <a-c>/// Name of the remote
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// URL of the remote repository
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Remove the remote named &lt;name&gt;
+</a-c>    rm <a-p>{</a-p>
+        <a-c>/// Name of the remote to remove
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// List all remotes
+</a-c>    ls <a-p>{</a-p>
+        <a-c>/// Show remote URLs after names
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">--version</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;--version&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
@@ -1572,97 +1479,93 @@ title = "Args"
 <p class="description">Error when a required argument in a nested subcommand is missing.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// Git-like CLI with subcommands.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">GitLikeArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show version information
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named)]
-</span><span style="color:#9abdf5;">    version</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Git command to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">subcommand)]
-</span><span style="color:#9abdf5;">    command</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> GitCommand,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Available commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">GitCommand </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Clone a repository into a new directory
-</span><span style="color:#9abdf5;">    </span><span style="color:#0db9d7;">Clone </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// The repository URL to clone
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Directory to clone into
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        directory</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Clone only the specified branch
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Create a shallow clone with limited history
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named)]
-</span><span style="color:#9abdf5;">        depth</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Show the working tree status
-</span><span style="color:#9abdf5;">    Status {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show short-format output
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        short</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show the branch even in short-format
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        branch</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Manage set of tracked repositories
-</span><span style="color:#9abdf5;">    Remote {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Remote action to perform
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::subcommand)]
-</span><span style="color:#9abdf5;">        action</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> RemoteAction</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="font-style:italic;color:#565f89;">/// Remote management commands
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">RemoteAction </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
-</span><span style="color:#9abdf5;">    Add {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// URL of the remote repository
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        url</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Remove the remote named &lt;name&gt;
-</span><span style="color:#9abdf5;">    rm {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Name of the remote to remove
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::positional)]
-</span><span style="color:#9abdf5;">        name</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// List all remotes
-</span><span style="color:#9abdf5;">    ls {
-</span><span style="color:#9abdf5;">        </span><span style="font-style:italic;color:#565f89;">/// Show remote URLs after names
-</span><span style="color:#9abdf5;">        </span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(args::named</span><span style="color:#89ddff;">,</span><span style="color:#9abdf5;"> args::short)]
-</span><span style="color:#9abdf5;">        verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// Git-like CLI with subcommands.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>GitLikeArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Show version information
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+    <a-pr>version</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Git command to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+    <a-pr>command</a-pr><a-p>:</a-p> <a-t>GitCommand</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Available commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>GitCommand</a-t> <a-p>{</a-p>
+    <a-c>/// Clone a repository into a new directory
+</a-c>    <a-cr>Clone</a-cr> <a-p>{</a-p>
+        <a-c>/// The repository URL to clone
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// Directory to clone into
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>directory</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Clone only the specified branch
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+        <a-c>/// Create a shallow clone with limited history
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>)]</a-p>
+        <a-pr>depth</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Show the working tree status
+</a-c>    <a-cr>Status</a-cr> <a-p>{</a-p>
+        <a-c>/// Show short-format output
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>short</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+        <a-c>/// Show the branch even in short-format
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>branch</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Manage set of tracked repositories
+</a-c>    <a-cr>Remote</a-cr> <a-p>{</a-p>
+        <a-c>/// Remote action to perform
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>subcommand</a-at><a-p>)]</a-p>
+        <a-pr>action</a-pr><a-p>:</a-p> <a-t>RemoteAction</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Remote management commands
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>RemoteAction</a-t> <a-p>{</a-p>
+    <a-c>/// Add a remote named &lt;name&gt; for the repository at &lt;url&gt;
+</a-c>    <a-cr>Add</a-cr> <a-p>{</a-p>
+        <a-c>/// Name of the remote
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+        <a-c>/// URL of the remote repository
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// Remove the remote named &lt;name&gt;
+</a-c>    rm <a-p>{</a-p>
+        <a-c>/// Name of the remote to remove
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+        <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-c>/// List all remotes
+</a-c>    ls <a-p>{</a-p>
+        <a-c>/// Show remote URLs after names
+</a-c>        <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+        <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">remote</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">add</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">origin</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;remote&quot;</a-s><a-p>,</a-p> <a-s>&quot;add&quot;</a-s><a-p>,</a-p> <a-s>&quot;origin&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
@@ -1683,33 +1586,29 @@ title = "Args"
 <p class="description">Error when a value cannot be parsed as the expected type.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="font-style:italic;color:#565f89;">/// A simple CLI tool for file processing.
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleArgs </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Enable verbose output
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    verbose</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Number of parallel jobs to run
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">named, </span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">short)]
-</span><span style="color:#9abdf5;">    jobs</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">usize</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Input file to process
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    input</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="font-style:italic;color:#565f89;">/// Output file (defaults to stdout)
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">args</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">positional)]
-</span><span style="color:#9abdf5;">    output</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple CLI tool for file processing.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleArgs</a-t> <a-p>{</a-p>
+    <a-c>/// Enable verbose output
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>verbose</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
 
+    <a-c>/// Number of parallel jobs to run
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>named</a-at><a-p>,</a-p><a-at> args</a-at><a-p>::</a-p><a-at>short</a-at><a-p>)]</a-p>
+    <a-pr>jobs</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>usize</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Input file to process
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>input</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-c>/// Output file (defaults to stdout)
+</a-c>    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>args</a-at><a-p>::</a-p><a-at>positional</a-at><a-p>)]</a-p>
+    <a-pr>output</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#2ac3de;">from_slice</span><span style="color:#9abdf5;">(</span><span style="color:#89ddff;">&amp;</span><span style="color:#9abdf5;">[</span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">-j</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">not-a-number</span><span style="color:#89ddff;">&quot;, &quot;</span><span style="color:#9ece6a;">input.txt</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">])</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-f>from_slice</a-f><a-p>(</a-p><a-o>&amp;</a-o><a-p>[</a-p><a-s>&quot;-j&quot;</a-s><a-p>,</a-p> <a-s>&quot;not-a-number&quot;</a-s><a-p>,</a-p> <a-s>&quot;input.txt&quot;</a-s><a-p>])</a-p></code></pre>
 </div>
 <div class="error">
 <h4>Error</h4>
@@ -1728,9 +1627,9 @@ title = "Args"
 <footer class="showcase-provenance">
 <p>This showcase was auto-generated from source code.</p>
 <dl>
-<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/a275f00e2c5593da5eaa528fe0b00814b555b5d7/facet-args/examples/args_showcase.rs"><code>facet-args/examples/args_showcase.rs</code></a></dd>
-<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/a275f00e2c5593da5eaa528fe0b00814b555b5d7"><code>a275f00e2</code></a></dd>
-<dt>Generated</dt><dd><time datetime="2025-12-12T07:18:58+01:00">2025-12-12T07:18:58+01:00</time></dd>
+<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/c5842bc4cd833fedc52522b20f09daedff260a0e/facet-args/examples/args_showcase.rs"><code>facet-args/examples/args_showcase.rs</code></a></dd>
+<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/c5842bc4cd833fedc52522b20f09daedff260a0e"><code>c5842bc4c</code></a></dd>
+<dt>Generated</dt><dd><time datetime="2026-01-04T12:56:12+01:00">2026-01-04T12:56:12+01:00</time></dd>
 <dt>Compiler</dt><dd><code>rustc 1.91.1 (ed61e7d7e 2025-11-07)</code></dd>
 </dl>
 </footer>

--- a/docs/content/guide/showcases/assert.md
+++ b/docs/content/guide/showcases/assert.md
@@ -13,26 +13,24 @@ title = "Assertions"
 <p class="description">Two values with identical content pass <code>assert_same!</code> — no <code>PartialEq</code> required.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Config </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">debug</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">tags</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Vec</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Config</a-t> <a-p>{</a-p>
+    <a-pr>host</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
 
+    <a-pr>port</a-pr><a-p>:</a-p> <a-t>u16</a-t><a-p>,</a-p>
+
+    <a-pr>debug</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+    <a-pr>tags</a-pr><a-p>:</a-p> <a-t>Vec</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Config</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">host</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">localhost</span>"<span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">port</span><span style="opacity:0.7">: </span><span style="color:rgb(224,186,81)">8080</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">debug</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">tags</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;String&gt;</span><span style="opacity:0.7"> [</span>"<span style="color:rgb(158,206,106)">prod</span>"<span style="opacity:0.7">,</span> "<span style="color:rgb(158,206,106)">api</span>"<span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Config</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">host</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">localhost</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">port</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(224,186,81)">8080</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">debug</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">tags</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;String&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span>"<span style="color:rgb(158,206,106)">prod</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span> "<span style="color:rgb(158,206,106)">api</span><span style="color:inherit">"</span><span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
@@ -43,26 +41,24 @@ title = "Assertions"
 <p class="description">Different type names (<code>Config</code> vs <code>ConfigV2</code>) with the same structure are considered "same". Useful for comparing DTOs across API versions or testing serialization roundtrips.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Config </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">debug</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">tags</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Vec</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Config</a-t> <a-p>{</a-p>
+    <a-pr>host</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
 
+    <a-pr>port</a-pr><a-p>:</a-p> <a-t>u16</a-t><a-p>,</a-p>
+
+    <a-pr>debug</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+    <a-pr>tags</a-pr><a-p>:</a-p> <a-t>Vec</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Config</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">host</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">localhost</span>"<span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">port</span><span style="opacity:0.7">: </span><span style="color:rgb(224,186,81)">8080</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">debug</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">tags</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;String&gt;</span><span style="opacity:0.7"> [</span>"<span style="color:rgb(158,206,106)">prod</span>"<span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Config</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">host</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">localhost</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">port</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(224,186,81)">8080</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">debug</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">tags</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;String&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span>"<span style="color:rgb(158,206,106)">prod</span><span style="color:inherit">"</span><span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
@@ -73,32 +69,30 @@ title = "Assertions"
 <p class="description">Nested structs are compared recursively, field by field.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Person </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">age</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">address</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> Address,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Address </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">street</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">city</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Person</a-t> <a-p>{</a-p>
+    <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
 
+    <a-pr>age</a-pr><a-p>:</a-p> <a-t>u32</a-t><a-p>,</a-p>
+
+    <a-pr>address</a-pr><a-p>:</a-p> <a-t>Address</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Address</a-t> <a-p>{</a-p>
+    <a-pr>street</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-pr>city</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Alice</span>"<span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">age</span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">30</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">address</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Address</span><span style="opacity:0.7"> {</span>
-    <span style="color:rgb(115,218,202)">street</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">123 Main St</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">city</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Springfield</span>"<span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Alice</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">age</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">30</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">address</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Address</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+    <span style="color:rgb(115,218,202)">street</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">123 Main St</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">city</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Springfield</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
@@ -110,35 +104,41 @@ title = "Assertions"
 <p class="description">When values differ, you get a precise structural diff showing exactly which fields changed and at what path — then render it as Rust, JSON, or XML for whichever toolchain you need.</p>
 <div class="diff-output">
 <h4>Rust Diff Output</h4>
-<pre><code><span style="color:rgb(86,95,137)">{</span>
-    <span style="color:rgb(115,218,202)">debug</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(247,118,142)">true</span> → <span style="color:rgb(115,218,202)">false</span>
-    <span style="color:rgb(115,218,202)">host</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(247,118,142)">"localhost"</span> → <span style="color:rgb(115,218,202)">"prod.example.com"</span>
-    <span style="color:rgb(115,218,202)">port</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(247,118,142)">8080</span> → <span style="color:rgb(115,218,202)">443</span>
-    <span style="color:rgb(115,218,202)">tags</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(86,95,137)">[</span>
-        <span style="color:rgb(86,95,137)">.. 1 unchanged item</span>
-        <span style="color:rgb(247,118,142)">- "api"</span>
-    <span style="color:rgb(86,95,137)">]</span>
-<span style="color:rgb(86,95,137)">}</span></code></pre>
+<pre><code><span style="color:rgb(86,95,137)">{</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">debug</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(247,118,142)">true</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">false</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">host</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(247,118,142)">"localhost"</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">"prod.example.com"</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">port</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(247,118,142)">8080</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">443</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">tags</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">[</span><span style="color:inherit">
+        </span><span style="color:rgb(86,95,137)">.. 1 unchanged item</span><span style="color:inherit">
+        </span><span style="color:rgb(247,118,142)">- "api"</span><span style="color:inherit">
+    </span><span style="color:rgb(86,95,137)">]</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">}</span><span style="color:inherit"></span></code></pre>
 </div>
 <div class="diff-output">
 <h4>JSON Diff Output</h4>
-<pre><code>    <span style="color:rgb(220,220,220)">{</span> <span style="color:rgb(100,100,100)">/* Config */</span>
-      <span style="color:rgb(229,192,123);opacity:0.7">←</span> <span style="color:rgb(255,234,162);opacity:0.7">"debug": </span><span style="color:rgb(255,234,162);opacity:0.7">true</span><span style="color:rgb(224,209,189);opacity:0.7"></span> , <span style="color:rgb(255,234,162);opacity:0.7">"host": </span><span style="color:rgb(229,192,123);opacity:0.7">"localhost"</span><span style="color:rgb(224,209,189);opacity:0.7"></span>       , <span style="color:rgb(255,234,162);opacity:0.7">"port": </span><span style="color:rgb(255,234,162);opacity:0.7">8080</span><span style="color:rgb(224,209,189);opacity:0.7"></span>
-      <span style="color:rgb(97,175,239);opacity:0.7">→</span> <span style="color:rgb(142,216,255);opacity:0.7">"debug": </span><span style="color:rgb(142,216,255);opacity:0.7">false</span><span style="color:rgb(184,204,228);opacity:0.7"></span>, <span style="color:rgb(142,216,255);opacity:0.7">"host": </span><span style="color:rgb(97,175,239);opacity:0.7">"prod.example.com"</span><span style="color:rgb(184,204,228);opacity:0.7"></span>, <span style="color:rgb(142,216,255);opacity:0.7">"port": </span><span style="color:rgb(142,216,255);opacity:0.7">443</span><span style="color:rgb(184,204,228);opacity:0.7"></span>
-    <span style="color:rgb(220,220,220)"></span>
-        <span style="color:rgb(220,220,220)">"tags": [</span><span style="color:rgb(220,220,220)">]</span><span style="color:rgb(100,100,100)">,</span>
-    <span style="color:rgb(220,220,220)">}</span>
-</code></pre>
+<pre><code>    <span style="color:rgb(220,220,220)">{</span><span style="color:inherit"> </span><span style="color:rgb(100,100,100)">/* @Config */</span><span style="color:inherit">
+      </span><span style="color:rgb(229,192,123);background-color:rgb(54,48,38)">←</span> <span style="color:rgb(255,234,162);background-color:rgb(85,81,77)">"debug": </span><span style="color:rgb(255,234,162);background-color:rgb(85,81,77)">true</span><span style="color:rgb(224,209,189);background-color:rgb(54,48,38)"></span> , <span style="color:rgb(255,234,162);background-color:rgb(85,81,77)">"host": </span><span style="color:rgb(229,192,123);background-color:rgb(85,81,77)">"localhost"</span><span style="color:rgb(224,209,189);background-color:rgb(54,48,38)"></span>       , <span style="color:rgb(255,234,162);background-color:rgb(85,81,77)">"port": </span><span style="color:rgb(255,234,162);background-color:rgb(85,81,77)">8080</span><span style="color:rgb(224,209,189);background-color:rgb(54,48,38)"></span>
+      <span style="color:rgb(97,175,239);background-color:rgb(38,48,57)">→</span> <span style="color:rgb(142,216,255);background-color:rgb(69,73,77)">"debug": </span><span style="color:rgb(142,216,255);background-color:rgb(69,73,77)">false</span><span style="color:rgb(184,204,228);background-color:rgb(38,48,57)"></span>, <span style="color:rgb(142,216,255);background-color:rgb(69,73,77)">"host": </span><span style="color:rgb(97,175,239);background-color:rgb(69,73,77)">"prod.example.com"</span><span style="color:rgb(184,204,228);background-color:rgb(38,48,57)"></span>, <span style="color:rgb(142,216,255);background-color:rgb(69,73,77)">"port": </span><span style="color:rgb(142,216,255);background-color:rgb(69,73,77)">443</span><span style="color:rgb(184,204,228);background-color:rgb(38,48,57)"></span>
+    <span style="color:rgb(220,220,220)"></span><span style="color:inherit">
+        </span><span style="color:rgb(220,220,220)">"tags": [</span><span style="color:inherit">
+            </span><span style="color:rgb(140,140,140)">"prod"</span><span style="color:inherit">
+            </span><span style="color:rgb(229,192,123);background-color:rgb(54,48,38)">-</span> <span style="color:rgb(229,192,123);background-color:rgb(54,48,38)">"api"</span>
+        <span style="color:rgb(220,220,220)">]</span><span style="color:inherit"></span><span style="color:rgb(100,100,100)">,</span><span style="color:inherit">
+    </span><span style="color:rgb(220,220,220)">}</span><span style="color:inherit">
+</span></code></pre>
 </div>
 <div class="diff-output">
 <h4>XML Diff Output</h4>
-<pre><code>    <span style="color:rgb(220,220,220)">&lt;Config</span>
-      <span style="color:rgb(229,192,123);opacity:0.7">←</span> <span style="color:rgb(255,234,162);opacity:0.7">debug="</span><span style="color:rgb(255,234,162);opacity:0.7">true</span><span style="color:rgb(224,209,189);opacity:0.7">"</span>  <span style="color:rgb(255,234,162);opacity:0.7">host="</span><span style="color:rgb(229,192,123);opacity:0.7">localhost</span><span style="color:rgb(224,209,189);opacity:0.7">"</span>        <span style="color:rgb(255,234,162);opacity:0.7">port="</span><span style="color:rgb(255,234,162);opacity:0.7">8080</span><span style="color:rgb(224,209,189);opacity:0.7">"</span>
-      <span style="color:rgb(97,175,239);opacity:0.7">→</span> <span style="color:rgb(142,216,255);opacity:0.7">debug="</span><span style="color:rgb(142,216,255);opacity:0.7">false</span><span style="color:rgb(184,204,228);opacity:0.7">"</span> <span style="color:rgb(142,216,255);opacity:0.7">host="</span><span style="color:rgb(97,175,239);opacity:0.7">prod.example.com</span><span style="color:rgb(184,204,228);opacity:0.7">"</span> <span style="color:rgb(142,216,255);opacity:0.7">port="</span><span style="color:rgb(142,216,255);opacity:0.7">443</span><span style="color:rgb(184,204,228);opacity:0.7">"</span>
-    <span style="color:rgb(220,220,220)">&gt;</span>
-        <span style="color:rgb(220,220,220)">&lt;tags&gt;</span><span style="color:rgb(220,220,220)">&lt;/tags&gt;</span><span style="color:rgb(100,100,100)"></span>
-    <span style="color:rgb(220,220,220)">&lt;/Config&gt;</span>
-</code></pre>
+<pre><code>    <span style="color:rgb(220,220,220)">&lt;@Config</span><span style="color:inherit">
+      </span><span style="color:rgb(229,192,123);background-color:rgb(54,48,38)">←</span> <span style="color:rgb(255,234,162);background-color:rgb(85,81,77)">debug="</span><span style="color:rgb(255,234,162);background-color:rgb(85,81,77)">true</span><span style="color:rgb(224,209,189);background-color:rgb(54,48,38)">"</span>  <span style="color:rgb(255,234,162);background-color:rgb(85,81,77)">host="</span><span style="color:rgb(229,192,123);background-color:rgb(85,81,77)">localhost</span><span style="color:rgb(224,209,189);background-color:rgb(54,48,38)">"</span>        <span style="color:rgb(255,234,162);background-color:rgb(85,81,77)">port="</span><span style="color:rgb(255,234,162);background-color:rgb(85,81,77)">8080</span><span style="color:rgb(224,209,189);background-color:rgb(54,48,38)">"</span>
+      <span style="color:rgb(97,175,239);background-color:rgb(38,48,57)">→</span> <span style="color:rgb(142,216,255);background-color:rgb(69,73,77)">debug="</span><span style="color:rgb(142,216,255);background-color:rgb(69,73,77)">false</span><span style="color:rgb(184,204,228);background-color:rgb(38,48,57)">"</span> <span style="color:rgb(142,216,255);background-color:rgb(69,73,77)">host="</span><span style="color:rgb(97,175,239);background-color:rgb(69,73,77)">prod.example.com</span><span style="color:rgb(184,204,228);background-color:rgb(38,48,57)">"</span> <span style="color:rgb(142,216,255);background-color:rgb(69,73,77)">port="</span><span style="color:rgb(142,216,255);background-color:rgb(69,73,77)">443</span><span style="color:rgb(184,204,228);background-color:rgb(38,48,57)">"</span>
+    <span style="color:rgb(220,220,220)">&gt;</span><span style="color:inherit">
+        </span><span style="color:rgb(220,220,220)"></span><span style="color:inherit">
+            </span><span style="color:rgb(140,140,140)">prod</span><span style="color:inherit">
+            </span><span style="color:rgb(229,192,123);background-color:rgb(54,48,38)">-</span> <span style="color:rgb(229,192,123);background-color:rgb(54,48,38)">api</span>
+        <span style="color:rgb(220,220,220)"></span><span style="color:inherit"></span><span style="color:rgb(100,100,100)"></span><span style="color:inherit">
+    </span><span style="color:rgb(220,220,220)">&lt;/@Config&gt;</span><span style="color:inherit">
+</span></code></pre>
 </div>
 </section>
 
@@ -148,21 +148,21 @@ title = "Assertions"
 <p class="description">Vector comparisons show exactly which indices differ, which elements were added, and which were removed.</p>
 <div class="diff-output">
 <h4>Diff Output</h4>
-<pre><code><span style="color:rgb(86,95,137)">[</span>
-    <span style="color:rgb(86,95,137)">.. 2 unchanged items</span>
-    <span style="color:rgb(247,118,142)">3</span> → <span style="color:rgb(115,218,202)">99</span>
-    <span style="color:rgb(86,95,137)">.. 1 unchanged item</span>
-    <span style="color:rgb(247,118,142)">- 5</span>
-<span style="color:rgb(86,95,137)">]</span></code></pre>
+<pre><code><span style="color:rgb(86,95,137)">[</span><span style="color:inherit">
+    </span><span style="color:rgb(86,95,137)">.. 2 unchanged items</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">3</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">99</span><span style="color:inherit">
+    </span><span style="color:rgb(86,95,137)">.. 1 unchanged item</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">- 5</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">]</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
 <footer class="showcase-provenance">
 <p>This showcase was auto-generated from source code.</p>
 <dl>
-<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/a275f00e2c5593da5eaa528fe0b00814b555b5d7/facet-assert/examples/assert_showcase.rs"><code>facet-assert/examples/assert_showcase.rs</code></a></dd>
-<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/a275f00e2c5593da5eaa528fe0b00814b555b5d7"><code>a275f00e2</code></a></dd>
-<dt>Generated</dt><dd><time datetime="2025-12-12T07:18:58+01:00">2025-12-12T07:18:58+01:00</time></dd>
+<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/c5842bc4cd833fedc52522b20f09daedff260a0e/facet-assert/examples/assert_showcase.rs"><code>facet-assert/examples/assert_showcase.rs</code></a></dd>
+<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/c5842bc4cd833fedc52522b20f09daedff260a0e"><code>c5842bc4c</code></a></dd>
+<dt>Generated</dt><dd><time datetime="2026-01-04T12:56:12+01:00">2026-01-04T12:56:12+01:00</time></dd>
 <dt>Compiler</dt><dd><code>rustc 1.91.1 (ed61e7d7e 2025-11-07)</code></dd>
 </dl>
 </footer>

--- a/docs/content/guide/showcases/derive.md
+++ b/docs/content/guide/showcases/derive.md
@@ -17,27 +17,25 @@ The `#[derive(Facet)]` macro provides helpful compile-time error messages when a
 <p class="description">Using both <code>#[repr(C)]</code> and <code>#[repr(Rust)]</code> is not allowed.<br>Facet defers to rustc's E0566 error for this - no duplicate diagnostic.</p>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">use </span><span style="color:#c0caf5;">facet</span><span style="color:#89ddff;">::</span><span style="color:#c0caf5;">Facet</span><span style="color:#89ddff;">;
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">C</span><span style="color:#89ddff;">,</span><span style="color:#c0caf5;"> Rust</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">Status </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Active</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    Inactive</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#bb9af7;">fn </span><span style="color:#7aa2f7;">main</span><span style="color:#9abdf5;">() {}
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-k>use</a-k> facet<a-p>::</a-p><a-cr>Facet</a-cr><a-p>;</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-cr>C</a-cr><a-p>,</a-p><a-at> </a-at><a-cr>Rust</a-cr><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>Status</a-t> <a-p>{</a-p>
+    <a-cr>Active</a-cr><a-p>,</a-p>
+    <a-cr>Inactive</a-cr><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-k>fn</a-k> <a-f>main</a-f><a-p>()</a-p> <a-p>{}</a-p>
+</code></pre>
 </div>
 <div class="compiler-error">
 <h4>Compiler Error</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:#e06c75">error[E0566]</span><span style="font-weight:bold">: conflicting representation hints</span>
- <span style="font-weight:bold"></span><span style="color:#61afef">--&gt; </span>src/main.rs:4:8
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">4</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span> #[repr(C, Rust)]
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>        <span style="font-weight:bold"></span><span style="color:#e06c75">^</span>  <span style="font-weight:bold"></span><span style="color:#e06c75">^^^^</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:#ff0000">error[E0566]</span><span style="font-weight:bold">: conflicting representation hints</span>
+ <span style="font-weight:bold"></span><span style="color:#0000ff">--&gt; </span>src/main.rs:4:8
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">4</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span> #[repr(C, Rust)]
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>        <span style="font-weight:bold"></span><span style="color:#ff0000">^</span>  <span style="font-weight:bold"></span><span style="color:#ff0000">^^^^</span>
 
 <span style="font-weight:bold">For more information about this error, try &#96;rustc --explain E0566&#96;.</span>
 <span style="font-weight:bold"></span><span style="color:#e06c75">error</span>: could not compile &#96;test&#96; (bin "test") due to 1 previous error</code></pre>
@@ -50,24 +48,22 @@ The `#[derive(Facet)]` macro provides helpful compile-time error messages when a
 <p class="description">Combining <code>#[repr(C)]</code> with <code>#[repr(transparent)]</code> is not valid.<br>Facet defers to rustc's E0692 error for this - no duplicate diagnostic.</p>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">use </span><span style="color:#c0caf5;">facet</span><span style="color:#89ddff;">::</span><span style="color:#c0caf5;">Facet</span><span style="color:#89ddff;">;
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">C</span><span style="color:#89ddff;">,</span><span style="color:#c0caf5;"> transparent</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Wrapper</span><span style="color:#9abdf5;">(</span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">)</span><span style="color:#89ddff;">;
-</span><span style="color:#c0caf5;">
-</span><span style="color:#bb9af7;">fn </span><span style="color:#7aa2f7;">main</span><span style="color:#9abdf5;">() {}
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-k>use</a-k> facet<a-p>::</a-p><a-cr>Facet</a-cr><a-p>;</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-cr>C</a-cr><a-p>,</a-p><a-at> transparent</a-at><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Wrapper</a-t><a-p>(</a-p><a-t>u32</a-t><a-p>);</a-p>
+
+<a-k>fn</a-k> <a-f>main</a-f><a-p>()</a-p> <a-p>{}</a-p>
+</code></pre>
 </div>
 <div class="compiler-error">
 <h4>Compiler Error</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:#e06c75">error[E0692]</span><span style="font-weight:bold">: transparent struct cannot have other repr hints</span>
- <span style="font-weight:bold"></span><span style="color:#61afef">--&gt; </span>src/main.rs:4:8
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">4</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span> #[repr(C, transparent)]
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>        <span style="font-weight:bold"></span><span style="color:#e06c75">^</span>  <span style="font-weight:bold"></span><span style="color:#e06c75">^^^^^^^^^^^</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:#ff0000">error[E0692]</span><span style="font-weight:bold">: transparent struct cannot have other repr hints</span>
+ <span style="font-weight:bold"></span><span style="color:#0000ff">--&gt; </span>src/main.rs:4:8
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">4</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span> #[repr(C, transparent)]
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>        <span style="font-weight:bold"></span><span style="color:#ff0000">^</span>  <span style="font-weight:bold"></span><span style="color:#ff0000">^^^^^^^^^^^</span>
 
 <span style="font-weight:bold">For more information about this error, try &#96;rustc --explain E0692&#96;.</span>
 <span style="font-weight:bold"></span><span style="color:#e06c75">error</span>: could not compile &#96;test&#96; (bin "test") due to 1 previous error</code></pre>
@@ -80,37 +76,35 @@ The `#[derive(Facet)]` macro provides helpful compile-time error messages when a
 <p class="description">Using <code>#[repr(transparent)]</code> with a primitive type like <code>u8</code> is not allowed.<br>Facet defers to rustc's E0692 error for this - no duplicate diagnostic.</p>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">use </span><span style="color:#c0caf5;">facet</span><span style="color:#89ddff;">::</span><span style="color:#c0caf5;">Facet</span><span style="color:#89ddff;">;
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">transparent</span><span style="color:#89ddff;">,</span><span style="color:#c0caf5;"> u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">Status </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Active</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    Inactive</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#bb9af7;">fn </span><span style="color:#7aa2f7;">main</span><span style="color:#9abdf5;">() {}
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-k>use</a-k> facet<a-p>::</a-p><a-cr>Facet</a-cr><a-p>;</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-at>transparent</a-at><a-p>,</a-p><a-at> </a-at><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>Status</a-t> <a-p>{</a-p>
+    <a-cr>Active</a-cr><a-p>,</a-p>
+    <a-cr>Inactive</a-cr><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-k>fn</a-k> <a-f>main</a-f><a-p>()</a-p> <a-p>{}</a-p>
+</code></pre>
 </div>
 <div class="compiler-error">
 <h4>Compiler Error</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:#e06c75">error[E0692]</span><span style="font-weight:bold">: transparent enum cannot have other repr hints</span>
- <span style="font-weight:bold"></span><span style="color:#61afef">--&gt; </span>src/main.rs:4:8
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">4</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span> #[repr(transparent, u8)]
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>        <span style="font-weight:bold"></span><span style="color:#e06c75">^^^^^^^^^^^</span>  <span style="font-weight:bold"></span><span style="color:#e06c75">^^</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:#ff0000">error[E0692]</span><span style="font-weight:bold">: transparent enum cannot have other repr hints</span>
+ <span style="font-weight:bold"></span><span style="color:#0000ff">--&gt; </span>src/main.rs:4:8
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">4</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span> #[repr(transparent, u8)]
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>        <span style="font-weight:bold"></span><span style="color:#ff0000">^^^^^^^^^^^</span>  <span style="font-weight:bold"></span><span style="color:#ff0000">^^</span>
 
-<span style="font-weight:bold"></span><span style="color:#e06c75">error[E0731]</span><span style="font-weight:bold">: transparent enum needs exactly one variant, but has 2</span>
- <span style="font-weight:bold"></span><span style="color:#61afef">--&gt; </span>src/main.rs:5:1
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">5</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span> enum Status {
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span> <span style="font-weight:bold"></span><span style="color:#e06c75">^^^^^^^^^^^</span> <span style="font-weight:bold"></span><span style="color:#e06c75">needs exactly one variant, but has 2</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">6</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span>     Active,
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>     <span style="font-weight:bold"></span><span style="color:#61afef">------</span> <span style="font-weight:bold"></span><span style="color:#61afef">variant here</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">7</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span>     Inactive,
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>     <span style="font-weight:bold"></span><span style="color:#61afef">--------</span> <span style="font-weight:bold"></span><span style="color:#61afef">too many variants in &#96;Status&#96;</span>
+<span style="font-weight:bold"></span><span style="color:#ff0000">error[E0731]</span><span style="font-weight:bold">: transparent enum needs exactly one variant, but has 2</span>
+ <span style="font-weight:bold"></span><span style="color:#0000ff">--&gt; </span>src/main.rs:5:1
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">5</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span> enum Status {
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span> <span style="font-weight:bold"></span><span style="color:#ff0000">^^^^^^^^^^^</span> <span style="font-weight:bold"></span><span style="color:#ff0000">needs exactly one variant, but has 2</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">6</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>     Active,
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>     <span style="font-weight:bold"></span><span style="color:#0000ff">------</span> <span style="font-weight:bold"></span><span style="color:#0000ff">variant here</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">7</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>     Inactive,
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>     <span style="font-weight:bold"></span><span style="color:#0000ff">--------</span> <span style="font-weight:bold"></span><span style="color:#0000ff">too many variants in &#96;Status&#96;</span>
 
 <span style="font-weight:bold">Some errors have detailed explanations: E0692, E0731.</span>
 <span style="font-weight:bold">For more information about an error, try &#96;rustc --explain E0692&#96;.</span>
@@ -124,40 +118,38 @@ The `#[derive(Facet)]` macro provides helpful compile-time error messages when a
 <p class="description">Specifying multiple primitive types in <code>#[repr(...)]</code> is not allowed.<br>Facet defers to rustc's E0566 error for this - no duplicate diagnostic.</p>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">use </span><span style="color:#c0caf5;">facet</span><span style="color:#89ddff;">::</span><span style="color:#c0caf5;">Facet</span><span style="color:#89ddff;">;
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#89ddff;">,</span><span style="color:#c0caf5;"> u16</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">Priority </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Low</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    Medium</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    High</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#bb9af7;">fn </span><span style="color:#7aa2f7;">main</span><span style="color:#9abdf5;">() {}
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-k>use</a-k> facet<a-p>::</a-p><a-cr>Facet</a-cr><a-p>;</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>,</a-p><a-at> </a-at><a-t>u16</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>Priority</a-t> <a-p>{</a-p>
+    <a-cr>Low</a-cr><a-p>,</a-p>
+    <a-cr>Medium</a-cr><a-p>,</a-p>
+    <a-cr>High</a-cr><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-k>fn</a-k> <a-f>main</a-f><a-p>()</a-p> <a-p>{}</a-p>
+</code></pre>
 </div>
 <div class="compiler-error">
 <h4>Compiler Error</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:#e06c75">error[E0566]</span><span style="font-weight:bold">: conflicting representation hints</span>
- <span style="font-weight:bold"></span><span style="color:#61afef">--&gt; </span>src/main.rs:4:8
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">4</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span> #[repr(u8, u16)]
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>        <span style="font-weight:bold"></span><span style="color:#e06c75">^^</span>  <span style="font-weight:bold"></span><span style="color:#e06c75">^^^</span>
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-  <span style="font-weight:bold"></span><span style="color:#61afef">= </span><span style="font-weight:bold">warning</span>: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-  <span style="font-weight:bold"></span><span style="color:#61afef">= </span><span style="font-weight:bold">note</span>: for more information, see issue #68585 &lt;https://github.com/rust-lang/rust/issues/68585&gt;
-  <span style="font-weight:bold"></span><span style="color:#61afef">= </span><span style="font-weight:bold">note</span>: &#96;#[deny(conflicting_repr_hints)]&#96; (part of &#96;#[deny(future_incompatible)]&#96;) on by default
+<pre><code><span style="font-weight:bold"></span><span style="color:#ff0000">error[E0566]</span><span style="font-weight:bold">: conflicting representation hints</span>
+ <span style="font-weight:bold"></span><span style="color:#0000ff">--&gt; </span>src/main.rs:4:8
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">4</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span> #[repr(u8, u16)]
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>        <span style="font-weight:bold"></span><span style="color:#ff0000">^^</span>  <span style="font-weight:bold"></span><span style="color:#ff0000">^^^</span>
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+  <span style="font-weight:bold"></span><span style="color:#0000ff">= </span><span style="font-weight:bold">warning</span>: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+  <span style="font-weight:bold"></span><span style="color:#0000ff">= </span><span style="font-weight:bold">note</span>: for more information, see issue #68585 &lt;https://github.com/rust-lang/rust/issues/68585&gt;
+  <span style="font-weight:bold"></span><span style="color:#0000ff">= </span><span style="font-weight:bold">note</span>: &#96;#[deny(conflicting_repr_hints)]&#96; (part of &#96;#[deny(future_incompatible)]&#96;) on by default
 
 <span style="font-weight:bold"></span><span style="color:#e5c07b">warning</span><span style="font-weight:bold">: enum &#96;Priority&#96; is never used</span>
- <span style="font-weight:bold"></span><span style="color:#61afef">--&gt; </span>src/main.rs:5:6
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">5</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span> enum Priority {
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>      <span style="font-weight:bold"></span><span style="color:#e5c07b">^^^^^^^^</span>
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-  <span style="font-weight:bold"></span><span style="color:#61afef">= </span><span style="font-weight:bold">note</span>: &#96;#[warn(dead_code)]&#96; (part of &#96;#[warn(unused)]&#96;) on by default
+ <span style="font-weight:bold"></span><span style="color:#0000ff">--&gt; </span>src/main.rs:5:6
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">5</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span> enum Priority {
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>      <span style="font-weight:bold"></span><span style="color:#e5c07b">^^^^^^^^</span>
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+  <span style="font-weight:bold"></span><span style="color:#0000ff">= </span><span style="font-weight:bold">note</span>: &#96;#[warn(dead_code)]&#96; (part of &#96;#[warn(unused)]&#96;) on by default
 
 <span style="font-weight:bold">For more information about this error, try &#96;rustc --explain E0566&#96;.</span>
 <span style="font-weight:bold"></span><span style="color:#e5c07b">warning</span>: &#96;test&#96; (bin "test") generated 1 warning
@@ -171,27 +163,25 @@ The `#[derive(Facet)]` macro provides helpful compile-time error messages when a
 <p class="description">Using <code>#[repr(packed)]</code> is valid Rust, but facet doesn't support it.<br>This is a facet-specific error with a helpful message.</p>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">use </span><span style="color:#c0caf5;">facet</span><span style="color:#89ddff;">::</span><span style="color:#c0caf5;">Facet</span><span style="color:#89ddff;">;
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">packed</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Data </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">a</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u8</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">b</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#bb9af7;">fn </span><span style="color:#7aa2f7;">main</span><span style="color:#9abdf5;">() {}
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-k>use</a-k> facet<a-p>::</a-p><a-cr>Facet</a-cr><a-p>;</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-at>packed</a-at><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Data</a-t> <a-p>{</a-p>
+    <a-pr>a</a-pr><a-p>:</a-p> <a-t>u8</a-t><a-p>,</a-p>
+    <a-pr>b</a-pr><a-p>:</a-p> <a-t>u32</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-k>fn</a-k> <a-f>main</a-f><a-p>()</a-p> <a-p>{}</a-p>
+</code></pre>
 </div>
 <div class="compiler-error">
 <h4>Compiler Error</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:#e06c75">error</span><span style="font-weight:bold">: unsupported repr &#96;packed&#96; - facet only supports C, Rust, transparent, and primitive integer types</span>
- <span style="font-weight:bold"></span><span style="color:#61afef">--&gt; </span>src/main.rs:4:8
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">4</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span> #[repr(packed)]
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>        <span style="font-weight:bold"></span><span style="color:#e06c75">^^^^^^</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:#ff0000">error</span><span style="font-weight:bold">: unsupported repr &#96;packed&#96; - facet only supports C, Rust, transparent, and primitive integer types</span>
+ <span style="font-weight:bold"></span><span style="color:#0000ff">--&gt; </span>src/main.rs:4:8
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">4</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span> #[repr(packed)]
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>        <span style="font-weight:bold"></span><span style="color:#ff0000">^^^^^^</span>
 
 <span style="font-weight:bold"></span><span style="color:#e06c75">error</span>: could not compile &#96;test&#96; (bin "test") due to 1 previous error</code></pre>
 </div>
@@ -203,42 +193,40 @@ The `#[derive(Facet)]` macro provides helpful compile-time error messages when a
 <p class="description">Having multiple separate <code>#[repr(...)]</code> attributes triggers rustc's E0566.<br>Facet defers to rustc for this - no duplicate diagnostic.</p>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">use </span><span style="color:#c0caf5;">facet</span><span style="color:#89ddff;">::</span><span style="color:#c0caf5;">Facet</span><span style="color:#89ddff;">;
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">C</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">Status </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Active</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    Inactive</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#bb9af7;">fn </span><span style="color:#7aa2f7;">main</span><span style="color:#9abdf5;">() {}
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-k>use</a-k> facet<a-p>::</a-p><a-cr>Facet</a-cr><a-p>;</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-cr>C</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>Status</a-t> <a-p>{</a-p>
+    <a-cr>Active</a-cr><a-p>,</a-p>
+    <a-cr>Inactive</a-cr><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-k>fn</a-k> <a-f>main</a-f><a-p>()</a-p> <a-p>{}</a-p>
+</code></pre>
 </div>
 <div class="compiler-error">
 <h4>Compiler Error</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:#e06c75">error[E0566]</span><span style="font-weight:bold">: conflicting representation hints</span>
- <span style="font-weight:bold"></span><span style="color:#61afef">--&gt; </span>src/main.rs:4:8
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">4</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span> #[repr(C)]
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>        <span style="font-weight:bold"></span><span style="color:#e06c75">^</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">5</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span> #[repr(u8)]
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>        <span style="font-weight:bold"></span><span style="color:#e06c75">^^</span>
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-  <span style="font-weight:bold"></span><span style="color:#61afef">= </span><span style="font-weight:bold">warning</span>: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-  <span style="font-weight:bold"></span><span style="color:#61afef">= </span><span style="font-weight:bold">note</span>: for more information, see issue #68585 &lt;https://github.com/rust-lang/rust/issues/68585&gt;
-  <span style="font-weight:bold"></span><span style="color:#61afef">= </span><span style="font-weight:bold">note</span>: &#96;#[deny(conflicting_repr_hints)]&#96; (part of &#96;#[deny(future_incompatible)]&#96;) on by default
+<pre><code><span style="font-weight:bold"></span><span style="color:#ff0000">error[E0566]</span><span style="font-weight:bold">: conflicting representation hints</span>
+ <span style="font-weight:bold"></span><span style="color:#0000ff">--&gt; </span>src/main.rs:4:8
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">4</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span> #[repr(C)]
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>        <span style="font-weight:bold"></span><span style="color:#ff0000">^</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">5</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span> #[repr(u8)]
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>        <span style="font-weight:bold"></span><span style="color:#ff0000">^^</span>
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+  <span style="font-weight:bold"></span><span style="color:#0000ff">= </span><span style="font-weight:bold">warning</span>: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+  <span style="font-weight:bold"></span><span style="color:#0000ff">= </span><span style="font-weight:bold">note</span>: for more information, see issue #68585 &lt;https://github.com/rust-lang/rust/issues/68585&gt;
+  <span style="font-weight:bold"></span><span style="color:#0000ff">= </span><span style="font-weight:bold">note</span>: &#96;#[deny(conflicting_repr_hints)]&#96; (part of &#96;#[deny(future_incompatible)]&#96;) on by default
 
 <span style="font-weight:bold"></span><span style="color:#e5c07b">warning</span><span style="font-weight:bold">: enum &#96;Status&#96; is never used</span>
- <span style="font-weight:bold"></span><span style="color:#61afef">--&gt; </span>src/main.rs:6:6
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">6</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span> enum Status {
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>      <span style="font-weight:bold"></span><span style="color:#e5c07b">^^^^^^</span>
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-  <span style="font-weight:bold"></span><span style="color:#61afef">= </span><span style="font-weight:bold">note</span>: &#96;#[warn(dead_code)]&#96; (part of &#96;#[warn(unused)]&#96;) on by default
+ <span style="font-weight:bold"></span><span style="color:#0000ff">--&gt; </span>src/main.rs:6:6
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">6</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span> enum Status {
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>      <span style="font-weight:bold"></span><span style="color:#e5c07b">^^^^^^</span>
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+  <span style="font-weight:bold"></span><span style="color:#0000ff">= </span><span style="font-weight:bold">note</span>: &#96;#[warn(dead_code)]&#96; (part of &#96;#[warn(unused)]&#96;) on by default
 
 <span style="font-weight:bold">For more information about this error, try &#96;rustc --explain E0566&#96;.</span>
 <span style="font-weight:bold"></span><span style="color:#e5c07b">warning</span>: &#96;test&#96; (bin "test") generated 1 warning
@@ -255,27 +243,25 @@ The `#[derive(Facet)]` macro provides helpful compile-time error messages when a
 <p class="description">Using an unknown case convention in <code>rename_all</code> is a facet-specific error.<br>Valid options: <code>camelCase</code>, <code>snake_case</code>, <code>kebab-case</code>, <code>PascalCase</code>, <code>SCREAMING_SNAKE_CASE</code>.</p>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">use </span><span style="color:#c0caf5;">facet</span><span style="color:#89ddff;">::</span><span style="color:#c0caf5;">Facet</span><span style="color:#89ddff;">;
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">rename_all </span><span style="color:#89ddff;">= &quot;</span><span style="color:#9ece6a;">SCREAMING_SNAKE</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Config </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">user_name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">max_retries</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#bb9af7;">fn </span><span style="color:#7aa2f7;">main</span><span style="color:#9abdf5;">() {}
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-k>use</a-k> facet<a-p>::</a-p><a-cr>Facet</a-cr><a-p>;</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>rename_all = </a-at><a-s>&quot;SCREAMING_SNAKE&quot;</a-s><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Config</a-t> <a-p>{</a-p>
+    <a-pr>user_name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-pr>max_retries</a-pr><a-p>:</a-p> <a-t>u32</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-k>fn</a-k> <a-f>main</a-f><a-p>()</a-p> <a-p>{}</a-p>
+</code></pre>
 </div>
 <div class="compiler-error">
 <h4>Compiler Error</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:#e06c75">error</span><span style="font-weight:bold">: unknown #[facet(rename_all = "...")] rule: &#96;SCREAMING_SNAKE&#96;. Valid options: camelCase, snake_case, kebab-case, PascalCase, SCREAMING_SNAKE_CASE, SCREAMING-KEBAB-CASE, lowercase, UPPERCASE</span>
- <span style="font-weight:bold"></span><span style="color:#61afef">--&gt; </span>src/main.rs:4:9
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>
-<span style="font-weight:bold"></span><span style="color:#61afef">4</span> <span style="font-weight:bold"></span><span style="color:#61afef">|</span> #[facet(rename_all = "SCREAMING_SNAKE")]
-  <span style="font-weight:bold"></span><span style="color:#61afef">|</span>         <span style="font-weight:bold"></span><span style="color:#e06c75">^^^^^^^^^^</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:#ff0000">error</span><span style="font-weight:bold">: unknown #[facet(rename_all = "...")] rule: &#96;SCREAMING_SNAKE&#96;. Valid options: camelCase, snake_case, kebab-case, PascalCase, SCREAMING_SNAKE_CASE, SCREAMING-KEBAB-CASE, lowercase, UPPERCASE</span>
+ <span style="font-weight:bold"></span><span style="color:#0000ff">--&gt; </span>src/main.rs:4:9
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>
+<span style="font-weight:bold"></span><span style="color:#0000ff">4</span> <span style="font-weight:bold"></span><span style="color:#0000ff">|</span> #[facet(rename_all = "SCREAMING_SNAKE")]
+  <span style="font-weight:bold"></span><span style="color:#0000ff">|</span>         <span style="font-weight:bold"></span><span style="color:#ff0000">^^^^^^^^^^</span>
 
 <span style="font-weight:bold"></span><span style="color:#e06c75">error</span>: could not compile &#96;test&#96; (bin "test") due to 1 previous error</code></pre>
 </div>
@@ -287,19 +273,17 @@ The `#[derive(Facet)]` macro provides helpful compile-time error messages when a
 <p class="description">Using <code>#[facet(rename = "...")]</code> on a struct/enum is a facet-specific error.<br>A container's name is controlled by its parent field, not by itself.</p>
 <div class="input">
 <h4>Rust Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">use </span><span style="color:#c0caf5;">facet</span><span style="color:#89ddff;">::</span><span style="color:#c0caf5;">Facet</span><span style="color:#89ddff;">;
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">rename </span><span style="color:#89ddff;">= &quot;</span><span style="color:#9ece6a;">MyConfig</span><span style="color:#89ddff;">&quot;</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Config </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">value</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#bb9af7;">fn </span><span style="color:#7aa2f7;">main</span><span style="color:#9abdf5;">() {}
-</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-k>use</a-k> facet<a-p>::</a-p><a-cr>Facet</a-cr><a-p>;</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>rename = </a-at><a-s>&quot;MyConfig&quot;</a-s><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Config</a-t> <a-p>{</a-p>
+    <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-pr>value</a-pr><a-p>:</a-p> <a-t>u32</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-k>fn</a-k> <a-f>main</a-f><a-p>()</a-p> <a-p>{}</a-p>
+</code></pre>
 </div>
 <div class="compiler-error">
 <h4>Compiler Error</h4>
@@ -310,9 +294,9 @@ The `#[derive(Facet)]` macro provides helpful compile-time error messages when a
 <footer class="showcase-provenance">
 <p>This showcase was auto-generated from source code.</p>
 <dl>
-<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/a275f00e2c5593da5eaa528fe0b00814b555b5d7/facet/examples/derive_showcase.rs"><code>facet/examples/derive_showcase.rs</code></a></dd>
-<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/a275f00e2c5593da5eaa528fe0b00814b555b5d7"><code>a275f00e2</code></a></dd>
-<dt>Generated</dt><dd><time datetime="2025-12-12T07:18:58+01:00">2025-12-12T07:18:58+01:00</time></dd>
+<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/c5842bc4cd833fedc52522b20f09daedff260a0e/facet/examples/derive_showcase.rs"><code>facet/examples/derive_showcase.rs</code></a></dd>
+<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/c5842bc4cd833fedc52522b20f09daedff260a0e"><code>c5842bc4c</code></a></dd>
+<dt>Generated</dt><dd><time datetime="2026-01-04T12:56:12+01:00">2026-01-04T12:56:12+01:00</time></dd>
 <dt>Compiler</dt><dd><code>rustc 1.91.1 (ed61e7d7e 2025-11-07)</code></dd>
 </dl>
 </footer>

--- a/docs/content/guide/showcases/diff.md
+++ b/docs/content/guide/showcases/diff.md
@@ -12,19 +12,19 @@ facet-diff provides comprehensive diffing capabilities for any type that impleme
 <section class="scenario">
 <p class="description">Changes to multiple fields in a struct including nested settings.</p>
 <div class="output">
-<pre><code><span style="color:rgb(115,218,202)">age</span>: <span style="color:rgb(247,118,142)">30</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">31</span>
-<span style="color:rgb(115,218,202)">email</span>: <span style="color:rgb(247,118,142)">"alice@example.com"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"alice@newdomain.com"</span>
-<span style="color:rgb(115,218,202)">settings.theme</span>: <span style="color:rgb(247,118,142)">"dark"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"light"</span>
+<pre><code><span style="color:rgb(115,218,202)">email</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"alice@example.com"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"alice@newdomain.com"</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">settings.theme</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"dark"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"light"</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">age</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">30</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">31</span><span style="color:inherit">
 
-<span style="color:rgb(86,95,137)">{</span>
-    <span style="color:rgb(86,95,137)">.. 1 unchanged field</span>
-    <span style="color:rgb(115,218,202)">age</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(247,118,142)">30</span> → <span style="color:rgb(115,218,202)">31</span>
-    <span style="color:rgb(115,218,202)">email</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(247,118,142)">"alice@example.com"</span> → <span style="color:rgb(115,218,202)">"alice@newdomain.com"</span>
-    <span style="color:rgb(115,218,202)">settings</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(86,95,137)">{</span>
-        <span style="color:rgb(86,95,137)">.. 1 unchanged field</span>
-        <span style="color:rgb(115,218,202)">theme</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(247,118,142)">"dark"</span> → <span style="color:rgb(115,218,202)">"light"</span>
-    <span style="color:rgb(86,95,137)">}</span>
-<span style="color:rgb(86,95,137)">}</span></code></pre>
+</span><span style="color:rgb(86,95,137)">{</span><span style="color:inherit">
+    </span><span style="color:rgb(86,95,137)">.. 1 unchanged field</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">age</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(247,118,142)">30</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">31</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">email</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(247,118,142)">"alice@example.com"</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">"alice@newdomain.com"</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">settings</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">{</span><span style="color:inherit">
+        </span><span style="color:rgb(86,95,137)">.. 1 unchanged field</span><span style="color:inherit">
+        </span><span style="color:rgb(115,218,202)">theme</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(247,118,142)">"dark"</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">"light"</span><span style="color:inherit">
+    </span><span style="color:rgb(86,95,137)">}</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">}</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
@@ -33,8 +33,8 @@ facet-diff provides comprehensive diffing capabilities for any type that impleme
 <section class="scenario">
 <p class="description">Changes to fields deep within nested structures.</p>
 <div class="output">
-<pre><code><span style="color:rgb(115,218,202)">sections.[0].heading</span>: <span style="color:rgb(247,118,142)">"Intro"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"Introduction"</span>
-<span style="color:rgb(115,218,202)">sections.[1].content</span>: <span style="color:rgb(247,118,142)">"Some content here"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"Updated content"</span></code></pre>
+<pre><code><span style="color:rgb(115,218,202)">sections.[0].heading</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"Intro"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"Introduction"</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">sections.[1].content</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"Some content here"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"Updated content"</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
@@ -44,24 +44,24 @@ facet-diff provides comprehensive diffing capabilities for any type that impleme
 <p class="description">Various operations on sequences including single element changes, insertions, deletions, and reordering.</p>
 <div class="output">
 <pre><code>a) Single element change:
-<span style="color:rgb(115,218,202)">[2]</span>: <span style="color:rgb(247,118,142)">3</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">99</span>
+<span style="color:rgb(115,218,202)">[2]</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">3</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">99</span><span style="color:inherit">
 
 b) Insertions and deletions:
-<span style="color:rgb(86,95,137)">[</span>
-    <span style="color:rgb(247,118,142)">- 1</span>
-    <span style="color:rgb(247,118,142)">- 2</span>
-    <span style="color:rgb(115,218,202)">+ 1</span>
-    <span style="color:rgb(115,218,202)">+ 4</span>
-    <span style="color:rgb(115,218,202)">+ 5</span>
-    <span style="color:rgb(86,95,137)">.. 1 unchanged item</span>
-<span style="color:rgb(86,95,137)">]</span>
+</span><span style="color:rgb(86,95,137)">[</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">- 1</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">- 2</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">+ 1</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">+ 4</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">+ 5</span><span style="color:inherit">
+    </span><span style="color:rgb(86,95,137)">.. 1 unchanged item</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">]</span><span style="color:inherit">
 
 c) Reordering:
-<span style="color:rgb(86,95,137)">[</span>
-    <span style="color:rgb(115,218,202)">+ "c"</span>
-    <span style="color:rgb(86,95,137)">.. 2 unchanged items</span>
-    <span style="color:rgb(247,118,142)">- "c"</span>
-<span style="color:rgb(86,95,137)">]</span></code></pre>
+</span><span style="color:rgb(86,95,137)">[</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">+ "c"</span><span style="color:inherit">
+    </span><span style="color:rgb(86,95,137)">.. 2 unchanged items</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">- "c"</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">]</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
@@ -71,12 +71,12 @@ c) Reordering:
 <p class="description">Enum diffing including same variant with different data and different variants.</p>
 <div class="output">
 <pre><code>a) Same variant, different data:
-<span style="color:rgb(115,218,202)">::Inactive.reason</span>: <span style="color:rgb(247,118,142)">"vacation"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"sick leave"</span>
+<span style="color:rgb(115,218,202)">::Inactive.reason</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"vacation"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"sick leave"</span><span style="color:inherit">
 
 b) Different variants:
-<span style="color:rgb(247,118,142)">Status::Active</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">Status::Pending {
+</span><span style="color:rgb(247,118,142)">Status::Active</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">Status::Pending {
   since: 42,
-}</span></code></pre>
+}</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
@@ -86,11 +86,11 @@ b) Different variants:
 <p class="description">Option types including inner value changes and None to Some transitions.</p>
 <div class="output">
 <pre><code>a) Some to Some (inner change):
-<span style="color:rgb(115,218,202)">email</span>: <span style="color:rgb(247,118,142)">"bob@example.com"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"bob@company.com"</span>
-<span style="color:rgb(115,218,202)">settings.notifications</span>: <span style="color:rgb(247,118,142)">false</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">true</span>
+<span style="color:rgb(115,218,202)">email</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"bob@example.com"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"bob@company.com"</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">settings.notifications</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">false</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">true</span><span style="color:inherit">
 
 b) None to Some:
-<span style="color:rgb(247,118,142)">None</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">Some(42)</span></code></pre>
+</span><span style="color:rgb(247,118,142)">None</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">Some(42)</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
@@ -99,17 +99,17 @@ b) None to Some:
 <section class="scenario">
 <p class="description">Large number of changes that get truncated to show summary.</p>
 <div class="output">
-<pre><code><span style="color:rgb(115,218,202)">[2]</span>: <span style="color:rgb(247,118,142)">2</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">200</span>
-<span style="color:rgb(115,218,202)">[4]</span>: <span style="color:rgb(247,118,142)">4</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">400</span>
-<span style="color:rgb(115,218,202)">[6]</span>: <span style="color:rgb(247,118,142)">6</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">600</span>
-<span style="color:rgb(115,218,202)">[8]</span>: <span style="color:rgb(247,118,142)">8</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">800</span>
-<span style="color:rgb(115,218,202)">[10]</span>: <span style="color:rgb(247,118,142)">10</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">1000</span>
-<span style="color:rgb(115,218,202)">[12]</span>: <span style="color:rgb(247,118,142)">12</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">1200</span>
-<span style="color:rgb(115,218,202)">[14]</span>: <span style="color:rgb(247,118,142)">14</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">1400</span>
-<span style="color:rgb(115,218,202)">[16]</span>: <span style="color:rgb(247,118,142)">16</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">1600</span>
-<span style="color:rgb(115,218,202)">[18]</span>: <span style="color:rgb(247,118,142)">18</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">1800</span>
-<span style="color:rgb(115,218,202)">[20]</span>: <span style="color:rgb(247,118,142)">20</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">2000</span>
-<span style="color:rgb(86,95,137)">... and 4 more changes</span></code></pre>
+<pre><code><span style="color:rgb(115,218,202)">[2]</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">2</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">200</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">[4]</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">4</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">400</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">[6]</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">6</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">600</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">[8]</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">8</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">800</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">[10]</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">10</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">1000</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">[12]</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">12</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">1200</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">[14]</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">14</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">1400</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">[16]</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">16</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">1600</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">[18]</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">18</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">1800</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">[20]</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">20</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">2000</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">... and 4 more changes</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
@@ -118,7 +118,7 @@ b) None to Some:
 <section class="scenario">
 <p class="description">Comparing a value with itself shows no differences.</p>
 <div class="output">
-<pre><code><span style="color:rgb(86,95,137)">(no changes)</span></code></pre>
+<pre><code><span style="color:rgb(86,95,137)">(no changes)</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
@@ -128,25 +128,25 @@ b) None to Some:
 <p class="description">Diffing primitive types including integers, floats, booleans, characters, and strings.</p>
 <div class="output">
 <pre><code>a) Integers:
-  i32: <span style="color:rgb(247,118,142)">42</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">-42</span>
-  i128 min→max: <span style="color:rgb(247,118,142)">-170141183460469231731687303715884105728</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">170141183460469231731687303715884105727</span>
-  u64 0→max: <span style="color:rgb(247,118,142)">0</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">18446744073709551615</span>
+  i32: <span style="color:rgb(247,118,142)">42</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">-42</span><span style="color:inherit">
+  i128 min→max: </span><span style="color:rgb(247,118,142)">-170141183460469231731687303715884105728</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">170141183460469231731687303715884105727</span><span style="color:inherit">
+  u64 0→max: </span><span style="color:rgb(247,118,142)">0</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">18446744073709551615</span><span style="color:inherit">
 
 b) Floats:
-  f64: <span style="color:rgb(247,118,142)">3.141592653589793</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">2.718281828459045</span>
-  f64 inf→-inf: <span style="color:rgb(247,118,142)">inf</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">-inf</span>
-  f64 NaN→NaN: <span style="color:rgb(247,118,142)">NaN</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">NaN</span>
+  f64: </span><span style="color:rgb(247,118,142)">3.141592653589793</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">2.718281828459045</span><span style="color:inherit">
+  f64 inf→-inf: </span><span style="color:rgb(247,118,142)">inf</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">-inf</span><span style="color:inherit">
+  f64 NaN→NaN: </span><span style="color:rgb(247,118,142)">NaN</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">NaN</span><span style="color:inherit">
 
 c) Booleans:
-  bool: <span style="color:rgb(247,118,142)">true</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">false</span>
+  bool: </span><span style="color:rgb(247,118,142)">true</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">false</span><span style="color:inherit">
 
 d) Characters:
-  char: <span style="color:rgb(247,118,142)">A</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">Z</span>
-  emoji: <span style="color:rgb(247,118,142)">🦀</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">🐍</span>
+  char: </span><span style="color:rgb(247,118,142)">A</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">Z</span><span style="color:inherit">
+  emoji: </span><span style="color:rgb(247,118,142)">🦀</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">🐍</span><span style="color:inherit">
 
 e) Strings:
-  &amp;str: <span style="color:rgb(247,118,142)">"hello"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"world"</span>
-  String unicode: <span style="color:rgb(247,118,142)">"Hello 世界"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"Hello 🌍"</span></code></pre>
+  &amp;str: </span><span style="color:rgb(247,118,142)">"hello"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"world"</span><span style="color:inherit">
+  String unicode: </span><span style="color:rgb(247,118,142)">"Hello 世界"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"Hello 🌍"</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
@@ -156,28 +156,28 @@ e) Strings:
 <p class="description">Detection of Unicode confusable characters using the Unicode TR39 confusables database. These include homoglyphs that look similar but are from different scripts.</p>
 <div class="output">
 <pre><code>a) Latin 'a' vs Cyrillic 'а' (detected):
-<span style="color:rgb(247,118,142)">"abc"</span> → <span style="color:rgb(115,218,202)">"аbc"</span>
-<span style="color:rgb(86,95,137)">(strings are visually confusable but differ in 1 position):</span>
-  [0]: <span style="color:rgb(247,118,142)">'a' (U+0061)</span> vs <span style="color:rgb(115,218,202)">'\u{0430}'</span>
+<span style="color:rgb(247,118,142)">"abc"</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">"аbc"</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">(strings are visually confusable but differ in 1 position):</span><span style="color:inherit">
+  [0]: </span><span style="color:rgb(247,118,142)">'a' (U+0061)</span><span style="color:inherit"> vs </span><span style="color:rgb(115,218,202)">'\u{0430}'</span><span style="color:inherit">
 
 b) Latin 'o' vs Greek 'ο' (detected):
-<span style="color:rgb(247,118,142)">"foo"</span> → <span style="color:rgb(115,218,202)">"fοo"</span>
-<span style="color:rgb(86,95,137)">(strings are visually confusable but differ in 1 position):</span>
-  [1]: <span style="color:rgb(247,118,142)">'o' (U+006F)</span> vs <span style="color:rgb(115,218,202)">'\u{03BF}'</span>
+</span><span style="color:rgb(247,118,142)">"foo"</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">"fοo"</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">(strings are visually confusable but differ in 1 position):</span><span style="color:inherit">
+  [1]: </span><span style="color:rgb(247,118,142)">'o' (U+006F)</span><span style="color:inherit"> vs </span><span style="color:rgb(115,218,202)">'\u{03BF}'</span><span style="color:inherit">
 
 c) Latin 'e' vs Cyrillic 'е' (detected):
-<span style="color:rgb(247,118,142)">"hello"</span> → <span style="color:rgb(115,218,202)">"hеllo"</span>
-<span style="color:rgb(86,95,137)">(strings are visually confusable but differ in 1 position):</span>
-  [1]: <span style="color:rgb(247,118,142)">'e' (U+0065)</span> vs <span style="color:rgb(115,218,202)">'\u{0435}'</span>
+</span><span style="color:rgb(247,118,142)">"hello"</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">"hеllo"</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">(strings are visually confusable but differ in 1 position):</span><span style="color:inherit">
+  [1]: </span><span style="color:rgb(247,118,142)">'e' (U+0065)</span><span style="color:inherit"> vs </span><span style="color:rgb(115,218,202)">'\u{0435}'</span><span style="color:inherit">
 
 d) With zero-width joiner (not in TR39):
-<span style="color:rgb(247,118,142)">"test"</span> → <span style="color:rgb(115,218,202)">"te‍st"</span>
+</span><span style="color:rgb(247,118,142)">"test"</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">"te‍st"</span><span style="color:inherit">
 
 e) Different quote styles (not in TR39):
-<span style="color:rgb(247,118,142)">r""quoted""</span> → <span style="color:rgb(115,218,202)">"“quoted”"</span>
+</span><span style="color:rgb(247,118,142)">r""quoted""</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">"“quoted”"</span><span style="color:inherit">
 
 f) Greek Iota vs Latin I (not in TR39):
-<span style="color:rgb(247,118,142)">"userId"</span> → <span style="color:rgb(115,218,202)">"userΙd"</span></code></pre>
+</span><span style="color:rgb(247,118,142)">"userId"</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">"userΙd"</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
@@ -187,32 +187,32 @@ f) Greek Iota vs Latin I (not in TR39):
 <p class="description">Diffing byte arrays including ASCII and binary data.</p>
 <div class="output">
 <pre><code>a) ASCII bytes:
-  <span style="color:rgb(86,95,137)">[</span>
-    <span style="color:rgb(247,118,142)">- 104</span>
-    <span style="color:rgb(247,118,142)">- 101</span>
-    <span style="color:rgb(247,118,142)">- 108</span>
-    <span style="color:rgb(247,118,142)">- 108</span>
-    <span style="color:rgb(115,218,202)">+ 119</span>
-    <span style="color:rgb(86,95,137)">.. 1 unchanged item</span>
-    <span style="color:rgb(115,218,202)">+ 114</span>
-    <span style="color:rgb(115,218,202)">+ 108</span>
-    <span style="color:rgb(115,218,202)">+ 100</span>
-<span style="color:rgb(86,95,137)">]</span>
+  <span style="color:rgb(86,95,137)">[</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">- 104</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">- 101</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">- 108</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">- 108</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">+ 119</span><span style="color:inherit">
+    </span><span style="color:rgb(86,95,137)">.. 1 unchanged item</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">+ 114</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">+ 108</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">+ 100</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">]</span><span style="color:inherit">
 
 b) Binary data:
-  <span style="color:rgb(86,95,137)">[</span>
-    <span style="color:rgb(247,118,142)">- 0</span>
-    <span style="color:rgb(247,118,142)">- 255</span>
-    <span style="color:rgb(247,118,142)">- 66</span>
-    <span style="color:rgb(247,118,142)">- 19</span>
-    <span style="color:rgb(115,218,202)">+ 0</span>
-    <span style="color:rgb(115,218,202)">+ 254</span>
-    <span style="color:rgb(115,218,202)">+ 66</span>
-    <span style="color:rgb(115,218,202)">+ 55</span>
-<span style="color:rgb(86,95,137)">]</span>
+  </span><span style="color:rgb(86,95,137)">[</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">- 0</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">- 255</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">- 66</span><span style="color:inherit">
+    </span><span style="color:rgb(247,118,142)">- 19</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">+ 0</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">+ 254</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">+ 66</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">+ 55</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">]</span><span style="color:inherit">
 
 c) Vec&lt;u8&gt;:
-  <span style="color:rgb(115,218,202)">[2]</span>: <span style="color:rgb(247,118,142)">3</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">99</span></code></pre>
+  </span><span style="color:rgb(115,218,202)">[2]</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">3</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">99</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
@@ -222,43 +222,43 @@ c) Vec&lt;u8&gt;:
 <p class="description">Deeply nested structures demonstrating change detection at multiple nesting levels.</p>
 <div class="output">
 <pre><code>a) Change at deepest level (level 6):
-<span style="color:rgb(115,218,202)">inner.inner.inner.inner.inner.value</span>: <span style="color:rgb(247,118,142)">42</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">999</span>
-<span style="color:rgb(115,218,202)">inner.inner.inner.inner.inner.tag</span>: <span style="color:rgb(247,118,142)">"original"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"modified"</span>
+<span style="color:rgb(115,218,202)">inner.inner.inner.inner.inner.tag</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"original"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"modified"</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">inner.inner.inner.inner.inner.value</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">42</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">999</span><span style="color:inherit">
 
 b) Changes at multiple levels (2, 4, 6):
-<span style="color:rgb(115,218,202)">inner.priority</span>: <span style="color:rgb(247,118,142)">1</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">5</span>
-<span style="color:rgb(115,218,202)">inner.inner.inner.inner.inner.value</span>: <span style="color:rgb(247,118,142)">42</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">100</span>
-<span style="color:rgb(115,218,202)">inner.inner.inner.enabled</span>: <span style="color:rgb(247,118,142)">true</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">false</span>
+</span><span style="color:rgb(115,218,202)">inner.priority</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">1</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">5</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">inner.inner.inner.inner.inner.value</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">42</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">100</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">inner.inner.inner.enabled</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">true</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">false</span><span style="color:inherit">
 
 c) Changes at every level:
-<span style="color:rgb(115,218,202)">inner.inner.name</span>: <span style="color:rgb(247,118,142)">"old"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"new"</span>
-<span style="color:rgb(115,218,202)">inner.inner.inner.inner.inner.tag</span>: <span style="color:rgb(247,118,142)">"a"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"b"</span>
-<span style="color:rgb(115,218,202)">inner.inner.inner.inner.inner.value</span>: <span style="color:rgb(247,118,142)">1</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">2</span>
-<span style="color:rgb(115,218,202)">inner.inner.inner.inner.count</span>: <span style="color:rgb(247,118,142)">10</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">20</span>
-<span style="color:rgb(115,218,202)">inner.inner.inner.enabled</span>: <span style="color:rgb(247,118,142)">true</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">false</span>
-<span style="color:rgb(115,218,202)">inner.priority</span>: <span style="color:rgb(247,118,142)">1</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">2</span>
-<span style="color:rgb(115,218,202)">label</span>: <span style="color:rgb(247,118,142)">"label-old"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"label-new"</span>
+</span><span style="color:rgb(115,218,202)">inner.priority</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">1</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">2</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">inner.inner.inner.inner.count</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">10</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">20</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">inner.inner.inner.inner.inner.value</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">1</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">2</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">inner.inner.inner.inner.inner.tag</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"a"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"b"</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">inner.inner.inner.enabled</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">true</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">false</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">inner.inner.name</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"old"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"new"</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">label</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"label-old"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"label-new"</span><span style="color:inherit">
 
 d) Tree format for deep change:
-<span style="color:rgb(86,95,137)">{</span>
-    <span style="color:rgb(86,95,137)">.. 1 unchanged field</span>
-    <span style="color:rgb(115,218,202)">inner</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(86,95,137)">{</span>
-        <span style="color:rgb(86,95,137)">.. 1 unchanged field</span>
-        <span style="color:rgb(115,218,202)">inner</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(86,95,137)">{</span>
-            <span style="color:rgb(86,95,137)">.. 1 unchanged field</span>
-            <span style="color:rgb(115,218,202)">inner</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(86,95,137)">{</span>
-                <span style="color:rgb(86,95,137)">.. 1 unchanged field</span>
-                <span style="color:rgb(115,218,202)">inner</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(86,95,137)">{</span>
-                    <span style="color:rgb(86,95,137)">.. 1 unchanged field</span>
-                    <span style="color:rgb(115,218,202)">inner</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(86,95,137)">{</span>
-                        <span style="color:rgb(86,95,137)">.. 1 unchanged field</span>
-                        <span style="color:rgb(115,218,202)">value</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(247,118,142)">42</span> → <span style="color:rgb(115,218,202)">999</span>
-                    <span style="color:rgb(86,95,137)">}</span>
-                <span style="color:rgb(86,95,137)">}</span>
-            <span style="color:rgb(86,95,137)">}</span>
-        <span style="color:rgb(86,95,137)">}</span>
-    <span style="color:rgb(86,95,137)">}</span>
-<span style="color:rgb(86,95,137)">}</span></code></pre>
+</span><span style="color:rgb(86,95,137)">{</span><span style="color:inherit">
+    </span><span style="color:rgb(86,95,137)">.. 1 unchanged field</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">inner</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">{</span><span style="color:inherit">
+        </span><span style="color:rgb(86,95,137)">.. 1 unchanged field</span><span style="color:inherit">
+        </span><span style="color:rgb(115,218,202)">inner</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">{</span><span style="color:inherit">
+            </span><span style="color:rgb(86,95,137)">.. 1 unchanged field</span><span style="color:inherit">
+            </span><span style="color:rgb(115,218,202)">inner</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">{</span><span style="color:inherit">
+                </span><span style="color:rgb(86,95,137)">.. 1 unchanged field</span><span style="color:inherit">
+                </span><span style="color:rgb(115,218,202)">inner</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">{</span><span style="color:inherit">
+                    </span><span style="color:rgb(86,95,137)">.. 1 unchanged field</span><span style="color:inherit">
+                    </span><span style="color:rgb(115,218,202)">inner</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">{</span><span style="color:inherit">
+                        </span><span style="color:rgb(86,95,137)">.. 1 unchanged field</span><span style="color:inherit">
+                        </span><span style="color:rgb(115,218,202)">value</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(247,118,142)">42</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">999</span><span style="color:inherit">
+                    </span><span style="color:rgb(86,95,137)">}</span><span style="color:inherit">
+                </span><span style="color:rgb(86,95,137)">}</span><span style="color:inherit">
+            </span><span style="color:rgb(86,95,137)">}</span><span style="color:inherit">
+        </span><span style="color:rgb(86,95,137)">}</span><span style="color:inherit">
+    </span><span style="color:rgb(86,95,137)">}</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">}</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
@@ -268,41 +268,41 @@ d) Tree format for deep change:
 <p class="description">Structure with many fields demonstrating diff truncation and summarization.</p>
 <div class="output">
 <pre><code>a) Single field change (among 20 fields):
-<span style="color:rgb(115,218,202)">field_18</span>: <span style="color:rgb(247,118,142)">300</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">999</span>
+<span style="color:rgb(115,218,202)">field_18</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">300</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">999</span><span style="color:inherit">
 
 b) Scattered changes (fields 2, 8, 14, 19):
-<span style="color:rgb(115,218,202)">field_19</span>: <span style="color:rgb(247,118,142)">400</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">888</span>
-<span style="color:rgb(115,218,202)">field_02</span>: <span style="color:rgb(247,118,142)">"b"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"CHANGED"</span>
-<span style="color:rgb(115,218,202)">field_08</span>: <span style="color:rgb(247,118,142)">3</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">999</span>
-<span style="color:rgb(115,218,202)">field_14</span>: <span style="color:rgb(247,118,142)">true</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">false</span>
+</span><span style="color:rgb(115,218,202)">field_14</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">true</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">false</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">field_08</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">3</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">999</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">field_02</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"b"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"CHANGED"</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">field_19</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">400</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">888</span><span style="color:inherit">
 
 c) Many changes (exceeds truncation limit):
-<span style="color:rgb(115,218,202)">field_15</span>: <span style="color:rgb(247,118,142)">true</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">false</span>
-<span style="color:rgb(115,218,202)">field_19</span>: <span style="color:rgb(247,118,142)">400</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">4000</span>
-<span style="color:rgb(115,218,202)">field_17</span>: <span style="color:rgb(247,118,142)">200</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">2000</span>
-<span style="color:rgb(115,218,202)">field_20</span>: <span style="color:rgb(247,118,142)">500</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">5000</span>
-<span style="color:rgb(115,218,202)">field_11</span>: <span style="color:rgb(247,118,142)">true</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">false</span>
-<span style="color:rgb(115,218,202)">field_10</span>: <span style="color:rgb(247,118,142)">5</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">50</span>
-<span style="color:rgb(115,218,202)">field_16</span>: <span style="color:rgb(247,118,142)">100</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">1000</span>
-<span style="color:rgb(115,218,202)">field_06</span>: <span style="color:rgb(247,118,142)">1</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">10</span>
-<span style="color:rgb(115,218,202)">field_18</span>: <span style="color:rgb(247,118,142)">300</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">3000</span>
-<span style="color:rgb(115,218,202)">field_05</span>: <span style="color:rgb(247,118,142)">"e"</span> <span style="color:rgb(86,95,137)">→</span> <span style="color:rgb(115,218,202)">"E"</span>
-<span style="color:rgb(86,95,137)">... and 10 more changes</span>
+</span><span style="color:rgb(115,218,202)">field_12</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">true</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">false</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">field_11</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">true</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">false</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">field_02</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"b"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"B"</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">field_10</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">5</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">50</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">field_06</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">1</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">10</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">field_03</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">"c"</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">"C"</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">field_08</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">3</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">30</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">field_19</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">400</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">4000</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">field_07</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">2</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">20</span><span style="color:inherit">
+</span><span style="color:rgb(115,218,202)">field_13</span><span style="color:inherit">: </span><span style="color:rgb(247,118,142)">true</span><span style="color:inherit"> </span><span style="color:rgb(86,95,137)">→</span><span style="color:inherit"> </span><span style="color:rgb(115,218,202)">false</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">... and 10 more changes</span><span style="color:inherit">
 
 d) Tree format with few changes:
-<span style="color:rgb(86,95,137)">{</span>
-    <span style="color:rgb(86,95,137)">.. 19 unchanged fields</span>
-    <span style="color:rgb(115,218,202)">field_12</span><span style="color:rgb(86,95,137)">:</span> <span style="color:rgb(247,118,142)">true</span> → <span style="color:rgb(115,218,202)">false</span>
-<span style="color:rgb(86,95,137)">}</span></code></pre>
+</span><span style="color:rgb(86,95,137)">{</span><span style="color:inherit">
+    </span><span style="color:rgb(86,95,137)">.. 19 unchanged fields</span><span style="color:inherit">
+    </span><span style="color:rgb(115,218,202)">field_12</span><span style="color:inherit"></span><span style="color:rgb(86,95,137)">:</span><span style="color:inherit"> </span><span style="color:rgb(247,118,142)">true</span><span style="color:inherit"> → </span><span style="color:rgb(115,218,202)">false</span><span style="color:inherit">
+</span><span style="color:rgb(86,95,137)">}</span><span style="color:inherit"></span></code></pre>
 </div>
 </section>
 
 <footer class="showcase-provenance">
 <p>This showcase was auto-generated from source code.</p>
 <dl>
-<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/a275f00e2c5593da5eaa528fe0b00814b555b5d7/facet-diff/examples/diff_showcase.rs"><code>facet-diff/examples/diff_showcase.rs</code></a></dd>
-<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/a275f00e2c5593da5eaa528fe0b00814b555b5d7"><code>a275f00e2</code></a></dd>
-<dt>Generated</dt><dd><time datetime="2025-12-12T07:18:58+01:00">2025-12-12T07:18:58+01:00</time></dd>
+<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/c5842bc4cd833fedc52522b20f09daedff260a0e/facet-diff/examples/diff_showcase.rs"><code>facet-diff/examples/diff_showcase.rs</code></a></dd>
+<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/c5842bc4cd833fedc52522b20f09daedff260a0e"><code>c5842bc4c</code></a></dd>
+<dt>Generated</dt><dd><time datetime="2026-01-04T12:56:12+01:00">2026-01-04T12:56:12+01:00</time></dd>
 <dt>Compiler</dt><dd><code>rustc 1.91.1 (ed61e7d7e 2025-11-07)</code></dd>
 </dl>
 </footer>

--- a/docs/content/guide/showcases/from_value.md
+++ b/docs/content/guide/showcases/from_value.md
@@ -17,30 +17,28 @@ title = "From Value"
 <div class="input">
 <h4>Value Input</h4>
 <pre><code><span style="opacity:0.7">{</span>
-  <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Alice</span>"<span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">age</span><span style="opacity:0.7">: </span><span style="color:rgb(255,158,100)">30</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">email</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">alice@example.com</span>"<span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Alice</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">age</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(255,158,100)">30</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">email</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">alice@example.com</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Person </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">age</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">email</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Person</a-t> <a-p>{</a-p>
+    <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
 
+    <a-pr>age</a-pr><a-p>:</a-p> <a-t>u32</a-t><a-p>,</a-p>
+
+    <a-pr>email</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Alice</span>"<span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">age</span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">30</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">email</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">alice@example.com</span>"<span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Alice</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">age</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">30</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">email</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">alice@example.com</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
@@ -52,64 +50,62 @@ title = "From Value"
 <div class="input">
 <h4>Value Input</h4>
 <pre><code><span style="opacity:0.7">{</span>
-  <span style="color:rgb(115,218,202)">person</span><span style="opacity:0.7">: </span><span style="opacity:0.7">{</span>
-    <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Bob</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">age</span><span style="opacity:0.7">: </span><span style="color:rgb(255,158,100)">42</span><span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">email</span><span style="opacity:0.7">: </span><span style="color:rgb(187,154,247)">null</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">person</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="opacity:0.7">{</span>
+    <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Bob</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">age</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(255,158,100)">42</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">email</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(187,154,247)">null</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">address</span><span style="opacity:0.7">: </span><span style="opacity:0.7">{</span>
-    <span style="color:rgb(115,218,202)">street</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">123 Main St</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">city</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Springfield</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">zip</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">12345</span>"<span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">address</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="opacity:0.7">{</span>
+    <span style="color:rgb(115,218,202)">street</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">123 Main St</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">city</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Springfield</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">zip</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">12345</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">department</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Engineering</span>"<span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">department</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Engineering</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Employee </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">person</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> Person,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">address</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> Address,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">department</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Address </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">street</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">city</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">zip</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Person </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">age</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">email</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Employee</a-t> <a-p>{</a-p>
+    <a-pr>person</a-pr><a-p>:</a-p> <a-t>Person</a-t><a-p>,</a-p>
 
+    <a-pr>address</a-pr><a-p>:</a-p> <a-t>Address</a-t><a-p>,</a-p>
+
+    <a-pr>department</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Address</a-t> <a-p>{</a-p>
+    <a-pr>street</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-pr>city</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-pr>zip</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Person</a-t> <a-p>{</a-p>
+    <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-pr>age</a-pr><a-p>:</a-p> <a-t>u32</a-t><a-p>,</a-p>
+
+    <a-pr>email</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Employee</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">person</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="opacity:0.7"> {</span>
-    <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Bob</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">age</span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">42</span><span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">email</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Employee</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">person</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+    <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Bob</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">age</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">42</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">email</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">address</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Address</span><span style="opacity:0.7"> {</span>
-    <span style="color:rgb(115,218,202)">street</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">123 Main St</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">city</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Springfield</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">zip</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">12345</span>"<span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">address</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Address</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+    <span style="color:rgb(115,218,202)">street</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">123 Main St</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">city</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Springfield</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">zip</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">12345</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">department</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Engineering</span>"<span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">department</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Engineering</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
@@ -120,25 +116,23 @@ title = "From Value"
 <p class="description">A string value deserializes into a unit variant.</p>
 <div class="input">
 <h4>Value Input</h4>
-<pre><code>"<span style="color:rgb(158,206,106)">Active</span>"</code></pre>
+<pre><code>"<span style="color:rgb(158,206,106)">Active</span><span style="color:inherit">"</span></code></pre>
 </div>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">Status </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Active</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Inactive</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Pending</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>Status</a-t> <a-p>{</a-p>
+    <a-cr>Active</a-cr><a-p>,</a-p>
 
+    <a-cr>Inactive</a-cr><a-p>,</a-p>
+
+    <a-cr>Pending</a-cr><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Status</span><span style="opacity:0.7">::</span><span style="font-weight:bold">Active</span></code></pre>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Status</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">Active</span></code></pre>
 </div>
 </section>
 
@@ -149,30 +143,28 @@ title = "From Value"
 <div class="input">
 <h4>Value Input</h4>
 <pre><code><span style="opacity:0.7">{</span>
-  <span style="color:rgb(115,218,202)">Text</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Hello world!</span>"<span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">Text</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Hello world!</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">Message </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Text(</span><span style="color:#0db9d7;">String</span><span style="color:#9abdf5;">)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Number(</span><span style="color:#bb9af7;">i32</span><span style="color:#9abdf5;">)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Data {
-</span><span style="color:#9abdf5;">        id</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u64</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        payload</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>Message</a-t> <a-p>{</a-p>
+    <a-cr>Text</a-cr><a-p>(</a-p><a-t>String</a-t><a-p>),</a-p>
 
+    <a-cr>Number</a-cr><a-p>(</a-p><a-t>i32</a-t><a-p>),</a-p>
+
+    <a-cr>Data</a-cr> <a-p>{</a-p>
+        <a-pr>id</a-pr><a-p>:</a-p> <a-t>u64</a-t><a-p>,</a-p>
+
+        <a-pr>payload</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Message</span><span style="opacity:0.7">::</span><span style="font-weight:bold">Text</span><span style="opacity:0.7">(</span>"<span style="color:rgb(158,206,106)">Hello world!</span>"<span style="opacity:0.7">)</span></code></pre>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Message</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">Text</span><span style="opacity:0.7">(</span>"<span style="color:rgb(158,206,106)">Hello world!</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span></code></pre>
 </div>
 </section>
 
@@ -183,35 +175,33 @@ title = "From Value"
 <div class="input">
 <h4>Value Input</h4>
 <pre><code><span style="opacity:0.7">{</span>
-  <span style="color:rgb(115,218,202)">Data</span><span style="opacity:0.7">: </span><span style="opacity:0.7">{</span>
-    <span style="color:rgb(115,218,202)">id</span><span style="opacity:0.7">: </span><span style="color:rgb(255,158,100)">42</span><span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">payload</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">secret data</span>"<span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">Data</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="opacity:0.7">{</span>
+    <span style="color:rgb(115,218,202)">id</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(255,158,100)">42</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">payload</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">secret data</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">Message </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Text(</span><span style="color:#0db9d7;">String</span><span style="color:#9abdf5;">)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Number(</span><span style="color:#bb9af7;">i32</span><span style="color:#9abdf5;">)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Data {
-</span><span style="color:#9abdf5;">        id</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u64</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        payload</span><span style="color:#89ddff;">: </span><span style="color:#0db9d7;">String</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>Message</a-t> <a-p>{</a-p>
+    <a-cr>Text</a-cr><a-p>(</a-p><a-t>String</a-t><a-p>),</a-p>
 
+    <a-cr>Number</a-cr><a-p>(</a-p><a-t>i32</a-t><a-p>),</a-p>
+
+    <a-cr>Data</a-cr> <a-p>{</a-p>
+        <a-pr>id</a-pr><a-p>:</a-p> <a-t>u64</a-t><a-p>,</a-p>
+
+        <a-pr>payload</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Message</span><span style="opacity:0.7">::</span><span style="font-weight:bold">Data</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">id</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,179)">42</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">payload</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">secret data</span>"<span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Message</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">Data</span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">id</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,179)">42</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">payload</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">secret data</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
@@ -223,22 +213,20 @@ title = "From Value"
 <div class="input">
 <h4>Value Input</h4>
 <pre><code><span style="opacity:0.7">[</span>
-  <span style="color:rgb(255,158,100)">1</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(255,158,100)">2</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(255,158,100)">3</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(255,158,100)">4</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(255,158,100)">5</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(255,158,100)">1</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(255,158,100)">2</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(255,158,100)">3</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(255,158,100)">4</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(255,158,100)">5</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">]</span></code></pre>
 </div>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;i32&gt;</span><span style="opacity:0.7"> [</span><span style="color:rgb(224,81,93)">1</span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">2</span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">3</span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">4</span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">5</span><span style="opacity:0.7">]</span></code></pre>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;i32&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span><span style="color:rgb(224,81,93)">1</span><span style="color:inherit"></span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">2</span><span style="color:inherit"></span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">3</span><span style="color:inherit"></span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">4</span><span style="color:inherit"></span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">5</span><span style="color:inherit"></span><span style="opacity:0.7">]</span></code></pre>
 </div>
 </section>
 
@@ -249,20 +237,18 @@ title = "From Value"
 <div class="input">
 <h4>Value Input</h4>
 <pre><code><span style="opacity:0.7">[</span>
-  "<span style="color:rgb(158,206,106)">a</span>"<span style="opacity:0.7">,</span>
-  "<span style="color:rgb(158,206,106)">b</span>"<span style="opacity:0.7">,</span>
-  "<span style="color:rgb(158,206,106)">c</span>"<span style="opacity:0.7">,</span>
+  "<span style="color:rgb(158,206,106)">a</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  "<span style="color:rgb(158,206,106)">b</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  "<span style="color:rgb(158,206,106)">c</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">]</span></code></pre>
 </div>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">[String; 3]</span><span style="opacity:0.7"> [</span>"<span style="color:rgb(158,206,106)">a</span>"<span style="opacity:0.7">,</span> "<span style="color:rgb(158,206,106)">b</span>"<span style="opacity:0.7">,</span> "<span style="color:rgb(158,206,106)">c</span>"<span style="opacity:0.7">]</span></code></pre>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">[String; 3]</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span>"<span style="color:rgb(158,206,106)">a</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span> "<span style="color:rgb(158,206,106)">b</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span> "<span style="color:rgb(158,206,106)">c</span><span style="color:inherit">"</span><span style="opacity:0.7">]</span></code></pre>
 </div>
 </section>
 
@@ -273,23 +259,21 @@ title = "From Value"
 <div class="input">
 <h4>Value Input</h4>
 <pre><code><span style="opacity:0.7">{</span>
-  <span style="color:rgb(115,218,202)">x</span><span style="opacity:0.7">: </span><span style="color:rgb(255,158,100)">10</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">y</span><span style="opacity:0.7">: </span><span style="color:rgb(255,158,100)">20</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">z</span><span style="opacity:0.7">: </span><span style="color:rgb(255,158,100)">30</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">x</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(255,158,100)">10</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">y</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(255,158,100)">20</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">z</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(255,158,100)">30</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">HashMap&lt;String, i32&gt;</span><span style="opacity:0.7"> [</span>
-  "<span style="color:rgb(158,206,106)">z</span>"<span style="opacity:0.7"> =&gt; </span><span style="color:rgb(224,81,93)">30</span><span style="opacity:0.7">,</span>
-  "<span style="color:rgb(158,206,106)">x</span>"<span style="opacity:0.7"> =&gt; </span><span style="color:rgb(224,81,93)">10</span><span style="opacity:0.7">,</span>
-  "<span style="color:rgb(158,206,106)">y</span>"<span style="opacity:0.7"> =&gt; </span><span style="color:rgb(224,81,93)">20</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">HashMap&lt;String, i32&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span>
+  "<span style="color:rgb(158,206,106)">y</span><span style="color:inherit">"</span><span style="opacity:0.7"> =&gt; </span><span style="color:rgb(224,81,93)">20</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  "<span style="color:rgb(158,206,106)">x</span><span style="color:inherit">"</span><span style="opacity:0.7"> =&gt; </span><span style="color:rgb(224,81,93)">10</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  "<span style="color:rgb(158,206,106)">z</span><span style="color:inherit">"</span><span style="opacity:0.7"> =&gt; </span><span style="color:rgb(224,81,93)">30</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">]</span></code></pre>
 </div>
 </section>
@@ -301,22 +285,20 @@ title = "From Value"
 <div class="input">
 <h4>Value Input</h4>
 <pre><code><span style="opacity:0.7">[</span>
-  <span style="color:rgb(255,158,100)">1</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(187,154,247)">null</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(255,158,100)">3</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(187,154,247)">null</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(255,158,100)">5</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(255,158,100)">1</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(187,154,247)">null</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(255,158,100)">3</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(187,154,247)">null</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(255,158,100)">5</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">]</span></code></pre>
 </div>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;Option&gt;</span><span style="opacity:0.7"> [</span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::Some(</span><span style="color:rgb(224,81,93)">1</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span> <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span> <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::Some(</span><span style="color:rgb(224,81,93)">3</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span> <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span> <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::Some(</span><span style="color:rgb(224,81,93)">5</span><span style="opacity:0.7">)</span><span style="opacity:0.7">]</span></code></pre>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;Option&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span><span style="color:rgb(224,81,93)">1</span><span style="color:inherit"></span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span> <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span> <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span><span style="color:rgb(224,81,93)">3</span><span style="color:inherit"></span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span> <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span> <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span><span style="color:rgb(224,81,93)">5</span><span style="color:inherit"></span><span style="opacity:0.7">)</span><span style="opacity:0.7">]</span></code></pre>
 </div>
 </section>
 
@@ -327,28 +309,26 @@ title = "From Value"
 <div class="input">
 <h4>Value Input</h4>
 <pre><code><span style="opacity:0.7">{</span>
-  <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">minimal</span>"<span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">minimal</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Config </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">enabled</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">max_retries</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#bb9af7;">u32</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Config</a-t> <a-p>{</a-p>
+    <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
 
+    <a-pr>enabled</a-pr><a-p>:</a-p> <a-t>bool</a-t><a-p>,</a-p>
+
+    <a-pr>max_retries</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>u32</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Config</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">minimal</span>"<span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">enabled</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">false</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">max_retries</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Config</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">minimal</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">enabled</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">false</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">max_retries</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
@@ -362,13 +342,13 @@ title = "From Value"
 <p class="description">Trying to deserialize a string as an integer.</p>
 <div class="error">
 <h4>Error</h4>
-<pre><code>  <span style="color:#e06c75">×</span> reflection error: Operation failed on shape i32: Failed to parse string value
+<pre><code>  <span style="color:#e06c75">×</span> reflection error: failed to parse "not a number" as i32
 
 Error: 
   <span style="color:#e06c75">×</span> input.json
    ╭────
- <span style="opacity:0.7">1</span> │ <span style="color:rgb(192,197,206)">"</span><span style="color:rgb(163,190,140)">not a number</span><span style="color:rgb(192,197,206)">"
-   · </span><span style="color:#c678dd;font-weight:bold">───────┬──────</span>
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(125,207,255)">"not a number"</span>
+   · <span style="color:#c678dd;font-weight:bold">───────┬──────</span>
    ·        <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">this value</span>
    ╰────
 </code></pre>
@@ -385,8 +365,8 @@ Error: 
 Error: 
   <span style="color:#e06c75">×</span> input.json
    ╭────
- <span style="opacity:0.7">1</span> │ <span style="color:rgb(208,135,112)">1000
-   · </span><span style="color:#c678dd;font-weight:bold">──┬─</span>
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(122,162,247)">1000</span>
+   · <span style="color:#c678dd;font-weight:bold">──┬─</span>
    ·   <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">this value: 1000 out of range for u8</span>
    ╰────
 </code></pre>
@@ -403,13 +383,13 @@ Error: 
 Error: 
   <span style="color:#e06c75">×</span> input.json
    ╭─[1:1]
- <span style="opacity:0.7">1</span> │ <span style="color:#c678dd;font-weight:bold">╭</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> <span style="color:rgb(192,197,206)">[
- </span><span style="opacity:0.7">2</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">  </span><span style="color:rgb(208,135,112)">1</span><span style="color:rgb(192,197,206)">,
- </span><span style="opacity:0.7">3</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">  </span><span style="color:rgb(208,135,112)">2</span><span style="color:rgb(192,197,206)">,
- </span><span style="opacity:0.7">4</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">  </span><span style="color:rgb(208,135,112)">3</span><span style="color:rgb(192,197,206)">,
- </span><span style="opacity:0.7">5</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">  </span><span style="color:rgb(208,135,112)">4
- </span><span style="opacity:0.7">6</span> │ <span style="color:#c678dd;font-weight:bold">├</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> <span style="color:rgb(192,197,206)">]
-   · </span><span style="color:#c678dd;font-weight:bold">╰</span><span style="color:#c678dd;font-weight:bold">───</span><span style="color:#c678dd;font-weight:bold">─</span> <span style="color:#c678dd;font-weight:bold">this value</span>
+ <span style="opacity:0.7">1</span> │ <span style="color:#c678dd;font-weight:bold">╭</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> [
+ <span style="opacity:0.7">2</span> │ <span style="color:#c678dd;font-weight:bold">│</span>     <span style="color:rgb(122,162,247)">1</span>,
+ <span style="opacity:0.7">3</span> │ <span style="color:#c678dd;font-weight:bold">│</span>     <span style="color:rgb(122,162,247)">2</span>,
+ <span style="opacity:0.7">4</span> │ <span style="color:#c678dd;font-weight:bold">│</span>     <span style="color:rgb(122,162,247)">3</span>,
+ <span style="opacity:0.7">5</span> │ <span style="color:#c678dd;font-weight:bold">│</span>     <span style="color:rgb(122,162,247)">4</span>
+ <span style="opacity:0.7">6</span> │ <span style="color:#c678dd;font-weight:bold">├</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> ]
+   · <span style="color:#c678dd;font-weight:bold">╰</span><span style="color:#c678dd;font-weight:bold">───</span><span style="color:#c678dd;font-weight:bold">─</span> <span style="color:#c678dd;font-weight:bold">this value</span>
    ╰────
 </code></pre>
 </div>
@@ -425,22 +405,22 @@ Error: 
 Error: 
   <span style="color:#e06c75">×</span> input.json
    ╭────
- <span style="opacity:0.7">1</span> │ <span style="color:rgb(192,197,206)">"</span><span style="color:rgb(163,190,140)">Unknown</span><span style="color:rgb(192,197,206)">"
-   · </span><span style="color:#c678dd;font-weight:bold">────┬────</span>
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(125,207,255)">"Unknown"</span>
+   · <span style="color:#c678dd;font-weight:bold">────┬────</span>
    ·     <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">this value</span>
    ╰────
 
 Error: 
   <span style="color:#e06c75">×</span> target.rs
    ╭─[1:1]
- <span style="opacity:0.7">1</span> │ <span style="color:#c678dd;font-weight:bold">╭</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> <span style="color:rgb(192,197,206)">#</span><span style="color:rgb(192,197,206)">[</span><span style="color:rgb(191,97,106)">derive</span><span style="color:rgb(192,197,206)">(</span><span style="color:rgb(192,197,206)">Facet</span><span style="color:rgb(192,197,206)">)</span><span style="color:rgb(192,197,206)">]
- </span><span style="opacity:0.7">2</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">#</span><span style="color:rgb(192,197,206)">[</span><span style="color:rgb(191,97,106)">repr</span><span style="color:rgb(192,197,206)">(</span><span style="color:rgb(192,197,206)">u8</span><span style="color:rgb(192,197,206)">)</span><span style="color:rgb(192,197,206)">]
- </span><span style="opacity:0.7">3</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(180,142,173)">enum</span><span style="color:rgb(192,197,206)"> </span><span style="color:rgb(192,197,206)">Status</span><span style="color:rgb(192,197,206)"> </span><span style="color:rgb(192,197,206)">{
- </span><span style="opacity:0.7">4</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">    Active</span><span style="color:rgb(192,197,206)">,
- </span><span style="opacity:0.7">5</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">    Inactive</span><span style="color:rgb(192,197,206)">,
- </span><span style="opacity:0.7">6</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">    Pending</span><span style="color:rgb(192,197,206)">,
- </span><span style="opacity:0.7">7</span> │ <span style="color:#c678dd;font-weight:bold">├</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> <span style="color:rgb(192,197,206)">}
-   · </span><span style="color:#c678dd;font-weight:bold">╰</span><span style="color:#c678dd;font-weight:bold">───</span><span style="color:#c678dd;font-weight:bold">─</span> <span style="color:#c678dd;font-weight:bold">target type</span>
+ <span style="opacity:0.7">1</span> │ <span style="color:#c678dd;font-weight:bold">╭</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> #[derive(Facet)]
+ <span style="opacity:0.7">2</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   #[repr(u8)]
+ <span style="opacity:0.7">3</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(224,175,104)">enum</span> Status {
+ <span style="opacity:0.7">4</span> │ <span style="color:#c678dd;font-weight:bold">│</span>       Active,
+ <span style="opacity:0.7">5</span> │ <span style="color:#c678dd;font-weight:bold">│</span>       Inactive,
+ <span style="opacity:0.7">6</span> │ <span style="color:#c678dd;font-weight:bold">│</span>       Pending,
+ <span style="opacity:0.7">7</span> │ <span style="color:#c678dd;font-weight:bold">├</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> }
+   · <span style="color:#c678dd;font-weight:bold">╰</span><span style="color:#c678dd;font-weight:bold">───</span><span style="color:#c678dd;font-weight:bold">─</span> <span style="color:#c678dd;font-weight:bold">target type</span>
    ╰────
 </code></pre>
 </div>
@@ -456,24 +436,24 @@ Error: 
 Error: 
   <span style="color:#e06c75">×</span> input.json
    ╭─[1:1]
- <span style="opacity:0.7">1</span> │ <span style="color:#c678dd;font-weight:bold">╭</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> <span style="color:rgb(192,197,206)">[
- </span><span style="opacity:0.7">2</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">  </span><span style="color:rgb(208,135,112)">1</span><span style="color:rgb(192,197,206)">,
- </span><span style="opacity:0.7">3</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">  </span><span style="color:rgb(208,135,112)">2</span><span style="color:rgb(192,197,206)">,
- </span><span style="opacity:0.7">4</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">  </span><span style="color:rgb(208,135,112)">3
- </span><span style="opacity:0.7">5</span> │ <span style="color:#c678dd;font-weight:bold">├</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> <span style="color:rgb(192,197,206)">]
-   · </span><span style="color:#c678dd;font-weight:bold">╰</span><span style="color:#c678dd;font-weight:bold">───</span><span style="color:#c678dd;font-weight:bold">─</span> <span style="color:#c678dd;font-weight:bold">got Array</span>
+ <span style="opacity:0.7">1</span> │ <span style="color:#c678dd;font-weight:bold">╭</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> [
+ <span style="opacity:0.7">2</span> │ <span style="color:#c678dd;font-weight:bold">│</span>     <span style="color:rgb(122,162,247)">1</span>,
+ <span style="opacity:0.7">3</span> │ <span style="color:#c678dd;font-weight:bold">│</span>     <span style="color:rgb(122,162,247)">2</span>,
+ <span style="opacity:0.7">4</span> │ <span style="color:#c678dd;font-weight:bold">│</span>     <span style="color:rgb(122,162,247)">3</span>
+ <span style="opacity:0.7">5</span> │ <span style="color:#c678dd;font-weight:bold">├</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> ]
+   · <span style="color:#c678dd;font-weight:bold">╰</span><span style="color:#c678dd;font-weight:bold">───</span><span style="color:#c678dd;font-weight:bold">─</span> <span style="color:#c678dd;font-weight:bold">got Array</span>
    ╰────
 
 Error: 
   <span style="color:#e06c75">×</span> target.rs
    ╭─[1:1]
- <span style="opacity:0.7">1</span> │ <span style="color:#c678dd;font-weight:bold">╭</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> <span style="color:rgb(192,197,206)">#</span><span style="color:rgb(192,197,206)">[</span><span style="color:rgb(191,97,106)">derive</span><span style="color:rgb(192,197,206)">(</span><span style="color:rgb(192,197,206)">Facet</span><span style="color:rgb(192,197,206)">)</span><span style="color:rgb(192,197,206)">]
- </span><span style="opacity:0.7">2</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(180,142,173)">struct</span><span style="color:rgb(192,197,206)"> </span><span style="color:rgb(192,197,206)">Person</span><span style="color:rgb(192,197,206)"> </span><span style="color:rgb(192,197,206)">{
- </span><span style="opacity:0.7">3</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">    </span><span style="color:rgb(191,97,106)">name</span><span style="color:rgb(192,197,206)">:</span><span style="color:rgb(192,197,206)"> String,
- </span><span style="opacity:0.7">4</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">    </span><span style="color:rgb(191,97,106)">age</span><span style="color:rgb(192,197,206)">:</span><span style="color:rgb(192,197,206)"> </span><span style="color:rgb(180,142,173)">u32</span><span style="color:rgb(192,197,206)">,
- </span><span style="opacity:0.7">5</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(192,197,206)">    </span><span style="color:rgb(191,97,106)">email</span><span style="color:rgb(192,197,206)">:</span><span style="color:rgb(192,197,206)"> </span><span style="color:rgb(192,197,206)">Option</span><span style="color:rgb(192,197,206)">&lt;</span><span style="color:rgb(192,197,206)">String</span><span style="color:rgb(192,197,206)">&gt;</span><span style="color:rgb(192,197,206)">,
- </span><span style="opacity:0.7">6</span> │ <span style="color:#c678dd;font-weight:bold">├</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> <span style="color:rgb(192,197,206)">}
-   · </span><span style="color:#c678dd;font-weight:bold">╰</span><span style="color:#c678dd;font-weight:bold">───</span><span style="color:#c678dd;font-weight:bold">─</span> <span style="color:#c678dd;font-weight:bold">expected object</span>
+ <span style="opacity:0.7">1</span> │ <span style="color:#c678dd;font-weight:bold">╭</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> #[derive(Facet)]
+ <span style="opacity:0.7">2</span> │ <span style="color:#c678dd;font-weight:bold">│</span>   <span style="color:rgb(224,175,104)">struct</span> Person {
+ <span style="opacity:0.7">3</span> │ <span style="color:#c678dd;font-weight:bold">│</span>       name: String,
+ <span style="opacity:0.7">4</span> │ <span style="color:#c678dd;font-weight:bold">│</span>       age: u32,
+ <span style="opacity:0.7">5</span> │ <span style="color:#c678dd;font-weight:bold">│</span>       email: Option&lt;String&gt;,
+ <span style="opacity:0.7">6</span> │ <span style="color:#c678dd;font-weight:bold">├</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> }
+   · <span style="color:#c678dd;font-weight:bold">╰</span><span style="color:#c678dd;font-weight:bold">───</span><span style="color:#c678dd;font-weight:bold">─</span> <span style="color:#c678dd;font-weight:bold">expected object</span>
    ╰────
 </code></pre>
 </div>
@@ -481,9 +461,9 @@ Error: 
 <footer class="showcase-provenance">
 <p>This showcase was auto-generated from source code.</p>
 <dl>
-<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/a275f00e2c5593da5eaa528fe0b00814b555b5d7/facet-value/examples/from_value_showcase.rs"><code>facet-value/examples/from_value_showcase.rs</code></a></dd>
-<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/a275f00e2c5593da5eaa528fe0b00814b555b5d7"><code>a275f00e2</code></a></dd>
-<dt>Generated</dt><dd><time datetime="2025-12-12T07:18:58+01:00">2025-12-12T07:18:58+01:00</time></dd>
+<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/c5842bc4cd833fedc52522b20f09daedff260a0e/facet-value/examples/from_value_showcase.rs"><code>facet-value/examples/from_value_showcase.rs</code></a></dd>
+<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/c5842bc4cd833fedc52522b20f09daedff260a0e"><code>c5842bc4c</code></a></dd>
+<dt>Generated</dt><dd><time datetime="2026-01-04T12:56:12+01:00">2026-01-04T12:56:12+01:00</time></dd>
 <dt>Compiler</dt><dd><code>rustc 1.91.1 (ed61e7d7e 2025-11-07)</code></dd>
 </dl>
 </footer>

--- a/docs/content/guide/showcases/html.md
+++ b/docs/content/guide/showcases/html.md
@@ -1,0 +1,427 @@
++++
+title = "HTML"
++++
+
+<div class="showcase">
+
+[`facet-html`](https://docs.rs/facet-html) parses and serializes HTML documents using Facet. Define your document structure with `#[facet(html::element)]` for child elements, `#[facet(html::attribute)]` for tag attributes, and `#[facet(html::text)]` for text content.
+
+
+## Parsing HTML
+
+
+### Simple Document
+
+<section class="scenario">
+<p class="description">Parse a basic HTML document with head, body, and nested elements.</p>
+<details class="target-type">
+<summary>Target Type</summary>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple page structure with head and body.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimplePage</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>element</a-at><a-p>)]</a-p>
+    <a-pr>head</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>SimpleHead</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>element</a-at><a-p>)]</a-p>
+    <a-pr>body</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>SimpleBody</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleBody</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>class</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>elements</a-at><a-p>)]</a-p>
+    <a-pr>children</a-pr><a-p>:</a-p> <a-t>Vec</a-t><a-p>&lt;</a-p><a-t>BodyElement</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Elements that can appear in the body.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>BodyElement</a-t> <a-p>{</a-p>
+    h1<a-p>(</a-p><a-t>Heading</a-t><a-p>),</a-p>
+
+    p<a-p>(</a-p><a-t>Paragraph</a-t><a-p>),</a-p>
+
+    div<a-p>(</a-p><a-t>DivElement</a-t><a-p>),</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>DivElement</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>id</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>class</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>text</a-at><a-p>)]</a-p>
+    <a-pr>content</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Paragraph</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>class</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>text</a-at><a-p>)]</a-p>
+    <a-pr>text</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Heading</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>id</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>text</a-at><a-p>)]</a-p>
+    <a-pr>text</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleHead</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>element</a-at><a-p>)]</a-p>
+    <a-pr>title</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>SimpleTitle</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleTitle</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>text</a-at><a-p>)]</a-p>
+    <a-pr>text</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
+</details>
+<div class="input">
+<h4>HTML Input</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>&lt;html&gt;
+    &lt;head&gt;&lt;title&gt;My Page&lt;/title&gt;&lt;/head&gt;
+    &lt;body class=&quot;main&quot;&gt;
+        &lt;h1 id=&quot;header&quot;&gt;Welcome&lt;/h1&gt;
+        &lt;p&gt;Hello, world!&lt;/p&gt;
+    &lt;/body&gt;
+&lt;/html&gt;</code></pre>
+</div>
+<div class="success">
+<h4>Success</h4>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">SimplePage</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">head</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">SimpleHead</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+    <span style="color:rgb(115,218,202)">title</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">SimpleTitle</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+      <span style="color:rgb(115,218,202)">text</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">My Page</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="opacity:0.7">}</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+  <span style="opacity:0.7">}</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">body</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">SimpleBody</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+    <span style="color:rgb(115,218,202)">class</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">main</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">children</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;BodyElement&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span>
+      <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">BodyElement</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">h1</span><span style="opacity:0.7">(</span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Heading</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+        <span style="color:rgb(115,218,202)">id</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">header</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+        <span style="color:rgb(115,218,202)">text</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Welcome</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+      <span style="opacity:0.7">}</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+      <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">BodyElement</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">p</span><span style="opacity:0.7">(</span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Paragraph</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+        <span style="color:rgb(115,218,202)">class</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+        <span style="color:rgb(115,218,202)">text</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Hello, world!</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+      <span style="opacity:0.7">}</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+    <span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
+  <span style="opacity:0.7">}</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+<span style="opacity:0.7">}</span></code></pre>
+</div>
+</section>
+
+### Nested Elements
+
+<section class="scenario">
+<p class="description">Parse nested HTML elements into an enum-based content model.</p>
+<details class="target-type">
+<summary>Target Type</summary>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple page structure with head and body.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimplePage</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>element</a-at><a-p>)]</a-p>
+    <a-pr>head</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>SimpleHead</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>element</a-at><a-p>)]</a-p>
+    <a-pr>body</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>SimpleBody</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleBody</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>class</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>elements</a-at><a-p>)]</a-p>
+    <a-pr>children</a-pr><a-p>:</a-p> <a-t>Vec</a-t><a-p>&lt;</a-p><a-t>BodyElement</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p>
+
+<a-c>/// Elements that can appear in the body.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>BodyElement</a-t> <a-p>{</a-p>
+    h1<a-p>(</a-p><a-t>Heading</a-t><a-p>),</a-p>
+
+    p<a-p>(</a-p><a-t>Paragraph</a-t><a-p>),</a-p>
+
+    div<a-p>(</a-p><a-t>DivElement</a-t><a-p>),</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>DivElement</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>id</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>class</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>text</a-at><a-p>)]</a-p>
+    <a-pr>content</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Paragraph</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>class</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>text</a-at><a-p>)]</a-p>
+    <a-pr>text</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Heading</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>id</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>text</a-at><a-p>)]</a-p>
+    <a-pr>text</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleHead</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>element</a-at><a-p>)]</a-p>
+    <a-pr>title</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>SimpleTitle</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>SimpleTitle</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>text</a-at><a-p>)]</a-p>
+    <a-pr>text</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
+</details>
+<div class="input">
+<h4>HTML Input</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>&lt;html&gt;
+    &lt;body&gt;
+        &lt;div id=&quot;container&quot; class=&quot;wrapper&quot;&gt;
+            &lt;h1&gt;Title&lt;/h1&gt;
+            &lt;p class=&quot;intro&quot;&gt;Introduction paragraph.&lt;/p&gt;
+            &lt;div class=&quot;content&quot;&gt;Main content here.&lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/body&gt;
+&lt;/html&gt;</code></pre>
+</div>
+<div class="success">
+<h4>Success</h4>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">SimplePage</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">head</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">body</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">SimpleBody</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+    <span style="color:rgb(115,218,202)">class</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">children</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;BodyElement&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span>
+      <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">BodyElement</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">div</span><span style="opacity:0.7">(</span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">DivElement</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+        <span style="color:rgb(115,218,202)">id</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">container</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+        <span style="color:rgb(115,218,202)">class</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">wrapper</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+        <span style="color:rgb(115,218,202)">content</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)"></span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+      <span style="opacity:0.7">}</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+    <span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
+  <span style="opacity:0.7">}</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+<span style="opacity:0.7">}</span></code></pre>
+</div>
+</section>
+
+### Form Elements
+
+<section class="scenario">
+<p class="description">Parse HTML form elements with their attributes.</p>
+<details class="target-type">
+<summary>Target Type</summary>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A form element with various input types.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>ContactForm</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>action</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>method</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>elements</a-at><a-p>)]</a-p>
+    <a-pr>inputs</a-pr><a-p>:</a-p> <a-t>Vec</a-t><a-p>&lt;</a-p><a-t>FormInput</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>FormInput</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>type</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>name</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>placeholder</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>required</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
+</details>
+<div class="input">
+<h4>HTML Input</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>&lt;form action=&quot;/submit&quot; method=&quot;post&quot;&gt;
+    &lt;input type=&quot;text&quot; name=&quot;username&quot; placeholder=&quot;Username&quot; required /&gt;
+    &lt;input type=&quot;email&quot; name=&quot;email&quot; placeholder=&quot;Email&quot; /&gt;
+    &lt;input type=&quot;submit&quot; name=&quot;submit&quot; /&gt;
+&lt;/form&gt;</code></pre>
+</div>
+<div class="success">
+<h4>Success</h4>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">ContactForm</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">action</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">/submit</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">method</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">post</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">inputs</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;FormInput&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span>
+    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">FormInput</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+      <span style="color:rgb(115,218,202)">type</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">text</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">username</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">placeholder</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">Username</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">required</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)"></span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+    <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
+    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">FormInput</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+      <span style="color:rgb(115,218,202)">type</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">email</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">email</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">placeholder</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">Email</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">required</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+    <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
+    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">FormInput</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+      <span style="color:rgb(115,218,202)">type</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">submit</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">submit</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">placeholder</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">required</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+    <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
+  <span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
+<span style="opacity:0.7">}</span></code></pre>
+</div>
+</section>
+
+## Serialization
+
+
+### Minified Output
+
+<section class="scenario">
+<p class="description">Serialize to compact HTML without extra whitespace.</p>
+<details class="target-type">
+<summary>Target Type</summary>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>DivElement</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>id</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>class</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>text</a-at><a-p>)]</a-p>
+    <a-pr>content</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
+</details>
+<div class="serialized-output">
+<h4>HTML Output</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>&lt;DivElement id=&quot;main&quot; class=&quot;container&quot;&gt;Hello!&lt;/DivElement&gt;</code></pre>
+</div>
+</section>
+
+### Pretty-Printed Output
+
+<section class="scenario">
+<p class="description">Serialize with indentation for readability.</p>
+<details class="target-type">
+<summary>Target Type</summary>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A form element with various input types.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>ContactForm</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>action</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>method</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>elements</a-at><a-p>)]</a-p>
+    <a-pr>inputs</a-pr><a-p>:</a-p> <a-t>Vec</a-t><a-p>&lt;</a-p><a-t>FormInput</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>FormInput</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>type</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>name</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>placeholder</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>required</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
+</details>
+<div class="serialized-output">
+<h4>HTML Output</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>&lt;form action=&quot;/api/contact&quot; method=&quot;post&quot;&gt;
+  &lt;input type=&quot;text&quot; name=&quot;name&quot; placeholder=&quot;Your name&quot; required&gt;  &lt;input type=&quot;email&quot; name=&quot;email&quot; placeholder=&quot;your@email.com&quot;&gt;&lt;/form&gt;
+</code></pre>
+</div>
+</section>
+
+## Advanced Features
+
+
+### Extra Attributes (data-*, aria-*)
+
+<section class="scenario">
+<p class="description">Unknown attributes like <code>data-*</code> and <code>aria-*</code> are captured in the <code>extra</code> field via <code>#[facet(flatten)]</code>.</p>
+<details class="target-type">
+<summary>Target Type</summary>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A div that captures extra attributes (data-*, aria-*, etc.)
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>DivWithExtras</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>id</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>attribute</a-at><a-p>)]</a-p>
+    <a-pr>class</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-c>/// Captures data-*, aria-*, and other unknown attributes
+</a-c>    <a-pr>extra</a-pr><a-p>:</a-p> <a-t>BTreeMap</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>,</a-p> <a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>html</a-at><a-p>::</a-p><a-at>text</a-at><a-p>)]</a-p>
+    <a-pr>content</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
+</details>
+<div class="input">
+<h4>HTML Input</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>&lt;div id=&quot;widget&quot; class=&quot;card&quot; data-user-id=&quot;123&quot; data-theme=&quot;dark&quot; aria-label=&quot;User Card&quot;&gt;Content&lt;/div&gt;</code></pre>
+</div>
+<div class="success">
+<h4>Success</h4>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">DivWithExtras</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">id</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">widget</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">class</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">card</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">extra</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">BTreeMap&lt;String, String&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span>
+    "<span style="color:rgb(158,206,106)">aria-label</span><span style="color:inherit">"</span><span style="opacity:0.7"> =&gt; </span>"<span style="color:rgb(158,206,106)">User Card</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    "<span style="color:rgb(158,206,106)">data-theme</span><span style="color:inherit">"</span><span style="opacity:0.7"> =&gt; </span>"<span style="color:rgb(158,206,106)">dark</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    "<span style="color:rgb(158,206,106)">data-user-id</span><span style="color:inherit">"</span><span style="opacity:0.7"> =&gt; </span>"<span style="color:rgb(158,206,106)">123</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">content</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Content</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+<span style="opacity:0.7">}</span></code></pre>
+</div>
+</section>
+
+<footer class="showcase-provenance">
+<p>This showcase was auto-generated from source code.</p>
+<dl>
+<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/c5842bc4cd833fedc52522b20f09daedff260a0e/facet-html/examples/html_showcase.rs"><code>facet-html/examples/html_showcase.rs</code></a></dd>
+<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/c5842bc4cd833fedc52522b20f09daedff260a0e"><code>c5842bc4c</code></a></dd>
+<dt>Generated</dt><dd><time datetime="2026-01-04T12:56:12+01:00">2026-01-04T12:56:12+01:00</time></dd>
+<dt>Compiler</dt><dd><code>rustc 1.91.1 (ed61e7d7e 2025-11-07)</code></dd>
+</dl>
+</footer>
+</div>

--- a/docs/content/guide/showcases/kdl.md
+++ b/docs/content/guide/showcases/kdl.md
@@ -4,951 +4,464 @@ title = "KDL"
 
 <div class="showcase">
 
-[`facet-kdl`](https://docs.rs/facet-kdl) provides serialization and deserialization for [KDL](https://kdl.dev), a document language with a focus on human readability. Use attributes like `kdl::property`, `kdl::argument`, and `kdl::child` to control how your types map to KDL's node-based structure.
+[`facet-kdl`](https://docs.rs/facet-kdl) parses KDL documents into Rust types using `Facet` attributes. Map KDL arguments with `kdl::argument`, properties with `kdl::property`, and child nodes with `kdl::child` or `kdl::children`.
 
 
-## Basic Node with Properties
+## Successful Parsing
+
+
+### Simple Node with Argument and Property
 
 <section class="scenario">
-<p class="description">Simple struct with <code>#[facet(kdl::property)]</code> fields becomes KDL properties.</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">person </span><span style="color:#7dcfff;">name</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">Alice</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">age</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">30 </span><span style="color:#7dcfff;">email</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">alice@example.com</span><span style="color:#89ddff;">&quot;
-</span></pre>
-
-</div>
+<p class="description">Parse a node with a positional argument and a property.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">PersonDoc </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    person</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> Person,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Person </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    age</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    email</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple server configuration.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>ServerConfig</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>child</a-at><a-p>)]</a-p>
+    <a-pr>server</a-pr><a-p>:</a-p> <a-t>Server</a-t><a-p>,</a-p>
+<a-p>}</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Server</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>argument</a-at><a-p>)]</a-p>
+    <a-pr>host</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>property</a-at><a-p>)]</a-p>
+    <a-pr>port</a-pr><a-p>:</a-p> <a-t>u16</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
+<div class="input">
+<h4>KDL Input</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-v>server</a-v> <a-s>&quot;localhost&quot;</a-s> <a-v>port</a-v><a-o>=</a-o><a-n>8080</a-n></code></pre>
+</div>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">PersonDoc</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">person</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="opacity:0.7"> {</span>
-    <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Alice</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">age</span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">30</span><span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">email</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">alice@example.com</span>"<span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">ServerConfig</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">server</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Server</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+    <span style="color:rgb(115,218,202)">host</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">localhost</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">port</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(224,186,81)">8080</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
 
-## Node with Argument
+### Node with Properties
 
 <section class="scenario">
-<p class="description"><code>#[facet(kdl::argument)]</code> field becomes a positional argument after the node name.<br>Result: <code>server "web-01" host="localhost" port=8080</code></p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">server </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">web-01</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">host</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">localhost</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">port</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">8080
-</span></pre>
-
-</div>
+<p class="description">Parse a node with multiple key=value properties.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">ServerDoc </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    server</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> Server,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Server </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">argument)]
-</span><span style="color:#9abdf5;">    name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// Configuration with child nodes.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>DatabaseConfig</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>child</a-at><a-p>)]</a-p>
+    <a-pr>database</a-pr><a-p>:</a-p> <a-t>Database</a-t><a-p>,</a-p>
+<a-p>}</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Database</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>property</a-at><a-p>)]</a-p>
+    <a-pr>url</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>property</a-at><a-p>)]</a-p>
+    <a-pr>pool_size</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>u32</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
+<div class="input">
+<h4>KDL Input</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-v>database</a-v> <a-v>url</a-v><a-o>=</a-o><a-s>&quot;postgres://localhost/mydb&quot;</a-s> <a-v>pool_size</a-v><a-o>=</a-o><a-n>10</a-n></code></pre>
+</div>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">ServerDoc</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">server</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Server</span><span style="opacity:0.7"> {</span>
-    <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">web-01</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">host</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">localhost</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">port</span><span style="opacity:0.7">: </span><span style="color:rgb(224,186,81)">8080</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">DatabaseConfig</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">database</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Database</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+    <span style="color:rgb(115,218,202)">url</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">postgres://localhost/mydb</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">pool_size</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span><span style="color:rgb(207,81,224)">10</span><span style="color:inherit"></span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
 
-## Nested Nodes (Children)
+### Multiple Child Nodes
 
 <section class="scenario">
-<p class="description"><code>#[facet(kdl::child)]</code> fields become nested child nodes in braces.<br>The address struct becomes a child node of company.</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">company </span><span style="color:#7dcfff;">name</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">Acme Corp</span><span style="color:#89ddff;">&quot; </span><span style="color:#9abdf5;">{
-</span><span style="color:#c0caf5;">    </span><span style="color:#f7768e;">address </span><span style="color:#7dcfff;">street</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">123 Main St</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">city</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">Springfield</span><span style="color:#89ddff;">&quot;
-</span><span style="color:#9abdf5;">}
-</span></pre>
-
-</div>
+<p class="description">Parse multiple nodes of the same type into a Vec.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">CompanyDoc </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    company</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> Company,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Company </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    address</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> Address,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Address </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    street</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    city</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// Configuration expecting multiple children.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>UsersConfig</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>children</a-at><a-p>)]</a-p>
+    <a-pr>users</a-pr><a-p>:</a-p> <a-t>Vec</a-t><a-p>&lt;</a-p><a-t>User</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>User</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>argument</a-at><a-p>)]</a-p>
+    <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>property</a-at><a-p>)]</a-p>
+    <a-pr>admin</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>bool</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
-<div class="success">
-<h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">CompanyDoc</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">company</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Company</span><span style="opacity:0.7"> {</span>
-    <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Acme Corp</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">address</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Address</span><span style="opacity:0.7"> {</span>
-      <span style="color:rgb(115,218,202)">street</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">123 Main St</span>"<span style="opacity:0.7">,</span>
-      <span style="color:rgb(115,218,202)">city</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Springfield</span>"<span style="opacity:0.7">,</span>
-    <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
-  <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
-<span style="opacity:0.7">}</span></code></pre>
-</div>
-</section>
-
-## Vec as Repeated Children
-
-<section class="scenario">
-<p class="description"><code>#[facet(kdl::children)]</code> on a <code>Vec</code> field creates repeated child nodes.<br>Each <code>Member</code> becomes a separate <code>member</code> node.</p>
 <div class="input">
 <h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">member </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">Bob</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">role</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">Engineer</span><span style="color:#89ddff;">&quot;
-</span><span style="color:#f7768e;">member </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">Carol</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">role</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">Designer</span><span style="color:#89ddff;">&quot;
-</span><span style="color:#f7768e;">member </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">Dave</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">role</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">Manager</span><span style="color:#89ddff;">&quot;
-</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>
+<a-v>user</a-v> <a-s>&quot;alice&quot;</a-s> <a-v>admin</a-v><a-o>=</a-o><a-co>#true</a-co>
+<a-v>user</a-v> <a-s>&quot;bob&quot;</a-s>
+<a-v>user</a-v> <a-s>&quot;charlie&quot;</a-s> <a-v>admin</a-v><a-o>=</a-o><a-co>#false</a-co>
+</code></pre>
 </div>
-<details class="target-type">
-<summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">TeamDoc </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">children)]
-</span><span style="color:#9abdf5;">    member</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Vec</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">Member</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Member </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">argument)]
-</span><span style="color:#9abdf5;">    name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    role</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">}</span></pre>
-
-</details>
 <div class="success">
 <h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">TeamDoc</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">member</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;Member&gt;</span><span style="opacity:0.7"> [</span>
-    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Member</span><span style="opacity:0.7"> {</span>
-      <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Bob</span>"<span style="opacity:0.7">,</span>
-      <span style="color:rgb(115,218,202)">role</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Engineer</span>"<span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">UsersConfig</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">users</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;User&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span>
+    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">User</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+      <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">alice</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">admin</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span><span style="color:rgb(81,224,114)">true</span><span style="color:inherit"></span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
     <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
-    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Member</span><span style="opacity:0.7"> {</span>
-      <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Carol</span>"<span style="opacity:0.7">,</span>
-      <span style="color:rgb(115,218,202)">role</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Designer</span>"<span style="opacity:0.7">,</span>
+    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">User</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+      <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">bob</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">admin</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
     <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
-    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Member</span><span style="opacity:0.7"> {</span>
-      <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Dave</span>"<span style="opacity:0.7">,</span>
-      <span style="color:rgb(115,218,202)">role</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Manager</span>"<span style="opacity:0.7">,</span>
+    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">User</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+      <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">charlie</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">admin</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span><span style="color:rgb(81,224,114)">false</span><span style="color:inherit"></span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
     <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 </section>
 
-## Complex Nested Config
+## KDL Syntax Errors
+
+
+### Unclosed String
 
 <section class="scenario">
-<p class="description">A realistic application config showing:<br>- Top-level properties (<code>debug</code>, <code>features</code>)<br>- Child nodes with arguments (<code>server</code>, <code>database</code>)<br>- Nested children (<code>tls</code> inside <code>server</code>)<br>- Optional children (<code>tls</code> is <code>Option&lt;TlsConfig&gt;</code>)</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">server </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">api-gateway</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">host</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">0.0.0.0</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">port</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">443 </span><span style="color:#9abdf5;">{
-</span><span style="color:#c0caf5;">    </span><span style="color:#f7768e;">tls </span><span style="color:#7dcfff;">cert_path</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">/etc/ssl/cert.pem</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">key_path</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">/etc/ssl/key.pem</span><span style="color:#89ddff;">&quot;
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#f7768e;">database </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">primary</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">url</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">postgres://localhost/mydb</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">pool_size</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">10
-</span></pre>
-
-</div>
+<p class="description">KDL syntax error when a string literal is not closed.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">AppConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    debug</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    server</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> ServerConfig,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    database</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> DatabaseConfig,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    features</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Vec</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">DatabaseConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">argument)]
-</span><span style="color:#9abdf5;">    name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    url</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    pool_size</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">ServerConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">argument)]
-</span><span style="color:#9abdf5;">    name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    tls</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">TlsConfig</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">TlsConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    cert_path</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    key_path</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple server configuration.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>ServerConfig</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>child</a-at><a-p>)]</a-p>
+    <a-pr>server</a-pr><a-p>:</a-p> <a-t>Server</a-t><a-p>,</a-p>
+<a-p>}</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Server</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>argument</a-at><a-p>)]</a-p>
+    <a-pr>host</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>property</a-at><a-p>)]</a-p>
+    <a-pr>port</a-pr><a-p>:</a-p> <a-t>u16</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
+<div class="input">
+<h4>KDL Input</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-v>server</a-v> &quot;localhost port=8080</code></pre>
+</div>
 <div class="error">
 <h4>Error</h4>
-<pre><code><span style="color:#e06c75">kdl::invalid_document_shape</span>
-
-  <span style="color:#e06c75">×</span> invalid shape Undefined — needed struct with child/children fields
-</code></pre>
-</div>
-</section>
-
-## Roundtrip: Rust → KDL → Rust
-
-<section class="scenario">
-<p class="description">Demonstrates serialization followed by deserialization.<br>The value survives the roundtrip intact.</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">config </span><span style="color:#7dcfff;">debug</span><span style="color:#89ddff;">=</span><span style="color:#c0caf5;">#</span><span style="color:#ff9e64;">true </span><span style="color:#7dcfff;">max_connections</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">100 </span><span style="color:#7dcfff;">timeout_ms</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">5000
-</span></pre>
-
-</div>
-<details class="target-type">
-<summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">ConfigDoc </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    config</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> Config,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Config </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    debug</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    max_connections</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    timeout_ms</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
-
-</details>
-<div class="success">
-<h4>Success</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">ConfigDoc</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">config</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Config</span><span style="opacity:0.7"> {</span>
-    <span style="color:rgb(115,218,202)">debug</span><span style="opacity:0.7">: </span><span style="color:rgb(81,224,114)">true</span><span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">max_connections</span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">100</span><span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">timeout_ms</span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">5000</span><span style="opacity:0.7">,</span>
-  <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
-<span style="opacity:0.7">}</span></code></pre>
-</div>
-</section>
-
-## Ambiguous Flattened Enum
-
-<section class="scenario">
-<p class="description">Both TypeA and TypeB variants have identical fields (value, priority).<br>The solver cannot determine which variant to use.</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">resource </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">test</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">value</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">hello</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">priority</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">10</span></pre>
-
-</div>
-<details class="target-type">
-<summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">AmbiguousConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    resource</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> AmbiguousResource,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">AmbiguousResource </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">argument)]
-</span><span style="color:#9abdf5;">    name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">kind</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> AmbiguousKind,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">AmbiguousKind </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    TypeA(CommonFields)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    TypeB(CommonFields)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">CommonFields </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    value</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    priority</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
-
-</details>
-<div class="error">
-<h4>Error</h4>
-<pre><code><span style="color:#e06c75">kdl::solver</span>
-
-  <span style="color:#e06c75">×</span> Ambiguous: multiple resolutions match: ["AmbiguousKind::TypeA", "AmbiguousKind::TypeB"]
-<span style="color:#56b6c2">  help: </span>multiple variants match: AmbiguousKind::TypeA, AmbiguousKind::TypeB
-        use a KDL type annotation to specify the variant, e.g.: (VariantName)node-name ...
-</code></pre>
-</div>
-</section>
-
-## NoMatch with Per-Candidate Failures
-
-<section class="scenario">
-<p class="description">Provide field names that don't exactly match any variant.<br>The solver shows WHY each candidate failed with 'did you mean?' suggestions.</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">backend </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">cache</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">hst</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">localhost</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">conn_str</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">pg</span><span style="color:#89ddff;">&quot;</span></pre>
-
-</div>
-<details class="target-type">
-<summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">NoMatchConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    backend</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> NoMatchBackend,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">NoMatchBackend </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">argument)]
-</span><span style="color:#9abdf5;">    name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">kind</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> NoMatchKind,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">NoMatchKind </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Sqlite(SqliteBackend)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Postgres(PostgresBackend)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Redis(RedisBackend)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">RedisBackend </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    password</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">PostgresBackend </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    connection_string</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    pool_size</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SqliteBackend </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    database_path</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    journal_mode</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">}</span></pre>
-
-</details>
-<div class="error">
-<h4>Error</h4>
-<pre><code><span style="color:#e06c75">kdl::solver</span>
-
-  <span style="color:#e06c75">×</span> No matching configuration for fields ["conn_str", "hst", "name"]
-  <span style="color:#e06c75">│</span> 
-  <span style="color:#e06c75">│</span> No variant matched:
-  <span style="color:#e06c75">│</span>   - NoMatchKind::Redis: missing fields ["host", "port"], unknown fields ["conn_str", "hst"]
-  <span style="color:#e06c75">│</span>   - NoMatchKind::Postgres: missing fields ["connection_string", "pool_size"], unknown fields ["conn_str", "hst"]
-  <span style="color:#e06c75">│</span>   - NoMatchKind::Sqlite: missing fields ["database_path", "journal_mode"], unknown fields ["conn_str", "hst"]
-  <span style="color:#e06c75">│</span> 
-  <span style="color:#e06c75">│</span> Unknown fields: ["conn_str", "hst"]
-  <span style="color:#e06c75">│</span>   Did you mean 'connection_string' instead of 'conn_str'?
-  <span style="color:#e06c75">│</span>   Did you mean 'host' instead of 'hst'?
-   ╭────
- <span style="opacity:0.7">1</span> │ backend "cache" hst="localhost" conn_str="pg"
-   · <span style="color:#c678dd;font-weight:bold">                ─┬─</span><span style="color:#e5c07b;font-weight:bold">             ────┬───</span>
-   ·                  <span style="color:#c678dd;font-weight:bold">│</span>                  <span style="color:#e5c07b;font-weight:bold">╰── </span><span style="color:#e5c07b;font-weight:bold">did you mean &#96;connection_string&#96;?</span>
-   ·                  <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">did you mean &#96;host&#96;?</span>
+<pre><code>  <span style="color:#e06c75">×</span> Failed to parse KDL document
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">input.kdl:1:8</span>]
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(205,214,244)">server</span> "localhost port=8080
+   · <span style="color:#c678dd;font-weight:bold">       ──────────┬─────────</span>
+   ·                  <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">not quoted string</span>
    ╰────
-<span style="color:#56b6c2">  help: </span>did you mean NoMatchKind::Redis?
-        
-        all variants checked:
-          - NoMatchKind::Redis: missing host, port, unexpected conn_str, hst
-          - NoMatchKind::Postgres: missing connection_string, pool_size, unexpected conn_str, hst
-          - NoMatchKind::Sqlite: missing database_path, journal_mode, unexpected conn_str, hst
-        
-          conn_str -&gt; connection_string (did you mean connection_string?)
-          hst -&gt; host (did you mean host?)
-        
 </code></pre>
 </div>
 </section>
 
-## Unknown Fields with 'Did You Mean?' Suggestions
+### Unclosed Brace
 
 <section class="scenario">
-<p class="description">Misspell field names and see the solver suggest corrections!<br>Uses Jaro-Winkler similarity to find close matches.</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">server </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">web</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">hostnam</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">localhost</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">prot</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">8080</span></pre>
-
-</div>
+<p class="description">KDL syntax error when a children block is not closed.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">TypoConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    server</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> TypoServer,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">TypoServer </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">argument)]
-</span><span style="color:#9abdf5;">    name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">kind</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> TypoKind,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">TypoKind </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Web(WebServer)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Api(ApiServer)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">ApiServer </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    endpoint</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    timeout_ms</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    retry_count</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u8</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">WebServer </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    hostname</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    ssl_enabled</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">bool</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple server configuration.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>ServerConfig</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>child</a-at><a-p>)]</a-p>
+    <a-pr>server</a-pr><a-p>:</a-p> <a-t>Server</a-t><a-p>,</a-p>
+<a-p>}</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Server</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>argument</a-at><a-p>)]</a-p>
+    <a-pr>host</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>property</a-at><a-p>)]</a-p>
+    <a-pr>port</a-pr><a-p>:</a-p> <a-t>u16</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
+<div class="input">
+<h4>KDL Input</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>
+<a-v>parent</a-v> <a-p>{</a-p>
+    <a-v>child</a-v> <a-s>&quot;value&quot;</a-s>
+</code></pre>
+</div>
 <div class="error">
 <h4>Error</h4>
-<pre><code><span style="color:#e06c75">kdl::solver</span>
-
-  <span style="color:#e06c75">×</span> No matching configuration for fields ["hostnam", "name", "prot"]
-  <span style="color:#e06c75">│</span> 
-  <span style="color:#e06c75">│</span> No variant matched:
-  <span style="color:#e06c75">│</span>   - TypoKind::Web: missing fields ["hostname", "port", "ssl_enabled"], unknown fields ["hostnam", "prot"]
-  <span style="color:#e06c75">│</span>   - TypoKind::Api: missing fields ["endpoint", "retry_count", "timeout_ms"], unknown fields ["hostnam", "prot"]
-  <span style="color:#e06c75">│</span> 
-  <span style="color:#e06c75">│</span> Unknown fields: ["hostnam", "prot"]
-  <span style="color:#e06c75">│</span>   Did you mean 'hostname' instead of 'hostnam'?
-  <span style="color:#e06c75">│</span>   Did you mean 'port' instead of 'prot'?
-   ╭────
- <span style="opacity:0.7">1</span> │ server "web" hostnam="localhost" prot=8080
-   · <span style="color:#c678dd;font-weight:bold">             ───┬───</span><span style="color:#e5c07b;font-weight:bold">             ──┬─</span>
-   ·                 <span style="color:#c678dd;font-weight:bold">│</span>                  <span style="color:#e5c07b;font-weight:bold">╰── </span><span style="color:#e5c07b;font-weight:bold">did you mean &#96;port&#96;?</span>
-   ·                 <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">did you mean &#96;hostname&#96;?</span>
+<pre><code>  <span style="color:#e06c75">×</span> Failed to parse KDL document
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">input.kdl:2:8</span>]
+ <span style="opacity:0.7">1</span> │     
+ <span style="opacity:0.7">2</span> │ <span style="color:#e5c07b;font-weight:bold">╭</span><span style="color:#e5c07b;font-weight:bold">─</span><span style="color:#e5c07b;font-weight:bold">▶</span> <span style="color:rgb(205,214,244)">parent</span> <span style="color:rgb(147,153,178)">{</span>
+   · <span style="color:#e5c07b;font-weight:bold">│</span>   <span style="color:#c678dd;font-weight:bold">       ┬</span>
+   · <span style="color:#e5c07b;font-weight:bold">│</span>          <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">not closed</span>
+ <span style="opacity:0.7">3</span> │ <span style="color:#e5c07b;font-weight:bold">├</span><span style="color:#e5c07b;font-weight:bold">─</span><span style="color:#e5c07b;font-weight:bold">▶</span>     <span style="color:rgb(205,214,244)">child</span> <span style="color:rgb(166,227,161)">"value"</span>
+   · <span style="color:#e5c07b;font-weight:bold">╰</span><span style="color:#e5c07b;font-weight:bold">───</span><span style="color:#e5c07b;font-weight:bold">─</span> <span style="color:#e5c07b;font-weight:bold">not closed</span>
    ╰────
-<span style="color:#56b6c2">  help: </span>did you mean TypoKind::Web?
-        
-        all variants checked:
-          - TypoKind::Web: missing hostname, port, ssl_enabled, unexpected hostnam, prot
-          - TypoKind::Api: missing endpoint, retry_count, timeout_ms, unexpected hostnam, prot
-        
-          hostnam -&gt; hostname (did you mean hostname?)
-          prot -&gt; port (did you mean port?)
-        
 </code></pre>
 </div>
 </section>
 
-## Value Overflow Detection
+### Invalid Number
 
 <section class="scenario">
-<p class="description">When a value doesn't fit ANY candidate type, the solver reports it.<br>count=5000000000 exceeds both u8 (max 255) and u32 (max ~4 billion).</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">data </span><span style="color:#7dcfff;">count</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">5000000000</span></pre>
-
-</div>
+<p class="description">Error when a property value looks like a number but isn't valid.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">ValueConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    data</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> ValueData,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">ValueData </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">payload</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> ValuePayload,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">ValuePayload </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Small(SmallValue)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Large(LargeValue)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">LargeValue </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    count</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SmallValue </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    count</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u8</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple server configuration.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>ServerConfig</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>child</a-at><a-p>)]</a-p>
+    <a-pr>server</a-pr><a-p>:</a-p> <a-t>Server</a-t><a-p>,</a-p>
+<a-p>}</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Server</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>argument</a-at><a-p>)]</a-p>
+    <a-pr>host</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>property</a-at><a-p>)]</a-p>
+    <a-pr>port</a-pr><a-p>:</a-p> <a-t>u16</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
+<div class="input">
+<h4>KDL Input</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-v>server</a-v> <a-s>&quot;localhost&quot;</a-s> <a-v>port</a-v><a-o>=</a-o><a-n>808</a-n>O</code></pre>
+</div>
 <div class="error">
 <h4>Error</h4>
-<pre><code><span style="color:#e06c75">kdl::invalid_value</span>
-
-  <span style="color:#e06c75">×</span> invalid value for shape: value Integer(5000000000) doesn't fit any candidate type for field 'count'
+<pre><code>  <span style="color:#e06c75">×</span> Failed to parse KDL document
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">input.kdl:1:1</span>]
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(205,214,244)">server</span> <span style="color:rgb(166,227,161)">"localhost"</span> <span style="color:rgb(205,214,244)">port</span><span style="color:rgb(148,226,213)">=</span><span style="color:rgb(250,179,135)">808</span>O
+   · <span style="color:#c678dd;font-weight:bold">─────────────┬─────────────</span>
+   ·              <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">not property value</span>
+   ╰────
 </code></pre>
 </div>
 </section>
 
-## Multi-Line Config with Typos
+## Schema Mismatch Errors
+
+
+### Expected Scalar, Got Struct
 
 <section class="scenario">
-<p class="description">A more realistic multi-line configuration file with several typos.<br>Shows how the solver sorts candidates by closeness to the input.</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">database </span><span style="color:#89ddff;">&quot;</span><span style="color:#9ece6a;">production</span><span style="color:#89ddff;">&quot;</span><span style="color:#c0caf5;"> \
-</span><span style="color:#c0caf5;">    </span><span style="color:#7dcfff;">hots</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">db.example.com</span><span style="color:#89ddff;">&quot;</span><span style="color:#c0caf5;"> \
-</span><span style="color:#c0caf5;">    </span><span style="color:#7dcfff;">prot</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">3306</span><span style="color:#c0caf5;"> \
-</span><span style="color:#c0caf5;">    </span><span style="color:#7dcfff;">usernme</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">admin</span><span style="color:#89ddff;">&quot;</span><span style="color:#c0caf5;"> \
-</span><span style="color:#c0caf5;">    </span><span style="color:#7dcfff;">pasword</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">secret123</span><span style="color:#89ddff;">&quot;
-</span></pre>
-
-</div>
+<p class="description">Error when a field expects a scalar value but receives a child node. This happens when using <code>kdl::property</code> for what should be <code>kdl::child</code>.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">MultiLineConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    database</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> MultiLineDatabase,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">MultiLineDatabase </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">argument)]
-</span><span style="color:#9abdf5;">    name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">kind</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> MultiLineDbKind,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">MultiLineDbKind </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    MySql(MySqlConfig)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Postgres(PgConfig)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Mongo(MongoConfig)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">MongoConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    uri</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    replica_set</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">PgConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    database</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    ssl_mode</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">MySqlConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    username</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    password</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// Rust config similar to dodeca&#39;s RustConfig.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>RustConfigWrapper</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>child</a-at><a-p>)]</a-p>
+    <a-pr>rust</a-pr><a-p>:</a-p> <a-t>RustConfig</a-t><a-p>,</a-p>
+<a-p>}</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>RustConfig</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>property</a-at><a-p>)]</a-p>
+    <a-pr>command</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>property</a-at><a-p>)]</a-p>
+    <a-pr>args</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>Vec</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
+<div class="input">
+<h4>KDL Input</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code>
+<a-v>rust</a-v> <a-p>{</a-p>
+    <a-v>command</a-v> <a-s>&quot;cargo&quot;</a-s>
+    <a-v>args</a-v> <a-s>&quot;run&quot;</a-s> <a-s>&quot;--quiet&quot;</a-s> <a-s>&quot;--release&quot;</a-s>
+<a-p>}</a-p>
+</code></pre>
+</div>
 <div class="error">
 <h4>Error</h4>
-<pre><code><span style="color:#e06c75">kdl::solver</span>
+<pre><code>  <span style="color:#e06c75">×</span> expected &#96;String&#96; value, got element
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">input.kdl:3:5</span>]
+ <span style="opacity:0.7">2</span> │ <span style="color:rgb(205,214,244)">rust</span> <span style="color:rgb(147,153,178)">{</span>
+ <span style="opacity:0.7">3</span> │     <span style="color:rgb(205,214,244)">command</span> <span style="color:rgb(166,227,161)">"cargo"</span>
+   · <span style="color:#c678dd;font-weight:bold">    ───────┬───────</span>
+   ·            <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">got element here</span>
+ <span style="opacity:0.7">4</span> │     <span style="color:rgb(205,214,244)">args</span> <span style="color:rgb(166,227,161)">"run"</span> <span style="color:rgb(166,227,161)">"--quiet"</span> <span style="color:rgb(166,227,161)">"--release"</span>
+   ╰────
+<span style="color:#56b6c2">  help: </span>field &#96;command&#96; is marked with &#96;#[facet(kdl::property)]&#96;, so use &#96;command="value"&#96; syntax instead of &#96;command "value"&#96;
 
-  <span style="color:#e06c75">×</span> No matching configuration for fields ["hots", "name", "pasword", "prot", "usernme"]
-  <span style="color:#e06c75">│</span> 
-  <span style="color:#e06c75">│</span> No variant matched:
-  <span style="color:#e06c75">│</span>   - MultiLineDbKind::MySql: missing fields ["host", "password", "port", "username"], unknown fields ["hots", "pasword", "prot", "usernme"]
-  <span style="color:#e06c75">│</span>   - MultiLineDbKind::Postgres: missing fields ["database", "host", "port", "ssl_mode"], unknown fields ["hots", "pasword", "prot", "usernme"]
-  <span style="color:#e06c75">│</span>   - MultiLineDbKind::Mongo: missing field 'uri', unknown fields ["hots", "pasword", "prot", "usernme"]
-  <span style="color:#e06c75">│</span> 
-  <span style="color:#e06c75">│</span> Unknown fields: ["hots", "pasword", "prot", "usernme"]
-  <span style="color:#e06c75">│</span>   Did you mean 'host' instead of 'hots'?
-  <span style="color:#e06c75">│</span>   Did you mean 'password' instead of 'pasword'?
-  <span style="color:#e06c75">│</span>   Did you mean 'port' instead of 'prot'?
-  <span style="color:#e06c75">│</span>   Did you mean 'username' instead of 'usernme'?
-   ╭─[2:5]
- <span style="opacity:0.7">1</span> │ database "production" \
- <span style="opacity:0.7">2</span> │     hots="db.example.com" \
-   · <span style="color:#c678dd;font-weight:bold">    ──┬─</span>
-   ·       <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">did you mean &#96;host&#96;?</span>
- <span style="opacity:0.7">3</span> │     prot=3306 \
+Error: 
+  <span style="color:#e06c75">×</span> expected type &#96;RustConfigWrapper&#96;
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">RustConfig.rs:2:8</span>]
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(249,226,175)">#[derive(Facet)]</span>
+ <span style="opacity:0.7">2</span> │ <span style="color:rgb(203,166,247)">struct</span> RustConfig <span style="color:rgb(147,153,178)">{</span>
+   · <span style="color:#c678dd;font-weight:bold">       ──────────</span>
+ <span style="opacity:0.7">3</span> │     <span style="color:rgb(249,226,175)">#[facet(kdl::property)]</span>
+ <span style="opacity:0.7">4</span> │     <span style="color:rgb(137,180,250)">command</span><span style="color:rgb(147,153,178)">:</span> <span style="color:rgb(249,226,175)">Option</span><span style="color:rgb(147,153,178)">&lt;</span><span style="color:rgb(249,226,175)">String</span><span style="color:rgb(147,153,178)">&gt;,</span>
+   · <span style="color:#e5c07b;font-weight:bold">    ───┬───</span>
+   ·        <span style="color:#e5c07b;font-weight:bold">╰── </span><span style="color:#e5c07b;font-weight:bold">as requested here</span>
+ <span style="opacity:0.7">5</span> │     <span style="color:rgb(249,226,175)">#[facet(kdl::property)]</span>
+   ╰────
+
+Error: 
+  <span style="color:#e06c75">×</span> in type &#96;RustConfigWrapper&#96;
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">RustConfigWrapper.rs:2:8</span>]
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(249,226,175)">#[derive(Facet)]</span>
+ <span style="opacity:0.7">2</span> │ <span style="color:rgb(203,166,247)">struct</span> <span style="color:rgb(249,226,175)">RustConfigWrapper</span> <span style="color:rgb(147,153,178)">{</span>
+   · <span style="color:#c678dd;font-weight:bold">       ─────────────────</span>
+ <span style="opacity:0.7">3</span> │     <span style="color:rgb(249,226,175)">#[facet(kdl::child)]</span>
+ <span style="opacity:0.7">4</span> │     <span style="color:rgb(137,180,250)">rust</span><span style="color:rgb(147,153,178)">:</span> <span style="color:rgb(249,226,175)">RustConfig</span><span style="color:rgb(147,153,178)">,</span>
    · <span style="color:#e5c07b;font-weight:bold">    ──┬─</span>
-   ·       <span style="color:#e5c07b;font-weight:bold">╰── </span><span style="color:#e5c07b;font-weight:bold">did you mean &#96;port&#96;?</span>
- <span style="opacity:0.7">4</span> │     usernme="admin" \
-   · <span style="color:#98c379;font-weight:bold">    ───┬───</span>
-   ·        <span style="color:#98c379;font-weight:bold">╰── </span><span style="color:#98c379;font-weight:bold">did you mean &#96;username&#96;?</span>
- <span style="opacity:0.7">5</span> │     pasword="secret123"
-   · <span style="color:#c678dd;font-weight:bold">    ───┬───</span>
-   ·        <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">did you mean &#96;password&#96;?</span>
+   ·       <span style="color:#e5c07b;font-weight:bold">╰── </span><span style="color:#e5c07b;font-weight:bold">via this field</span>
+ <span style="opacity:0.7">5</span> │ <span style="color:rgb(147,153,178)">}</span>
    ╰────
-<span style="color:#56b6c2">  help: </span>did you mean MultiLineDbKind::MySql?
-        
-        all variants checked:
-          - MultiLineDbKind::MySql: missing host, password, port, username, unexpected hots, pasword, prot, usernme
-          - MultiLineDbKind::Postgres: missing database, host, port, ssl_mode, unexpected hots, pasword, prot, usernme
-          - MultiLineDbKind::Mongo: missing uri, unexpected hots, pasword, prot, usernme
-        
-          hots -&gt; host (did you mean host?)
-          pasword -&gt; password (did you mean password?)
-          prot -&gt; port (did you mean port?)
-          usernme -&gt; username (did you mean username?)
-        
 </code></pre>
 </div>
 </section>
 
-## Unknown Field
+### Missing Required Field
 
 <section class="scenario">
-<p class="description">KDL contains a property that doesn't exist in the target struct.<br>With #[facet(deny_unknown_fields)], this is an error.</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">server </span><span style="color:#7dcfff;">host</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">localhost</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">prot</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">8080</span></pre>
-
-</div>
+<p class="description">Error when a required field (without <code>default</code>) is not provided.</p>
 <details class="target-type">
 <summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">deny_unknown_fields</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    server</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> SimpleServer,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">deny_unknown_fields</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleServer </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple server configuration.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>ServerConfig</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>child</a-at><a-p>)]</a-p>
+    <a-pr>server</a-pr><a-p>:</a-p> <a-t>Server</a-t><a-p>,</a-p>
+<a-p>}</a-p>
 
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Server</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>argument</a-at><a-p>)]</a-p>
+    <a-pr>host</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>property</a-at><a-p>)]</a-p>
+    <a-pr>port</a-pr><a-p>:</a-p> <a-t>u16</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
 </details>
+<div class="input">
+<h4>KDL Input</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-v>server</a-v> <a-v>port</a-v><a-o>=</a-o><a-n>8080</a-n></code></pre>
+</div>
 <div class="error">
 <h4>Error</h4>
-<pre><code><span style="color:#e06c75">kdl::unknown_property</span>
+<pre><code><span style="color:#e06c75">facet::missing_field</span>
 
-  <span style="color:#e06c75">×</span> unknown property 'prot', expected one of: host, port
-   ╭────
- <span style="opacity:0.7">1</span> │ server host="localhost" prot=8080
-   · <span style="color:#c678dd;font-weight:bold">                        ──┬─</span>
-   ·                           <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">unknown property &#96;prot&#96;</span>
+  <span style="color:#e06c75">×</span> missing field &#96;host&#96; in type &#96;Server&#96;
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">input.kdl:1:1</span>]
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(205,214,244)">server</span> <span style="color:rgb(205,214,244)">port</span><span style="color:rgb(148,226,213)">=</span><span style="color:rgb(250,179,135)">8080</span>
+   · <span style="color:#c678dd;font-weight:bold">────────┬───────</span>
+   ·         <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">missing field 'host'</span>
    ╰────
-<span style="color:#56b6c2">  help: </span>expected one of: host, port
-</code></pre>
-</div>
-</section>
-
-## Missing Required Field
-
-<section class="scenario">
-<p class="description">KDL is missing a required field that has no default.</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">server </span><span style="color:#7dcfff;">host</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">localhost</span><span style="color:#89ddff;">&quot;</span></pre>
-
-</div>
-<details class="target-type">
-<summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">deny_unknown_fields</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    server</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> SimpleServer,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">deny_unknown_fields</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleServer </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
-
-</details>
-<div class="error">
-<h4>Error</h4>
-<pre><code><span style="color:#e06c75">kdl::reflect</span>
-
-  <span style="color:#e06c75">×</span> Field 'SimpleServer::port' was not initialized. If you need to leave fields partially initialized and come back later, use deferred mode (begin_deferred/finish_deferred)
-</code></pre>
-</div>
-</section>
-
-## Syntax Error: Unquoted Boolean
-
-<section class="scenario">
-<p class="description">KDL 2.0 requires booleans to be written as #true/#false.<br>Bare <code>true</code> or <code>false</code> is a syntax error with a helpful message.</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">server </span><span style="color:#7dcfff;">host</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">localhost</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">enabled</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">true</span></pre>
-
-</div>
-<details class="target-type">
-<summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">deny_unknown_fields</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    server</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> SimpleServer,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">deny_unknown_fields</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleServer </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
-
-</details>
-<div class="error">
-<h4>Error</h4>
-<pre><code><span style="color:#e06c75">kdl::parse</span>
-
-  <span style="color:#e06c75">×</span> Failed to parse KDL document
+<span style="color:#56b6c2">  help: </span>add &#96;host&#96; to your input, or mark the field as optional with #[facet(default)]
 
 Error: 
-  <span style="color:#e06c75">×</span> Expected identifier string
-   ╭────
- <span style="opacity:0.7">1</span> │ server host="localhost" enabled=true
-   · <span style="color:#c678dd;font-weight:bold">                                ──┬─</span>
-   ·                                   <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">not identifier string</span>
-   ╰────
-</code></pre>
-</div>
-</section>
-
-## Syntax Error: Unclosed Brace
-
-<section class="scenario">
-<p class="description">Missing closing brace in nested node structure.<br>The parser provides line/column information for the error.</p>
-<div class="input">
-<h4>KDL Input</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#f7768e;">server </span><span style="color:#7dcfff;">host</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">localhost</span><span style="color:#89ddff;">&quot; </span><span style="color:#7dcfff;">port</span><span style="color:#89ddff;">=</span><span style="color:#ff9e64;">8080 </span><span style="color:#9abdf5;">{
-</span><span style="color:#c0caf5;">    </span><span style="color:#f7768e;">tls </span><span style="color:#7dcfff;">cert</span><span style="color:#89ddff;">=&quot;</span><span style="color:#9ece6a;">/path/to/cert</span><span style="color:#89ddff;">&quot;
-</span></pre>
-
-</div>
-<details class="target-type">
-<summary>Target Type</summary>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">deny_unknown_fields</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleConfig </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">child)]
-</span><span style="color:#9abdf5;">    server</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> SimpleServer,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">facet</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">deny_unknown_fields</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">SimpleServer </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    host</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    #[facet(</span><span style="color:#7dcfff;">kdl</span><span style="color:#89ddff;">::</span><span style="color:#9abdf5;">property)]
-</span><span style="color:#9abdf5;">    port</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u16</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
-
-</details>
-<div class="error">
-<h4>Error</h4>
-<pre><code><span style="color:#e06c75">kdl::parse</span>
-
-  <span style="color:#e06c75">×</span> Failed to parse KDL document
-
-Error: 
-  <span style="color:#e06c75">×</span> No closing '}' for child block
-   ╭─[1:35]
- <span style="opacity:0.7">1</span> │ server host="localhost" port=8080 {
-   · <span style="color:#c678dd;font-weight:bold">                                  ┬</span>
-   ·                                   <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">not closed</span>
- <span style="opacity:0.7">2</span> │     tls cert="/path/to/cert"
+  <span style="color:#e06c75">×</span> expected type &#96;ServerConfig&#96;
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">Server.rs:2:8</span>]
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(249,226,175)">#[derive(Facet)]</span>
+ <span style="opacity:0.7">2</span> │ <span style="color:rgb(203,166,247)">struct</span> Server <span style="color:rgb(147,153,178)">{</span>
+   · <span style="color:#c678dd;font-weight:bold">       ──────</span>
+ <span style="opacity:0.7">3</span> │     <span style="color:rgb(249,226,175)">#[facet(kdl::argument)]</span>
+ <span style="opacity:0.7">4</span> │     <span style="color:rgb(137,180,250)">host</span><span style="color:rgb(147,153,178)">:</span> <span style="color:rgb(249,226,175)">String</span><span style="color:rgb(147,153,178)">,</span>
+   · <span style="color:#e5c07b;font-weight:bold">    ──┬─</span>
+   ·       <span style="color:#e5c07b;font-weight:bold">╰── </span><span style="color:#e5c07b;font-weight:bold">as requested here</span>
+ <span style="opacity:0.7">5</span> │     <span style="color:rgb(249,226,175)">#[facet(kdl::property)]</span>
    ╰────
 
 Error: 
-  <span style="color:#e06c75">×</span> Closing '}' was not found after nodes
-   ╭─[1:36]
- <span style="opacity:0.7">1</span> │ <span style="color:#c678dd;font-weight:bold">╭</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span> server host="localhost" port=8080 {
- <span style="opacity:0.7">2</span> │ <span style="color:#c678dd;font-weight:bold">├</span><span style="color:#c678dd;font-weight:bold">─</span><span style="color:#c678dd;font-weight:bold">▶</span>     tls cert="/path/to/cert"
-   · <span style="color:#c678dd;font-weight:bold">╰</span><span style="color:#c678dd;font-weight:bold">───</span><span style="color:#c678dd;font-weight:bold">─</span> <span style="color:#c678dd;font-weight:bold">not closed</span>
+  <span style="color:#e06c75">×</span> in type &#96;ServerConfig&#96;
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">ServerConfig.rs:2:8</span>]
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(249,226,175)">#[derive(Facet)]</span>
+ <span style="opacity:0.7">2</span> │ <span style="color:rgb(203,166,247)">struct</span> <span style="color:rgb(249,226,175)">ServerConfig</span> <span style="color:rgb(147,153,178)">{</span>
+   · <span style="color:#c678dd;font-weight:bold">       ────────────</span>
+ <span style="opacity:0.7">3</span> │     <span style="color:rgb(249,226,175)">#[facet(kdl::child)]</span>
+ <span style="opacity:0.7">4</span> │     <span style="color:rgb(137,180,250)">server</span><span style="color:rgb(147,153,178)">:</span> <span style="color:rgb(249,226,175)">Server</span><span style="color:rgb(147,153,178)">,</span>
+   · <span style="color:#e5c07b;font-weight:bold">    ───┬──</span>
+   ·        <span style="color:#e5c07b;font-weight:bold">╰── </span><span style="color:#e5c07b;font-weight:bold">via this field</span>
+ <span style="opacity:0.7">5</span> │ <span style="color:rgb(147,153,178)">}</span>
+   ╰────
+</code></pre>
+</div>
+</section>
+
+### Wrong Value Type
+
+<section class="scenario">
+<p class="description">Error when a property value cannot be parsed as the expected type.</p>
+<details class="target-type">
+<summary>Target Type</summary>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-c>/// A simple server configuration.
+</a-c><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>ServerConfig</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>child</a-at><a-p>)]</a-p>
+    <a-pr>server</a-pr><a-p>:</a-p> <a-t>Server</a-t><a-p>,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Server</a-t> <a-p>{</a-p>
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>argument</a-at><a-p>)]</a-p>
+    <a-pr>host</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-at>#</a-at><a-p>[</a-p><a-at>facet</a-at><a-p>(</a-p><a-at>kdl</a-at><a-p>::</a-p><a-at>property</a-at><a-p>)]</a-p>
+    <a-pr>port</a-pr><a-p>:</a-p> <a-t>u16</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
+</details>
+<div class="input">
+<h4>KDL Input</h4>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-v>server</a-v> <a-s>&quot;localhost&quot;</a-s> <a-v>port</a-v><a-o>=</a-o><a-s>&quot;not-a-number&quot;</a-s></code></pre>
+</div>
+<div class="error">
+<h4>Error</h4>
+<pre><code>  <span style="color:#e06c75">×</span> failed to parse "not-a-number" as u16
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">input.kdl:1:20</span>]
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(205,214,244)">server</span> <span style="color:rgb(166,227,161)">"localhost"</span> <span style="color:rgb(205,214,244)">port</span><span style="color:rgb(148,226,213)">=</span><span style="color:rgb(166,227,161)">"not-a-number"</span>
+   · <span style="color:#c678dd;font-weight:bold">                   ─────────┬─────────</span>
+   ·                             <span style="color:#c678dd;font-weight:bold">╰── </span><span style="color:#c678dd;font-weight:bold">invalid value for &#96;u16&#96;</span>
+   ╰────
+
+Error: 
+  <span style="color:#e06c75">×</span> expected type &#96;ServerConfig&#96;
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">Server.rs:2:8</span>]
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(249,226,175)">#[derive(Facet)]</span>
+ <span style="opacity:0.7">2</span> │ <span style="color:rgb(203,166,247)">struct</span> Server <span style="color:rgb(147,153,178)">{</span>
+   · <span style="color:#c678dd;font-weight:bold">       ──────</span>
+ <span style="opacity:0.7">3</span> │     <span style="color:rgb(249,226,175)">#[facet(kdl::argument)]</span>
+   ╰────
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">Server.rs:6:5</span>]
+ <span style="opacity:0.7">5</span> │     <span style="color:rgb(249,226,175)">#[facet(kdl::property)]</span>
+ <span style="opacity:0.7">6</span> │     port<span style="color:rgb(147,153,178)">:</span> u16<span style="color:rgb(147,153,178)">,</span>
+   · <span style="color:#e5c07b;font-weight:bold">    ──┬─</span>
+   ·       <span style="color:#e5c07b;font-weight:bold">╰── </span><span style="color:#e5c07b;font-weight:bold">as requested here</span>
+ <span style="opacity:0.7">7</span> │ <span style="color:rgb(147,153,178)">}</span>
+   ╰────
+
+Error: 
+  <span style="color:#e06c75">×</span> in type &#96;ServerConfig&#96;
+   ╭─[<span style="color:#56b6c2;font-weight:bold;text-decoration:underline">ServerConfig.rs:2:8</span>]
+ <span style="opacity:0.7">1</span> │ <span style="color:rgb(249,226,175)">#[derive(Facet)]</span>
+ <span style="opacity:0.7">2</span> │ <span style="color:rgb(203,166,247)">struct</span> <span style="color:rgb(249,226,175)">ServerConfig</span> <span style="color:rgb(147,153,178)">{</span>
+   · <span style="color:#c678dd;font-weight:bold">       ────────────</span>
+ <span style="opacity:0.7">3</span> │     <span style="color:rgb(249,226,175)">#[facet(kdl::child)]</span>
+ <span style="opacity:0.7">4</span> │     <span style="color:rgb(137,180,250)">server</span><span style="color:rgb(147,153,178)">:</span> <span style="color:rgb(249,226,175)">Server</span><span style="color:rgb(147,153,178)">,</span>
+   · <span style="color:#e5c07b;font-weight:bold">    ───┬──</span>
+   ·        <span style="color:#e5c07b;font-weight:bold">╰── </span><span style="color:#e5c07b;font-weight:bold">via this field</span>
+ <span style="opacity:0.7">5</span> │ <span style="color:rgb(147,153,178)">}</span>
    ╰────
 </code></pre>
 </div>
@@ -957,9 +470,9 @@ Error: 
 <footer class="showcase-provenance">
 <p>This showcase was auto-generated from source code.</p>
 <dl>
-<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/a275f00e2c5593da5eaa528fe0b00814b555b5d7/facet-kdl/examples/kdl_showcase.rs"><code>facet-kdl/examples/kdl_showcase.rs</code></a></dd>
-<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/a275f00e2c5593da5eaa528fe0b00814b555b5d7"><code>a275f00e2</code></a></dd>
-<dt>Generated</dt><dd><time datetime="2025-12-12T07:18:58+01:00">2025-12-12T07:18:58+01:00</time></dd>
+<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/c5842bc4cd833fedc52522b20f09daedff260a0e/facet-kdl/examples/kdl_showcase.rs"><code>facet-kdl/examples/kdl_showcase.rs</code></a></dd>
+<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/c5842bc4cd833fedc52522b20f09daedff260a0e"><code>c5842bc4c</code></a></dd>
+<dt>Generated</dt><dd><time datetime="2026-01-04T12:56:12+01:00">2026-01-04T12:56:12+01:00</time></dd>
 <dt>Compiler</dt><dd><code>rustc 1.91.1 (ed61e7d7e 2025-11-07)</code></dd>
 </dl>
 </footer>

--- a/docs/content/guide/showcases/pretty.md
+++ b/docs/content/guide/showcases/pretty.md
@@ -13,13 +13,11 @@ title = "Pretty Printing"
 <p class="description">Simple numeric types show their value directly, and their shape reveals the underlying primitive type.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="color:rgb(224,81,93)">42</span></code></pre>
+<pre><code><span style="color:rgb(224,81,93)">42</span><span style="color:inherit"></span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </div>
 </section>
 
@@ -29,13 +27,11 @@ title = "Pretty Printing"
 <p class="description">Floating-point numbers are displayed with their full precision.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="color:rgb(81,86,224)">3.141592653589793</span></code></pre>
+<pre><code><span style="color:rgb(81,86,224)">3.141592653589793</span><span style="color:inherit"></span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </div>
 </section>
 
@@ -45,13 +41,11 @@ title = "Pretty Printing"
 <p class="description">Boolean values are shown as `true` or `false`.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="color:rgb(81,224,114)">true</span></code></pre>
+<pre><code><span style="color:rgb(81,224,114)">true</span><span style="color:inherit"></span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </div>
 </section>
 
@@ -61,13 +55,11 @@ title = "Pretty Printing"
 <p class="description">Character values are displayed with their Unicode representation.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="color:rgb(81,224,91)">🦀</span></code></pre>
+<pre><code><span style="color:rgb(81,224,91)">🦀</span><span style="color:inherit"></span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </div>
 </section>
 
@@ -77,13 +69,11 @@ title = "Pretty Printing"
 <p class="description">String types show their content in quotes.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code>"<span style="color:rgb(158,206,106)">Hello, facet!</span>"</code></pre>
+<pre><code>"<span style="color:rgb(158,206,106)">Hello, facet!</span><span style="color:inherit">"</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </div>
 </section>
 
@@ -93,17 +83,15 @@ title = "Pretty Printing"
 <p class="description">Tuples are displayed with their elements, and the shape shows each element's type.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">(f64, u32)</span> <span style="opacity:0.7">(</span>
-  <span style="color:rgb(81,86,224)">3.5</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(207,81,224)">41</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">(f64, u32)</span><span style="color:inherit"></span> <span style="opacity:0.7">(</span>
+  <span style="color:rgb(81,86,224)">3.5</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(207,81,224)">41</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">)</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">(…)(f64, u32)</span><span style="color:#89ddff;">;</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-p>(</a-p>…<a-p>)(</a-p>f64<a-p>,</a-p> u32<a-p>);</a-p></code></pre>
 </div>
 </section>
 
@@ -113,18 +101,16 @@ title = "Pretty Printing"
 <p class="description">Larger tuples work the same way — each element type is tracked.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">(&amp;str, u32, bool)</span> <span style="opacity:0.7">(</span>
-  "<span style="color:rgb(158,206,106)">Alice</span>"<span style="opacity:0.7">,</span>
-  <span style="color:rgb(207,81,224)">30</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(81,224,114)">true</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">(&amp;str, u32, bool)</span><span style="color:inherit"></span> <span style="opacity:0.7">(</span>
+  "<span style="color:rgb(158,206,106)">Alice</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(207,81,224)">30</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(81,224,114)">true</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">)</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">(…)(&amp;T, u32, bool)</span><span style="color:#89ddff;">;</span></pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-p>(</a-p>…<a-p>)(</a-p><a-o>&amp;</a-o><a-cr>T</a-cr><a-p>,</a-p> u32<a-p>,</a-p> bool<a-p>);</a-p></code></pre>
 </div>
 </section>
 
@@ -134,21 +120,19 @@ title = "Pretty Printing"
 <p class="description">Struct fields are displayed with their names and values. The shape shows field names, types, and offsets.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Point</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">x</span><span style="opacity:0.7">: </span><span style="color:rgb(81,86,224)">1.5</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">y</span><span style="opacity:0.7">: </span><span style="color:rgb(81,86,224)">2.5</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Point</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">x</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,86,224)">1.5</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">y</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(81,86,224)">2.5</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Point </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">x</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">f64</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">y</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">f64</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Point</a-t> <a-p>{</a-p>
+    <a-pr>x</a-pr><a-p>:</a-p> <a-t>f64</a-t><a-p>,</a-p>
 
+    <a-pr>y</a-pr><a-p>:</a-p> <a-t>f64</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
 </div>
 </section>
 
@@ -158,24 +142,22 @@ title = "Pretty Printing"
 <p class="description">Optional fields show `Some(...)` or `None`. The shape includes the full Option type.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Alice</span>"<span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">age</span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">30</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">email</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">alice@example.com</span>"<span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Alice</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">age</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">30</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">email</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">alice@example.com</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Person </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">age</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">email</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Person</a-t> <a-p>{</a-p>
+    <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
 
+    <a-pr>age</a-pr><a-p>:</a-p> <a-t>u32</a-t><a-p>,</a-p>
+
+    <a-pr>email</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p></code></pre>
 </div>
 </section>
 
@@ -185,23 +167,21 @@ title = "Pretty Printing"
 <p class="description">Unit variants display just the variant name. The shape shows all possible variants.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Color</span><span style="opacity:0.7">::</span><span style="font-weight:bold">Blue</span></code></pre>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Color</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">Blue</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">Color </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Red</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Green</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Blue</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Rgb(</span><span style="color:#bb9af7;">u8</span><span style="color:#89ddff;">, </span><span style="color:#bb9af7;">u8</span><span style="color:#89ddff;">, </span><span style="color:#bb9af7;">u8</span><span style="color:#9abdf5;">)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>Color</a-t> <a-p>{</a-p>
+    <a-cr>Red</a-cr><a-p>,</a-p>
 
+    <a-cr>Green</a-cr><a-p>,</a-p>
+
+    <a-cr>Blue</a-cr><a-p>,</a-p>
+
+    <a-cr>Rgb</a-cr><a-p>(</a-p><a-t>u8</a-t><a-p>,</a-p> <a-t>u8</a-t><a-p>,</a-p> <a-t>u8</a-t><a-p>),</a-p>
+<a-p>}</a-p></code></pre>
 </div>
 </section>
 
@@ -211,27 +191,25 @@ title = "Pretty Printing"
 <p class="description">Tuple variants show their contained values.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Color</span><span style="opacity:0.7">::</span><span style="font-weight:bold">Rgb</span><span style="opacity:0.7">(</span>
-  <span style="color:rgb(222,81,224)">255</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(222,81,224)">128</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(222,81,224)">0</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Color</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">Rgb</span><span style="opacity:0.7">(</span>
+  <span style="color:rgb(222,81,224)">255</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(222,81,224)">128</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(222,81,224)">0</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">)</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">Color </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Red</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Green</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Blue</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Rgb(</span><span style="color:#bb9af7;">u8</span><span style="color:#89ddff;">, </span><span style="color:#bb9af7;">u8</span><span style="color:#89ddff;">, </span><span style="color:#bb9af7;">u8</span><span style="color:#9abdf5;">)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>Color</a-t> <a-p>{</a-p>
+    <a-cr>Red</a-cr><a-p>,</a-p>
 
+    <a-cr>Green</a-cr><a-p>,</a-p>
+
+    <a-cr>Blue</a-cr><a-p>,</a-p>
+
+    <a-cr>Rgb</a-cr><a-p>(</a-p><a-t>u8</a-t><a-p>,</a-p> <a-t>u8</a-t><a-p>,</a-p> <a-t>u8</a-t><a-p>),</a-p>
+<a-p>}</a-p></code></pre>
 </div>
 </section>
 
@@ -241,28 +219,26 @@ title = "Pretty Printing"
 <p class="description">Struct variants display their field names and values.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Message</span><span style="opacity:0.7">::</span><span style="font-weight:bold">Move</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">x</span><span style="opacity:0.7">: </span><span style="color:rgb(224,81,93)">10</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">y</span><span style="opacity:0.7">: </span><span style="color:rgb(224,81,93)">20</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Message</span><span style="color:inherit"></span><span style="opacity:0.7">::</span><span style="font-weight:bold">Move</span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">x</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(224,81,93)">10</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">y</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(224,81,93)">20</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">repr</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">u8</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">enum </span><span style="color:#c0caf5;">Message </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    Quit</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Move {
-</span><span style="color:#9abdf5;">        x</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">i32</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">        y</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">i32</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">    }</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    Write(</span><span style="color:#0db9d7;">String</span><span style="color:#9abdf5;">)</span><span style="color:#89ddff;">,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-at>#</a-at><a-p>[</a-p><a-at>repr</a-at><a-p>(</a-p><a-t>u8</a-t><a-p>)]</a-p>
+<a-k>enum</a-k> <a-t>Message</a-t> <a-p>{</a-p>
+    <a-cr>Quit</a-cr><a-p>,</a-p>
 
+    <a-cr>Move</a-cr> <a-p>{</a-p>
+        <a-pr>x</a-pr><a-p>:</a-p> <a-t>i32</a-t><a-p>,</a-p>
+
+        <a-pr>y</a-pr><a-p>:</a-p> <a-t>i32</a-t><a-p>,</a-p>
+    <a-p>},</a-p>
+
+    <a-cr>Write</a-cr><a-p>(</a-p><a-t>String</a-t><a-p>),</a-p>
+<a-p>}</a-p></code></pre>
 </div>
 </section>
 
@@ -272,13 +248,11 @@ title = "Pretty Printing"
 <p class="description">Vectors show their elements in a list. The shape describes the element type.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;i32&gt;</span><span style="opacity:0.7"> [</span><span style="color:rgb(224,81,93)">1</span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">2</span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">3</span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">4</span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">5</span><span style="opacity:0.7">]</span></code></pre>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;i32&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span><span style="color:rgb(224,81,93)">1</span><span style="color:inherit"></span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">2</span><span style="color:inherit"></span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">3</span><span style="color:inherit"></span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">4</span><span style="color:inherit"></span><span style="opacity:0.7">,</span> <span style="color:rgb(224,81,93)">5</span><span style="color:inherit"></span><span style="opacity:0.7">]</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </div>
 </section>
 
@@ -288,15 +262,13 @@ title = "Pretty Printing"
 <p class="description">Fixed-size arrays show their elements. The shape includes the array length.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">[u8; 4]</span><span style="opacity:0.7"> [</span>
-   <span style="color:rgb(224,81,145)">0a</span> <span style="color:rgb(224,138,81)">14</span> <span style="color:rgb(224,81,222)">1e</span> <span style="color:rgb(160,81,224)">28</span>
-<span style="opacity:0.7">]</span></code></pre>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">[u8; 4]</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span>
+   <span style="color:rgb(224,81,145)">0a</span><span style="color:inherit"> </span><span style="color:rgb(224,138,81)">14</span><span style="color:inherit"> </span><span style="color:rgb(224,81,222)">1e</span><span style="color:inherit"> </span><span style="color:rgb(160,81,224)">28</span><span style="color:inherit">
+</span><span style="opacity:0.7">]</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </div>
 </section>
 
@@ -306,17 +278,15 @@ title = "Pretty Printing"
 <p class="description">Maps display their key-value pairs. The shape describes both key and value types.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">HashMap&lt;String, i32&gt;</span><span style="opacity:0.7"> [</span>
-  "<span style="color:rgb(158,206,106)">three</span>"<span style="opacity:0.7"> =&gt; </span><span style="color:rgb(224,81,93)">3</span><span style="opacity:0.7">,</span>
-  "<span style="color:rgb(158,206,106)">two</span>"<span style="opacity:0.7"> =&gt; </span><span style="color:rgb(224,81,93)">2</span><span style="opacity:0.7">,</span>
-  "<span style="color:rgb(158,206,106)">one</span>"<span style="opacity:0.7"> =&gt; </span><span style="color:rgb(224,81,93)">1</span><span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">HashMap&lt;String, i32&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span>
+  "<span style="color:rgb(158,206,106)">three</span><span style="color:inherit">"</span><span style="opacity:0.7"> =&gt; </span><span style="color:rgb(224,81,93)">3</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  "<span style="color:rgb(158,206,106)">two</span><span style="color:inherit">"</span><span style="opacity:0.7"> =&gt; </span><span style="color:rgb(224,81,93)">2</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+  "<span style="color:rgb(158,206,106)">one</span><span style="color:inherit">"</span><span style="opacity:0.7"> =&gt; </span><span style="color:rgb(224,81,93)">1</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">]</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </div>
 </section>
 
@@ -326,13 +296,11 @@ title = "Pretty Printing"
 <p class="description">Option::Some displays its contained value.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">present</span>"<span style="opacity:0.7">)</span></code></pre>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">present</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </div>
 </section>
 
@@ -342,13 +310,11 @@ title = "Pretty Printing"
 <p class="description">Option::None displays cleanly without the type clutter.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::None</span></code></pre>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </div>
 </section>
 
@@ -362,9 +328,7 @@ title = "Pretty Printing"
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </div>
 </section>
 
@@ -378,9 +342,7 @@ title = "Pretty Printing"
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-</pre>
-
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code></code></pre>
 </div>
 </section>
 
@@ -390,66 +352,64 @@ title = "Pretty Printing"
 <p class="description">Complex nested types are pretty-printed with proper indentation. The shape shows the full type hierarchy.</p>
 <div class="value-output">
 <h4>Value</h4>
-<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Company</span><span style="opacity:0.7"> {</span>
-  <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Acme Corp</span>"<span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">address</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Address</span><span style="opacity:0.7"> {</span>
-    <span style="color:rgb(115,218,202)">street</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">123 Main St</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">city</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Springfield</span>"<span style="opacity:0.7">,</span>
-    <span style="color:rgb(115,218,202)">zip</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">12345</span>"<span style="opacity:0.7">,</span>
+<pre><code><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Company</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+  <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Acme Corp</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">address</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Address</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+    <span style="color:rgb(115,218,202)">street</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">123 Main St</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">city</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Springfield</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+    <span style="color:rgb(115,218,202)">zip</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">12345</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
-  <span style="color:rgb(115,218,202)">employees</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;Person&gt;</span><span style="opacity:0.7"> [</span>
-    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="opacity:0.7"> {</span>
-      <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Alice</span>"<span style="opacity:0.7">,</span>
-      <span style="color:rgb(115,218,202)">age</span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">30</span><span style="opacity:0.7">,</span>
-      <span style="color:rgb(115,218,202)">email</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">alice@acme.com</span>"<span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
+  <span style="color:rgb(115,218,202)">employees</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Vec&lt;Person&gt;</span><span style="color:inherit"></span><span style="opacity:0.7"> [</span>
+    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+      <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Alice</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">age</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">30</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">email</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::Some(</span>"<span style="color:rgb(158,206,106)">alice@acme.com</span><span style="color:inherit">"</span><span style="opacity:0.7">)</span><span style="opacity:0.7">,</span>
     <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
-    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="opacity:0.7"> {</span>
-      <span style="color:rgb(115,218,202)">name</span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Bob</span>"<span style="opacity:0.7">,</span>
-      <span style="color:rgb(115,218,202)">age</span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">25</span><span style="opacity:0.7">,</span>
-      <span style="color:rgb(115,218,202)">email</span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
+    <span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Person</span><span style="color:inherit"></span><span style="opacity:0.7"> {</span>
+      <span style="color:rgb(115,218,202)">name</span><span style="color:inherit"></span><span style="opacity:0.7">: </span>"<span style="color:rgb(158,206,106)">Bob</span><span style="color:inherit">"</span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">age</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="color:rgb(207,81,224)">25</span><span style="color:inherit"></span><span style="opacity:0.7">,</span>
+      <span style="color:rgb(115,218,202)">email</span><span style="color:inherit"></span><span style="opacity:0.7">: </span><span style="font-weight:bold"></span><span style="color:rgb(122,162,247)">Option</span><span style="color:inherit"></span><span style="opacity:0.7">::None</span><span style="opacity:0.7">,</span>
     <span style="opacity:0.7">}</span><span style="opacity:0.7">,</span>
   <span style="opacity:0.7">]</span><span style="opacity:0.7">,</span>
 <span style="opacity:0.7">}</span></code></pre>
 </div>
 <div class="shape-output">
 <h4>Shape</h4>
-<pre style="background-color:#1a1b26;">
-<span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Company </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">address</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> Address,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">employees</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Vec</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">Person</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Person </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">name</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">age</span><span style="color:#89ddff;">: </span><span style="color:#bb9af7;">u32</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">email</span><span style="color:#89ddff;">: </span><span style="color:#9abdf5;">Option</span><span style="color:#89ddff;">&lt;</span><span style="color:#9abdf5;">String</span><span style="color:#89ddff;">&gt;</span><span style="color:#9abdf5;">,
-</span><span style="color:#9abdf5;">}
-</span><span style="color:#c0caf5;">
-</span><span style="color:#89ddff;">#</span><span style="color:#9abdf5;">[</span><span style="color:#c0caf5;">derive</span><span style="color:#9abdf5;">(</span><span style="color:#c0caf5;">Facet</span><span style="color:#9abdf5;">)]
-</span><span style="color:#bb9af7;">struct </span><span style="color:#c0caf5;">Address </span><span style="color:#9abdf5;">{
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">street</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">city</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">
-</span><span style="color:#9abdf5;">    </span><span style="color:#7dcfff;">zip</span><span style="color:#89ddff;">:</span><span style="color:#9abdf5;"> String,
-</span><span style="color:#9abdf5;">}</span></pre>
+<pre style="background-color:#1a1b26; color:#c0caf5; padding:12px; border-radius:8px; font-family:var(--facet-mono, SFMono-Regular, Consolas, 'Liberation Mono', monospace); font-size:0.9rem; overflow:auto;"><code><a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Company</a-t> <a-p>{</a-p>
+    <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
 
+    <a-pr>address</a-pr><a-p>:</a-p> <a-t>Address</a-t><a-p>,</a-p>
+
+    <a-pr>employees</a-pr><a-p>:</a-p> <a-t>Vec</a-t><a-p>&lt;</a-p><a-t>Person</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Person</a-t> <a-p>{</a-p>
+    <a-pr>name</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-pr>age</a-pr><a-p>:</a-p> <a-t>u32</a-t><a-p>,</a-p>
+
+    <a-pr>email</a-pr><a-p>:</a-p> <a-t>Option</a-t><a-p>&lt;</a-p><a-t>String</a-t><a-p>&gt;,</a-p>
+<a-p>}</a-p>
+
+<a-at>#</a-at><a-p>[</a-p><a-at>derive</a-at><a-p>(</a-p><a-cr>Facet</a-cr><a-p>)]</a-p>
+<a-k>struct</a-k> <a-t>Address</a-t> <a-p>{</a-p>
+    <a-pr>street</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-pr>city</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+
+    <a-pr>zip</a-pr><a-p>:</a-p> <a-t>String</a-t><a-p>,</a-p>
+<a-p>}</a-p></code></pre>
 </div>
 </section>
 
 <footer class="showcase-provenance">
 <p>This showcase was auto-generated from source code.</p>
 <dl>
-<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/a275f00e2c5593da5eaa528fe0b00814b555b5d7/facet-pretty/examples/pretty_showcase.rs"><code>facet-pretty/examples/pretty_showcase.rs</code></a></dd>
-<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/a275f00e2c5593da5eaa528fe0b00814b555b5d7"><code>a275f00e2</code></a></dd>
-<dt>Generated</dt><dd><time datetime="2025-12-12T07:18:58+01:00">2025-12-12T07:18:58+01:00</time></dd>
+<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/c5842bc4cd833fedc52522b20f09daedff260a0e/facet-pretty/examples/pretty_showcase.rs"><code>facet-pretty/examples/pretty_showcase.rs</code></a></dd>
+<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/c5842bc4cd833fedc52522b20f09daedff260a0e"><code>c5842bc4c</code></a></dd>
+<dt>Generated</dt><dd><time datetime="2026-01-04T12:56:12+01:00">2026-01-04T12:56:12+01:00</time></dd>
 <dt>Compiler</dt><dd><code>rustc 1.91.1 (ed61e7d7e 2025-11-07)</code></dd>
 </dl>
 </footer>

--- a/docs/content/guide/showcases/spans.md
+++ b/docs/content/guide/showcases/spans.md
@@ -444,9 +444,9 @@ title = "Spans"
 <footer class="showcase-provenance">
 <p>This showcase was auto-generated from source code.</p>
 <dl>
-<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/a275f00e2c5593da5eaa528fe0b00814b555b5d7/facet-pretty/examples/spans_showcase.rs"><code>facet-pretty/examples/spans_showcase.rs</code></a></dd>
-<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/a275f00e2c5593da5eaa528fe0b00814b555b5d7"><code>a275f00e2</code></a></dd>
-<dt>Generated</dt><dd><time datetime="2025-12-12T07:18:58+01:00">2025-12-12T07:18:58+01:00</time></dd>
+<dt>Source</dt><dd><a href="https://github.com/facet-rs/facet/blob/c5842bc4cd833fedc52522b20f09daedff260a0e/facet-pretty/examples/spans_showcase.rs"><code>facet-pretty/examples/spans_showcase.rs</code></a></dd>
+<dt>Commit</dt><dd><a href="https://github.com/facet-rs/facet/commit/c5842bc4cd833fedc52522b20f09daedff260a0e"><code>c5842bc4c</code></a></dd>
+<dt>Generated</dt><dd><time datetime="2026-01-04T12:56:12+01:00">2026-01-04T12:56:12+01:00</time></dd>
 <dt>Compiler</dt><dd><code>rustc 1.91.1 (ed61e7d7e 2025-11-07)</code></dd>
 </dl>
 </footer>

--- a/facet-html/Cargo.toml
+++ b/facet-html/Cargo.toml
@@ -33,6 +33,7 @@ facet = { workspace = true, features = ["doc"] }
 facet-diff = { path = "../facet-diff" }
 facet-assert = { path = "../facet-assert" }
 facet-html-dom = { path = "../facet-html-dom" }
+facet-showcase = { path = "../facet-showcase" }
 datatest-stable = "0.3"
 
 [[test]]

--- a/facet-html/examples/html_showcase.rs
+++ b/facet-html/examples/html_showcase.rs
@@ -1,0 +1,292 @@
+//! facet-html Showcase
+//!
+//! This example demonstrates facet-html's capabilities for HTML parsing and serialization,
+//! including custom type definitions and integration with facet-html-dom.
+//!
+//! Run with: cargo run -p facet-html --example html_showcase
+
+use facet::Facet;
+use facet_html as html;
+use facet_showcase::{Language, ShowcaseRunner};
+
+// =============================================================================
+// Custom Type Definitions
+// =============================================================================
+
+/// A simple page structure with head and body.
+#[derive(Facet, Debug)]
+#[facet(rename = "html")]
+struct SimplePage {
+    #[facet(html::element, default)]
+    head: Option<SimpleHead>,
+    #[facet(html::element, default)]
+    body: Option<SimpleBody>,
+}
+
+#[derive(Facet, Debug)]
+#[facet(rename = "head")]
+struct SimpleHead {
+    #[facet(html::element, default)]
+    title: Option<SimpleTitle>,
+}
+
+#[derive(Facet, Debug)]
+#[facet(rename = "title")]
+struct SimpleTitle {
+    #[facet(html::text, default)]
+    text: String,
+}
+
+#[derive(Facet, Debug)]
+#[facet(rename = "body")]
+struct SimpleBody {
+    #[facet(html::attribute, default)]
+    class: Option<String>,
+    #[facet(html::elements, default)]
+    children: Vec<BodyElement>,
+}
+
+/// Elements that can appear in the body.
+#[allow(dead_code)]
+#[derive(Facet, Debug)]
+#[repr(u8)]
+enum BodyElement {
+    #[facet(rename = "h1")]
+    H1(Heading),
+    #[facet(rename = "p")]
+    P(Paragraph),
+    #[facet(rename = "div")]
+    Div(DivElement),
+}
+
+#[derive(Facet, Debug)]
+struct Heading {
+    #[facet(html::attribute, default)]
+    id: Option<String>,
+    #[facet(html::text, default)]
+    text: String,
+}
+
+#[derive(Facet, Debug)]
+struct Paragraph {
+    #[facet(html::attribute, default)]
+    class: Option<String>,
+    #[facet(html::text, default)]
+    text: String,
+}
+
+#[derive(Facet, Debug)]
+struct DivElement {
+    #[facet(html::attribute, default)]
+    id: Option<String>,
+    #[facet(html::attribute, default)]
+    class: Option<String>,
+    #[facet(html::text, default)]
+    content: String,
+}
+
+/// A form element with various input types.
+#[derive(Facet, Debug)]
+#[facet(rename = "form")]
+struct ContactForm {
+    #[facet(html::attribute, default)]
+    action: Option<String>,
+    #[facet(html::attribute, default)]
+    method: Option<String>,
+    #[facet(html::elements, default)]
+    inputs: Vec<FormInput>,
+}
+
+#[derive(Facet, Debug)]
+#[facet(rename = "input")]
+struct FormInput {
+    #[facet(html::attribute, default, rename = "type")]
+    input_type: Option<String>,
+    #[facet(html::attribute, default)]
+    name: Option<String>,
+    #[facet(html::attribute, default)]
+    placeholder: Option<String>,
+    #[facet(html::attribute, default)]
+    required: Option<String>,
+}
+
+/// A div that captures extra attributes (data-*, aria-*, etc.)
+#[derive(Facet, Debug, Default)]
+#[facet(rename = "div")]
+struct DivWithExtras {
+    #[facet(html::attribute, default)]
+    id: Option<String>,
+    #[facet(html::attribute, default)]
+    class: Option<String>,
+    /// Captures data-*, aria-*, and other unknown attributes
+    #[facet(flatten, default)]
+    extra: std::collections::BTreeMap<String, String>,
+    #[facet(html::text, default)]
+    content: String,
+}
+
+fn main() {
+    let mut runner = ShowcaseRunner::new("HTML").language(Language::Html);
+
+    runner.header();
+    runner.intro("[`facet-html`](https://docs.rs/facet-html) parses and serializes HTML documents using Facet. Define your document structure with `#[facet(html::element)]` for child elements, `#[facet(html::attribute)]` for tag attributes, and `#[facet(html::text)]` for text content.");
+
+    // =========================================================================
+    // PART 1: Basic Parsing
+    // =========================================================================
+    runner.section("Parsing HTML");
+
+    showcase_simple_document(&mut runner);
+    showcase_nested_elements(&mut runner);
+    showcase_form_elements(&mut runner);
+
+    // =========================================================================
+    // PART 2: Serialization
+    // =========================================================================
+    runner.section("Serialization");
+
+    showcase_serialize_minified(&mut runner);
+    showcase_serialize_pretty(&mut runner);
+
+    // =========================================================================
+    // PART 3: Advanced Features
+    // =========================================================================
+    runner.section("Advanced Features");
+
+    showcase_extra_attributes(&mut runner);
+
+    runner.footer();
+}
+
+// =============================================================================
+// Parsing Scenarios
+// =============================================================================
+
+fn showcase_simple_document(runner: &mut ShowcaseRunner) {
+    let input = r#"<html>
+    <head><title>My Page</title></head>
+    <body class="main">
+        <h1 id="header">Welcome</h1>
+        <p>Hello, world!</p>
+    </body>
+</html>"#;
+
+    let result: SimplePage = html::from_str(input).expect("valid HTML");
+
+    runner
+        .scenario("Simple Document")
+        .description("Parse a basic HTML document with head, body, and nested elements.")
+        .target_type::<SimplePage>()
+        .input(Language::Html, input)
+        .success(&result)
+        .finish();
+}
+
+fn showcase_nested_elements(runner: &mut ShowcaseRunner) {
+    let input = r#"<html>
+    <body>
+        <div id="container" class="wrapper">
+            <h1>Title</h1>
+            <p class="intro">Introduction paragraph.</p>
+            <div class="content">Main content here.</div>
+        </div>
+    </body>
+</html>"#;
+
+    let result: SimplePage = html::from_str(input).expect("valid HTML");
+
+    runner
+        .scenario("Nested Elements")
+        .description("Parse nested HTML elements into an enum-based content model.")
+        .target_type::<SimplePage>()
+        .input(Language::Html, input)
+        .success(&result)
+        .finish();
+}
+
+fn showcase_form_elements(runner: &mut ShowcaseRunner) {
+    let input = r#"<form action="/submit" method="post">
+    <input type="text" name="username" placeholder="Username" required />
+    <input type="email" name="email" placeholder="Email" />
+    <input type="submit" name="submit" />
+</form>"#;
+
+    let result: ContactForm = html::from_str(input).expect("valid HTML");
+
+    runner
+        .scenario("Form Elements")
+        .description("Parse HTML form elements with their attributes.")
+        .target_type::<ContactForm>()
+        .input(Language::Html, input)
+        .success(&result)
+        .finish();
+}
+
+// =============================================================================
+// Serialization Scenarios
+// =============================================================================
+
+fn showcase_serialize_minified(runner: &mut ShowcaseRunner) {
+    let div = DivElement {
+        id: Some("main".to_string()),
+        class: Some("container".to_string()),
+        content: "Hello!".to_string(),
+    };
+
+    let output = html::to_string(&div).unwrap();
+
+    runner
+        .scenario("Minified Output")
+        .description("Serialize to compact HTML without extra whitespace.")
+        .target_type::<DivElement>()
+        .serialized_output(Language::Html, &output)
+        .finish();
+}
+
+fn showcase_serialize_pretty(runner: &mut ShowcaseRunner) {
+    let form = ContactForm {
+        action: Some("/api/contact".to_string()),
+        method: Some("post".to_string()),
+        inputs: vec![
+            FormInput {
+                input_type: Some("text".to_string()),
+                name: Some("name".to_string()),
+                placeholder: Some("Your name".to_string()),
+                required: Some("required".to_string()),
+            },
+            FormInput {
+                input_type: Some("email".to_string()),
+                name: Some("email".to_string()),
+                placeholder: Some("your@email.com".to_string()),
+                required: None,
+            },
+        ],
+    };
+
+    let output = html::to_string_pretty(&form).unwrap();
+
+    runner
+        .scenario("Pretty-Printed Output")
+        .description("Serialize with indentation for readability.")
+        .target_type::<ContactForm>()
+        .serialized_output(Language::Html, &output)
+        .finish();
+}
+
+// =============================================================================
+// Advanced Features
+// =============================================================================
+
+fn showcase_extra_attributes(runner: &mut ShowcaseRunner) {
+    let input = r#"<div id="widget" class="card" data-user-id="123" data-theme="dark" aria-label="User Card">Content</div>"#;
+
+    let result: DivWithExtras = html::from_str(input).expect("valid HTML");
+
+    runner
+        .scenario("Extra Attributes (data-*, aria-*)")
+        .description("Unknown attributes like `data-*` and `aria-*` are captured in the `extra` field via `#[facet(flatten)]`.")
+        .target_type::<DivWithExtras>()
+        .input(Language::Html, input)
+        .success(&result)
+        .finish();
+}

--- a/facet-showcase/src/highlighter.rs
+++ b/facet-showcase/src/highlighter.rs
@@ -18,6 +18,8 @@ pub enum Language {
     Yaml,
     /// XML format
     Xml,
+    /// HTML format
+    Html,
     /// KDL format
     Kdl,
     /// Rust code (for type definitions)
@@ -33,6 +35,7 @@ impl Language {
             Language::Json => "json",
             Language::Yaml => "yaml",
             Language::Xml => "xml",
+            Language::Html => "html",
             Language::Kdl => "kdl",
             Language::Rust => "rs",
             Language::Plain => "txt",
@@ -45,6 +48,7 @@ impl Language {
             Language::Json => "JSON",
             Language::Yaml => "YAML",
             Language::Xml => "XML",
+            Language::Html => "HTML",
             Language::Kdl => "KDL",
             Language::Rust => "Rust",
             Language::Plain => "Output",
@@ -56,6 +60,7 @@ impl Language {
             Language::Json => Some("json"),
             Language::Yaml => Some("yaml"),
             Language::Xml => Some("xml"),
+            Language::Html => Some("html"),
             Language::Kdl => Some("kdl"),
             Language::Rust => Some("rust"),
             Language::Plain => None, // No syntax highlighting


### PR DESCRIPTION
## Summary

Fixes the contradictory documentation in facet-html-dom and significantly improves the HTML crates' documentation overall. Also adds an HTML showcase page to the documentation website.

Fixes #1617

## Changes

### Doc Fix (Issue #1617)
- Fixed contradictory statement in `facet-html-dom/src/lib.rs` where GlobalAttrs doc said data-*/aria-* attributes are "ignored during parsing" when they're actually captured in the `extra` field

### facet-html Documentation
- Updated lib.rs examples to use `html::` attributes consistently (was incorrectly using `xml::` and bare attributes)
- Fixed incorrect comment referencing `facet_format_html` → `facet_html`
- Improved the facet-html-dom usage example with actual runnable code

### facet-html-dom Documentation  
- Added comprehensive module documentation with Quick Start example
- Documented content models (`FlowContent`, `PhrasingContent`)
- Documented `GlobalAttrs` and the `extra` field for data-*/aria-*
- Documented custom element handling
- Added doc links to all element category types

### New HTML Showcase
- Added `facet-html/examples/html_showcase.rs` demonstrating:
  - Parsing HTML documents into typed structs
  - Serialization (minified and pretty-printed)
  - Extra attribute capture (data-*, aria-*)
- Added `Language::Html` variant to facet-showcase highlighter
- Generated `docs/content/guide/showcases/html.md`

## Test plan
- [x] `cargo check --all-features --all-targets` passes
- [x] `cargo nextest run -p facet-html -p facet-html-dom` passes (67 tests)
- [x] Doc tests pass
- [x] Clippy passes