### PR TITLE
fix: support flatten in internally-tagged enum variants

### DIFF
--- a/facet-json/tests/issue_1775.rs
+++ b/facet-json/tests/issue_1775.rs
@@ -1,0 +1,76 @@
+use facet::Facet;
+use facet_json::{from_str as from_json, to_string as to_json};
+
+#[derive(Facet, Debug, Clone, PartialEq, Eq)]
+pub struct Base {
+    pub name: String,
+    pub value: i32,
+}
+
+#[derive(Facet, Debug, Clone, PartialEq, Eq)]
+#[facet(tag = "type")]
+#[repr(C)]
+pub enum Wrapper {
+    #[facet(rename = "foo")]
+    Foo {
+        #[facet(flatten)]
+        base: Base,
+        extra: String,
+    },
+    #[facet(rename = "bar")]
+    Bar {
+        #[facet(flatten)]
+        base: Base,
+    },
+}
+
+#[test]
+fn test_flatten_in_internally_tagged_enum_foo() {
+    let foo = Wrapper::Foo {
+        base: Base {
+            name: "test".to_string(),
+            value: 42,
+        },
+        extra: "extra".to_string(),
+    };
+
+    let json = to_json(&foo).expect("Failed to serialize JSON");
+    eprintln!("Serialized JSON: {}", json);
+
+    let deserialized: Wrapper = from_json(&json).expect("Failed to deserialize JSON");
+    assert_eq!(foo, deserialized);
+}
+
+#[test]
+fn test_flatten_in_internally_tagged_enum_bar() {
+    let bar = Wrapper::Bar {
+        base: Base {
+            name: "bar_test".to_string(),
+            value: 123,
+        },
+    };
+
+    let json = to_json(&bar).expect("Failed to serialize JSON");
+    eprintln!("Serialized JSON: {}", json);
+
+    let deserialized: Wrapper = from_json(&json).expect("Failed to deserialize JSON");
+    assert_eq!(bar, deserialized);
+}
+
+#[test]
+fn test_flatten_roundtrip_from_manual_json() {
+    // Test deserializing from manually constructed JSON
+    let json = r#"{"type":"foo","name":"manual","value":99,"extra":"test"}"#;
+    let deserialized: Wrapper = from_json(json).expect("Failed to deserialize JSON");
+
+    assert_eq!(
+        deserialized,
+        Wrapper::Foo {
+            base: Base {
+                name: "manual".to_string(),
+                value: 99,
+            },
+            extra: "test".to_string(),
+        }
+    );
+}

--- a/facet-yaml/tests/issue_1775.rs
+++ b/facet-yaml/tests/issue_1775.rs
@@ -1,0 +1,42 @@
+use facet::Facet;
+use facet_yaml::{from_str as from_yaml, to_string as to_yaml};
+
+#[derive(Facet, Debug, Clone, PartialEq, Eq)]
+pub struct Base {
+    pub name: String,
+    pub value: i32,
+}
+
+#[derive(Facet, Debug, Clone, PartialEq, Eq)]
+#[facet(tag = "type")]
+#[repr(C)]
+pub enum Wrapper {
+    #[facet(rename = "foo")]
+    Foo {
+        #[facet(flatten)]
+        base: Base,
+        extra: String,
+    },
+    #[facet(rename = "bar")]
+    Bar {
+        #[facet(flatten)]
+        base: Base,
+    },
+}
+
+#[test]
+fn test_flatten_in_internally_tagged_enum_yaml() {
+    let foo = Wrapper::Foo {
+        base: Base {
+            name: "test".to_string(),
+            value: 42,
+        },
+        extra: "extra".to_string(),
+    };
+
+    let yaml = to_yaml(&foo).expect("Failed to serialize YAML");
+    eprintln!("Serialized YAML:\n{}", yaml);
+
+    let deserialized: Wrapper = from_yaml(&yaml).expect("Failed to deserialize YAML");
+    assert_eq!(foo, deserialized);
+}


### PR DESCRIPTION
## Summary

When deserializing internally-tagged enums with flattened fields in variants, the deserializer now correctly maps serialized keys through the flattened struct.

For example, given:
```rust
#[derive(Facet)]
#[facet(tag = "type")]
pub enum Wrapper {
    Foo {
        #[facet(flatten)]
        base: Base,  // Base has fields: name, value
        extra: String,
    },
}
```

Previously, JSON like `{"type":"foo","name":"test","value":42,"extra":"extra"}` would fail to deserialize because keys `"name"` and `"value"` were skipped as unknown fields - the deserializer only looked at direct variant fields (`base`, `extra`).

Now it recursively searches through flattened fields to find the correct path (`["base", "name"]` for the `"name"` key).

## Changes

- Added `find_field_path()` helper that recursively searches through flattened fields
- Modified `deserialize_enum_internally_tagged()` to use path-based field lookup when variants have flattened fields
- Added tests for both JSON and YAML

## Test plan

- [x] Added `facet-json/tests/issue_1775.rs` with roundtrip tests
- [x] Added `facet-yaml/tests/issue_1775.rs` with roundtrip test
- [x] All 254 facet-json tests pass
- [x] All 180 facet-yaml tests pass

Fixes #1775