### PR TITLE
feat: add more shorthand aliases to 𝟋 module (Ok, Err, transmute, forget, drop_in_place)

### DIFF
--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -104,6 +104,13 @@ pub mod 𝟋 {
     pub use crate::VariantBuilder as 𝟋VarB;
     pub use ::core::option::Option::None as 𝟋None;
     pub use ::core::option::Option::Some as 𝟋Some;
+    pub use ::core::result::Result::Err as 𝟋Err;
+    pub use ::core::result::Result::Ok as 𝟋Ok;
+
+    // === Core utility re-exports ===
+    pub use ::core::mem::forget as 𝟋forget;
+    pub use ::core::mem::transmute as 𝟋transmute;
+    pub use ::core::ptr::drop_in_place as 𝟋drop_in_place;
 
     /// Helper to get shape of a type as a function - monomorphized per type
     pub use crate::shape_of as 𝟋shp;

--- a/facet-macros-impl/src/process_enum.rs
+++ b/facet-macros-impl/src/process_enum.rs
@@ -356,8 +356,8 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                     ) -> ::core::result::Result<#facet_crate::PtrMut, __alloc::string::String> {
                         let proxy: #proxy_type = proxy_ptr.read();
                         match <#enum_type #bgp_display as ::core::convert::TryFrom<#proxy_type>>::try_from(proxy) {
-                            ::core::result::Result::Ok(value) => ::core::result::Result::Ok(field_ptr.put(value)),
-                            ::core::result::Result::Err(e) => ::core::result::Result::Err(__alloc::string::ToString::to_string(&e)),
+                            𝟋Ok(value) => 𝟋Ok(field_ptr.put(value)),
+                            𝟋Err(e) => 𝟋Err(__alloc::string::ToString::to_string(&e)),
                         }
                     }
 
@@ -367,8 +367,8 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                     ) -> ::core::result::Result<#facet_crate::PtrMut, __alloc::string::String> {
                         let field_ref: &#enum_type #bgp_display = field_ptr.get();
                         match <#proxy_type as ::core::convert::TryFrom<&#enum_type #bgp_display>>::try_from(field_ref) {
-                            ::core::result::Result::Ok(proxy) => ::core::result::Result::Ok(proxy_ptr.put(proxy)),
-                            ::core::result::Result::Err(e) => ::core::result::Result::Err(__alloc::string::ToString::to_string(&e)),
+                            𝟋Ok(proxy) => 𝟋Ok(proxy_ptr.put(proxy)),
+                            𝟋Err(e) => 𝟋Err(__alloc::string::ToString::to_string(&e)),
                         }
                     }
 

--- a/facet-macros-impl/src/process_struct.rs
+++ b/facet-macros-impl/src/process_struct.rs
@@ -253,7 +253,7 @@ fn gen_vtable_direct(
                             // (caller can downgrade to PtrConst if needed)
                             let wrapper_ptr = src as *mut #struct_type;
                             let inner_ptr: *mut _ = unsafe { &raw mut (*wrapper_ptr).0 };
-                            ::core::result::Result::Ok(#facet_crate::PtrMut::new(inner_ptr as *mut u8))
+                            𝟋Ok(#facet_crate::PtrMut::new(inner_ptr as *mut u8))
                         }
                         __try_borrow_inner
                     })
