### PR TITLE
feat: add Facet implementation for tendril crate

### DIFF
--- a/.config/captain/readme-templates/readme-footer.md
+++ b/.config/captain/readme-templates/readme-footer.md
@@ -1,5 +1,3 @@
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,7 +1463,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1538,7 +1538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1699,6 +1699,7 @@ dependencies = [
  "smartstring",
  "smol_str",
  "stable_deref_trait",
+ "tendril",
  "time",
  "ulid",
  "url",
@@ -1868,6 +1869,7 @@ dependencies = [
  "mime",
  "serde_json",
  "smol_str",
+ "tendril",
  "tokio",
  "tracing",
  "zmij",
@@ -3107,7 +3109,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3158,7 +3160,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3460,12 +3462,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4494,7 +4502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5104,7 +5112,17 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
 ]
 
 [[package]]
@@ -5992,7 +6010,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ Some crates are developed completely independently from the facet org:
 - [facet_generate](https://github.com/redbadger/facet-generate) reflects Facet types into Java, Swift and TypeScript
 - [multi-array-list](https://lib.rs/crates/multi-array-list) provides an experimental `MultiArrayList` type
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-args/README.md
+++ b/facet-args/README.md
@@ -47,8 +47,6 @@ The behavior of facet-args is still in flux, but here are the broad strokes:
   * After parsing every available argument, uninitialized struct fields are filled with their default value
     if they have `facet(default)` set: this includes `Vec`.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-asn1/README.md
+++ b/facet-asn1/README.md
@@ -13,8 +13,6 @@ ASN.1 DER/BER serialization and deserialization for facet.
 This crate provides ASN.1 DER (Distinguished Encoding Rules) support via the
 `FormatParser` and `FormatSerializer` traits.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-assert/README.md
+++ b/facet-assert/README.md
@@ -146,8 +146,6 @@ fn test_config_parsing() {
 - `assert_sameish_with!(a, b, options)` — with custom comparison options
 - `debug_assert_sameish!(...)` — only in debug builds
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-atom/README.md
+++ b/facet-atom/README.md
@@ -86,8 +86,6 @@ assert_eq!(feed.entries.len(), 1);
 - [RFC 4287 - The Atom Syndication Format](https://www.rfc-editor.org/rfc/rfc4287)
 - [Atom on Wikipedia](https://en.wikipedia.org/wiki/Atom_(web_standard))
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-axum/README.md
+++ b/facet-axum/README.md
@@ -68,8 +68,6 @@ let app = Router::new()
 - `postcard`: Enables `Postcard<T>` extractor/response using `facet-postcard`
 - `all`: Enables all format features
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-bloatbench/README.md
+++ b/facet-bloatbench/README.md
@@ -17,8 +17,6 @@ Synthetic schema generator and A/B build-time/code-size benchmark used for compa
 
 This crate is for internal benchmarking only and is not published.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -68,6 +68,8 @@ lock_api = ["alloc", "dep:lock_api"]
 iddqd = ["alloc", "dep:iddqd"]
 # Provide Facet trait implementations for yoke::Yoke
 yoke = ["alloc", "dep:yoke", "dep:stable_deref_trait"]
+# Provide facet trait implementation for tendril::Tendril
+tendril = ["alloc", "dep:tendril"]
 
 # Provide Facet trait implementations for tuples up to size 12. Without it,
 # Facet is only implemented for tuples up to size 4.
@@ -106,6 +108,7 @@ rust_decimal = { workspace = true, optional = true }
 lock_api = { version = "0.4", optional = true, default-features = false }
 iddqd = { workspace = true, optional = true }
 yoke = { version = "0.8.1", optional = true }
+tendril = { version = "0.5.0", optional = true }
 stable_deref_trait = { version = "1.2.1", optional = true }
 
 

--- a/facet-core/README.md
+++ b/facet-core/README.md
@@ -10,8 +10,6 @@ Defines the `Facet` trait and implements it for a lot (a LOT) of builtin types.
 
 This crate is foundational to facet's reflection capabilities, providing the type system that enables runtime type manipulation.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-core/src/impls/crates/mod.rs
+++ b/facet-core/src/impls/crates/mod.rs
@@ -13,6 +13,7 @@ mod ruint;
 mod rust_decimal;
 mod smartstring;
 mod smol_str;
+mod tendril;
 mod time;
 mod ulid;
 mod url;

--- a/facet-core/src/impls/crates/tendril.rs
+++ b/facet-core/src/impls/crates/tendril.rs
@@ -1,0 +1,111 @@
+#![cfg(feature = "tendril")]
+
+use tendril::{Atomic, StrTendril, Tendril, fmt};
+
+use crate::{
+    Def, Facet, PtrConst, Shape, ShapeBuilder, TryFromOutcome, Type, UserType, VTableDirect,
+    vtable_direct,
+};
+
+/// Atomic variant of StrTendril (Send + Sync)
+pub type AtomicStrTendril = Tendril<fmt::UTF8, Atomic>;
+
+/// Try to convert from &str or String to `StrTendril`
+///
+/// # Safety
+/// `dst` must be valid for writes, `src` must point to valid data of type described by `src_shape`
+unsafe fn str_tendril_try_from(
+    dst: *mut StrTendril,
+    src_shape: &'static Shape,
+    src: PtrConst,
+) -> TryFromOutcome {
+    // Check if source is &str (Copy type, use get)
+    if src_shape.id == <&str as Facet>::SHAPE.id {
+        let str_ref: &str = unsafe { src.get::<&str>() };
+        unsafe { dst.write(StrTendril::from(str_ref)) };
+        return TryFromOutcome::Converted;
+    }
+
+    // Check if source is String (consume via read)
+    if src_shape.id == <alloc::string::String as Facet>::SHAPE.id {
+        let string: alloc::string::String = unsafe { src.read::<alloc::string::String>() };
+        unsafe { dst.write(StrTendril::from(string)) };
+        return TryFromOutcome::Converted;
+    }
+
+    TryFromOutcome::Unsupported
+}
+
+/// Try to convert from &str or String to `AtomicStrTendril`
+///
+/// # Safety
+/// `dst` must be valid for writes, `src` must point to valid data of type described by `src_shape`
+unsafe fn atomic_str_tendril_try_from(
+    dst: *mut AtomicStrTendril,
+    src_shape: &'static Shape,
+    src: PtrConst,
+) -> TryFromOutcome {
+    // Check if source is &str (Copy type, use get)
+    if src_shape.id == <&str as Facet>::SHAPE.id {
+        let str_ref: &str = unsafe { src.get::<&str>() };
+        unsafe { dst.write(AtomicStrTendril::from(str_ref)) };
+        return TryFromOutcome::Converted;
+    }
+
+    // Check if source is String (consume via read)
+    if src_shape.id == <alloc::string::String as Facet>::SHAPE.id {
+        let string: alloc::string::String = unsafe { src.read::<alloc::string::String>() };
+        unsafe { dst.write(AtomicStrTendril::from(string)) };
+        return TryFromOutcome::Converted;
+    }
+
+    TryFromOutcome::Unsupported
+}
+
+unsafe impl Facet<'_> for StrTendril {
+    const SHAPE: &'static Shape = &const {
+        const VTABLE: VTableDirect = vtable_direct!(StrTendril =>
+            Display,
+            Debug,
+            Hash,
+            PartialEq,
+            PartialOrd,
+            Ord,
+            FromStr,
+            [try_from = str_tendril_try_from],
+        );
+
+        ShapeBuilder::for_sized::<StrTendril>("StrTendril")
+            .module_path("tendril")
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::Scalar)
+            .vtable_direct(&VTABLE)
+            .eq()
+            .build()
+    };
+}
+
+unsafe impl Facet<'_> for AtomicStrTendril {
+    const SHAPE: &'static Shape = &const {
+        const VTABLE: VTableDirect = vtable_direct!(AtomicStrTendril =>
+            Display,
+            Debug,
+            Hash,
+            PartialEq,
+            PartialOrd,
+            Ord,
+            FromStr,
+            [try_from = atomic_str_tendril_try_from],
+        );
+
+        ShapeBuilder::for_sized::<AtomicStrTendril>("AtomicStrTendril")
+            .module_path("tendril")
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::Scalar)
+            .vtable_direct(&VTABLE)
+            .eq()
+            .send()
+            .sync()
+            .build()
+    };
+}

