### PR TITLE
Enable internally/adjacently tagged enum tests for YAML

### DIFF
--- a/facet-yaml/tests/format_suite.rs
+++ b/facet-yaml/tests/format_suite.rs
@@ -205,13 +205,21 @@ impl FormatSuite for YamlSlice {
     // -- Enum tagging cases --
 
     fn enum_internally_tagged() -> CaseSpec {
-        // TODO: internally tagged enums need probe evidence implementation
-        CaseSpec::skip("internally tagged enums not yet implemented")
+        CaseSpec::from_str(indoc!(
+            r#"
+            type: Circle
+            radius: 5.0
+        "#
+        ))
     }
 
     fn enum_adjacently_tagged() -> CaseSpec {
-        // TODO: adjacently tagged enums need probe evidence implementation
-        CaseSpec::skip("adjacently tagged enums not yet implemented")
+        CaseSpec::from_str(indoc!(
+            r#"
+            t: Message
+            c: hello
+        "#
+        ))
     }
 
     // -- Advanced cases --


### PR DESCRIPTION
## Summary

Enables the two previously-skipped tagged enum tests for YAML (internally tagged and adjacently tagged). The probe evidence implementation already exists in `facet-format` and works correctly with the YAML parser - the tests were simply marked as skipped with outdated comments.

Fixes #1638

## Test plan

- [x] `cargo nextest run --package facet-yaml -E 'test(~internally_tagged) or test(~adjacently_tagged)'` - both tests pass
- [x] Full test suite passes