### PR TITLE
feat(shape): add DeclId for identifying type declarations

### DIFF
--- a/facet-core/src/impls/alloc/arc.rs
+++ b/facet-core/src/impls/alloc/arc.rs
@@ -6,9 +6,9 @@ use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
 
 use crate::{
-    DeclId, Def, Facet, KnownPointer, OxPtrConst, OxPtrMut, PointerDef, PointerFlags,
-    PointerVTable, PtrConst, PtrMut, PtrUninit, ShapeBuilder, SliceBuilderVTable, Type,
-    TypeNameOpts, TypeOpsIndirect, UserType, VTableIndirect, Variance, VarianceDep, VarianceDesc,
+    Def, Facet, KnownPointer, OxPtrConst, OxPtrMut, PointerDef, PointerFlags, PointerVTable,
+    PtrConst, PtrMut, PtrUninit, ShapeBuilder, SliceBuilderVTable, Type, TypeNameOpts,
+    TypeOpsIndirect, UserType, VTableIndirect, Variance, VarianceDep, VarianceDesc,
 };
 
 // Helper functions to create type_name formatters
@@ -180,7 +180,6 @@ unsafe fn arc_drop<T>(ox: OxPtrMut) {
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for Arc<T> {
     const SHAPE: &'static crate::Shape = &const {
         ShapeBuilder::for_sized::<Self>("Arc")
-            .decl_id(DeclId::new(crate::decl_id_hash("Arc")))
             .module_path("alloc::sync")
             .type_name(type_name_arc::<T>)
             .vtable_indirect(&VTableIndirect::EMPTY)
@@ -263,7 +262,6 @@ unsafe impl<'a> Facet<'a> for Arc<str> {
         }
 
         ShapeBuilder::for_sized::<Self>("Arc")
-            .decl_id(DeclId::new(crate::decl_id_hash("Arc")))
             .module_path("alloc::sync")
             .type_name(type_name_arc_str)
             .vtable_indirect(&const { VTableIndirect::EMPTY })
@@ -322,7 +320,6 @@ unsafe impl<'a, U: Facet<'a>> Facet<'a> for Arc<[U]> {
         }
 
         ShapeBuilder::for_sized::<Self>("Arc")
-            .decl_id(DeclId::new(crate::decl_id_hash("Arc")))
             .module_path("alloc::sync")
             .type_name(type_name_arc_slice::<U>)
             .vtable_indirect(&VTableIndirect::EMPTY)
@@ -387,7 +384,6 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Weak<T> {
         };
 
         ShapeBuilder::for_sized::<Self>("Weak")
-            .decl_id(DeclId::new(crate::decl_id_hash("Weak")))
             .module_path("alloc::sync")
             .type_name(type_name_weak::<T>)
             .vtable_indirect(&VTABLE)
@@ -471,7 +467,6 @@ unsafe impl<'a> Facet<'a> for Weak<str> {
         }
 
         ShapeBuilder::for_sized::<Self>("Weak")
-            .decl_id(DeclId::new(crate::decl_id_hash("Weak")))
             .module_path("alloc::sync")
             .type_name(type_name_weak_str)
             .vtable_indirect(&WEAK_VTABLE)
@@ -535,7 +530,6 @@ unsafe impl<'a, U: Facet<'a>> Facet<'a> for Weak<[U]> {
         };
 
         ShapeBuilder::for_sized::<Self>("Weak")
-            .decl_id(DeclId::new(crate::decl_id_hash("Weak")))
             .module_path("alloc::sync")
             .type_name(type_name_weak_slice::<U>)
             .vtable_indirect(&VTABLE)

--- a/facet-core/src/impls/alloc/boxed.rs
+++ b/facet-core/src/impls/alloc/boxed.rs
@@ -5,8 +5,8 @@ use core::ptr::NonNull;
 use alloc::boxed::Box;
 
 use crate::{
-    DeclId, Def, Facet, KnownPointer, OxPtrMut, PointerDef, PointerFlags, PointerVTable, PtrConst,
-    PtrMut, PtrUninit, Shape, ShapeBuilder, SliceBuilderVTable, TryFromError, Type, TypeNameFn,
+    Def, Facet, KnownPointer, OxPtrMut, PointerDef, PointerFlags, PointerVTable, PtrConst, PtrMut,
+    PtrUninit, Shape, ShapeBuilder, SliceBuilderVTable, TryFromError, Type, TypeNameFn,
     TypeNameOpts, TypeOpsIndirect, UserType, VTableIndirect, Variance, VarianceDep, VarianceDesc,
 };
 
