### PR TITLE
fix(soundness): make shape field private on Ox* types

### DIFF
--- a/facet-core/src/types/builtins.rs
+++ b/facet-core/src/types/builtins.rs
@@ -59,7 +59,7 @@ pub struct OxPtrConst {
     /// The pointer to the data.
     pub(crate) ptr: PtrConst,
     /// The shape describing the type.
-    pub shape: &'static Shape,
+    pub(crate) shape: &'static Shape,
 }
 
 impl OxPtrConst {
@@ -105,7 +105,7 @@ pub struct OxPtrMut {
     /// The pointer to the data.
     pub(crate) ptr: PtrMut,
     /// The shape describing the type.
-    pub shape: &'static Shape,
+    pub(crate) shape: &'static Shape,
 }
 
 impl OxPtrMut {
@@ -190,7 +190,7 @@ pub struct OxPtrUninit {
     /// The pointer to uninitialized data.
     pub(crate) ptr: PtrUninit,
     /// The shape describing the type.
-    pub shape: &'static Shape,
+    pub(crate) shape: &'static Shape,
 }
 
 impl OxPtrUninit {
@@ -250,7 +250,7 @@ pub struct OxRef<'a> {
     /// The pointer to the data.
     pub(crate) ptr: PtrConst,
     /// The shape describing the type.
-    pub shape: &'static Shape,
+    pub(crate) shape: &'static Shape,
     /// Phantom lifetime
     phantom: PhantomData<&'a ()>,
 }
@@ -390,7 +390,7 @@ pub struct OxMut<'a> {
     /// The pointer to the data.
     pub(crate) ptr: PtrMut,
     /// The shape describing the type.
-    pub shape: &'static Shape,
+    pub(crate) shape: &'static Shape,
     /// Phantom lifetime
     phantom: PhantomData<&'a mut ()>,
 }

--- a/facet-shapelike/src/shape_like.rs
+++ b/facet-shapelike/src/shape_like.rs
@@ -74,7 +74,7 @@ pub struct AttrLike {
 impl From<&Attr> for AttrLike {
     fn from(attr: &Attr) -> Self {
         let ptr = attr.data.ptr();
-        let shape = attr.data.shape;
+        let shape = attr.data.shape();
         let peek = unsafe { Peek::unchecked_new(ptr, shape) };
         let data = facet_postcard::peek_to_vec(peek).unwrap();
         Self {


### PR DESCRIPTION
## Summary

Fixes a soundness issue where the `shape` field on `OxRef`, `OxMut`, and related types was public, allowing safe code to mutate it and lie about the type being pointed to. This could cause type confusion and memory safety violations.

Fixes #1691

## Changes

- Changed `pub shape` to `pub(crate) shape` on:
  - `OxPtrConst`
  - `OxPtrMut`
  - `OxPtrUninit`
  - `OxRef`
  - `OxMut`
- Updated `facet-shapelike` to use `.shape()` method instead of field access

## Breaking Change

This is a source-breaking change. Callers using `.shape` field access must now use `.shape()` method instead. All types already had getter methods, so migration is straightforward.

## Test Plan

- All 2755 tests pass
- `cargo check` passes across the workspace