### PR TITLE
feat(pretty): add Clone impl and make methods const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,6 +2676,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3109,6 +3115,23 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3634,6 +3657,10 @@ name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+dependencies = [
+ "supports-color 2.1.0",
+ "supports-color 3.0.2",
+]
 
 [[package]]
 name = "palette"
@@ -5015,6 +5042,25 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
 
 [[package]]
 name = "syn"

--- a/facet-diff-core/src/display.rs
+++ b/facet-diff-core/src/display.rs
@@ -89,7 +89,7 @@ impl<'mem, 'facet> Display for Diff<'mem, 'facet> {
             }
             Diff::Replace { from, to } => {
                 let printer = PrettyPrinter::default()
-                    .with_colors(false)
+                    .with_colors(facet_pretty::ColorMode::Never)
                     .with_minimal_option_names(true);
 
                 // Check if both values are strings and visually confusable
@@ -124,7 +124,7 @@ impl<'mem, 'facet> Display for Diff<'mem, 'facet> {
                 value,
             } => {
                 let printer = PrettyPrinter::default()
-                    .with_colors(false)
+                    .with_colors(facet_pretty::ColorMode::Never)
                     .with_minimal_option_names(true);
 
                 // Show variant if present (e.g., "Some" for Option::Some)
@@ -284,7 +284,7 @@ impl<'mem, 'facet> Display for Updates<'mem, 'facet> {
 impl<'mem, 'facet> Display for ReplaceGroup<'mem, 'facet> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let printer = PrettyPrinter::default()
-            .with_colors(false)
+            .with_colors(facet_pretty::ColorMode::Never)
             .with_minimal_option_names(true);
 
         // If it's a 1-to-1 replacement, check for equality

--- a/facet-diff/src/diff.rs
+++ b/facet-diff/src/diff.rs
@@ -1107,7 +1107,7 @@ impl<'mem, 'facet> LeafChange<'mem, 'facet> {
         use facet_pretty::PrettyPrinter;
 
         let printer = PrettyPrinter::default()
-            .with_colors(false)
+            .with_colors(facet_pretty::ColorMode::Never)
             .with_minimal_option_names(true);
 
         let mut out = String::new();
@@ -1142,7 +1142,7 @@ impl<'mem, 'facet> LeafChange<'mem, 'facet> {
         use owo_colors::OwoColorize;
 
         let printer = PrettyPrinter::default()
-            .with_colors(false)
+            .with_colors(facet_pretty::ColorMode::Never)
             .with_minimal_option_names(true);
 
         let mut out = String::new();

--- a/facet-diff/tests/diff_snapshots.rs
+++ b/facet-diff/tests/diff_snapshots.rs
@@ -50,7 +50,7 @@ where
     B: facet::Facet<'a>,
 {
     let printer = PrettyPrinter::default()
-        .with_colors(true)
+        .with_colors(facet_pretty::ColorMode::Always)
         .with_minimal_option_names(true);
 
     let before_str = printer.format_peek(Peek::new(before));

--- a/facet-format-suite/src/lib.rs
+++ b/facet-format-suite/src/lib.rs
@@ -838,7 +838,10 @@ pub fn all_cases<S: FormatSuite + 'static>() -> Vec<SuiteCase> {
         #[cfg(feature = "iddqd")]
         SuiteCase::new::<S, IddqdBiHashMapWrapper>(&CASE_IDDQD_BI_HASH_MAP, S::iddqd_bi_hash_map),
         #[cfg(feature = "iddqd")]
-        SuiteCase::new::<S, IddqdTriHashMapWrapper>(&CASE_IDDQD_TRI_HASH_MAP, S::iddqd_tri_hash_map),
+        SuiteCase::new::<S, IddqdTriHashMapWrapper>(
+            &CASE_IDDQD_TRI_HASH_MAP,
+            S::iddqd_tri_hash_map,
+        ),
         // Dynamic value cases
         #[cfg(feature = "facet-value")]
         SuiteCase::new::<S, facet_value::Value>(&CASE_VALUE_NULL, S::value_null),

--- a/facet-pretty/Cargo.toml
+++ b/facet-pretty/Cargo.toml
@@ -26,7 +26,7 @@ camino = ["alloc", "facet-core/camino"]
 [dependencies]
 facet-core = { path = "../facet-core", version = "0.42.0" }
 facet-reflect = { path = "../facet-reflect", version = "0.42.0" }
-owo-colors = "4"
+owo-colors = { version = "4", features = ["supports-colors"] }
 
 [dev-dependencies]
 camino = { workspace = true }

--- a/facet-pretty/src/color.rs
+++ b/facet-pretty/src/color.rs
@@ -32,7 +32,7 @@ impl RGB {
 }
 
 /// A color generator that produces unique colors based on a hash value
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct ColorGenerator {
     base_hue: f32,
     saturation: f32,
@@ -41,18 +41,18 @@ pub struct ColorGenerator {
 
 impl Default for ColorGenerator {
     fn default() -> Self {
-        Self {
-            base_hue: 210.0,
-            saturation: 0.7,
-            lightness: 0.6,
-        }
+        Self::new()
     }
 }
 
 impl ColorGenerator {
     /// Create a new color generator with default settings
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            base_hue: 210.0,
+            saturation: 0.7,
+            lightness: 0.6,
+        }
     }
 
     /// Set the base hue (0-360)
@@ -74,7 +74,7 @@ impl ColorGenerator {
     }
 
     /// Generate an RGB color based on a hash value
-    pub fn generate_color(&self, hash: u64) -> RGB {
+    pub const fn generate_color(&self, hash: u64) -> RGB {
         // Use the hash to generate a hue offset
         let hue_offset = (hash % 360) as f32;
         let hue = (self.base_hue + hue_offset) % 360.0;
@@ -92,7 +92,7 @@ impl ColorGenerator {
     }
 
     /// Convert HSL color values to RGB
-    fn hsl_to_rgb(&self, h: f32, s: f32, l: f32) -> RGB {
+    const fn hsl_to_rgb(&self, h: f32, s: f32, l: f32) -> RGB {
         let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
         let x = c * (1.0 - ((h / 60.0) % 2.0 - 1.0).abs());
         let m = l - c / 2.0;

--- a/facet-pretty/src/display.rs
+++ b/facet-pretty/src/display.rs
@@ -30,7 +30,7 @@ impl<'a, T: Facet<'a>> FacetPretty<'a> for T {
     fn pretty(&'a self) -> PrettyDisplay<'a, Self> {
         PrettyDisplay {
             value: self,
-            printer: PrettyPrinter::default(),
+            printer: PrettyPrinter::new(),
         }
     }
 
@@ -69,7 +69,7 @@ mod tests {
     #[test]
     fn test_pretty_with_custom_printer() {
         let test = TestStruct { field: 42 };
-        let printer = PrettyPrinter::new().with_colors(false);
+        let printer = PrettyPrinter::new().with_colors(false.into());
         let display = test.pretty_with(printer);
 
         let mut output = String::new();

--- a/facet-pretty/tests/pretty_print.rs
+++ b/facet-pretty/tests/pretty_print.rs
@@ -79,7 +79,7 @@ fn test_pretty_print_simple() {
     let custom_printer = PrettyPrinter::new()
         .with_indent_size(4)
         .with_max_depth(3)
-        .with_colors(false);
+        .with_colors(false.into());
 
     let custom_output = custom_printer.format(&person);
 
@@ -138,7 +138,7 @@ fn test_sensitive_fields() {
 
 #[test]
 fn test_tuple() {
-    let printer = PrettyPrinter::new().with_colors(false);
+    let printer = PrettyPrinter::new().with_colors(false.into());
     assert_eq!(
         printer.format(&(1, 2)),
         r#"
@@ -153,41 +153,41 @@ fn test_tuple() {
 
 #[test]
 fn test_str() {
-    let printer = PrettyPrinter::new().with_colors(false);
+    let printer = PrettyPrinter::new().with_colors(false.into());
     assert_snapshot!(printer.format(&"hello"));
 }
 
 #[test]
 fn test_vec_u8() {
-    let printer = PrettyPrinter::new().with_colors(false);
+    let printer = PrettyPrinter::new().with_colors(false.into());
     let bytes = vec![1u8, 2u8, 3u8, 4u8];
     assert_snapshot!(printer.format(&bytes));
 }
 
 #[test]
 fn test_byte_slice() {
-    let printer = PrettyPrinter::new().with_colors(false);
+    let printer = PrettyPrinter::new().with_colors(false.into());
     let bytes = [1, 2, 3, 4];
     assert_snapshot!(printer.format(&bytes[..]));
 }
 
 #[test]
 fn test_vec_u32() {
-    let printer = PrettyPrinter::new().with_colors(false);
+    let printer = PrettyPrinter::new().with_colors(false.into());
     let nums = vec![1u32, 2u32, 3u32, 4u32];
     assert_snapshot!(printer.format(&nums));
 }
 
 #[test]
 fn test_u32_slice() {
-    let printer = PrettyPrinter::new().with_colors(false);
+    let printer = PrettyPrinter::new().with_colors(false.into());
     let nums = [1u32, 2u32, 3u32, 4u32];
     assert_snapshot!(printer.format(&nums[..]));
 }
 
 #[test]
 fn test_map() {
-    let printer = PrettyPrinter::new().with_colors(false);
+    let printer = PrettyPrinter::new().with_colors(false.into());
     let map = BTreeMap::from([("abc", 1), ("def", 2)]);
     assert_snapshot!(printer.format(&map));
 }
@@ -207,6 +207,6 @@ fn test_shared_static_str_not_cycle() {
         a: "same",
         b: "same",
     };
-    let printer = PrettyPrinter::new().with_colors(false);
+    let printer = PrettyPrinter::new().with_colors(false.into());
     assert_snapshot!(printer.format(&val));
 }

--- a/facet-pretty/tests/proxy.rs
+++ b/facet-pretty/tests/proxy.rs
@@ -42,7 +42,9 @@ impl From<&ProxyInt> for IntAsString {
 #[test]
 fn test_proxy_container_pretty_print() {
     let proxy_int = ProxyInt { value: 42 };
-    let output = PrettyPrinter::new().with_colors(false).format(&proxy_int);
+    let output = PrettyPrinter::new()
+        .with_colors(false.into())
+        .format(&proxy_int);
 
     assert_snapshot!(output, @r#""42""#);
 }
@@ -76,7 +78,7 @@ fn test_proxy_field_level_pretty_print() {
         name: "test".to_string(),
         count: 100,
     };
-    let output = PrettyPrinter::new().with_colors(false).format(&data);
+    let output = PrettyPrinter::new().with_colors(false.into()).format(&data);
 
     assert_snapshot!(output, @r#"
     ProxyFieldLevel {


### PR DESCRIPTION
## Summary
- Add `Clone` and `PartialEq` implementations for `PrettyPrinter` and `ColorGenerator` so printers can be reused across multiple formatting operations
- Make more methods `const`: `ColorGenerator::new()`, `generate_color()`, `hsl_to_rgb()`, and `PrettyPrinter::new()`
- Replace `with_colors(bool)` with `with_colors(ColorMode)` enum for more explicit control (Auto/Always/Never)
- Use `LazyLock` for `NO_COLOR` environment variable check (evaluated once per process)

## Test plan
- [x] Existing tests updated and passing
- [x] Verified workspace tests pass (unrelated async flatten test failure is pre-existing)