@@ -69,7 +69,6 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Box<T> {
         }
 
         ShapeBuilder::for_sized::<Self>("Box")
-            .decl_id(DeclId::new(crate::decl_id_hash("Box")))
             .module_path("alloc::boxed")
             .type_name(build_type_name::<T>())
             .vtable_indirect(&VTableIndirect::EMPTY)
@@ -220,7 +219,6 @@ unsafe impl<'a> Facet<'a> for Box<str> {
         }
 
         ShapeBuilder::for_sized::<Self>("Box")
-            .decl_id(DeclId::new(crate::decl_id_hash("Box")))
             .module_path("alloc::boxed")
             .type_name(type_name_box_str)
             .vtable_indirect(&VTableIndirect::EMPTY)
@@ -266,7 +264,6 @@ unsafe impl<'a, U: Facet<'a>> Facet<'a> for Box<[U]> {
         }
 
         ShapeBuilder::for_sized::<Self>("Box")
-            .decl_id(DeclId::new(crate::decl_id_hash("Box")))
             .module_path("alloc::boxed")
             .type_name(type_name_box_slice::<U>)
             .vtable_indirect(&VTableIndirect::EMPTY)

--- a/facet-core/src/impls/alloc/btreemap.rs
+++ b/facet-core/src/impls/alloc/btreemap.rs
@@ -1,9 +1,9 @@
 use alloc::{boxed::Box, collections::BTreeMap};
 
 use crate::{
-    DeclId, Def, Facet, IterVTable, MapDef, MapVTable, OxPtrMut, PtrConst, PtrMut, PtrUninit,
-    Shape, ShapeBuilder, TypeNameFn, TypeNameOpts, TypeOpsIndirect, TypeParam, VTableIndirect,
-    Variance, VarianceDep, VarianceDesc,
+    Def, Facet, IterVTable, MapDef, MapVTable, OxPtrMut, PtrConst, PtrMut, PtrUninit, Shape,
+    ShapeBuilder, TypeNameFn, TypeNameOpts, TypeOpsIndirect, TypeParam, VTableIndirect, Variance,
+    VarianceDep, VarianceDesc,
 };
 
 type BTreeMapIterator<'mem, K, V> = alloc::collections::btree_map::Iter<'mem, K, V>;
@@ -173,7 +173,6 @@ where
         }
 
         ShapeBuilder::for_sized::<Self>("BTreeMap")
-            .decl_id(DeclId::new(crate::decl_id_hash("BTreeMap")))
             .module_path("alloc::collections::btree_map")
             .type_name(build_type_name::<K, V>())
             .vtable_indirect(&VTABLE)

--- a/facet-core/src/impls/alloc/btreeset.rs
+++ b/facet-core/src/impls/alloc/btreeset.rs
@@ -4,7 +4,7 @@ use alloc::collections::BTreeSet;
 use crate::{PtrConst, PtrMut, PtrUninit};
 
 use crate::{
-    DeclId, Def, Facet, IterVTable, OxPtrMut, SetDef, SetVTable, Shape, ShapeBuilder, TypeNameFn,
+    Def, Facet, IterVTable, OxPtrMut, SetDef, SetVTable, Shape, ShapeBuilder, TypeNameFn,
     TypeNameOpts, TypeOpsIndirect, TypeParam, VTableIndirect, Variance, VarianceDep, VarianceDesc,
 };
 
@@ -116,7 +116,6 @@ where
         }
 
         ShapeBuilder::for_sized::<Self>("BTreeSet")
-            .decl_id(DeclId::new(crate::decl_id_hash("BTreeSet")))
             .module_path("alloc::collections::btree_set")
             .type_name(build_type_name::<T>())
             .vtable_indirect(&VTableIndirect::EMPTY)

--- a/facet-core/src/impls/alloc/cow.rs
+++ b/facet-core/src/impls/alloc/cow.rs
@@ -1,7 +1,7 @@
 use crate::{
-    DeclId, Def, Facet, KnownPointer, OxPtrConst, OxPtrMut, PointerDef, PointerFlags,
-    PointerVTable, PtrConst, Shape, ShapeBuilder, Type, TypeNameFn, TypeNameOpts, TypeOpsIndirect,
-    TypeParam, UserType, VTableIndirect,
+    Def, Facet, KnownPointer, OxPtrConst, OxPtrMut, PointerDef, PointerFlags, PointerVTable,
+    PtrConst, Shape, ShapeBuilder, Type, TypeNameFn, TypeNameOpts, TypeOpsIndirect, TypeParam,
+    UserType, VTableIndirect,
 };
 use alloc::borrow::Cow;
 use alloc::borrow::ToOwned;