--- a/facet-csv/README.md
+++ b/facet-csv/README.md
@@ -8,8 +8,6 @@
 
 Provides CSV serialization and deserialization for Facet types using the `facet-format` framework.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-default/README.md
+++ b/facet-default/README.md
@@ -87,8 +87,6 @@ pub enum Request {
 }
 ```
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-dessert/README.md
+++ b/facet-dessert/README.md
@@ -13,8 +13,6 @@ Sweet helpers for facet deserialization - shared between facet-format and facet-
 Provides common setter functions for handling string, bytes, and scalar values
 when deserializing into facet types.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-diff-core/README.md
+++ b/facet-diff-core/README.md
@@ -37,8 +37,6 @@ This crate is typically used by serializers (facet-xml, facet-json, etc.) to
 render diffs consistently. You probably want to use `facet-diff` directly
 instead of this crate.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-diff/README.md
+++ b/facet-diff/README.md
@@ -93,8 +93,6 @@ facet-diff uses facet-reflect to traverse values structurally:
 - **facet-reflect**: Reflection API for traversing Facet values
 - **facet-pretty**: Pretty-printing for Facet values
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-dom/README.md
+++ b/facet-dom/README.md
@@ -67,8 +67,6 @@ The deserializer maps DOM concepts to Rust types using facet attributes:
 Handles automatic case conversion between DOM naming (kebab-case) and
 Rust naming (snake_case), plus singularization for collection fields.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-error/README.md
+++ b/facet-error/README.md
@@ -49,8 +49,6 @@ This generates:
 - `#[facet(error::from)]` - generate `From` implementations
 - Support for error wrapping and transparent delegation
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-format-suite/README.md
+++ b/facet-format-suite/README.md
@@ -11,8 +11,6 @@
 Shared conformance test suite harness for `facet-format-*` crates.
 
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-format/README.md
+++ b/facet-format/README.md
@@ -10,8 +10,6 @@
 
 Experimental shared serialization/deserialization core for Facet formats.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-json-schema/README.md
