### PR TITLE
fix(facet-format): use effective_name() for enum variant hints

### DIFF
--- a/facet-format/src/deserializer/dynamic.rs
+++ b/facet-format/src/deserializer/dynamic.rs
@@ -214,7 +214,7 @@ where
             .variants
             .iter()
             .map(|v| EnumVariantHint {
-                name: v.name,
+                name: v.effective_name(),
                 kind: v.data.kind,
                 field_count: v.data.fields.len(),
             })
@@ -263,7 +263,8 @@ where
                             wip = self.set_string_value(wip, Cow::Borrowed(input_tag))?;
                         } else {
                             // Direct match: use effective_name (wire format name)
-                            wip = self.set_string_value(wip, Cow::Borrowed(variant.effective_name()))?;
+                            wip = self
+                                .set_string_value(wip, Cow::Borrowed(variant.effective_name()))?;
                         }
                     }
                     StructKind::TupleStruct | StructKind::Tuple => {

--- a/facet-format/src/deserializer/eenum.rs
+++ b/facet-format/src/deserializer/eenum.rs
@@ -26,7 +26,7 @@ where
                 .variants
                 .iter()
                 .map(|v| crate::EnumVariantHint {
-                    name: v.name,
+                    name: v.effective_name(),
                     kind: v.data.kind,
                     field_count: v.data.fields.len(),
                 })

--- a/facet-postcard/tests/roundtrip.rs
+++ b/facet-postcard/tests/roundtrip.rs
@@ -2424,3 +2424,156 @@ mod ordered_float_roundtrip {
         .collect()
     );
 }
+
+// =============================================================================
+// Enum Rename Tests
+// =============================================================================
+//
+// These tests verify that enums with #[facet(rename)] and #[facet(rename_all)]
+// attributes roundtrip correctly through postcard serialization.
+
+mod enum_rename {
+    use super::*;
+
+    // Test enum with rename_all = "snake_case"
+    #[derive(Debug, PartialEq, Facet)]
+    #[facet(rename_all = "snake_case")]
+    #[repr(u8)]
+    enum SnakeCaseEnum {
+        CircularDependency,
+        InvalidNaming,
+        MissingField,
+    }
+
+    test_roundtrip!(
+        enum_rename_all_snake_case_first,
+        SnakeCaseEnum,
+        SnakeCaseEnum::CircularDependency
+    );
+    test_roundtrip!(
+        enum_rename_all_snake_case_second,
+        SnakeCaseEnum,
+        SnakeCaseEnum::InvalidNaming
+    );
+    test_roundtrip!(
+        enum_rename_all_snake_case_third,
+        SnakeCaseEnum,
+        SnakeCaseEnum::MissingField
+    );
+
+    // Test enum with rename_all = "camelCase"
+    #[derive(Debug, PartialEq, Facet)]
+    #[facet(rename_all = "camelCase")]
+    #[repr(u8)]
+    enum CamelCaseEnum {
+        FirstVariant,
+        SecondVariant,
+    }
+
+    test_roundtrip!(
+        enum_rename_all_camel_case_first,
+        CamelCaseEnum,
+        CamelCaseEnum::FirstVariant
+    );
+    test_roundtrip!(
+        enum_rename_all_camel_case_second,
+        CamelCaseEnum,
+        CamelCaseEnum::SecondVariant
+    );
+
+    // Test enum with individual rename on variants
+    #[derive(Debug, PartialEq, Facet)]
+    #[repr(u8)]
+    enum IndividualRenameEnum {
+        #[facet(rename = "renamed_first")]
+        First,
+        #[facet(rename = "renamed_second")]
+        Second,
+        Third, // Not renamed
+    }
+
+    test_roundtrip!(
+        enum_individual_rename_first,
+        IndividualRenameEnum,
+        IndividualRenameEnum::First
+    );
+    test_roundtrip!(
+        enum_individual_rename_second,
+        IndividualRenameEnum,
+        IndividualRenameEnum::Second
+    );
+    test_roundtrip!(
+        enum_individual_rename_third,
+        IndividualRenameEnum,
+        IndividualRenameEnum::Third
+    );
+
+    // Test enum with rename_all and newtype variants
+    #[derive(Debug, PartialEq, Facet)]
+    #[facet(rename_all = "snake_case")]
+    #[repr(u8)]
+    enum SnakeCaseWithData {
+        SimpleValue(u32),
+        ComplexMessage(String),
+        EmptyCase,
+    }
+
+    test_roundtrip!(
+        enum_snake_case_newtype_first,
+        SnakeCaseWithData,
+        SnakeCaseWithData::SimpleValue(42)
+    );
+    test_roundtrip!(
+        enum_snake_case_newtype_second,
+        SnakeCaseWithData,
+        SnakeCaseWithData::ComplexMessage("hello".to_string())
+    );
+    test_roundtrip!(
+        enum_snake_case_unit,
+        SnakeCaseWithData,
+        SnakeCaseWithData::EmptyCase
+    );
+
+    // Test enum with rename_all and struct variants
+    #[derive(Debug, PartialEq, Facet)]
+    #[facet(rename_all = "snake_case")]
+    #[repr(u8)]
+    enum SnakeCaseStructVariants {
+        PointValue { x: i32, y: i32 },
+        NamedPerson { name: String, age: u32 },
+    }
+
+    test_roundtrip!(
+        enum_snake_case_struct_point,
+        SnakeCaseStructVariants,
+        SnakeCaseStructVariants::PointValue { x: 10, y: -20 }
+    );
+    test_roundtrip!(
+        enum_snake_case_struct_person,
+        SnakeCaseStructVariants,
+        SnakeCaseStructVariants::NamedPerson {
+            name: "Alice".to_string(),
+            age: 30
+        }
+    );
+
+    // Test enum with rename_all and tuple variants
+    #[derive(Debug, PartialEq, Facet)]
+    #[facet(rename_all = "snake_case")]
+    #[repr(u8)]
+    enum SnakeCaseTupleVariants {
+        TwoNumbers(u32, u32),
+        ThreeStrings(String, String, String),
+    }
+
+    test_roundtrip!(
+        enum_snake_case_tuple_two,
+        SnakeCaseTupleVariants,
+        SnakeCaseTupleVariants::TwoNumbers(1, 2)
+    );
+    test_roundtrip!(
+        enum_snake_case_tuple_three,
+        SnakeCaseTupleVariants,
+        SnakeCaseTupleVariants::ThreeStrings("a".to_string(), "b".to_string(), "c".to_string())
+    );
+}


### PR DESCRIPTION
## Summary

Fixes enum deserialization in `facet-format` to properly handle `#[facet(rename)]` and `#[facet(rename_all)]` attributes by using `effective_name()` instead of `name` when building `EnumVariantHint`. This is a continuation of the work started in commit 414cd009.

## Changes

- Update `facet-format/src/deserializer/dynamic.rs` to use `v.effective_name()` instead of `v.name`
- Update `facet-format/src/deserializer/eenum.rs` to use `v.effective_name()` instead of `v.name`
- Add comprehensive roundtrip tests in `facet-postcard/tests/roundtrip.rs` covering:
  - `rename_all = "snake_case"` enums
  - `rename_all = "camelCase"` enums
  - Individual `#[facet(rename = "...")]` on variants
  - Enums with newtype, tuple, and struct variants

## Testing

All new tests pass with `cargo nextest run -p facet-postcard`. The tests verify that renamed enum variants correctly roundtrip through postcard serialization.