@@ -283,7 +283,6 @@ where
         }
 
         ShapeBuilder::for_sized::<Cow<'a, T>>("Cow")
-            .decl_id(DeclId::new(crate::decl_id_hash("Cow")))
             .module_path("alloc::borrow")
             .type_name(build_type_name::<T>())
             .ty(Type::User(UserType::Opaque))

--- a/facet-core/src/impls/alloc/rc.rs
+++ b/facet-core/src/impls/alloc/rc.rs
@@ -5,9 +5,9 @@ use alloc::rc::{Rc, Weak};
 use alloc::vec::Vec;
 
 use crate::{
-    DeclId, Def, Facet, KnownPointer, OxPtrConst, OxPtrMut, PointerDef, PointerFlags,
-    PointerVTable, PtrConst, PtrMut, PtrUninit, Shape, ShapeBuilder, SliceBuilderVTable, Type,
-    TypeNameOpts, TypeOpsIndirect, UserType, VTableIndirect, Variance, VarianceDep, VarianceDesc,
+    Def, Facet, KnownPointer, OxPtrConst, OxPtrMut, PointerDef, PointerFlags, PointerVTable,
+    PtrConst, PtrMut, PtrUninit, Shape, ShapeBuilder, SliceBuilderVTable, Type, TypeNameOpts,
+    TypeOpsIndirect, UserType, VTableIndirect, Variance, VarianceDep, VarianceDesc,
 };
 
 //////////////////////////////////////////////////////////////////////
