### PR TITLE
feat(pretty): add proxy support for pretty-printing

### DIFF
--- a/facet-pretty/src/printer.rs
+++ b/facet-pretty/src/printer.rs
@@ -1395,7 +1395,7 @@ impl PrettyPrinter {
 
         // Handle proxy types by converting to the proxy representation and formatting that
         if let Some(proxy_def) = shape.proxy {
-            return self.format_via_proxy_unified(
+            let result = self.format_via_proxy_unified(
                 value,
                 proxy_def,
                 out,
@@ -1403,8 +1403,16 @@ impl PrettyPrinter {
                 format_depth,
                 type_depth,
                 short,
-                current_path,
+                current_path.clone(),
             );
+
+            visited.remove(&value.id());
+
+            // Record span for this value
+            let value_end = out.position();
+            out.record_span(current_path, (value_start, value_end));
+
+            return result;
         }
 
         match (shape.def, shape.ty) {


### PR DESCRIPTION
Fix pretty-printing for types using `#[facet(proxy = ...)]` and `#[facet(transparent)]`.

  Previously, `facet-pretty` did not check for proxy definitions when formatting values, causing types with proxies to fall through to the default case and print `unsupported peek variant: ⟨TypeName⟩`. Additionally, transparent wrapper types were not being unwrapped, so a type like `IntAsString(String)` would print as `IntAsString("value")` instead of just `"value"`.

  This brings `facet-pretty` in line with `facet-format`'s serialization behavior:
  - Add `innermost_peek()` call to unwrap transparent wrappers before formatting
  - Check `shape.proxy` for container-level proxies
  - Check `field.proxy()` for field-level proxies in struct/tuple fields