### PR TITLE
refactor(variance): replace function-based variance with declarative model

### DIFF
--- a/facet-core/src/impls/alloc/arc.rs
+++ b/facet-core/src/impls/alloc/arc.rs
@@ -7,8 +7,8 @@ use alloc::vec::Vec;
 
 use crate::{
     Def, Facet, KnownPointer, OxPtrConst, OxPtrMut, PointerDef, PointerFlags, PointerVTable,
-    PtrConst, PtrMut, PtrUninit, Shape, ShapeBuilder, SliceBuilderVTable, Type, TypeNameOpts,
-    TypeOpsIndirect, UserType, VTableIndirect,
+    PtrConst, PtrMut, PtrUninit, ShapeBuilder, SliceBuilderVTable, Type, TypeNameOpts,
+    TypeOpsIndirect, UserType, VTableIndirect, Variance, VarianceDep, VarianceDesc,
 };
 
 // Helper functions to create type_name formatters
@@ -214,7 +214,10 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Arc<T> {
             }])
             .inner(T::SHAPE)
             // Arc<T> propagates T's variance
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const { [VarianceDep::covariant(T::SHAPE)] },
+            })
             .build()
     };
 }
@@ -410,7 +413,10 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Weak<T> {
             }])
             .inner(T::SHAPE)
             // Weak<T> propagates T's variance
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const { [VarianceDep::covariant(T::SHAPE)] },
+            })
             .build()
     };
 }

--- a/facet-core/src/impls/alloc/boxed.rs
+++ b/facet-core/src/impls/alloc/boxed.rs
@@ -7,7 +7,7 @@ use alloc::boxed::Box;
 use crate::{
     Def, Facet, KnownPointer, OxPtrMut, PointerDef, PointerFlags, PointerVTable, PtrConst, PtrMut,
     PtrUninit, Shape, ShapeBuilder, SliceBuilderVTable, TryFromError, Type, TypeNameFn,
-    TypeNameOpts, TypeOpsIndirect, UserType, VTableIndirect,
+    TypeNameOpts, TypeOpsIndirect, UserType, VTableIndirect, Variance, VarianceDep, VarianceDesc,
 };
 
 // Named function for try_from
@@ -107,7 +107,10 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Box<T> {
             }])
             .inner(T::SHAPE)
             // Box<T> propagates T's variance
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const { [VarianceDep::covariant(T::SHAPE)] },
+            })
             .build()
     };
 }

--- a/facet-core/src/impls/alloc/btreemap.rs
+++ b/facet-core/src/impls/alloc/btreemap.rs
@@ -2,7 +2,8 @@ use alloc::{boxed::Box, collections::BTreeMap};
 
 use crate::{
     Def, Facet, IterVTable, MapDef, MapVTable, OxPtrMut, PtrConst, PtrMut, PtrUninit, Shape,
-    ShapeBuilder, TypeNameFn, TypeNameOpts, TypeOpsIndirect, TypeParam, VTableIndirect,
+    ShapeBuilder, TypeNameFn, TypeNameOpts, TypeOpsIndirect, TypeParam, VTableIndirect, Variance,
+    VarianceDep, VarianceDesc,
 };
 
 type BTreeMapIterator<'mem, K, V> = alloc::collections::btree_map::Iter<'mem, K, V>;
@@ -190,7 +191,15 @@ where
                 },
             ])
             // BTreeMap<K, V> combines K and V variances
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const {
+                    [
+                        VarianceDep::covariant(K::SHAPE),
+                        VarianceDep::covariant(V::SHAPE),
+                    ]
+                },
+            })
             .type_ops_indirect(
                 &const {
                     TypeOpsIndirect {

--- a/facet-core/src/impls/alloc/btreeset.rs
+++ b/facet-core/src/impls/alloc/btreeset.rs
@@ -5,7 +5,7 @@ use crate::{PtrConst, PtrMut, PtrUninit};
 
 use crate::{
     Def, Facet, IterVTable, OxPtrMut, SetDef, SetVTable, Shape, ShapeBuilder, TypeNameFn,
-    TypeNameOpts, TypeOpsIndirect, TypeParam, VTableIndirect,
+    TypeNameOpts, TypeOpsIndirect, TypeParam, VTableIndirect, Variance, VarianceDep, VarianceDesc,
 };
 
 type BTreeSetIterator<'mem, T> = alloc::collections::btree_set::Iter<'mem, T>;
@@ -138,7 +138,10 @@ where
             }])
             .inner(T::SHAPE)
             // BTreeSet<T> propagates T's variance
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const { [VarianceDep::covariant(T::SHAPE)] },
+            })
             .build()
     };
 }

