### PR TITLE
fix(soundness): propagate variance correctly for reference types

### DIFF
--- a/facet-core/src/impls/core/reference.rs
+++ b/facet-core/src/impls/core/reference.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use crate::{
     Def, Facet, HashProxy, KnownPointer, OxPtrConst, OxPtrMut, PointerDef, PointerFlags,
     PointerType, PointerVTable, PtrConst, Shape, ShapeBuilder, Type, TypeNameOpts, TypeOpsIndirect,
-    TypeParam, VTableIndirect, ValuePointerType,
+    TypeParam, VTableIndirect, ValuePointerType, Variance,
 };
 
 /// Type-erased type_name for &T - reads the pointee type from the shape
@@ -259,6 +259,8 @@ unsafe impl<'a, T: ?Sized + Facet<'a>> Facet<'a> for &'a T {
                 shape: T::SHAPE,
             }])
             .inner(T::SHAPE)
+            // &T is covariant in T, so propagate T's variance
+            .variance(Shape::computed_variance)
             .vtable_indirect(&REF_VTABLE)
             .type_ops_indirect(&REF_TYPE_OPS)
             .build()
@@ -297,6 +299,8 @@ unsafe impl<'a, T: ?Sized + Facet<'a>> Facet<'a> for &'a mut T {
                 shape: T::SHAPE,
             }])
             .inner(T::SHAPE)
+            // &mut T is invariant in T
+            .variance(Variance::INVARIANT)
             .vtable_indirect(&REF_MUT_VTABLE)
             .type_ops_indirect(&REF_MUT_TYPE_OPS)
             .build()


### PR DESCRIPTION
## Summary

Fixes #1696

Before this fix, `&T` always reported `Covariant` regardless of T's variance. This allowed unsound lifetime shrinking on types like `&&fn(&'a str)` which should be invariant (because `fn` is invariant).

## Changes

- `&T` now propagates T's variance via `Shape::computed_variance`
- `&mut T` is now correctly marked as invariant (since mutable references are invariant in T)
- Added regression tests for:
  - `reference_to_fn_ptr_variance` - verifies `&fn()` is invariant
  - `shrink_lifetime_ref_to_fn_ptr_panics` - verifies lifetime shrinking is rejected
  - `mut_ref_is_invariant` - verifies `&mut T` is invariant
  - `shared_ref_propagates_variance` - verifies `&T` propagates T's variance

## Test plan

- [x] `cargo check --all-features --all-targets` passes
- [x] All variance tests pass
- [x] New regression tests verify the fix