### PR TITLE
fix: disable default features on rust_decimal to avoid serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ tracing-subscriber = { version = "^0.3.22", default-features = false, features =
 ulid = "^1.2.1"
 unsynn = "^0.3.0"
 uuid = "^1.19.0"
-rust_decimal = "^1.38.0"
+rust_decimal = { version = "^1.38.0", default-features = false, features = ["std"] }
 iddqd = { version = "^0.3", default-features = false }
 libtest-mimic = "^0.8.1"
 


### PR DESCRIPTION
## Summary

rust_decimal's default features include serde, which pulls in the entire serde ecosystem even for users who don't need serialization.

This change adds `default-features = false` with explicit `std` feature, matching the pattern used for other workspace dependencies like chrono, bytes, and indexmap.

## Motivation

When using facet with the `rust_decimal` feature enabled, serde gets pulled in transitively even though facet itself doesn't use serde for rust_decimal. This adds unnecessary compile time and binary size for projects that intentionally avoid serde.

## Changes

- Added `default-features = false, features = ["std"]` to the rust_decimal workspace dependency