### PR TITLE
fix: handle cow enums before numeric/index encoding

### DIFF
--- a/facet-postcard/tests/integration/cow_enum.rs
+++ b/facet-postcard/tests/integration/cow_enum.rs
@@ -1,0 +1,65 @@
+//! Test case for cow-like enums with #[repr(u8)]
+//!
+//! This tests that enums marked with both #[facet(cow)] and #[repr(u8)]
+//! serialize/deserialize correctly with postcard.
+
+#![cfg(feature = "jit")]
+
+use facet::Facet;
+use facet_postcard::{from_slice, to_vec};
+
+/// A cow-like enum similar to hotmeal's Stem type
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+#[facet(cow)]
+#[repr(u8)]
+pub enum Stem<'a> {
+    Borrowed(&'a str),
+    Owned(String),
+}
+
+#[test]
+fn test_stem_owned_roundtrip() {
+    facet_testhelpers::setup();
+
+    let original: Stem<'static> = Stem::Owned("hello".to_string());
+    let bytes = to_vec(&original).expect("serialization should succeed");
+    eprintln!("Serialized bytes: {:?}", bytes);
+
+    let decoded: Stem<'static> = from_slice(&bytes).expect("deserialization should succeed");
+    match &decoded {
+        Stem::Owned(s) => assert_eq!(s, "hello"),
+        Stem::Borrowed(_) => panic!("expected Owned variant"),
+    }
+}
+
+#[test]
+fn test_stem_borrowed_roundtrip() {
+    facet_testhelpers::setup();
+
+    // When serializing Borrowed, it should serialize the inner value transparently
+    let original: Stem<'static> = Stem::Borrowed("world");
+    let bytes = to_vec(&original).expect("serialization should succeed");
+    eprintln!("Serialized bytes: {:?}", bytes);
+
+    // Deserializing always goes to Owned (can't create borrowed reference into owned data)
+    let decoded: Stem<'static> = from_slice(&bytes).expect("deserialization should succeed");
+    match &decoded {
+        Stem::Owned(s) => assert_eq!(s, "world"),
+        Stem::Borrowed(_) => panic!("expected Owned variant after deserialization"),
+    }
+}
+
+#[test]
+fn test_vec_stem_roundtrip() {
+    facet_testhelpers::setup();
+
+    let original: Vec<Stem<'static>> = vec![
+        Stem::Owned("first".to_string()),
+        Stem::Owned("second".to_string()),
+    ];
+    let bytes = to_vec(&original).expect("serialization should succeed");
+    eprintln!("Serialized bytes: {:?}", bytes);
+
+    let decoded: Vec<Stem<'static>> = from_slice(&bytes).expect("deserialization should succeed");
+    assert_eq!(decoded.len(), 2);
+}

--- a/facet-postcard/tests/integration/mod.rs
+++ b/facet-postcard/tests/integration/mod.rs
@@ -1,3 +1,4 @@
+mod cow_enum;
 mod cross_compat;
 mod external_types;
 mod issue_1453;


### PR DESCRIPTION
## Summary

Cow-like enums (marked with `#[facet(cow)]`) should serialize/deserialize transparently as their inner value, without any variant wrapper or discriminant.

## Problem

Previously, the code checked `is_numeric()` and `EnumVariantEncoding::Index` before checking `is_cow()`, which meant cow enums with `#[repr(u8)]` would be serialized with a discriminant byte, but then fail to deserialize because the cow deserialization path expected no discriminant.

This caused a "skip_value not supported for postcard (non-self-describing)" error when trying to roundtrip types like hotmeal's `Stem`:

```rust
#[derive(Facet)]
#[facet(cow)]
#[repr(u8)]
pub enum Stem<'a> {
    Borrowed(&'a str),
    Owned(CompactString),
}
```

## Fix

Move the `is_cow()` check to happen BEFORE the numeric/index encoding checks in both the serializer and deserializer, ensuring cow enums are always handled transparently regardless of their repr.

## Testing

Added test case in `facet-postcard/tests/integration/cow_enum.rs` that reproduces the issue and verifies the fix.