### PR TITLE
facet-typescript: Fix generation of tuple structs

### DIFF
--- a/facet-typescript/src/snapshots/facet_typescript__tests__enum_with_tuple_variant.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__enum_with_tuple_variant.snap
@@ -1,0 +1,8 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts
+---
+export type Event =
+  | { Click: { x: number; y: number } }
+  | { Move: [number, number] }
+  | { Resize: { dimensions: [number, number] } };

--- a/facet-typescript/src/snapshots/facet_typescript__tests__struct_with_single_element_tuple.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__struct_with_single_element_tuple.snap
@@ -1,0 +1,7 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts
+---
+export interface Wrapper {
+  value: [string];
+}

--- a/facet-typescript/src/snapshots/facet_typescript__tests__struct_with_tuple_field.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__struct_with_tuple_field.snap
@@ -1,0 +1,7 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts
+---
+export interface Container {
+  coordinates: [number, number];
+}


### PR DESCRIPTION
Previously the code would generate (...) for tuples, now inline the type definition instead to get correct typescript code.