+++ b/facet-json-schema/README.md
@@ -51,8 +51,6 @@ println!("{}", schema);
 ```
 
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -41,7 +41,8 @@ mime = { version = "0.3", optional = true }
 
 [dev-dependencies]
 compact_str = { workspace = true }
-facet = { path = "../facet", features = ["doc", "net", "compact_str", "smol_str", "iddqd"] }
+facet = { path = "../facet", features = ["doc", "net", "compact_str", "smol_str", "iddqd", "tendril"] }
+tendril = "0.5.0"
 facet-format = { path = "../facet-format", features = ["jit", "net", "tracing"] }
 facet-reflect = { path = "../facet-reflect", features = ["tracing"] }
 facet-testhelpers = { path = "../facet-testhelpers" }

--- a/facet-json/README.md
+++ b/facet-json/README.md
@@ -10,8 +10,6 @@
 
 JSON parser prototype built on top of the shared format abstraction experiments.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-json/tests/tendril.rs
+++ b/facet-json/tests/tendril.rs
@@ -1,0 +1,100 @@
+#![forbid(unsafe_code)]
+
+use facet::Facet;
+use tendril::{Atomic, StrTendril, Tendril, fmt};
+
+/// Atomic variant of StrTendril (Send + Sync)
+type AtomicStrTendril = Tendril<fmt::UTF8, Atomic>;
+
+#[derive(Facet, Debug, PartialEq)]
+struct Document {
+    title: StrTendril,
+    body: StrTendril,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct AtomicDocument {
+    title: AtomicStrTendril,
+    body: AtomicStrTendril,
+}
+
+#[test]
+fn str_tendril_serialize() {
+    let doc = Document {
+        title: StrTendril::from("Hello"),
+        body: StrTendril::from("World"),
+    };
+
+    let json = facet_json::to_string(&doc).expect("should serialize");
+    assert_eq!(json, r#"{"title":"Hello","body":"World"}"#);
+}
+
+#[test]
+fn str_tendril_deserialize() {
+    let json = r#"{"title":"Hello","body":"World"}"#;
+    let doc: Document = facet_json::from_str(json).expect("should deserialize");
+
+    assert_eq!(&*doc.title, "Hello");
+    assert_eq!(&*doc.body, "World");
+}
+
+#[test]
+fn str_tendril_roundtrip() {
+    let original = Document {
+        title: StrTendril::from("Test Title"),
+        body: StrTendril::from("Some body text with special chars: éàü"),
+    };
+
+    let json = facet_json::to_string(&original).expect("should serialize");
+    let restored: Document = facet_json::from_str(&json).expect("should deserialize");
+
+    assert_eq!(original, restored);
+}
+
+#[test]
+fn atomic_str_tendril_serialize() {
+    let doc = AtomicDocument {
+        title: AtomicStrTendril::from("Hello"),
+        body: AtomicStrTendril::from("World"),
+    };
+
+    let json = facet_json::to_string(&doc).expect("should serialize");
+    assert_eq!(json, r#"{"title":"Hello","body":"World"}"#);
+}
+
+#[test]
+fn atomic_str_tendril_deserialize() {
+    let json = r#"{"title":"Hello","body":"World"}"#;
+    let doc: AtomicDocument = facet_json::from_str(json).expect("should deserialize");
+
+    assert_eq!(&*doc.title, "Hello");
+    assert_eq!(&*doc.body, "World");
+}
+
+#[test]
+fn atomic_str_tendril_roundtrip() {
+    let original = AtomicDocument {
+        title: AtomicStrTendril::from("Test Title"),
+        body: AtomicStrTendril::from("Some body text with special chars: éàü"),
+    };
+
+    let json = facet_json::to_string(&original).expect("should serialize");
+    let restored: AtomicDocument = facet_json::from_str(&json).expect("should deserialize");
+
+    assert_eq!(&*original.title, &*restored.title);
+    assert_eq!(&*original.body, &*restored.body);
+}
+
+#[test]
+fn str_tendril_empty_string() {
+    let doc = Document {
+        title: StrTendril::from(""),
+        body: StrTendril::from(""),
+    };
+
+    let json = facet_json::to_string(&doc).expect("should serialize");
+    assert_eq!(json, r#"{"title":"","body":""}"#);
+
+    let restored: Document = facet_json::from_str(&json).expect("should deserialize");
+    assert_eq!(doc, restored);
+}

--- a/facet-macro-parse/README.md
+++ b/facet-macro-parse/README.md
@@ -10,8 +10,6 @@ Parser for facet derive macros.
 
 Takes a `TokenStream` from a derive macro invocation and produces the parsed type representations defined in `facet-macro-types`. This crate bridges proc-macro input to the structured AST used for code generation.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-macro-template/README.md
+++ b/facet-macro-template/README.md
@@ -10,8 +10,6 @@ Token-based templating engine for facet macro code generation.
 
 Provides utilities for generating the `Facet` trait implementation code from the parsed type representations, producing the final `TokenStream` output for derive macros.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-macro-types/README.md
+++ b/facet-macro-types/README.md
@@ -10,8 +10,6 @@ Defines the unsynn grammar and type definitions used throughout the facet macro 
 
 This crate provides the foundational AST types that represent Rust type declarations (structs, enums, unions) as parsed from token streams, enabling the derive macro infrastructure.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-macros-impl/README.md
+++ b/facet-macros-impl/README.md
@@ -10,8 +10,6 @@ Implementation of facet derive macros, combining parsing and code generation.
 
 This crate provides the internal implementation for `#[derive(Facet)]` and related procedural macros. It's used by `facet-macros` (the proc-macro crate) and should not be used directly.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-macros/README.md
