### PR TITLE
facet-typescript: Fix output for untagged enum unit variants

### DIFF
--- a/facet-typescript/src/snapshots/facet_typescript__tests__test_untagged_enum_unit_and_newtype_variants.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__test_untagged_enum_unit_and_newtype_variants.snap
@@ -1,0 +1,6 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 1509
+expression: ts
+---
+export type Enum = "Daily" | "Weekly" | number;

--- a/facet-typescript/src/snapshots/facet_typescript__tests__test_untagged_enum_with_tuple_variant.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__test_untagged_enum_with_tuple_variant.snap
@@ -1,0 +1,6 @@
+---
+source: facet-typescript/src/lib.rs
+assertion_line: 1524
+expression: ts
+---
+export type Message = string | [string, number] | { x: number; y: number };

--- a/facet-typescript/src/snapshots/facet_typescript__tests__untagged_enum_unit_and_struct_variants.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__untagged_enum_unit_and_struct_variants.snap
@@ -1,6 +1,6 @@
 ---
 source: facet-typescript/src/lib.rs
-assertion_line: 639
+assertion_line: 885
 expression: ts
 ---
-export type Event = null | { x: number; y: number };
+export type Event = "None" | { x: number; y: number };


### PR DESCRIPTION
Unit variants now serialize as their name string, not null. Added tests also. This was a bug that is now fixed.

There was actually a test case from before with a snapshot that checked for the wrong output, so I corrected that too.