### PR TITLE
Fix multilevel flatten and multiple flattened enums (Phase 2)

### DIFF
--- a/facet-xml/tests/format_suite.rs
+++ b/facet-xml/tests/format_suite.rs
@@ -437,13 +437,15 @@ impl FormatSuite for XmlSlice {
     }
 
     fn flatten_multilevel() -> CaseSpec {
-        // TODO: multilevel nested flatten not yet supported in FormatDeserializer
-        CaseSpec::skip("multilevel nested flatten not yet implemented in format layer")
+        CaseSpec::from_str(
+            r#"<record><top_field>top</top_field><mid_field>42</mid_field><deep_field>100</deep_field></record>"#,
+        )
     }
 
     fn flatten_multiple_enums() -> CaseSpec {
-        // TODO: multiple flattened enums not yet supported in FormatDeserializer
-        CaseSpec::skip("multiple flattened enums not yet implemented in format layer")
+        CaseSpec::from_str(
+            r#"<record><name>service</name><Password><password>secret</password></Password><Tcp><port>8080</port></Tcp></record>"#,
+        )
     }
 
     // ── Scalar cases ──

--- a/facet-yaml/src/parser.rs
+++ b/facet-yaml/src/parser.rs
@@ -442,7 +442,17 @@ impl<'de> YamlParser<'de> {
         let mut evidence = Vec::new();
         let mut pos = self.pos;
 
-        // Skip to MappingStart if we have one peeked
+        // Skip preamble (StreamStart, DocumentStart) if we haven't started yet
+        while pos < self.events.len() {
+            match &self.events[pos].event {
+                OwnedEvent::StreamStart | OwnedEvent::DocumentStart => {
+                    pos += 1;
+                }
+                _ => break,
+            }
+        }
+
+        // Skip MappingStart if we have one
         if pos < self.events.len()
             && let OwnedEvent::MappingStart { .. } = &self.events[pos].event
         {

--- a/facet-yaml/tests/format_suite.rs
+++ b/facet-yaml/tests/format_suite.rs
@@ -357,13 +357,11 @@ impl FormatSuite for YamlSlice {
     }
 
     fn flatten_multilevel() -> CaseSpec {
-        // TODO: multilevel nested flatten not yet supported in FormatDeserializer
-        CaseSpec::skip("multilevel nested flatten not yet implemented in format layer")
+        CaseSpec::from_str("top_field: top\nmid_field: 42\ndeep_field: 100")
     }
 
     fn flatten_multiple_enums() -> CaseSpec {
-        // TODO: multiple flattened enums not yet supported in FormatDeserializer
-        CaseSpec::skip("multiple flattened enums not yet implemented in format layer")
+        CaseSpec::from_str("name: service\nPassword:\n  password: secret\nTcp:\n  port: 8080")
     }
 
     // -- Scalar cases --


### PR DESCRIPTION
## Summary

Implements format layer improvements for advanced flatten scenarios from #1613, fixing 4 previously skipped tests.

Fixes #1637

## Changes

### YAML Parser Fix
- `build_probe()` now skips `StreamStart` and `DocumentStart` events before scanning for field keys
- This fixed the solver receiving empty fields `[]` instead of the actual YAML content

### Flattened Enum Serialization Fix
- When serializing flattened enums, yield the inner variant value (not the whole enum)
- This prevents double variant name wrapping like `Password: Password: password: secret`
- Applies to both direct enum fields and `Option<Enum>` fields

### Test Enablement
- `flatten_multilevel` (YAML + XML): Tests 3 levels of nested flatten (A -> B -> C)
- `flatten_multiple_enums` (YAML + XML): Tests 2 different enums flattened into the same struct

## Test Plan

- [x] All 2628 tests pass
- [x] 4 previously skipped tests now pass
- [x] Pre-push hooks pass (clippy, build, tests, docs)