### PR TITLE
fix: make PeekList::new and PeekNdArray::new unsafe to prevent untrusted vtable UB

### DIFF
--- a/facet-reflect/src/peek/list.rs
+++ b/facet-reflect/src/peek/list.rs
@@ -82,8 +82,8 @@ enum PeekListIterStateKind {
 /// Lets you read from a list (implements read-only [`facet_core::ListVTable`] proxies)
 #[derive(Clone, Copy)]
 pub struct PeekList<'mem, 'facet> {
-    pub(crate) value: Peek<'mem, 'facet>,
-    pub(crate) def: ListDef,
+    value: Peek<'mem, 'facet>,
+    def: ListDef,
 }
 
 impl Debug for PeekList<'_, '_> {
@@ -94,8 +94,18 @@ impl Debug for PeekList<'_, '_> {
 
 impl<'mem, 'facet> PeekList<'mem, 'facet> {
     /// Creates a new peek list
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `def` contains valid vtable function pointers that:
+    /// - Correctly implement the list operations for the actual type
+    /// - Do not cause undefined behavior when called
+    /// - Return pointers within valid memory bounds
+    /// - Match the element type specified in `def.t()`
+    ///
+    /// Violating these requirements can lead to memory safety issues.
     #[inline]
-    pub fn new(value: Peek<'mem, 'facet>, def: ListDef) -> Self {
+    pub unsafe fn new(value: Peek<'mem, 'facet>, def: ListDef) -> Self {
         Self { value, def }
     }
 

--- a/facet-reflect/src/peek/ndarray.rs
+++ b/facet-reflect/src/peek/ndarray.rs
@@ -5,8 +5,8 @@ use facet_core::{NdArrayDef, PtrConst};
 /// Lets you read from an n-dimensional array (implements read-only [`facet_core::NdArrayVTable`] proxies)
 #[derive(Clone, Copy)]
 pub struct PeekNdArray<'mem, 'facet> {
-    pub(crate) value: Peek<'mem, 'facet>,
-    pub(crate) def: NdArrayDef,
+    value: Peek<'mem, 'facet>,
+    def: NdArrayDef,
 }
 
 impl Debug for PeekNdArray<'_, '_> {
@@ -43,8 +43,18 @@ impl core::fmt::Debug for StrideError {
 }
 impl<'mem, 'facet> PeekNdArray<'mem, 'facet> {
     /// Creates a new peek array
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `def` contains valid vtable function pointers that:
+    /// - Correctly implement the ndarray operations for the actual type
+    /// - Do not cause undefined behavior when called
+    /// - Return pointers within valid memory bounds
+    /// - Match the element type specified in `def.t()`
+    ///
+    /// Violating these requirements can lead to memory safety issues.
     #[inline]
-    pub fn new(value: Peek<'mem, 'facet>, def: NdArrayDef) -> Self {
+    pub unsafe fn new(value: Peek<'mem, 'facet>, def: NdArrayDef) -> Self {
         Self { value, def }
     }
 

--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -691,7 +691,10 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
     #[inline]
     pub fn into_list(self) -> Result<PeekList<'mem, 'facet>, ReflectError> {
         if let Def::List(def) = self.shape.def {
-            return Ok(PeekList { value: self, def });
+            // SAFETY: The ListDef comes from self.shape.def, where self.shape is obtained
+            // from a trusted source (either T::SHAPE from the Facet trait, or validated
+            // through other safe constructors). The vtable is therefore trusted.
+            return Ok(unsafe { PeekList::new(self, def) });
         }
 
         Err(ReflectError::WasNotA {
@@ -704,7 +707,10 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
     #[inline]
     pub fn into_ndarray(self) -> Result<PeekNdArray<'mem, 'facet>, ReflectError> {
         if let Def::NdArray(def) = self.shape.def {
-            return Ok(PeekNdArray { value: self, def });
+            // SAFETY: The NdArrayDef comes from self.shape.def, where self.shape is obtained
+            // from a trusted source (either T::SHAPE from the Facet trait, or validated
+            // through other safe constructors). The vtable is therefore trusted.
+            return Ok(unsafe { PeekNdArray::new(self, def) });
         }
 
         Err(ReflectError::WasNotA {

--- a/facet-reflect/tests/compile_tests.rs
+++ b/facet-reflect/tests/compile_tests.rs
@@ -397,14 +397,17 @@ fn test_attr_non_sync_data() {
     run_compilation_test(&test);
 }
 
-/// Soundness test for GitHub issue #1665
+/// Soundness test for GitHub issues #1665, #1684, #1685
 ///
-/// Before the fix, PeekListLike::new(), PeekMap::new(), and PeekSet::new() were safe
-/// but accepted untrusted vtables, allowing UB when those vtables had malicious function pointers.
+/// Before the fix, PeekListLike::new(), PeekMap::new(), PeekSet::new(), PeekList::new(),
+/// and PeekNdArray::new() were safe but accepted untrusted vtables, allowing UB when
+/// those vtables had malicious function pointers.
 ///
 /// After the fix, these constructors are unsafe, so this code should fail to compile.
 ///
 /// See: https://github.com/facet-rs/facet/issues/1665
+/// See: https://github.com/facet-rs/facet/issues/1684
+/// See: https://github.com/facet-rs/facet/issues/1685
 #[test]
 #[cfg(not(miri))]
 fn test_peek_untrusted_vtable() {

--- a/facet-reflect/tests/peek/compile_tests/untrusted_vtable.rs
+++ b/facet-reflect/tests/peek/compile_tests/untrusted_vtable.rs
@@ -1,25 +1,33 @@
-// Soundness test for GitHub issue #1665
+// Soundness test for GitHub issues #1665, #1684, #1685
 //
-// Before the fix, PeekListLike::new(), PeekMap::new(), and PeekSet::new() were safe
-// but accepted untrusted vtables, allowing UB when those vtables had malicious function pointers.
+// Before the fix, PeekListLike::new(), PeekMap::new(), PeekSet::new(), PeekList::new(),
+// and PeekNdArray::new() were safe but accepted untrusted vtables, allowing UB when
+// those vtables had malicious function pointers.
 //
 // After the fix, these constructors are unsafe, so this code should fail to compile.
 //
 // See: https://github.com/facet-rs/facet/issues/1665
+// See: https://github.com/facet-rs/facet/issues/1684
+// See: https://github.com/facet-rs/facet/issues/1685
 
 use facet::Facet;
-use facet_reflect::{ListLikeDef, Peek, PeekListLike};
+use facet_reflect::{ListLikeDef, Peek, PeekList, PeekListLike, PeekNdArray};
 
 fn main() -> eyre::Result<()> {
-    // Try to create a PeekListLike using the constructor
-    // This should fail to compile because PeekListLike::new is unsafe
     let values = vec![1, 2, 3];
     let peek = Peek::new(&values);
 
     // Extract the ListDef from the shape
     if let facet::Def::List(list_def) = peek.shape().def {
-        // This line should fail to compile - new() is unsafe
+        // These lines should fail to compile - new() is unsafe
         let _list_like = PeekListLike::new(peek, ListLikeDef::List(list_def));
+        let _list = PeekList::new(peek, list_def);
+    }
+
+    // Test PeekNdArray as well (issue #1685)
+    if let facet::Def::NdArray(ndarray_def) = peek.shape().def {
+        // This line should fail to compile - new() is unsafe
+        let _ndarray = PeekNdArray::new(peek, ndarray_def);
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Makes `PeekList::new()` and `PeekNdArray::new()` constructors unsafe to prevent soundness issues where untrusted vtables could cause undefined behavior. This follows the same pattern as the fix for #1665.

## Changes

- Make `PeekList` and `PeekNdArray` struct fields private (was `pub(crate)`)
- Make `PeekList::new()` and `PeekNdArray::new()` unsafe with safety documentation
- Update `into_list()` and `into_ndarray()` in `value.rs` to use unsafe blocks with SAFETY comments
- Extend compile test to verify these constructors require unsafe

## Testing

- All existing tests pass
- Extended compile test verifies that calling `PeekList::new()` and `PeekNdArray::new()` without unsafe fails to compile

Fixes #1684
Fixes #1685