### PR TITLE
feat(postcard): add to_vec_with_shape for shape-guided serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,6 +1906,7 @@ dependencies = [
  "facet",
  "facet-core",
  "facet-format",
+ "facet-json",
  "facet-path",
  "facet-reflect",
  "facet-testhelpers",

--- a/facet-format/src/lib.rs
+++ b/facet-format/src/lib.rs
@@ -24,7 +24,7 @@ pub use parser::FormatJitParser;
 pub use parser::{EnumVariantHint, FormatParser, ProbeStream, ScalarTypeHint};
 pub use serializer::{
     DynamicValueEncoding, DynamicValueTag, EnumVariantEncoding, FieldOrdering, FormatSerializer,
-    MapEncoding, SerializeError, StructFieldMode, serialize_root,
+    MapEncoding, SerializeError, StructFieldMode, serialize_root, serialize_value_with_shape,
 };
 pub use solver::{SolveOutcome, SolveVariantError, solve_variant};
 pub use visitor::{FieldMatch, StructFieldTracker};

--- a/facet-postcard/Cargo.toml
+++ b/facet-postcard/Cargo.toml
@@ -47,6 +47,7 @@ chrono = { workspace = true, features = ["clock"] }
 divan = { workspace = true }
 facet = { path = "../facet", features = ["all-impls", "doc"] }
 facet-format = { path = "../facet-format", features = ["jit"] }
+facet-json = { path = "../facet-json" }
 facet-testhelpers = { path = "../facet-testhelpers" }
 facet-value = { path = "../facet-value" }
 jiff = { workspace = true }

--- a/facet-postcard/src/lib.rs
+++ b/facet-postcard/src/lib.rs
@@ -61,7 +61,7 @@ pub use error::{PostcardError, SerializeError};
 #[cfg(feature = "jit")]
 pub use jit::PostcardJitFormat;
 pub use parser::PostcardParser;
-pub use serialize::{Writer, peek_to_vec, to_vec, to_writer_fallible};
+pub use serialize::{Writer, peek_to_vec, to_vec, to_vec_with_shape, to_writer_fallible};
 pub use shape_deser::from_slice_with_shape;
 
 // Re-export DeserializeError for convenience


### PR DESCRIPTION
## Summary

Add `to_vec_with_shape` function, the inverse of `from_slice_with_shape`. This allows serializing dynamic values (like `facet_value::Value`) to postcard bytes using a target shape to guide serialization, rather than encoding the Value type discriminants.

## Changes

- Add `serialize_value_with_shape` to `facet-format/src/serializer.rs` - core implementation that handles all shape types (scalars, structs, enums, lists, maps, arrays, options, etc.)
- Add `to_vec_with_shape` to `facet-postcard/src/serialize.rs` - convenience wrapper exposing the functionality
- Support for smart pointers, transparent wrappers, and various numeric coercions
- Comprehensive tests for structs, vecs, nested types, and roundtrip serialization

## Use Case

This enables the workflow:
1. Parse JSON/YAML into a `Value` 
2. Serialize it to postcard bytes matching a specific typed schema
3. Deserialize with a typed Facet struct

```rust
let value: Value = facet_json::from_str(r#"{"x": 10, "y": 20}"#).unwrap();
let bytes = to_vec_with_shape(&value, Point::SHAPE).unwrap();
let point: Point = facet_postcard::from_slice(&bytes).unwrap();
```

## Test plan

- [x] Test struct serialization matches typed serialization
- [x] Test vec serialization matches typed serialization  
- [x] Test nested struct serialization
- [x] Test roundtrip: typed -> postcard -> Value -> postcard -> typed