### PR TITLE
feat(facet-core): add chrono::Duration support

### DIFF
--- a/facet-asn1/tests/format_suite.rs
+++ b/facet-asn1/tests/format_suite.rs
@@ -463,6 +463,14 @@ impl FormatSuite for Asn1Slice {
         CaseSpec::skip("ASN.1 is a binary format, requires binary input not JSON strings")
     }
 
+    fn chrono_duration() -> CaseSpec {
+        CaseSpec::skip("ASN.1 is a binary format, requires binary input not JSON strings")
+    }
+
+    fn chrono_duration_negative() -> CaseSpec {
+        CaseSpec::skip("ASN.1 is a binary format, requires binary input not JSON strings")
+    }
+
     fn bytes_bytes() -> CaseSpec {
         CaseSpec::skip("ASN.1 is a binary format, requires binary input not JSON strings")
     }

--- a/facet-format-suite/src/lib.rs
+++ b/facet-format-suite/src/lib.rs
@@ -423,6 +423,14 @@ pub trait FormatSuite {
     #[cfg(feature = "chrono")]
     fn chrono_in_vec() -> CaseSpec;
 
+    /// Case: `chrono::Duration` type - serializes as (secs, nanos) tuple.
+    #[cfg(feature = "chrono")]
+    fn chrono_duration() -> CaseSpec;
+
+    /// Case: `chrono::Duration` with negative value - tests signed (secs, nanos) handling.
+    #[cfg(feature = "chrono")]
+    fn chrono_duration_negative() -> CaseSpec;
+
     // ── Bytes crate tests ──
 
     /// Case: `bytes::Bytes` type.
@@ -764,6 +772,13 @@ pub fn all_cases<S: FormatSuite + 'static>() -> Vec<SuiteCase> {
         SuiteCase::new::<S, ChronoNaiveTimeWrapper>(&CASE_CHRONO_NAIVE_TIME, S::chrono_naive_time),
         #[cfg(feature = "chrono")]
         SuiteCase::new::<S, ChronoInVecWrapper>(&CASE_CHRONO_IN_VEC, S::chrono_in_vec),
+        #[cfg(feature = "chrono")]
+        SuiteCase::new::<S, ChronoDurationWrapper>(&CASE_CHRONO_DURATION, S::chrono_duration),
+        #[cfg(feature = "chrono")]
+        SuiteCase::new::<S, ChronoDurationNegativeWrapper>(
+            &CASE_CHRONO_DURATION_NEGATIVE,
+            S::chrono_duration_negative,
+        ),
         // Bytes crate cases
         #[cfg(feature = "bytes")]
         SuiteCase::new::<S, BytesBytesWrapper>(&CASE_BYTES_BYTES, S::bytes_bytes),
@@ -3456,6 +3471,25 @@ const CASE_CHRONO_IN_VEC: CaseDescriptor<ChronoInVecWrapper> = CaseDescriptor {
     },
 };
 
+#[cfg(feature = "chrono")]
+const CASE_CHRONO_DURATION: CaseDescriptor<ChronoDurationWrapper> = CaseDescriptor {
+    id: "third_party::chrono_duration",
+    description: "chrono::Duration type - serializes as (secs, nanos) tuple",
+    expected: || ChronoDurationWrapper {
+        duration: chrono::Duration::seconds(3600) + chrono::Duration::nanoseconds(500_000_000),
+    },
+};
+
+#[cfg(feature = "chrono")]
+const CASE_CHRONO_DURATION_NEGATIVE: CaseDescriptor<ChronoDurationNegativeWrapper> =
+    CaseDescriptor {
+        id: "third_party::chrono_duration_negative",
+        description: "chrono::Duration negative value - tests signed (secs, nanos) handling",
+        expected: || ChronoDurationNegativeWrapper {
+            duration: chrono::Duration::seconds(-90) + chrono::Duration::nanoseconds(-250_000_000),
+        },
+    };
+
 // ── Bytes crate case descriptors ──
 
 #[cfg(feature = "bytes")]
