### PR TITLE
feat(facet): add #[facet(cow)] attribute for cow-like enum semantics

### DIFF
--- a/facet-core/src/impls/core/option.rs
+++ b/facet-core/src/impls/core/option.rs
@@ -267,6 +267,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Option<T> {
                                 .build(),
                             ]
                         },
+                        is_cow: false,
                     })
                 } else {
                     UserType::Opaque

--- a/facet-json/tests/integration/issue_1896.rs
+++ b/facet-json/tests/integration/issue_1896.rs
@@ -1,0 +1,70 @@
+//! Test for #[facet(cow)] attribute on enums.
+//!
+//! This tests the cow-like deserialization semantics where an enum like:
+//!   enum Stem<'a> { Borrowed(&'a str), Owned(String) }
+//! can be deserialized from JSON (where borrowing is not possible) by
+//! automatically selecting the Owned variant.
+
+use facet::Facet;
+use facet_json::from_str;
+
+/// A cow-like enum that can hold either a borrowed or owned string.
+#[derive(Debug, PartialEq, Facet)]
+#[facet(cow)]
+#[repr(u8)]
+pub enum Stem<'a> {
+    Borrowed(&'a str),
+    Owned(String),
+}
+
+/// A struct containing a cow-like field.
+#[derive(Debug, PartialEq, Facet)]
+pub struct Document<'a> {
+    pub title: Stem<'a>,
+    pub content: Stem<'a>,
+}
+
+#[test]
+fn test_cow_enum_deserialize_owned_variant() {
+    // When deserializing from JSON (BORROW=false), selecting "Borrowed" should
+    // automatically redirect to "Owned" variant.
+    let json = r#"{"Borrowed": "hello"}"#;
+    let result: Stem<'static> = from_str(json).expect("should deserialize");
+
+    // Should be Owned, not Borrowed, because JSON deserialization cannot borrow
+    assert_eq!(result, Stem::Owned("hello".to_string()));
+}
+
+#[test]
+fn test_cow_enum_deserialize_owned_variant_explicit() {
+    // Explicitly selecting "Owned" variant should work normally.
+    let json = r#"{"Owned": "world"}"#;
+    let result: Stem<'static> = from_str(json).expect("should deserialize");
+
+    assert_eq!(result, Stem::Owned("world".to_string()));
+}
+
+#[test]
+fn test_cow_enum_in_struct() {
+    // Test cow-like enums inside a struct.
+    let json = r#"{"title": {"Borrowed": "My Title"}, "content": {"Owned": "Some content"}}"#;
+    let result: Document<'static> = from_str(json).expect("should deserialize");
+
+    assert_eq!(result.title, Stem::Owned("My Title".to_string()));
+    assert_eq!(result.content, Stem::Owned("Some content".to_string()));
+}
+
+#[test]
+fn test_cow_enum_roundtrip() {
+    use facet_json::to_string;
+
+    let doc = Document {
+        title: Stem::Owned("Test".to_string()),
+        content: Stem::Owned("Content".to_string()),
+    };
+
+    let json = to_string(&doc).expect("should serialize");
+    let parsed: Document<'static> = from_str(&json).expect("should deserialize");
+
+    assert_eq!(parsed, doc);
+}

--- a/facet-json/tests/integration/mod.rs
+++ b/facet-json/tests/integration/mod.rs
@@ -6,6 +6,7 @@ mod issue_1726;
 mod issue_1775;
 mod issue_1791;
 mod issue_1852;
+mod issue_1896;
 mod jit_deserialize;
 mod nested_flatten_map;
 mod opaque_proxy_enum;

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -172,6 +172,34 @@ pub mod builtin {
             /// Usage: `#[facet(is_numeric)]`
             IsNumeric,
 
+            /// Marks an enum as having cow-like semantics (Borrowed/Owned variants).
+            ///
+            /// When deserializing into a cow-like enum and borrowing is not available
+            /// (e.g., from JSON), the deserializer automatically selects the `Owned` variant
+            /// instead of the `Borrowed` variant. This allows types like `Stem<'a>` to be
+            /// deserialized from formats that cannot provide borrowed data.
+            ///
+            /// Requirements:
+            /// - The enum must have exactly 2 variants named `Borrowed` and `Owned`
+            /// - `Borrowed` typically contains a reference type (e.g., `&'a str`)
+            /// - `Owned` contains an owned equivalent (e.g., `String`, `CompactString`)
+            ///
+            /// Usage: `#[facet(cow)]`
+            ///
+            /// # Example
+            ///
+            /// ```ignore
+            /// #[derive(Facet)]
+            /// #[facet(cow)]
+            /// #[repr(u8)]
+            /// pub enum Stem<'a> {
+            ///     Borrowed(&'a str),
+            ///     Owned(CompactString),
+            /// }
+            /// ```
+            #[target(container)]
+            Cow,
+
             /// Marks a type as Plain Old Data.
             ///
             /// POD types have no invariants - any combination of valid field values


### PR DESCRIPTION
## Summary

Add support for `#[facet(cow)]` attribute on enums with Borrowed/Owned variant patterns. When deserializing such enums and borrowing is not available (e.g., from JSON where `BORROW=false`), the deserializer automatically redirects `Borrowed` variant selection to `Owned`, allowing cow-like types to be deserialized without manual intervention.

## Changes

- **facet-core**: Add `is_cow` field to `EnumType` with `borrowed_variant()`/`owned_variant()` helper methods
- **facet-core**: Add `cow()` builder method to `EnumTypeBuilder`
- **facet**: Add `#[facet(cow)]` builtin attribute definition with documentation
- **facet-macros-impl**: Implement macro processing for `#[facet(cow)]` with validation (must have exactly `Borrowed` and `Owned` variants)
- **facet-format**: Update enum deserializer to redirect `Borrowed` -> `Owned` when `BORROW=false` and `is_cow=true`
- **facet-json**: Add tests for cow enum deserialization (issue #1896)

## Test plan

- [x] New integration tests in `facet-json/tests/integration/issue_1896.rs`
  - Test deserializing `{"Borrowed": "value"}` yields `Owned` variant
  - Test deserializing `{"Owned": "value"}` works normally
  - Test cow enums inside structs
  - Test roundtrip serialization/deserialization