### PR TITLE
feat(postcard): add from_slice_with_shape for shape-guided deserialization

### DIFF
--- a/facet-format/src/deserializer.rs
+++ b/facet-format/src/deserializer.rs
@@ -6,7 +6,7 @@ use alloc::string::String;
 use core::fmt;
 
 use facet_core::{
-    Def, Facet, KnownPointer, NumericType, PrimitiveType, StructKind, Type, UserType,
+    Def, Facet, KnownPointer, NumericType, PrimitiveType, Shape, StructKind, Type, UserType,
 };
 pub use facet_path::{Path, PathStep};
 use facet_reflect::{HeapValue, Partial, ReflectError, Resolution, is_spanned_shape};
@@ -207,6 +207,40 @@ where
             .materialize::<T>()
             .map_err(DeserializeError::reflect)
     }
+
+    /// Deserialize using an explicit source shape for parser hints.
+    ///
+    /// This is useful for non-self-describing formats like postcard where you need
+    /// to decode data that was serialized using a specific type, but you only have
+    /// the shape information at runtime (not the concrete type).
+    ///
+    /// The target type `T` should typically be a `DynamicValue` like `facet_value::Value`.
+    pub fn deserialize_with_shape<T>(
+        &mut self,
+        source_shape: &'static Shape,
+    ) -> Result<T, DeserializeError<P::Error>>
+    where
+        T: Facet<'static>,
+    {
+        #[allow(unsafe_code)]
+        let wip: Partial<'input, false> = unsafe {
+            core::mem::transmute::<Partial<'static, false>, Partial<'input, false>>(
+                Partial::alloc_owned::<T>().map_err(DeserializeError::reflect)?,
+            )
+        };
+        let partial = self.deserialize_into_with_shape(wip, source_shape)?;
+        let heap_value: HeapValue<'input, false> =
+            partial.build().map_err(DeserializeError::reflect)?;
+
+        #[allow(unsafe_code)]
+        let heap_value: HeapValue<'static, false> = unsafe {
+            core::mem::transmute::<HeapValue<'input, false>, HeapValue<'static, false>>(heap_value)
+        };
+
+        heap_value
+            .materialize::<T>()
+            .map_err(DeserializeError::reflect)
+    }
 }
 
 impl<'input, const BORROW: bool, P> FormatDeserializer<'input, BORROW, P>
@@ -380,6 +414,659 @@ where
                 shape.def
             ))),
         }
