### PR TITLE
fix: mark function pointers as invariant to prevent lifetime UB

### DIFF
--- a/facet-core/src/impls/core/fn_ptr.rs
+++ b/facet-core/src/impls/core/fn_ptr.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Facet, FunctionAbi, FunctionPointerDef, PointerType, Shape, ShapeBuilder, Type, TypeOpsDirect,
-    TypeParam, VTableDirect, type_ops_direct, vtable_direct,
+    TypeParam, VTableDirect, Variance, type_ops_direct, vtable_direct,
 };
 
 macro_rules! impl_facet_for_fn_ptr {
@@ -54,6 +54,10 @@ macro_rules! impl_facet_for_fn_ptr {
                     ])
                     .vtable_direct(&const { build_vtable::<$($args,)* R>() })
                     .type_ops_direct(&const { build_type_ops::<$($args,)* R>() })
+                    // Function pointers are invariant over their lifetime parameters.
+                    // Arguments are contravariant, returns are covariant, combining to invariant.
+                    // See: https://github.com/facet-rs/facet/issues/1664
+                    .variance(Variance::INVARIANT)
                     .eq()
                     .copy()
                     .build()


### PR DESCRIPTION
Function pointers must be invariant over their lifetime parameters because:
- Arguments are contravariant
- Return types are covariant
- Combined, these make the overall type invariant

This prevents a soundness hole where shrink_lifetime could be used to
manipulate lifetimes in a way that allows storing short-lived references
in static storage.

Fixes #1664
