### PR TITLE
facet-typescript: Fix untagged enums, tuple structs and proxies

### DIFF
--- a/facet-typescript/src/lib.rs
+++ b/facet-typescript/src/lib.rs
@@ -99,6 +99,129 @@ impl TypeScriptGenerator {
         }
     }
 
+    /// Unwrap through options, pointers, transparent wrappers, and proxies to get the effective shape.
+    ///
+    /// Returns the unwrapped shape along with a flag indicating whether an `Option` was encountered.
+    fn unwrap_to_inner_shape(shape: &'static Shape) -> (&'static Shape, bool) {
+        // Unwrap Option<T> first so we can mark fields as optional.
+        if let Def::Option(opt) = &shape.def {
+            let (inner, _) = Self::unwrap_to_inner_shape(opt.t);
+            return (inner, true);
+        }
+        // Unwrap pointers (Arc, Box, etc.)
+        if let Def::Pointer(ptr) = &shape.def
+            && let Some(pointee) = ptr.pointee
+        {
+            return Self::unwrap_to_inner_shape(pointee);
+        }
+        // Unwrap transparent wrappers
+        if let Some(inner) = shape.inner {
+            let (inner_shape, is_optional) = Self::unwrap_to_inner_shape(inner);
+            return (inner_shape, is_optional);
+        }
+        // Handle proxy types - use the proxy's shape for serialization
+        if let Some(proxy_def) = shape.proxy {
+            return Self::unwrap_to_inner_shape(proxy_def.shape);
+        }
+        (shape, false)
+    }
+
+    /// Format a field for inline object types (e.g., in enum variants).
+    /// Returns a string like `"fieldName: Type"` or `"fieldName?: Type"` for Option fields.
+    fn format_inline_field(&mut self, field: &Field, force_optional: bool) -> String {
+        let field_name = field.effective_name();
+        let field_shape = field.shape.get();
+
+        if let Def::Option(opt) = &field_shape.def {
+            let inner_type = self.type_for_shape(opt.t);
+            format!("{}?: {}", field_name, inner_type)
+        } else if force_optional {
+            let field_type = self.type_for_shape(field_shape);
+            format!("{}?: {}", field_name, field_type)
+        } else {
+            let field_type = self.type_for_shape(field_shape);
+            format!("{}: {}", field_name, field_type)
+        }
+    }
+
+    /// Collect inline field strings for a struct's fields, handling skip and flatten.
+    fn collect_inline_fields(
+        &mut self,
+        fields: &'static [Field],
+        force_optional: bool,
+    ) -> Vec<String> {
+        let mut result = Vec::new();
+        for field in fields {
+            if field.flags.contains(facet_core::FieldFlags::SKIP) {
+                continue;
+            }
+            if field.is_flattened() {
+                let (inner_shape, parent_is_optional) =
+                    Self::unwrap_to_inner_shape(field.shape.get());
+                if let Type::User(UserType::Struct(st)) = &inner_shape.ty {
+                    result.extend(
+                        self.collect_inline_fields(st.fields, force_optional || parent_is_optional),
+                    );
+                    continue;
+                }
+            }
+            result.push(self.format_inline_field(field, force_optional));
+        }
+        result
+    }
+
+    /// Write struct fields to output, handling skip and flatten recursively.
+    fn write_struct_fields(&mut self, fields: &'static [Field], force_optional: bool) {
+        for field in fields {
+            if field.flags.contains(facet_core::FieldFlags::SKIP) {
+                continue;
+            }
+            if field.is_flattened() {
+                let (inner_shape, parent_is_optional) =
+                    Self::unwrap_to_inner_shape(field.shape.get());
+                if let Type::User(UserType::Struct(st)) = &inner_shape.ty {
+                    self.write_struct_fields(st.fields, force_optional || parent_is_optional);
+                    continue;
+                }
+            }
+            self.write_field(field, force_optional);
+        }
+    }
+
+    /// Write a single field to the output.
+    fn write_field(&mut self, field: &Field, force_optional: bool) {
+        // Generate doc comment for field
+        if !field.doc.is_empty() {
+            self.write_indent();
+            self.output.push_str("/**\n");
+            for line in field.doc {
+                self.write_indent();
+                self.output.push_str(" *");
+                self.output.push_str(line);
+                self.output.push('\n');
+            }
+            self.write_indent();
+            self.output.push_str(" */\n");
+        }
+
+        let field_name = field.effective_name();
+        let field_shape = field.shape.get();
+
+        self.write_indent();
+
+        // Use optional marker for Option fields or when explicitly forced (flattened Option parents).
+        if let Def::Option(opt) = &field_shape.def {
+            let inner_type = self.type_for_shape(opt.t);
+            writeln!(self.output, "{}?: {};", field_name, inner_type).unwrap();
+        } else if force_optional {
+            let field_type = self.type_for_shape(field_shape);
+            writeln!(self.output, "{}?: {};", field_name, field_type).unwrap();
+        } else {
+            let field_type = self.type_for_shape(field_shape);
+            writeln!(self.output, "{}: {};", field_name, field_type).unwrap();
+        }
+    }
+
     fn generate_shape(&mut self, shape: &'static Shape) {
         // Handle transparent wrappers - generate the inner type instead
         if let Some(inner) = shape.inner {
@@ -115,7 +238,7 @@ impl TypeScriptGenerator {
             return;
         }
 
-        // Generate doc comment if present
+        // Generate doc comment if present (before proxy handling so proxied types keep their docs)
         if !shape.doc.is_empty() {
             self.output.push_str("/**\n");
             for line in shape.doc {
@@ -124,6 +247,35 @@ impl TypeScriptGenerator {
                 self.output.push('\n');
             }
             self.output.push_str(" */\n");
+        }
+
+        // Handle proxy types - use the proxy's shape for generation
+        // but keep the original type name
+        if let Some(proxy_def) = shape.proxy {
+            let proxy_shape = proxy_def.shape;
+            match &proxy_shape.ty {
+                Type::User(UserType::Struct(st)) => {
+                    self.generate_struct(shape, st.fields, st.kind);
+                    return;
+                }
+                Type::User(UserType::Enum(en)) => {
+                    self.generate_enum(shape, en);
+                    return;
+                }
+                _ => {
+                    // For non-struct/enum proxies (scalars, tuples, collections, etc.),
+                    // generate a type alias to the proxy's type
+                    let proxy_type = self.type_for_shape(proxy_shape);
+                    writeln!(
+                        self.output,
+                        "export type {} = {};",
+                        shape.type_identifier, proxy_type
+                    )
+                    .unwrap();
+                    self.output.push('\n');
+                    return;
+                }
+            }
         }
 
         match &shape.ty {
@@ -186,43 +338,7 @@ impl TypeScriptGenerator {
                 writeln!(self.output, "export interface {} {{", shape.type_identifier).unwrap();
                 self.indent += 1;
 
-                for field in fields {
-                    // Skip fields marked with skip
-                    if field.flags.contains(facet_core::FieldFlags::SKIP) {
-                        continue;
-                    }
-
-                    // Generate doc comment for field
-                    if !field.doc.is_empty() {
-                        self.write_indent();
-                        self.output.push_str("/**\n");
-                        for line in field.doc {
-                            self.write_indent();
-                            self.output.push_str(" *");
-                            self.output.push_str(line);
-                            self.output.push('\n');
-                        }
-                        self.write_indent();
-                        self.output.push_str(" */\n");
-                    }
-
-                    let field_name = field.effective_name();
-                    let is_option = matches!(field.shape.get().def, Def::Option(_));
-
-                    self.write_indent();
-
-                    // Use optional marker for Option fields
-                    if is_option {
-                        // Unwrap the Option to get the inner type
-                        if let Def::Option(opt) = &field.shape.get().def {
-                            let inner_type = self.type_for_shape(opt.t);
-                            writeln!(self.output, "{}?: {};", field_name, inner_type).unwrap();
-                        }
-                    } else {
-                        let field_type = self.type_for_shape(field.shape.get());
-                        writeln!(self.output, "{}: {};", field_name, field_type).unwrap();
-                    }
-                }
+                self.write_struct_fields(fields, false);
 
                 self.indent -= 1;
                 self.output.push_str("}\n");
@@ -238,7 +354,50 @@ impl TypeScriptGenerator {
             .iter()
             .all(|v| matches!(v.data.kind, StructKind::Unit));
 
-        if all_unit {
+        // Check if the enum is untagged
+        let is_untagged = shape.is_untagged();
+
+        if is_untagged {
+            // Untagged enum: simple union of variant types
+            let mut variant_types = Vec::new();
+
+            for variant in enum_type.variants {
+                match variant.data.kind {
+                    StructKind::Unit => {
+                        // Unit variant in untagged enum - this is unusual but we represent as null
+                        variant_types.push("null".to_string());
+                    }
+                    StructKind::TupleStruct if variant.data.fields.len() == 1 => {
+                        // Newtype variant: just the inner type
+                        let inner = self.type_for_shape(variant.data.fields[0].shape.get());
+                        variant_types.push(inner);
+                    }
+                    StructKind::TupleStruct => {
+                        // Multi-element tuple variant: [T1, T2, ...]
+                        let types: Vec<String> = variant
+                            .data
+                            .fields
+                            .iter()
+                            .map(|f| self.type_for_shape(f.shape.get()))
+                            .collect();
+                        variant_types.push(format!("[{}]", types.join(", ")));
+                    }
+                    _ => {
+                        // Struct variant: inline object type
+                        let field_types = self.collect_inline_fields(variant.data.fields, false);
+                        variant_types.push(format!("{{ {} }}", field_types.join("; ")));
+                    }
+                }
+            }
+
+            writeln!(
+                self.output,
+                "export type {} = {};",
+                shape.type_identifier,
+                variant_types.join(" | ")
+            )
+            .unwrap();
+        } else if all_unit {
             // Simple string literal union
             let variants: Vec<String> = enum_type
                 .variants
@@ -269,14 +428,23 @@ impl TypeScriptGenerator {
                         let inner = self.type_for_shape(variant.data.fields[0].shape.get());
                         variant_types.push(format!("{{ {}: {} }}", variant_name, inner));
                     }
+                    StructKind::TupleStruct => {
+                        // Multi-element tuple variant: { VariantName: [T1, T2, ...] }
+                        let types: Vec<String> = variant
+                            .data
+                            .fields
+                            .iter()
+                            .map(|f| self.type_for_shape(f.shape.get()))
+                            .collect();
+                        variant_types.push(format!(
+                            "{{ {}: [{}] }}",
+                            variant_name,
+                            types.join(", ")
+                        ));
+                    }
                     _ => {
                         // Struct variant: { VariantName: { ...fields } }
-                        let mut field_types = Vec::new();
-                        for field in variant.data.fields {
-                            let field_name = field.effective_name();
-                            let field_type = self.type_for_shape(field.shape.get());
-                            field_types.push(format!("{}: {}", field_name, field_type));
-                        }
+                        let field_types = self.collect_inline_fields(variant.data.fields, false);
                         variant_types.push(format!(
                             "{{ {}: {{ {} }} }}",
                             variant_name,
@@ -391,6 +559,7 @@ impl TypeScriptGenerator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::collections::BTreeMap;
     use facet::Facet;
 
     #[test]
@@ -568,6 +737,430 @@ mod tests {
         }
 
         let ts = to_typescript::<Event>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_untagged_enum() {
+        #[derive(Facet)]
+        #[facet(untagged)]
+        #[repr(C)]
+        #[allow(dead_code)]
+        pub enum Value {
+            Text(String),
+            Number(f64),
+        }
+
+        let ts = to_typescript::<Value>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_untagged_enum_unit_and_struct_variants() {
+        #[derive(Facet)]
+        #[facet(untagged)]
+        #[repr(C)]
+        #[allow(dead_code)]
+        pub enum Event {
+            None,
+            Data { x: i32, y: i32 },
+        }
+
+        let ts = to_typescript::<Event>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_enum_with_tuple_struct_variant() {
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        pub struct Point {
+            x: f64,
+            y: f64,
+        }
+
+        #[derive(Facet)]
+        #[repr(u8)]
+        #[allow(dead_code)]
+        pub enum Shape {
+            Line(Point, Point),
+        }
+
+        let ts = to_typescript::<Shape>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_enum_with_proxy_struct() {
+        #[derive(Facet)]
+        #[facet(proxy = PointProxy)]
+        #[allow(dead_code)]
+        pub struct Point {
+            xxx: f64,
+            yyy: f64,
+        }
+
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        pub struct PointProxy {
+            x: f64,
+            y: f64,
+        }
+
+        impl From<PointProxy> for Point {
+            fn from(p: PointProxy) -> Self {
+                Self { xxx: p.x, yyy: p.y }
+            }
+        }
+
+        impl From<&Point> for PointProxy {
+            fn from(p: &Point) -> Self {
+                Self { x: p.xxx, y: p.yyy }
+            }
+        }
+
+        #[derive(Facet)]
+        #[repr(u8)]
+        #[facet(untagged)]
+        #[allow(dead_code)]
+        pub enum Shape {
+            Circle { center: Point, radius: f64 },
+            Line(Point, Point),
+        }
+
+        let ts = to_typescript::<Shape>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_enum_with_proxy_enum() {
+        #[derive(Facet)]
+        #[repr(u8)]
+        #[facet(proxy = StatusProxy)]
+        pub enum Status {
+            Unknown,
+        }
+
+        #[derive(Facet)]
+        #[repr(u8)]
+        pub enum StatusProxy {
+            Active,
+            Inactive,
+        }
+
+        impl From<StatusProxy> for Status {
+            fn from(_: StatusProxy) -> Self {
+                Self::Unknown
+            }
+        }
+
+        impl From<&Status> for StatusProxy {
+            fn from(_: &Status) -> Self {
+                Self::Active
+            }
+        }
+
+        let ts = to_typescript::<Status>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_proxy_to_scalar() {
+        /// A user ID that serializes as a string
+        #[derive(Facet)]
+        #[facet(proxy = String)]
+        #[allow(dead_code)]
+        pub struct UserId(u64);
+
+        impl From<String> for UserId {
+            fn from(s: String) -> Self {
+                Self(s.parse().unwrap_or(0))
+            }
+        }
+
+        impl From<&UserId> for String {
+            fn from(id: &UserId) -> Self {
+                id.0.to_string()
+            }
+        }
+
+        let ts = to_typescript::<UserId>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_proxy_preserves_doc_comments() {
+        /// This is a point in 2D space.
+        /// It has x and y coordinates.
+        #[derive(Facet)]
+        #[facet(proxy = PointProxy)]
+        #[allow(dead_code)]
+        pub struct Point {
+            internal_x: f64,
+            internal_y: f64,
+        }
+
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        pub struct PointProxy {
+            x: f64,
+            y: f64,
+        }
+
+        impl From<PointProxy> for Point {
+            fn from(p: PointProxy) -> Self {
+                Self {
+                    internal_x: p.x,
+                    internal_y: p.y,
+                }
+            }
+        }
+
+        impl From<&Point> for PointProxy {
+            fn from(p: &Point) -> Self {
+                Self {
+                    x: p.internal_x,
+                    y: p.internal_y,
+                }
+            }
+        }
+
+        let ts = to_typescript::<Point>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_untagged_enum_optional_fields() {
+        #[derive(Facet)]
+        #[facet(untagged)]
+        #[repr(C)]
+        #[allow(dead_code)]
+        pub enum Config {
+            Simple {
+                name: String,
+            },
+            Full {
+                name: String,
+                description: Option<String>,
+                count: Option<u32>,
+            },
+        }
+
+        let ts = to_typescript::<Config>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_flatten_variants() {
+        use std::sync::Arc;
+
+        // Inner struct with a skipped field to test skip handling
+        #[derive(Facet)]
+        pub struct Coords {
+            pub x: i32,
+            pub y: i32,
+            #[facet(skip)]
+            pub internal: u8,
+        }
+
+        // Direct flatten
+        #[derive(Facet)]
+        pub struct FlattenDirect {
+            pub name: String,
+            #[facet(flatten)]
+            pub coords: Coords,
+        }
+
+        // Flatten through Arc<T>
+        #[derive(Facet)]
+        pub struct FlattenArc {
+            pub name: String,
+            #[facet(flatten)]
+            pub coords: Arc<Coords>,
+        }
+
+        // Flatten through Box<T>
+        #[derive(Facet)]
+        pub struct FlattenBox {
+            pub name: String,
+            #[facet(flatten)]
+            pub coords: Box<Coords>,
+        }
+
+        // Flatten Option<T> makes inner fields optional
+        #[derive(Facet)]
+        pub struct FlattenOption {
+            pub name: String,
+            #[facet(flatten)]
+            pub coords: Option<Coords>,
+        }
+
+        // Nested Option<Arc<T>> tests multi-layer unwrapping
+        #[derive(Facet)]
+        pub struct FlattenOptionArc {
+            pub name: String,
+            #[facet(flatten)]
+            pub coords: Option<Arc<Coords>>,
+        }
+
+        // Non-struct flatten (BTreeMap) falls through to normal field output
+        #[derive(Facet)]
+        pub struct FlattenMap {
+            pub name: String,
+            #[facet(flatten)]
+            pub extra: BTreeMap<String, String>,
+        }
+
+        let ts_direct = to_typescript::<FlattenDirect>();
+        let ts_arc = to_typescript::<FlattenArc>();
+        let ts_box = to_typescript::<FlattenBox>();
+        let ts_option = to_typescript::<FlattenOption>();
+        let ts_option_arc = to_typescript::<FlattenOptionArc>();
+        let ts_map = to_typescript::<FlattenMap>();
+
+        insta::assert_snapshot!("flatten_direct", ts_direct);
+        insta::assert_snapshot!("flatten_arc", ts_arc);
+        insta::assert_snapshot!("flatten_box", ts_box);
+        insta::assert_snapshot!("flatten_option", ts_option);
+        insta::assert_snapshot!("flatten_option_arc", ts_option_arc);
+        insta::assert_snapshot!("flatten_map", ts_map);
+    }
+
+    #[test]
+    fn test_tagged_enum_optional_fields() {
+        #[derive(Facet)]
+        #[repr(u8)]
+        #[allow(dead_code)]
+        enum Message {
+            Simple {
+                text: String,
+            },
+            Full {
+                text: String,
+                metadata: Option<String>,
+                count: Option<u32>,
+            },
+        }
+
+        let ts = to_typescript::<Message>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_flatten_proxy_struct() {
+        #[derive(Facet)]
+        #[facet(proxy = CoordsProxy)]
+        #[allow(dead_code)]
+        struct Coords {
+            internal_x: f64,
+            internal_y: f64,
+        }
+
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        struct CoordsProxy {
+            x: f64,
+            y: f64,
+        }
+
+        impl From<CoordsProxy> for Coords {
+            fn from(p: CoordsProxy) -> Self {
+                Self {
+                    internal_x: p.x,
+                    internal_y: p.y,
+                }
+            }
+        }
+
+        impl From<&Coords> for CoordsProxy {
+            fn from(c: &Coords) -> Self {
+                Self {
+                    x: c.internal_x,
+                    y: c.internal_y,
+                }
+            }
+        }
+
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        struct Shape {
+            name: String,
+            #[facet(flatten)]
+            coords: Coords,
+        }
+
+        let ts = to_typescript::<Shape>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_enum_variant_skipped_field() {
+        #[derive(Facet)]
+        #[repr(u8)]
+        #[allow(dead_code)]
+        enum Event {
+            Data {
+                visible: String,
+                #[facet(skip)]
+                internal: u64,
+            },
+        }
+
+        let ts = to_typescript::<Event>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_enum_variant_flatten() {
+        // BUG: Enum struct variants should inline flattened fields
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        struct Metadata {
+            author: String,
+            version: u32,
+        }
+
+        #[derive(Facet)]
+        #[repr(u8)]
+        #[allow(dead_code)]
+        enum Document {
+            Article {
+                title: String,
+                #[facet(flatten)]
+                meta: Metadata,
+            },
+        }
+
+        let ts = to_typescript::<Document>();
+        insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_nested_flatten_struct() {
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        struct Inner {
+            x: i32,
+            y: i32,
+        }
+
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        struct Middle {
+            #[facet(flatten)]
+            inner: Inner,
+            z: i32,
+        }
+
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        struct Outer {
+            name: String,
+            #[facet(flatten)]
+            middle: Middle,
+        }
+
+        let ts = to_typescript::<Outer>();
         insta::assert_snapshot!(ts);
     }
 }

--- a/facet-typescript/src/snapshots/facet_typescript__tests__enum_variant_flatten.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__enum_variant_flatten.snap
@@ -1,0 +1,6 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts
+---
+export type Document =
+  | { Article: { title: string; author: string; version: number } };

--- a/facet-typescript/src/snapshots/facet_typescript__tests__enum_variant_skipped_field.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__enum_variant_skipped_field.snap
@@ -1,0 +1,6 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts
+---
+export type Event =
+  | { Data: { visible: string } };

--- a/facet-typescript/src/snapshots/facet_typescript__tests__enum_with_proxy_enum.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__enum_with_proxy_enum.snap
@@ -1,0 +1,6 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 776
+expression: ts
+---
+export type Status = "Active" | "Inactive";

--- a/facet-typescript/src/snapshots/facet_typescript__tests__enum_with_proxy_struct.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__enum_with_proxy_struct.snap
@@ -1,0 +1,11 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 735
+expression: ts
+---
+export type Shape = { center: Point; radius: number } | [Point, Point];
+
+export interface Point {
+  x: number;
+  y: number;
+}

--- a/facet-typescript/src/snapshots/facet_typescript__tests__enum_with_tuple_struct_variant.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__enum_with_tuple_struct_variant.snap
@@ -1,0 +1,12 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 683
+expression: ts
+---
+export type Shape =
+  | { Line: [Point, Point] };
+
+export interface Point {
+  x: number;
+  y: number;
+}

--- a/facet-typescript/src/snapshots/facet_typescript__tests__flatten_arc.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__flatten_arc.snap
@@ -1,0 +1,10 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 995
+expression: ts_arc
+---
+export interface FlattenArc {
+  name: string;
+  x: number;
+  y: number;
+}

--- a/facet-typescript/src/snapshots/facet_typescript__tests__flatten_box.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__flatten_box.snap
@@ -1,0 +1,9 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts_box
+---
+export interface FlattenBox {
+  name: string;
+  x: number;
+  y: number;
+}

--- a/facet-typescript/src/snapshots/facet_typescript__tests__flatten_direct.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__flatten_direct.snap
@@ -1,0 +1,10 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 994
+expression: ts_direct
+---
+export interface FlattenDirect {
+  name: string;
+  x: number;
+  y: number;
+}

--- a/facet-typescript/src/snapshots/facet_typescript__tests__flatten_map.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__flatten_map.snap
@@ -1,0 +1,8 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts_map
+---
+export interface FlattenMap {
+  name: string;
+  extra: Record<string, string>;
+}

--- a/facet-typescript/src/snapshots/facet_typescript__tests__flatten_option.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__flatten_option.snap
@@ -1,0 +1,9 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts_option
+---
+export interface FlattenOption {
+  name: string;
+  x?: number;
+  y?: number;
+}

--- a/facet-typescript/src/snapshots/facet_typescript__tests__flatten_option_arc.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__flatten_option_arc.snap
@@ -1,0 +1,9 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts_option_arc
+---
+export interface FlattenOptionArc {
+  name: string;
+  x?: number;
+  y?: number;
+}

--- a/facet-typescript/src/snapshots/facet_typescript__tests__flatten_proxy_struct.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__flatten_proxy_struct.snap
@@ -1,0 +1,9 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts
+---
+export interface Shape {
+  name: string;
+  x: number;
+  y: number;
+}

--- a/facet-typescript/src/snapshots/facet_typescript__tests__nested_flatten_struct.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__nested_flatten_struct.snap
@@ -1,0 +1,10 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts
+---
+export interface Outer {
+  name: string;
+  x: number;
+  y: number;
+  z: number;
+}

--- a/facet-typescript/src/snapshots/facet_typescript__tests__proxy_preserves_doc_comments.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__proxy_preserves_doc_comments.snap
@@ -1,0 +1,13 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 1033
+expression: ts
+---
+/**
+ * This is a point in 2D space.
+ * It has x and y coordinates.
+ */
+export interface Point {
+  x: number;
+  y: number;
+}

--- a/facet-typescript/src/snapshots/facet_typescript__tests__proxy_to_scalar.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__proxy_to_scalar.snap
@@ -1,0 +1,9 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 982
+expression: ts
+---
+/**
+ * A user ID that serializes as a string
+ */
+export type UserId = string;

--- a/facet-typescript/src/snapshots/facet_typescript__tests__tagged_enum_optional_fields.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__tagged_enum_optional_fields.snap
@@ -1,0 +1,7 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts
+---
+export type Message =
+  | { Simple: { text: string } }
+  | { Full: { text: string; metadata?: string; count?: number } };

--- a/facet-typescript/src/snapshots/facet_typescript__tests__untagged_enum.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__untagged_enum.snap
@@ -1,0 +1,6 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 624
+expression: ts
+---
+export type Value = string | number;

--- a/facet-typescript/src/snapshots/facet_typescript__tests__untagged_enum_optional_fields.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__untagged_enum_optional_fields.snap
@@ -1,0 +1,6 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 1088
+expression: ts
+---
+export type Config = { name: string } | { name: string; description?: string; count?: number };

--- a/facet-typescript/src/snapshots/facet_typescript__tests__untagged_enum_unit_and_struct_variants.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__untagged_enum_unit_and_struct_variants.snap
@@ -1,0 +1,6 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 639
+expression: ts
+---
+export type Event = null | { x: number; y: number };


### PR DESCRIPTION
Several fixes to typescript generation including tests.

Structured as three sepperate, self contained commits.

These are all (to my mind) bugs that I found while genereating typescript types for my codebase