--- a/facet-core/src/impls/alloc/rc.rs
+++ b/facet-core/src/impls/alloc/rc.rs
@@ -7,7 +7,7 @@ use alloc::vec::Vec;
 use crate::{
     Def, Facet, KnownPointer, OxPtrConst, OxPtrMut, PointerDef, PointerFlags, PointerVTable,
     PtrConst, PtrMut, PtrUninit, Shape, ShapeBuilder, SliceBuilderVTable, Type, TypeNameOpts,
-    TypeOpsIndirect, UserType, VTableIndirect,
+    TypeOpsIndirect, UserType, VTableIndirect, Variance, VarianceDep, VarianceDesc,
 };
 
 //////////////////////////////////////////////////////////////////////
@@ -101,7 +101,10 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Rc<T> {
             }])
             .inner(T::SHAPE)
             // Rc<T> propagates T's variance
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const { [VarianceDep::covariant(T::SHAPE)] },
+            })
             .vtable_indirect(
                 &const {
                     VTableIndirect {
@@ -490,7 +493,10 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Weak<T> {
             }])
             .inner(T::SHAPE)
             // Weak<T> propagates T's variance
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const { [VarianceDep::covariant(T::SHAPE)] },
+            })
             .vtable_indirect(
                 &const {
                     VTableIndirect {

--- a/facet-core/src/impls/alloc/vec.rs
+++ b/facet-core/src/impls/alloc/vec.rs
@@ -413,7 +413,10 @@ where
             }])
             .inner(T::SHAPE)
             // Vec<T> propagates T's variance
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const { [VarianceDep::covariant(T::SHAPE)] },
+            })
             .vtable_indirect(&const {
                 VTableIndirect {
                     debug: Some(vec_debug_erased),

--- a/facet-core/src/impls/builtin.rs
+++ b/facet-core/src/impls/builtin.rs
@@ -1,13 +1,11 @@
-use crate::{Opaque, Shape, Variance};
-
-use crate::Facet;
+use crate::{Facet, Opaque, Shape, VarianceDesc};
 
 // Opaque<T> is a lifetime boundary; require 'static to prevent lifetime laundering
 // through reflection. See issue #1563 for details.
 unsafe impl<'facet, T: 'static> Facet<'facet> for Opaque<T> {
     const SHAPE: &'static Shape = &const {
         Shape::builder_for_sized::<Opaque<T>>("Opaque")
-            .variance(Variance::INVARIANT)
+            .variance(VarianceDesc::INVARIANT)
             .build()
     };
 }

--- a/facet-core/src/impls/core/array.rs
+++ b/facet-core/src/impls/core/array.rs
@@ -4,7 +4,8 @@ use core::{cmp::Ordering, fmt};
 
 use crate::{
     ArrayDef, ArrayVTable, Def, Facet, HashProxy, OxPtrConst, OxPtrMut, OxRef, PtrConst, PtrMut,
-    Shape, ShapeBuilder, Type, TypeNameOpts, TypeOpsIndirect, TypeParam, VTableIndirect,
+    Shape, ShapeBuilder, Type, TypeNameOpts, TypeOpsIndirect, TypeParam, VTableIndirect, Variance,
+    VarianceDep, VarianceDesc,
 };
 
 /// Extract the ArrayDef from a shape, returns None if not an array
@@ -270,7 +271,10 @@ where
             }])
             .inner(T::SHAPE)
             // [T; N] propagates T's variance
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const { [VarianceDep::covariant(T::SHAPE)] },
+            })
             .vtable_indirect(&ARRAY_VTABLE)
             .type_ops_indirect(
                 &const {

--- a/facet-core/src/impls/core/option.rs
+++ b/facet-core/src/impls/core/option.rs
@@ -5,7 +5,7 @@ use core::cmp::Ordering;
 use crate::{
     Def, EnumRepr, EnumType, Facet, FieldBuilder, HashProxy, OptionDef, OptionVTable, OxPtrConst,
     OxPtrMut, OxRef, PtrConst, Repr, Shape, ShapeBuilder, Type, TypeOpsIndirect, TypeParam,
-    UserType, VTableIndirect, VariantBuilder,
+    UserType, VTableIndirect, Variance, VarianceDep, VarianceDesc, VariantBuilder,
 };
 
 /// Extract the OptionDef from a shape, returns None if not an Option
@@ -284,7 +284,10 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Option<T> {
             .vtable_indirect(&const { build_vtable() })
             .type_ops_indirect(&const { build_type_ops::<T>() })
             // Option<T> propagates T's variance
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const { [VarianceDep::covariant(T::SHAPE)] },
+            })
             .build()
     };
 }

