### PR TITLE
fix(derive): respect builtin #[facet(default = ...)] in derive(Default)

### DIFF
--- a/facet-default/tests/integration.rs
+++ b/facet-default/tests/integration.rs
@@ -135,3 +135,42 @@ fn test_mixed_defaults() {
     assert_eq!(record.title, "untitled");
     assert!(record.active);
 }
+
+/// Test builtin #[facet(default = ...)] syntax (issue #1680)
+/// This tests that derive(Default) respects field-level default values
+/// specified using the builtin syntax rather than the namespaced default::value syntax.
+#[test]
+fn test_builtin_default_syntax() {
+    #[derive(Facet, Debug, PartialEq)]
+    #[facet(derive(Default))]
+    pub struct Config {
+        #[facet(default = true)]
+        enabled: bool,
+        #[facet(default = false)]
+        disabled: bool,
+        #[facet(default = 42)]
+        number: i32,
+    }
+
+    let config = Config::default();
+    assert!(config.enabled, "enabled should be true");
+    assert!(!config.disabled, "disabled should be false");
+    assert_eq!(config.number, 42, "number should be 42");
+}
+
+/// Test builtin #[facet(default)] without value (uses Default::default())
+#[test]
+fn test_builtin_default_no_value() {
+    #[derive(Facet, Debug, PartialEq)]
+    #[facet(derive(Default))]
+    pub struct Settings {
+        #[facet(default)]
+        count: usize,
+        #[facet(default = 100)]
+        limit: usize,
+    }
+
+    let settings = Settings::default();
+    assert_eq!(settings.count, 0, "count should use Default::default()");
+    assert_eq!(settings.limit, 100, "limit should be 100");
+}


### PR DESCRIPTION
## Summary

Fixes #1680. When using `#[facet(derive(Default))]`, the generated `Default` implementation was ignoring field-level `#[facet(default = ...)]` attributes and instead using `::core::default::Default::default()` for all fields.

## Changes

- Updated `emit_field_default_expr` and `field_default_tokens` in `facet-macros-impl/src/plugin.rs` to check for the builtin `default` attribute (where `ns` is `None`) before falling back to the namespaced `default::value` and `default::func` variants
- Added two integration tests in `facet-default/tests/integration.rs`:
  - `test_builtin_default_syntax`: Verifies that `#[facet(default = value)]` works correctly
  - `test_builtin_default_no_value`: Verifies that `#[facet(default)]` without a value uses `Default::default()`

## Test plan

- [x] `cargo check --all-features --all-targets` passes
- [x] `cargo nextest run --package facet-default` passes (8/8 tests)
- [x] `cargo nextest run --package facet-macros-impl` passes (8/8 tests)
- [x] New tests verify the exact reproduction case from the issue