### PR TITLE
feat(facet-reflect): Add from_raw and finish_in_place for stack-friendly deserialization

### DIFF
--- a/facet-reflect/src/partial/partial_api/build.rs
+++ b/facet-reflect/src/partial/partial_api/build.rs
@@ -96,4 +96,103 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
             }
         }
     }
+
+    /// Finishes deserialization in-place, validating the value without moving it.
+    ///
+    /// This is intended for use with [`from_raw`](Self::from_raw) where the value
+    /// is deserialized into caller-provided memory (e.g., a `MaybeUninit<T>` on the stack).
+    ///
+    /// On success, the caller can safely assume the memory contains a fully initialized,
+    /// valid value and call `MaybeUninit::assume_init()`.
+    ///
+    /// On failure, any partially initialized data is cleaned up (dropped), and the
+    /// memory should be considered uninitialized.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called with more than one frame on the stack (i.e., if you haven't
+    /// called `end()` enough times to return to the root level).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use std::mem::MaybeUninit;
+    /// use facet_core::{Facet, PtrUninit};
+    /// use facet_reflect::Partial;
+    ///
+    /// let mut slot = MaybeUninit::<MyStruct>::uninit();
+    /// let ptr = PtrUninit::new(slot.as_mut_ptr().cast());
+    ///
+    /// let partial = unsafe { Partial::from_raw(ptr, MyStruct::SHAPE)? };
+    /// // ... deserialize into partial ...
+    /// partial.finish_in_place()?;
+    ///
+    /// // Now safe to assume initialized
+    /// let value = unsafe { slot.assume_init() };
+    /// ```
+    pub fn finish_in_place(mut self) -> Result<(), ReflectError> {
+        if self.frames().len() != 1 {
+            return Err(ReflectError::InvariantViolation {
+                invariant: "Partial::finish_in_place() expects a single frame — call end() until that's the case",
+            });
+        }
+
+        let frame = self.frames_mut().last_mut().unwrap();
+
+        // Fill in defaults for any unset fields before checking initialization
+        crate::trace!(
+            "finish_in_place(): calling fill_defaults for {}, tracker={:?}, is_init={}",
+            frame.allocated.shape(),
+            frame.tracker.kind(),
+            frame.is_init
+        );
+        frame.fill_defaults()?;
+        crate::trace!(
+            "finish_in_place(): after fill_defaults, tracker={:?}, is_init={}",
+            frame.tracker.kind(),
+            frame.is_init
+        );
+
+        let frame = self.frames_mut().pop().unwrap();
+
+        // Check initialization before proceeding
+        crate::trace!(
+            "finish_in_place(): calling require_full_initialization, tracker={:?}",
+            frame.tracker.kind()
+        );
+        let init_result = frame.require_full_initialization();
+        crate::trace!(
+            "finish_in_place(): require_full_initialization returned {:?}",
+            init_result.is_ok()
+        );
+        if let Err(e) = init_result {
+            // Put the frame back so Drop can handle cleanup properly
+            self.frames_mut().push(frame);
+            return Err(e);
+        }
+
+        // Check invariants if present
+        // Safety: The value is fully initialized at this point (we just checked with require_full_initialization)
+        let value_ptr = unsafe { frame.data.assume_init().as_const() };
+        if let Some(result) = unsafe { frame.allocated.shape().call_invariants(value_ptr) } {
+            match result {
+                Ok(()) => {
+                    // Invariants passed
+                }
+                Err(message) => {
+                    // Put the frame back so Drop can handle cleanup properly
+                    let shape = frame.allocated.shape();
+                    self.frames_mut().push(frame);
+                    return Err(ReflectError::UserInvariantFailed { message, shape });
+                }
+            }
+        }
+
+        // Mark as built to prevent Drop from cleaning up the now-valid value.
+        // The caller owns the memory and will handle the value from here.
+        self.state = PartialState::Built;
+
+        // Frame is dropped here without deallocation (External ownership doesn't dealloc)
+        Ok(())
+    }
 }

--- a/facet-reflect/src/partial/partial_api/misc.rs
+++ b/facet-reflect/src/partial/partial_api/misc.rs
@@ -480,9 +480,11 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         // Return WITHOUT popping - the frame stays and will be built/dropped normally
                         return Ok(self);
                     }
-                    FrameOwnership::TrackedBuffer | FrameOwnership::BorrowedInPlace => {
+                    FrameOwnership::TrackedBuffer
+                    | FrameOwnership::BorrowedInPlace
+                    | FrameOwnership::External => {
                         return Err(ReflectError::InvariantViolation {
-                            invariant: "SmartPointerSlice cannot have TrackedBuffer/BorrowedInPlace ownership after conversion",
+                            invariant: "SmartPointerSlice cannot have TrackedBuffer/BorrowedInPlace/External ownership after conversion",
                         });
                     }
                 }


### PR DESCRIPTION
## Summary

Adds a new API for deserializing into caller-provided memory (e.g., `MaybeUninit<T>` on the stack) without heap allocation. This enables reflection-based deserialization in performance-sensitive contexts where avoiding allocation is important.

- Add `FrameOwnership::External` for caller-owned memory that deinits on cleanup but does not deallocate
- Add `Partial::from_raw(ptr, shape)` to create a Partial that writes into external memory
- Add `Partial::finish_in_place()` to validate full initialization without moving the value

### Example usage

```rust
let mut slot = MaybeUninit::<MyStruct>::uninit();
let ptr = PtrUninit::new(slot.as_mut_ptr().cast::<u8>());

let partial: Partial<'_> = unsafe { Partial::from_raw(ptr, MyStruct::SHAPE)? };
// ... deserialize into partial ...
partial.finish_in_place()?;

// Now safe to assume initialized
let value = unsafe { slot.assume_init() };
```

### Safety guarantees

| Scenario | Behavior |
|----------|----------|
| Drop before `finish_in_place` | Initialized fields are dropped, memory is NOT freed |
| `finish_in_place` succeeds | Value stays in place, caller can `assume_init` |
| `finish_in_place` fails | Cleanup happens, caller must NOT `assume_init` |
| Panic during operation | Undefined state (documented in safety contract) |

## Test plan

- [x] `from_raw_simple_struct` - basic struct deserialization into stack memory
- [x] `from_raw_nested_struct` - nested struct with owned fields (String)
- [x] `from_raw_drop_on_error` - verifies partial state is cleaned up on failure
- [x] `from_raw_drop_on_partial_drop` - verifies cleanup when Partial is dropped without finish
- [x] `from_raw_with_vec` - complex type with Vec field
- [x] Full test suite passes (448 tests)