### PR TITLE
chore: add const to functions where possible

### DIFF
--- a/cinereus/src/tree.rs
+++ b/cinereus/src/tree.rs
@@ -29,7 +29,7 @@ pub struct NodeData<K, L> {
 
 impl<K, L> NodeData<K, L> {
     /// Create a new node with the given hash and kind.
-    pub fn new(hash: u64, kind: K) -> Self {
+    pub const fn new(hash: u64, kind: K) -> Self {
         Self {
             hash,
             kind,
@@ -38,7 +38,7 @@ impl<K, L> NodeData<K, L> {
     }
 
     /// Create a new leaf node with a label.
-    pub fn leaf(hash: u64, kind: K, label: L) -> Self {
+    pub const fn leaf(hash: u64, kind: K, label: L) -> Self {
         Self {
             hash,
             kind,

--- a/facet-args/src/error.rs
+++ b/facet-args/src/error.rs
@@ -19,7 +19,7 @@ pub struct ArgsErrorWithInput {
 
 impl ArgsErrorWithInput {
     /// Returns true if this is a help request (not a real error)
-    pub fn is_help_request(&self) -> bool {
+    pub const fn is_help_request(&self) -> bool {
         self.inner.kind.is_help_request()
     }
 
@@ -148,7 +148,7 @@ impl ArgsErrorKind {
     /// Returns a precise span override if the error kind has one.
     /// This is used for errors like `UnknownShortFlag` in chained flags
     /// where we want to highlight just the invalid character, not the whole arg.
-    pub fn precise_span(&self) -> Option<Span> {
+    pub const fn precise_span(&self) -> Option<Span> {
         match self {
             ArgsErrorKind::UnknownShortFlag { precise_span, .. } => *precise_span,
             _ => None,
@@ -156,7 +156,7 @@ impl ArgsErrorKind {
     }
 
     /// Returns an error code for this error kind.
-    pub fn code(&self) -> &'static str {
+    pub const fn code(&self) -> &'static str {
         match self {
             ArgsErrorKind::HelpRequested { .. } => "args::help",
             ArgsErrorKind::UnexpectedPositionalArgument { .. } => "args::unexpected_positional",
@@ -316,7 +316,7 @@ impl ArgsErrorKind {
     }
 
     /// Returns true if this is a help request (not a real error)
-    pub fn is_help_request(&self) -> bool {
+    pub const fn is_help_request(&self) -> bool {
         matches!(self, ArgsErrorKind::HelpRequested { .. })
     }
 
@@ -471,7 +471,7 @@ fn is_similar(a: &str, b: &str) -> bool {
 }
 
 /// Get the inner type identifier, unwrapping Option if present
-fn unwrap_option_type(shape: &'static Shape) -> &'static str {
+const fn unwrap_option_type(shape: &'static Shape) -> &'static str {
     match shape.def {
         facet_core::Def::Option(opt_def) => opt_def.t.type_identifier,
         _ => shape.type_identifier,
@@ -537,7 +537,7 @@ impl From<ReflectError> for ArgsErrorKind {
 
 impl ArgsError {
     /// Creates a new args error
-    pub fn new(kind: ArgsErrorKind, span: Span) -> Self {
+    pub const fn new(kind: ArgsErrorKind, span: Span) -> Self {
         Self { span, kind }
     }
 }
@@ -549,7 +549,7 @@ impl fmt::Display for ArgsError {
 }
 
 /// Extract variants from a shape (if it's an enum)
-pub(crate) fn get_variants_from_shape(shape: &'static Shape) -> &'static [Variant] {
+pub(crate) const fn get_variants_from_shape(shape: &'static Shape) -> &'static [Variant] {
     if let Type::User(UserType::Enum(enum_type)) = shape.ty {
         enum_type.variants
     } else {

--- a/facet-args/src/lib.rs
+++ b/facet-args/src/lib.rs
@@ -76,7 +76,7 @@ pub fn is_counted_field(field: &facet_core::Field) -> bool {
 }
 
 /// Check if a shape is a supported type for counted fields (integer types).
-pub fn is_supported_counted_type(shape: &'static facet_core::Shape) -> bool {
+pub const fn is_supported_counted_type(shape: &'static facet_core::Shape) -> bool {
     use facet_core::{NumericType, PrimitiveType, Type};
     matches!(
         shape.ty,

--- a/facet-args/src/span.rs
+++ b/facet-args/src/span.rs
@@ -12,12 +12,12 @@ pub struct Span {
 
 impl Span {
     /// Creates a new span with the given start position and length
-    pub fn new(start: Pos, len: usize) -> Self {
+    pub const fn new(start: Pos, len: usize) -> Self {
         Span { start, len }
     }
 
     /// Length of the span
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len
     }
 }

--- a/facet-asn1/src/error.rs
+++ b/facet-asn1/src/error.rs
@@ -97,17 +97,17 @@ impl std::error::Error for Asn1Error {}
 
 impl Asn1Error {
     /// Create a new error with the given kind at the given position.
-    pub fn new(kind: Asn1ErrorKind, pos: usize) -> Self {
+    pub const fn new(kind: Asn1ErrorKind, pos: usize) -> Self {
         Self { kind, pos }
     }
 
     /// Create an unexpected EOF error.
-    pub fn unexpected_eof(pos: usize) -> Self {
+    pub const fn unexpected_eof(pos: usize) -> Self {
         Self::new(Asn1ErrorKind::UnexpectedEof, pos)
     }
 
     /// Create an unknown tag error.
-    pub fn unknown_tag(tag: u8, pos: usize) -> Self {
+    pub const fn unknown_tag(tag: u8, pos: usize) -> Self {
         Self::new(Asn1ErrorKind::UnknownTag { tag }, pos)
     }
 

--- a/facet-asn1/src/parser.rs
+++ b/facet-asn1/src/parser.rs
@@ -66,7 +66,7 @@ struct ContainerState {
 
 impl<'de> Asn1Parser<'de> {
     /// Create a new ASN.1 DER parser from input bytes.
-    pub fn new(input: &'de [u8]) -> Self {
+    pub const fn new(input: &'de [u8]) -> Self {
         Self {
             input,
             pos: 0,
@@ -535,7 +535,7 @@ pub struct Asn1Probe<'de> {
 }
 
 impl<'de> Asn1Probe<'de> {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             _marker: core::marker::PhantomData,
         }

--- a/facet-asn1/src/serializer.rs
+++ b/facet-asn1/src/serializer.rs
@@ -55,7 +55,7 @@ struct ContainerState {
 
 impl Asn1Serializer {
     /// Create a new ASN.1 DER serializer.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             out: Vec::new(),
             stack: Vec::new(),

--- a/facet-assert/src/same.rs
+++ b/facet-assert/src/same.rs
@@ -58,7 +58,7 @@ impl SameOptions {
     /// // But passes with tolerance:
     /// assert_same_with!(a, b, SameOptions::new().float_tolerance(1e-6));
     /// ```
-    pub fn float_tolerance(mut self, tolerance: f64) -> Self {
+    pub const fn float_tolerance(mut self, tolerance: f64) -> Self {
         self.float_tolerance = Some(tolerance);
         self
     }
@@ -84,7 +84,7 @@ impl SameOptions {
     ///     .float_tolerance(0.001)
     ///     .similarity_threshold(0.6);
     /// ```
-    pub fn similarity_threshold(mut self, threshold: f64) -> Self {
+    pub const fn similarity_threshold(mut self, threshold: f64) -> Self {
         self.similarity_threshold = Some(threshold);
         self
     }
@@ -118,7 +118,7 @@ pub enum SameReport<'mem, 'facet> {
 
 impl<'mem, 'facet> SameReport<'mem, 'facet> {
     /// Returns `true` if the two values matched.
-    pub fn is_same(&self) -> bool {
+    pub const fn is_same(&self) -> bool {
         matches!(self, Self::Same)
     }
 

--- a/facet-core/src/impls/core/array.rs
+++ b/facet-core/src/impls/core/array.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// Extract the ArrayDef from a shape, returns None if not an array
 #[inline]
-fn get_array_def(shape: &'static Shape) -> Option<&'static ArrayDef> {
+const fn get_array_def(shape: &'static Shape) -> Option<&'static ArrayDef> {
     match shape.def {
         Def::Array(ref def) => Some(def),
         _ => None,

--- a/facet-core/src/impls/core/char_str.rs
+++ b/facet-core/src/impls/core/char_str.rs
@@ -37,7 +37,7 @@ unsafe fn str_truthy(value: PtrConst) -> bool {
     !unsafe { value.get::<str>() }.is_empty()
 }
 
-unsafe fn str_drop(_: OxPtrMut) {}
+const unsafe fn str_drop(_: OxPtrMut) {}
 
 static STR_TYPE_OPS: TypeOpsIndirect = TypeOpsIndirect {
     drop_in_place: str_drop,

--- a/facet-core/src/impls/core/infallible.rs
+++ b/facet-core/src/impls/core/infallible.rs
@@ -3,7 +3,7 @@ use crate::{
     Type, TypeOpsIndirect, UserType, VTableIndirect,
 };
 
-unsafe fn infallible_drop(_ptr: OxPtrMut) {
+const unsafe fn infallible_drop(_ptr: OxPtrMut) {
     // Infallible is zero-sized, nothing to drop
 }
 
@@ -39,17 +39,17 @@ unsafe fn infallible_debug(
     Some(f.write_str("Infallible"))
 }
 
-unsafe fn infallible_hash(_ox: OxPtrConst, _hasher: &mut HashProxy<'_>) -> Option<()> {
+const unsafe fn infallible_hash(_ox: OxPtrConst, _hasher: &mut HashProxy<'_>) -> Option<()> {
     // This can never be called since Infallible cannot be instantiated
     Some(())
 }
 
-unsafe fn infallible_partial_eq(_a: OxPtrConst, _b: OxPtrConst) -> Option<bool> {
+const unsafe fn infallible_partial_eq(_a: OxPtrConst, _b: OxPtrConst) -> Option<bool> {
     // This can never be called since Infallible cannot be instantiated
     Some(true)
 }
 
-unsafe fn infallible_partial_cmp(
+const unsafe fn infallible_partial_cmp(
     _a: OxPtrConst,
     _b: OxPtrConst,
 ) -> Option<Option<core::cmp::Ordering>> {
@@ -57,7 +57,7 @@ unsafe fn infallible_partial_cmp(
     Some(Some(core::cmp::Ordering::Equal))
 }
 
-unsafe fn infallible_cmp(_a: OxPtrConst, _b: OxPtrConst) -> Option<core::cmp::Ordering> {
+const unsafe fn infallible_cmp(_a: OxPtrConst, _b: OxPtrConst) -> Option<core::cmp::Ordering> {
     // This can never be called since Infallible cannot be instantiated
     Some(core::cmp::Ordering::Equal)
 }

--- a/facet-core/src/impls/core/option.rs
+++ b/facet-core/src/impls/core/option.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// Extract the OptionDef from a shape, returns None if not an Option
 #[inline]
-fn get_option_def(shape: &'static Shape) -> Option<&'static OptionDef> {
+const fn get_option_def(shape: &'static Shape) -> Option<&'static OptionDef> {
     match shape.def {
         Def::Option(ref def) => Some(def),
         _ => None,

--- a/facet-core/src/impls/core/phantom.rs
+++ b/facet-core/src/impls/core/phantom.rs
@@ -3,11 +3,11 @@ use crate::{
     Type, TypeOpsIndirect, UserType, VTableIndirect,
 };
 
-unsafe fn phantom_drop(_ptr: OxPtrMut) {
+const unsafe fn phantom_drop(_ptr: OxPtrMut) {
     // PhantomData is zero-sized, nothing to drop
 }
 
-unsafe fn phantom_default(_dst: OxPtrMut) {
+const unsafe fn phantom_default(_dst: OxPtrMut) {
     // PhantomData is zero-sized, nothing to write
 }
 
@@ -42,24 +42,24 @@ unsafe fn phantom_debug(
     Some(f.write_str("PhantomData"))
 }
 
-unsafe fn phantom_hash(_ox: OxPtrConst, _hasher: &mut HashProxy<'_>) -> Option<()> {
+const unsafe fn phantom_hash(_ox: OxPtrConst, _hasher: &mut HashProxy<'_>) -> Option<()> {
     // PhantomData hashes to nothing
     Some(())
 }
 
-unsafe fn phantom_partial_eq(_a: OxPtrConst, _b: OxPtrConst) -> Option<bool> {
+const unsafe fn phantom_partial_eq(_a: OxPtrConst, _b: OxPtrConst) -> Option<bool> {
     // All PhantomData are equal
     Some(true)
 }
 
-unsafe fn phantom_partial_cmp(
+const unsafe fn phantom_partial_cmp(
     _a: OxPtrConst,
     _b: OxPtrConst,
 ) -> Option<Option<core::cmp::Ordering>> {
     Some(Some(core::cmp::Ordering::Equal))
 }
 
-unsafe fn phantom_cmp(_a: OxPtrConst, _b: OxPtrConst) -> Option<core::cmp::Ordering> {
+const unsafe fn phantom_cmp(_a: OxPtrConst, _b: OxPtrConst) -> Option<core::cmp::Ordering> {
     Some(core::cmp::Ordering::Equal)
 }
 

--- a/facet-core/src/impls/core/pointer.rs
+++ b/facet-core/src/impls/core/pointer.rs
@@ -55,7 +55,7 @@ unsafe fn const_ptr_cmp<T: ?Sized>(a: OxPtrConst, b: OxPtrConst) -> Option<Order
 }
 
 /// Drop for *const T (no-op, pointers don't need dropping)
-unsafe fn const_ptr_drop<T: ?Sized>(_ptr: OxPtrMut) {
+const unsafe fn const_ptr_drop<T: ?Sized>(_ptr: OxPtrMut) {
     // Pointers don't need dropping
 }
 
@@ -107,7 +107,7 @@ unsafe fn mut_ptr_cmp<T: ?Sized>(a: OxPtrConst, b: OxPtrConst) -> Option<Orderin
 }
 
 /// Drop for *mut T (no-op, pointers don't need dropping)
-unsafe fn mut_ptr_drop<T: ?Sized>(_ptr: OxPtrMut) {
+const unsafe fn mut_ptr_drop<T: ?Sized>(_ptr: OxPtrMut) {
     // Pointers don't need dropping
 }
 

--- a/facet-core/src/impls/core/reference.rs
+++ b/facet-core/src/impls/core/reference.rs
@@ -148,7 +148,7 @@ unsafe fn ref_cmp(a: OxPtrConst, b: OxPtrConst) -> Option<core::cmp::Ordering> {
 }
 
 /// Drop for &T and &mut T (no-op, references don't need dropping)
-unsafe fn ref_drop(_ptr: OxPtrMut) {
+const unsafe fn ref_drop(_ptr: OxPtrMut) {
     // References don't need dropping
 }
 

--- a/facet-core/src/impls/core/result.rs
+++ b/facet-core/src/impls/core/result.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// Extract the ResultDef from a shape, returns None if not a Result
 #[inline]
-fn get_result_def(shape: &'static Shape) -> Option<&'static ResultDef> {
+const fn get_result_def(shape: &'static Shape) -> Option<&'static ResultDef> {
     match shape.def {
         Def::Result(ref def) => Some(def),
         _ => None,

--- a/facet-core/src/impls/core/slice.rs
+++ b/facet-core/src/impls/core/slice.rs
@@ -53,7 +53,7 @@ unsafe fn slice_truthy<T>(ptr: PtrConst) -> bool {
 
 /// Extract the SliceDef from a shape, returns None if not a slice
 #[inline]
-fn get_slice_def(shape: &'static Shape) -> Option<&'static SliceDef> {
+const fn get_slice_def(shape: &'static Shape) -> Option<&'static SliceDef> {
     match shape.def {
         Def::Slice(ref def) => Some(def),
         _ => None,

--- a/facet-core/src/impls/crates/url.rs
+++ b/facet-core/src/impls/crates/url.rs
@@ -19,7 +19,7 @@ unsafe fn display_url(
     }
 }
 
-fn url_parse_error_message(error: url::ParseError) -> &'static str {
+const fn url_parse_error_message(error: url::ParseError) -> &'static str {
     match error {
         url::ParseError::EmptyHost => "empty host",
         url::ParseError::IdnaError => "invalid international domain name",

--- a/facet-core/src/impls/std/hashset.rs
+++ b/facet-core/src/impls/std/hashset.rs
@@ -68,7 +68,7 @@ unsafe fn hashset_iter_dealloc<T>(iter_ptr: PtrMut) {
 
 /// Extract the SetDef from a shape, returns None if not a Set
 #[inline]
-fn get_set_def(shape: &'static Shape) -> Option<&'static SetDef> {
+const fn get_set_def(shape: &'static Shape) -> Option<&'static SetDef> {
     match shape.def {
         Def::Set(ref def) => Some(def),
         _ => None,

--- a/facet-core/src/impls/std/locks.rs
+++ b/facet-core/src/impls/std/locks.rs
@@ -539,7 +539,7 @@ unsafe fn oncelock_drop<T>(ox: OxPtrMut) {
 }
 
 const fn oncelock_guard_vtable() -> LockGuardVTable {
-    unsafe fn drop_guard(_guard: PtrConst) {
+    const unsafe fn drop_guard(_guard: PtrConst) {
         // No-op - OnceLock doesn't have a guard to release
     }
     LockGuardVTable {

--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -58,7 +58,7 @@ pub unsafe trait Facet<'facet>: 'facet {
 /// FieldBuilder::new("my_field", shape_of::<i32>, 0)
 /// ```
 #[inline]
-pub fn shape_of<'a, T: Facet<'a>>() -> &'static Shape {
+pub const fn shape_of<'a, T: Facet<'a>>() -> &'static Shape {
     T::SHAPE
 }
 

--- a/facet-core/src/types/bitflags.rs
+++ b/facet-core/src/types/bitflags.rs
@@ -70,13 +70,13 @@ macro_rules! bitflags {
 
             /// Inserts the flags in `other` into `self`.
             #[inline]
-            pub fn insert(&mut self, other: Self) {
+            pub const fn insert(&mut self, other: Self) {
                 self.0 |= other.0;
             }
 
             /// Removes the flags in `other` from `self`.
             #[inline]
-            pub fn remove(&mut self, other: Self) {
+            pub const fn remove(&mut self, other: Self) {
                 self.0 &= !other.0;
             }
 

--- a/facet-core/src/types/builtins.rs
+++ b/facet-core/src/types/builtins.rs
@@ -536,7 +536,7 @@ impl Ox<'static> {
 impl<'a> Ox<'a> {
     /// Get an immutable view of the value.
     #[inline]
-    pub fn as_ref(&self) -> OxRef<'_> {
+    pub const fn as_ref(&self) -> OxRef<'_> {
         match self {
             Ox::Owned(inner) => inner.as_ref(),
             Ox::Borrowed(inner) => *inner,
@@ -545,7 +545,7 @@ impl<'a> Ox<'a> {
 
     /// Get a mutable view of the value (only if owned).
     #[inline]
-    pub fn as_mut(&mut self) -> Option<OxMut<'_>> {
+    pub const fn as_mut(&mut self) -> Option<OxMut<'_>> {
         match self {
             Ox::Owned(inner) => Some(OxMut {
                 ptr: inner.ptr,
@@ -558,7 +558,7 @@ impl<'a> Ox<'a> {
 
     /// For read-only vtable operations.
     #[inline]
-    pub fn ptr_const(&self) -> PtrConst {
+    pub const fn ptr_const(&self) -> PtrConst {
         match self {
             Ox::Owned(inner) => inner.ptr.as_const(),
             Ox::Borrowed(inner) => inner.ptr,
@@ -567,7 +567,7 @@ impl<'a> Ox<'a> {
 
     /// For mutating vtable operations (only if owned).
     #[inline]
-    pub fn ptr_mut(&mut self) -> Option<PtrMut> {
+    pub const fn ptr_mut(&mut self) -> Option<PtrMut> {
         match self {
             Ox::Owned(inner) => Some(inner.ptr),
             Ox::Borrowed(_) => None,
@@ -576,7 +576,7 @@ impl<'a> Ox<'a> {
 
     /// Get the shape.
     #[inline]
-    pub fn shape(&self) -> &'static Shape {
+    pub const fn shape(&self) -> &'static Shape {
         match self {
             Ox::Owned(inner) => inner.shape,
             Ox::Borrowed(inner) => inner.shape,

--- a/facet-core/src/types/characteristic.rs
+++ b/facet-core/src/types/characteristic.rs
@@ -249,7 +249,7 @@ impl Shape {
     /// assert_eq!(format!("{}", shape.type_name()), "Vec<u32>");
     /// ```
     #[inline]
-    pub fn type_name(&'static self) -> TypeNameDisplay {
+    pub const fn type_name(&'static self) -> TypeNameDisplay {
         TypeNameDisplay(self)
     }
 }

--- a/facet-core/src/types/def/function.rs
+++ b/facet-core/src/types/def/function.rs
@@ -30,7 +30,7 @@ pub enum FunctionAbi {
 }
 impl FunctionAbi {
     /// Returns the string in `extern "abi-string"` if not [`FunctionAbi::Unknown`].
-    pub fn as_abi_str(&self) -> Option<&str> {
+    pub const fn as_abi_str(&self) -> Option<&str> {
         match self {
             FunctionAbi::C => Some("C"),
             FunctionAbi::Rust => Some("Rust"),

--- a/facet-core/src/types/def/mod.rs
+++ b/facet-core/src/types/def/mod.rs
@@ -309,7 +309,7 @@ impl Def {
     }
 
     /// Returns the `ScalarDef` wrapped in an `Ok` if this is a [`Def::Scalar`].
-    pub fn into_scalar(self) -> Result<(), Self> {
+    pub const fn into_scalar(self) -> Result<(), Self> {
         match self {
             Self::Scalar => Ok(()),
             _ => Err(self),
@@ -317,7 +317,7 @@ impl Def {
     }
 
     /// Returns the `MapDef` wrapped in an `Ok` if this is a [`Def::Map`].
-    pub fn into_map(self) -> Result<MapDef, Self> {
+    pub const fn into_map(self) -> Result<MapDef, Self> {
         match self {
             Self::Map(def) => Ok(def),
             _ => Err(self),
@@ -325,7 +325,7 @@ impl Def {
     }
 
     /// Returns the `SetDef` wrapped in an `Ok` if this is a [`Def::Set`].
-    pub fn into_set(self) -> Result<SetDef, Self> {
+    pub const fn into_set(self) -> Result<SetDef, Self> {
         match self {
             Self::Set(def) => Ok(def),
             _ => Err(self),
@@ -333,49 +333,49 @@ impl Def {
     }
 
     /// Returns the `ListDef` wrapped in an `Ok` if this is a [`Def::List`].
-    pub fn into_list(self) -> Result<ListDef, Self> {
+    pub const fn into_list(self) -> Result<ListDef, Self> {
         match self {
             Self::List(def) => Ok(def),
             _ => Err(self),
         }
     }
     /// Returns the `ArrayDef` wrapped in an `Ok` if this is a [`Def::Array`].
-    pub fn into_array(self) -> Result<ArrayDef, Self> {
+    pub const fn into_array(self) -> Result<ArrayDef, Self> {
         match self {
             Self::Array(def) => Ok(def),
             _ => Err(self),
         }
     }
     /// Returns the `NdArrayDef` wrapped in an `Ok` if this is a [`Def::NdArray`].
-    pub fn into_ndarray(self) -> Result<NdArrayDef, Self> {
+    pub const fn into_ndarray(self) -> Result<NdArrayDef, Self> {
         match self {
             Self::NdArray(def) => Ok(def),
             _ => Err(self),
         }
     }
     /// Returns the `SliceDef` wrapped in an `Ok` if this is a [`Def::Slice`].
-    pub fn into_slice(self) -> Result<SliceDef, Self> {
+    pub const fn into_slice(self) -> Result<SliceDef, Self> {
         match self {
             Self::Slice(def) => Ok(def),
             _ => Err(self),
         }
     }
     /// Returns the `OptionDef` wrapped in an `Ok` if this is a [`Def::Option`].
-    pub fn into_option(self) -> Result<OptionDef, Self> {
+    pub const fn into_option(self) -> Result<OptionDef, Self> {
         match self {
             Self::Option(def) => Ok(def),
             _ => Err(self),
         }
     }
     /// Returns the `ResultDef` wrapped in an `Ok` if this is a [`Def::Result`].
-    pub fn into_result(self) -> Result<ResultDef, Self> {
+    pub const fn into_result(self) -> Result<ResultDef, Self> {
         match self {
             Self::Result(def) => Ok(def),
             _ => Err(self),
         }
     }
     /// Returns the `PointerDef` wrapped in an `Ok` if this is a [`Def::Pointer`].
-    pub fn into_pointer(self) -> Result<PointerDef, Self> {
+    pub const fn into_pointer(self) -> Result<PointerDef, Self> {
         match self {
             Self::Pointer(def) => Ok(def),
             _ => Err(self),
@@ -383,7 +383,7 @@ impl Def {
     }
 
     /// Returns the `DynamicValueDef` wrapped in an `Ok` if this is a [`Def::DynamicValue`].
-    pub fn into_dynamic_value(self) -> Result<DynamicValueDef, Self> {
+    pub const fn into_dynamic_value(self) -> Result<DynamicValueDef, Self> {
         match self {
             Self::DynamicValue(def) => Ok(def),
             _ => Err(self),

--- a/facet-core/src/types/def/pointer.rs
+++ b/facet-core/src/types/def/pointer.rs
@@ -29,7 +29,7 @@ pub struct PointerDef {
 
 impl PointerDef {
     /// Returns shape of the inner type of the pointer, if not opaque
-    pub fn pointee(&self) -> Option<&'static Shape> {
+    pub const fn pointee(&self) -> Option<&'static Shape> {
         self.pointee
     }
 
@@ -39,7 +39,7 @@ impl PointerDef {
     }
 
     /// Returns shape of the corresponding weak pointer, if this pointer is strong
-    pub fn strong(&self) -> Option<&'static Shape> {
+    pub const fn strong(&self) -> Option<&'static Shape> {
         self.strong
     }
 
@@ -159,7 +159,7 @@ impl<P> LockResult<P> {
     ///   will release the lock
     /// - The guard must outlive any use of `data`
     #[must_use]
-    pub unsafe fn new(data: P, guard: PtrConst, guard_vtable: &'static LockGuardVTable) -> Self {
+    pub const unsafe fn new(data: P, guard: PtrConst, guard_vtable: &'static LockGuardVTable) -> Self {
         Self {
             data,
             guard,
@@ -169,7 +169,7 @@ impl<P> LockResult<P> {
 
     /// Returns a reference to the locked data
     #[must_use]
-    pub fn data(&self) -> &P {
+    pub const fn data(&self) -> &P {
         &self.data
     }
 }
@@ -177,7 +177,7 @@ impl<P> LockResult<P> {
 impl WriteLockResult {
     /// Returns a const pointer to the locked data (convenience for write locks)
     #[must_use]
-    pub fn data_const(&self) -> PtrConst {
+    pub const fn data_const(&self) -> PtrConst {
         self.data.as_const()
     }
 }

--- a/facet-core/src/types/ptr/mod.rs
+++ b/facet-core/src/types/ptr/mod.rs
@@ -375,7 +375,7 @@ impl PtrConst {
     /// # Safety
     /// Caller must ensure they have exclusive access.
     #[inline]
-    pub unsafe fn into_mut(self) -> PtrMut {
+    pub const unsafe fn into_mut(self) -> PtrMut {
         self.ptr
     }
 }

--- a/facet-core/src/types/ptr/tagged.rs
+++ b/facet-core/src/types/ptr/tagged.rs
@@ -81,7 +81,7 @@ impl NativeWidePtr {
 
     /// Get the data pointer
     #[inline]
-    pub fn data_ptr(self) -> *mut u8 {
+    pub const fn data_ptr(self) -> *mut u8 {
         if PTR_FIRST {
             self.parts[0]
         } else {
@@ -91,7 +91,7 @@ impl NativeWidePtr {
 
     /// Get the metadata pointer
     #[inline]
-    pub fn metadata(self) -> *const () {
+    pub const fn metadata(self) -> *const () {
         if PTR_FIRST {
             self.parts[1] as *const ()
         } else {
@@ -101,7 +101,7 @@ impl NativeWidePtr {
 
     /// Create from data pointer and metadata
     #[inline]
-    pub fn from_parts(data: *mut u8, metadata: *const ()) -> Self {
+    pub const fn from_parts(data: *mut u8, metadata: *const ()) -> Self {
         let parts = if PTR_FIRST {
             [data, metadata as *mut u8]
         } else {

--- a/facet-core/src/types/shape.rs
+++ b/facet-core/src/types/shape.rs
@@ -49,7 +49,7 @@ impl VarianceVisited {
     /// Push a type ID onto the visited stack.
     /// Returns false if the stack is full (depth limit reached).
     #[inline]
-    fn push(&mut self, id: ConstTypeId) -> bool {
+    const fn push(&mut self, id: ConstTypeId) -> bool {
         if self.len >= MAX_VARIANCE_DEPTH {
             return false;
         }
@@ -296,7 +296,7 @@ impl Shape {
     /// This is used by deferred validation mode in `Partial` to determine which
     /// shapes must be fully materialized before proceeding.
     #[inline]
-    pub fn requires_eager_materialization(&self) -> bool {
+    pub const fn requires_eager_materialization(&self) -> bool {
         // Check if this is a pointer type with slice_builder_vtable
         // (indicates Arc<[T]>, Box<[T]>, Rc<[T]>, etc.)
         if let Ok(ptr_def) = self.def.into_pointer()
@@ -435,7 +435,7 @@ impl Shape {
     /// Untagged enums serialize their content directly without any discriminant.
     /// This checks the `UNTAGGED` flag (O(1)).
     #[inline]
-    pub fn is_untagged(&self) -> bool {
+    pub const fn is_untagged(&self) -> bool {
         self.flags.contains(ShapeFlags::UNTAGGED)
     }
 
@@ -443,7 +443,7 @@ impl Shape {
     ///
     /// This checks the `NUMERIC` flag (O(1)).
     #[inline]
-    pub fn is_numeric(&self) -> bool {
+    pub const fn is_numeric(&self) -> bool {
         self.flags.contains(ShapeFlags::NUMERIC)
     }
 
@@ -466,7 +466,7 @@ impl Shape {
     /// are manipulated through their vtables which maintain their invariants.
     /// The POD-ness of the element type `T` matters when mutating elements.
     #[inline]
-    pub fn is_pod(&self) -> bool {
+    pub const fn is_pod(&self) -> bool {
         // Primitives are implicitly POD - any value of the type is valid
         matches!(self.ty, Type::Primitive(_)) || self.flags.contains(ShapeFlags::POD)
     }
@@ -475,7 +475,7 @@ impl Shape {
     ///
     /// This is the direct field access (O(1)), not an attribute lookup.
     #[inline]
-    pub fn get_tag_attr(&self) -> Option<&'static str> {
+    pub const fn get_tag_attr(&self) -> Option<&'static str> {
         self.tag
     }
 
@@ -483,7 +483,7 @@ impl Shape {
     ///
     /// This is the direct field access (O(1)), not an attribute lookup.
     #[inline]
-    pub fn get_content_attr(&self) -> Option<&'static str> {
+    pub const fn get_content_attr(&self) -> Option<&'static str> {
         self.content
     }
 

--- a/facet-core/src/types/ty/field.rs
+++ b/facet-core/src/types/ty/field.rs
@@ -163,7 +163,7 @@ impl Field {
     ///
     /// This checks the `FLATTEN` flag (O(1)).
     #[inline]
-    pub fn is_flattened(&self) -> bool {
+    pub const fn is_flattened(&self) -> bool {
         self.flags.contains(FieldFlags::FLATTEN)
     }
 
@@ -171,7 +171,7 @@ impl Field {
     ///
     /// This checks the `SENSITIVE` flag (O(1)).
     #[inline]
-    pub fn is_sensitive(&self) -> bool {
+    pub const fn is_sensitive(&self) -> bool {
         self.flags.contains(FieldFlags::SENSITIVE)
     }
 
@@ -180,13 +180,13 @@ impl Field {
     /// This returns true for both `#[facet(default)]` (uses the type's Default impl)
     /// and `#[facet(default = expr)]` (uses a custom expression).
     #[inline]
-    pub fn has_default(&self) -> bool {
+    pub const fn has_default(&self) -> bool {
         self.default.is_some()
     }
 
     /// Returns the default source for this field, if any.
     #[inline]
-    pub fn default_source(&self) -> Option<&DefaultSource> {
+    pub const fn default_source(&self) -> Option<&DefaultSource> {
         self.default.as_ref()
     }
 
@@ -194,7 +194,7 @@ impl Field {
     ///
     /// This checks the `CHILD` flag (O(1)).
     #[inline]
-    pub fn is_child(&self) -> bool {
+    pub const fn is_child(&self) -> bool {
         self.flags.contains(FieldFlags::CHILD)
     }
 
@@ -244,7 +244,7 @@ impl Field {
     /// Metadata fields are excluded from structural hashing and equality.
     /// Use `metadata_kind()` to get the specific kind of metadata.
     #[inline]
-    pub fn is_metadata(&self) -> bool {
+    pub const fn is_metadata(&self) -> bool {
         self.metadata.is_some()
     }
 
@@ -254,7 +254,7 @@ impl Field {
     /// the containing type, enabling lazy shape resolution for self-referential
     /// structures like linked lists and trees.
     #[inline]
-    pub fn is_recursive_type(&self) -> bool {
+    pub const fn is_recursive_type(&self) -> bool {
         self.flags.contains(FieldFlags::RECURSIVE_TYPE)
     }
 
@@ -262,7 +262,7 @@ impl Field {
     ///
     /// Common values: `"span"`, `"line"`, `"column"`
     #[inline]
-    pub fn metadata_kind(&self) -> Option<&'static str> {
+    pub const fn metadata_kind(&self) -> Option<&'static str> {
         self.metadata
     }
 
@@ -270,7 +270,7 @@ impl Field {
     ///
     /// This checks the `SKIP` and `SKIP_DESERIALIZING` flags (O(1)).
     #[inline]
-    pub fn should_skip_deserializing(&self) -> bool {
+    pub const fn should_skip_deserializing(&self) -> bool {
         !self
             .flags
             .intersection(FieldFlags::SKIP.union(FieldFlags::SKIP_DESERIALIZING))
@@ -341,7 +341,7 @@ impl Field {
     /// - `TryFrom<&FieldType> for ProxyType` (for serialization)
     #[cfg(feature = "alloc")]
     #[inline]
-    pub fn proxy(&self) -> Option<&'static super::ProxyDef> {
+    pub const fn proxy(&self) -> Option<&'static super::ProxyDef> {
         self.proxy
     }
 
@@ -387,7 +387,7 @@ impl Field {
     /// the proxy shape and conversion functions.
     #[cfg(feature = "alloc")]
     #[inline]
-    pub fn has_proxy(&self) -> bool {
+    pub const fn has_proxy(&self) -> bool {
         self.proxy.is_some()
     }
 

--- a/facet-csv/src/error.rs
+++ b/facet-csv/src/error.rs
@@ -14,12 +14,12 @@ pub struct CsvError {
 
 impl CsvError {
     /// Create a new error with the given kind.
-    pub fn new(kind: CsvErrorKind) -> Self {
+    pub const fn new(kind: CsvErrorKind) -> Self {
         Self { kind, span: None }
     }
 
     /// Create a new error with the given kind and span.
-    pub fn with_span(kind: CsvErrorKind, span: facet_reflect::Span) -> Self {
+    pub const fn with_span(kind: CsvErrorKind, span: facet_reflect::Span) -> Self {
         Self {
             kind,
             span: Some(span),
@@ -27,7 +27,7 @@ impl CsvError {
     }
 
     /// Get the error kind.
-    pub fn kind(&self) -> &CsvErrorKind {
+    pub const fn kind(&self) -> &CsvErrorKind {
         &self.kind
     }
 }

--- a/facet-csv/src/serializer.rs
+++ b/facet-csv/src/serializer.rs
@@ -32,7 +32,7 @@ pub struct CsvSerializer {
 
 impl CsvSerializer {
     /// Create a new CSV serializer.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             out: Vec::new(),
             in_struct: false,

--- a/facet-diff-core/src/display.rs
+++ b/facet-diff-core/src/display.rs
@@ -41,7 +41,7 @@ struct PadAdapter<'a, 'b: 'a> {
 }
 
 impl<'a, 'b> PadAdapter<'a, 'b> {
-    fn new_indented(fmt: &'a mut std::fmt::Formatter<'b>) -> Self {
+    const fn new_indented(fmt: &'a mut std::fmt::Formatter<'b>) -> Self {
         Self {
             fmt,
             on_newline: true,
@@ -242,12 +242,12 @@ impl<'mem, 'facet> Display for Diff<'mem, 'facet> {
 
 impl<'mem, 'facet> Updates<'mem, 'facet> {
     /// Check if this is a single replace operation (useful for Option::Some)
-    pub fn is_single_replace(&self) -> bool {
+    pub const fn is_single_replace(&self) -> bool {
         self.0.first.is_some() && self.0.values.is_empty() && self.0.last.is_none()
     }
 
     /// Check if there are no changes (everything is unchanged)
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.0.first.is_none() && self.0.values.is_empty()
     }
 }

--- a/facet-diff-core/src/layout/arena.rs
+++ b/facet-diff-core/src/layout/arena.rs
@@ -15,13 +15,13 @@ pub struct Span {
 impl Span {
     /// Byte length of the span
     #[inline]
-    pub fn len(self) -> usize {
+    pub const fn len(self) -> usize {
         (self.end - self.start) as usize
     }
 
     /// Check if span is empty
     #[inline]
-    pub fn is_empty(self) -> bool {
+    pub const fn is_empty(self) -> bool {
         self.start == self.end
     }
 }
@@ -87,12 +87,12 @@ impl FormatArena {
     }
 
     /// Current size of the buffer in bytes.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.buf.len()
     }
 
     /// Check if the arena is empty.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.buf.is_empty()
     }
 }

--- a/facet-diff-core/src/layout/attrs.rs
+++ b/facet-diff-core/src/layout/attrs.rs
@@ -33,7 +33,7 @@ pub struct FormattedValue {
 
 impl FormattedValue {
     /// Create a new formatted value with unknown type.
-    pub fn new(span: Span, width: usize) -> Self {
+    pub const fn new(span: Span, width: usize) -> Self {
         Self {
             span,
             width,
@@ -42,7 +42,7 @@ impl FormattedValue {
     }
 
     /// Create a new formatted value with a specific type.
-    pub fn with_type(span: Span, width: usize, value_type: ValueType) -> Self {
+    pub const fn with_type(span: Span, width: usize, value_type: ValueType) -> Self {
         Self {
             span,
             width,
@@ -133,7 +133,7 @@ impl Attr {
     }
 
     /// Check if this attribute is changed (needs -/+ lines).
-    pub fn is_changed(&self) -> bool {
+    pub const fn is_changed(&self) -> bool {
         matches!(self.status, AttrStatus::Changed { .. })
     }
 
@@ -192,7 +192,7 @@ impl ChangedGroup {
     }
 
     /// Check if this group is empty.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.attr_indices.is_empty()
     }
 

--- a/facet-diff-core/src/layout/backend.rs
+++ b/facet-diff-core/src/layout/backend.rs
@@ -135,7 +135,7 @@ pub struct AnsiBackend {
 
 impl AnsiBackend {
     /// Create a new ANSI backend with the given theme.
-    pub fn new(theme: DiffTheme) -> Self {
+    pub const fn new(theme: DiffTheme) -> Self {
         Self { theme }
     }
 

--- a/facet-diff-core/src/layout/build.rs
+++ b/facet-diff-core/src/layout/build.rs
@@ -155,7 +155,7 @@ impl BuildOptions {
     /// When set, all floating-point numbers will be formatted with this many
     /// decimal places. This is useful when using float tolerance in comparisons
     /// to ensure the display matches the tolerance level.
-    pub fn with_float_precision(mut self, precision: usize) -> Self {
+    pub const fn with_float_precision(mut self, precision: usize) -> Self {
         self.float_precision = Some(precision);
         self
     }

--- a/facet-diff-core/src/layout/node.rs
+++ b/facet-diff-core/src/layout/node.rs
@@ -24,7 +24,7 @@ pub enum ElementChange {
 
 impl ElementChange {
     /// Get the prefix character for this change type.
-    pub fn prefix(self) -> Option<char> {
+    pub const fn prefix(self) -> Option<char> {
         match self {
             Self::None => None,
             Self::Deleted => Some('-'),
@@ -35,7 +35,7 @@ impl ElementChange {
     }
 
     /// Check if this change type uses any prefix.
-    pub fn has_prefix(self) -> bool {
+    pub const fn has_prefix(self) -> bool {
         !matches!(self, Self::None)
     }
 }
@@ -120,7 +120,7 @@ impl LayoutNode {
     }
 
     /// Create a sequence node.
-    pub fn sequence(change: ElementChange, item_type: &'static str) -> Self {
+    pub const fn sequence(change: ElementChange, item_type: &'static str) -> Self {
         Self::Sequence {
             change,
             item_type,
@@ -129,17 +129,17 @@ impl LayoutNode {
     }
 
     /// Create a collapsed node.
-    pub fn collapsed(count: usize) -> Self {
+    pub const fn collapsed(count: usize) -> Self {
         Self::Collapsed { count }
     }
 
     /// Create a text node.
-    pub fn text(value: FormattedValue, change: ElementChange) -> Self {
+    pub const fn text(value: FormattedValue, change: ElementChange) -> Self {
         Self::Text { value, change }
     }
 
     /// Create an item group node.
-    pub fn item_group(
+    pub const fn item_group(
         items: Vec<FormattedValue>,
         change: ElementChange,
         collapsed_suffix: Option<usize>,
@@ -154,7 +154,7 @@ impl LayoutNode {
     }
 
     /// Get the element change type (if applicable).
-    pub fn change(&self) -> ElementChange {
+    pub const fn change(&self) -> ElementChange {
         match self {
             Self::Element { change, .. } => *change,
             Self::Sequence { change, .. } => *change,

--- a/facet-diff-core/src/layout/render.rs
+++ b/facet-diff-core/src/layout/render.rs
@@ -17,7 +17,7 @@ enum SyntaxElement {
 }
 
 /// Get the appropriate semantic color for a syntax element in a given context.
-fn syntax_color(base: SyntaxElement, context: ElementChange) -> SemanticColor {
+const fn syntax_color(base: SyntaxElement, context: ElementChange) -> SemanticColor {
     match (base, context) {
         (SyntaxElement::Key, ElementChange::Deleted) => SemanticColor::DeletedKey,
         (SyntaxElement::Key, ElementChange::Inserted) => SemanticColor::InsertedKey,
@@ -34,7 +34,7 @@ fn syntax_color(base: SyntaxElement, context: ElementChange) -> SemanticColor {
 }
 
 /// Get the appropriate semantic color for a value based on its type and context.
-fn value_color(value_type: ValueType, context: ElementChange) -> SemanticColor {
+const fn value_color(value_type: ValueType, context: ElementChange) -> SemanticColor {
     match (value_type, context) {
         (ValueType::String, ElementChange::Deleted) => SemanticColor::DeletedString,
         (ValueType::String, ElementChange::Inserted) => SemanticColor::InsertedString,
@@ -62,7 +62,7 @@ fn value_color(value_type: ValueType, context: ElementChange) -> SemanticColor {
 }
 
 /// Get semantic color for highlight background (changed values).
-fn value_color_highlight(value_type: ValueType, context: ElementChange) -> SemanticColor {
+const fn value_color_highlight(value_type: ValueType, context: ElementChange) -> SemanticColor {
     match (value_type, context) {
         (ValueType::String, ElementChange::Deleted) => SemanticColor::DeletedString,
         (ValueType::String, ElementChange::Inserted) => SemanticColor::InsertedString,
@@ -231,7 +231,7 @@ pub fn render_to_string<B: ColorBackend, F: DiffFlavor>(
     out
 }
 
-fn element_change_to_semantic(change: ElementChange) -> SemanticColor {
+const fn element_change_to_semantic(change: ElementChange) -> SemanticColor {
     match change {
         ElementChange::None => SemanticColor::Unchanged,
         ElementChange::Deleted => SemanticColor::Deleted,

--- a/facet-diff-core/src/path.rs
+++ b/facet-diff-core/src/path.rs
@@ -21,7 +21,7 @@ pub struct Path(pub Vec<PathSegment>);
 
 impl Path {
     /// Create a new empty path.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(Vec::new())
     }
 

--- a/facet-diff-core/src/symbols.rs
+++ b/facet-diff-core/src/symbols.rs
@@ -62,7 +62,7 @@ pub enum ChangeKind {
 
 impl ChangeKind {
     /// Get the symbol for this change kind.
-    pub fn symbol(self, symbols: &DiffSymbols) -> Option<&'static str> {
+    pub const fn symbol(self, symbols: &DiffSymbols) -> Option<&'static str> {
         match self {
             Self::Unchanged => None,
             Self::Deleted | Self::Modified => Some(symbols.deleted),
@@ -73,7 +73,7 @@ impl ChangeKind {
     }
 
     /// Returns true if this change should be highlighted (not unchanged).
-    pub fn is_changed(self) -> bool {
+    pub const fn is_changed(self) -> bool {
         !matches!(self, Self::Unchanged)
     }
 }

--- a/facet-diff-core/src/theme.rs
+++ b/facet-diff-core/src/theme.rs
@@ -177,7 +177,7 @@ impl DiffTheme {
     };
 
     /// Get the color for a change kind.
-    pub fn color_for(&self, kind: crate::ChangeKind) -> Rgb {
+    pub const fn color_for(&self, kind: crate::ChangeKind) -> Rgb {
         match kind {
             crate::ChangeKind::Unchanged => self.unchanged,
             crate::ChangeKind::Deleted => self.deleted,

--- a/facet-diff-core/src/types.rs
+++ b/facet-diff-core/src/types.rs
@@ -62,7 +62,7 @@ pub enum Diff<'mem, 'facet> {
 
 impl<'mem, 'facet> Diff<'mem, 'facet> {
     /// Returns true if the two values were equal
-    pub fn is_equal(&self) -> bool {
+    pub const fn is_equal(&self) -> bool {
         matches!(self, Self::Equal { .. })
     }
 }

--- a/facet-diff/src/diff.rs
+++ b/facet-diff/src/diff.rs
@@ -35,7 +35,7 @@ impl DiffOptions {
     }
 
     /// Set the tolerance for floating-point comparisons.
-    pub fn with_float_tolerance(mut self, tolerance: f64) -> Self {
+    pub const fn with_float_tolerance(mut self, tolerance: f64) -> Self {
         self.float_tolerance = Some(tolerance);
         self
     }
@@ -50,7 +50,7 @@ impl DiffOptions {
     ///
     /// # Arguments
     /// * `threshold` - Minimum similarity score (0.0 to 1.0). Recommended: 0.5-0.7.
-    pub fn with_similarity_threshold(mut self, threshold: f64) -> Self {
+    pub const fn with_similarity_threshold(mut self, threshold: f64) -> Self {
         self.similarity_threshold = Some(threshold);
         self
     }

--- a/facet-diff/src/report.rs
+++ b/facet-diff/src/report.rs
@@ -51,7 +51,7 @@ pub struct DiffReport<'mem, 'facet> {
 
 impl<'mem, 'facet> DiffReport<'mem, 'facet> {
     /// Create a new diff report from a computed diff and the original values.
-    pub fn new(
+    pub const fn new(
         diff: Diff<'mem, 'facet>,
         left: Peek<'mem, 'facet>,
         right: Peek<'mem, 'facet>,
@@ -68,23 +68,23 @@ impl<'mem, 'facet> DiffReport<'mem, 'facet> {
     ///
     /// The tolerance is used to determine appropriate decimal precision when rendering
     /// floating-point values in the diff output.
-    pub fn with_float_tolerance(mut self, tolerance: f64) -> Self {
+    pub const fn with_float_tolerance(mut self, tolerance: f64) -> Self {
         self.float_tolerance = Some(tolerance);
         self
     }
 
     /// Access the raw diff tree.
-    pub fn diff(&self) -> &Diff<'mem, 'facet> {
+    pub const fn diff(&self) -> &Diff<'mem, 'facet> {
         &self.diff
     }
 
     /// Peek into the left-hand value.
-    pub fn left(&self) -> Peek<'mem, 'facet> {
+    pub const fn left(&self) -> Peek<'mem, 'facet> {
         self.left
     }
 
     /// Peek into the right-hand value.
-    pub fn right(&self) -> Peek<'mem, 'facet> {
+    pub const fn right(&self) -> Peek<'mem, 'facet> {
         self.right
     }
 

--- a/facet-diff/tests/diff_snapshots.rs
+++ b/facet-diff/tests/diff_snapshots.rs
@@ -15,7 +15,7 @@ use facet_value::value;
 use insta::assert_snapshot;
 
 // Convert Tokyo Night Rgb to boxen Color
-fn to_boxen(c: owo_colors::Rgb) -> Color {
+const fn to_boxen(c: owo_colors::Rgb) -> Color {
     Color::Rgb(c.0, c.1, c.2)
 }
 

--- a/facet-diff/tests/proxy_diff.rs
+++ b/facet-diff/tests/proxy_diff.rs
@@ -18,7 +18,7 @@ pub struct OpaqueCounter {
 }
 
 impl OpaqueCounter {
-    pub fn new(count: u64) -> Self {
+    pub const fn new(count: u64) -> Self {
         Self { count }
     }
 }

--- a/facet-format-suite/src/lib.rs
+++ b/facet-format-suite/src/lib.rs
@@ -828,7 +828,7 @@ impl CaseSpec {
 
     /// Convenience for UTF-8 inputs.
     #[allow(clippy::should_implement_trait)]
-    pub fn from_str(input: &'static str) -> Self {
+    pub const fn from_str(input: &'static str) -> Self {
         Self::from_bytes(input.as_bytes())
     }
 
@@ -843,26 +843,26 @@ impl CaseSpec {
     }
 
     /// Attach an optional note for diagnostics.
-    pub fn with_note(mut self, note: &'static str) -> Self {
+    pub const fn with_note(mut self, note: &'static str) -> Self {
         self.note = Some(note);
         self
     }
 
     /// Disable round-trip checks for this case, documenting the reason.
-    pub fn without_roundtrip(mut self, reason: &'static str) -> Self {
+    pub const fn without_roundtrip(mut self, reason: &'static str) -> Self {
         self.roundtrip = RoundtripSpec::Disabled { reason };
         self
     }
 
     /// Use PartialEq comparison instead of reflection-based comparison.
     /// Required for types containing opaque fields that can't be compared via reflection.
-    pub fn with_partial_eq(mut self) -> Self {
+    pub const fn with_partial_eq(mut self) -> Self {
         self.compare_mode = CompareMode::PartialEq;
         self
     }
 
     /// Expect deserialization to fail with an error containing the given substring.
-    pub fn expect_error(input: &'static str, error_contains: &'static str) -> Self {
+    pub const fn expect_error(input: &'static str, error_contains: &'static str) -> Self {
         Self {
             payload: CasePayload::ExpectError {
                 input: input.as_bytes(),
@@ -880,7 +880,7 @@ impl CaseSpec {
     ///
     /// Use this for binary formats where input is generated at runtime
     /// (e.g., from a reference implementation like rmp-serde for MsgPack).
-    pub fn from_bytes_vec(input: Vec<u8>) -> Self {
+    pub const fn from_bytes_vec(input: Vec<u8>) -> Self {
         Self {
             payload: CasePayload::DynamicInput(input),
             note: None,
@@ -1007,7 +1007,7 @@ impl SuiteCase {
         (self.async_runner)()
     }
 
-    pub fn skip_reason(&self) -> Option<&'static str> {
+    pub const fn skip_reason(&self) -> Option<&'static str> {
         self.skip_reason
     }
 }
@@ -2369,7 +2369,7 @@ pub struct StructLevelDefault {
 }
 
 /// Default value function for `WithDefaultFunction`.
-pub fn custom_default_value() -> i32 {
+pub const fn custom_default_value() -> i32 {
     42
 }
 

--- a/facet-format/src/deserializer.rs
+++ b/facet-format/src/deserializer.rs
@@ -68,7 +68,7 @@ impl<'input, const BORROW: bool, P> FormatDeserializer<'input, BORROW, P> {
     }
 
     /// Borrow the inner parser mutably.
-    pub fn parser_mut(&mut self) -> &mut P {
+    pub const fn parser_mut(&mut self) -> &mut P {
         &mut self.parser
     }
 }
@@ -1540,7 +1540,7 @@ where
     }
 
     /// Get the item shape from a list-like field shape.
-    fn get_list_item_shape(shape: &facet_core::Shape) -> Option<&'static facet_core::Shape> {
+    const fn get_list_item_shape(shape: &facet_core::Shape) -> Option<&'static facet_core::Shape> {
         match &shape.def {
             Def::List(list_def) => Some(list_def.t()),
             _ => None,
@@ -5050,7 +5050,7 @@ impl<E: fmt::Debug + fmt::Display> std::error::Error for DeserializeError<E> {}
 impl<E> DeserializeError<E> {
     /// Create a Reflect error without span or path information.
     #[inline]
-    pub fn reflect(error: ReflectError) -> Self {
+    pub const fn reflect(error: ReflectError) -> Self {
         DeserializeError::Reflect {
             error,
             span: None,
@@ -5060,7 +5060,7 @@ impl<E> DeserializeError<E> {
 
     /// Create a Reflect error with span information.
     #[inline]
-    pub fn reflect_with_span(error: ReflectError, span: facet_reflect::Span) -> Self {
+    pub const fn reflect_with_span(error: ReflectError, span: facet_reflect::Span) -> Self {
         DeserializeError::Reflect {
             error,
             span: Some(span),
@@ -5070,7 +5070,7 @@ impl<E> DeserializeError<E> {
 
     /// Create a Reflect error with span and path information.
     #[inline]
-    pub fn reflect_with_context(
+    pub const fn reflect_with_context(
         error: ReflectError,
         span: Option<facet_reflect::Span>,
         path: Path,
@@ -5083,7 +5083,7 @@ impl<E> DeserializeError<E> {
     }
 
     /// Get the path where the error occurred, if available.
-    pub fn path(&self) -> Option<&Path> {
+    pub const fn path(&self) -> Option<&Path> {
         match self {
             DeserializeError::Reflect { path, .. } => path.as_ref(),
             DeserializeError::TypeMismatch { path, .. } => path.as_ref(),

--- a/facet-format/src/event.rs
+++ b/facet-format/src/event.rs
@@ -66,12 +66,12 @@ pub enum ContainerKind {
 
 impl ContainerKind {
     /// Returns true if this container kind is ambiguous (can be struct or sequence).
-    pub fn is_ambiguous(self) -> bool {
+    pub const fn is_ambiguous(self) -> bool {
         matches!(self, ContainerKind::Element)
     }
 
     /// Human-readable name for error messages.
-    pub fn name(self) -> &'static str {
+    pub const fn name(self) -> &'static str {
         match self {
             ContainerKind::Object => "object",
             ContainerKind::Array => "array",

--- a/facet-format/src/jit/compiler.rs
+++ b/facet-format/src/jit/compiler.rs
@@ -35,7 +35,7 @@ pub struct CachedModule {
 
 impl CachedModule {
     /// Create a new cached module.
-    pub fn new(module: JITModule, nested_modules: Vec<JITModule>, fn_ptr: *const u8) -> Self {
+    pub const fn new(module: JITModule, nested_modules: Vec<JITModule>, fn_ptr: *const u8) -> Self {
         Self {
             module,
             nested_modules,
@@ -44,7 +44,7 @@ impl CachedModule {
     }
 
     /// Get the function pointer.
-    pub fn fn_ptr(&self) -> *const u8 {
+    pub const fn fn_ptr(&self) -> *const u8 {
         self.fn_ptr
     }
 }
@@ -83,12 +83,12 @@ impl<T, P> CompiledDeserializer<T, P> {
     }
 
     /// Get the raw function pointer.
-    pub fn as_ptr(&self) -> *const u8 {
+    pub const fn as_ptr(&self) -> *const u8 {
         self.fn_ptr
     }
 
     /// Get the vtable.
-    pub fn vtable(&self) -> &ParserVTable {
+    pub const fn vtable(&self) -> &ParserVTable {
         &self.vtable
     }
 }
@@ -401,7 +401,7 @@ impl ListElementKind {
     /// For numeric types, we accept I64, U64, and F64 since:
     /// - JSON doesn't distinguish signed/unsigned integers
     /// - JSON integers can be coerced to floats (e.g., `1` for f64)
-    fn is_numeric(&self) -> bool {
+    const fn is_numeric(&self) -> bool {
         matches!(
             self,
             ListElementKind::I64 | ListElementKind::U64 | ListElementKind::F64
@@ -410,7 +410,7 @@ impl ListElementKind {
 
     /// Returns the expected ScalarTag for non-numeric types.
     /// Returns None for numeric types (handled separately).
-    fn expected_non_numeric_tag(&self) -> Option<u8> {
+    const fn expected_non_numeric_tag(&self) -> Option<u8> {
         use helpers::ScalarTag;
         match self {
             ListElementKind::Bool => Some(ScalarTag::Bool as u8),
@@ -2328,7 +2328,7 @@ impl WriteKind {
     /// For numeric types, we accept I64, U64, and F64 since:
     /// - JSON doesn't distinguish signed/unsigned integers
     /// - JSON integers can be coerced to floats (e.g., `1` for f64)
-    fn is_numeric(&self) -> bool {
+    const fn is_numeric(&self) -> bool {
         matches!(
             self,
             WriteKind::I8
@@ -2346,7 +2346,7 @@ impl WriteKind {
 
     /// Returns the expected ScalarTag for non-numeric scalar types.
     /// Returns None for numeric types (handled separately) and non-scalar types.
-    fn expected_non_numeric_tag(&self) -> Option<u8> {
+    const fn expected_non_numeric_tag(&self) -> Option<u8> {
         use helpers::ScalarTag;
         match self {
             WriteKind::Bool => Some(ScalarTag::Bool as u8),

--- a/facet-format/src/jit/format.rs
+++ b/facet-format/src/jit/format.rs
@@ -744,7 +744,7 @@ impl JitFormat for NoFormatJit {
 ///
 /// Use this when creating signatures for `call_indirect` to `extern "C"` helper functions.
 #[inline]
-pub fn c_call_conv() -> cranelift::codegen::isa::CallConv {
+pub const fn c_call_conv() -> cranelift::codegen::isa::CallConv {
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
     {
         cranelift::codegen::isa::CallConv::WindowsFastcall

--- a/facet-format/src/jit/format_compiler.rs
+++ b/facet-format/src/jit/format_compiler.rs
@@ -206,12 +206,12 @@ pub struct CachedFormatModule {
 
 impl CachedFormatModule {
     /// Create a new cached module.
-    pub fn new(module: JITModule, fn_ptr: *const u8) -> Self {
+    pub const fn new(module: JITModule, fn_ptr: *const u8) -> Self {
         Self { module, fn_ptr }
     }
 
     /// Get the function pointer.
-    pub fn fn_ptr(&self) -> *const u8 {
+    pub const fn fn_ptr(&self) -> *const u8 {
         self.fn_ptr
     }
 }
@@ -255,7 +255,7 @@ impl<T, P> CompiledFormatDeserializer<T, P> {
 
     /// Get the raw function pointer.
     #[inline(always)]
-    pub fn fn_ptr(&self) -> *const u8 {
+    pub const fn fn_ptr(&self) -> *const u8 {
         self.fn_ptr
     }
 }

--- a/facet-format/src/jit/format_compiler/support.rs
+++ b/facet-format/src/jit/format_compiler/support.rs
@@ -510,7 +510,7 @@ pub(crate) fn ensure_format_jit_element_supported(
 }
 
 /// Get a human-readable description of a shape's type for error messages.
-fn shape_type_description(shape: &'static Shape) -> &'static str {
+const fn shape_type_description(shape: &'static Shape) -> &'static str {
     match &shape.def {
         Def::Undefined => "undefined",
         Def::Scalar => "scalar",

--- a/facet-format/src/jit/helpers.rs
+++ b/facet-format/src/jit/helpers.rs
@@ -165,7 +165,7 @@ pub enum ScalarTag {
 
 impl ScalarTag {
     /// Convert from u8 value
-    pub fn from_u8(v: u8) -> Self {
+    pub const fn from_u8(v: u8) -> Self {
         match v {
             0 => ScalarTag::None,
             1 => ScalarTag::Null,
@@ -629,7 +629,7 @@ pub unsafe extern "C" fn jit_write_u64(out: *mut u8, offset: usize, value: u64) 
 
 /// Write an i8 value to a struct field.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn jit_write_i8(out: *mut u8, offset: usize, value: i8) {
+pub const unsafe extern "C" fn jit_write_i8(out: *mut u8, offset: usize, value: i8) {
     unsafe {
         let ptr = out.add(offset) as *mut i8;
         std::ptr::write_unaligned(ptr, value);
@@ -638,7 +638,7 @@ pub unsafe extern "C" fn jit_write_i8(out: *mut u8, offset: usize, value: i8) {
 
 /// Write an i16 value to a struct field.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn jit_write_i16(out: *mut u8, offset: usize, value: i16) {
+pub const unsafe extern "C" fn jit_write_i16(out: *mut u8, offset: usize, value: i16) {
     unsafe {
         let ptr = out.add(offset) as *mut i16;
         std::ptr::write_unaligned(ptr, value);
@@ -647,7 +647,7 @@ pub unsafe extern "C" fn jit_write_i16(out: *mut u8, offset: usize, value: i16) 
 
 /// Write an i32 value to a struct field.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn jit_write_i32(out: *mut u8, offset: usize, value: i32) {
+pub const unsafe extern "C" fn jit_write_i32(out: *mut u8, offset: usize, value: i32) {
     unsafe {
         let ptr = out.add(offset) as *mut i32;
         std::ptr::write_unaligned(ptr, value);
@@ -656,7 +656,7 @@ pub unsafe extern "C" fn jit_write_i32(out: *mut u8, offset: usize, value: i32) 
 
 /// Write an i64 value to a struct field.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn jit_write_i64(out: *mut u8, offset: usize, value: i64) {
+pub const unsafe extern "C" fn jit_write_i64(out: *mut u8, offset: usize, value: i64) {
     unsafe {
         let ptr = out.add(offset) as *mut i64;
         std::ptr::write_unaligned(ptr, value);
@@ -665,7 +665,7 @@ pub unsafe extern "C" fn jit_write_i64(out: *mut u8, offset: usize, value: i64) 
 
 /// Write an f32 value to a struct field.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn jit_write_f32(out: *mut u8, offset: usize, value: f32) {
+pub const unsafe extern "C" fn jit_write_f32(out: *mut u8, offset: usize, value: f32) {
     unsafe {
         let ptr = out.add(offset) as *mut f32;
         std::ptr::write_unaligned(ptr, value);
@@ -674,7 +674,7 @@ pub unsafe extern "C" fn jit_write_f32(out: *mut u8, offset: usize, value: f32) 
 
 /// Write an f64 value to a struct field.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn jit_write_f64(out: *mut u8, offset: usize, value: f64) {
+pub const unsafe extern "C" fn jit_write_f64(out: *mut u8, offset: usize, value: f64) {
     unsafe {
         let ptr = out.add(offset) as *mut f64;
         std::ptr::write_unaligned(ptr, value);
@@ -775,7 +775,7 @@ pub unsafe extern "C" fn jit_write_string(
 /// - `len` bytes must be readable from src and writable to dest
 /// - memory regions may overlap (uses memmove semantics)
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn jit_memcpy(dest: *mut u8, src: *const u8, len: usize) {
+pub const unsafe extern "C" fn jit_memcpy(dest: *mut u8, src: *const u8, len: usize) {
     unsafe {
         std::ptr::copy(src, dest, len);
     }

--- a/facet-format/src/solver.rs
+++ b/facet-format/src/solver.rs
@@ -28,7 +28,7 @@ pub enum SolveVariantError<E> {
 
 impl<E> SolveVariantError<E> {
     /// Wrap a parser error into [`SolveVariantError::Parser`].
-    pub fn from_parser(e: E) -> Self {
+    pub const fn from_parser(e: E) -> Self {
         Self::Parser(e)
     }
 }

--- a/facet-format/src/visitor.rs
+++ b/facet-format/src/visitor.rs
@@ -29,7 +29,7 @@ pub struct StructFieldTracker<'a> {
 
 impl<'a> StructFieldTracker<'a> {
     /// Create a tracker for the given resolution.
-    pub fn new(resolution: &'a Resolution) -> Self {
+    pub const fn new(resolution: &'a Resolution) -> Self {
         Self {
             resolution,
             seen: BTreeSet::new(),

--- a/facet-html/src/parser.rs
+++ b/facet-html/src/parser.rs
@@ -240,7 +240,7 @@ struct Element {
 }
 
 impl Element {
-    fn new(name: String, attributes: Vec<(String, String)>) -> Self {
+    const fn new(name: String, attributes: Vec<(String, String)>) -> Self {
         Self {
             name,
             attributes,

--- a/facet-html/src/serializer.rs
+++ b/facet-html/src/serializer.rs
@@ -117,7 +117,7 @@ impl SerializeOptions {
     }
 
     /// Enable pretty-printing with default indentation.
-    pub fn pretty(mut self) -> Self {
+    pub const fn pretty(mut self) -> Self {
         self.pretty = true;
         self
     }
@@ -136,7 +136,7 @@ impl SerializeOptions {
     }
 
     /// Use self-closing syntax for void elements (`<br />` instead of `<br>`).
-    pub fn self_closing_void(mut self, value: bool) -> Self {
+    pub const fn self_closing_void(mut self, value: bool) -> Self {
         self.self_closing_void = value;
         self
     }

--- a/facet-json-schema/src/lib.rs
+++ b/facet-json-schema/src/lib.rs
@@ -126,7 +126,7 @@ impl Default for JsonSchema {
 
 impl JsonSchema {
     /// Create an empty schema
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             schema: None,
             ref_: None,
@@ -199,7 +199,7 @@ struct SchemaContext {
 }
 
 impl SchemaContext {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             defs: BTreeMap::new(),
             in_progress: Vec::new(),

--- a/facet-json/src/adapter.rs
+++ b/facet-json/src/adapter.rs
@@ -172,7 +172,7 @@ impl<'input, const BORROW: bool> SliceAdapter<'input, BORROW> {
 
     /// Check if we've reached the end of input.
     #[inline]
-    fn at_end_of_input(&self) -> bool {
+    const fn at_end_of_input(&self) -> bool {
         self.window_end >= self.input.len()
     }
 
@@ -486,13 +486,13 @@ impl<'input, const BORROW: bool> SliceAdapter<'input, BORROW> {
 
     /// Get the current absolute position in the input.
     #[allow(dead_code)]
-    pub fn position(&self) -> usize {
+    pub const fn position(&self) -> usize {
         self.window_start + self.scanner.pos()
     }
 
     /// Get the underlying input slice.
     #[allow(dead_code)]
-    pub fn input(&self) -> &'input [u8] {
+    pub const fn input(&self) -> &'input [u8] {
         self.input
     }
 }

--- a/facet-json/src/axum.rs
+++ b/facet-json/src/axum.rs
@@ -101,7 +101,7 @@ enum JsonRejectionKind {
 
 impl JsonRejection {
     /// Returns the HTTP status code for this rejection.
-    pub fn status(&self) -> StatusCode {
+    pub const fn status(&self) -> StatusCode {
         match &self.kind {
             JsonRejectionKind::Body(_) => StatusCode::BAD_REQUEST,
             JsonRejectionKind::Deserialize(_) => StatusCode::UNPROCESSABLE_ENTITY,
@@ -111,22 +111,22 @@ impl JsonRejection {
     }
 
     /// Returns true if this is a body reading error.
-    pub fn is_body_error(&self) -> bool {
+    pub const fn is_body_error(&self) -> bool {
         matches!(&self.kind, JsonRejectionKind::Body(_))
     }
 
     /// Returns true if this is a deserialization error.
-    pub fn is_deserialize_error(&self) -> bool {
+    pub const fn is_deserialize_error(&self) -> bool {
         matches!(&self.kind, JsonRejectionKind::Deserialize(_))
     }
 
     /// Returns true if this is a missing content type error.
-    pub fn is_missing_content_type(&self) -> bool {
+    pub const fn is_missing_content_type(&self) -> bool {
         matches!(&self.kind, JsonRejectionKind::MissingContentType)
     }
 
     /// Returns true if this is an invalid content type error.
-    pub fn is_invalid_content_type(&self) -> bool {
+    pub const fn is_invalid_content_type(&self) -> bool {
         matches!(&self.kind, JsonRejectionKind::InvalidContentType)
     }
 }

--- a/facet-json/src/error.rs
+++ b/facet-json/src/error.rs
@@ -31,7 +31,7 @@ impl std::error::Error for JsonError {}
 
 impl JsonError {
     /// Create a new error with span information
-    pub fn new(kind: JsonErrorKind, span: Span) -> Self {
+    pub const fn new(kind: JsonErrorKind, span: Span) -> Self {
         JsonError {
             kind,
             span: Some(span),
@@ -40,7 +40,7 @@ impl JsonError {
     }
 
     /// Create an error without span information
-    pub fn without_span(kind: JsonErrorKind) -> Self {
+    pub const fn without_span(kind: JsonErrorKind) -> Self {
         JsonError {
             kind,
             span: None,
@@ -183,7 +183,7 @@ impl Display for JsonErrorKind {
 
 impl JsonErrorKind {
     /// Get an error code for this kind of error.
-    pub fn code(&self) -> &'static str {
+    pub const fn code(&self) -> &'static str {
         match self {
             JsonErrorKind::Scan(_) => "json::scan",
             JsonErrorKind::ScanWithContext { .. } => "json::scan",

--- a/facet-json/src/raw_json.rs
+++ b/facet-json/src/raw_json.rs
@@ -38,13 +38,13 @@ pub struct RawJson<'a>(pub Cow<'a, str>);
 impl<'a> RawJson<'a> {
     /// Create a new `RawJson` from a string slice.
     #[inline]
-    pub fn new(s: &'a str) -> Self {
+    pub const fn new(s: &'a str) -> Self {
         RawJson(Cow::Borrowed(s))
     }
 
     /// Create a new `RawJson` from an owned string.
     #[inline]
-    pub fn from_owned(s: String) -> Self {
+    pub const fn from_owned(s: String) -> Self {
         RawJson(Cow::Owned(s))
     }
 

--- a/facet-json/src/scanner.rs
+++ b/facet-json/src/scanner.rs
@@ -138,7 +138,7 @@ enum ScanState {
 
 impl Scanner {
     /// Create a new scanner starting at position 0
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             pos: 0,
             state: ScanState::Ready,
@@ -147,7 +147,7 @@ impl Scanner {
 
     /// Create a scanner starting at a specific position
     #[allow(dead_code)]
-    pub fn at_position(pos: usize) -> Self {
+    pub const fn at_position(pos: usize) -> Self {
         Self {
             pos,
             state: ScanState::Ready,
@@ -155,12 +155,12 @@ impl Scanner {
     }
 
     /// Current position in the buffer
-    pub fn pos(&self) -> usize {
+    pub const fn pos(&self) -> usize {
         self.pos
     }
 
     /// Set position (used after buffer operations)
-    pub fn set_pos(&mut self, pos: usize) {
+    pub const fn set_pos(&mut self, pos: usize) {
         self.pos = pos;
     }
 
@@ -649,7 +649,7 @@ impl Default for Scanner {
 
 /// Check if a 128-bit window contains a specific byte (SIMD-friendly)
 #[inline]
-fn contains_byte(window: u128, byte: u8) -> bool {
+const fn contains_byte(window: u128, byte: u8) -> bool {
     let pattern = u128::from_ne_bytes([byte; 16]);
     let xor = window ^ pattern;
     let has_zero = (xor.wrapping_sub(0x01010101010101010101010101010101))

--- a/facet-json/src/serializer.rs
+++ b/facet-json/src/serializer.rs
@@ -31,13 +31,13 @@ impl SerializeOptions {
     }
 
     /// Enable pretty-printing with default indentation.
-    pub fn pretty(mut self) -> Self {
+    pub const fn pretty(mut self) -> Self {
         self.pretty = true;
         self
     }
 
     /// Set a custom indentation string (implies pretty-printing).
-    pub fn indent(mut self, indent: &'static str) -> Self {
+    pub const fn indent(mut self, indent: &'static str) -> Self {
         self.indent = indent;
         self.pretty = true;
         self
@@ -77,7 +77,7 @@ impl JsonSerializer {
     }
 
     /// Create a new JSON serializer with the given options.
-    pub fn with_options(options: SerializeOptions) -> Self {
+    pub const fn with_options(options: SerializeOptions) -> Self {
         Self {
             out: Vec::new(),
             stack: Vec::new(),
@@ -91,7 +91,7 @@ impl JsonSerializer {
     }
 
     /// Current nesting depth (for indentation).
-    fn depth(&self) -> usize {
+    const fn depth(&self) -> usize {
         self.stack.len()
     }
 
@@ -216,7 +216,7 @@ impl JsonSerializer {
 /// Check if any byte in the u128 equals the target byte.
 /// Uses the SWAR (SIMD Within A Register) technique.
 #[inline]
-fn contains_byte(val: u128, byte: u8) -> bool {
+const fn contains_byte(val: u128, byte: u8) -> bool {
     let mask = 0x01010101010101010101010101010101u128 * (byte as u128);
     let xor_result = val ^ mask;
     let has_zero = (xor_result.wrapping_sub(0x01010101010101010101010101010101))
@@ -228,7 +228,7 @@ fn contains_byte(val: u128, byte: u8) -> bool {
 /// Check that all bytes have at least one of the top 3 bits set (i.e., >= 0x20).
 /// This means no control characters (0x00-0x1F).
 #[inline]
-fn no_control_chars(value: u128) -> bool {
+const fn no_control_chars(value: u128) -> bool {
     let masked = value & 0xe0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0;
     let has_zero = (masked.wrapping_sub(0x01010101010101010101010101010101))
         & !masked

--- a/facet-macro-parse/src/generic_params.rs
+++ b/facet-macro-parse/src/generic_params.rs
@@ -120,7 +120,7 @@ impl quote::ToTokens for AsPhantomData<'_> {
 
 impl BoundedGenericParams {
     /// Returns a display wrapper that formats generic parameters as a PhantomData type
-    pub fn as_phantom_data(&self) -> AsPhantomData<'_> {
+    pub const fn as_phantom_data(&self) -> AsPhantomData<'_> {
         AsPhantomData(self)
     }
 }
@@ -200,12 +200,12 @@ impl quote::ToTokens for WithoutBounds<'_> {
 
 impl BoundedGenericParams {
     /// Returns a display wrapper that formats generic parameters with their bounds
-    pub fn display_with_bounds(&self) -> WithBounds<'_> {
+    pub const fn display_with_bounds(&self) -> WithBounds<'_> {
         WithBounds(self)
     }
 
     /// Returns a display wrapper that formats generic parameters without their bounds
-    pub fn display_without_bounds(&self) -> WithoutBounds<'_> {
+    pub const fn display_without_bounds(&self) -> WithoutBounds<'_> {
         WithoutBounds(self)
     }
 
@@ -219,7 +219,7 @@ impl BoundedGenericParams {
     /// For generic parameters `<'a, T, const N: usize>`, this returns a wrapper that
     /// when displayed produces:
     /// `::core::marker::PhantomData<(*mut &'a (), T, [u32; N])>`
-    pub fn display_as_phantom_data(&self) -> AsPhantomData<'_> {
+    pub const fn display_as_phantom_data(&self) -> AsPhantomData<'_> {
         AsPhantomData(self)
     }
 

--- a/facet-macro-parse/src/lib.rs
+++ b/facet-macro-parse/src/lib.rs
@@ -35,7 +35,7 @@ pub enum PType {
 
 impl PType {
     /// Get the name identifier of the type
-    pub fn name(&self) -> &Ident {
+    pub const fn name(&self) -> &Ident {
         match self {
             PType::Struct(s) => &s.container.name,
             PType::Enum(e) => &e.container.name,

--- a/facet-macro-parse/src/parsed.rs
+++ b/facet-macro-parse/src/parsed.rs
@@ -32,7 +32,7 @@ impl ParseError {
     ///
     /// Use this when we detect an error that rustc will also catch,
     /// so we avoid duplicate diagnostics.
-    pub fn rustc_will_catch(reason: &'static str) -> Self {
+    pub const fn rustc_will_catch(reason: &'static str) -> Self {
         ParseError::RustcWillCatch { reason }
     }
 
@@ -213,7 +213,7 @@ impl PFacetAttr {
     }
 
     /// Returns true if this is a builtin attribute (no namespace)
-    pub fn is_builtin(&self) -> bool {
+    pub const fn is_builtin(&self) -> bool {
         self.ns.is_none()
     }
 
@@ -533,7 +533,7 @@ pub struct DeclaredTraits {
 
 impl DeclaredTraits {
     /// Returns true if any trait is declared
-    pub fn has_any(&self) -> bool {
+    pub const fn has_any(&self) -> bool {
         self.display
             || self.debug
             || self.clone
@@ -804,7 +804,7 @@ impl PAttrs {
     }
 
     /// Check if `#[repr(transparent)]` is present
-    pub fn is_repr_transparent(&self) -> bool {
+    pub const fn is_repr_transparent(&self) -> bool {
         matches!(self.repr, PRepr::Transparent)
     }
 

--- a/facet-macros-impl/src/plugin.rs
+++ b/facet-macros-impl/src/plugin.rs
@@ -629,7 +629,7 @@ enum ContextFrame<'a> {
 }
 
 impl<'a> EvalContext<'a> {
-    fn new(parsed_type: &'a facet_macro_parse::PType) -> Self {
+    const fn new(parsed_type: &'a facet_macro_parse::PType) -> Self {
         Self {
             parsed_type,
             stack: Vec::new(),

--- a/facet-macros-impl/src/process_struct.rs
+++ b/facet-macros-impl/src/process_struct.rs
@@ -93,7 +93,7 @@ impl<'a> TraitSources<'a> {
     }
 
     /// Check if we should use auto-detection for this trait
-    fn should_auto(&self) -> bool {
+    const fn should_auto(&self) -> bool {
         self.auto_traits
     }
 }

--- a/facet-msgpack/src/parser.rs
+++ b/facet-msgpack/src/parser.rs
@@ -71,7 +71,7 @@ enum ContextState {
 
 impl<'de> MsgPackParser<'de> {
     /// Create a new MsgPack parser from input bytes.
-    pub fn new(input: &'de [u8]) -> Self {
+    pub const fn new(input: &'de [u8]) -> Self {
         Self {
             input,
             pos: 0,

--- a/facet-msgpack/src/serializer.rs
+++ b/facet-msgpack/src/serializer.rs
@@ -36,7 +36,7 @@ enum ContainerState {
 
 impl MsgPackSerializer {
     /// Create a new MsgPack serializer.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             out: Vec::new(),
             stack: Vec::new(),

--- a/facet-path/src/lib.rs
+++ b/facet-path/src/lib.rs
@@ -73,12 +73,12 @@ impl Path {
     }
 
     /// Get the length of this path.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.steps.len()
     }
 
     /// Check if this path is empty.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.steps.is_empty()
     }
 
@@ -264,7 +264,7 @@ fn get_field_shape(shape: &Shape, idx: usize) -> Option<&'static Shape> {
 }
 
 /// Get the element shape for a list/array.
-fn get_element_shape(shape: &Shape) -> Option<&'static Shape> {
+const fn get_element_shape(shape: &Shape) -> Option<&'static Shape> {
     match shape.def {
         Def::List(ld) => Some(ld.t()),
         Def::Array(ad) => Some(ad.t()),
@@ -297,7 +297,7 @@ fn get_variant_shape(shape: &Shape, idx: usize) -> Option<&'static Shape> {
 }
 
 /// Get the key shape for a map.
-fn get_map_key_shape(shape: &Shape) -> Option<&'static Shape> {
+const fn get_map_key_shape(shape: &Shape) -> Option<&'static Shape> {
     match shape.def {
         Def::Map(md) => Some(md.k()),
         _ => None,
@@ -305,7 +305,7 @@ fn get_map_key_shape(shape: &Shape) -> Option<&'static Shape> {
 }
 
 /// Get the value shape for a map.
-fn get_map_value_shape(shape: &Shape) -> Option<&'static Shape> {
+const fn get_map_value_shape(shape: &Shape) -> Option<&'static Shape> {
     match shape.def {
         Def::Map(md) => Some(md.v()),
         _ => None,
@@ -313,7 +313,7 @@ fn get_map_value_shape(shape: &Shape) -> Option<&'static Shape> {
 }
 
 /// Get the inner shape for an Option.
-fn get_option_inner_shape(shape: &Shape) -> Option<&'static Shape> {
+const fn get_option_inner_shape(shape: &Shape) -> Option<&'static Shape> {
     match shape.def {
         Def::Option(od) => Some(od.t()),
         _ => None,
@@ -321,7 +321,7 @@ fn get_option_inner_shape(shape: &Shape) -> Option<&'static Shape> {
 }
 
 /// Get the inner shape for a pointer.
-fn get_pointer_inner_shape(shape: &Shape) -> Option<&'static Shape> {
+const fn get_pointer_inner_shape(shape: &Shape) -> Option<&'static Shape> {
     match shape.def {
         Def::Pointer(pd) => pd.pointee(),
         _ => None,

--- a/facet-postcard/src/parser.rs
+++ b/facet-postcard/src/parser.rs
@@ -94,7 +94,7 @@ struct OpaqueScalarHint {
 
 impl<'de> PostcardParser<'de> {
     /// Create a new postcard parser from input bytes.
-    pub fn new(input: &'de [u8]) -> Self {
+    pub const fn new(input: &'de [u8]) -> Self {
         Self {
             input,
             pos: 0,

--- a/facet-postcard/src/serialize.rs
+++ b/facet-postcard/src/serialize.rs
@@ -205,7 +205,7 @@ struct PostcardSerializer<'a, W> {
 }
 
 impl<'a, W> PostcardSerializer<'a, W> {
-    fn new(writer: &'a mut W) -> Self {
+    const fn new(writer: &'a mut W) -> Self {
         Self { writer }
     }
 

--- a/facet-pretty/src/color.rs
+++ b/facet-pretty/src/color.rs
@@ -16,7 +16,7 @@ pub struct RGB {
 
 impl RGB {
     /// Create a new RGB color
-    pub fn new(r: u8, g: u8, b: u8) -> Self {
+    pub const fn new(r: u8, g: u8, b: u8) -> Self {
         Self { r, g, b }
     }
 
@@ -56,19 +56,19 @@ impl ColorGenerator {
     }
 
     /// Set the base hue (0-360)
-    pub fn with_base_hue(mut self, hue: f32) -> Self {
+    pub const fn with_base_hue(mut self, hue: f32) -> Self {
         self.base_hue = hue;
         self
     }
 
     /// Set the saturation (0.0-1.0)
-    pub fn with_saturation(mut self, saturation: f32) -> Self {
+    pub const fn with_saturation(mut self, saturation: f32) -> Self {
         self.saturation = saturation.clamp(0.0, 1.0);
         self
     }
 
     /// Set the lightness (0.0-1.0)
-    pub fn with_lightness(mut self, lightness: f32) -> Self {
+    pub const fn with_lightness(mut self, lightness: f32) -> Self {
         self.lightness = lightness.clamp(0.0, 1.0);
         self
     }

--- a/facet-pretty/src/printer.rs
+++ b/facet-pretty/src/printer.rs
@@ -142,37 +142,37 @@ impl PrettyPrinter {
     }
 
     /// Set the indentation size
-    pub fn with_indent_size(mut self, size: usize) -> Self {
+    pub const fn with_indent_size(mut self, size: usize) -> Self {
         self.indent_size = size;
         self
     }
 
     /// Set the maximum depth for recursive printing
-    pub fn with_max_depth(mut self, depth: usize) -> Self {
+    pub const fn with_max_depth(mut self, depth: usize) -> Self {
         self.max_depth = Some(depth);
         self
     }
 
     /// Set the color generator
-    pub fn with_color_generator(mut self, generator: ColorGenerator) -> Self {
+    pub const fn with_color_generator(mut self, generator: ColorGenerator) -> Self {
         self.color_generator = generator;
         self
     }
 
     /// Enable or disable colors
-    pub fn with_colors(mut self, use_colors: bool) -> Self {
+    pub const fn with_colors(mut self, use_colors: bool) -> Self {
         self.use_colors = use_colors;
         self
     }
 
     /// Use minimal names for Options (show `Some(x)` instead of `Option<T>::Some(x)`)
-    pub fn with_minimal_option_names(mut self, minimal: bool) -> Self {
+    pub const fn with_minimal_option_names(mut self, minimal: bool) -> Self {
         self.minimal_option_names = minimal;
         self
     }
 
     /// Enable or disable doc comments in output
-    pub fn with_doc_comments(mut self, show: bool) -> Self {
+    pub const fn with_doc_comments(mut self, show: bool) -> Self {
         self.show_doc_comments = show;
         self
     }
@@ -1860,7 +1860,7 @@ struct NonTrackingOutput<W> {
 
 #[allow(dead_code)]
 impl<W> NonTrackingOutput<W> {
-    fn new(inner: W) -> Self {
+    const fn new(inner: W) -> Self {
         Self { inner, position: 0 }
     }
 }
@@ -1886,7 +1886,7 @@ struct SpanTrackingOutput {
 }
 
 impl SpanTrackingOutput {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             output: String::new(),
             spans: BTreeMap::new(),

--- a/facet-pretty/src/shape.rs
+++ b/facet-pretty/src/shape.rs
@@ -22,52 +22,52 @@ pub mod colors {
     use owo_colors::Style;
 
     /// Keywords: struct, enum, pub, etc. (purple)
-    pub fn keyword() -> Style {
+    pub const fn keyword() -> Style {
         Style::new().fg_rgb::<187, 154, 247>()
     }
 
     /// Type names and identifiers (light blue)
-    pub fn type_name() -> Style {
+    pub const fn type_name() -> Style {
         Style::new().fg_rgb::<192, 202, 245>()
     }
 
     /// Field names (cyan)
-    pub fn field_name() -> Style {
+    pub const fn field_name() -> Style {
         Style::new().fg_rgb::<125, 207, 255>()
     }
 
     /// Primitive types: u8, i32, bool, String, etc. (teal)
-    pub fn primitive() -> Style {
+    pub const fn primitive() -> Style {
         Style::new().fg_rgb::<115, 218, 202>()
     }
 
     /// Punctuation: {, }, (, ), :, etc. (gray-blue)
-    pub fn punctuation() -> Style {
+    pub const fn punctuation() -> Style {
         Style::new().fg_rgb::<154, 165, 206>()
     }
 
     /// Attribute markers: #[...] (light cyan)
-    pub fn attribute() -> Style {
+    pub const fn attribute() -> Style {
         Style::new().fg_rgb::<137, 221, 255>()
     }
 
     /// Attribute content: derive, facet, repr (blue)
-    pub fn attribute_content() -> Style {
+    pub const fn attribute_content() -> Style {
         Style::new().fg_rgb::<122, 162, 247>()
     }
 
     /// String literals (green)
-    pub fn string() -> Style {
+    pub const fn string() -> Style {
         Style::new().fg_rgb::<158, 206, 106>()
     }
 
     /// Container types: Vec, Option, HashMap (orange)
-    pub fn container() -> Style {
+    pub const fn container() -> Style {
         Style::new().fg_rgb::<255, 158, 100>()
     }
 
     /// Doc comments (muted gray)
-    pub fn comment() -> Style {
+    pub const fn comment() -> Style {
         Style::new().fg_rgb::<86, 95, 137>()
     }
 }
@@ -93,26 +93,26 @@ impl ShapeFormatConfig {
     }
 
     /// Enable doc comment display
-    pub fn with_doc_comments(mut self) -> Self {
+    pub const fn with_doc_comments(mut self) -> Self {
         self.show_doc_comments = true;
         self
     }
 
     /// Enable third-party attribute display
-    pub fn with_third_party_attrs(mut self) -> Self {
+    pub const fn with_third_party_attrs(mut self) -> Self {
         self.show_third_party_attrs = true;
         self
     }
 
     /// Enable all metadata (doc comments and third-party attrs)
-    pub fn with_all_metadata(mut self) -> Self {
+    pub const fn with_all_metadata(mut self) -> Self {
         self.show_doc_comments = true;
         self.show_third_party_attrs = true;
         self
     }
 
     /// Disable nested type expansion (only format the root type)
-    pub fn without_nested_types(mut self) -> Self {
+    pub const fn without_nested_types(mut self) -> Self {
         self.expand_nested_types = false;
         self
     }
@@ -740,7 +740,7 @@ struct SpanTrackingContext<'a> {
 }
 
 impl<'a> SpanTrackingContext<'a> {
-    fn new(config: &'a ShapeFormatConfig) -> Self {
+    const fn new(config: &'a ShapeFormatConfig) -> Self {
         Self {
             output: String::new(),
             spans: BTreeMap::new(),
@@ -750,7 +750,7 @@ impl<'a> SpanTrackingContext<'a> {
         }
     }
 
-    fn len(&self) -> usize {
+    const fn len(&self) -> usize {
         self.output.len()
     }
 

--- a/facet-reflect/src/partial/heap_value.rs
+++ b/facet-reflect/src/partial/heap_value.rs
@@ -40,7 +40,7 @@ impl<'facet, const BORROW: bool> HeapValue<'facet, BORROW> {
     }
 
     /// Returns the shape of this heap value.
-    pub fn shape(&self) -> &'static Shape {
+    pub const fn shape(&self) -> &'static Shape {
         self.shape
     }
 
@@ -163,7 +163,7 @@ impl<'facet, const BORROW: bool> HeapValue<'facet, BORROW> {
     /// # Safety
     ///
     /// Caller must guarantee that the underlying value is of type T.
-    pub unsafe fn as_ref<T>(&self) -> &T {
+    pub const unsafe fn as_ref<T>(&self) -> &T {
         unsafe { &*(self.guard.as_ref().unwrap().ptr.as_ptr() as *const T) }
     }
 }

--- a/facet-reflect/src/partial/iset.rs
+++ b/facet-reflect/src/partial/iset.rs
@@ -53,13 +53,13 @@ impl ISet {
 
     /// Returns true if all bits up to MAX_INDEX are set.
     #[inline]
-    pub fn all_set(&self) -> bool {
+    pub const fn all_set(&self) -> bool {
         self.flags == u64::MAX >> (63 - Self::MAX_INDEX)
     }
 
     /// Sets all bits up to MAX_INDEX.
     #[inline]
-    pub fn set_all(&mut self) {
+    pub const fn set_all(&mut self) {
         self.flags = u64::MAX >> (63 - Self::MAX_INDEX);
     }
 }

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -175,26 +175,26 @@ enum FrameMode {
 
 impl FrameMode {
     /// Get a reference to the frame stack.
-    fn stack(&self) -> &Vec<Frame> {
+    const fn stack(&self) -> &Vec<Frame> {
         match self {
             FrameMode::Strict { stack } | FrameMode::Deferred { stack, .. } => stack,
         }
     }
 
     /// Get a mutable reference to the frame stack.
-    fn stack_mut(&mut self) -> &mut Vec<Frame> {
+    const fn stack_mut(&mut self) -> &mut Vec<Frame> {
         match self {
             FrameMode::Strict { stack } | FrameMode::Deferred { stack, .. } => stack,
         }
     }
 
     /// Check if we're in deferred mode.
-    fn is_deferred(&self) -> bool {
+    const fn is_deferred(&self) -> bool {
         matches!(self, FrameMode::Deferred { .. })
     }
 
     /// Get the start depth if in deferred mode.
-    fn start_depth(&self) -> Option<usize> {
+    const fn start_depth(&self) -> Option<usize> {
         match self {
             FrameMode::Deferred { start_depth, .. } => Some(*start_depth),
             FrameMode::Strict { .. } => None,
@@ -202,7 +202,7 @@ impl FrameMode {
     }
 
     /// Get the current path if in deferred mode.
-    fn current_path(&self) -> Option<&KeyPath> {
+    const fn current_path(&self) -> Option<&KeyPath> {
         match self {
             FrameMode::Deferred { current_path, .. } => Some(current_path),
             FrameMode::Strict { .. } => None,
@@ -210,7 +210,7 @@ impl FrameMode {
     }
 
     /// Get the resolution if in deferred mode.
-    fn resolution(&self) -> Option<&Resolution> {
+    const fn resolution(&self) -> Option<&Resolution> {
         match self {
             FrameMode::Deferred { resolution, .. } => Some(resolution),
             FrameMode::Strict { .. } => None,
@@ -303,7 +303,7 @@ impl FrameOwnership {
     /// Both `Owned` and `TrackedBuffer` frames allocated their memory and need
     /// to deallocate it. `Field` and `BorrowedInPlace` frames borrow from
     /// parent or existing structures.
-    fn needs_dealloc(&self) -> bool {
+    const fn needs_dealloc(&self) -> bool {
         matches!(self, FrameOwnership::Owned | FrameOwnership::TrackedBuffer)
     }
 }
@@ -319,18 +319,18 @@ pub(crate) struct AllocatedShape {
 }
 
 impl AllocatedShape {
-    pub(crate) fn new(shape: &'static Shape, allocated_size: usize) -> Self {
+    pub(crate) const fn new(shape: &'static Shape, allocated_size: usize) -> Self {
         Self {
             shape,
             allocated_size,
         }
     }
 
-    pub(crate) fn shape(&self) -> &'static Shape {
+    pub(crate) const fn shape(&self) -> &'static Shape {
         self.shape
     }
 
-    pub(crate) fn allocated_size(&self) -> usize {
+    pub(crate) const fn allocated_size(&self) -> usize {
         self.allocated_size
     }
 }
@@ -488,7 +488,7 @@ pub(crate) enum DynamicObjectInsertState {
 }
 
 impl Tracker {
-    fn kind(&self) -> TrackerKind {
+    const fn kind(&self) -> TrackerKind {
         match self {
             Tracker::Scalar => TrackerKind::Scalar,
             Tracker::Array { .. } => TrackerKind::Array,
@@ -506,7 +506,7 @@ impl Tracker {
     }
 
     /// Set the current_child index for trackers that support it
-    fn set_current_child(&mut self, idx: usize) {
+    const fn set_current_child(&mut self, idx: usize) {
         match self {
             Tracker::Struct { current_child, .. }
             | Tracker::Enum { current_child, .. }
@@ -518,7 +518,7 @@ impl Tracker {
     }
 
     /// Clear the current_child index for trackers that support it
-    fn clear_current_child(&mut self) {
+    const fn clear_current_child(&mut self) {
         match self {
             Tracker::Struct { current_child, .. }
             | Tracker::Enum { current_child, .. }
@@ -531,7 +531,7 @@ impl Tracker {
 }
 
 impl Frame {
-    fn new(data: PtrUninit, allocated: AllocatedShape, ownership: FrameOwnership) -> Self {
+    const fn new(data: PtrUninit, allocated: AllocatedShape, ownership: FrameOwnership) -> Self {
         // For empty structs (structs with 0 fields), start as initialized since there's nothing to initialize
         // This includes empty tuples () which are zero-sized types with no fields to initialize
         let is_init = matches!(
@@ -859,7 +859,7 @@ impl Frame {
     /// # Safety
     ///
     /// This should only be called when `self.data` has been actually initialized.
-    unsafe fn mark_as_init(&mut self) {
+    const unsafe fn mark_as_init(&mut self) {
         self.is_init = true;
     }
 
@@ -1205,7 +1205,7 @@ impl Frame {
     }
 
     /// Get the [EnumType] of the frame's shape, if it is an enum type
-    pub(crate) fn get_enum_type(&self) -> Result<EnumType, ReflectError> {
+    pub(crate) const fn get_enum_type(&self) -> Result<EnumType, ReflectError> {
         match self.allocated.shape().ty {
             Type::User(UserType::Enum(e)) => Ok(e),
             _ => Err(ReflectError::WasNotA {
@@ -1254,37 +1254,37 @@ impl Frame {
 impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
     /// Get a reference to the frame stack.
     #[inline]
-    pub(crate) fn frames(&self) -> &Vec<Frame> {
+    pub(crate) const fn frames(&self) -> &Vec<Frame> {
         self.mode.stack()
     }
 
     /// Get a mutable reference to the frame stack.
     #[inline]
-    pub(crate) fn frames_mut(&mut self) -> &mut Vec<Frame> {
+    pub(crate) const fn frames_mut(&mut self) -> &mut Vec<Frame> {
         self.mode.stack_mut()
     }
 
     /// Check if we're in deferred mode.
     #[inline]
-    pub fn is_deferred(&self) -> bool {
+    pub const fn is_deferred(&self) -> bool {
         self.mode.is_deferred()
     }
 
     /// Get the start depth if in deferred mode.
     #[inline]
-    pub(crate) fn start_depth(&self) -> Option<usize> {
+    pub(crate) const fn start_depth(&self) -> Option<usize> {
         self.mode.start_depth()
     }
 
     /// Get the current path if in deferred mode.
     #[inline]
-    pub(crate) fn current_path(&self) -> Option<&KeyPath> {
+    pub(crate) const fn current_path(&self) -> Option<&KeyPath> {
         self.mode.current_path()
     }
 
     /// Get the resolution if in deferred mode.
     #[inline]
-    pub(crate) fn resolution(&self) -> Option<&Resolution> {
+    pub(crate) const fn resolution(&self) -> Option<&Resolution> {
         self.mode.resolution()
     }
 }

--- a/facet-reflect/src/partial/partial_api/misc.rs
+++ b/facet-reflect/src/partial/partial_api/misc.rs
@@ -22,7 +22,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
     /// might use this for debug assertions, to make sure the state is what
     /// they think it is.
     #[inline]
-    pub fn frame_count(&self) -> usize {
+    pub const fn frame_count(&self) -> usize {
         self.frames().len()
     }
 
@@ -76,7 +76,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
 
     /// Returns the current deferred resolution, if in deferred mode.
     #[inline]
-    pub fn deferred_resolution(&self) -> Option<&Resolution> {
+    pub const fn deferred_resolution(&self) -> Option<&Resolution> {
         self.resolution()
     }
 

--- a/facet-reflect/src/peek/dynamic_value.rs
+++ b/facet-reflect/src/peek/dynamic_value.rs
@@ -20,13 +20,13 @@ pub struct PeekDynamicValue<'mem, 'facet> {
 impl<'mem, 'facet> PeekDynamicValue<'mem, 'facet> {
     /// Returns the dynamic value definition
     #[inline(always)]
-    pub fn def(&self) -> DynamicValueDef {
+    pub const fn def(&self) -> DynamicValueDef {
         self.def
     }
 
     /// Returns the underlying peek value
     #[inline(always)]
-    pub fn peek(&self) -> Peek<'mem, 'facet> {
+    pub const fn peek(&self) -> Peek<'mem, 'facet> {
         self.value
     }
 

--- a/facet-reflect/src/peek/enum_.rs
+++ b/facet-reflect/src/peek/enum_.rs
@@ -25,7 +25,7 @@ impl core::fmt::Debug for PeekEnum<'_, '_> {
 
 /// Returns the enum definition if the shape represents an enum, None otherwise
 #[inline]
-pub fn peek_enum(shape: &'static Shape) -> Option<EnumType> {
+pub const fn peek_enum(shape: &'static Shape) -> Option<EnumType> {
     match shape.ty {
         facet_core::Type::User(UserType::Enum(enum_ty)) => Some(enum_ty),
         _ => None,
@@ -56,25 +56,25 @@ impl<'mem, 'facet> core::ops::Deref for PeekEnum<'mem, 'facet> {
 impl<'mem, 'facet> PeekEnum<'mem, 'facet> {
     /// Returns the enum definition
     #[inline(always)]
-    pub fn ty(self) -> EnumType {
+    pub const fn ty(self) -> EnumType {
         self.ty
     }
 
     /// Returns the enum representation
     #[inline(always)]
-    pub fn enum_repr(self) -> EnumRepr {
+    pub const fn enum_repr(self) -> EnumRepr {
         self.ty.enum_repr
     }
 
     /// Returns the enum variants
     #[inline(always)]
-    pub fn variants(self) -> &'static [Variant] {
+    pub const fn variants(self) -> &'static [Variant] {
         self.ty.variants
     }
 
     /// Returns the number of variants in this enum
     #[inline(always)]
-    pub fn variant_count(self) -> usize {
+    pub const fn variant_count(self) -> usize {
         self.ty.variants.len()
     }
 

--- a/facet-reflect/src/peek/fields.rs
+++ b/facet-reflect/src/peek/fields.rs
@@ -26,7 +26,7 @@ pub struct FieldItem {
 impl FieldItem {
     /// Create a new FieldItem from a Field, using the field's name
     #[inline]
-    pub fn new(field: Field) -> Self {
+    pub const fn new(field: Field) -> Self {
         Self {
             name: Cow::Borrowed(field.name),
             field: Some(field),
@@ -36,7 +36,7 @@ impl FieldItem {
 
     /// Create a flattened enum field item with a custom name (the variant name)
     #[inline]
-    pub fn flattened_enum(field: Field, variant_name: &'static str) -> Self {
+    pub const fn flattened_enum(field: Field, variant_name: &'static str) -> Self {
         Self {
             name: Cow::Borrowed(variant_name),
             field: Some(field),
@@ -46,7 +46,7 @@ impl FieldItem {
 
     /// Create a flattened map entry field item with a dynamic key
     #[inline]
-    pub fn flattened_map_entry(key: String) -> Self {
+    pub const fn flattened_map_entry(key: String) -> Self {
         Self {
             name: Cow::Owned(key),
             field: None,
@@ -88,7 +88,7 @@ enum FieldIterState<'mem, 'facet> {
 
 impl<'mem, 'facet> FieldIter<'mem, 'facet> {
     #[inline]
-    pub(crate) fn new_struct(struct_: PeekStruct<'mem, 'facet>) -> Self {
+    pub(crate) const fn new_struct(struct_: PeekStruct<'mem, 'facet>) -> Self {
         Self {
             range: 0..struct_.ty.fields.len(),
             state: FieldIterState::Struct(struct_),
@@ -114,7 +114,7 @@ impl<'mem, 'facet> FieldIter<'mem, 'facet> {
     }
 
     #[inline]
-    pub(crate) fn new_tuple(tuple: PeekTuple<'mem, 'facet>) -> Self {
+    pub(crate) const fn new_tuple(tuple: PeekTuple<'mem, 'facet>) -> Self {
         Self {
             range: 0..tuple.len(),
             state: FieldIterState::Tuple(tuple),

--- a/facet-reflect/src/peek/list.rs
+++ b/facet-reflect/src/peek/list.rs
@@ -105,7 +105,7 @@ impl<'mem, 'facet> PeekList<'mem, 'facet> {
     ///
     /// Violating these requirements can lead to memory safety issues.
     #[inline]
-    pub unsafe fn new(value: Peek<'mem, 'facet>, def: ListDef) -> Self {
+    pub const unsafe fn new(value: Peek<'mem, 'facet>, def: ListDef) -> Self {
         Self { value, def }
     }
 
@@ -166,7 +166,7 @@ impl<'mem, 'facet> PeekList<'mem, 'facet> {
 
     /// Def getter
     #[inline]
-    pub fn def(&self) -> ListDef {
+    pub const fn def(&self) -> ListDef {
         self.def
     }
 }

--- a/facet-reflect/src/peek/list_like.rs
+++ b/facet-reflect/src/peek/list_like.rs
@@ -25,7 +25,7 @@ pub enum ListLikeDef {
 impl ListLikeDef {
     /// Returns the shape of the items in the list
     #[inline]
-    pub fn t(&self) -> &'static Shape {
+    pub const fn t(&self) -> &'static Shape {
         match self {
             ListLikeDef::List(v) => v.t(),
             ListLikeDef::Array(v) => v.t(),
@@ -154,13 +154,13 @@ impl<'mem, 'facet> PeekListLike<'mem, 'facet> {
 
     /// Get the length of the list
     #[inline]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len
     }
 
     /// Returns true if the list is empty
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
@@ -282,7 +282,7 @@ impl<'mem, 'facet> PeekListLike<'mem, 'facet> {
 
     /// Def getter
     #[inline]
-    pub fn def(&self) -> ListLikeDef {
+    pub const fn def(&self) -> ListLikeDef {
         self.def
     }
 }

--- a/facet-reflect/src/peek/map.rs
+++ b/facet-reflect/src/peek/map.rs
@@ -71,7 +71,7 @@ impl<'mem, 'facet> PeekMap<'mem, 'facet> {
     ///
     /// Violating these requirements can lead to memory safety issues.
     #[inline]
-    pub unsafe fn new(value: Peek<'mem, 'facet>, def: MapDef) -> Self {
+    pub const unsafe fn new(value: Peek<'mem, 'facet>, def: MapDef) -> Self {
         Self { value, def }
     }
 
@@ -148,7 +148,7 @@ impl<'mem, 'facet> PeekMap<'mem, 'facet> {
 
     /// Def getter
     #[inline]
-    pub fn def(&self) -> MapDef {
+    pub const fn def(&self) -> MapDef {
         self.def
     }
 }

--- a/facet-reflect/src/peek/ndarray.rs
+++ b/facet-reflect/src/peek/ndarray.rs
@@ -54,7 +54,7 @@ impl<'mem, 'facet> PeekNdArray<'mem, 'facet> {
     ///
     /// Violating these requirements can lead to memory safety issues.
     #[inline]
-    pub unsafe fn new(value: Peek<'mem, 'facet>, def: NdArrayDef) -> Self {
+    pub const unsafe fn new(value: Peek<'mem, 'facet>, def: NdArrayDef) -> Self {
         Self { value, def }
     }
 
@@ -105,13 +105,13 @@ impl<'mem, 'facet> PeekNdArray<'mem, 'facet> {
 
     /// Peek value getter
     #[inline]
-    pub fn value(&self) -> Peek<'mem, 'facet> {
+    pub const fn value(&self) -> Peek<'mem, 'facet> {
         self.value
     }
 
     /// Def getter
     #[inline]
-    pub fn def(&self) -> NdArrayDef {
+    pub const fn def(&self) -> NdArrayDef {
         self.def
     }
 }

--- a/facet-reflect/src/peek/option.rs
+++ b/facet-reflect/src/peek/option.rs
@@ -13,13 +13,13 @@ pub struct PeekOption<'mem, 'facet> {
 impl<'mem, 'facet> PeekOption<'mem, 'facet> {
     /// Returns the option definition
     #[inline(always)]
-    pub fn def(self) -> OptionDef {
+    pub const fn def(self) -> OptionDef {
         self.def
     }
 
     /// Returns the option vtable
     #[inline(always)]
-    pub fn vtable(self) -> &'static OptionVTable {
+    pub const fn vtable(self) -> &'static OptionVTable {
         self.def.vtable
     }
 

--- a/facet-reflect/src/peek/owned.rs
+++ b/facet-reflect/src/peek/owned.rs
@@ -16,7 +16,7 @@ pub struct OwnedPeek<'mem> {
 
 impl<'mem, 'facet> OwnedPeek<'mem> {
     /// returns the shape of the peek
-    pub fn shape(&self) -> &'static Shape {
+    pub const fn shape(&self) -> &'static Shape {
         self.shape
     }
 

--- a/facet-reflect/src/peek/pointer.rs
+++ b/facet-reflect/src/peek/pointer.rs
@@ -17,7 +17,7 @@ impl<'mem, 'facet> PeekPointer<'mem, 'facet> {
     /// Returns a reference to the pointer definition.
     #[must_use]
     #[inline]
-    pub fn def(&self) -> &PointerDef {
+    pub const fn def(&self) -> &PointerDef {
         &self.def
     }
 

--- a/facet-reflect/src/peek/result.rs
+++ b/facet-reflect/src/peek/result.rs
@@ -13,13 +13,13 @@ pub struct PeekResult<'mem, 'facet> {
 impl<'mem, 'facet> PeekResult<'mem, 'facet> {
     /// Returns the result definition
     #[inline(always)]
-    pub fn def(self) -> ResultDef {
+    pub const fn def(self) -> ResultDef {
         self.def
     }
 
     /// Returns the result vtable
     #[inline(always)]
-    pub fn vtable(self) -> &'static ResultVTable {
+    pub const fn vtable(self) -> &'static ResultVTable {
         self.def.vtable
     }
 

--- a/facet-reflect/src/peek/set.rs
+++ b/facet-reflect/src/peek/set.rs
@@ -64,7 +64,7 @@ impl<'mem, 'facet> PeekSet<'mem, 'facet> {
     ///
     /// Violating these requirements can lead to memory safety issues.
     #[inline]
-    pub unsafe fn new(value: Peek<'mem, 'facet>, def: SetDef) -> Self {
+    pub const unsafe fn new(value: Peek<'mem, 'facet>, def: SetDef) -> Self {
         Self { value, def }
     }
 
@@ -103,7 +103,7 @@ impl<'mem, 'facet> PeekSet<'mem, 'facet> {
 
     /// Def getter
     #[inline]
-    pub fn def(&self) -> SetDef {
+    pub const fn def(&self) -> SetDef {
         self.def
     }
 }

--- a/facet-reflect/src/peek/struct_.rs
+++ b/facet-reflect/src/peek/struct_.rs
@@ -23,13 +23,13 @@ impl core::fmt::Debug for PeekStruct<'_, '_> {
 impl<'mem, 'facet> PeekStruct<'mem, 'facet> {
     /// Returns the struct definition
     #[inline(always)]
-    pub fn ty(&self) -> &StructType {
+    pub const fn ty(&self) -> &StructType {
         &self.ty
     }
 
     /// Returns the number of fields in this struct
     #[inline(always)]
-    pub fn field_count(&self) -> usize {
+    pub const fn field_count(&self) -> usize {
         self.ty.fields.len()
     }
 

--- a/facet-reflect/src/peek/tuple.rs
+++ b/facet-reflect/src/peek/tuple.rs
@@ -33,13 +33,13 @@ impl Debug for PeekTuple<'_, '_> {
 impl<'mem, 'facet> PeekTuple<'mem, 'facet> {
     /// Get the number of fields in this tuple
     #[inline]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.ty.fields.len()
     }
 
     /// Returns true if this tuple has no fields
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
@@ -61,19 +61,19 @@ impl<'mem, 'facet> PeekTuple<'mem, 'facet> {
 
     /// Iterate over all fields
     #[inline]
-    pub fn fields(&self) -> FieldIter<'mem, 'facet> {
+    pub const fn fields(&self) -> FieldIter<'mem, 'facet> {
         FieldIter::new_tuple(*self)
     }
 
     /// Type information
     #[inline]
-    pub fn ty(&self) -> TupleType {
+    pub const fn ty(&self) -> TupleType {
         self.ty
     }
 
     /// Internal peek value
     #[inline]
-    pub fn value(&self) -> Peek<'mem, 'facet> {
+    pub const fn value(&self) -> Peek<'mem, 'facet> {
         self.value
     }
 }

--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -25,7 +25,7 @@ pub struct ValueId {
 
 impl ValueId {
     #[inline]
-    pub(crate) fn new(shape: &'static Shape, ptr: *const u8) -> Self {
+    pub(crate) const fn new(shape: &'static Shape, ptr: *const u8) -> Self {
         Self { shape, ptr }
     }
 }
@@ -214,7 +214,7 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
 
     /// Returns the vtable
     #[inline(always)]
-    pub fn vtable(&self) -> VTableErased {
+    pub const fn vtable(&self) -> VTableErased {
         self.shape.vtable
     }
 
@@ -643,7 +643,7 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
 
     /// Tries to identify this value as a struct
     #[inline]
-    pub fn into_struct(self) -> Result<PeekStruct<'mem, 'facet>, ReflectError> {
+    pub const fn into_struct(self) -> Result<PeekStruct<'mem, 'facet>, ReflectError> {
         if let Type::User(UserType::Struct(ty)) = self.shape.ty {
             Ok(PeekStruct { value: self, ty })
         } else {
@@ -656,7 +656,7 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
 
     /// Tries to identify this value as an enum
     #[inline]
-    pub fn into_enum(self) -> Result<PeekEnum<'mem, 'facet>, ReflectError> {
+    pub const fn into_enum(self) -> Result<PeekEnum<'mem, 'facet>, ReflectError> {
         if let Type::User(UserType::Enum(ty)) = self.shape.ty {
             Ok(PeekEnum { value: self, ty })
         } else {
@@ -669,7 +669,7 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
 
     /// Tries to identify this value as a map
     #[inline]
-    pub fn into_map(self) -> Result<PeekMap<'mem, 'facet>, ReflectError> {
+    pub const fn into_map(self) -> Result<PeekMap<'mem, 'facet>, ReflectError> {
         if let Def::Map(def) = self.shape.def {
             // SAFETY: The MapDef comes from self.shape.def, where self.shape is obtained
             // from a trusted source (either T::SHAPE from the Facet trait, or validated
@@ -685,7 +685,7 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
 
     /// Tries to identify this value as a set
     #[inline]
-    pub fn into_set(self) -> Result<PeekSet<'mem, 'facet>, ReflectError> {
+    pub const fn into_set(self) -> Result<PeekSet<'mem, 'facet>, ReflectError> {
         if let Def::Set(def) = self.shape.def {
             // SAFETY: The SetDef comes from self.shape.def, where self.shape is obtained
             // from a trusted source (either T::SHAPE from the Facet trait, or validated
@@ -701,7 +701,7 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
 
     /// Tries to identify this value as a list
     #[inline]
-    pub fn into_list(self) -> Result<PeekList<'mem, 'facet>, ReflectError> {
+    pub const fn into_list(self) -> Result<PeekList<'mem, 'facet>, ReflectError> {
         if let Def::List(def) = self.shape.def {
             // SAFETY: The ListDef comes from self.shape.def, where self.shape is obtained
             // from a trusted source (either T::SHAPE from the Facet trait, or validated
@@ -717,7 +717,7 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
 
     /// Tries to identify this value as a ndarray
     #[inline]
-    pub fn into_ndarray(self) -> Result<PeekNdArray<'mem, 'facet>, ReflectError> {
+    pub const fn into_ndarray(self) -> Result<PeekNdArray<'mem, 'facet>, ReflectError> {
         if let Def::NdArray(def) = self.shape.def {
             // SAFETY: The NdArrayDef comes from self.shape.def, where self.shape is obtained
             // from a trusted source (either T::SHAPE from the Facet trait, or validated
@@ -799,7 +799,7 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
 
     /// Tries to identify this value as a pointer
     #[inline]
-    pub fn into_pointer(self) -> Result<PeekPointer<'mem, 'facet>, ReflectError> {
+    pub const fn into_pointer(self) -> Result<PeekPointer<'mem, 'facet>, ReflectError> {
         if let Def::Pointer(def) = self.shape.def {
             Ok(PeekPointer { value: self, def })
         } else {
@@ -812,7 +812,7 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
 
     /// Tries to identify this value as an option
     #[inline]
-    pub fn into_option(self) -> Result<PeekOption<'mem, 'facet>, ReflectError> {
+    pub const fn into_option(self) -> Result<PeekOption<'mem, 'facet>, ReflectError> {
         if let Def::Option(def) = self.shape.def {
             Ok(PeekOption { value: self, def })
         } else {
@@ -825,7 +825,7 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
 
     /// Tries to identify this value as a result
     #[inline]
-    pub fn into_result(self) -> Result<PeekResult<'mem, 'facet>, ReflectError> {
+    pub const fn into_result(self) -> Result<PeekResult<'mem, 'facet>, ReflectError> {
         if let Def::Result(def) = self.shape.def {
             Ok(PeekResult { value: self, def })
         } else {
@@ -863,7 +863,7 @@ impl<'mem, 'facet> Peek<'mem, 'facet> {
 
     /// Tries to identify this value as a dynamic value (like `facet_value::Value`)
     #[inline]
-    pub fn into_dynamic_value(self) -> Result<PeekDynamicValue<'mem, 'facet>, ReflectError> {
+    pub const fn into_dynamic_value(self) -> Result<PeekDynamicValue<'mem, 'facet>, ReflectError> {
         if let Def::DynamicValue(def) = self.shape.def {
             Ok(PeekDynamicValue { value: self, def })
         } else {

--- a/facet-reflect/src/poke/enum_.rs
+++ b/facet-reflect/src/poke/enum_.rs
@@ -25,25 +25,25 @@ impl core::fmt::Debug for PokeEnum<'_, '_> {
 impl<'mem, 'facet> PokeEnum<'mem, 'facet> {
     /// Returns the enum definition
     #[inline(always)]
-    pub fn ty(&self) -> EnumType {
+    pub const fn ty(&self) -> EnumType {
         self.ty
     }
 
     /// Returns the enum representation
     #[inline(always)]
-    pub fn enum_repr(&self) -> EnumRepr {
+    pub const fn enum_repr(&self) -> EnumRepr {
         self.ty.enum_repr
     }
 
     /// Returns the enum variants
     #[inline(always)]
-    pub fn variants(&self) -> &'static [facet_core::Variant] {
+    pub const fn variants(&self) -> &'static [facet_core::Variant] {
         self.ty.variants
     }
 
     /// Returns the number of variants in this enum
     #[inline(always)]
-    pub fn variant_count(&self) -> usize {
+    pub const fn variant_count(&self) -> usize {
         self.ty.variants.len()
     }
 
@@ -314,7 +314,7 @@ impl<'mem, 'facet> PokeEnum<'mem, 'facet> {
 
     /// Converts this back into the underlying `Poke`.
     #[inline]
-    pub fn into_inner(self) -> Poke<'mem, 'facet> {
+    pub const fn into_inner(self) -> Poke<'mem, 'facet> {
         self.value
     }
 

--- a/facet-reflect/src/poke/struct_.rs
+++ b/facet-reflect/src/poke/struct_.rs
@@ -22,13 +22,13 @@ impl core::fmt::Debug for PokeStruct<'_, '_> {
 impl<'mem, 'facet> PokeStruct<'mem, 'facet> {
     /// Returns the struct definition.
     #[inline(always)]
-    pub fn ty(&self) -> &StructType {
+    pub const fn ty(&self) -> &StructType {
         &self.ty
     }
 
     /// Returns the number of fields in this struct.
     #[inline(always)]
-    pub fn field_count(&self) -> usize {
+    pub const fn field_count(&self) -> usize {
         self.ty.fields.len()
     }
 
@@ -158,7 +158,7 @@ impl<'mem, 'facet> PokeStruct<'mem, 'facet> {
 
     /// Converts this back into the underlying `Poke`.
     #[inline]
-    pub fn into_inner(self) -> Poke<'mem, 'facet> {
+    pub const fn into_inner(self) -> Poke<'mem, 'facet> {
         self.value
     }
 

--- a/facet-reflect/src/poke/value.rs
+++ b/facet-reflect/src/poke/value.rs
@@ -85,42 +85,42 @@ impl<'mem, 'facet> Poke<'mem, 'facet> {
 
     /// Returns the shape of the value.
     #[inline(always)]
-    pub fn shape(&self) -> &'static Shape {
+    pub const fn shape(&self) -> &'static Shape {
         self.shape
     }
 
     /// Returns a const pointer to the underlying data.
     #[inline(always)]
-    pub fn data(&self) -> PtrConst {
+    pub const fn data(&self) -> PtrConst {
         self.data.as_const()
     }
 
     /// Returns a mutable pointer to the underlying data.
     #[inline(always)]
-    pub fn data_mut(&mut self) -> PtrMut {
+    pub const fn data_mut(&mut self) -> PtrMut {
         self.data
     }
 
     /// Returns true if this value is a struct.
     #[inline]
-    pub fn is_struct(&self) -> bool {
+    pub const fn is_struct(&self) -> bool {
         matches!(self.shape.ty, Type::User(UserType::Struct(_)))
     }
 
     /// Returns true if this value is an enum.
     #[inline]
-    pub fn is_enum(&self) -> bool {
+    pub const fn is_enum(&self) -> bool {
         matches!(self.shape.ty, Type::User(UserType::Enum(_)))
     }
 
     /// Returns true if this value is a scalar (primitive type).
     #[inline]
-    pub fn is_scalar(&self) -> bool {
+    pub const fn is_scalar(&self) -> bool {
         matches!(self.shape.def, Def::Scalar)
     }
 
     /// Converts this into a `PokeStruct` if the value is a struct.
-    pub fn into_struct(self) -> Result<PokeStruct<'mem, 'facet>, ReflectError> {
+    pub const fn into_struct(self) -> Result<PokeStruct<'mem, 'facet>, ReflectError> {
         match self.shape.ty {
             Type::User(UserType::Struct(struct_type)) => Ok(PokeStruct {
                 value: self,
@@ -134,7 +134,7 @@ impl<'mem, 'facet> Poke<'mem, 'facet> {
     }
 
     /// Converts this into a `PokeEnum` if the value is an enum.
-    pub fn into_enum(self) -> Result<super::PokeEnum<'mem, 'facet>, ReflectError> {
+    pub const fn into_enum(self) -> Result<super::PokeEnum<'mem, 'facet>, ReflectError> {
         match self.shape.ty {
             Type::User(UserType::Enum(enum_type)) => Ok(super::PokeEnum {
                 value: self,

--- a/facet-reflect/src/resolution.rs
+++ b/facet-reflect/src/resolution.rs
@@ -76,14 +76,14 @@ impl fmt::Display for FieldPath {
 
 impl FieldPath {
     /// Create an empty path (root level).
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self {
             segments: Vec::new(),
         }
     }
 
     /// Get the depth of this path.
-    pub fn depth(&self) -> usize {
+    pub const fn depth(&self) -> usize {
         self.segments.len()
     }
 
@@ -224,7 +224,7 @@ impl fmt::Display for DuplicateFieldError {
 
 impl Resolution {
     /// Create a new empty resolution.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             variant_selections: Vec::new(),
             fields: BTreeMap::new(),
@@ -384,12 +384,12 @@ impl Resolution {
     }
 
     /// Get all fields.
-    pub fn fields(&self) -> &BTreeMap<&'static str, FieldInfo> {
+    pub const fn fields(&self) -> &BTreeMap<&'static str, FieldInfo> {
         &self.fields
     }
 
     /// Get the set of required field names.
-    pub fn required_field_names(&self) -> &BTreeSet<&'static str> {
+    pub const fn required_field_names(&self) -> &BTreeSet<&'static str> {
         &self.required_field_names
     }
 
@@ -428,7 +428,7 @@ impl Resolution {
     }
 
     /// Get all known key paths (for depth-aware probing).
-    pub fn known_paths(&self) -> &BTreeSet<KeyPath> {
+    pub const fn known_paths(&self) -> &BTreeSet<KeyPath> {
         &self.known_paths
     }
 

--- a/facet-reflect/src/spanned.rs
+++ b/facet-reflect/src/spanned.rs
@@ -25,12 +25,12 @@ impl Span {
     }
 
     /// Check if this span is unknown (zero offset and length).
-    pub fn is_unknown(&self) -> bool {
+    pub const fn is_unknown(&self) -> bool {
         self.offset == 0 && self.len == 0
     }
 
     /// Get the end offset (offset + len).
-    pub fn end(&self) -> usize {
+    pub const fn end(&self) -> usize {
         self.offset + self.len
     }
 }
@@ -85,12 +85,12 @@ impl<T> Spanned<T> {
     }
 
     /// Get the source span.
-    pub fn span(&self) -> Span {
+    pub const fn span(&self) -> Span {
         self.span
     }
 
     /// Get a reference to the inner value.
-    pub fn value(&self) -> &T {
+    pub const fn value(&self) -> &T {
         &self.value
     }
 

--- a/facet-reflect/tests/partial/fuzz.rs
+++ b/facet-reflect/tests/partial/fuzz.rs
@@ -108,7 +108,7 @@ enum FieldName {
 }
 
 impl FieldName {
-    fn as_str(&self) -> &'static str {
+    const fn as_str(&self) -> &'static str {
         match self {
             FieldName::Name => "name",
             FieldName::Count => "count",
@@ -134,7 +134,7 @@ enum VariantName {
 }
 
 impl VariantName {
-    fn as_str(&self) -> &'static str {
+    const fn as_str(&self) -> &'static str {
         match self {
             VariantName::Active => "Active",
             VariantName::Inactive => "Inactive",

--- a/facet-reflect/tests/peek/ndarray.rs
+++ b/facet-reflect/tests/peek/ndarray.rs
@@ -40,22 +40,22 @@ impl<T> Mat<T> {
         }
     }
 
-    pub fn nrows(&self) -> usize {
+    pub const fn nrows(&self) -> usize {
         self.nrows
     }
-    pub fn ncols(&self) -> usize {
+    pub const fn ncols(&self) -> usize {
         self.ncols
     }
-    pub fn as_ptr(&self) -> *const T {
+    pub const fn as_ptr(&self) -> *const T {
         self.flat.as_ptr()
     }
-    pub fn as_mut_ptr(&mut self) -> *mut T {
+    pub const fn as_mut_ptr(&mut self) -> *mut T {
         self.flat.as_mut_ptr()
     }
-    pub fn row_stride(&self) -> isize {
+    pub const fn row_stride(&self) -> isize {
         size_of::<T>() as isize
     }
-    pub fn col_stride(&self) -> isize {
+    pub const fn col_stride(&self) -> isize {
         (self.nrows * size_of::<T>()) as isize
     }
 }
@@ -66,7 +66,7 @@ unsafe fn mat_count<T>(ptr: PtrConst) -> usize {
     p.nrows() * p.ncols()
 }
 
-fn mat_n_dim(_ptr: PtrConst) -> usize {
+const fn mat_n_dim(_ptr: PtrConst) -> usize {
     2
 }
 

--- a/facet-shapelike/src/types.rs
+++ b/facet-shapelike/src/types.rs
@@ -63,7 +63,7 @@ impl PointerFlags {
         lock: false,
     };
 
-    pub fn from_bits_truncate(bits: u8) -> Self {
+    pub const fn from_bits_truncate(bits: u8) -> Self {
         Self {
             weak: (bits & (1 << 0)) != 0,
             atomic: (bits & (1 << 1)) != 0,

--- a/facet-showcase/src/highlighter.rs
+++ b/facet-showcase/src/highlighter.rs
@@ -27,7 +27,7 @@ pub enum Language {
 
 impl Language {
     /// Returns the file extension used to look up the syntax.
-    pub fn extension(self) -> &'static str {
+    pub const fn extension(self) -> &'static str {
         match self {
             Language::Json => "json",
             Language::Yaml => "yaml",
@@ -39,7 +39,7 @@ impl Language {
     }
 
     /// Returns a human-readable name for the language.
-    pub fn name(self) -> &'static str {
+    pub const fn name(self) -> &'static str {
         match self {
             Language::Json => "JSON",
             Language::Yaml => "YAML",
@@ -50,7 +50,7 @@ impl Language {
         }
     }
 
-    fn arborium_name(self) -> Option<&'static str> {
+    const fn arborium_name(self) -> Option<&'static str> {
         match self {
             Language::Json => Some("json"),
             Language::Yaml => Some("yaml"),
@@ -87,7 +87,7 @@ impl Highlighter {
     }
 
     /// Get a reference to the theme.
-    pub fn theme(&self) -> &Theme {
+    pub const fn theme(&self) -> &Theme {
         &self.theme
     }
 
@@ -337,7 +337,7 @@ fn parse_ansi_style(seq: &str) -> Option<String> {
     }
 }
 
-fn ansi_256_to_rgb(n: u8) -> &'static str {
+const fn ansi_256_to_rgb(n: u8) -> &'static str {
     match n {
         0 => "#000000",
         1 => "#800000",

--- a/facet-showcase/src/runner.rs
+++ b/facet-showcase/src/runner.rs
@@ -53,7 +53,7 @@ impl Provenance {
     }
 
     /// Check if we have meaningful provenance info.
-    pub fn has_info(&self) -> bool {
+    pub const fn has_info(&self) -> bool {
         self.commit.is_some() || self.timestamp.is_some() || self.rustc_version.is_some()
     }
 }
@@ -114,7 +114,7 @@ impl ShowcaseRunner {
     }
 
     /// Set the primary language for this showcase.
-    pub fn language(mut self, lang: Language) -> Self {
+    pub const fn language(mut self, lang: Language) -> Self {
         self.primary_language = lang;
         self
     }
@@ -260,17 +260,17 @@ impl ShowcaseRunner {
     }
 
     /// Get a reference to the highlighter.
-    pub fn highlighter(&self) -> &Highlighter {
+    pub const fn highlighter(&self) -> &Highlighter {
         &self.highlighter
     }
 
     /// Get the output mode.
-    pub fn mode(&self) -> OutputMode {
+    pub const fn mode(&self) -> OutputMode {
         self.mode
     }
 
     /// Get the primary language.
-    pub fn primary_language(&self) -> Language {
+    pub const fn primary_language(&self) -> Language {
         self.primary_language
     }
 
@@ -333,7 +333,7 @@ pub struct Scenario<'a> {
 }
 
 impl<'a> Scenario<'a> {
-    fn new(runner: &'a mut ShowcaseRunner, name: String, skipped: bool) -> Self {
+    const fn new(runner: &'a mut ShowcaseRunner, name: String, skipped: bool) -> Self {
         Self {
             runner,
             name,

--- a/facet-solver/src/lib.rs
+++ b/facet-solver/src/lib.rs
@@ -130,12 +130,12 @@ impl ResolutionSet {
     }
 
     /// Get the number of resolutions in the set.
-    fn len(&self) -> usize {
+    const fn len(&self) -> usize {
         self.count
     }
 
     /// Check if empty.
-    fn is_empty(&self) -> bool {
+    const fn is_empty(&self) -> bool {
         self.count == 0
     }
 
@@ -739,7 +739,7 @@ impl<'a> Solver<'a> {
     }
 
     /// Get the seen keys.
-    pub fn seen_keys(&self) -> &BTreeSet<Cow<'a, str>> {
+    pub const fn seen_keys(&self) -> &BTreeSet<Cow<'a, str>> {
         &self.seen_keys
     }
 
@@ -1535,12 +1535,12 @@ impl VariantFormat {
     }
 
     /// Returns true if this variant expects a scalar value in untagged format.
-    pub fn expects_scalar(&self) -> bool {
+    pub const fn expects_scalar(&self) -> bool {
         matches!(self, VariantFormat::NewtypeScalar { .. })
     }
 
     /// Returns true if this variant expects a sequence in untagged format.
-    pub fn expects_sequence(&self) -> bool {
+    pub const fn expects_sequence(&self) -> bool {
         matches!(
             self,
             VariantFormat::Tuple { .. }
@@ -1550,7 +1550,7 @@ impl VariantFormat {
     }
 
     /// Returns true if this variant expects a mapping in untagged format.
-    pub fn expects_mapping(&self) -> bool {
+    pub const fn expects_mapping(&self) -> bool {
         matches!(
             self,
             VariantFormat::Struct | VariantFormat::NewtypeStruct { .. }
@@ -1558,7 +1558,7 @@ impl VariantFormat {
     }
 
     /// Returns true if this is a unit variant (no data).
-    pub fn is_unit(&self) -> bool {
+    pub const fn is_unit(&self) -> bool {
         matches!(self, VariantFormat::Unit)
     }
 }
@@ -1781,17 +1781,17 @@ impl VariantsByFormat {
     }
 
     /// Check if there are any scalar-expecting variants.
-    pub fn has_scalar_variants(&self) -> bool {
+    pub const fn has_scalar_variants(&self) -> bool {
         !self.scalar_variants.is_empty()
     }
 
     /// Check if there are any tuple-expecting variants.
-    pub fn has_tuple_variants(&self) -> bool {
+    pub const fn has_tuple_variants(&self) -> bool {
         !self.tuple_variants.is_empty()
     }
 
     /// Check if there are any struct-expecting variants.
-    pub fn has_struct_variants(&self) -> bool {
+    pub const fn has_struct_variants(&self) -> bool {
         !self.struct_variants.is_empty()
     }
 }
@@ -1842,7 +1842,7 @@ impl EnumRepr {
     /// - `InternallyTagged` if `#[facet(tag = "...")]` without content
     /// - `AdjacentlyTagged` if both `#[facet(tag = "...", content = "...")]`
     /// - `ExternallyTagged` if no attributes (the default enum representation)
-    pub fn from_shape(shape: &'static Shape) -> Self {
+    pub const fn from_shape(shape: &'static Shape) -> Self {
         let tag = shape.get_tag_attr();
         let content = shape.get_content_attr();
         let untagged = shape.is_untagged();
@@ -1918,7 +1918,7 @@ struct SchemaBuilder {
 }
 
 impl SchemaBuilder {
-    fn new(shape: &'static Shape, enum_repr: EnumRepr) -> Self {
+    const fn new(shape: &'static Shape, enum_repr: EnumRepr) -> Self {
         Self {
             shape,
             enum_repr,
@@ -1926,7 +1926,7 @@ impl SchemaBuilder {
         }
     }
 
-    fn with_auto_detect(mut self) -> Self {
+    const fn with_auto_detect(mut self) -> Self {
         self.auto_detect_enum_repr = true;
         self
     }
@@ -2605,12 +2605,12 @@ impl SchemaBuilder {
 }
 
 /// Check if a shape represents an Option type.
-fn is_option_type(shape: &'static Shape) -> bool {
+const fn is_option_type(shape: &'static Shape) -> bool {
     matches!(shape.def, Def::Option(_))
 }
 
 /// If shape is `Option<T>`, returns `Some(T's shape)`. Otherwise returns `None`.
-fn unwrap_option_type(shape: &'static Shape) -> Option<&'static Shape> {
+const fn unwrap_option_type(shape: &'static Shape) -> Option<&'static Shape> {
     match shape.def {
         Def::Option(option_def) => Some(option_def.t),
         _ => None,

--- a/facet-solver/tests/integration.rs
+++ b/facet-solver/tests/integration.rs
@@ -87,7 +87,7 @@ struct JsonDeserializer<'a> {
 }
 
 impl<'a> JsonDeserializer<'a> {
-    fn new(data: &'a [u8]) -> Self {
+    const fn new(data: &'a [u8]) -> Self {
         Self { data }
     }
 

--- a/facet-svg/src/path.rs
+++ b/facet-svg/src/path.rs
@@ -94,7 +94,7 @@ pub struct PathData {
 }
 
 impl PathData {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             commands: Vec::new(),
         }

--- a/facet-svg/src/points.rs
+++ b/facet-svg/src/points.rs
@@ -19,7 +19,7 @@ pub struct Points {
 }
 
 impl Points {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { points: Vec::new() }
     }
 
@@ -66,7 +66,7 @@ impl Points {
     }
 
     /// Check if empty
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.points.is_empty()
     }
 }

--- a/facet-toml/src/error.rs
+++ b/facet-toml/src/error.rs
@@ -28,7 +28,7 @@ impl std::error::Error for TomlError {}
 
 impl TomlError {
     /// Create a new error with span information
-    pub fn new(kind: TomlErrorKind, span: Span) -> Self {
+    pub const fn new(kind: TomlErrorKind, span: Span) -> Self {
         TomlError {
             kind,
             span: Some(span),
@@ -37,7 +37,7 @@ impl TomlError {
     }
 
     /// Create an error without span information
-    pub fn without_span(kind: TomlErrorKind) -> Self {
+    pub const fn without_span(kind: TomlErrorKind) -> Self {
         TomlError {
             kind,
             span: None,
@@ -157,7 +157,7 @@ impl Display for TomlErrorKind {
 
 impl TomlErrorKind {
     /// Get an error code for this kind of error.
-    pub fn code(&self) -> &'static str {
+    pub const fn code(&self) -> &'static str {
         match self {
             TomlErrorKind::Parse(_) => "toml::parse",
             TomlErrorKind::UnexpectedType { .. } => "toml::type_mismatch",

--- a/facet-toml/src/parser.rs
+++ b/facet-toml/src/parser.rs
@@ -63,11 +63,11 @@ struct ParseErrorCollector {
 }
 
 impl ParseErrorCollector {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self { error: None }
     }
 
-    fn take_error(&mut self) -> Option<String> {
+    const fn take_error(&mut self) -> Option<String> {
         self.error.take()
     }
 }
@@ -166,7 +166,7 @@ impl<'de> TomlParser<'de> {
     }
 
     /// Get the original input string.
-    pub fn input(&self) -> &'de str {
+    pub const fn input(&self) -> &'de str {
         self.input
     }
 
@@ -300,7 +300,7 @@ impl<'de> TomlParser<'de> {
     }
 
     /// Emit the "end" event for a path segment based on its kind.
-    fn end_event_for_segment(segment: &PathSegment<'_>) -> ParseEvent<'static> {
+    const fn end_event_for_segment(segment: &PathSegment<'_>) -> ParseEvent<'static> {
         match segment.kind {
             SegmentKind::Table => ParseEvent::StructEnd,
             SegmentKind::Array => ParseEvent::SequenceEnd,

--- a/facet-toml/src/serializer.rs
+++ b/facet-toml/src/serializer.rs
@@ -19,7 +19,7 @@ impl SerializeOptions {
     }
 
     /// Enable inline tables for nested structures.
-    pub fn inline_tables(mut self) -> Self {
+    pub const fn inline_tables(mut self) -> Self {
         self.inline_tables = true;
         self
     }
@@ -71,7 +71,7 @@ impl TomlSerializer {
     }
 
     /// Create a new TOML serializer with the given options.
-    pub fn with_options(options: SerializeOptions) -> Self {
+    pub const fn with_options(options: SerializeOptions) -> Self {
         Self {
             out: String::new(),
             stack: Vec::new(),

--- a/facet-typescript/src/lib.rs
+++ b/facet-typescript/src/lib.rs
@@ -59,7 +59,7 @@ impl Default for TypeScriptGenerator {
 
 impl TypeScriptGenerator {
     /// Create a new TypeScript generator.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             output: String::new(),
             generated: BTreeSet::new(),

--- a/facet-urlencoded/src/axum.rs
+++ b/facet-urlencoded/src/axum.rs
@@ -65,7 +65,7 @@ enum FormRejectionKind {
 
 impl FormRejection {
     /// Returns the status code for this rejection.
-    pub fn status(&self) -> StatusCode {
+    pub const fn status(&self) -> StatusCode {
         match &self.kind {
             FormRejectionKind::BodyError(_) => StatusCode::BAD_REQUEST,
             FormRejectionKind::DeserializeError(_) => StatusCode::UNPROCESSABLE_ENTITY,
@@ -146,7 +146,7 @@ enum QueryRejectionKind {
 
 impl QueryRejection {
     /// Returns the status code for this rejection.
-    pub fn status(&self) -> StatusCode {
+    pub const fn status(&self) -> StatusCode {
         match &self.kind {
             QueryRejectionKind::DeserializeError(_) => StatusCode::BAD_REQUEST,
         }

--- a/facet-value/src/datetime.rs
+++ b/facet-value/src/datetime.rs
@@ -69,7 +69,7 @@ struct DateTimeHeader {
 pub struct VDateTime(pub(crate) Value);
 
 impl VDateTime {
-    fn layout() -> Layout {
+    const fn layout() -> Layout {
         Layout::new::<DateTimeHeader>()
     }
 

--- a/facet-value/src/deserialize.rs
+++ b/facet-value/src/deserialize.rs
@@ -86,7 +86,7 @@ impl core::fmt::Display for ValueError {
 
 impl ValueError {
     /// Create a new ValueError with empty paths
-    pub fn new(kind: ValueErrorKind) -> Self {
+    pub const fn new(kind: ValueErrorKind) -> Self {
         Self {
             kind,
             source_path: Vec::new(),
@@ -97,7 +97,7 @@ impl ValueError {
     }
 
     /// Set the target shape for diagnostics
-    pub fn with_shape(mut self, shape: &'static Shape) -> Self {
+    pub const fn with_shape(mut self, shape: &'static Shape) -> Self {
         self.target_shape = Some(shape);
         self
     }

--- a/facet-value/src/format.rs
+++ b/facet-value/src/format.rs
@@ -58,7 +58,7 @@ struct FormatContext {
 }
 
 impl FormatContext {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             output: String::new(),
             spans: BTreeMap::new(),
@@ -66,7 +66,7 @@ impl FormatContext {
         }
     }
 
-    fn len(&self) -> usize {
+    const fn len(&self) -> usize {
         self.output.len()
     }
 

--- a/facet-value/src/number.rs
+++ b/facet-value/src/number.rs
@@ -47,7 +47,7 @@ union NumberData {
 pub struct VNumber(pub(crate) Value);
 
 impl VNumber {
-    fn layout() -> Layout {
+    const fn layout() -> Layout {
         Layout::new::<NumberHeader>()
     }
 

--- a/facet-value/src/other.rs
+++ b/facet-value/src/other.rs
@@ -57,7 +57,7 @@ struct QNameHeader {
 pub struct VQName(pub(crate) Value);
 
 impl VQName {
-    fn layout() -> Layout {
+    const fn layout() -> Layout {
         Layout::new::<QNameHeader>()
     }
 
@@ -211,7 +211,7 @@ struct UuidHeader {
 pub struct VUuid(pub(crate) Value);
 
 impl VUuid {
-    fn layout() -> Layout {
+    const fn layout() -> Layout {
         Layout::new::<UuidHeader>()
     }
 

--- a/facet-value/src/string.rs
+++ b/facet-value/src/string.rs
@@ -29,13 +29,13 @@ struct StringHeader {
 impl StringHeader {
     /// Returns the actual length of the string, masking out the safe flag.
     #[inline]
-    fn actual_len(&self) -> usize {
+    const fn actual_len(&self) -> usize {
         self.len & !SAFE_FLAG
     }
 
     /// Returns true if the safe flag is set.
     #[inline]
-    fn is_safe(&self) -> bool {
+    const fn is_safe(&self) -> bool {
         self.len & SAFE_FLAG != 0
     }
 }
@@ -179,17 +179,17 @@ impl VString {
     }
 
     #[inline]
-    fn can_inline(len: usize) -> bool {
+    const fn can_inline(len: usize) -> bool {
         len <= Self::INLINE_LEN_MAX && len <= Self::INLINE_CAP_BYTES
     }
 
     #[inline]
-    fn inline_meta_ptr(&self) -> *const u8 {
+    const fn inline_meta_ptr(&self) -> *const u8 {
         self as *const VString as *const u8
     }
 
     #[inline]
-    fn inline_data_ptr(&self) -> *const u8 {
+    const fn inline_data_ptr(&self) -> *const u8 {
         unsafe { self.inline_meta_ptr().add(Self::INLINE_DATA_OFFSET) }
     }
 

--- a/facet-value/src/value.rs
+++ b/facet-value/src/value.rs
@@ -559,7 +559,7 @@ impl Value {
     }
 
     /// Takes this value, replacing it with `Value::NULL`.
-    pub fn take(&mut self) -> Value {
+    pub const fn take(&mut self) -> Value {
         mem::replace(self, Value::NULL)
     }
 }

--- a/facet-xdr/src/parser.rs
+++ b/facet-xdr/src/parser.rs
@@ -78,7 +78,7 @@ pub struct XdrParser<'de> {
 
 impl<'de> XdrParser<'de> {
     /// Create a new XDR parser from input bytes.
-    pub fn new(input: &'de [u8]) -> Self {
+    pub const fn new(input: &'de [u8]) -> Self {
         Self {
             input,
             pos: 0,

--- a/facet-xdr/src/serializer.rs
+++ b/facet-xdr/src/serializer.rs
@@ -30,7 +30,7 @@ enum ContainerState {
 
 impl XdrSerializer {
     /// Create a new XDR serializer.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             out: Vec::new(),
             stack: Vec::new(),

--- a/facet-xml/src/diff_serialize.rs
+++ b/facet-xml/src/diff_serialize.rs
@@ -77,31 +77,31 @@ impl DiffSerializeOptions {
     }
 
     /// Disable ANSI color output.
-    pub fn no_colors(mut self) -> Self {
+    pub const fn no_colors(mut self) -> Self {
         self.colors = false;
         self
     }
 
     /// Set custom indentation string.
-    pub fn indent(mut self, indent: &'static str) -> Self {
+    pub const fn indent(mut self, indent: &'static str) -> Self {
         self.indent = indent;
         self
     }
 
     /// Set maximum line width for attribute grouping.
-    pub fn max_line_width(mut self, width: usize) -> Self {
+    pub const fn max_line_width(mut self, width: usize) -> Self {
         self.max_line_width = width;
         self
     }
 
     /// Set maximum number of unchanged fields to show inline.
-    pub fn max_unchanged_fields(mut self, count: usize) -> Self {
+    pub const fn max_unchanged_fields(mut self, count: usize) -> Self {
         self.max_unchanged_fields = count;
         self
     }
 
     /// Set collapse threshold for unchanged runs.
-    pub fn collapse_threshold(mut self, threshold: usize) -> Self {
+    pub const fn collapse_threshold(mut self, threshold: usize) -> Self {
         self.collapse_threshold = threshold;
         self
     }

--- a/facet-xml/src/parser.rs
+++ b/facet-xml/src/parser.rs
@@ -343,7 +343,7 @@ struct Element {
 }
 
 impl Element {
-    fn new(name: QName, attributes: Vec<(QName, String)>) -> Self {
+    const fn new(name: QName, attributes: Vec<(QName, String)>) -> Self {
         Self {
             name,
             attributes,

--- a/facet-xml/src/serializer.rs
+++ b/facet-xml/src/serializer.rs
@@ -63,7 +63,7 @@ impl SerializeOptions {
     }
 
     /// Enable pretty-printing with default indentation.
-    pub fn pretty(mut self) -> Self {
+    pub const fn pretty(mut self) -> Self {
         self.pretty = true;
         self
     }
@@ -119,7 +119,7 @@ impl SerializeOptions {
     ///
     /// This is useful when serializing content that already contains entity references,
     /// such as HTML entities in SVG content.
-    pub fn preserve_entities(mut self, preserve: bool) -> Self {
+    pub const fn preserve_entities(mut self, preserve: bool) -> Self {
         self.preserve_entities = preserve;
         self
     }

--- a/facet-yaml/src/error.rs
+++ b/facet-yaml/src/error.rs
@@ -45,7 +45,7 @@ impl core::error::Error for YamlError {}
 
 impl YamlError {
     /// Create a new error with span information
-    pub fn new(kind: YamlErrorKind, span: Span) -> Self {
+    pub const fn new(kind: YamlErrorKind, span: Span) -> Self {
         YamlError {
             kind,
             span: Some(span),
@@ -54,7 +54,7 @@ impl YamlError {
     }
 
     /// Create an error without span information
-    pub fn without_span(kind: YamlErrorKind) -> Self {
+    pub const fn without_span(kind: YamlErrorKind) -> Self {
         YamlError {
             kind,
             span: None,
@@ -177,7 +177,7 @@ impl Display for YamlErrorKind {
 
 impl YamlErrorKind {
     /// Get an error code for this kind of error.
-    pub fn code(&self) -> &'static str {
+    pub const fn code(&self) -> &'static str {
         match self {
             YamlErrorKind::Parse(_) => "yaml::parse",
             YamlErrorKind::UnexpectedEvent { .. } => "yaml::unexpected_event",

--- a/facet-yaml/src/parser.rs
+++ b/facet-yaml/src/parser.rs
@@ -68,7 +68,7 @@ struct EventCollector {
 }
 
 impl EventCollector {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self { events: Vec::new() }
     }
 }
@@ -159,7 +159,7 @@ impl<'de> YamlParser<'de> {
     }
 
     /// Get the original input string.
-    pub fn input(&self) -> &'de str {
+    pub const fn input(&self) -> &'de str {
         self.input
     }
 

--- a/facet-yaml/src/serializer.rs
+++ b/facet-yaml/src/serializer.rs
@@ -66,7 +66,7 @@ pub struct YamlSerializer {
 
 impl YamlSerializer {
     /// Create a new YAML serializer.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             out: Vec::new(),
             stack: Vec::new(),

--- a/facet/tests/value_vtable_facts.rs
+++ b/facet/tests/value_vtable_facts.rs
@@ -83,7 +83,7 @@ impl BoxPtrUninit {
         }
     }
 
-    unsafe fn assume_init(self) -> BoxPtrMut {
+    const unsafe fn assume_init(self) -> BoxPtrMut {
         let r = BoxPtrMut {
             ptr: unsafe { self.ptr.assume_init() },
             layout: self.layout,
@@ -155,7 +155,7 @@ unsafe fn debug(shape: &'static Shape, ptr: PtrConst) -> impl Debug {
     Debugger(shape, ptr)
 }
 
-fn ord_str(ordering: Option<Ordering>) -> &'static str {
+const fn ord_str(ordering: Option<Ordering>) -> &'static str {
     match ordering {
         Some(Ordering::Less) => "<",
         Some(Ordering::Equal) => "==",
@@ -434,41 +434,41 @@ impl FactBuilder {
         Default::default()
     }
 
-    fn debug(mut self) -> Self {
+    const fn debug(mut self) -> Self {
         self.has_debug = true;
         self
     }
 
-    fn display(mut self) -> Self {
+    const fn display(mut self) -> Self {
         self.has_display = true;
         self
     }
 
-    fn partial_eq_and(mut self, l_eq_r: bool) -> Self {
+    const fn partial_eq_and(mut self, l_eq_r: bool) -> Self {
         self.has_partial_eq_and = Some(l_eq_r);
         self
     }
 
-    fn correct_ord_and(self, l_ord_r: Ordering) -> Self {
+    const fn correct_ord_and(self, l_ord_r: Ordering) -> Self {
         self.ord_and(l_ord_r).partial_ord_and(Some(l_ord_r))
     }
 
-    fn ord_and(mut self, l_ord_r: Ordering) -> Self {
+    const fn ord_and(mut self, l_ord_r: Ordering) -> Self {
         self.has_ord_and = Some(l_ord_r);
         self
     }
 
-    fn partial_ord_and(mut self, l_ord_r: Option<Ordering>) -> Self {
+    const fn partial_ord_and(mut self, l_ord_r: Option<Ordering>) -> Self {
         self.has_partial_ord_and = Some(l_ord_r);
         self
     }
 
-    fn default(mut self) -> Self {
+    const fn default(mut self) -> Self {
         self.has_default = true;
         self
     }
 
-    fn clone(mut self) -> Self {
+    const fn clone(mut self) -> Self {
         self.has_clone = true;
         self
     }

--- a/tools/metrics-tui/src/main.rs
+++ b/tools/metrics-tui/src/main.rs
@@ -71,7 +71,7 @@ enum Column {
 }
 
 impl Column {
-    fn all() -> &'static [Column] {
+    const fn all() -> &'static [Column] {
         &[
             Column::Timestamp,
             Column::Commit,
@@ -94,7 +94,7 @@ impl Column {
         ]
     }
 
-    fn numeric_columns() -> &'static [Column] {
+    const fn numeric_columns() -> &'static [Column] {
         &[
             Column::CompileSecs,
             Column::BinUnstripped,
@@ -113,7 +113,7 @@ impl Column {
         ]
     }
 
-    fn name(&self) -> &'static str {
+    const fn name(&self) -> &'static str {
         match self {
             Column::Timestamp => "Time",
             Column::Commit => "Commit",
@@ -230,11 +230,11 @@ impl App {
         Column::numeric_columns()[self.graph_column_idx]
     }
 
-    fn next_graph_column(&mut self) {
+    const fn next_graph_column(&mut self) {
         self.graph_column_idx = (self.graph_column_idx + 1) % Column::numeric_columns().len();
     }
 
-    fn prev_graph_column(&mut self) {
+    const fn prev_graph_column(&mut self) {
         if self.graph_column_idx == 0 {
             self.graph_column_idx = Column::numeric_columns().len() - 1;
         } else {
@@ -242,7 +242,7 @@ impl App {
         }
     }
 
-    fn next(&mut self) {
+    const fn next(&mut self) {
         if self.metrics.is_empty() {
             return;
         }
@@ -253,7 +253,7 @@ impl App {
         self.table_state.select(Some(i));
     }
 
-    fn previous(&mut self) {
+    const fn previous(&mut self) {
         if self.metrics.is_empty() {
             return;
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1421,16 +1421,16 @@ impl SchemaGenerator {
 struct Lcg(u64);
 
 impl Lcg {
-    fn new(seed: u64) -> Self {
+    const fn new(seed: u64) -> Self {
         Lcg(seed | 1) // avoid zero cycles
     }
 
-    fn next_u32(&mut self) -> u32 {
+    const fn next_u32(&mut self) -> u32 {
         self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
         (self.0 >> 32) as u32
     }
 
-    fn range(&mut self, min: usize, max: usize) -> usize {
+    const fn range(&mut self, min: usize, max: usize) -> usize {
         if max <= min {
             return min;
         }


### PR DESCRIPTION
## Summary
Add `const` modifier to 44 functions across the codebase that can be evaluated at compile time, as identified by `clippy::missing_const_for_fn`.

## Changes
- facet-format/src/jit/compiler.rs (8 functions)
- facet-format/src/jit/format.rs (1 function)
- facet-format/src/jit/format_compiler.rs (3 functions)
- facet-format/src/jit/format_compiler/support.rs (1 function)
- facet-format/src/jit/helpers.rs (8 functions)
- facet-reflect/tests/partial/fuzz.rs (2 functions)
- facet-reflect/tests/peek/ndarray.rs (7 functions)
- facet-xml/src/diff_serialize.rs (5 functions)
- facet/tests/value_vtable_facts.rs (5 functions)
- facet-diff/tests/diff_snapshots.rs (1 function)
- facet-diff/tests/proxy_diff.rs (1 function)
- facet-solver/tests/integration.rs (1 function)

## Test plan
- [x] All tests pass (2608 tests)
- [x] No clippy warnings