### PR TITLE
feat: add tag/content for #[facet(other)] variants

### DIFF
--- a/facet-core/src/types/ty/field.rs
+++ b/facet-core/src/types/ty/field.rs
@@ -269,6 +269,24 @@ impl Field {
         self.has_builtin_attr("other")
     }
 
+    /// Returns true if this field is marked with `#[facet(is_tag)]`.
+    ///
+    /// Within an `#[facet(other)]` variant, this field captures the variant tag name
+    /// when deserializing self-describing formats that emit VariantTag events.
+    #[inline]
+    pub fn is_variant_tag(&self) -> bool {
+        self.has_builtin_attr("is_tag")
+    }
+
+    /// Returns true if this field is marked with `#[facet(is_content)]`.
+    ///
+    /// Within an `#[facet(other)]` variant, this field captures the variant payload
+    /// when deserializing self-describing formats that emit VariantTag events.
+    #[inline]
+    pub fn is_variant_content(&self) -> bool {
+        self.has_builtin_attr("is_content")
+    }
+
     /// Returns the metadata kind if this field stores metadata.
     ///
     /// Common values: `"span"`, `"line"`, `"column"`

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -139,6 +139,20 @@ pub mod builtin {
             /// Usage: `#[facet(other)]`
             Other,
 
+            /// Marks a field within an `#[facet(other)]` variant as capturing the variant tag name.
+            /// For self-describing formats that emit VariantTag events (like Styx or XML),
+            /// this field receives the unknown tag name as a String.
+            ///
+            /// Usage: `#[facet(is_tag)]` on a String field within an `#[facet(other)]` variant.
+            IsTag,
+
+            /// Marks a field within an `#[facet(other)]` variant as capturing the variant payload.
+            /// For self-describing formats that emit VariantTag events, this field receives
+            /// the deserialized content that follows the tag.
+            ///
+            /// Usage: `#[facet(is_content)]` on a field within an `#[facet(other)]` variant.
+            IsContent,
+
             /// Serializes/Deserializers enum to/from integer based on variant discriminant.
             ///
             /// Usage: `#[facet(is_numeric)]`


### PR DESCRIPTION
These field-level attributes allow capturing both the variant tag name and its payload when deserializing self-describing formats that emit VariantTag events (like Styx or XML).

- Add IsTag and IsContent to builtin attribute grammar
- Add is_variant_tag() and is_variant_content() methods to Field
- Add deserialize_other_variant_with_captured_tag helper in facet-format