### PR TITLE
test(facet-core): re-enable pointer type tests

### DIFF
--- a/facet-core/tests/pointer.rs
+++ b/facet-core/tests/pointer.rs
@@ -1,39 +1,37 @@
-// TODO: Re-enable once pointer impls are migrated to new VTable API
-// use facet_core::{Facet, PointerType, Type};
-// use facet_testhelpers::test;
+use facet_core::{Facet, PointerType, Type};
 
-// #[test]
-// fn shape_name_string_slice_const_ptr() {
-//     let shape = <*const str as Facet>::SHAPE;
-//     match shape.ty {
-//         Type::Pointer(PointerType::Raw(vpt)) => {
-//             assert!(!vpt.mutable);
-//             assert_eq!(vpt.target.to_string(), "str");
-//         }
-//         _ => panic!("wrong type {:?}", shape.ty),
-//     }
-// }
+#[test]
+fn shape_name_string_slice_const_ptr() {
+    let shape = <*const str as Facet>::SHAPE;
+    match shape.ty {
+        Type::Pointer(PointerType::Raw(vpt)) => {
+            assert!(!vpt.mutable);
+            assert_eq!(vpt.target.to_string(), "str");
+        }
+        _ => panic!("wrong type {:?}", shape.ty),
+    }
+}
 
-// #[test]
-// fn shape_name_string_slice_mut_ptr() {
-//     let shape = <*mut str as Facet>::SHAPE;
-//     match shape.ty {
-//         Type::Pointer(PointerType::Raw(vpt)) => {
-//             assert!(vpt.mutable);
-//             assert_eq!(vpt.target.to_string(), "str");
-//         }
-//         _ => panic!("wrong type {:?}", shape.ty),
-//     }
-// }
+#[test]
+fn shape_name_string_slice_mut_ptr() {
+    let shape = <*mut str as Facet>::SHAPE;
+    match shape.ty {
+        Type::Pointer(PointerType::Raw(vpt)) => {
+            assert!(vpt.mutable);
+            assert_eq!(vpt.target.to_string(), "str");
+        }
+        _ => panic!("wrong type {:?}", shape.ty),
+    }
+}
 
-// #[test]
-// fn shape_name_string_slice_ref() {
-//     let shape = <&str as Facet>::SHAPE;
-//     match shape.ty {
-//         Type::Pointer(PointerType::Reference(vpt)) => {
-//             assert!(!vpt.mutable);
-//             assert_eq!(vpt.target.to_string(), "str");
-//         }
-//         _ => panic!("wrong type {:?}", shape.ty),
-//     }
-// }
+#[test]
+fn shape_name_string_slice_ref() {
+    let shape = <&str as Facet>::SHAPE;
+    match shape.ty {
+        Type::Pointer(PointerType::Reference(vpt)) => {
+            assert!(!vpt.mutable);
+            assert_eq!(vpt.target.to_string(), "str");
+        }
+        _ => panic!("wrong type {:?}", shape.ty),
+    }
+}


### PR DESCRIPTION
## Summary

Re-enables the pointer type tests in `facet-core` that were previously commented out. These tests verify that pointer types (`*const str`, `*mut str`, `&str`) have the correct `Shape` representations and that the `PointerType` variants work correctly.

## Changes

- Re-enable `shape_name_string_slice_const_ptr` test for const raw pointers
- Re-enable `shape_name_string_slice_mut_ptr` test for mutable raw pointers  
- Re-enable `shape_name_string_slice_ref` test for references
- Remove outdated TODO comment about VTable API migration

## Test plan

- [x] All re-enabled tests pass locally (verified via pre-push hooks)
- [x] Clippy checks pass
- [x] Doc tests pass