### PR TITLE
fix(facet-json): correctly handle escape sequences after multi-byte UTF-8

### DIFF
--- a/facet-json/src/scanner.rs
+++ b/facet-json/src/scanner.rs
@@ -802,22 +802,24 @@ pub fn decode_string_owned(
                 result.push(byte as char);
                 i += 1;
             } else {
-                // Multi-byte UTF-8 sequence - find the end of valid UTF-8
+                // Multi-byte UTF-8 sequence - consume only one character
                 let remaining = &slice[i..];
                 match str::from_utf8(remaining) {
                     Ok(s) => {
-                        result.push_str(s);
-                        break;
+                        // Consume exactly one UTF-8 char, then continue scanning
+                        let ch = s.chars().next().expect("non-empty remaining slice");
+                        result.push(ch);
+                        i += ch.len_utf8();
                     }
                     Err(e) => {
-                        // Partial valid UTF-8
+                        // Partial valid UTF-8 - extract one character if possible
                         let valid_len = e.valid_up_to();
                         if valid_len > 0 {
-                            // Re-validate the valid portion (safe, no unsafe)
                             let valid = str::from_utf8(&remaining[..valid_len])
                                 .expect("valid_up_to guarantees valid UTF-8");
-                            result.push_str(valid);
-                            i += valid_len;
+                            let ch = valid.chars().next().expect("non-empty valid slice");
+                            result.push(ch);
+                            i += ch.len_utf8();
                         } else {
                             return Err(ScanError {
                                 kind: ScanErrorKind::InvalidUtf8,

--- a/facet-json/tests/escapes.rs
+++ b/facet-json/tests/escapes.rs
@@ -1,0 +1,77 @@
+//! Regression tests for escape sequence handling in JSON strings.
+//!
+//! See: https://github.com/bearcove/facet/issues/1891
+
+/// Test that escape sequences after multi-byte UTF-8 characters are correctly decoded.
+#[test]
+fn test_escape_after_multibyte_utf8() {
+    // The original bug: "中文\n" would deserialize with literal backslash-n
+    // instead of a newline character.
+    let original = "中文\n".to_string();
+    let json = facet_json::to_string(&original).unwrap();
+    let roundtrip: String = facet_json::from_str(&json).unwrap();
+    assert_eq!(original, roundtrip);
+    assert_eq!(roundtrip.as_bytes().last(), Some(&b'\n'));
+}
+
+/// Test various escape sequences following Unicode characters.
+#[test]
+fn test_various_escapes_after_unicode() {
+    let test_cases = [
+        ("中文\t", "tab after Chinese"),
+        ("日本語\\", "backslash after Japanese"),
+        ("한글\"", "quote after Korean"),
+        ("中文\u{0041}", "unicode escape \\u0041 (A) after Chinese"),
+        ("émoji\r\n", "CRLF after accented char"),
+    ];
+
+    for (original, desc) in test_cases {
+        let json = facet_json::to_string(&original).unwrap();
+        let roundtrip: String = facet_json::from_str(&json).unwrap();
+        assert_eq!(original, roundtrip, "failed for: {}", desc);
+    }
+}
+
+/// Test multiple escape sequences interspersed with Unicode.
+#[test]
+fn test_interspersed_unicode_and_escapes() {
+    let original = "你好\n世界\t再见\n";
+    let json = facet_json::to_string(&original).unwrap();
+    let roundtrip: String = facet_json::from_str(&json).unwrap();
+    assert_eq!(original, roundtrip);
+}
+
+/// Test emoji followed by escape sequences.
+#[test]
+fn test_emoji_followed_by_escapes() {
+    let test_cases = [
+        ("🎉\n", "party emoji then newline"),
+        ("👨‍👩‍👧‍👦\t", "family emoji (ZWJ sequence) then tab"),
+        ("🇺🇸\\", "flag emoji then backslash"),
+        ("😀\r\n🎊", "emoji, CRLF, emoji"),
+    ];
+
+    for (original, desc) in test_cases {
+        let json = facet_json::to_string(&original).unwrap();
+        let roundtrip: String = facet_json::from_str(&json).unwrap();
+        assert_eq!(original, roundtrip, "failed for: {}", desc);
+    }
+}
+
+/// Test that pure ASCII strings with escapes still work.
+#[test]
+fn test_ascii_escapes_still_work() {
+    let original = "hello\nworld\ttab\\backslash\"quote";
+    let json = facet_json::to_string(&original).unwrap();
+    let roundtrip: String = facet_json::from_str(&json).unwrap();
+    assert_eq!(original, roundtrip);
+}
+
+/// Test escape sequences before Unicode (should have always worked, but verify).
+#[test]
+fn test_escapes_before_unicode() {
+    let original = "\n中文";
+    let json = facet_json::to_string(&original).unwrap();
+    let roundtrip: String = facet_json::from_str(&json).unwrap();
+    assert_eq!(original, roundtrip);
+}


### PR DESCRIPTION
## Summary

Fixes a bug where escape sequences (like `\n`, `\t`, `\\`) following multi-byte UTF-8 characters would not be correctly decoded. Instead of being interpreted as escape sequences, they were consumed as literal characters.

The root cause was that the scanner consumed the entire remaining valid UTF-8 slice after encountering a multi-byte character, preventing return to the main loop where escape sequences are detected.

## Changes

- Modified `facet-json/src/scanner.rs` to consume only one UTF-8 character at a time, then return to the main scanning loop
- Added regression tests in `facet-json/tests/escapes.rs` covering:
  - Escape sequences after Chinese, Japanese, Korean characters
  - Escape sequences after emoji (including ZWJ sequences)
  - Interspersed Unicode and escape sequences
  - Pure ASCII escapes (verifying no regression)

## Test plan

- [x] Added regression tests that verify the fix
- [x] `cargo nextest run` passes

Fixes #1891