+++ b/facet-macros/README.md
@@ -8,8 +8,6 @@
 
 Implements the `Facet` derive macro for facet. Uses [unsynn](https://crates.io/crates/unsynn) to provide fast compilation times.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-msgpack/README.md
+++ b/facet-msgpack/README.md
@@ -10,8 +10,6 @@
 
 MessagePack binary format for facet using the Tier-2 JIT architecture.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-path/README.md
+++ b/facet-path/README.md
@@ -42,8 +42,6 @@ let formatted = path.format_with_shape(my_shape);
 
 
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-perf-shootout/README.md
+++ b/facet-perf-shootout/README.md
@@ -41,8 +41,6 @@ To regenerate benchmark code after editing YAML files:
 cargo xtask gen-benchmarks
 ```
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-postcard/README.md
+++ b/facet-postcard/README.md
@@ -58,8 +58,6 @@ tag byte:
 1e                      # value: varint 30
 ```
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-pretty/README.md
+++ b/facet-pretty/README.md
@@ -8,8 +8,6 @@
 
 Provides pretty-printing capabilities for Facet types.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-python/README.md
+++ b/facet-python/README.md
@@ -62,8 +62,6 @@ class User(TypedDict, total=False):
 - **Reserved keywords**: Automatically handles Python reserved words as field names
 - **Generic support**: Maps Rust generics to Python type parameters
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-reflect/README.md
+++ b/facet-reflect/README.md
@@ -17,8 +17,6 @@ information about the shape of types to allow:
 This allows, respectively, serialization and deserialization, without risking breaking
 invariants in types that implement `Facet`.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-shapelike/README.md
+++ b/facet-shapelike/README.md
@@ -10,8 +10,6 @@
 
 This implements a struct which is a fully serialiable version of a Shape, called Shapelike, this is useful if you wanna ever use a shape in other program or in another point in type
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-showcase/README.md
+++ b/facet-showcase/README.md
@@ -11,8 +11,6 @@ Unified showcase infrastructure for facet format crates.
 Provides a framework for creating consistent, colorful showcases of format crate
 capabilities, including syntax highlighting, error display, and multiple output
 modes (terminal, HTML, Markdown).
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-singularize/README.md
+++ b/facet-singularize/README.md
@@ -39,8 +39,6 @@ Benchmarked to be fast enough for hot paths. The implementation prioritizes
 predictable performance over completeness—it handles the common cases well
 rather than trying to be a full linguistic library.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-solver/README.md
+++ b/facet-solver/README.md
@@ -253,8 +253,6 @@ directly**. No buffering, no loss of fidelity.
 | [serde_json#721](https://github.com/serde-rs/json/issues/721) | `arbitrary_precision` + `flatten` loses precision | No buffering through `serde_json::Value` |
 | [serde_json#1155](https://github.com/serde-rs/json/issues/1155) | `u128` in flattened struct fails | Direct deserialization, no `Value` intermediary |
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-svg/README.md
+++ b/facet-svg/README.md
@@ -73,8 +73,6 @@ assert_eq!(svg.width, Some("100".to_string()));
 - Extracting geometric data from SVG files
 - Type-safe SVG manipulation in Rust applications
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-testhelpers-macros/README.md
+++ b/facet-testhelpers-macros/README.md
@@ -8,8 +8,6 @@
 
 Provides a proc macro attribute named `#[test]` which calls `facet_testhelpers::setup()`
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-testhelpers/README.md
+++ b/facet-testhelpers/README.md
@@ -40,8 +40,6 @@ Then run tests with:
 cargo nextest run
 ```
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-tokio-postgres/README.md
+++ b/facet-tokio-postgres/README.md
@@ -10,8 +10,6 @@
 
 Deserialize tokio-postgres Rows into any type implementing Facet.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-toml/README.md
+++ b/facet-toml/README.md
@@ -11,8 +11,6 @@
 TOML parser built on top of the shared format abstraction, enabling streaming
 deserialization with facet's deferred materialization.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-typescript/README.md
+++ b/facet-typescript/README.md
@@ -62,8 +62,6 @@ let ts = gen.finish();
 ```
 
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-urlencoded/README.md
+++ b/facet-urlencoded/README.md
@@ -8,8 +8,6 @@
 
 Provides URL-encoded form data deserialization for Facet types.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-validate/README.md
+++ b/facet-validate/README.md
@@ -61,8 +61,6 @@ facet-json = { version = "0.41", features = ["validate"] }
 facet-validate = "0.41"
 ```
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-value/README.md
+++ b/facet-value/README.md
@@ -41,8 +41,6 @@ let person2: Person = from_value(value).unwrap();
 assert_eq!(person, person2);
 ```
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-xdr/README.md
+++ b/facet-xdr/README.md
@@ -8,8 +8,6 @@
 
 Provides XDR (External Data Representation) serialization and deserialization for Facet types using the `facet-format` framework.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-xml-diff/README.md
+++ b/facet-xml-diff/README.md
@@ -74,8 +74,6 @@ let options = DiffSerializeOptions {
 - Generating human-readable change logs
 - Testing serialization by comparing expected vs actual output
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-xml-node/README.md
+++ b/facet-xml-node/README.md
@@ -59,8 +59,6 @@ for child in &element.children {
 | Typed structs with `#[derive(Facet)]` | Known XML schema, compile-time safety |
 | `facet-xml-node::Element` | Unknown/dynamic XML, runtime flexibility |
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-xml/README.md
+++ b/facet-xml/README.md
@@ -448,8 +448,6 @@ enum Point {
 # assert_eq!(point, Point::Coords { x: 10, y: 20 });
 ```
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet-yaml/README.md
+++ b/facet-yaml/README.md
@@ -8,8 +8,6 @@
 
 Provides YAML serialization and deserialization for Facet types using the `facet-format` framework.
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -64,6 +64,7 @@ compact_str = [
 ] # Provide Facet trait implementations for compact_str::CompactString
 uuid = ["facet-core/uuid"] # Provide Facet trait implementations for uuid::Uuid
 ulid = ["facet-core/ulid"] # Provide Facet trait implementations for ulid::Ulid
+tendril = ["facet-core/tendril"] # Provide Facet trait implementations for tendril::Tendril
 ordered-float = [
     "facet-core/ordered-float",
 ] # Provide Facet trait implementations for ordered_float types

--- a/facet/README.md
+++ b/facet/README.md
@@ -80,8 +80,6 @@ Some crates are developed completely independently from the facet org:
 - [facet_generate](https://github.com/redbadger/facet-generate) reflects Facet types into Java, Swift and TypeScript
 - [multi-array-list](https://lib.rs/crates/multi-array-list) provides an experimental `MultiArrayList` type
 
-## LLM contribution policy
-
 ## Sponsors
 
 Thanks to all individual sponsors:


### PR DESCRIPTION
## Summary

Add support for the [tendril](https://crates.io/crates/tendril) crate's string types, enabling facet-powered serialization and deserialization for efficient copy-on-write strings commonly used in HTML/XML parsing scenarios.

## Changes

- **Facet implementations for tendril types**:
  - `StrTendril` - Standard tendril string (single-threaded)
  - `AtomicStrTendril` - Thread-safe variant (Send + Sync)
  
- **Type conversions**: Added `try_from` implementations supporting conversion from `&str` and `String`

- **Feature flag**: New `tendril` feature in facet-core, facet-json, and facet crates

- **Tests**: Comprehensive JSON serialization/deserialization tests including:
  - Basic serialize/deserialize
  - Roundtrip with special characters
  - Empty string handling
  - Both regular and atomic variants

## Testing

All tests pass with `cargo nextest run --features tendril` in the facet-json crate.