### PR TITLE
fix(pretty): prevent false cycle detection for shared pointers

### DIFF
--- a/facet-pretty/src/printer.rs
+++ b/facet-pretty/src/printer.rs
@@ -860,6 +860,7 @@ impl PrettyPrinter {
             (d, t) => write!(f, "unsupported peek variant: {value:?} ({d:?}, {t:?})")?,
         }
 
+        visited.remove(&value.id());
         Ok(())
     }
 

--- a/facet-pretty/tests/pretty_print.rs
+++ b/facet-pretty/tests/pretty_print.rs
@@ -191,3 +191,22 @@ fn test_map() {
     let map = BTreeMap::from([("abc", 1), ("def", 2)]);
     assert_snapshot!(printer.format(&map));
 }
+
+/// Multiple fields pointing to the same interned static string should NOT be flagged as cycles.
+/// This is a regression test for a bug where sibling fields with the same pointer were
+/// incorrectly detected as cycles.
+#[derive(Facet)]
+struct MultipleStaticStr {
+    a: &'static str,
+    b: &'static str,
+}
+
+#[test]
+fn test_shared_static_str_not_cycle() {
+    let val = MultipleStaticStr {
+        a: "same",
+        b: "same",
+    };
+    let printer = PrettyPrinter::new().with_colors(false);
+    assert_snapshot!(printer.format(&val));
+}

--- a/facet-pretty/tests/snapshots/pretty_print__shared_static_str_not_cycle.snap
+++ b/facet-pretty/tests/snapshots/pretty_print__shared_static_str_not_cycle.snap
@@ -1,0 +1,8 @@
+---
+source: facet-pretty/tests/pretty_print.rs
+expression: printer.format(&val)
+---
+MultipleStaticStr {
+  a: "same",
+  b: "same",
+}


### PR DESCRIPTION
Add visited.remove() before returning from format_peek_internal_ to ensure values are only tracked while processing them. This fixes false cycle detection when sibling fields point to the same memory address (e.g., multiple &'static str fields with the same interned string).

This is what PR #1733 was intended to do, but that branch got borked with unrelated changes !