### PR TITLE
fix: preserve extension attributes when derive plugins are present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,7 +1582,9 @@ name = "facet"
 version = "0.42.0"
 dependencies = [
  "autocfg",
+ "facet-args",
  "facet-core",
+ "facet-default",
  "facet-macros",
  "facet-reflect",
  "facet-showcase",

--- a/facet-macros-impl/src/plugin.rs
+++ b/facet-macros-impl/src/plugin.rs
@@ -330,7 +330,11 @@ fn strip_plugin_items_from_content(content: TokenStream) -> TokenStream {
 ///
 /// Returns true for:
 /// - `derive(...)` - plugin registration
-/// - `namespace::key` patterns (e.g., error::from, error::source)
+///
+/// NOTE: We intentionally do NOT strip `namespace::key` patterns here.
+/// Extension attributes like `args::positional`, `dibs::table`, `error::from`
+/// must be preserved so they can be processed by the Facet derive and stored
+/// in the Shape's attributes field.
 fn is_plugin_item(item: &TokenStream) -> bool {
     let mut iter = item.clone().into_iter();
 
@@ -339,15 +343,6 @@ fn is_plugin_item(item: &TokenStream) -> bool {
 
         // Check for derive(...)
         if name == "derive" {
-            return true;
-        }
-
-        // Check for namespace::key pattern
-        if let Some(proc_macro2::TokenTree::Punct(p1)) = iter.next()
-            && p1.as_char() == ':'
-            && let Some(proc_macro2::TokenTree::Punct(p2)) = iter.next()
-            && p2.as_char() == ':'
-        {
             return true;
         }
     }

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -133,6 +133,8 @@ facet-reflect = { path = "../facet-reflect", version = "0.42.0", optional = true
 static_assertions = { workspace = true, optional = true }
 
 [dev-dependencies]
+facet-args = { path = "../facet-args" }
+facet-default = { path = "../facet-default" }
 facet-reflect = { path = "../facet-reflect" }
 facet-showcase = { path = "../facet-showcase" }
 facet-testhelpers = { path = "../facet-testhelpers" }

--- a/facet/tests/derive_with_extension_attrs.rs
+++ b/facet/tests/derive_with_extension_attrs.rs
@@ -1,0 +1,50 @@
+//! Test that container-level extension attributes work alongside derive plugins.
+//!
+//! Bug repro: when #[facet(derive(X))] is present, container-level extension
+//! attributes from other #[facet(...)] annotations are being dropped.
+
+use facet::Facet;
+use facet_args as args;
+use facet_default as _;
+
+// WITHOUT derive: extension attribute IS captured
+#[derive(Facet)]
+#[facet(args::positional)]
+struct WithoutDerive {
+    x: i32,
+}
+
+// WITH derive: extension attribute is DROPPED (BUG)
+#[derive(Facet)]
+#[facet(derive(Default))]
+#[facet(args::positional)]
+struct WithDerive {
+    x: i32,
+}
+
+#[test]
+fn test_extension_attr_without_derive() {
+    let shape = WithoutDerive::SHAPE;
+    let attr = shape
+        .attributes
+        .iter()
+        .find(|a| a.ns == Some("args") && a.key == "positional");
+    assert!(
+        attr.is_some(),
+        "Extension attribute should be present without derive"
+    );
+}
+
+#[test]
+fn test_extension_attr_with_derive() {
+    let shape = WithDerive::SHAPE;
+    let attr = shape
+        .attributes
+        .iter()
+        .find(|a| a.ns == Some("args") && a.key == "positional");
+    // BUG: This currently fails because the attribute is dropped when derive is present
+    assert!(
+        attr.is_some(),
+        "Extension attribute should be present WITH derive (currently broken)"
+    );
+}


### PR DESCRIPTION
## Problem

When `#[facet(derive(X))]` was combined with namespaced extension attributes like `#[facet(args::positional)]` or `#[facet(dibs::table = "users")]`, the extension attributes were incorrectly being stripped before processing.

For example:
```rust
#[derive(Facet)]
#[facet(derive(Default))]
#[facet(args::positional)]  // This attribute was being dropped!
struct MyStruct {
    x: i32,
}
```

The `args::positional` attribute would not appear in `MyStruct::SHAPE.attributes`.

## Root Cause

The `is_plugin_item()` function in `facet-macros-impl/src/plugin.rs` was treating ALL `namespace::key` patterns as plugin items to be stripped. But these are legitimate extension attributes that should be preserved and stored in the Shape's attributes field.

## Fix

Changed `is_plugin_item()` to only strip `derive(...)` items, leaving extension attributes intact for the Facet derive to process.

## Testing

Added a regression test `facet/tests/derive_with_extension_attrs.rs` that verifies extension attributes are preserved both with and without derive plugins present.

All existing tests pass.