@@ -497,8 +497,8 @@ fn gen_vtable_indirect(
                     if impls!(#struct_type: ::core::str::FromStr) {
                         𝟋Some(
                             match (&&SpezEmpty::<#struct_type>::SPEZ).spez_parse(s, target.ptr().as_uninit()) {
-                                ::core::result::Result::Ok(_) => ::core::result::Result::Ok(()),
-                                ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
+                                𝟋Ok(_) => 𝟋Ok(()),
+                                𝟋Err(e) => 𝟋Err(e),
                             }
                         )
                     } else {
@@ -596,7 +596,7 @@ fn gen_type_ops_direct(
     let default_field = if has_default {
         quote! {
             default_in_place: 𝟋Some(
-                unsafe { ::core::mem::transmute(#facet_crate::𝟋::𝟋default_for::<Self>() as unsafe fn(*mut Self)) }
+                unsafe { 𝟋transmute(#facet_crate::𝟋::𝟋default_for::<Self>() as unsafe fn(*mut Self)) }
             ),
         }
     } else if sources.should_auto() {
@@ -626,7 +626,7 @@ fn gen_type_ops_direct(
     let clone_field = if has_clone {
         quote! {
             clone_into: 𝟋Some(
-                unsafe { ::core::mem::transmute(#facet_crate::𝟋::𝟋clone_for::<Self>() as unsafe fn(*const Self, *mut Self)) }
+                unsafe { 𝟋transmute(#facet_crate::𝟋::𝟋clone_for::<Self>() as unsafe fn(*const Self, *mut Self)) }
             ),
         }
     } else if sources.should_auto() {
@@ -671,7 +671,7 @@ fn gen_type_ops_direct(
     Some(quote! {
         #facet_crate::TypeOps::Direct(&const {
             #facet_crate::TypeOpsDirect {
-                drop_in_place: unsafe { ::core::mem::transmute(::core::ptr::drop_in_place::<Self> as unsafe fn(*mut Self)) },
+                drop_in_place: unsafe { 𝟋transmute(𝟋drop_in_place::<Self> as unsafe fn(*mut Self)) },
                 #default_field
                 #clone_field
                 #truthy_field
@@ -967,8 +967,8 @@ pub(crate) fn gen_field_from_pfield(
                             ) -> ::core::result::Result<#facet_crate::PtrMut, __alloc::string::String> {
                                 let proxy: #proxy_type = proxy_ptr.read();
                                 match <#field_type as ::core::convert::TryFrom<#proxy_type>>::try_from(proxy) {
-                                    ::core::result::Result::Ok(value) => ::core::result::Result::Ok(field_ptr.put(value)),
-                                    ::core::result::Result::Err(e) => ::core::result::Result::Err(__alloc::string::ToString::to_string(&e)),
+                                    𝟋Ok(value) => 𝟋Ok(field_ptr.put(value)),
+                                    𝟋Err(e) => 𝟋Err(__alloc::string::ToString::to_string(&e)),
                                 }
                             }
 
@@ -978,8 +978,8 @@ pub(crate) fn gen_field_from_pfield(
                             ) -> ::core::result::Result<#facet_crate::PtrMut, __alloc::string::String> {
                                 let field_ref: &#field_type = field_ptr.get();
                                 match <#proxy_type as ::core::convert::TryFrom<&#field_type>>::try_from(field_ref) {
-                                    ::core::result::Result::Ok(proxy) => ::core::result::Result::Ok(proxy_ptr.put(proxy)),
-                                    ::core::result::Result::Err(e) => ::core::result::Result::Err(__alloc::string::ToString::to_string(&e)),
+                                    𝟋Ok(proxy) => 𝟋Ok(proxy_ptr.put(proxy)),
+                                    𝟋Err(e) => 𝟋Err(__alloc::string::ToString::to_string(&e)),
                                 }
                             }
 
@@ -1191,12 +1191,12 @@ pub(crate) fn gen_field_from_pfield(
                         match unsafe { __dst_shape.call_try_from(__src_shape, __src_ptr, __dst_ptr) } {
                             Some(#facet_crate::TryFromOutcome::Converted) => {
                                 // Don't run destructor on source value since we consumed it
-                                ::core::mem::forget(__src_value);
+                                𝟋forget(__src_value);
                                 unsafe { __ptr.assume_init() }
                             },
                             Some(#facet_crate::TryFromOutcome::Failed(e)) => {
                                 // Source was consumed, forget it
-                                ::core::mem::forget(__src_value);
+                                𝟋forget(__src_value);
                                 panic!("default value conversion failed: {}", e)
                             },
                             Some(#facet_crate::TryFromOutcome::Unsupported) => {
@@ -1599,7 +1599,7 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
                     // (caller can downgrade to PtrConst if needed)
                     let wrapper_ptr = src as *mut Self;
                     let inner_ptr: *mut _ = unsafe { &raw mut (*wrapper_ptr).0 };
-                    ::core::result::Result::Ok(#facet_crate::PtrMut::new(inner_ptr as *mut u8))
+                    #facet_crate::𝟋::𝟋Ok(#facet_crate::PtrMut::new(inner_ptr as *mut u8))
                 }
             }
         }
@@ -1772,8 +1772,8 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
                         extern crate alloc as __alloc;
                         let proxy: #proxy_type = proxy_ptr.read();
                         match <#struct_type #bgp_display as ::core::convert::TryFrom<#proxy_type>>::try_from(proxy) {
-                            ::core::result::Result::Ok(value) => ::core::result::Result::Ok(field_ptr.put(value)),
-                            ::core::result::Result::Err(e) => ::core::result::Result::Err(__alloc::string::ToString::to_string(&e)),
+                            #facet_crate::𝟋::𝟋Ok(value) => #facet_crate::𝟋::𝟋Ok(field_ptr.put(value)),
+                            #facet_crate::𝟋::𝟋Err(e) => #facet_crate::𝟋::𝟋Err(__alloc::string::ToString::to_string(&e)),
                         }
                     }
 
@@ -1785,8 +1785,8 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
                         extern crate alloc as __alloc;
                         let field_ref: &#struct_type #bgp_display = field_ptr.get();
                         match <#proxy_type as ::core::convert::TryFrom<&#struct_type #bgp_display>>::try_from(field_ref) {
-                            ::core::result::Result::Ok(proxy) => ::core::result::Result::Ok(proxy_ptr.put(proxy)),
-                            ::core::result::Result::Err(e) => ::core::result::Result::Err(__alloc::string::ToString::to_string(&e)),
+                            #facet_crate::𝟋::𝟋Ok(proxy) => #facet_crate::𝟋::𝟋Ok(proxy_ptr.put(proxy)),
+                            #facet_crate::𝟋::𝟋Err(e) => #facet_crate::𝟋::𝟋Err(__alloc::string::ToString::to_string(&e)),
                         }
                     }
 


### PR DESCRIPTION
## Follow-up to #1785

Add more shorthand aliases to the `𝟋` module for commonly used core items.

## New Aliases

| Full path | Alias |
|-----------|-------|
| `::core::result::Result::Ok` | `𝟋Ok` |
| `::core::result::Result::Err` | `𝟋Err` |
| `::core::mem::transmute` | `𝟋transmute` |
| `::core::mem::forget` | `𝟋forget` |
| `::core::ptr::drop_in_place` | `𝟋drop_in_place` |

## Changes

- Added aliases in `facet-core/src/lib.rs`
- Updated usages in `facet-macros-impl/src/process_struct.rs`
- Updated usages in `facet-macros-impl/src/process_enum.rs`

## Note

Code in standalone impl blocks (like `proxy_inherent_impl` and `transparent_inherent_impl`) uses fully qualified paths like `#facet_crate::𝟋::𝟋Ok` since they're outside the SHAPE const block where `use #facet_crate::𝟋::*` is in scope.

## Not included

`::core::default::Default::default` was not added because re-exporting trait associated items is unstable (rust-lang/rust#134691).

Closes #1786