### PR TITLE
Add Facet implementations for jiff::civil::Date and jiff::civil::Time

### DIFF
--- a/facet-asn1/tests/format_suite.rs
+++ b/facet-asn1/tests/format_suite.rs
@@ -453,6 +453,14 @@ impl FormatSuite for Asn1Slice {
         CaseSpec::skip("ASN.1 is a binary format, requires binary input not JSON strings")
     }
 
+    fn jiff_civil_date() -> CaseSpec {
+        CaseSpec::skip("ASN.1 is a binary format, requires binary input not JSON strings")
+    }
+
+    fn jiff_civil_time() -> CaseSpec {
+        CaseSpec::skip("ASN.1 is a binary format, requires binary input not JSON strings")
+    }
+
     fn chrono_datetime_utc() -> CaseSpec {
         CaseSpec::skip("ASN.1 is a binary format, requires binary input not JSON strings")
     }

--- a/facet-format-suite/src/lib.rs
+++ b/facet-format-suite/src/lib.rs
@@ -413,6 +413,14 @@ pub trait FormatSuite {
     #[cfg(feature = "jiff02")]
     fn jiff_civil_datetime() -> CaseSpec;
 
+    /// Case: jiff::civil::Date type.
+    #[cfg(feature = "jiff02")]
+    fn jiff_civil_date() -> CaseSpec;
+
+    /// Case: jiff::civil::Time type.
+    #[cfg(feature = "jiff02")]
+    fn jiff_civil_time() -> CaseSpec;
+
     /// Case: `chrono::DateTime<Utc>` type.
     #[cfg(feature = "chrono")]
     fn chrono_datetime_utc() -> CaseSpec;
@@ -792,6 +800,10 @@ pub fn all_cases<S: FormatSuite + 'static>() -> Vec<SuiteCase> {
             &CASE_JIFF_CIVIL_DATETIME,
             S::jiff_civil_datetime,
         ),
+        #[cfg(feature = "jiff02")]
+        SuiteCase::new::<S, JiffCivilDateWrapper>(&CASE_JIFF_CIVIL_DATE, S::jiff_civil_date),
+        #[cfg(feature = "jiff02")]
+        SuiteCase::new::<S, JiffCivilTimeWrapper>(&CASE_JIFF_CIVIL_TIME, S::jiff_civil_time),
         #[cfg(feature = "chrono")]
         SuiteCase::new::<S, ChronoDateTimeUtcWrapper>(
             &CASE_CHRONO_DATETIME_UTC,
@@ -3551,6 +3563,24 @@ const CASE_JIFF_CIVIL_DATETIME: CaseDescriptor<JiffCivilDateTimeWrapper> = CaseD
     },
 };
 
