### PR TITLE
Use OxPtrUninit for vtable functions writing to uninitialized memory

### DIFF
--- a/facet-core/src/impls/alloc/string.rs
+++ b/facet-core/src/impls/alloc/string.rs
@@ -96,14 +96,15 @@ mod tests {
         let Some(ptr) = NonNull::new(ptr) else {
             alloc::alloc::handle_alloc_error(layout)
         };
-        let ptr_mut = crate::PtrMut::new(ptr.as_ptr());
+        let ptr_uninit = crate::PtrUninit::new(ptr.as_ptr());
 
         // Parse the string using the new API
-        let result = unsafe { shape.call_parse("hello world", ptr_mut) };
+        let result = unsafe { shape.call_parse("hello world", ptr_uninit) };
         assert!(result.is_some(), "String should have parse function");
         assert!(result.unwrap().is_ok());
 
         // Get the parsed value
+        let ptr_mut = unsafe { ptr_uninit.assume_init() };
         let parsed = unsafe { ptr_mut.get::<String>() };
         assert_eq!(parsed, &String::from("hello world"));
 

--- a/facet-core/src/types/shape.rs
+++ b/facet-core/src/types/shape.rs
@@ -961,16 +961,16 @@ impl Shape {
     pub unsafe fn call_parse(
         &'static self,
         s: &str,
-        dst: crate::PtrMut,
+        dst: crate::PtrUninit,
     ) -> Option<Result<(), crate::ParseError>> {
         match self.vtable {
             VTableErased::Direct(vt) => {
                 let parse_fn = vt.parse?;
-                Some(unsafe { parse_fn(s, dst.data_ptr() as *mut ()) })
+                Some(unsafe { parse_fn(s, dst.as_mut_byte_ptr() as *mut ()) })
             }
             VTableErased::Indirect(vt) => {
                 let parse_fn = vt.parse?;
-                let ox = crate::OxPtrMut::new(dst, self);
+                let ox = crate::OxPtrUninit::new(dst, self);
                 unsafe { parse_fn(s, ox) }
             }
         }
@@ -986,16 +986,16 @@ impl Shape {
     pub unsafe fn call_parse_bytes(
         &'static self,
         bytes: &[u8],
-        dst: crate::PtrMut,
+        dst: crate::PtrUninit,
     ) -> Option<Result<(), crate::ParseError>> {
         match self.vtable {
             VTableErased::Direct(vt) => {
                 let parse_fn = vt.parse_bytes?;
-                Some(unsafe { parse_fn(bytes, dst.data_ptr() as *mut ()) })
+                Some(unsafe { parse_fn(bytes, dst.as_mut_byte_ptr() as *mut ()) })
             }
             VTableErased::Indirect(vt) => {
                 let parse_fn = vt.parse_bytes?;
-                let ox = crate::OxPtrMut::new(dst, self);
+                let ox = crate::OxPtrUninit::new(dst, self);
                 unsafe { parse_fn(bytes, ox) }
             }
         }
@@ -1011,16 +1011,16 @@ impl Shape {
         &'static self,
         src_shape: &'static Shape,
         src: crate::PtrConst,
-        dst: crate::PtrMut,
+        dst: crate::PtrUninit,
     ) -> Option<crate::TryFromOutcome> {
         match self.vtable {
             VTableErased::Direct(vt) => {
                 let try_from_fn = vt.try_from?;
-                Some(unsafe { try_from_fn(dst.data_ptr() as *mut (), src_shape, src) })
+                Some(unsafe { try_from_fn(dst.as_mut_byte_ptr() as *mut (), src_shape, src) })
             }
             VTableErased::Indirect(vt) => {
                 let try_from_fn = vt.try_from?;
-                let ox_dst = crate::OxPtrMut::new(dst, self);
+                let ox_dst = crate::OxPtrUninit::new(dst, self);
                 Some(unsafe { try_from_fn(ox_dst, src_shape, src) })
             }
         }

--- a/facet-dom/src/raw_markup.rs
+++ b/facet-dom/src/raw_markup.rs
@@ -2,7 +2,7 @@
 
 use std::ops::Deref;
 
-use facet_core::{OxPtrConst, OxPtrMut, ParseError, PtrConst, TryFromOutcome, VTableIndirect};
+use facet_core::{OxPtrConst, OxPtrUninit, ParseError, PtrConst, TryFromOutcome, VTableIndirect};
 
 /// A string containing raw markup captured verbatim from the source.
 ///
@@ -20,28 +20,28 @@ unsafe fn display_raw_markup(
 }
 
 unsafe fn try_from_raw_markup(
-    target: OxPtrMut,
+    target: OxPtrUninit,
     src_shape: &'static facet_core::Shape,
     src: PtrConst,
 ) -> TryFromOutcome {
     // Handle &str
     if src_shape.id == <&str as facet_core::Facet>::SHAPE.id {
         let s: &str = unsafe { src.get::<&str>() };
-        unsafe { *target.as_mut::<RawMarkup>() = RawMarkup(s.to_owned()) };
+        unsafe { target.put(RawMarkup(s.to_owned())) };
         TryFromOutcome::Converted
     }
     // Handle String
     else if src_shape.id == <String as facet_core::Facet>::SHAPE.id {
         let s = unsafe { src.read::<String>() };
-        unsafe { *target.as_mut::<RawMarkup>() = RawMarkup(s) };
+        unsafe { target.put(RawMarkup(s)) };
         TryFromOutcome::Converted
     } else {
         TryFromOutcome::Unsupported
     }
 }
 
-unsafe fn parse_raw_markup(s: &str, target: OxPtrMut) -> Option<Result<(), ParseError>> {
-    unsafe { *target.as_mut::<RawMarkup>() = RawMarkup(s.to_owned()) };
+unsafe fn parse_raw_markup(s: &str, target: OxPtrUninit) -> Option<Result<(), ParseError>> {
+    unsafe { target.put(RawMarkup(s.to_owned())) };
     Some(Ok(()))
 }
 

--- a/facet-format/src/deserializer/scalar_matches.rs
+++ b/facet-format/src/deserializer/scalar_matches.rs
@@ -88,12 +88,12 @@ where
                 {
                     // Attempt to parse - this is a probe, not the actual deserialization
                     let mut temp = [0u8; 128];
-                    let temp_ptr = facet_core::PtrMut::new(temp.as_mut_ptr());
+                    let temp_ptr = facet_core::PtrUninit::new(temp.as_mut_ptr());
                     // SAFETY: temp buffer is properly aligned and sized for this shape
                     if let Some(Ok(())) = unsafe { shape.call_parse(s.as_ref(), temp_ptr) } {
                         // Parse succeeded - drop the temp value
                         // SAFETY: we just successfully parsed into temp_ptr
-                        unsafe { shape.call_drop_in_place(temp_ptr) };
+                        unsafe { shape.call_drop_in_place(temp_ptr.assume_init()) };
                         return true;
                     }
                 }

--- a/facet-macros-impl/src/process_enum.rs
+++ b/facet-macros-impl/src/process_enum.rs
@@ -1127,15 +1127,15 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                         #facet_crate::TryFromOutcome::Converted
                     }
 
-                    /// try_from wrapper for VTableIndirect (OxPtrMut signature)
+                    /// try_from wrapper for VTableIndirect (OxPtrUninit signature)
                     #[doc(hidden)]
                     unsafe fn __facet_try_from_ref_indirect(
-                        dst: #facet_crate::OxPtrMut,
+                        dst: #facet_crate::OxPtrUninit,
                         src_shape: &'static #facet_crate::Shape,
                         src: #facet_crate::PtrConst,
                     ) -> #facet_crate::TryFromOutcome {
                         Self::__facet_try_from_ref(
-                            dst.ptr().as_ptr::<Self>() as *mut Self,
+                            dst.ptr().as_mut_byte_ptr() as *mut Self,
                             src_shape,
                             src,
                         )

--- a/facet-reflect/src/partial/partial_api/set.rs
+++ b/facet-reflect/src/partial/partial_api/set.rs
@@ -381,7 +381,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
         frame.deinit_for_replace();
 
         // Parse the string value using the type's parse function
-        let result = unsafe { shape.call_parse(s, frame.data.assume_init()) };
+        let result = unsafe { shape.call_parse(s, frame.data) };
 
         match result {
             Some(Ok(())) => {
@@ -418,7 +418,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
         frame.deinit_for_replace();
 
         // Parse the bytes using the type's parse_bytes function
-        let result = unsafe { shape.call_parse_bytes(bytes, frame.data.assume_init()) };
+        let result = unsafe { shape.call_parse_bytes(bytes, frame.data) };
 
         match result {
             Some(Ok(())) => {

--- a/facet/tests/derive.rs
+++ b/facet/tests/derive.rs
@@ -1314,7 +1314,7 @@ fn from_ref_infallible() {
     let src_ptr = facet::PtrConst::new(src_str);
 
     let mut uninit = core::mem::MaybeUninit::<BorrowedData<'_>>::uninit();
-    let dst_ptr = facet::PtrMut::new(uninit.as_mut_ptr());
+    let dst_ptr = facet::PtrUninit::from_maybe_uninit(&mut uninit);
 
     let outcome = unsafe { shape.call_try_from(src_shape, src_ptr, dst_ptr) };
     assert!(
@@ -1358,7 +1358,7 @@ fn try_from_ref_fallible() {
     let src_ptr = facet::PtrConst::new(src_str);
 
     let mut uninit = core::mem::MaybeUninit::<AsStr>::uninit();
-    let dst_ptr = facet::PtrMut::new(uninit.as_mut_ptr());
+    let dst_ptr = facet::PtrUninit::from_maybe_uninit(&mut uninit);
 
     let outcome = unsafe { shape.call_try_from(src_shape, src_ptr, dst_ptr) };
     assert!(
@@ -1374,7 +1374,7 @@ fn try_from_ref_fallible() {
     let invalid_ptr = facet::PtrConst::new(invalid_str);
 
     let mut uninit2 = core::mem::MaybeUninit::<AsStr>::uninit();
-    let dst_ptr2 = facet::PtrMut::new(uninit2.as_mut_ptr());
+    let dst_ptr2 = facet::PtrUninit::from_maybe_uninit(&mut uninit2);
 
     let outcome2 = unsafe { shape.call_try_from(src_shape, invalid_ptr, dst_ptr2) };
     assert!(
@@ -1410,7 +1410,7 @@ fn from_ref_wrong_source_type() {
     let wrong_ptr = facet::PtrConst::new(&wrong_value as *const i32);
 
     let mut uninit = core::mem::MaybeUninit::<TextData<'_>>::uninit();
-    let dst_ptr = facet::PtrMut::new(uninit.as_mut_ptr());
+    let dst_ptr = facet::PtrUninit::from_maybe_uninit(&mut uninit);
 
     let outcome = unsafe { shape.call_try_from(wrong_shape, wrong_ptr, dst_ptr) };
     assert!(
@@ -1456,7 +1456,7 @@ fn from_ref_enum() {
     let src_ptr = facet::PtrConst::new(src_str);
 
     let mut uninit = core::mem::MaybeUninit::<Status<'_>>::uninit();
-    let dst_ptr = facet::PtrMut::new(uninit.as_mut_ptr());
+    let dst_ptr = facet::PtrUninit::from_maybe_uninit(&mut uninit);
 
     let outcome = unsafe { shape.call_try_from(src_shape, src_ptr, dst_ptr) };
     assert!(
@@ -1472,7 +1472,7 @@ fn from_ref_enum() {
     let src_ptr2 = facet::PtrConst::new(src_str2);
 
     let mut uninit2 = core::mem::MaybeUninit::<Status<'_>>::uninit();
-    let dst_ptr2 = facet::PtrMut::new(uninit2.as_mut_ptr());
+    let dst_ptr2 = facet::PtrUninit::from_maybe_uninit(&mut uninit2);
 
     let outcome2 = unsafe { shape.call_try_from(src_shape, src_ptr2, dst_ptr2) };
     assert!(


### PR DESCRIPTION
## Summary

Changes the vtable function signatures for `parse`, `parse_bytes`, and `try_from` to use `OxPtrUninit` instead of `OxPtrMut` for their destination parameters. This provides type-level enforcement that implementations must use `dst.put(value)` rather than assignment, which would incorrectly try to drop uninitialized memory.

## Changes

- Updated `ScalarVTable` fields `parse`, `parse_bytes`, and `try_from` to accept `OxPtrUninit` instead of `OxPtrMut`
- Added `OxPtrUninit` import to vtable.rs
- Updated all scalar implementations in `facet-core/src/impls/` (String, chrono types, jiff types, rust_decimal, time, ulid, url, uuid, yoke)
- Updated macro-generated code in `facet-macros-impl` for both structs and enums
- Updated `facet-reflect` partial API set/misc operations
- Updated `facet-dom` raw_markup implementation
- Updated `facet-format` deserializer scalar_matches
- Enhanced documentation to clarify the safety requirements

## Testing

All existing tests continue to pass. The test in `facet-core/src/impls/alloc/string.rs` was updated to use the new `PtrUninit` type and call `assume_init()` after parsing.