### PR TITLE
Remove Spanned<T> from facet-reflect, improve span tracking

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -706,6 +706,14 @@ impl<'de> FormatParser<'de> for JsonParser<'de> {
     fn format_namespace(&self) -> Option<&'static str> {
         Some("json")
     }
+
+    fn current_span(&self) -> Option<facet_reflect::Span> {
+        // Return the span of the most recently consumed token
+        // This is used by metadata containers to track source locations
+        let offset = self.last_token_start;
+        let len = self.current_offset.saturating_sub(offset);
+        Some(facet_reflect::Span::new(offset, len))
+    }
 }
 
 // =============================================================================

--- a/facet-reflect/src/lib.rs
+++ b/facet-reflect/src/lib.rs
@@ -32,9 +32,7 @@ mod scalar;
 pub use scalar::*;
 
 mod spanned;
-pub use spanned::{
-    Span, Spanned, find_span_metadata_field, get_spanned_inner_shape, is_spanned_shape,
-};
+pub use spanned::{Span, get_metadata_container_value_shape};
 
 #[cfg(feature = "tracing")]
 #[allow(unused_imports)]

--- a/facet-reflect/src/peek/value.rs
+++ b/facet-reflect/src/peek/value.rs
@@ -1448,9 +1448,28 @@ mod tests {
         assert!(covariant.is_some());
     }
 
+    /// Local Spanned<T> for testing metadata_container behavior.
+    /// Users define their own version using #[facet(metadata_container)].
+    #[derive(Debug, Clone, facet::Facet)]
+    #[facet(metadata_container)]
+    struct Spanned<T> {
+        value: T,
+        #[facet(metadata = "span")]
+        span: Option<crate::Span>,
+    }
+
+    impl<T> Spanned<T> {
+        fn new(value: T, span: crate::Span) -> Self {
+            Self {
+                value,
+                span: Some(span),
+            }
+        }
+    }
+
     #[test]
     fn test_spanned_structural_hash_ignores_span() {
-        use crate::{Span, Spanned};
+        use crate::Span;
         use core::hash::Hasher;
         use std::hash::DefaultHasher;
 
@@ -1475,7 +1494,7 @@ mod tests {
 
     #[test]
     fn test_spanned_structural_hash_differs_for_different_values() {
-        use crate::{Span, Spanned};
+        use crate::Span;
         use core::hash::Hasher;
         use std::hash::DefaultHasher;
 
@@ -1500,7 +1519,6 @@ mod tests {
 
     #[test]
     fn test_spanned_field_metadata() {
-        use crate::Spanned;
         use facet_core::{Type, UserType};
 
         // Get the shape for Spanned<i32>

--- a/facet-solver/src/lib.rs
+++ b/facet-solver/src/lib.rs
@@ -1623,13 +1623,13 @@ impl VariantFormat {
                     // Dereference through pointers to get the actual inner type
                     let inner_shape = deref_pointer(field_shape);
 
-                    // Check if this is a Spanned<T> wrapper and unwrap it for classification
+                    // Check if this is a metadata container (like Spanned<T>) and unwrap it for classification
                     // This allows untagged enum variants containing Spanned<String> etc.
                     // to match scalar values transparently
-                    let classification_shape = if let Some(spanned_inner) =
-                        facet_reflect::get_spanned_inner_shape(field_shape)
+                    let classification_shape = if let Some(inner) =
+                        facet_reflect::get_metadata_container_value_shape(field_shape)
                     {
-                        spanned_inner
+                        inner
                     } else {
                         field_shape
                     };


### PR DESCRIPTION
## Summary

This change removes the built-in `Spanned<T>` type from `facet-reflect` and instead encourages users to define their own using the `metadata_container` attribute.

## Why?

- Users can customize field names and types (e.g., `Option<Span>` vs `Span`)
- The derive macro approach is more idiomatic
- It demonstrates how to use the `metadata_container` feature
- `facet-reflect` can't depend on `facet-macros` anyway, so the manual impl was complex

## Changes

- Remove `Spanned<T>` struct and its manual `Facet` impl from `facet-reflect`
- Remove `is_spanned_shape()` and `find_span_metadata_field()` helpers
- Rename `get_spanned_inner_shape()` to `get_metadata_container_value_shape()`
- Keep `Span` struct (with manual Facet impl - necessary since facet-reflect can't depend on facet-macros)
- Update `facet-format` deserializer to properly populate span metadata from parser state
- Add `current_span()` to facet-json's `FormatParser` impl
- Update `facet-solver` to use new function name
- Update tests to define local `Spanned<T>`

## How users should define Spanned<T>

```rust
use facet::Facet;
use facet_reflect::Span;

#[derive(Debug, Clone, Facet)]
#[facet(metadata_container)]
pub struct Spanned<T> {
    pub value: T,
    #[facet(metadata = "span")]
    pub span: Option<Span>,
}
```

The deserializer will automatically populate the span field from the parser's current position when deserializing into a metadata container.