### PR TITLE
feat(facet-postcard): specialize Vec<u8> deserialization

### DIFF
--- a/facet-format/src/parser.rs
+++ b/facet-format/src/parser.rs
@@ -107,6 +107,23 @@ pub trait FormatParser<'de> {
         // Default: ignore (self-describing formats don't need this)
     }
 
+    /// Hint to the parser that a byte sequence (`Vec<u8>`, `&[u8]`, etc.) is expected.
+    ///
+    /// For binary formats like postcard that store `Vec<u8>` as raw bytes (varint length
+    /// followed by raw data), this allows bulk reading instead of element-by-element
+    /// deserialization.
+    ///
+    /// If the parser handles this hint, it should emit `Scalar(Bytes(...))` directly.
+    /// If it doesn't support this optimization, it should return `false` and the
+    /// deserializer will fall back to element-by-element deserialization via `hint_sequence`.
+    ///
+    /// Returns `true` if the hint is handled (parser will emit `Scalar(Bytes(...))`),
+    /// `false` otherwise.
+    fn hint_byte_sequence(&mut self) -> bool {
+        // Default: not supported, fall back to element-by-element
+        false
+    }
+
     /// Hint to the parser that a fixed-size array is expected.
     ///
     /// For non-self-describing formats, this tells the parser the array length


### PR DESCRIPTION
## Summary

Implements Vec<u8> specialization for postcard deserialization to fix the severe performance issue reported in #1798. Instead of deserializing each byte individually through the reflection path, this now reads bytes in bulk (varint length + raw bytes).

Fixes #1798

## Changes

- Add `hint_byte_sequence()` method to the `Parser` trait that parsers can implement to signal they support bulk byte reading
- In the deserializer, detect `Vec<u8>` (by checking if list element type is `u8`) and call `hint_byte_sequence()` to opt into the optimization
- For postcard parser: implement `hint_byte_sequence()` to set a pending flag, then emit `Scalar(Bytes(...))` with the bulk-read data
- Fallback to element-by-element deserialization if parser doesn't support the hint

## Test plan

- [ ] Run existing facet-postcard tests to ensure no regressions
- [ ] Test with real-world byte-heavy payloads to verify performance improvement