### PR TITLE
Fix workspace deps for release-plz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-defs"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "facet",
  "facet-args",
@@ -2129,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "facet-showcase"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "arborium",
  "facet",
@@ -6338,7 +6338,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "benchmark-defs",
  "facet",

--- a/facet-args/Cargo.toml
+++ b/facet-args/Cargo.toml
@@ -27,7 +27,7 @@ owo-colors = "4"
 tracing = { workspace = true }
 
 [dev-dependencies]
-facet = { workspace = true, features = ["all-impls"] }
+facet = { path = "../facet", features = ["all-impls"] }
 facet-pretty = { path = "../facet-pretty" }
 facet-showcase = { path = "../facet-showcase" }
 insta = { workspace = true }

--- a/facet-asn1/Cargo.toml
+++ b/facet-asn1/Cargo.toml
@@ -24,7 +24,7 @@ facet-reflect = { path = "../facet-reflect", version = "0.42.0", default-feature
 miette = { workspace = true }
 
 [dev-dependencies]
-facet = { workspace = true, features = ["all-impls"] }
+facet = { path = "../facet", features = ["all-impls"] }
 facet-testhelpers = { path = "../facet-testhelpers" }
 facet-format-suite = { path = "../facet-format-suite", features = ["third-party"] }
 libtest-mimic = "0.8"

--- a/facet-assert/Cargo.toml
+++ b/facet-assert/Cargo.toml
@@ -22,7 +22,7 @@ facet-diff-core = { path = "../facet-diff-core", version = "0.42.0" }
 facet-reflect = { path = "../facet-reflect", version = "0.42.0", features = ["miette"] }
 
 [dev-dependencies]
-facet = { workspace = true }
+facet = { path = "../facet" }
 facet-showcase = { path = "../facet-showcase" }
 owo-colors = "4"
 

--- a/facet-atom/Cargo.toml
+++ b/facet-atom/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://facet.rs"
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { workspace = true }
+facet = { path = "../facet", version = "0.42.0" }
 facet-format = { path = "../facet-format", version = "0.42.0" }
 facet-xml = { path = "../facet-xml", version = "0.42.0" }
 

--- a/facet-axum/Cargo.toml
+++ b/facet-axum/Cargo.toml
@@ -37,7 +37,7 @@ facet-urlencoded = { path = "../facet-urlencoded", version = "0.42.0", optional 
 
 [dev-dependencies]
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json"] }
-facet = { workspace = true, features = ["all-impls", "doc"] }
+facet = { path = "../facet", features = ["all-impls", "doc"] }
 tokio = { workspace = true, features = ["io-util", "rt", "rt-multi-thread"] }
 tower = { version = "0.5", default-features = false, features = ["util"] }
 

--- a/facet-csv/Cargo.toml
+++ b/facet-csv/Cargo.toml
@@ -25,7 +25,7 @@ zmij = { version = "1", optional = true }
 itoa = { version = "1", optional = true }
 
 [dev-dependencies]
-facet = { workspace = true, features = ["doc", "net"] }
+facet = { path = "../facet", features = ["doc", "net"] }
 # facet-format-suite = { path = "../facet-format-suite", version = "0.35.0", features = ["third-party"] }
 # indoc = { workspace = true }
 # libtest-mimic = "0.8.1"

--- a/facet-diff-core/Cargo.toml
+++ b/facet-diff-core/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { workspace = true }
 unicode-width = "0.2"
 
 [dev-dependencies]
-facet = { workspace = true, features = ["all-impls", "doc"] }
+facet = { path = "../facet", features = ["all-impls", "doc"] }
 facet-diff = { path = "../facet-diff" }
 facet-value = { path = "../facet-value" }
 facet-xml = { path = "../facet-xml" }

--- a/facet-diff/Cargo.toml
+++ b/facet-diff/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 
 [dependencies]
 cinereus = { path = "../cinereus", version = "0.42.0" }
-facet = { workspace = true }
+facet = { path = "../facet", version = "0.42.0" }
 facet-core = { path = "../facet-core", version = "0.42.0" }
 facet-diff-core = { path = "../facet-diff-core", version = "0.42.0" }
 facet-pretty = { path = "../facet-pretty", version = "0.42.0" }

--- a/facet-format-suite/Cargo.toml
+++ b/facet-format-suite/Cargo.toml
@@ -23,7 +23,7 @@ bytestring = { workspace = true, optional = true }
 camino = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true, features = ["clock"] }
 compact_str = { workspace = true, optional = true }
-facet = { workspace = true, features = ["doc", "all-impls"] } # facet-format-suite is meant to be comprehensive
+facet = { path = "../facet", version = "0.42.0", features = ["doc", "all-impls"] } # facet-format-suite is meant to be comprehensive
 facet-assert = { path = "../facet-assert", version = "0.42.0" }
 facet-pretty = { path = "../facet-pretty", version = "0.42.0" }
 facet-value = { path = "../facet-value", version = "0.42.0", optional = true }

--- a/facet-html-dom/Cargo.toml
+++ b/facet-html-dom/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { workspace = true }
+facet = { path = "../facet", version = "0.42.0" }
 facet-html = { path = "../facet-html", version = "0.42.0" }
 
 [lints]

--- a/facet-html/Cargo.toml
+++ b/facet-html/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { workspace = true }
+facet = { path = "../facet", version = "0.42.0" }
 facet-core = { path = "../facet-core", version = "0.42.0" }
 facet-format = { path = "../facet-format", version = "0.42.0" }
 facet-xml = { path = "../facet-xml", version = "0.42.0" }
@@ -29,7 +29,7 @@ zmij = { version = "1", optional = true }
 itoa = { version = "1", optional = true }
 
 [dev-dependencies]
-facet = { workspace = true, features = ["doc"] }
+facet = { path = "../facet", features = ["doc"] }
 facet-diff = { path = "../facet-diff" }
 facet-assert = { path = "../facet-assert" }
 facet-html-dom = { path = "../facet-html-dom" }

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -40,7 +40,7 @@ mime = { version = "0.3", optional = true }
 [dev-dependencies]
 brotli = "7"
 compact_str = { workspace = true }
-facet = { workspace = true, features = ["doc", "net", "compact_str", "smol_str"] }
+facet = { path = "../facet", features = ["doc", "net", "compact_str", "smol_str"] }
 facet-format = { path = "../facet-format", features = ["jit"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/facet-kdl/Cargo.toml
+++ b/facet-kdl/Cargo.toml
@@ -33,7 +33,7 @@ http = { workspace = true, optional = true }
 http-body-util = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
-facet = { workspace = true, features = ["doc", "net"] }
+facet = { path = "../facet", features = ["doc", "net"] }
 facet-showcase = { path = "../facet-showcase" }
 
 [features]

--- a/facet-msgpack/Cargo.toml
+++ b/facet-msgpack/Cargo.toml
@@ -28,7 +28,7 @@ http-body-util = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 divan = { workspace = true }
-facet = { workspace = true, features = ["all-impls"] }
+facet = { path = "../facet", features = ["all-impls"] }
 facet-format = { path = "../facet-format", features = ["jit"] }
 facet-format-suite = { path = "../facet-format-suite", features = ["third-party", "msgpack"] }
 libtest-mimic = "0.8"

--- a/facet-pretty/Cargo.toml
+++ b/facet-pretty/Cargo.toml
@@ -30,7 +30,7 @@ owo-colors = "4"
 
 [dev-dependencies]
 camino = { workspace = true }
-facet = { workspace = true, features = ["all-impls"] }
+facet = { path = "../facet", features = ["all-impls"] }
 facet-showcase = { path = "../facet-showcase" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 insta = { workspace = true }

--- a/facet-reflect/Cargo.toml
+++ b/facet-reflect/Cargo.toml
@@ -60,7 +60,7 @@ uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
 eyre = { workspace = true }
-facet = { workspace = true, features = ["net", "nonzero"] }
+facet = { path = "../facet", features = ["net", "nonzero"] }
 facet-testhelpers = { path = "../facet-testhelpers" }
 facet-value = { path = "../facet-value" }
 insta = { workspace = true }

--- a/facet-shapelike/Cargo.toml
+++ b/facet-shapelike/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 [features]
 
 [dependencies]
-facet = { workspace = true, features = ["all-impls", "doc"] }
+facet = { path = "../facet", version = "0.42.0", features = ["all-impls", "doc"] }
 facet-core = { path = "../facet-core", version = "0.42.0", features = ["alloc"] }
 facet-postcard = { path = "../facet-postcard", version = "0.42.0" }
 facet-reflect = { path = "../facet-reflect", version = "0.42.0", default-features = false, features = ["miette"] }

--- a/facet-showcase/Cargo.toml
+++ b/facet-showcase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-showcase"
-version = "0.41.0"
+version = "0.42.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Unified showcase infrastructure for facet format crates"
@@ -15,7 +15,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
 arborium = { workspace = true, features = ["lang-kdl", "lang-rust", "lang-xml", "lang-yaml"] }
-facet = { workspace = true, features = ["all-impls", "doc"] }
+facet = { path = "../facet", version = "0.42.0", features = ["all-impls", "doc"] }
 facet-pretty = { path = "../facet-pretty", version = "0.42.0" }
 miette = { workspace = true }
 miette-arborium = "2.4.5"

--- a/facet-solver/Cargo.toml
+++ b/facet-solver/Cargo.toml
@@ -26,7 +26,7 @@ strsim = { workspace = true, optional = true }
 
 [dev-dependencies]
 divan = { workspace = true }
-facet = { workspace = true, features = ["all-impls", "doc"] }
+facet = { path = "../facet", features = ["all-impls", "doc"] }
 json-event-parser = "0.2"
 miette = { workspace = true }
 thiserror = "2"

--- a/facet-svg/Cargo.toml
+++ b/facet-svg/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://facet.rs"
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { workspace = true }
+facet = { path = "../facet", version = "0.42.0" }
 facet-format = { path = "../facet-format", version = "0.42.0" }
 facet-xml = { path = "../facet-xml", version = "0.42.0" }
 

--- a/facet-tokio-postgres/Cargo.toml
+++ b/facet-tokio-postgres/Cargo.toml
@@ -23,7 +23,7 @@ postgres-types = "0.2"
 rust_decimal = { workspace = true, optional = true, features = ["db-tokio-postgres"] }
 
 [dev-dependencies]
-facet = { workspace = true }
+facet = { path = "../facet" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 testcontainers = "0.26"
 testcontainers-modules = { version = "0.14", features = ["postgres"] }

--- a/facet-toml/Cargo.toml
+++ b/facet-toml/Cargo.toml
@@ -34,7 +34,7 @@ http = { workspace = true, optional = true }
 http-body-util = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
-facet = { workspace = true, features = ["doc", "net"] }
+facet = { path = "../facet", features = ["doc", "net"] }
 facet-format = { path = "../facet-format", features = ["jit"] }
 facet-format-suite = { path = "../facet-format-suite", features = ["third-party"] }
 facet-value = { path = "../facet-value" }

--- a/facet-typescript/Cargo.toml
+++ b/facet-typescript/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 facet-core = { path = "../facet-core", version = "0.42.0" }
 
 [dev-dependencies]
-facet = { workspace = true }
+facet = { path = "../facet" }
 insta = { workspace = true }
 
 [lints]

--- a/facet-urlencoded/Cargo.toml
+++ b/facet-urlencoded/Cargo.toml
@@ -32,7 +32,7 @@ http-body-util = { version = "0.1", default-features = false, optional = true }
 log = { workspace = true }
 
 [dev-dependencies]
-facet = { workspace = true, features = ["all-impls", "doc"] }
+facet = { path = "../facet", features = ["all-impls", "doc"] }
 facet-testhelpers = { path = "../facet-testhelpers" }
 
 [lints]

--- a/facet-value/Cargo.toml
+++ b/facet-value/Cargo.toml
@@ -31,7 +31,7 @@ miette = { version = "7", optional = true, default-features = false }
 [dev-dependencies]
 bolero = { workspace = true }
 divan = { workspace = true }
-facet = { workspace = true, features = ["all-impls", "doc"] }
+facet = { path = "../facet", features = ["all-impls", "doc"] }
 facet-assert = { path = "../facet-assert" }
 facet-diff = { path = "../facet-diff" }
 facet-pretty = { path = "../facet-pretty" }

--- a/facet-xdr/Cargo.toml
+++ b/facet-xdr/Cargo.toml
@@ -23,7 +23,7 @@ facet-reflect = { path = "../facet-reflect", version = "0.42.0" }
 miette = { workspace = true }
 
 [dev-dependencies]
-facet = { workspace = true, features = ["all-impls"] }
+facet = { path = "../facet", features = ["all-impls"] }
 xdr-codec = "0.4"
 
 [features]

--- a/facet-xml/Cargo.toml
+++ b/facet-xml/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { workspace = true }
+facet = { path = "../facet", version = "0.42.0" }
 facet-core = { path = "../facet-core", version = "0.42.0" }
 facet-format = { path = "../facet-format", version = "0.42.0" }
 facet-reflect = { path = "../facet-reflect", version = "0.42.0", features = ["miette"] }
@@ -41,7 +41,7 @@ facet-diff-core = { path = "../facet-diff-core", version = "0.42.0", optional = 
 
 [dev-dependencies]
 divan = { workspace = true }
-facet = { workspace = true, features = ["doc", "net"] }
+facet = { path = "../facet", features = ["doc", "net"] }
 facet-diff = { path = "../facet-diff" }
 facet-format = { path = "../facet-format", features = ["jit"] }
 facet-format-suite = { path = "../facet-format-suite", features = ["third-party", "tokio"] }

--- a/facet-yaml/Cargo.toml
+++ b/facet-yaml/Cargo.toml
@@ -34,7 +34,7 @@ http-body-util = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 datatest-stable = "0.3"
-facet = { workspace = true, features = ["doc", "net"] }
+facet = { path = "../facet", features = ["doc", "net"] }
 facet-format-suite = { path = "../facet-format-suite", features = ["third-party"] }
 indoc = { workspace = true }
 libtest-mimic = "0.8.1"

--- a/tools/benchmark-defs/Cargo.toml
+++ b/tools/benchmark-defs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmark-defs"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2024"
 rust-version = "1.89.0"
 publish = false
@@ -11,7 +11,7 @@ publish = false
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { workspace = true }
+facet = { path = "../../facet", version = "0.42.0" }
 facet-args = { path = "../../facet-args" }
 facet-kdl = { path = "../../facet-kdl" }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2024"
 rust-version = "1.89.0"
 publish = false
@@ -11,8 +11,8 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 [features]
 
 [dependencies]
-benchmark-defs = { path = "../tools/benchmark-defs", version = "0.41.0" }
-facet = { workspace = true, features = ["all-impls", "doc"] }
+benchmark-defs = { path = "../tools/benchmark-defs", version = "0.42.0" }
+facet = { path = "../facet", version = "0.42.0", features = ["all-impls", "doc"] }
 facet-args = { path = "../facet-args", version = "0.42.0" }
 facet-json = { path = "../facet-json", version = "0.42.0" }
 flate2 = "1.1"


### PR DESCRIPTION
Much like `cargo publish --workspace`, release-plz is lost when there are "seemingly circular" deps. This hopefully addresses it.