### PR TITLE
Fix flattened HashMap in array deserialization

### DIFF
--- a/facet-format/src/deserializer.rs
+++ b/facet-format/src/deserializer.rs
@@ -2269,6 +2269,10 @@ where
                                 // In deferred mode, the map frame might not be stored/restored,
                                 // so we always need to call begin_map() to re-enter it
                                 wip = wip.begin_map().map_err(DeserializeError::reflect)?;
+                            } else {
+                                // Direct case: in deferred mode (e.g., within an array element),
+                                // we need to re-enter the map even if already initialized
+                                wip = wip.begin_map().map_err(DeserializeError::reflect)?;
                             }
                         }
 

--- a/facet-toml/tests/issue_1644.rs
+++ b/facet-toml/tests/issue_1644.rs
@@ -1,0 +1,79 @@
+//! Regression test for https://github.com/facet-rs/facet/issues/1644
+//!
+//! Table with flatten nested in an array fails to deserialize.
+//! The error was: "must call begin_map() before begin_key()"
+
+use std::collections::HashMap;
+
+use facet::Facet;
+use facet_value::Value;
+
+#[derive(Facet, Debug)]
+struct Root {
+    pub item: Vec<Item>,
+}
+
+#[derive(Facet, Debug)]
+struct Item {
+    pub nested_item: NestedItem,
+}
+
+#[derive(Facet, Debug)]
+struct NestedItem {
+    #[facet(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[test]
+fn table_in_array_with_flatten() {
+    let toml = r#"
+        [[item]]
+
+        [item.nested_item]
+        foo = 1
+        bar = 2
+    "#;
+
+    let result: Root = facet_toml::from_str(toml).unwrap();
+    assert_eq!(result.item.len(), 1);
+    assert_eq!(result.item[0].nested_item.extra.len(), 2);
+    assert!(result.item[0].nested_item.extra.contains_key("foo"));
+    assert!(result.item[0].nested_item.extra.contains_key("bar"));
+}
+
+/// Test with multiple array elements
+#[test]
+fn multiple_array_elements_with_flatten() {
+    let toml = r#"
+        [[item]]
+
+        [item.nested_item]
+        foo = 1
+        bar = 2
+
+        [[item]]
+
+        [item.nested_item]
+        baz = 3
+    "#;
+
+    let result: Root = facet_toml::from_str(toml).unwrap();
+    assert_eq!(result.item.len(), 2);
+    assert_eq!(result.item[0].nested_item.extra.len(), 2);
+    assert_eq!(result.item[1].nested_item.extra.len(), 1);
+}
+
+/// Test with a single key (reportedly this works)
+#[test]
+fn flatten_with_single_key_works() {
+    let toml = r#"
+        [[item]]
+
+        [item.nested_item]
+        foo = 1
+    "#;
+
+    let result: Root = facet_toml::from_str(toml).unwrap();
+    assert_eq!(result.item.len(), 1);
+    assert_eq!(result.item[0].nested_item.extra.len(), 1);
+}


### PR DESCRIPTION
## Summary

Fixes #1644. When deserializing TOML with a flattened HashMap nested inside an array, the second key onwards would fail with "must call begin_map() before begin_key()".

## Changes

- **facet-format/src/deserializer.rs**: Added missing `begin_map()` call for the direct flattened map case when the field is already initialized. In deferred mode (used for array elements), the map frame state isn't preserved, so we need to re-enter the map for each key-value insertion.
- **facet-toml/tests/issue_1644.rs**: Added regression tests covering:
  - Table in array with flattened HashMap and multiple keys
  - Multiple array elements with flattened HashMaps
  - Single key case (which already worked)

## Test plan

- [x] Added regression test that reproduces the original issue
- [x] All existing tests pass (2638 tests)