### PR TITLE
fix(deserializer): pass tag metadata through nested metadata containers

### DIFF
--- a/facet-format/src/serializer.rs
+++ b/facet-format/src/serializer.rs
@@ -95,6 +95,18 @@ pub trait FormatSerializer {
     fn begin_struct(&mut self) -> Result<(), Self::Error>;
     /// Emit a field key within a struct.
     fn field_key(&mut self, key: &str) -> Result<(), Self::Error>;
+    /// Emit a rich field key with optional tag and documentation.
+    ///
+    /// This is called when serializing map keys that have been extracted from
+    /// metadata containers (like `ObjectKey` with tag support).
+    ///
+    /// Default implementation ignores tag and doc, just emits the name.
+    /// Formats that support tags (like Styx) should override this.
+    fn emit_field_key(&mut self, key: &crate::FieldKey<'_>) -> Result<(), Self::Error> {
+        // Default: ignore tag and doc, just emit the name (empty string if None)
+        let name = key.name.as_deref().unwrap_or("");
+        self.field_key(name)
+    }
     /// End a map/object/struct.
     fn end_struct(&mut self) -> Result<(), Self::Error>;
 


### PR DESCRIPTION
## Summary

When deserializing map keys into nested metadata containers like `Documented<ObjectKey>`, the tag metadata from `FieldKey` was being lost. For example, parsing `@string @int` as an ObjectKey resulted in `tag=None` instead of `tag=Some("string")`.

The issue was that `deserialize_map_key` was recursing into the value field of metadata containers with `tag=None`, losing the tag information that inner metadata containers need.

## Changes

- Adds `tag` parameter to `deserialize_map_key` 
- Passes tag through when recursing into value fields of metadata containers
- Adds support for `#[facet(metadata = "tag")]` fields in metadata containers
- Adds `FieldKey::tagged()` and `FieldKey::tagged_with_doc()` constructors
- Adds `emit_field_key()` method to FormatSerializer for rich key emission

## Test plan

- [x] All existing tests pass
- [x] Tested with styx schema validation for typed catch-all keys