--- a/facet-core/src/impls/core/pointer.rs
+++ b/facet-core/src/impls/core/pointer.rs
@@ -5,7 +5,7 @@ use core::hash::Hash;
 
 use crate::{
     Def, Facet, HashProxy, OxPtrConst, OxPtrMut, PointerType, Shape, ShapeBuilder, Type,
-    TypeOpsIndirect, TypeParam, VTableIndirect, ValuePointerType, Variance,
+    TypeOpsIndirect, TypeParam, VTableIndirect, ValuePointerType, VarianceDesc,
 };
 
 // For raw pointers, we use indirect vtable since they're generic over T
@@ -218,8 +218,8 @@ unsafe impl<'a, T: Facet<'a> + ?Sized> Facet<'a> for *mut T {
             .inner(T::SHAPE)
             .vtable_indirect(&const { build_mut_ptr_vtable::<T>() })
             .type_ops_indirect(&const { build_mut_ptr_type_ops::<T>() })
-            // *mut T is invariant in T
-            .variance(Variance::INVARIANT)
+            // *mut T is invariant in T (per Rust Reference)
+            .variance(VarianceDesc::INVARIANT)
             .eq()
             .copy()
             .build()

--- a/facet-core/src/impls/core/slice.rs
+++ b/facet-core/src/impls/core/slice.rs
@@ -236,7 +236,10 @@ where
                 shape: T::SHAPE,
             }])
             // [T] propagates T's variance
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const { [VarianceDep::covariant(T::SHAPE)] },
+            })
             .type_ops_indirect(
                 &const {
                     TypeOpsIndirect {

--- a/facet-core/src/impls/std/hashmap.rs
+++ b/facet-core/src/impls/std/hashmap.rs
@@ -7,7 +7,8 @@ use crate::{PtrConst, PtrMut, PtrUninit};
 
 use crate::{
     Def, Facet, IterVTable, MapDef, MapVTable, Shape, ShapeBuilder, Type, TypeNameFn, TypeNameOpts,
-    TypeOpsIndirect, TypeParam, UserType, VTableDirect, VTableIndirect,
+    TypeOpsIndirect, TypeParam, UserType, VTableDirect, VTableIndirect, Variance, VarianceDep,
+    VarianceDesc,
 };
 
 type HashMapIterator<'mem, K, V> = std::collections::hash_map::Iter<'mem, K, V>;
@@ -188,7 +189,15 @@ where
                 },
             ])
             // HashMap<K, V> combines K and V variances
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const {
+                    [
+                        VarianceDep::covariant(K::SHAPE),
+                        VarianceDep::covariant(V::SHAPE),
+                    ]
+                },
+            })
             .vtable_indirect(&VTableIndirect::EMPTY)
             .type_ops_indirect(
                 &const {

--- a/facet-core/src/impls/std/hashset.rs
+++ b/facet-core/src/impls/std/hashset.rs
@@ -6,7 +6,7 @@ use crate::{PtrConst, PtrMut, PtrUninit};
 use crate::{
     Def, Facet, HashProxy, IterVTable, OxPtrConst, OxPtrMut, OxRef, SetDef, SetVTable, Shape,
     ShapeBuilder, Type, TypeNameFn, TypeNameOpts, TypeOpsIndirect, TypeParam, UserType,
-    VTableIndirect,
+    VTableIndirect, Variance, VarianceDep, VarianceDesc,
 };
 
 type HashSetIterator<'mem, T> = std::collections::hash_set::Iter<'mem, T>;
@@ -260,7 +260,10 @@ where
             ])
             .inner(T::SHAPE)
             // HashSet<T> propagates T's variance
