### PR TITLE
fix(dessert): support enums as attribute values in XML deserialization

### DIFF
--- a/facet-xml/tests/eenum.rs
+++ b/facet-xml/tests/eenum.rs
@@ -4,6 +4,7 @@
 
 use facet::Facet;
 use facet_testhelpers::test;
+use facet_xml as xml;
 
 // ============================================================================
 // Basic enum variants
@@ -127,4 +128,78 @@ fn vec_of_enum_variants() {
             height: 20.0
         }
     );
+}
+
+// ============================================================================
+// Enum as attribute value (issue #1830)
+// ============================================================================
+
+#[test]
+fn enum_as_attribute_value() {
+    // Reproduces issue #1830: parsing enums as XML attribute values
+    // was allocating wrong shape (String instead of the enum type)
+
+    #[derive(Debug, Clone, Copy, PartialEq, Facet)]
+    #[repr(C)]
+    enum Name {
+        #[facet(rename = "voltage")]
+        Voltage,
+        #[facet(rename = "value")]
+        Value,
+        #[facet(rename = "adValue")]
+        AdValue,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Facet)]
+    #[facet(rename = "Property")]
+    struct XmlScaleRangeProperty {
+        #[facet(xml::attribute)]
+        value: f32,
+        #[facet(xml::attribute)]
+        name: Name,
+    }
+
+    let property: XmlScaleRangeProperty =
+        facet_xml::from_str(r#"<Property value="5" name="voltage" />"#).unwrap();
+    assert_eq!(property.value, 5.0);
+    assert!(matches!(property.name, Name::Voltage));
+
+    let property2: XmlScaleRangeProperty =
+        facet_xml::from_str(r#"<Property value="10" name="adValue" />"#).unwrap();
+    assert_eq!(property2.value, 10.0);
+    assert!(matches!(property2.name, Name::AdValue));
+}
+
+#[test]
+fn enum_as_attribute_value_with_option() {
+    // Test that Option<Enum> works as attribute value too
+
+    #[derive(Debug, Clone, Copy, PartialEq, Facet)]
+    #[repr(C)]
+    enum Priority {
+        #[facet(rename = "low")]
+        Low,
+        #[facet(rename = "medium")]
+        Medium,
+        #[facet(rename = "high")]
+        High,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Facet)]
+    #[facet(rename = "Task")]
+    struct Task {
+        #[facet(xml::attribute)]
+        name: String,
+        #[facet(xml::attribute)]
+        priority: Option<Priority>,
+    }
+
+    let task: Task = facet_xml::from_str(r#"<Task name="test" priority="high" />"#).unwrap();
+    assert_eq!(task.name, "test");
+    assert_eq!(task.priority, Some(Priority::High));
+
+    // Without the optional attribute
+    let task2: Task = facet_xml::from_str(r#"<Task name="test2" />"#).unwrap();
+    assert_eq!(task2.name, "test2");
+    assert_eq!(task2.priority, None);
 }


### PR DESCRIPTION
## Summary

Adds enum handling to `set_string_value` in facet-dessert, enabling enums to be deserialized from string attribute values. This fixes XML parsing where enum fields marked with `#[facet(xml::attribute)]` were incorrectly allocating the wrong shape (String instead of the enum type).

## Changes

- Added enum variant selection in `set_string_value()`:
  - Tries numeric discriminant parsing first for `repr(N)` enums
  - Falls back to name-based variant lookup using `effective_name()` (respects `#[facet(rename = "...")]`)
  - Returns a clear error if no matching variant is found
- Added regression tests for enum attribute values in `facet-xml/tests/eenum.rs`
- Tests cover both direct enums and `Option<Enum>` as attribute values

## Test plan

- [x] Added test `enum_as_attribute_value` - verifies basic enum parsing from XML attributes
- [x] Added test `enum_as_attribute_value_with_option` - verifies `Option<Enum>` works correctly
- [x] All existing tests pass

Fixes #1830