### PR TITLE
Fix untagged enum discrimination for StringlyTyped values

### DIFF
--- a/facet-xml/tests/format_suite.rs
+++ b/facet-xml/tests/format_suite.rs
@@ -523,9 +523,7 @@ impl FormatSuite for XmlSlice {
     }
 
     fn untagged_as_field() -> CaseSpec {
-        CaseSpec::skip(
-            "XML parser returns I64 but untagged enum expects U64 (numeric matching not yet supported)",
-        )
+        CaseSpec::from_str(r#"<value><name>test</name><value>42</value></value>"#)
     }
 
     fn untagged_unit_only() -> CaseSpec {

--- a/facet-yaml/tests/format_suite.rs
+++ b/facet-yaml/tests/format_suite.rs
@@ -454,9 +454,7 @@ impl FormatSuite for YamlSlice {
     }
 
     fn untagged_as_field() -> CaseSpec {
-        CaseSpec::skip(
-            "YAML parser returns I64 but untagged enum expects U64 (numeric matching not yet supported)",
-        )
+        CaseSpec::from_str("name: test\nvalue: 42")
     }
 
     fn untagged_unit_only() -> CaseSpec {


### PR DESCRIPTION
## Summary

Implements two-tier matching for untagged enum scalar variants when handling `StringlyTyped` values (from XML and other text-based formats). This ensures `StringlyTyped("42")` matches `Number(u64)` rather than `String(String)`, regardless of enum variant definition order.

Fixes #1639

## Changes

- **facet-format**: Added two-tier matching logic for `StringlyTyped` in untagged enum discrimination:
  - Tier 1: Try parseable types first (u64, i32, bool, etc.)
  - Tier 2: Fall back to String types only if nothing else matched
- **docs**: Added user-facing documentation explaining the two-tier matching behavior for text-based formats
- **tests**: Enabled `untagged_as_field` tests for both YAML and XML

## Test plan

- [x] All 2637 tests pass
- [x] `untagged::as_field` test passes for YAML
- [x] `untagged::as_field` test passes for XML