-            .variance(Shape::computed_variance)
+            .variance(VarianceDesc {
+                base: Variance::Bivariant,
+                deps: &const { [VarianceDep::covariant(T::SHAPE)] },
+            })
             .vtable_indirect(
                 &const {
                     VTableIndirect {

--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -99,6 +99,7 @@ pub mod 𝟋 {
     pub use crate::VTableDirect as 𝟋VtD;
     pub use crate::VTableErased as 𝟋VtE;
     pub use crate::Variance as 𝟋Vnc;
+    pub use crate::VarianceDesc as 𝟋VncD;
     pub use crate::Variant as 𝟋Var;
     pub use crate::VariantBuilder as 𝟋VarB;
 
@@ -112,8 +113,8 @@ pub mod 𝟋 {
     pub const 𝟋NODOC: &[&str] = &[];
     /// Empty flags
     pub const 𝟋NOFL: crate::FieldFlags = crate::FieldFlags::empty();
-    /// Computed variance function (for non-opaque types)
-    pub const 𝟋CV: fn(&'static crate::Shape) -> crate::Variance = crate::Shape::computed_variance;
+    /// Computed variance (for non-opaque types) - bivariant base with field walking fallback
+    pub const 𝟋CV: crate::VarianceDesc = crate::VarianceDesc::BIVARIANT;
 
     // === Type Aliases ===
     /// PhantomData type for shadow structs, invariant in lifetime `'a`.

--- a/facet-macros-impl/src/process_enum.rs
+++ b/facet-macros-impl/src/process_enum.rs
@@ -901,12 +901,12 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
         })
         .collect();
 
-    // Compute variance - delegate to Shape::computed_variance() at runtime
+    // Compute variance - for non-opaque types, use BIVARIANT which falls back to field walking
     let variance_call = if opaque {
         // Opaque types don't expose internals, use invariant for safety
-        quote! { .variance(𝟋Vnc::INVARIANT) }
+        quote! { .variance(𝟋VncD::INVARIANT) }
     } else {
-        // Point to Shape::computed_variance - it takes &Shape and walks fields
+        // Use BIVARIANT - the computed_variance_impl will walk fields when deps is empty
         quote! { .variance(𝟋CV) }
     };
 

--- a/facet-macros-impl/src/process_struct.rs
+++ b/facet-macros-impl/src/process_struct.rs
@@ -1524,12 +1524,12 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
         }
     };
 
-    // Compute variance - delegate to Shape::computed_variance() at runtime
+    // Compute variance - for non-opaque types, use BIVARIANT which falls back to field walking
     let variance_call = if opaque {
         // Opaque types don't expose internals, use invariant for safety
-        quote! { .variance(𝟋Vnc::INVARIANT) }
+        quote! { .variance(𝟋VncD::INVARIANT) }
     } else {
-        // Point to Shape::computed_variance - it takes &Shape and walks fields
+        // Use BIVARIANT - the computed_variance_impl will walk fields when deps is empty
         quote! { .variance(𝟋CV) }
     };
 

--- a/facet-reflect/tests/peek/ndarray.rs
+++ b/facet-reflect/tests/peek/ndarray.rs
@@ -3,7 +3,7 @@ use std::ops::{Index, IndexMut};
 use facet::{Type, TypeParam, UserType};
 use facet_core::{
     Def, Facet, NdArrayDef, NdArrayVTable, OxPtrMut, PtrConst, PtrMut, Shape, ShapeBuilder,
-    VTableIndirect, Variance,
+    VTableIndirect, VarianceDesc,
 };
 use facet_reflect::Peek;
 use facet_testhelpers::test;
@@ -183,7 +183,7 @@ unsafe impl<T: Facet<'static>> Facet<'static> for Mat<T> {
             }])
             .vtable_indirect(&VTableIndirect::EMPTY)
             .type_ops_indirect(&const { build_type_ops::<T>() })
