### PR TITLE
feat(facet-xml-node): add to_element serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,6 +2268,7 @@ dependencies = [
  "facet",
  "facet-core",
  "facet-dom",
+ "facet-reflect",
  "facet-xml",
 ]
 

--- a/facet-xml-node/Cargo.toml
+++ b/facet-xml-node/Cargo.toml
@@ -18,6 +18,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 facet = { path = "../facet", version = "0.42.0" }
 facet-core = { path = "../facet-core", version = "0.42.0" }
 facet-dom = { path = "../facet-dom", version = "0.42.0" }
+facet-reflect = { path = "../facet-reflect", version = "0.42.0" }
 facet-xml = { path = "../facet-xml", version = "0.42.0" }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Implements the `to_element` function to serialize Facet types into Element trees, complementing the existing `from_element` deserialization. This adds bidirectional conversion between typed Rust structs and XML Element nodes.

## Changes

- Added `ElementSerializer` struct implementing the `DomSerializer` trait
- Added `to_element<T>()` function for serializing Facet types to Element trees
- Added `ElementSerializeError` type for serialization errors
- Full support for XML attributes (`xml::attribute`), text content (`xml::text`), elements lists (`xml::elements`), tag fields (`xml::tag`), and doctype fields (`xml::doctype`)
- Comprehensive test coverage including:
  - Simple struct serialization
  - Attribute serialization
  - Full roundtrip tests (serialize → deserialize → compare)
- Added `facet-reflect` dependency to `facet-xml-node` for reflection support

## Testing

All new tests pass:
- `to_element_simple` - basic struct to element conversion
- `to_element_with_attrs` - handling XML attributes
- `roundtrip_simple` - serialize and deserialize simple struct
- `roundtrip_with_attrs` - roundtrip with multiple attributes

Fixes #1853