### PR TITLE
feat(facet-macros): add container-level format-specific proxy attributes

### DIFF
--- a/facet-postcard/README.md
+++ b/facet-postcard/README.md
@@ -10,6 +10,54 @@
 
 Postcard binary format for facet with Tier-0 and Tier-2 JIT deserialization support.
 
+## Wire Compatibility
+
+For **statically-typed structs, enums, and primitives**, facet-postcard produces
+wire-compatible output with the standard `postcard` crate. You can serialize with
+facet-postcard and deserialize with serde's postcard (and vice versa), as long as
+both sides agree on the schema.
+
+## Dynamic Values (`facet_value::Value`)
+
+> **Warning**: `Value` serialization uses a **facet-specific tagged encoding** that
+> is **NOT compatible** with standard postcard.
+
+Since postcard is not a self-describing format, there's no standard way to serialize
+dynamic/any values. facet-postcard solves this by prefixing each `Value` with a type
+tag byte:
+
+| Tag | Type     | Encoding                                    |
+|-----|----------|---------------------------------------------|
+| 0   | Null     | (no payload)                                |
+| 1   | Bool     | 1 byte (0 or 1)                             |
+| 2   | I64      | zigzag varint                               |
+| 3   | U64      | varint                                      |
+| 4   | F64      | 8 bytes little-endian                       |
+| 5   | String   | varint length + UTF-8 bytes                 |
+| 6   | Bytes    | varint length + raw bytes                   |
+| 7   | Array    | varint count + tagged elements recursively  |
+| 8   | Object   | varint count + (string key, tagged value) pairs |
+| 9   | DateTime | string (RFC3339)                            |
+
+**This means:**
+
+- You **cannot** deserialize facet-postcard `Value` bytes using serde's postcard
+- You **cannot** serialize with serde's postcard and deserialize as `Value` with facet-postcard
+- Both sides of an RPC/serialization boundary must use facet-postcard when `Value` is involved
+
+**Example wire format** for `{"name": "Alice", "age": 30}`:
+
+```
+08                      # tag 8 = Object
+02                      # 2 entries
+04 6e 61 6d 65          # key: string "name" (len=4)
+05                      # tag 5 = String
+05 41 6c 69 63 65       # value: string "Alice" (len=5)
+03 61 67 65             # key: string "age" (len=3)
+03                      # tag 3 = U64
+1e                      # value: varint 30
+```
+
 ## LLM contribution policy
 
 ## Sponsors


### PR DESCRIPTION
## Summary
- Add support for format-specific proxy attributes at the container level (e.g., `#[facet(json::proxy = ProxyType)]`)
- Complements field-level format-specific proxy support from PR #1809
- Container-level format proxies take precedence when the format matches, with fallback to format-agnostic `proxy`

This allows types to be serialized/deserialized differently based on the format:

```rust
#[derive(Facet)]
#[facet(json::proxy = JsonProxy)]
#[facet(xml::proxy = XmlProxy)]
#[facet(proxy = DefaultProxy)]
pub struct MyType { ... }
```

Implementation details:
- Update container attribute filtering to exclude namespaced `proxy` attributes from the attributes slice
- Generate inherent impl methods for each format-specific proxy with unique names per format index
- Add `.format_proxies()` call to ShapeBuilder chain in generated code
- Works correctly with generic types by using the same inherent impl pattern as the regular container-level proxy

Related to #1809

## Test plan
- [x] Added tests for container-level format-specific proxy serialization
- [x] Added tests for container-level format-specific proxy deserialization  
- [x] Added tests for roundtrip through JSON with container hex proxy
- [x] Added tests for Shape metadata inspection for container format proxies
- [x] Added tests for fallback from format-specific to format-agnostic container proxy
- [x] Added tests for container with only format-specific proxy (no fallback)
- [x] All 2746 existing tests pass
- [x] Clippy passes with no warnings