### PR TITLE
fix: prevent exponential variance computation for recursive types

### DIFF
--- a/facet-core/src/impls/alloc/btreemap.rs
+++ b/facet-core/src/impls/alloc/btreemap.rs
@@ -189,6 +189,8 @@ where
                     shape: V::SHAPE,
                 },
             ])
+            // BTreeMap<K, V> combines K and V variances
+            .variance(Shape::computed_variance)
             .type_ops_indirect(
                 &const {
                     TypeOpsIndirect {

--- a/facet-core/src/impls/alloc/btreeset.rs
+++ b/facet-core/src/impls/alloc/btreeset.rs
@@ -136,6 +136,9 @@ where
                 name: "T",
                 shape: T::SHAPE,
             }])
+            .inner(T::SHAPE)
+            // BTreeSet<T> propagates T's variance
+            .variance(Shape::computed_variance)
             .build()
     };
 }

--- a/facet-core/src/impls/core/array.rs
+++ b/facet-core/src/impls/core/array.rs
@@ -268,6 +268,9 @@ where
                 name: "T",
                 shape: T::SHAPE,
             }])
+            .inner(T::SHAPE)
+            // [T; N] propagates T's variance
+            .variance(Shape::computed_variance)
             .vtable_indirect(&ARRAY_VTABLE)
             .type_ops_indirect(
                 &const {

--- a/facet-core/src/impls/core/result.rs
+++ b/facet-core/src/impls/core/result.rs
@@ -250,6 +250,8 @@ unsafe impl<'a, T: Facet<'a>, E: Facet<'a>> Facet<'a> for Result<T, E> {
                     shape: E::SHAPE,
                 },
             ])
+            // Result<T, E> combines T and E variances
+            .variance(Shape::computed_variance)
             .vtable_indirect(&RESULT_VTABLE)
             .type_ops_indirect(&RESULT_TYPE_OPS)
             .build()

--- a/facet-core/src/impls/core/slice.rs
+++ b/facet-core/src/impls/core/slice.rs
@@ -235,6 +235,8 @@ where
                 name: "T",
                 shape: T::SHAPE,
             }])
+            // [T] propagates T's variance
+            .variance(Shape::computed_variance)
             .type_ops_indirect(
                 &const {
                     TypeOpsIndirect {

--- a/facet-core/src/impls/std/hashmap.rs
+++ b/facet-core/src/impls/std/hashmap.rs
@@ -187,6 +187,8 @@ where
                     shape: V::SHAPE,
                 },
             ])
+            // HashMap<K, V> combines K and V variances
+            .variance(Shape::computed_variance)
             .vtable_indirect(&VTableIndirect::EMPTY)
             .type_ops_indirect(
                 &const {

--- a/facet-core/src/impls/std/hashset.rs
+++ b/facet-core/src/impls/std/hashset.rs
@@ -258,6 +258,9 @@ where
                     shape: S::SHAPE,
                 },
             ])