@@ -3668,6 +3702,20 @@ pub struct ChronoNaiveTimeWrapper {
 #[derive(Facet, Debug, Clone, PartialEq)]
 pub struct ChronoInVecWrapper {
     pub timestamps: Vec<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Fixture for `chrono::Duration` test.
+#[cfg(feature = "chrono")]
+#[derive(Facet, Debug, Clone, PartialEq)]
+pub struct ChronoDurationWrapper {
+    pub duration: chrono::Duration,
+}
+
+/// Fixture for `chrono::Duration` negative test.
+#[cfg(feature = "chrono")]
+#[derive(Facet, Debug, Clone, PartialEq)]
+pub struct ChronoDurationNegativeWrapper {
+    pub duration: chrono::Duration,
 }
 
 // ── Bytes crate test fixtures ──

--- a/facet-json/tests/format_suite.rs
+++ b/facet-json/tests/format_suite.rs
@@ -756,6 +756,16 @@ impl FormatSuite for JsonSlice {
         CaseSpec::from_str(r#"{"timestamps":["2023-01-01T00:00:00Z","2023-06-15T12:30:00Z"]}"#)
     }
 
+    fn chrono_duration() -> CaseSpec {
+        // Duration serializes as (secs, nanos) tuple: 3600 seconds + 500_000_000 nanoseconds
+        CaseSpec::from_str(r#"{"duration":[3600,500000000]}"#)
+    }
+
+    fn chrono_duration_negative() -> CaseSpec {
+        // Negative duration: -90 seconds - 250_000_000 nanoseconds = -90.25 seconds
+        CaseSpec::from_str(r#"{"duration":[-90,-250000000]}"#)
+    }
+
     // ── Bytes crate cases ──
 
     fn bytes_bytes() -> CaseSpec {

--- a/facet-msgpack/tests/format_suite.rs
+++ b/facet-msgpack/tests/format_suite.rs
@@ -476,6 +476,14 @@ impl FormatSuite for MsgPackSlice {
         CaseSpec::skip("MsgPack is a binary format, requires binary input not JSON strings")
     }
 
+    fn chrono_duration() -> CaseSpec {
+        CaseSpec::skip("MsgPack is a binary format, requires binary input not JSON strings")
+    }
+
+    fn chrono_duration_negative() -> CaseSpec {
+        CaseSpec::skip("MsgPack is a binary format, requires binary input not JSON strings")
+    }
+
     fn bytes_bytes() -> CaseSpec {
         CaseSpec::skip("MsgPack is a binary format, requires binary input not JSON strings")
     }

--- a/facet-toml/tests/format_suite.rs
+++ b/facet-toml/tests/format_suite.rs
@@ -666,6 +666,14 @@ impl FormatSuite for TomlSlice {
         CaseSpec::from_str("timestamps = [2023-01-01T00:00:00Z, 2023-06-15T12:30:00Z]")
     }
 
+    fn chrono_duration() -> CaseSpec {
+        CaseSpec::from_str("duration = [3600, 500000000]")
+    }
+
+    fn chrono_duration_negative() -> CaseSpec {
+        CaseSpec::from_str("duration = [-90, -250000000]")
+    }
+
     // -- Bytes crate cases --
 
     fn bytes_bytes() -> CaseSpec {

--- a/facet-xml/tests/format_suite.rs
+++ b/facet-xml/tests/format_suite.rs
@@ -762,6 +762,18 @@ impl FormatSuite for XmlSlice {
         )
     }
 
+    fn chrono_duration() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"<record><duration><item>3600</item><item>500000000</item></duration></record>"#,
+        )
+    }
+
+    fn chrono_duration_negative() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"<record><duration><item>-90</item><item>-250000000</item></duration></record>"#,
+        )
+    }
+
     // ── Bytes crate cases ──
 
     fn bytes_bytes() -> CaseSpec {

--- a/facet-yaml/tests/format_suite.rs
+++ b/facet-yaml/tests/format_suite.rs
@@ -671,6 +671,14 @@ impl FormatSuite for YamlSlice {
         CaseSpec::from_str("timestamps:\n  - 2023-01-01T00:00:00Z\n  - 2023-06-15T12:30:00Z")
     }
 
+    fn chrono_duration() -> CaseSpec {
+        CaseSpec::from_str("duration:\n  - 3600\n  - 500000000")
+    }
+
+    fn chrono_duration_negative() -> CaseSpec {
+        CaseSpec::from_str("duration:\n  - -90\n  - -250000000")
+    }
+
     // -- Bytes crate cases --
 
     fn bytes_bytes() -> CaseSpec {


### PR DESCRIPTION
Follows the same logic as their own serde impl: (de)serialize as (seconds, nanoseconds).