+#[cfg(feature = "jiff02")]
+const CASE_JIFF_CIVIL_DATE: CaseDescriptor<JiffCivilDateWrapper> = CaseDescriptor {
+    id: "third_party::jiff_civil_date",
+    description: "jiff::civil::Date type",
+    expected: || JiffCivilDateWrapper {
+        date: "2024-06-19".parse().unwrap(),
+    },
+};
+
+#[cfg(feature = "jiff02")]
+const CASE_JIFF_CIVIL_TIME: CaseDescriptor<JiffCivilTimeWrapper> = CaseDescriptor {
+    id: "third_party::jiff_civil_time",
+    description: "jiff::civil::Time type",
+    expected: || JiffCivilTimeWrapper {
+        time: "15:22:45".parse().unwrap(),
+    },
+};
+
 #[cfg(feature = "chrono")]
 const CASE_CHRONO_DATETIME_UTC: CaseDescriptor<ChronoDateTimeUtcWrapper> = CaseDescriptor {
     id: "third_party::chrono_datetime_utc",
@@ -3868,6 +3898,20 @@ pub struct JiffTimestampWrapper {
 #[derive(Facet, Debug, Clone, PartialEq)]
 pub struct JiffCivilDateTimeWrapper {
     pub created_at: jiff::civil::DateTime,
+}
+
+/// Fixture for jiff::civil::Date test.
+#[cfg(feature = "jiff02")]
+#[derive(Facet, Debug, Clone, PartialEq)]
+pub struct JiffCivilDateWrapper {
+    pub date: jiff::civil::Date,
+}
+
+/// Fixture for jiff::civil::Time test.
+#[cfg(feature = "jiff02")]
+#[derive(Facet, Debug, Clone, PartialEq)]
+pub struct JiffCivilTimeWrapper {
+    pub time: jiff::civil::Time,
 }
 
 /// Fixture for `chrono::DateTime<Utc>` test.

--- a/facet-json/tests/format_suite.rs
+++ b/facet-json/tests/format_suite.rs
@@ -748,6 +748,14 @@ impl FormatSuite for JsonSlice {
         CaseSpec::from_str(r#"{"created_at":"2024-06-19T15:22:45"}"#)
     }
 
+    fn jiff_civil_date() -> CaseSpec {
+        CaseSpec::from_str(r#"{"date":"2024-06-19"}"#)
+    }
+
+    fn jiff_civil_time() -> CaseSpec {
+        CaseSpec::from_str(r#"{"time":"15:22:45"}"#)
+    }
+
     fn chrono_datetime_utc() -> CaseSpec {
         CaseSpec::from_str(r#"{"created_at":"2023-01-15T12:34:56Z"}"#)
     }
@@ -833,7 +841,9 @@ impl FormatSuite for JsonSlice {
     fn iddqd_tri_hash_map() -> CaseSpec {
         // TriHashMap serializes as array of values (Set semantics)
         // Single element ensures deterministic order for roundtrip
-        CaseSpec::from_str(r#"{"items":[{"id":1,"code":"A001","email":"alice@example.com","name":"Alice"}]}"#)
+        CaseSpec::from_str(
+            r#"{"items":[{"id":1,"code":"A001","email":"alice@example.com","name":"Alice"}]}"#,
+        )
     }
 
     // ── Dynamic value cases ──

--- a/facet-msgpack/tests/format_suite.rs
+++ b/facet-msgpack/tests/format_suite.rs
@@ -466,6 +466,14 @@ impl FormatSuite for MsgPackSlice {
         CaseSpec::skip("MsgPack is a binary format, requires binary input not JSON strings")
     }
 
+    fn jiff_civil_date() -> CaseSpec {
+        CaseSpec::skip("MsgPack is a binary format, requires binary input not JSON strings")
+    }
+
+    fn jiff_civil_time() -> CaseSpec {
+        CaseSpec::skip("MsgPack is a binary format, requires binary input not JSON strings")
+    }
+
     fn chrono_datetime_utc() -> CaseSpec {
         CaseSpec::skip("MsgPack is a binary format, requires binary input not JSON strings")
     }

--- a/facet-postcard/tests/integration/external_types.rs
+++ b/facet-postcard/tests/integration/external_types.rs
@@ -423,7 +423,10 @@ mod chrono_tests {
 #[cfg(feature = "jiff02")]
 mod jiff_tests {
     use super::*;
-    use jiff::{Timestamp, Zoned, civil::DateTime};
+    use jiff::{
+        Timestamp, Zoned,
+        civil::{Date, DateTime, Time},
+    };
 
     #[test]
     fn timestamp_roundtrip() {
@@ -441,6 +444,24 @@ mod jiff_tests {
         let bytes = to_vec(&dt).unwrap();
         let decoded: DateTime = from_slice(&bytes).unwrap();
         assert_eq!(dt, decoded);
+    }
+
+    #[test]
+    fn date_roundtrip() {
+        facet_testhelpers::setup();
+        let date: Date = "2024-06-19".parse().unwrap();
+        let bytes = to_vec(&date).unwrap();
+        let decoded: Date = from_slice(&bytes).unwrap();
+        assert_eq!(date, decoded);
+    }
+
+    #[test]
+    fn time_roundtrip() {
+        facet_testhelpers::setup();
+        let time: Time = "15:22:45".parse().unwrap();
+        let bytes = to_vec(&time).unwrap();
+        let decoded: Time = from_slice(&bytes).unwrap();
+        assert_eq!(time, decoded);
     }
 
     #[test]

--- a/facet-toml/tests/format_suite.rs
+++ b/facet-toml/tests/format_suite.rs
@@ -658,6 +658,14 @@ impl FormatSuite for TomlSlice {
         CaseSpec::from_str("created_at = 2024-06-19T15:22:45")
     }
 
+    fn jiff_civil_date() -> CaseSpec {
+        CaseSpec::from_str("date = 2024-06-19")
+    }
+
+    fn jiff_civil_time() -> CaseSpec {
+        CaseSpec::from_str("time = 15:22:45")
+    }
+
     fn chrono_datetime_utc() -> CaseSpec {
         CaseSpec::from_str("created_at = 2023-01-15T12:34:56Z")
     }

--- a/facet-yaml/tests/format_suite.rs
+++ b/facet-yaml/tests/format_suite.rs
@@ -663,6 +663,14 @@ impl FormatSuite for YamlSlice {
         CaseSpec::from_str("created_at: 2024-06-19T15:22:45")
     }
 
+    fn jiff_civil_date() -> CaseSpec {
+        CaseSpec::from_str("date: 2024-06-19")
+    }
+
+    fn jiff_civil_time() -> CaseSpec {
+        CaseSpec::from_str("time: 15:22:45")
+    }
+
     fn chrono_datetime_utc() -> CaseSpec {
         CaseSpec::from_str("created_at: 2023-01-15T12:34:56Z")
     }


### PR DESCRIPTION
## Summary

Extends the `jiff02` feature support to include the remaining civil types: `Date` (calendar date without time/timezone) and `Time` (time of day without date/timezone). This completes the jiff civil type support alongside the existing `DateTime` implementation.

Closes #1910

## Changes

- Add `Facet` implementation for `jiff::civil::Date` with display, parse, try_from, and partial_eq vtable functions
- Add `Facet` implementation for `jiff::civil::Time` with the same vtable functions
- Add format suite test cases for both types across all supported formats (JSON, YAML, TOML, msgpack, ASN1, postcard)
- Add unit tests for parsing and displaying both types

## Test plan

- [x] Unit tests in facet-core for Date and Time parsing/display
- [x] Format suite tests verify serialization/deserialization across all formats
- [x] All existing tests continue to pass