### PR TITLE
feat(core): add OnceLock and LazyLock support

### DIFF
--- a/facet-core/src/types/def/pointer.rs
+++ b/facet-core/src/types/def/pointer.rs
@@ -346,6 +346,10 @@ pub enum KnownPointer {
     Mutex,
     /// `RwLock<T>`, a reader-writer lock (requires std)
     RwLock,
+    /// `OnceLock<T>`, a cell that can be written to only once (requires std)
+    OnceLock,
+    /// `LazyLock<T, F>`, a lazy-initialized value (requires std)
+    LazyLock,
     /// [`NonNull<T>`](core::ptr::NonNull), a wrapper around a raw pointer that is not null
     NonNull,
     /// `&T`

--- a/facet-shapelike/src/shape_like.rs
+++ b/facet-shapelike/src/shape_like.rs
@@ -568,6 +568,8 @@ impl From<&PointerDef> for PointerDefLike {
                 facet_core::KnownPointer::OnceCell => KnownPointer::OnceCell,
                 facet_core::KnownPointer::Mutex => KnownPointer::Mutex,
                 facet_core::KnownPointer::RwLock => KnownPointer::RwLock,
+                facet_core::KnownPointer::OnceLock => KnownPointer::OnceLock,
+                facet_core::KnownPointer::LazyLock => KnownPointer::LazyLock,
                 facet_core::KnownPointer::NonNull => KnownPointer::NonNull,
                 facet_core::KnownPointer::SharedReference => KnownPointer::SharedReference,
                 facet_core::KnownPointer::ExclusiveReference => KnownPointer::ExclusiveReference,

--- a/facet-shapelike/src/types.rs
+++ b/facet-shapelike/src/types.rs
@@ -87,6 +87,8 @@ pub enum KnownPointer {
     OnceCell,
     Mutex,
     RwLock,
+    OnceLock,
+    LazyLock,
     NonNull,
     SharedReference,
     ExclusiveReference,


### PR DESCRIPTION
Implement Facet trait for std::sync lock types:
- OnceLock<T> with read_fn (fallible), new_into_fn
- LazyLock<T, F> with borrow_fn (infallible, forces initialization)

Key design decisions:
- OnceLock uses read_fn (not borrow_fn) because get() is fallible
- LazyLock uses borrow_fn because force() always succeeds
- Added KnownPointer::OnceLock and KnownPointer::LazyLock variants

Note: OnceLock semantics may need revisiting - there's currently no try_write_fn or similar to express fallible write operations like set().