+    }
+
+    /// Deserialize using an explicit source shape for parser hints.
+    ///
+    /// This walks `hint_shape` for control flow and parser hints, but builds
+    /// into the `wip` Partial (which should be a DynamicValue like `Value`).
+    pub fn deserialize_into_with_shape(
+        &mut self,
+        wip: Partial<'input, BORROW>,
+        hint_shape: &'static Shape,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
+        self.deserialize_value_recursive(wip, hint_shape)
+    }
+
+    /// Internal recursive deserialization using hint_shape for dispatch.
+    fn deserialize_value_recursive(
+        &mut self,
+        mut wip: Partial<'input, BORROW>,
+        hint_shape: &'static Shape,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
+        // Handle Option
+        if let Def::Option(opt_def) = &hint_shape.def {
+            self.parser.hint_option();
+            let event = self.expect_peek("value for option")?;
+            if matches!(event, ParseEvent::Scalar(ScalarValue::Null)) {
+                let _ = self.expect_event("null")?;
+                wip = wip.set_default().map_err(DeserializeError::reflect)?;
+            } else {
+                wip = self.deserialize_value_recursive(wip, opt_def.t)?;
+            }
+            return Ok(wip);
+        }
+
+        // Handle smart pointers - unwrap to inner type
+        if let Def::Pointer(ptr_def) = &hint_shape.def
+            && let Some(pointee) = ptr_def.pointee()
+        {
+            return self.deserialize_value_recursive(wip, pointee);
+        }
+
+        // Handle transparent wrappers (but not collections)
+        if let Some(inner) = hint_shape.inner
+            && !matches!(
+                &hint_shape.def,
+                Def::List(_) | Def::Map(_) | Def::Set(_) | Def::Array(_)
+            )
+        {
+            return self.deserialize_value_recursive(wip, inner);
+        }
+
+        // Dispatch based on hint shape type
+        match &hint_shape.ty {
+            Type::User(UserType::Struct(struct_def)) => {
+                if matches!(struct_def.kind, StructKind::Tuple | StructKind::TupleStruct) {
+                    self.deserialize_tuple_dynamic(wip, struct_def.fields)
+                } else {
+                    self.deserialize_struct_dynamic(wip, struct_def.fields)
+                }
+            }
+            Type::User(UserType::Enum(enum_def)) => {
+                self.deserialize_enum_dynamic(wip, hint_shape, enum_def)
+            }
+            _ => {
+                match &hint_shape.def {
+                    Def::Scalar => self.deserialize_scalar_dynamic(wip, hint_shape),
+                    Def::List(list_def) => self.deserialize_list_dynamic(wip, list_def.t),
+                    Def::Array(array_def) => {
+                        self.deserialize_array_dynamic(wip, array_def.t, array_def.n)
+                    }
+                    Def::Map(map_def) => self.deserialize_map_dynamic(wip, map_def.k, map_def.v),
+                    Def::Set(set_def) => self.deserialize_list_dynamic(wip, set_def.t),
+                    _ => Err(DeserializeError::Unsupported(format!(
+                        "unsupported hint shape for dynamic deserialization: {:?}",
+                        hint_shape.def
+                    ))),
+                }
+            }
+        }
+    }
+
+    fn deserialize_struct_dynamic(
+        &mut self,
+        mut wip: Partial<'input, BORROW>,
+        fields: &'static [facet_core::Field],
+    ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
+        self.parser.hint_struct_fields(fields.len());
+
+        let event = self.expect_event("struct start")?;
+        if !matches!(event, ParseEvent::StructStart(_)) {
+            return Err(DeserializeError::TypeMismatch {
+                expected: "struct",
+                got: format!("{event:?}"),
+                span: self.last_span,
+                path: Some(self.path_clone()),
+            });
+        }
+
+        wip = wip.begin_map().map_err(DeserializeError::reflect)?;
+
+        for field in fields {
+            let field_shape = field.shape.get();
+            let event = self.expect_event("field")?;
+            match event {
+                ParseEvent::OrderedField | ParseEvent::FieldKey(_) => {
+                    let key = field.rename.unwrap_or(field.name);
+                    wip = wip
+                        .begin_object_entry(key)
+                        .map_err(DeserializeError::reflect)?;
+                    wip = self.deserialize_value_recursive(wip, field_shape)?;
+                    wip = wip.end().map_err(DeserializeError::reflect)?;
+                }
+                ParseEvent::StructEnd => break,
+                _ => {
+                    return Err(DeserializeError::TypeMismatch {
+                        expected: "field or struct end",
+                        got: format!("{event:?}"),
+                        span: self.last_span,
+                        path: Some(self.path_clone()),
+                    });
+                }
+            }
+        }
+
+        // Consume remaining StructEnd if needed
+        if let Ok(event) = self.expect_peek("struct end")
+            && matches!(event, ParseEvent::StructEnd)
+        {
+            let _ = self.expect_event("struct end")?;
+        }
+
+        Ok(wip)
+    }
+
+    fn deserialize_tuple_dynamic(
+        &mut self,
+        mut wip: Partial<'input, BORROW>,
+        fields: &'static [facet_core::Field],
+    ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
+        self.parser.hint_struct_fields(fields.len());
+
+        let event = self.expect_event("tuple start")?;
+        if !matches!(event, ParseEvent::StructStart(_) | ParseEvent::SequenceStart(_)) {
+            return Err(DeserializeError::TypeMismatch {
+                expected: "tuple",
+                got: format!("{event:?}"),
+                span: self.last_span,
+                path: Some(self.path_clone()),
+            });
+        }
+
+        wip = wip.begin_list().map_err(DeserializeError::reflect)?;
+
+        for field in fields {
+            let field_shape = field.shape.get();
+            let event = self.expect_event("tuple element")?;
+            match event {
+                ParseEvent::OrderedField | ParseEvent::FieldKey(_) => {
+                    wip = wip.begin_list_item().map_err(DeserializeError::reflect)?;
+                    wip = self.deserialize_value_recursive(wip, field_shape)?;
+                    wip = wip.end().map_err(DeserializeError::reflect)?;
+                }
+                ParseEvent::StructEnd | ParseEvent::SequenceEnd => break,
+                _ => {
+                    return Err(DeserializeError::TypeMismatch {
+                        expected: "tuple element or end",
+                        got: format!("{event:?}"),
+                        span: self.last_span,
+                        path: Some(self.path_clone()),
+                    });
+                }
+            }
+        }
+
+        if let Ok(event) = self.expect_peek("tuple end")
+            && matches!(event, ParseEvent::StructEnd | ParseEvent::SequenceEnd)
+        {
+            let _ = self.expect_event("tuple end")?;
+        }
+
+        Ok(wip)
+    }
+
+    fn deserialize_enum_dynamic(
+        &mut self,
+        mut wip: Partial<'input, BORROW>,
+        _hint_shape: &'static Shape,
+        enum_def: &'static facet_core::EnumType,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
+        use crate::EnumVariantHint;
+
+        let variants: alloc::vec::Vec<EnumVariantHint> = enum_def
+            .variants
+            .iter()
+            .map(|v| EnumVariantHint {
+                name: v.name,
+                kind: v.data.kind,
+                field_count: v.data.fields.len(),
+            })
+            .collect();
+        self.parser.hint_enum(&variants);
+
+        let event = self.expect_event("enum")?;
+
+        match event {
+            ParseEvent::Scalar(ScalarValue::Str(s)) => {
+                // Unit variant as string (self-describing formats)
+                wip = self.set_string_value(wip, s)?;
+            }
+            ParseEvent::Scalar(ScalarValue::I64(i)) => {
+                wip = wip.set(i).map_err(DeserializeError::reflect)?;
+            }
+            ParseEvent::Scalar(ScalarValue::U64(u)) => {
+                wip = wip.set(u).map_err(DeserializeError::reflect)?;
+            }
+            ParseEvent::VariantTag(variant_name) => {
+                let variant = enum_def
+                    .variants
+                    .iter()
+                    .find(|v| v.name == variant_name)
+                    .ok_or_else(|| DeserializeError::Unsupported(format!(
+                        "unknown variant: {variant_name}"
+                    )))?;
+
+                match variant.data.kind {
+                    StructKind::Unit => {
+                        wip = self.set_string_value(wip, Cow::Borrowed(variant.name))?;
+                    }
+                    StructKind::TupleStruct | StructKind::Tuple => {
+                        if variant.data.fields.len() == 1 {
+                            wip = wip.begin_map().map_err(DeserializeError::reflect)?;
+                            wip = wip
+                                .begin_object_entry(variant.name)
+                                .map_err(DeserializeError::reflect)?;
+                            wip = self.deserialize_value_recursive(
+                                wip,
+                                variant.data.fields[0].shape.get(),
+                            )?;
+                            wip = wip.end().map_err(DeserializeError::reflect)?;
+                        } else {
+                            wip = wip.begin_map().map_err(DeserializeError::reflect)?;
+                            wip = wip
+                                .begin_object_entry(variant.name)
+                                .map_err(DeserializeError::reflect)?;
+                            wip = self.deserialize_tuple_dynamic(wip, variant.data.fields)?;
+                            wip = wip.end().map_err(DeserializeError::reflect)?;
+                        }
+                    }
+                    StructKind::Struct => {
+                        wip = wip.begin_map().map_err(DeserializeError::reflect)?;
+                        wip = wip
+                            .begin_object_entry(variant.name)
+                            .map_err(DeserializeError::reflect)?;
+                        wip = self.deserialize_struct_dynamic(wip, variant.data.fields)?;
+                        wip = wip.end().map_err(DeserializeError::reflect)?;
+                    }
+                }
+            }
+            ParseEvent::StructStart(_) => {
+                // Non-self-describing formats emit enum as {variant_name: value}
+                // The parser has already parsed the discriminant and will emit
+                // FieldKey events for the variant name
+                wip = self.deserialize_enum_as_struct(wip, enum_def)?;
+            }
+            _ => {
+                return Err(DeserializeError::TypeMismatch {
+                    expected: "enum variant",
+                    got: format!("{event:?}"),
+                    span: self.last_span,
+                    path: Some(self.path_clone()),
+                });
+            }
+        }
+
+        Ok(wip)
+    }
+
+    /// Deserialize enum represented as struct (used by postcard and similar formats).
+    ///
+    /// The parser emits the enum as `{variant_name: content}` where content depends
+    /// on the variant kind. The parser auto-handles struct/tuple variants by pushing
+    /// appropriate state, so we just consume the events it produces.
+    fn deserialize_enum_as_struct(
+        &mut self,
+        mut wip: Partial<'input, BORROW>,
+        enum_def: &'static facet_core::EnumType,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
+        // Get the variant name from FieldKey
+        let field_event = self.expect_event("enum field key")?;
+        let variant_name = match field_event {
+            ParseEvent::FieldKey(key) => key.name,
+            ParseEvent::StructEnd => {
+                // Empty struct - this shouldn't happen for valid enums
+                return Err(DeserializeError::Unsupported(
+                    "unexpected empty struct for enum".into(),
+                ));
+            }
+            _ => {
+                return Err(DeserializeError::TypeMismatch {
+                    expected: "field key for enum variant",
+                    got: format!("{field_event:?}"),
+                    span: self.last_span,
+                    path: Some(self.path_clone()),
+                });
+            }
+        };
+
+        // Find the variant definition
+        let variant = enum_def
+            .variants
+            .iter()
+            .find(|v| v.name == variant_name.as_ref())
+            .ok_or_else(|| {
+                DeserializeError::Unsupported(format!("unknown variant: {variant_name}"))
+            })?;
+
+        match variant.data.kind {
+            StructKind::Unit => {
+                // Unit variant - the parser will emit StructEnd next
+                wip = self.set_string_value(wip, variant_name)?;
+            }
+            StructKind::TupleStruct | StructKind::Tuple => {
+                wip = wip.begin_map().map_err(DeserializeError::reflect)?;
+                wip = wip
+                    .begin_object_entry(variant.name)
+                    .map_err(DeserializeError::reflect)?;
+                if variant.data.fields.len() == 1 {
+                    // Newtype variant - single field content, no wrapper
+                    wip = self.deserialize_value_recursive(wip, variant.data.fields[0].shape.get())?;
+                } else {
+                    // Multi-field tuple variant - parser emits SequenceStart
+                    let seq_event = self.expect_event("tuple variant start")?;
+                    if !matches!(seq_event, ParseEvent::SequenceStart(_)) {
+                        return Err(DeserializeError::TypeMismatch {
+                            expected: "SequenceStart for tuple variant",
+                            got: format!("{seq_event:?}"),
+                            span: self.last_span,
+                            path: Some(self.path_clone()),
+                        });
+                    }
+
+                    wip = wip.begin_list().map_err(DeserializeError::reflect)?;
+                    for field in variant.data.fields {
+                        // The parser's InSequence state will emit OrderedField for each element
+                        let _elem_event = self.expect_event("tuple element")?;
+                        wip = wip.begin_list_item().map_err(DeserializeError::reflect)?;
+                        wip = self.deserialize_value_recursive(wip, field.shape.get())?;
+                        wip = wip.end().map_err(DeserializeError::reflect)?;
+                    }
+
+                    let seq_end = self.expect_event("tuple variant end")?;
+                    if !matches!(seq_end, ParseEvent::SequenceEnd) {
+                        return Err(DeserializeError::TypeMismatch {
+                            expected: "SequenceEnd for tuple variant",
+                            got: format!("{seq_end:?}"),
+                            span: self.last_span,
+                            path: Some(self.path_clone()),
+                        });
+                    }
+                    wip = wip.end().map_err(DeserializeError::reflect)?;
+                }
+                wip = wip.end().map_err(DeserializeError::reflect)?;
+            }
+            StructKind::Struct => {
+                // The parser auto-emits StructStart and pushes InStruct state
+                let struct_event = self.expect_event("struct variant start")?;
+                if !matches!(struct_event, ParseEvent::StructStart(_)) {
+                    return Err(DeserializeError::TypeMismatch {
+                        expected: "StructStart for struct variant",
+                        got: format!("{struct_event:?}"),
+                        span: self.last_span,
+                        path: Some(self.path_clone()),
+                    });
+                }
+
+                wip = wip.begin_map().map_err(DeserializeError::reflect)?;
+                wip = wip
+                    .begin_object_entry(variant.name)
+                    .map_err(DeserializeError::reflect)?;
+                // begin_map() initializes the entry's value as an Object (doesn't push a frame)
+                wip = wip.begin_map().map_err(DeserializeError::reflect)?;
+
+                // Deserialize each field - parser will emit OrderedField for each
+                for field in variant.data.fields {
+                    let field_event = self.expect_event("struct field")?;
+                    match field_event {
+                        ParseEvent::OrderedField | ParseEvent::FieldKey(_) => {
+                            let key = field.rename.unwrap_or(field.name);
+                            wip = wip
+                                .begin_object_entry(key)
+                                .map_err(DeserializeError::reflect)?;
+                            wip = self.deserialize_value_recursive(wip, field.shape.get())?;
+                            wip = wip.end().map_err(DeserializeError::reflect)?;
+                        }
+                        ParseEvent::StructEnd => {
+                            return Err(DeserializeError::TypeMismatch {
+                                expected: "field",
+                                got: "StructEnd (struct ended too early)".into(),
+                                span: self.last_span,
+                                path: Some(self.path_clone()),
+                            });
+                        }
+                        _ => {
+                            return Err(DeserializeError::TypeMismatch {
+                                expected: "field",
+                                got: format!("{field_event:?}"),
+                                span: self.last_span,
+                                path: Some(self.path_clone()),
+                            });
+                        }
+                    }
+                }
+
+                // Consume inner StructEnd
+                let inner_end = self.expect_event("struct variant inner end")?;
+                if !matches!(inner_end, ParseEvent::StructEnd) {
+                    return Err(DeserializeError::TypeMismatch {
+                        expected: "StructEnd for struct variant inner",
+                        got: format!("{inner_end:?}"),
+                        span: self.last_span,
+                        path: Some(self.path_clone()),
+                    });
+                }
+                // Only end the object entry (begin_map doesn't push a frame)
+                wip = wip.end().map_err(DeserializeError::reflect)?;
+            }
+        }
+
+        // Consume the outer StructEnd
+        let end_event = self.expect_event("enum struct end")?;
+        if !matches!(end_event, ParseEvent::StructEnd) {
+            return Err(DeserializeError::TypeMismatch {
+                expected: "StructEnd for enum wrapper",
+                got: format!("{end_event:?}"),
+                span: self.last_span,
+                path: Some(self.path_clone()),
+            });
+        }
+
+        Ok(wip)
+    }
+
+    fn deserialize_scalar_dynamic(
+        &mut self,
+        mut wip: Partial<'input, BORROW>,
+        hint_shape: &'static Shape,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
+        let hint = match hint_shape.type_identifier {
+            "bool" => Some(ScalarTypeHint::Bool),
+            "u8" => Some(ScalarTypeHint::U8),
+            "u16" => Some(ScalarTypeHint::U16),
+            "u32" => Some(ScalarTypeHint::U32),
+            "u64" => Some(ScalarTypeHint::U64),
+            "u128" => Some(ScalarTypeHint::U128),
+            "usize" => Some(ScalarTypeHint::Usize),
+            "i8" => Some(ScalarTypeHint::I8),
+            "i16" => Some(ScalarTypeHint::I16),
+            "i32" => Some(ScalarTypeHint::I32),
+            "i64" => Some(ScalarTypeHint::I64),
+            "i128" => Some(ScalarTypeHint::I128),
+            "isize" => Some(ScalarTypeHint::Isize),
+            "f32" => Some(ScalarTypeHint::F32),
+            "f64" => Some(ScalarTypeHint::F64),
+            "String" | "&str" => Some(ScalarTypeHint::String),
+            "char" => Some(ScalarTypeHint::Char),
+            _ if hint_shape.is_from_str() => Some(ScalarTypeHint::String),
+            _ => None,
+        };
+        if let Some(h) = hint {
+            self.parser.hint_scalar_type(h);
+        }
+
+        let event = self.expect_event("scalar")?;
+
+        match event {
+            ParseEvent::Scalar(scalar) => match scalar {
+                ScalarValue::Null => {
+                    wip = wip.set_default().map_err(DeserializeError::reflect)?;
+                }
+                ScalarValue::Bool(b) => {
+                    wip = wip.set(b).map_err(DeserializeError::reflect)?;
+                }
+                ScalarValue::Char(c) => {
+                    wip = self.set_string_value(wip, Cow::Owned(c.to_string()))?;
+                }
+                ScalarValue::I64(i) => {
+                    wip = wip.set(i).map_err(DeserializeError::reflect)?;
+                }
+                ScalarValue::U64(u) => {
+                    wip = wip.set(u).map_err(DeserializeError::reflect)?;
+                }
+                ScalarValue::I128(i) => {
+                    wip = self.set_string_value(wip, Cow::Owned(i.to_string()))?;
+                }
+                ScalarValue::U128(u) => {
+                    wip = self.set_string_value(wip, Cow::Owned(u.to_string()))?;
+                }
+                ScalarValue::F64(f) => {
+                    wip = wip.set(f).map_err(DeserializeError::reflect)?;
+                }
+                ScalarValue::Str(s) | ScalarValue::StringlyTyped(s) => {
+                    wip = self.set_string_value(wip, s)?;
+                }
+                ScalarValue::Bytes(b) => {
+                    wip = self.set_bytes_value(wip, b)?;
+                }
+            },
+            _ => {
+                return Err(DeserializeError::TypeMismatch {
+                    expected: "scalar",
+                    got: format!("{event:?}"),
+                    span: self.last_span,
+                    path: Some(self.path_clone()),
+                });
+            }
+        }
+
+        Ok(wip)
+    }
+
+    fn deserialize_list_dynamic(
+        &mut self,
+        mut wip: Partial<'input, BORROW>,
+        element_shape: &'static Shape,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
+        self.parser.hint_sequence();
+
+        let event = self.expect_event("sequence start")?;
+        if !matches!(event, ParseEvent::SequenceStart(_)) {
+            return Err(DeserializeError::TypeMismatch {
+                expected: "sequence",
+                got: format!("{event:?}"),
+                span: self.last_span,
+                path: Some(self.path_clone()),
+            });
+        }
+
+        wip = wip.begin_list().map_err(DeserializeError::reflect)?;
+
+        loop {
+            let event = self.expect_peek("element or sequence end")?;
+            if matches!(event, ParseEvent::SequenceEnd) {
+                let _ = self.expect_event("sequence end")?;
+                break;
+            }
+
+            wip = wip.begin_list_item().map_err(DeserializeError::reflect)?;
+            wip = self.deserialize_value_recursive(wip, element_shape)?;
+            wip = wip.end().map_err(DeserializeError::reflect)?;
+        }
+
+        Ok(wip)
+    }
+
+    fn deserialize_array_dynamic(
+        &mut self,
+        mut wip: Partial<'input, BORROW>,
+        element_shape: &'static Shape,
+        len: usize,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
+        self.parser.hint_array(len);
+
+        let event = self.expect_event("array start")?;
+        if !matches!(event, ParseEvent::SequenceStart(_)) {
+            return Err(DeserializeError::TypeMismatch {
+                expected: "array",
+                got: format!("{event:?}"),
+                span: self.last_span,
+                path: Some(self.path_clone()),
+            });
+        }
+
+        wip = wip.begin_list().map_err(DeserializeError::reflect)?;
+
+        for _ in 0..len {
+            wip = wip.begin_list_item().map_err(DeserializeError::reflect)?;
+            wip = self.deserialize_value_recursive(wip, element_shape)?;
+            wip = wip.end().map_err(DeserializeError::reflect)?;
+        }
+
+        let event = self.expect_event("array end")?;
+        if !matches!(event, ParseEvent::SequenceEnd) {
+            return Err(DeserializeError::TypeMismatch {
+                expected: "array end",
+                got: format!("{event:?}"),
+                span: self.last_span,
+                path: Some(self.path_clone()),
+            });
+        }
+
+        Ok(wip)
+    }
+
+    fn deserialize_map_dynamic(
+        &mut self,
+        mut wip: Partial<'input, BORROW>,
+        key_shape: &'static Shape,
+        value_shape: &'static Shape,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
+        self.parser.hint_map();
+
+        let event = self.expect_event("map start")?;
+        if !matches!(event, ParseEvent::SequenceStart(_) | ParseEvent::StructStart(_)) {
+            return Err(DeserializeError::TypeMismatch {
+                expected: "map",
+                got: format!("{event:?}"),
+                span: self.last_span,
+                path: Some(self.path_clone()),
+            });
+        }
+
+        wip = wip.begin_map().map_err(DeserializeError::reflect)?;
+
+        let key_hint = match key_shape.type_identifier {
+            "String" | "&str" => Some(ScalarTypeHint::String),
+            "i64" | "i32" | "i16" | "i8" | "isize" => Some(ScalarTypeHint::I64),
+            "u64" | "u32" | "u16" | "u8" | "usize" => Some(ScalarTypeHint::U64),
+            _ => None,
+        };
+
+        loop {
+            let event = self.expect_peek("map entry or end")?;
+            if matches!(event, ParseEvent::SequenceEnd | ParseEvent::StructEnd) {
+                let _ = self.expect_event("map end")?;
+                break;
+            }
+
+            if let Some(h) = key_hint {
+                self.parser.hint_scalar_type(h);
+            }
+            let key_event = self.expect_event("map key")?;
+            let key_str: Cow<'_, str> = match key_event {
+                ParseEvent::Scalar(ScalarValue::Str(s)) => s,
+                ParseEvent::Scalar(ScalarValue::I64(i)) => Cow::Owned(i.to_string()),
+                ParseEvent::Scalar(ScalarValue::U64(u)) => Cow::Owned(u.to_string()),
+                ParseEvent::FieldKey(k) => k.name,
+                _ => {
+                    return Err(DeserializeError::TypeMismatch {
+                        expected: "map key",
+                        got: format!("{key_event:?}"),
+                        span: self.last_span,
+                        path: Some(self.path_clone()),
+                    });
+                }
+            };
+
+            wip = wip
+                .begin_object_entry(&key_str)
+                .map_err(DeserializeError::reflect)?;
+            wip = self.deserialize_value_recursive(wip, value_shape)?;
+            wip = wip.end().map_err(DeserializeError::reflect)?;
+        }
+
+        Ok(wip)
     }
 
     fn deserialize_option(

--- a/facet-postcard/Cargo.toml
+++ b/facet-postcard/Cargo.toml
@@ -20,6 +20,7 @@ facet-core = { path = "../facet-core", version = "0.42.0", default-features = fa
 facet-format = { path = "../facet-format", version = "0.42.0" }
 facet-path = { path = "../facet-path", version = "0.42.0", default-features = false, features = ["alloc"] }
 facet-reflect = { path = "../facet-reflect", version = "0.42.0", default-features = false }
+facet-value = { path = "../facet-value", version = "0.42.0" }
 tracing = { workspace = true }
 
 # Axum integration (optional)

--- a/facet-postcard/src/lib.rs
+++ b/facet-postcard/src/lib.rs
@@ -19,10 +19,11 @@
 //!
 //! # Deserialization
 //!
-//! There are two deserialization functions:
+//! There are three deserialization functions:
 //!
 //! - [`from_slice`]: Deserializes into owned types (`T: Facet<'static>`)
 //! - [`from_slice_borrowed`]: Deserializes with zero-copy borrowing from the input buffer
+//! - [`from_slice_with_shape`]: Deserializes into `Value` using runtime shape information
 //!
 //! ```
 //! use facet_postcard::from_slice;
@@ -46,6 +47,7 @@ extern crate alloc;
 mod error;
 mod parser;
 mod serialize;
+mod shape_deser;
 
 #[cfg(feature = "jit")]
 pub mod jit;
@@ -60,6 +62,7 @@ pub use error::{PostcardError, SerializeError};
 pub use jit::PostcardJitFormat;
 pub use parser::PostcardParser;
 pub use serialize::{Writer, peek_to_vec, to_vec, to_writer_fallible};
+pub use shape_deser::from_slice_with_shape;
 
 // Re-export DeserializeError for convenience
 pub use facet_format::DeserializeError;

--- a/facet-postcard/src/shape_deser.rs
+++ b/facet-postcard/src/shape_deser.rs
@@ -1,0 +1,145 @@
+//! Shape-based deserialization into `facet_value::Value`.
+//!
+//! This module provides deserialization from postcard bytes into a `Value` using only
+//! a `&'static Shape` at runtime, without requiring a concrete Rust type.
+
+use facet_core::Shape;
+use facet_format::{DeserializeError, FormatDeserializer};
+use facet_value::Value;
+
+use crate::error::PostcardError;
+use crate::parser::PostcardParser;
+
+/// Deserialize postcard bytes into a `Value` using shape information.
+///
+/// Since postcard is not a self-describing format, you need to provide the shape
+/// that describes the structure of the data.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_postcard::{from_slice_with_shape, to_vec};
+///
+/// #[derive(Facet)]
+/// struct Point { x: i32, y: i32 }
+///
+/// let point = Point { x: 10, y: 20 };
+/// let bytes = to_vec(&point).unwrap();
+///
+/// // Deserialize using the shape, not the type
+/// let value = from_slice_with_shape(&bytes, Point::SHAPE).unwrap();
+/// let obj = value.as_object().unwrap();
+/// assert_eq!(obj.get("x").unwrap().as_number().unwrap().to_i64(), Some(10));
+/// assert_eq!(obj.get("y").unwrap().as_number().unwrap().to_i64(), Some(20));
+/// ```
+pub fn from_slice_with_shape(
+    input: &[u8],
+    source_shape: &'static Shape,
+) -> Result<Value, DeserializeError<PostcardError>> {
+    let parser = PostcardParser::new(input);
+    let mut de = FormatDeserializer::new_owned(parser);
+    de.deserialize_with_shape(source_shape)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use facet::Facet;
+
+    #[test]
+    fn test_from_slice_with_shape_primitives() {
+        // Test i32
+        let bytes = crate::to_vec(&42i32).unwrap();
+        let value = from_slice_with_shape(&bytes, i32::SHAPE).unwrap();
+        assert_eq!(value.as_number().unwrap().to_i64(), Some(42));
+
+        // Test String
+        let bytes = crate::to_vec(&"hello".to_string()).unwrap();
+        let value = from_slice_with_shape(&bytes, String::SHAPE).unwrap();
+        assert_eq!(value.as_string().unwrap().as_str(), "hello");
+
+        // Test bool
+        let bytes = crate::to_vec(&true).unwrap();
+        let value = from_slice_with_shape(&bytes, bool::SHAPE).unwrap();
+        assert_eq!(value.as_bool(), Some(true));
+    }
+
+    #[test]
+    fn test_from_slice_with_shape_struct() {
+        #[derive(Facet)]
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        let point = Point { x: 10, y: 20 };
+        let bytes = crate::to_vec(&point).unwrap();
+        let value = from_slice_with_shape(&bytes, Point::SHAPE).unwrap();
+
+        let obj = value.as_object().unwrap();
+        assert_eq!(obj.get("x").unwrap().as_number().unwrap().to_i64(), Some(10));
+        assert_eq!(obj.get("y").unwrap().as_number().unwrap().to_i64(), Some(20));
+    }
+
+    #[test]
+    fn test_from_slice_with_shape_vec() {
+        let vec = vec![1i32, 2, 3, 4, 5];
+        let bytes = crate::to_vec(&vec).unwrap();
+        let value = from_slice_with_shape(&bytes, <Vec<i32>>::SHAPE).unwrap();
+
+        let arr = value.as_array().unwrap();
+        assert_eq!(arr.len(), 5);
+        assert_eq!(arr.get(0).unwrap().as_number().unwrap().to_i64(), Some(1));
+        assert_eq!(arr.get(4).unwrap().as_number().unwrap().to_i64(), Some(5));
+    }
+
+    #[test]
+    fn test_from_slice_with_shape_option() {
+        // Some value
+        let opt: Option<i32> = Some(42);
+        let bytes = crate::to_vec(&opt).unwrap();
+        let value = from_slice_with_shape(&bytes, <Option<i32>>::SHAPE).unwrap();
+        assert_eq!(value.as_number().unwrap().to_i64(), Some(42));
+
+        // None
+        let opt: Option<i32> = None;
+        let bytes = crate::to_vec(&opt).unwrap();
+        let value = from_slice_with_shape(&bytes, <Option<i32>>::SHAPE).unwrap();
+        assert!(value.is_null());
+    }
+
+    #[test]
+    fn test_from_slice_with_shape_enum() {
+        #[derive(Facet)]
+        #[repr(u8)]
+        #[allow(dead_code)]
+        enum Message {
+            Ping,
+            Text(String),
+            Point { x: i32, y: i32 },
+        }
+
+        // Unit variant
+        let msg = Message::Ping;
+        let bytes = crate::to_vec(&msg).unwrap();
+        let value = from_slice_with_shape(&bytes, Message::SHAPE).unwrap();
+        assert_eq!(value.as_string().unwrap().as_str(), "Ping");
+
+        // Newtype variant
+        let msg = Message::Text("hello".into());
+        let bytes = crate::to_vec(&msg).unwrap();
+        let value = from_slice_with_shape(&bytes, Message::SHAPE).unwrap();
+        let obj = value.as_object().unwrap();
+        assert_eq!(obj.get("Text").unwrap().as_string().unwrap().as_str(), "hello");
+
+        // Struct variant
+        let msg = Message::Point { x: 10, y: 20 };
+        let bytes = crate::to_vec(&msg).unwrap();
+        let value = from_slice_with_shape(&bytes, Message::SHAPE).unwrap();
+        let obj = value.as_object().unwrap();
+        let inner = obj.get("Point").unwrap().as_object().unwrap();
+        assert_eq!(inner.get("x").unwrap().as_number().unwrap().to_i64(), Some(10));
+        assert_eq!(inner.get("y").unwrap().as_number().unwrap().to_i64(), Some(20));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `from_slice_with_shape(bytes, shape) -> Value` to facet-postcard for deserializing postcard bytes into `facet_value::Value` using runtime shape information
- Enable HTTP bridges and RPC transcoding between JSON and postcard without knowing concrete types at compile time
- Add shape-guided deserialization methods to `FormatDeserializer` in facet-format that walk the source shape for parser hints while building into Value using standard Partial operations

## Test plan

- [x] Unit tests for primitives (i32, String, bool)
- [x] Unit tests for structs
- [x] Unit tests for Vec
- [x] Unit tests for Option (Some and None)
- [x] Unit tests for enums (unit, newtype, and struct variants)
- [x] All 778 existing facet-postcard tests pass
- [x] All facet-format tests pass

Closes #1751