### PR TITLE
Make proxy structs work in self-describing formats

### DIFF
--- a/facet-asn1/src/serializer.rs
+++ b/facet-asn1/src/serializer.rs
@@ -270,6 +270,10 @@ impl FormatSerializer for Asn1Serializer {
         Ok(())
     }
 
+    fn is_self_describing(&self) -> bool {
+        false
+    }
+
     fn scalar(&mut self, scalar: ScalarValue<'_>) -> Result<(), Self::Error> {
         match scalar {
             ScalarValue::Null | ScalarValue::Unit => self.write_null(),

--- a/facet-format/src/serializer.rs
+++ b/facet-format/src/serializer.rs
@@ -206,6 +206,17 @@ pub trait FormatSerializer {
         EnumVariantEncoding::Tagged
     }
 
+    /// Whether this format is self-describing (includes type information).
+    ///
+    /// Self-describing formats (JSON, YAML, TOML) can deserialize without hints
+    /// and treat newtypes transparently. Non-self-describing formats (ASN.1,
+    /// postcard, msgpack) require structural hints and wrap newtypes.
+    ///
+    /// Default is `true` for text-based formats.
+    fn is_self_describing(&self) -> bool {
+        true
+    }
+
     /// Preferred dynamic value encoding for this format.
     fn dynamic_value_encoding(&self) -> DynamicValueEncoding {
         DynamicValueEncoding::SelfDescribing
@@ -768,22 +779,41 @@ where
         let field_mode = serializer.struct_field_mode();
 
         if kind == StructKind::Tuple || kind == StructKind::TupleStruct {
-            // Serialize tuples as arrays without length prefixes.
-            // Tuples are positional, so use binary serialize to avoid skip predicates.
+            // Special case: newtype structs (single-field tuple structs) are serialized
+            // transparently for self-describing formats (Named field mode).
             let fields: alloc::vec::Vec<_> = struct_.fields_for_binary_serialize().collect();
-            serializer.begin_seq().map_err(SerializeError::Backend)?;
-            for (field_item, field_value) in fields {
-                // Check for field-level proxy
+            let is_newtype = kind == StructKind::TupleStruct
+                && fields.len() == 1
+                && serializer.is_self_describing();
+
+            if is_newtype {
+                // Serialize the single field directly without array wrapper
+                let (field_item, field_value) = &fields[0];
                 if let Some(proxy_def) = field_item
                     .field
                     .and_then(|f| f.effective_proxy(serializer.format_namespace()))
                 {
-                    serialize_via_proxy(serializer, field_value, proxy_def)?;
+                    serialize_via_proxy(serializer, *field_value, proxy_def)?;
                 } else {
-                    shared_serialize(serializer, field_value)?;
+                    shared_serialize(serializer, *field_value)?;
                 }
+            } else {
+                // Serialize tuples as arrays without length prefixes.
+                // Tuples are positional, so use binary serialize to avoid skip predicates.
+                serializer.begin_seq().map_err(SerializeError::Backend)?;
+                for (field_item, field_value) in fields {
+                    // Check for field-level proxy
+                    if let Some(proxy_def) = field_item
+                        .field
+                        .and_then(|f| f.effective_proxy(serializer.format_namespace()))
+                    {
+                        serialize_via_proxy(serializer, field_value, proxy_def)?;
+                    } else {
+                        shared_serialize(serializer, field_value)?;
+                    }
+                }
+                serializer.end_seq().map_err(SerializeError::Backend)?;
             }
-            serializer.end_seq().map_err(SerializeError::Backend)?;
         } else {
             // Regular structs as objects
             serializer

--- a/facet-json/tests/issue_1236.rs
+++ b/facet-json/tests/issue_1236.rs
@@ -1,0 +1,147 @@
+//! Test for https://github.com/facet-rs/facet/issues/1236
+//! Newtypes should be transparent in JSON/YAML/TOML but wrapped in binary formats.
+
+use std::{collections::HashMap, sync::Arc};
+
+use facet::Facet;
+
+#[derive(Clone, Debug, Facet)]
+struct Data {
+    #[facet(default, proxy = Proxy)]
+    pub corr: Option<Arc<HashMap<(String, String), f64>>>,
+}
+
+#[derive(Facet)]
+struct Proxy(Vec<(String, String, f64)>);
+
+impl TryFrom<Proxy> for Option<Arc<HashMap<(String, String), f64>>> {
+    type Error = String;
+
+    fn try_from(v: Proxy) -> Result<Self, Self::Error> {
+        let map = HashMap::from_iter(v.0.into_iter().map(|v| ((v.0, v.1), v.2)));
+        Ok(Some(Arc::new(map)))
+    }
+}
+
+impl From<&Option<Arc<HashMap<(String, String), f64>>>> for Proxy {
+    fn from(v: &Option<Arc<HashMap<(String, String), f64>>>) -> Self {
+        match v {
+            None => Proxy(vec![]),
+            Some(a) => {
+                let a: Vec<(String, String, f64)> = a
+                    .iter()
+                    .map(|((a, b), c)| (a.clone(), b.clone(), *c))
+                    .collect();
+                Proxy(a)
+            }
+        }
+    }
+}
+
+#[test]
+fn test_repro_1236() {
+    let json = r#"{"corr":[["a","b",0.95]]}"#;
+    let d: Data = facet_json::from_str(json).unwrap();
+    assert!(d.corr.is_some());
+    let corr = d.corr.as_ref().unwrap();
+    assert_eq!(corr.get(&("a".to_string(), "b".to_string())), Some(&0.95));
+
+    // Verify serialization roundtrip
+    let serialized = facet_json::to_string(&d).unwrap();
+    assert_eq!(serialized, json);
+}
+
+#[derive(Debug, PartialEq, Facet)]
+struct ScalarNewtype(i32);
+
+#[test]
+fn test_newtype_scalar_roundtrip() {
+    // Newtype with scalar should serialize transparently
+    let value = ScalarNewtype(42);
+    let json = facet_json::to_string(&value).unwrap();
+    assert_eq!(json, "42");
+
+    let parsed: ScalarNewtype = facet_json::from_str(&json).unwrap();
+    assert_eq!(parsed, value);
+}
+
+#[derive(Debug, PartialEq, Facet)]
+struct VecNewtype(Vec<i32>);
+
+#[test]
+fn test_newtype_vec_roundtrip() {
+    // Newtype with Vec should serialize transparently (no double wrapping)
+    let value = VecNewtype(vec![1, 2, 3]);
+    let json = facet_json::to_string(&value).unwrap();
+    assert_eq!(json, "[1,2,3]");
+
+    let parsed: VecNewtype = facet_json::from_str(&json).unwrap();
+    assert_eq!(parsed, value);
+}
+
+#[test]
+fn test_newtype_empty_vec_roundtrip() {
+    // Edge case: empty Vec inside newtype
+    let value = VecNewtype(vec![]);
+    let json = facet_json::to_string(&value).unwrap();
+    assert_eq!(json, "[]");
+
+    let parsed: VecNewtype = facet_json::from_str(&json).unwrap();
+    assert_eq!(parsed, value);
+}
+
+#[derive(Debug, PartialEq, Facet)]
+struct InnerNewtype(i32);
+
+#[derive(Debug, PartialEq, Facet)]
+struct OuterNewtype(InnerNewtype);
+
+#[test]
+fn test_nested_newtypes_roundtrip() {
+    // Nested newtypes should both be transparent
+    let value = OuterNewtype(InnerNewtype(42));
+    let json = facet_json::to_string(&value).unwrap();
+    assert_eq!(json, "42");
+
+    let parsed: OuterNewtype = facet_json::from_str(&json).unwrap();
+    assert_eq!(parsed, value);
+}
+
+#[test]
+fn test_plain_tuple_not_transparent() {
+    // Plain tuple (i32,) should serialize as array [42], not as 42
+    let value: (i32,) = (42,);
+    let json = facet_json::to_string(&value).unwrap();
+    assert_eq!(json, "[42]");
+
+    let parsed: (i32,) = facet_json::from_str(&json).unwrap();
+    assert_eq!(parsed, value);
+}
+
+#[derive(Debug, PartialEq, Facet)]
+struct TwoFieldTuple(i32, i32);
+
+#[test]
+fn test_multi_field_tuple_struct_not_transparent() {
+    // Tuple struct with 2+ fields is NOT a newtype, should use array syntax
+    let value = TwoFieldTuple(1, 2);
+    let json = facet_json::to_string(&value).unwrap();
+    assert_eq!(json, "[1,2]");
+
+    let parsed: TwoFieldTuple = facet_json::from_str(&json).unwrap();
+    assert_eq!(parsed, value);
+}
+
+#[derive(Debug, PartialEq, Facet)]
+struct TupleNewtype((i32, i32));
+
+#[test]
+fn test_newtype_containing_tuple_roundtrip() {
+    // Outer newtype is transparent, but inner tuple uses array syntax
+    let value = TupleNewtype((1, 2));
+    let json = facet_json::to_string(&value).unwrap();
+    assert_eq!(json, "[1,2]");
+
+    let parsed: TupleNewtype = facet_json::from_str(&json).unwrap();
+    assert_eq!(parsed, value);
+}


### PR DESCRIPTION
This is to fix issue 1236 where previously facet-json failed to parse a json using a proxy defined as a tuple struct