### PR TITLE
facet-typescript: Handle empty interfaces

### DIFF
--- a/facet-typescript/src/snapshots/facet_typescript__tests__test_empty_struct.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__test_empty_struct.snap
@@ -1,0 +1,6 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 1319
+expression: e
+---
+export type Empty = object;

--- a/facet-typescript/src/snapshots/facet_typescript__tests__test_empty_struct_multiple_references.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__test_empty_struct_multiple_references.snap
@@ -1,0 +1,12 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 1398
+expression: ts
+---
+export interface Container {
+  first: Empty;
+  second: Empty;
+  third?: Empty;
+}
+
+export type Empty = object;

--- a/facet-typescript/src/snapshots/facet_typescript__tests__test_empty_struct_with_skipped_fields.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__test_empty_struct_with_skipped_fields.snap
@@ -1,0 +1,6 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 1382
+expression: ts
+---
+export type EmptyAfterSkip = object;

--- a/facet-typescript/src/snapshots/facet_typescript__tests__test_empty_struct_wrap.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__test_empty_struct_wrap.snap
@@ -1,0 +1,10 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 1319
+expression: d
+---
+export interface Data {
+  empty: Empty;
+}
+
+export type Empty = object;

--- a/facet-typescript/src/snapshots/facet_typescript__tests__test_flatten_empty_struct.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__test_flatten_empty_struct.snap
@@ -1,0 +1,6 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 1413
+expression: ts
+---
+export type Wrapper = object;


### PR DESCRIPTION
Eslint compains on empty interfaces, correctly, since they allow also literal values such as "hello", so for empty structs change to output "object" as the typescript type

So the output will now be:

export type Empty = object;

instead of

export interface Empty {}