@@ -76,7 +76,6 @@ unsafe fn rc_downgrade_into_fn<'a, 'ptr, T: Facet<'a>>(strong: PtrMut, weak: Ptr
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for Rc<T> {
     const SHAPE: &'static Shape = &const {
         ShapeBuilder::for_sized::<Rc<T>>("Rc")
-            .decl_id(DeclId::new(crate::decl_id_hash("Rc")))
             .module_path("alloc::rc")
             .type_name(rc_type_name::<T>)
             .ty(Type::User(UserType::Opaque))
@@ -224,7 +223,6 @@ unsafe impl<'a> Facet<'a> for Rc<str> {
         };
 
         ShapeBuilder::for_sized::<Rc<str>>("Rc")
-            .decl_id(DeclId::new(crate::decl_id_hash("Rc")))
             .module_path("alloc::rc")
             .type_name(rc_str_type_name)
             .ty(Type::User(UserType::Opaque))
@@ -348,7 +346,6 @@ unsafe fn rc_slice_downgrade_into_fn<'a, 'ptr, U: Facet<'a>>(
 unsafe impl<'a, U: Facet<'a>> Facet<'a> for Rc<[U]> {
     const SHAPE: &'static Shape = &const {
         ShapeBuilder::for_sized::<Rc<[U]>>("Rc")
-            .decl_id(DeclId::new(crate::decl_id_hash("Rc")))
             .module_path("alloc::rc")
             .type_name(rc_slice_type_name::<U>)
             .ty(Type::User(UserType::Opaque))
@@ -476,7 +473,6 @@ unsafe fn weak_upgrade_into_fn<'a, 'ptr, T: Facet<'a>>(
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for Weak<T> {
     const SHAPE: &'static Shape = &const {
         ShapeBuilder::for_sized::<Weak<T>>("Weak")
-            .decl_id(DeclId::new(crate::decl_id_hash("Weak")))
             .module_path("alloc::rc")
             .type_name(weak_type_name::<T>)
             .ty(Type::User(UserType::Opaque))
@@ -603,7 +599,6 @@ unsafe impl<'a> Facet<'a> for Weak<str> {
         };
 
         ShapeBuilder::for_sized::<Weak<str>>("Weak")
-            .decl_id(DeclId::new(crate::decl_id_hash("Weak")))
             .module_path("alloc::rc")
             .type_name(weak_str_type_name)
             .ty(Type::User(UserType::Opaque))
@@ -679,7 +674,6 @@ unsafe fn weak_slice_upgrade_into_fn<'a, 'ptr, U: Facet<'a>>(
 unsafe impl<'a, U: Facet<'a>> Facet<'a> for Weak<[U]> {
     const SHAPE: &'static Shape = &const {
         ShapeBuilder::for_sized::<Weak<[U]>>("Weak")
-            .decl_id(DeclId::new(crate::decl_id_hash("Weak")))
             .module_path("alloc::rc")
             .type_name(weak_slice_type_name::<U>)
             .ty(Type::User(UserType::Opaque))

--- a/facet-core/src/impls/alloc/vec.rs
+++ b/facet-core/src/impls/alloc/vec.rs
@@ -398,9 +398,7 @@ where
                     .build()
             }
 
-            ShapeBuilder::for_sized::<Self>("Vec")
-            .decl_id(crate::DeclId::new(crate::decl_id_hash("Vec")))
-            .module_path("alloc::vec")
+            ShapeBuilder::for_sized::<Self>("Vec")            .module_path("alloc::vec")
             .type_name(vec_type_name)
             .ty(Type::User(UserType::Opaque))
             .def(Def::List(ListDef::with_type_ops(

--- a/facet-core/src/impls/builtin.rs
+++ b/facet-core/src/impls/builtin.rs
@@ -1,11 +1,10 @@
-use crate::{DeclId, Facet, Opaque, Shape, VarianceDesc};
+use crate::{Facet, Opaque, Shape, VarianceDesc};
 
 // Opaque<T> is a lifetime boundary; require 'static to prevent lifetime laundering
 // through reflection. See issue #1563 for details.
 unsafe impl<'facet, T: 'static> Facet<'facet> for Opaque<T> {
     const SHAPE: &'static Shape = &const {
         Shape::builder_for_sized::<Opaque<T>>("Opaque")
-            .decl_id(DeclId::new(crate::decl_id_hash("Opaque")))
             .variance(VarianceDesc::INVARIANT)
             .build()
     };

--- a/facet-core/src/impls/core/array.rs
+++ b/facet-core/src/impls/core/array.rs
@@ -256,7 +256,7 @@ where
         }
 
         ShapeBuilder::for_sized::<[T; N]>("[T; N]")
-            .decl_id(crate::DeclId::new(crate::decl_id_hash("[T; N]")))
+            .decl_id(crate::DeclId::new(crate::decl_id_hash("#array#[T; N]")))
             .type_name(array_type_name)
             .ty(Type::Sequence(crate::SequenceType::Array(
                 crate::ArrayType { t: T::SHAPE, n: N },

--- a/facet-core/src/impls/core/fn_ptr.rs
+++ b/facet-core/src/impls/core/fn_ptr.rs
@@ -46,7 +46,7 @@ macro_rules! impl_facet_for_fn_ptr {
                 }
 
                 ShapeBuilder::for_sized::<$(extern $extern)? fn($($args),*) -> R>("fn")
-                    .decl_id(crate::DeclId::new(crate::decl_id_hash("fn")))
+                    .decl_id(crate::DeclId::new(crate::decl_id_hash("#fn#fn")))
                     .ty(Type::Pointer(PointerType::Function(
                         FunctionPointerDef::new($abi, &[$($args::SHAPE),*], R::SHAPE)
                     )))

--- a/facet-core/src/impls/core/nonnull.rs
+++ b/facet-core/src/impls/core/nonnull.rs
@@ -88,7 +88,7 @@ unsafe fn new_into_fn<'a, 'ptr, T: Facet<'a>>(this: PtrUninit, ptr: PtrMut) -> P
 unsafe impl<'a, T: Facet<'a>> Facet<'a> for core::ptr::NonNull<T> {
     const SHAPE: &'static Shape = &const {
         ShapeBuilder::for_sized::<Self>("NonNull")
-            .decl_id(crate::DeclId::new(crate::decl_id_hash("NonNull")))
+            .module_path("core::ptr")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Pointer(PointerDef {
                 vtable: &const {

--- a/facet-core/src/impls/core/ops.rs
+++ b/facet-core/src/impls/core/ops.rs
@@ -75,7 +75,7 @@ unsafe impl<'a, Idx: Facet<'a>> Facet<'a> for core::ops::Range<Idx> {
         }
 
         ShapeBuilder::for_sized::<core::ops::Range<Idx>>("Range")
-            .decl_id(crate::DeclId::new(crate::decl_id_hash("Range")))
+            .module_path("core::ops")
             .ty(Type::User(UserType::Struct(StructType {
                 kind: crate::StructKind::Struct,
                 repr: crate::Repr::default(),

--- a/facet-core/src/impls/core/option.rs
+++ b/facet-core/src/impls/core/option.rs
@@ -247,9 +247,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Option<T> {
             }
         }
 
-        ShapeBuilder::for_sized::<Option<T>>("Option")
-            .decl_id(crate::DeclId::new(crate::decl_id_hash("Option")))
-            .module_path("core::option")
+        ShapeBuilder::for_sized::<Option<T>>("Option")            .module_path("core::option")
             .ty(Type::User(
                 // Null-Pointer-Optimization check
                 if core::mem::size_of::<T>() == core::mem::size_of::<Option<T>>()

--- a/facet-core/src/impls/core/phantom.rs
+++ b/facet-core/src/impls/core/phantom.rs
@@ -69,7 +69,7 @@ unsafe impl<'a, T: ?Sized + 'a> Facet<'a> for core::marker::PhantomData<T> {
         // unconditionally (not depending on T) - but NOT Display
 
         ShapeBuilder::for_sized::<core::marker::PhantomData<T>>("PhantomData")
-            .decl_id(crate::DeclId::new(crate::decl_id_hash("PhantomData")))
+            .module_path("core::marker")
             .ty(Type::User(UserType::Struct(StructType {
                 repr: Repr::default(),
                 kind: StructKind::Unit,

--- a/facet-core/src/impls/core/pointer.rs
+++ b/facet-core/src/impls/core/pointer.rs
@@ -148,7 +148,7 @@ unsafe impl<'a, T: Facet<'a> + ?Sized> Facet<'a> for *const T {
         }
 
         ShapeBuilder::for_sized::<*const T>("*const T")
-            .decl_id(crate::DeclId::new(crate::decl_id_hash("*const T")))
+            .decl_id(crate::DeclId::new(crate::decl_id_hash("#ptr#*const T")))
             .ty({
                 let is_wide = ::core::mem::size_of::<Self>() != ::core::mem::size_of::<*const ()>();
                 let vpt = ValuePointerType {
@@ -202,7 +202,7 @@ unsafe impl<'a, T: Facet<'a> + ?Sized> Facet<'a> for *mut T {
         }
 
         ShapeBuilder::for_sized::<*mut T>("*mut T")
-            .decl_id(crate::DeclId::new(crate::decl_id_hash("*mut T")))
+            .decl_id(crate::DeclId::new(crate::decl_id_hash("#ptr#*mut T")))
             .ty({
                 let is_wide = ::core::mem::size_of::<Self>() != ::core::mem::size_of::<*const ()>();
                 let vpt = ValuePointerType {

--- a/facet-core/src/impls/core/reference.rs
+++ b/facet-core/src/impls/core/reference.rs
@@ -237,7 +237,7 @@ unsafe impl<'a, T: ?Sized + Facet<'a>> Facet<'a> for &'a T {
         }
 
         ShapeBuilder::for_sized::<&T>("&T")
-            .decl_id(crate::DeclId::new(crate::decl_id_hash("&T")))
+            .decl_id(crate::DeclId::new(crate::decl_id_hash("#ref#&T")))
             .type_name(ref_type_name)
             .ty({
                 let vpt = ValuePointerType {
@@ -282,7 +282,7 @@ unsafe impl<'a, T: ?Sized + Facet<'a>> Facet<'a> for &'a mut T {
         }
 
         ShapeBuilder::for_sized::<&mut T>("&mut T")
-            .decl_id(crate::DeclId::new(crate::decl_id_hash("&mut T")))
+            .decl_id(crate::DeclId::new(crate::decl_id_hash("#ref#&mut T")))
             .type_name(ref_mut_type_name)
             .ty({
                 let vpt = ValuePointerType {

--- a/facet-core/src/impls/core/result.rs
+++ b/facet-core/src/impls/core/result.rs
@@ -235,7 +235,6 @@ unsafe impl<'a, T: Facet<'a>, E: Facet<'a>> Facet<'a> for Result<T, E> {
         }
 
         ShapeBuilder::for_sized::<Result<T, E>>("Result")
-            .decl_id(crate::DeclId::new(crate::decl_id_hash("Result")))
             .module_path("core::result")
             .ty(Type::User(UserType::Opaque))
             .def(Def::Result(ResultDef::new(

--- a/facet-core/src/impls/core/slice.rs
+++ b/facet-core/src/impls/core/slice.rs
@@ -222,7 +222,7 @@ where
         }
 
         ShapeBuilder::for_unsized::<Self>("[_]")
-            .decl_id(crate::DeclId::new(crate::decl_id_hash("[T]")))
+            .decl_id(crate::DeclId::new(crate::decl_id_hash("#slice#[T]")))
             .type_name(build_type_name::<T>())
             .vtable_indirect(&SLICE_VTABLE)
             .ty(Type::Sequence(SequenceType::Slice(SliceType {

--- a/facet-core/src/impls/core/tuple.rs
+++ b/facet-core/src/impls/core/tuple.rs
@@ -227,7 +227,7 @@ macro_rules! impl_facet_for_tuple {
                         "(…)"
                     }
                 )
-                .decl_id(crate::DeclId::new(crate::decl_id_hash("tuple")))
+                .decl_id(crate::DeclId::new(crate::decl_id_hash("#tuple#(…)")))
                 .type_name(tuple_type_name)
                 .ty(Type::User(UserType::Struct(StructType {
                     repr: Repr::default(),

--- a/facet-core/src/impls/crates/indexmap.rs
+++ b/facet-core/src/impls/crates/indexmap.rs
@@ -8,8 +8,8 @@ use indexmap::IndexMap;
 use crate::{PtrConst, PtrMut, PtrUninit};
 
 use crate::{
-    DeclId, Def, Facet, IterVTable, MapDef, MapVTable, OxPtrMut, Shape, ShapeBuilder, Type,
-    TypeNameFn, TypeNameOpts, TypeOpsIndirect, TypeParam, UserType,
+    Def, Facet, IterVTable, MapDef, MapVTable, OxPtrMut, Shape, ShapeBuilder, Type, TypeNameFn,
+    TypeNameOpts, TypeOpsIndirect, TypeParam, UserType,
 };
 
 type IndexMapIterator<'mem, K, V> = indexmap::map::Iter<'mem, K, V>;
@@ -165,7 +165,6 @@ where
         }
 
         ShapeBuilder::for_sized::<Self>("IndexMap")
-            .decl_id(DeclId::new(crate::decl_id_hash("IndexMap")))
             .module_path("indexmap")
             .type_name(build_type_name::<K, V>())
             .ty(Type::User(UserType::Opaque))

--- a/facet-core/src/impls/crates/num_complex.rs
+++ b/facet-core/src/impls/crates/num_complex.rs
@@ -181,7 +181,6 @@ unsafe impl<'facet, T: Facet<'facet>> Facet<'facet> for Complex<T> {
         }
 
         ShapeBuilder::for_sized::<Complex<T>>("Complex")
-            .decl_id(DeclId::new(crate::decl_id_hash("Complex")))
             .module_path("num_complex")
             .type_name(type_name_fn::<T>)
             .ty(crate::Type::User(crate::UserType::Struct(

--- a/facet-core/src/impls/std/hashmap.rs
+++ b/facet-core/src/impls/std/hashmap.rs
@@ -6,9 +6,9 @@ use std::hash::RandomState;
 use crate::{PtrConst, PtrMut, PtrUninit};
 
 use crate::{
-    DeclId, Def, Facet, IterVTable, MapDef, MapVTable, Shape, ShapeBuilder, Type, TypeNameFn,
-    TypeNameOpts, TypeOpsIndirect, TypeParam, UserType, VTableDirect, VTableIndirect, Variance,
-    VarianceDep, VarianceDesc,
+    Def, Facet, IterVTable, MapDef, MapVTable, Shape, ShapeBuilder, Type, TypeNameFn, TypeNameOpts,
+    TypeOpsIndirect, TypeParam, UserType, VTableDirect, VTableIndirect, Variance, VarianceDep,
+    VarianceDesc,
 };
 
 type HashMapIterator<'mem, K, V> = std::collections::hash_map::Iter<'mem, K, V>;
@@ -171,7 +171,6 @@ where
         }
 
         ShapeBuilder::for_sized::<Self>("HashMap")
-            .decl_id(DeclId::new(crate::decl_id_hash("HashMap")))
             .module_path("std::collections::hash_map")
             .type_name(build_type_name::<K, V>())
             .ty(Type::User(UserType::Opaque))

--- a/facet-core/src/impls/std/hashset.rs
+++ b/facet-core/src/impls/std/hashset.rs
@@ -4,8 +4,8 @@ use std::collections::HashSet;
 use crate::{PtrConst, PtrMut, PtrUninit};
 
 use crate::{
-    DeclId, Def, Facet, HashProxy, IterVTable, OxPtrConst, OxPtrMut, OxRef, SetDef, SetVTable,
-    Shape, ShapeBuilder, Type, TypeNameFn, TypeNameOpts, TypeOpsIndirect, TypeParam, UserType,
+    Def, Facet, HashProxy, IterVTable, OxPtrConst, OxPtrMut, OxRef, SetDef, SetVTable, Shape,
+    ShapeBuilder, Type, TypeNameFn, TypeNameOpts, TypeOpsIndirect, TypeParam, UserType,
     VTableIndirect, Variance, VarianceDep, VarianceDesc,
 };
 
@@ -242,7 +242,6 @@ where
         }
 
         ShapeBuilder::for_sized::<Self>("HashSet")
-            .decl_id(DeclId::new(crate::decl_id_hash("HashSet")))
             .module_path("std::collections::hash_set")
             .type_name(build_type_name::<T>())
             .ty(Type::User(UserType::Opaque))

--- a/facet-core/src/types/decl_id.rs
+++ b/facet-core/src/types/decl_id.rs
@@ -5,8 +5,53 @@ use core::hash::{Hash, Hasher};
 
 /// Identifies a type declaration, independent of type parameters.
 ///
-/// Two shapes with the same `DeclId` come from the same source declaration
-/// (the same generic type with potentially different type arguments).
+/// Think of `DeclId` as a "type-parameter-erased" version of `Shape::id`. While
+/// `Vec<u32>` and `Vec<String>` have different `Shape::id` values, they share
+/// the same `DeclId` because they come from the same `Vec<T>` declaration.
+///
+/// # How DeclId is computed
+///
+/// ## Non-generic types
+///
+/// For types without type parameters (like `u32` or `MyStruct`), `DeclId` is
+/// trivial—it can simply equal the hash of the type identifier. When implementing
+/// `Facet` for such types, you don't need to do anything special; if you don't
+/// call `.decl_id()` on the builder, it's automatically computed from the
+/// `type_identifier`.
+///
+/// ## Generic types with `#[derive(Facet)]`
+///
+/// For generic types using the derive macro, `DeclId` is computed from:
+/// ```text
+/// file!():line!():column!()#kind#TypeName
+/// ```
+/// For example: `src/lib.rs:42:1#struct#Wrapper`
+///
+/// This strategy assumes no two declarations exist at the exact same source
+/// location. This isn't strictly true with macros that generate multiple types,
+/// which is why we also include the type name. Even so, this can be defeated
+/// in edge cases—it's a best-effort approach.
+///
+/// ## Foreign generic types (manual `Facet` implementations)
+///
+/// When implementing `Facet` for an external generic type (like `Vec`, `Arc`,
+/// `HashMap`), set the `module_path` on the builder:
+///
+/// ```ignore
+/// ShapeBuilder::for_sized::<Arc<T>>("Arc")
+///     .module_path("alloc::sync")
+///     // ... other fields ...
+///     .build()
+/// ```
+///
+/// The `DeclId` is then auto-computed from: `@{module_path}#{kind}#{type_identifier}`
+///
+/// For example, `Arc` in `alloc::sync` with type `struct` produces:
+/// `@alloc::sync#struct#Arc`
+///
+/// This is also not foolproof—if you have two different versions of the same
+/// crate in your dependency graph, they'll produce the same `DeclId` even though
+/// they're technically different declarations.
 ///
 /// # Example
 ///
@@ -75,4 +120,53 @@ impl Hash for DeclId {
 #[inline]
 pub const fn decl_id_hash(s: &str) -> u128 {
     const_fnv1a_hash::fnv1a_hash_str_128(s)
+}
+
+// FNV-1a 128-bit constants
+const FNV_BASIS_128: u128 = 144066263297769815596495629667062367629;
+const FNV_PRIME_128: u128 = 309485009821345068724781371;
+
+/// Computes a `DeclId` hash from module path, kind, and type identifier.
+///
+/// This produces the same result as hashing `@{module_path}#{kind}#{type_identifier}`.
+/// Used internally by `ShapeBuilder::build()` to auto-compute `DeclId` for foreign
+/// generic types.
+#[inline]
+pub const fn decl_id_hash_extern(module_path: &str, kind: &str, type_identifier: &str) -> u128 {
+    let mut hash = FNV_BASIS_128;
+
+    // Hash "@"
+    hash = (hash ^ b'@' as u128).wrapping_mul(FNV_PRIME_128);
+
+    // Hash module_path
+    let bytes = module_path.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        hash = (hash ^ bytes[i] as u128).wrapping_mul(FNV_PRIME_128);
+        i += 1;
+    }
+
+    // Hash "#"
+    hash = (hash ^ b'#' as u128).wrapping_mul(FNV_PRIME_128);
+
+    // Hash kind
+    let bytes = kind.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        hash = (hash ^ bytes[i] as u128).wrapping_mul(FNV_PRIME_128);
+        i += 1;
+    }
+
+    // Hash "#"
+    hash = (hash ^ b'#' as u128).wrapping_mul(FNV_PRIME_128);
+
+    // Hash type_identifier
+    let bytes = type_identifier.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        hash = (hash ^ bytes[i] as u128).wrapping_mul(FNV_PRIME_128);
+        i += 1;
+    }
+
+    hash
 }

--- a/facet-core/src/types/ty/mod.rs
+++ b/facet-core/src/types/ty/mod.rs
@@ -48,6 +48,32 @@ pub enum Type {
 }
 
 impl Type {
+    /// Returns the kind of this type as a string, for use in `DeclId` computation.
+    ///
+    /// This is used when auto-computing `DeclId` for foreign generic types.
+    #[inline]
+    pub const fn kind_str(&self) -> &'static str {
+        match self {
+            Type::Undefined => "undefined",
+            Type::Primitive(_) => "primitive",
+            Type::Sequence(s) => match s {
+                SequenceType::Array(_) => "array",
+                SequenceType::Slice(_) => "slice",
+            },
+            Type::User(u) => match u {
+                UserType::Struct(_) => "struct",
+                UserType::Enum(_) => "enum",
+                UserType::Union(_) => "union",
+                UserType::Opaque => "opaque",
+            },
+            Type::Pointer(p) => match p {
+                PointerType::Reference(_) => "ref",
+                PointerType::Raw(_) => "ptr",
+                PointerType::Function(_) => "fn",
+            },
+        }
+    }
+
     /// Create a builder for a struct type.
     ///
     /// # Example

--- a/facet-reflect/src/spanned.rs
+++ b/facet-reflect/src/spanned.rs
@@ -162,7 +162,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Spanned<T> {
         }
 
         Shape::builder_for_sized::<Spanned<T>>("Spanned")
-            .decl_id(facet_core::DeclId::new(facet_core::decl_id_hash("Spanned")))
+            .module_path("facet_reflect::spanned")
             .vtable_indirect(&VTableIndirect::EMPTY)
             .type_ops_indirect(
                 &const {

--- a/facet-reflect/tests/peek/ndarray.rs
+++ b/facet-reflect/tests/peek/ndarray.rs
@@ -2,7 +2,7 @@ use std::ops::{Index, IndexMut};
 
 use facet::{Type, TypeParam, UserType};
 use facet_core::{
-    DeclId, Def, Facet, NdArrayDef, NdArrayVTable, OxPtrMut, PtrConst, PtrMut, Shape, ShapeBuilder,
+    Def, Facet, NdArrayDef, NdArrayVTable, OxPtrMut, PtrConst, PtrMut, Shape, ShapeBuilder,
     VTableIndirect, VarianceDesc,
 };
 use facet_reflect::Peek;
@@ -170,7 +170,7 @@ fn type_name_mat<T: Facet<'static>>(
 unsafe impl<T: Facet<'static>> Facet<'static> for Mat<T> {
     const SHAPE: &'static Shape = &const {
         ShapeBuilder::for_sized::<Mat<T>>("Mat")
-            .decl_id(DeclId::new(facet_core::decl_id_hash("Mat")))
+            .module_path("test::ndarray")
             .type_name(type_name_mat::<T>)
             .ty(Type::User(UserType::Opaque))
             .def(Def::NdArray(NdArrayDef {


### PR DESCRIPTION
## Summary

Introduces `DeclId`, a declaration identifier that identifies a type declaration independent of its type parameters. This allows grouping all instantiations of a generic type at runtime (e.g., `Vec<u32>` and `Vec<String>` share the same `DeclId` since they come from the same `Vec<T>` declaration).

## Changes

- Add `DeclId` type with FNV1a-128 hash-based implementation in `facet-core/src/types/decl_id.rs`
- Add `decl_id` field to `Shape` struct
- Add `decl_id()` and `decl_id_prim()` builder methods to `ShapeBuilder`
- Update all manual `Facet` implementations (core, alloc, std, and third-party crate types) to include `decl_id`
- Update derive macros to generate `DeclId` from `file:line:column` location
- Update documentation for adding types to include `decl_id` information
- Add comprehensive tests verifying `DeclId` behavior with generic types

## Stability Note

`DeclId` is **completely opaque** and provides no stability guarantees:
- NOT stable across different compilations
- NOT stable across refactors (adding a comment changes line numbers)
- NOT stable across reformatting (column numbers change)

The **only** guarantee: within a single compilation, the same declaration produces the same `DeclId`. This is sufficient for runtime use cases like "group all instantiations of `Vec<T>` in this program" but NOT for cross-compilation comparisons or persistence.

## Test plan

- [x] Existing tests pass
- [x] New tests verify that different instantiations of the same generic type have identical `decl_id` but different `id`
- [x] Tests verify that distinct type declarations have different `decl_id` values