### PR TITLE
fix(facet-kdl): implement transparent document model for roundtripping

### DIFF
--- a/facet-kdl/src/lib.rs
+++ b/facet-kdl/src/lib.rs
@@ -3,10 +3,50 @@
 //! This crate provides KDL (KDL Document Language) support using the
 //! `FormatParser` and `FormatSerializer` traits from `facet-format`.
 //!
-//! # KDL Format
+//! # KDL Data Model
 //!
-//! KDL is a document language focused on human readability. Each document
-//! consists of nodes, where each node has:
+//! **KDL is not XML.** Unlike XML which has exactly one root element, KDL documents
+//! can have **multiple root nodes**. This is a fundamental difference that affects
+//! how you design your Rust types.
+//!
+//! ## The Transparent Document Model
+//!
+//! When you serialize or deserialize with facet-kdl, the outermost Rust struct is
+//! the **document struct**. It's transparent - it doesn't appear in the KDL output.
+//! Instead, its fields become root-level nodes.
+//!
+//! ```ignore
+//! use facet::Facet;
+//!
+//! #[derive(Facet)]
+//! struct Config {
+//!     host: String,
+//!     port: u16,
+//! }
+//!
+//! let cfg = Config { host: "localhost".into(), port: 8080 };
+//! let kdl = facet_kdl::to_string(&cfg).unwrap();
+//! // Produces:
+//! // host "localhost"
+//! // port 8080
+//! ```
+//!
+//! Each field becomes its own root node. The struct name `Config` doesn't appear
+//! anywhere in the output.
+//!
+//! ## Why Fields Default to Child Nodes
+//!
+//! At the document level, there's no node to attach properties to. You can't write:
+//! ```kdl
+//! host="localhost" port=8080  // Invalid! Properties need a node name
+//! ```
+//!
+//! So fields without explicit `kdl::*` attributes default to being child nodes.
+//! If you want properties, you need a wrapper node.
+//!
+//! ## KDL Node Structure
+//!
+//! Each KDL node has:
 //! - A **name** (identifier)
 //! - **Arguments** (positional values after the name)
 //! - **Properties** (key=value pairs)
@@ -21,12 +61,70 @@
 //! - `#[facet(kdl::property)]` - Field receives a property value
 //! - `#[facet(kdl::child)]` - Field receives a single child node
 //! - `#[facet(kdl::children)]` - Field receives multiple child nodes as Vec
+//! - `#[facet(kdl::node_name)]` - Field receives the node's name (for dynamic dispatch)
 //!
-//! # Example
+//! # Examples
+//!
+//! ## Simple Roundtrip
 //!
 //! ```ignore
 //! use facet::Facet;
-//! use facet_kdl::from_str;
+//!
+//! #[derive(Facet, Debug, PartialEq)]
+//! struct Config {
+//!     host: String,
+//!     port: u16,
+//! }
+//!
+//! let cfg = Config { host: "https://example.com".into(), port: 443 };
+//!
+//! // Serialize to KDL
+//! let kdl = facet_kdl::to_string(&cfg).unwrap();
+//! assert_eq!(kdl, "host \"https://example.com\"\nport 443");
+//!
+//! // Deserialize back
+//! let parsed: Config = facet_kdl::from_str(&kdl).unwrap();
+//! assert_eq!(cfg, parsed);
+//! ```
+//!
+//! ## Multiple Root Nodes
+//!
+//! ```ignore
+//! use facet::Facet;
+//!
+//! #[derive(Facet, Debug)]
+//! struct RoutesConfig {
+//!     #[facet(kdl::children)]
+//!     routes: Vec<Route>,
+//! }
+//!
+//! #[derive(Facet, Debug)]
+//! struct Route {
+//!     #[facet(kdl::argument)]
+//!     path: String,
+//!     #[facet(kdl::property)]
+//!     handler: String,
+//! }
+//!
+//! let kdl = r#"
+//! route "/api/users" handler="users_handler"
+//! route "/api/posts" handler="posts_handler"
+//! "#;
+//!
+//! let config: RoutesConfig = facet_kdl::from_str(kdl).unwrap();
+//! assert_eq!(config.routes.len(), 2);
+//! ```
+//!
+//! ## Nested Structure with Arguments and Properties
+//!
+//! ```ignore
+//! use facet::Facet;
+//!
+//! #[derive(Facet, Debug)]
+//! struct ServerConfig {
+//!     #[facet(kdl::child)]
+//!     server: Server,
+//! }
 //!
 //! #[derive(Facet, Debug)]
 //! struct Server {
@@ -37,7 +135,7 @@
 //! }
 //!
 //! let kdl = r#"server "localhost" port=8080"#;
-//! let server: Server = from_str(kdl).unwrap();
+//! let config: ServerConfig = facet_kdl::from_str(kdl).unwrap();
 //! ```
 
 #![forbid(unsafe_code)]

--- a/facet-kdl/tests/issue_1706.rs
+++ b/facet-kdl/tests/issue_1706.rs
@@ -1,0 +1,28 @@
+use facet::Facet;
+
+/// Issue #1706: facet-kdl unable to roundtrip a simple struct
+/// https://github.com/facet-rs/facet/issues/1706
+///
+/// Simple structs should serialize and deserialize without requiring
+/// explicit kdl::* attributes or wrapper structs.
+
+#[derive(Debug, Facet, PartialEq)]
+struct Config {
+    host: String,
+    port: u16,
+}
+
+#[test]
+fn test_roundtrip() {
+    let cfg = Config {
+        host: String::from("https://kdl.dev"),
+        port: 443,
+    };
+
+    let serialized = facet_kdl::to_string(&cfg).unwrap();
+    eprintln!("Serialized:\n{}", serialized);
+
+    // This should now work - no wrapper struct needed!
+    let deserialized: Config = facet_kdl::from_str(&serialized).unwrap();
+    assert_eq!(cfg, deserialized);
+}


### PR DESCRIPTION
## Summary

Fixes #1706 - facet-kdl can now roundtrip simple structs without requiring wrapper types or explicit `kdl::*` attributes.

This PR implements the "transparent document model" for facet-kdl, enabling seamless serialization and deserialization of Rust structs to/from KDL documents.

## The Transparent Document Model

**KDL is not XML.** Unlike XML which has exactly one root element, KDL documents can have **multiple root nodes**. This PR embraces that by making the outermost Rust struct "transparent":

```rust
#[derive(Facet)]
struct Config {
    host: String,
    port: u16,
}
```

Serializes to:
```kdl
host "https://example.com"
port 443
```

And deserializes back correctly. The struct name `Config` doesn't appear anywhere - its fields become root-level nodes.

## Changes

- **Serializer** (`serializer.rs`): Document struct is now transparent - its fields become root-level nodes instead of being wrapped
- **Deserializer** (`deserializer.rs`): Extract `_arg` from nodes when deserializing into scalar types (handles `host "value"` → `String`)
- **Parser** (`parser.rs`): Empty nodes now emit `_node_name` for `kdl::node_name` attribute support
- **Documentation** (`lib.rs`): Comprehensive docs explaining the KDL data model, transparent document model, and why fields default to child nodes
- **Showcase** (`kdl_showcase.rs`): Added "Document Model" section with examples for transparent documents, multiple root nodes, and roundtripping
- **Tests** (`issue_1706.rs`, `basic.rs`): Added regression test and updated existing tests

## Test Plan

- [x] All 186 facet-kdl tests pass
- [x] New `issue_1706.rs` test verifies the fix
- [x] `kdl_showcase` example runs successfully