-            .variance(Variance::INVARIANT)
+            .variance(VarianceDesc::INVARIANT)
             .build()
     };
 }

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -255,7 +255,7 @@ pub mod builtin {
             builder_shape: None,
             type_name: None,
             proxy: None,
-            variance: crate::Variance::COVARIANT,
+            variance: crate::VarianceDesc::BIVARIANT,
             flags: crate::ShapeFlags::empty(),
             tag: None,
             content: None,

--- a/facet/tests/variance_bivariance_experiment.rs
+++ b/facet/tests/variance_bivariance_experiment.rs
@@ -1,0 +1,332 @@
+//! Tests for issue #1708: Bivariance support
+//!
+//! ## The Problem (Before)
+//!
+//! `facet_core::Variance` only had Covariant, Contravariant, and Invariant.
+//!
+//! Some types are "bivariant" - they are both covariant (`T<'long> <: T<'short>`)
+//! AND contravariant (`T<'short> <: T<'long>`). This includes all types containing
+//! none of: lifetimes, references, or interior mutability.
+//!
+//! Without bivariance, we couldn't accurately compute `fn(T)` variance when T had
+//! no lifetime constraints.
+//!
+//! ## The Solution (After)
+//!
+//! Added `Variance::Bivariant` - the "top" of the variance lattice:
+//!
+//! ```text
+//!        Bivariant (top - no constraints)
+//!        /        \
+//!   Covariant    Contravariant
+//!        \        /
+//!        Invariant (bottom - maximum constraints)
+//! ```
+//!
+//! Properties:
+//! - Bivariant is the identity for combine: `Bivariant.combine(X) == X`
+//! - Bivariant is stable under flip: `Bivariant.flip() == Bivariant`
+//! - Bivariant means "no lifetime constraints"
+
+use facet::{Facet, Variance};
+
+// =============================================================================
+// Bivariance for lifetime-free types
+// =============================================================================
+
+#[test]
+fn primitives_are_bivariant() {
+    // Types with no lifetime dependency are bivariant (can go either direction)
+    assert_eq!(i32::SHAPE.computed_variance(), Variance::Bivariant);
+    assert_eq!(String::SHAPE.computed_variance(), Variance::Bivariant);
+    assert_eq!(bool::SHAPE.computed_variance(), Variance::Bivariant);
+    assert_eq!(u64::SHAPE.computed_variance(), Variance::Bivariant);
+    assert_eq!(f64::SHAPE.computed_variance(), Variance::Bivariant);
+    assert_eq!(<()>::SHAPE.computed_variance(), Variance::Bivariant);
+}
+
+#[test]
+fn unit_struct_is_bivariant() {
+    #[derive(Facet)]
+    struct Unit;
+
+    assert_eq!(
+        Unit::SHAPE.computed_variance(),
+        Variance::Bivariant,
+        "Empty struct with no lifetime-carrying fields is bivariant"
+    );
+}
+
+#[test]
+fn struct_with_only_primitives_is_bivariant() {
+    #[derive(Facet)]
+    struct OnlyPrimitives {
+        a: i32,
+        b: bool,
+        c: f64,
+    }
+
+    assert_eq!(
+        OnlyPrimitives::SHAPE.computed_variance(),
+        Variance::Bivariant,
+        "Struct with only primitive fields is bivariant"
+    );
+}
+
+// =============================================================================
+// Function pointer variance (the key improvement from issue #1708)
+// =============================================================================
+
+#[test]
+#[cfg(feature = "fn-ptr")]
+fn fn_ptr_with_bivariant_args_is_bivariant() {
+    // fn(i32) -> i32 has no lifetime constraints
+    // - i32 argument is bivariant, flip(bivariant) = bivariant
+    // - i32 return is bivariant
+    // - bivariant.combine(bivariant) = bivariant
+    let shape = <fn(i32) -> i32>::SHAPE;
+    assert_eq!(
+        shape.computed_variance(),
+        Variance::Bivariant,
+        "fn(i32) -> i32 should be bivariant (no lifetime constraints)"
+    );
+}
+
+#[test]
+#[cfg(feature = "fn-ptr")]
+fn fn_ptr_returning_unit_is_bivariant() {
+    // fn() -> () has no lifetime constraints
+    let shape = <fn()>::SHAPE;
+    assert_eq!(
+        shape.computed_variance(),
+        Variance::Bivariant,
+        "fn() should be bivariant"
+    );
+}
+
+#[test]
+#[cfg(feature = "fn-ptr")]
+fn fn_ptr_with_multiple_bivariant_args_is_bivariant() {
+    // fn(i32, String, bool) -> f64 has no lifetime constraints
+    let shape = <fn(i32, String, bool) -> f64>::SHAPE;
+    assert_eq!(
+        shape.computed_variance(),
+        Variance::Bivariant,
+        "fn with all bivariant args and return is bivariant"
+    );
+}
+
+// =============================================================================
+// Struct with fn pointer that has no lifetime constraints
+// =============================================================================
+
+#[test]
+#[cfg(feature = "fn-ptr")]
+fn struct_with_bivariant_fn_ptr_is_bivariant() {
+    #[derive(Facet)]
+    struct Callback {
+        f: fn(i32) -> i32,
+    }
+
+    // This struct has no actual lifetime dependency!
+    // With bivariance support, we can now correctly identify this.
+    let shape = Callback::SHAPE;
+    assert_eq!(
+        shape.computed_variance(),
+        Variance::Bivariant,
+        "Struct with bivariant fn pointer is bivariant"
+    );
+}
+
+// =============================================================================
+// Variance algebra with bivariance
+// =============================================================================
+
+#[test]
+fn bivariant_is_identity_for_combine() {
+    // Bivariant.combine(X) == X for all X
+    assert_eq!(
+        Variance::Bivariant.combine(Variance::Bivariant),
+        Variance::Bivariant
+    );
+    assert_eq!(
+        Variance::Bivariant.combine(Variance::Covariant),
+        Variance::Covariant
+    );
+    assert_eq!(
+        Variance::Bivariant.combine(Variance::Contravariant),
+        Variance::Contravariant
+    );
+    assert_eq!(
+        Variance::Bivariant.combine(Variance::Invariant),
+        Variance::Invariant
+    );
+
+    // X.combine(Bivariant) == X for all X (commutativity)
+    assert_eq!(
+        Variance::Covariant.combine(Variance::Bivariant),
+        Variance::Covariant
+    );
+    assert_eq!(
+        Variance::Contravariant.combine(Variance::Bivariant),
+        Variance::Contravariant
+    );
+    assert_eq!(
+        Variance::Invariant.combine(Variance::Bivariant),
+        Variance::Invariant
+    );
+}
+
+#[test]
+fn invariant_still_dominates() {
+    // Invariant is the "bottom" of the lattice
+    assert_eq!(
+        Variance::Covariant.combine(Variance::Invariant),
+        Variance::Invariant
+    );
+    assert_eq!(
+        Variance::Contravariant.combine(Variance::Invariant),
+        Variance::Invariant
+    );
+    assert_eq!(
+        Variance::Bivariant.combine(Variance::Invariant),
+        Variance::Invariant
+    );
+}
+
+#[test]
+fn mixed_co_contra_is_invariant() {
+    // Covariant + Contravariant = Invariant (conflicting constraints)
+    assert_eq!(
+        Variance::Covariant.combine(Variance::Contravariant),
+        Variance::Invariant
+    );
+    assert_eq!(
+        Variance::Contravariant.combine(Variance::Covariant),
+        Variance::Invariant
+    );
+}
+
+// =============================================================================
+// Flip behavior with bivariance
+// =============================================================================
+
+#[test]
+fn bivariant_flip_is_bivariant() {
+    // Bivariant has no constraints to flip
+    assert_eq!(Variance::Bivariant.flip(), Variance::Bivariant);
+}
+
+#[test]
+fn flip_swaps_co_and_contra() {
+    assert_eq!(Variance::Covariant.flip(), Variance::Contravariant);
+    assert_eq!(Variance::Contravariant.flip(), Variance::Covariant);
+}
+
+#[test]
+fn invariant_flip_is_invariant() {
+    assert_eq!(Variance::Invariant.flip(), Variance::Invariant);
+}
+
+// =============================================================================
+// can_shrink and can_grow with bivariance
+// =============================================================================
+
+#[test]
+fn bivariant_can_shrink_and_grow() {
+    // Bivariant types have no lifetime constraints, so both are allowed
+    assert!(Variance::Bivariant.can_shrink(), "Bivariant can shrink");
+    assert!(Variance::Bivariant.can_grow(), "Bivariant can grow");
+}
+
+#[test]
+fn covariant_can_only_shrink() {
+    assert!(Variance::Covariant.can_shrink(), "Covariant can shrink");
+    assert!(!Variance::Covariant.can_grow(), "Covariant cannot grow");
+}
+
+#[test]
+fn contravariant_can_only_grow() {
+    assert!(
+        !Variance::Contravariant.can_shrink(),
+        "Contravariant cannot shrink"
+    );
+    assert!(Variance::Contravariant.can_grow(), "Contravariant can grow");
+}
+
+#[test]
+fn invariant_cannot_shrink_or_grow() {
+    assert!(!Variance::Invariant.can_shrink(), "Invariant cannot shrink");
+    assert!(!Variance::Invariant.can_grow(), "Invariant cannot grow");
+}
+
+// =============================================================================
+// Covariance still works correctly
+// =============================================================================
+
+#[test]
+fn reference_is_covariant() {
+    // From the Rust Reference:
+    // &'a T is covariant in 'a and covariant in T
+    // https://doc.rust-lang.org/reference/subtyping.html#r-subtyping.variance.builtin-types
+    //
+    // Even though i32 is bivariant (no lifetime constraints), &i32 introduces
+    // a reference lifetime, making it covariant.
+    // Covariant.combine(Bivariant) = Covariant
+    let shape = <&i32>::SHAPE;
+    assert_eq!(
+        shape.computed_variance(),
+        Variance::Covariant,
+        "&i32 is covariant (reference introduces lifetime)"
+    );
+}
+
+#[test]
+fn box_propagates_inner_variance() {
+    // Box<T> propagates T's variance
+    let shape = <Box<i32>>::SHAPE;
+    assert_eq!(
+        shape.computed_variance(),
+        Variance::Bivariant,
+        "Box<i32> propagates i32's bivariance"
+    );
+}
+
+#[test]
+fn vec_propagates_inner_variance() {
+    let shape = <Vec<i32>>::SHAPE;
+    assert_eq!(
+        shape.computed_variance(),
+        Variance::Bivariant,
+        "Vec<i32> propagates i32's bivariance"
+    );
+}
+
+// =============================================================================
+// Invariance still works correctly
+// =============================================================================
+
+#[test]
+fn mut_ptr_is_invariant() {
+    // *mut T is invariant (can't change the pointee)
+    let shape = <*mut i32>::SHAPE;
+    assert_eq!(
+        shape.computed_variance(),
+        Variance::Invariant,
+        "*mut T is invariant regardless of T"
+    );
+}
+
+#[test]
+fn struct_with_mut_ptr_is_invariant() {
+    #[derive(Facet)]
+    struct WithMutPtr {
+        ptr: *mut i32,
+    }
+
+    assert_eq!(
+        WithMutPtr::SHAPE.computed_variance(),
+        Variance::Invariant,
+        "Struct containing *mut T is invariant"
+    );
+}


### PR DESCRIPTION
## Summary

Replace the `Shape.variance` field from a function pointer to a new `VarianceDesc` struct. This eliminates a class of bugs where custom variance functions could break cycle detection by creating fresh visited sets.

The motivation is issue #1708 - with the old design, types like `&T` and `fn(...)` had custom variance functions (`ref_variance`, `fn_ptr_variance`) that recursively computed variance, but they didn't properly participate in cycle detection because each created its own visited set.

## Changes

### New types (`facet-core/src/types/variance.rs`)
- `VarianceDesc { base: Variance, deps: &'static [VarianceDep] }` - declarative variance description
- `VarianceDep { position: VariancePosition, shape: &'static Shape }` - a single dependency
- `VariancePosition::Covariant | Contravariant` - position transform for dependencies

### Updated variance computation (`facet-core/src/types/shape.rs`)
- `computed_variance_impl` now interprets `VarianceDesc`:
  1. Uses `base` variance as starting point
  2. Iterates over `deps`, computing and combining each dependency's variance (with position transform)
  3. Falls back to field walking for structs/enums when deps is empty (backward compatibility)

### Updated type implementations
- Invariant types (`*mut T`, `&mut T`, `Opaque<T>`) → `VarianceDesc::INVARIANT`
- Covariant propagating types (`&T`, `Box<T>`, `Vec<T>`, etc.) → `VarianceDesc` with `VarianceDep::covariant(T::SHAPE)`
- Multi-param types (`HashMap<K,V>`, `Result<T,E>`) → multiple covariant dependencies
- Function pointers → contravariant args + covariant return

### Updated derive macro
- `𝟋CV` constant changed from function pointer to `VarianceDesc::BIVARIANT`
- `𝟋VncD` alias added for `VarianceDesc` in prelude

## Test plan

- [x] All 2839 existing tests pass
- [x] Variance stack overflow tests continue to pass (cycle detection still works)
- [x] Bivariance tests pass