+            .inner(T::SHAPE)
+            // HashSet<T> propagates T's variance
+            .variance(Shape::computed_variance)
             .vtable_indirect(
                 &const {
                     VTableIndirect {

--- a/facet/tests/variance_stack_overflow.rs
+++ b/facet/tests/variance_stack_overflow.rs
@@ -1,4 +1,10 @@
 //! Test variance computation with recursive types.
+//!
+//! These tests verify:
+//! 1. Cycle detection prevents infinite recursion
+//! 2. Exponential blowup is prevented for multi-recursive types
+//! 3. Variance is computed correctly for recursive types
+//! 4. Early termination works when invariant is detected
 
 use facet::{Facet, Variance};
 
@@ -20,17 +26,18 @@ struct Simple {
 #[test]
 #[cfg_attr(miri, ignore)] // This is too slow in Miri
 fn test_recursive_variance_no_stack_overflow() {
-    // This should NOT blow the stack - depth limit should kick in
+    // This should NOT blow the stack - cycle detection handles it
     let shape = Node::SHAPE;
     let variance = (shape.variance)(shape);
 
-    // Recursive types hit the depth limit during variance computation.
-    // When the depth limit is hit, we conservatively return Invariant
-    // to ensure soundness (contravariant types can exist at any depth).
+    // Recursive types are handled via cycle detection.
+    // When a cycle is detected (same type being computed), we return Covariant
+    // as the neutral element - cycles don't contribute new variance information.
+    // Since Node only contains covariant fields (i32 and Box<Node>), it's Covariant.
     assert_eq!(
         variance,
-        Variance::Invariant,
-        "Recursive types return Invariant when depth limit is hit (conservative but sound)"
+        Variance::Covariant,
+        "Recursive types with only covariant fields are Covariant"
     );
 }
 
@@ -89,5 +96,175 @@ fn test_struct_with_mut_ptr_is_invariant() {
         variance,
         Variance::Invariant,
         "Struct containing *mut T must be Invariant"
+    );
+}
+
+// ============================================================================
+// Tests for issue #1704: Exponential variance computation
+// ============================================================================
+
+/// A type with multiple self-references - this used to cause exponential blowup.
+/// Without cycle detection, computing variance would be O(4^depth) operations.
+/// With cycle detection, it's O(number of unique types).
+#[derive(Facet)]
+struct MultiRecursive {
+    #[facet(recursive_type)]
+    a: Box<MultiRecursive>,
+    #[facet(recursive_type)]
+    b: Box<MultiRecursive>,
+    #[facet(recursive_type)]
+    c: Box<MultiRecursive>,
+    #[facet(recursive_type)]
+    d: Box<MultiRecursive>,
+}
+
+#[test]
+fn test_multi_recursive_variance_is_fast() {
+    // This test verifies the fix for issue #1704.
+    // Before the fix, this would take ~30 seconds.
+    // After the fix, it should be instant.
+    let start = std::time::Instant::now();
+    let shape = MultiRecursive::SHAPE;
+    let variance = shape.computed_variance();
+    let elapsed = start.elapsed();
+
+    // Should complete in under 100ms (being very generous here)
+    assert!(
+        elapsed.as_millis() < 100,
+        "Variance computation took {:?}, expected < 100ms",
+        elapsed
+    );
+
+    // All fields are Box<Self> which is covariant, so the result is Covariant
+    assert_eq!(
+        variance,
+        Variance::Covariant,
+        "MultiRecursive should be Covariant"
+    );
+}
+
+/// A recursive type with an invariant field - should be invariant
+#[derive(Facet)]
+struct RecursiveInvariant {
+    ptr: *mut i32,
+    #[facet(recursive_type)]
+    next: Box<RecursiveInvariant>,
+}
+
+#[test]
+fn test_recursive_with_invariant_field() {
+    let shape = RecursiveInvariant::SHAPE;
+    let variance = shape.computed_variance();
+
+    // Should be invariant because it contains *mut i32
+    assert_eq!(
+        variance,
+        Variance::Invariant,
+        "RecursiveInvariant should be Invariant due to *mut i32"
+    );
+}
+
+/// Tests that early termination works - once we see invariant, stop computing
+#[derive(Facet)]
+struct EarlyTermination {
+    // This field makes the struct invariant immediately
+    ptr: *mut i32,
+    // These fields would take a while to compute without early termination
+    #[facet(recursive_type)]
+    a: Box<EarlyTermination>,
+    #[facet(recursive_type)]
+    b: Box<EarlyTermination>,
+    #[facet(recursive_type)]
+    c: Box<EarlyTermination>,
+}
+
+#[test]
+fn test_early_termination_on_invariant() {
+    let start = std::time::Instant::now();
+    let shape = EarlyTermination::SHAPE;
+    let variance = shape.computed_variance();
+    let elapsed = start.elapsed();
+
+    // Should terminate early when *mut i32 is encountered
+    assert!(
+        elapsed.as_millis() < 100,
+        "Early termination took {:?}, expected < 100ms",
+        elapsed
+    );
+
+    assert_eq!(
+        variance,
+        Variance::Invariant,
+        "EarlyTermination should be Invariant due to *mut i32"
+    );
+}
+
+/// Test mutually recursive types
+#[derive(Facet)]
+struct TreeA {
+    value: i32,
+    #[facet(recursive_type)]
+    children: Vec<TreeB>,
+}
+
+#[derive(Facet)]
+struct TreeB {
+    value: String,
+    #[facet(recursive_type)]
+    parent: Option<Box<TreeA>>,
+}
+
+#[test]
+fn test_mutually_recursive_types() {
+    let shape_a = TreeA::SHAPE;
+    let shape_b = TreeB::SHAPE;
+
+    // Both should complete quickly
+    let start = std::time::Instant::now();
+    let variance_a = shape_a.computed_variance();
+    let variance_b = shape_b.computed_variance();
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed.as_millis() < 100,
+        "Mutually recursive variance took {:?}, expected < 100ms",
+        elapsed
+    );
+
+    // Both contain only covariant fields (i32, String, Vec, Option, Box)
+    assert_eq!(variance_a, Variance::Covariant, "TreeA should be Covariant");
+    assert_eq!(variance_b, Variance::Covariant, "TreeB should be Covariant");
+}
+
+/// Test the exact reproduction case from issue #1704
+#[derive(Facet)]
+struct IssueNode(
+    #[facet(recursive_type)] &'static IssueNode,
+    #[facet(recursive_type)] &'static IssueNode,
+    #[facet(recursive_type)] &'static IssueNode,
+    #[facet(recursive_type)] &'static IssueNode,
+);
+
+#[test]
+fn test_issue_1704_reproduction() {
+    // This is the exact type from issue #1704
+    // Before fix: ~30 seconds
+    // After fix: instant
+    let start = std::time::Instant::now();
+    let shape = IssueNode::SHAPE;
+    let variance = shape.computed_variance();
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed.as_millis() < 100,
+        "Issue #1704 reproduction took {:?}, expected < 100ms",
+        elapsed
+    );
+
+    // &'static T is covariant, so the result should be Covariant
+    assert_eq!(
+        variance,
+        Variance::Covariant,
+        "IssueNode should be Covariant (all fields are &'static Self)"
     );
 }


### PR DESCRIPTION
## Summary

Fixes #1704 where variance computation took ~30 seconds for types with multiple recursive fields like `Node(&'static Node, &'static Node, &'static Node, &'static Node)`. The algorithm was visiting the same shape 4^depth times, causing exponential blowup.

## Changes

- **Add visited set tracking** using `ConstTypeId` to detect cycles during variance computation
  - When a cycle is detected, return `Covariant` (neutral element - cycles don't add new variance info)
  - This prevents exponential blowup and correctly handles recursive types
- **Add early termination** when `Invariant` is encountered (anything combined with Invariant is Invariant)
- **Respect custom variance functions** before falling back to Def-based lookup
- **Add explicit variance propagation** to container types that were missing it:
  - Arrays, slices, HashSet, BTreeSet, HashMap, BTreeMap, Result

## Key insight

Recursive types like `Node(&'static Node, ...)` are actually **covariant**, not invariant. The old code incorrectly returned Invariant when hitting the depth limit. The fix correctly identifies cycles and returns the proper variance based on the non-cyclic parts of the type structure.

## Testing

Added comprehensive tests in `facet/tests/variance_stack_overflow.rs`:
- Multi-recursive types (exact reproduction of #1704)
- Recursive types with invariant fields
- Early termination on invariant
- Mutually recursive types

All tests verify completion in <100ms (before fix: ~30 seconds).