### PR TITLE
feat(facet): add lock_api feature re-export and documentation

### DIFF
--- a/docs/content/guide/ecosystem.md
+++ b/docs/content/guide/ecosystem.md
@@ -29,6 +29,7 @@ facet = { version = "{{ data.versions.facet }}", features = ["uuid", "chrono"] }
 | `bytes` | [bytes](https://docs.rs/bytes) | `Bytes`, `BytesMut` |
 | `ordered-float` | [ordered-float](https://docs.rs/ordered-float) | `OrderedFloat<f32>`, `OrderedFloat<f64>`, `NotNan<f32>`, `NotNan<f64>` |
 | `ruint` | [ruint](https://docs.rs/ruint) | `Uint<BITS, LIMBS>`, `Bits<BITS, LIMBS>` |
+| `lock_api` | [lock_api](https://docs.rs/lock_api) | `Mutex<R, T>`, `RwLock<R, T>`, `MutexGuard`, `RwLockReadGuard`, `RwLockWriteGuard` |
 
 ### Example: uUIDs
 

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -43,6 +43,7 @@ all-impls = [
     "smartstring",
     "smol_str",
     "rust_decimal",
+    "lock_api",
 ] # Enable all optional Facet trait implementations for third-party types
 alloc = ["facet-core/alloc"] # Enable allocation support for no_std environments
 nonzero = ["facet-core/nonzero"] # Provide Facet trait implementations for NonZero<T> types
@@ -92,6 +93,9 @@ smol_str = [
 rust_decimal = [
     "facet-core/rust_decimal",
 ] # Provide Facet trait implementations for rust_decimal::Decimal
+lock_api = [
+    "facet-core/lock_api",
+] # Provide Facet trait implementations for lock_api::Mutex and lock_api::RwLock
 
 # Provide Facet trait implementations for tuples up to size 12. Without it,
 # Facet is only implemented for tuples up to size 4.


### PR DESCRIPTION
- Add lock_api to all-impls feature list
- Add lock_api feature definition forwarding to facet-core
- Document lock_api types in ecosystem.md