### PR TITLE
Re-enable specialization-based auto-detection as default

### DIFF
--- a/facet-core/src/types/vtable.rs
+++ b/facet-core/src/types/vtable.rs
@@ -627,6 +627,100 @@ impl<T> TypedVTableDirectBuilder<T> {
         self
     }
 
+    // Optional variants for auto-detection via `impls!` macro
+
+    /// Set the display function from an Option.
+    /// Used for auto-detection where the function may not be available.
+    pub const fn display_opt(
+        mut self,
+        f: Option<fn(&T, &mut fmt::Formatter<'_>) -> fmt::Result>,
+    ) -> Self {
+        self.vtable.display = match f {
+            Some(f) => Some(unsafe {
+                transmute::<
+                    fn(&T, &mut fmt::Formatter<'_>) -> fmt::Result,
+                    unsafe fn(*const (), &mut fmt::Formatter<'_>) -> fmt::Result,
+                >(f)
+            }),
+            None => None,
+        };
+        self
+    }
+
+    /// Set the debug function from an Option.
+    /// Used for auto-detection where the function may not be available.
+    pub const fn debug_opt(
+        mut self,
+        f: Option<fn(&T, &mut fmt::Formatter<'_>) -> fmt::Result>,
+    ) -> Self {
+        self.vtable.debug = match f {
+            Some(f) => Some(unsafe {
+                transmute::<
+                    fn(&T, &mut fmt::Formatter<'_>) -> fmt::Result,
+                    unsafe fn(*const (), &mut fmt::Formatter<'_>) -> fmt::Result,
+                >(f)
+            }),
+            None => None,
+        };
+        self
+    }
+
+    /// Set the hash function from an Option.
+    /// Used for auto-detection where the function may not be available.
+    pub const fn hash_opt(mut self, f: Option<fn(&T, &mut HashProxy<'static>)>) -> Self {
+        self.vtable.hash = match f {
+            Some(f) => Some(unsafe {
+                transmute::<fn(&T, &mut HashProxy<'static>), unsafe fn(*const (), &mut HashProxy<'_>)>(
+                    f,
+                )
+            }),
+            None => None,
+        };
+        self
+    }
+
+    /// Set the partial_eq function from an Option.
+    /// Used for auto-detection where the function may not be available.
+    pub const fn partial_eq_opt(mut self, f: Option<fn(&T, &T) -> bool>) -> Self {
+        self.vtable.partial_eq = match f {
+            Some(f) => Some(unsafe {
+                transmute::<fn(&T, &T) -> bool, unsafe fn(*const (), *const ()) -> bool>(f)
+            }),
+            None => None,
+        };
+        self
+    }
+
+    /// Set the partial_cmp function from an Option.
+    /// Used for auto-detection where the function may not be available.
+    pub const fn partial_cmp_opt(mut self, f: Option<fn(&T, &T) -> Option<cmp::Ordering>>) -> Self {
+        self.vtable.partial_cmp = match f {
+            Some(f) => Some(unsafe {
+                transmute::<
+                    fn(&T, &T) -> Option<cmp::Ordering>,
+                    unsafe fn(*const (), *const ()) -> Option<cmp::Ordering>,
+                >(f)
+            }),
+            None => None,
+        };
+        self
+    }
+
+    /// Set the cmp function from an Option.
+    /// Used for auto-detection where the function may not be available.
+    pub const fn cmp_opt(mut self, f: Option<fn(&T, &T) -> cmp::Ordering>) -> Self {
+        self.vtable.cmp = match f {
+            Some(f) => Some(unsafe {
+                transmute::<
+                    fn(&T, &T) -> cmp::Ordering,
+                    unsafe fn(*const (), *const ()) -> cmp::Ordering,
+                >(f)
+            }),
+            None => None,
+        };
+        self
+    }
+
     /// Build the VTable.
     pub const fn build(self) -> VTableDirect {
         self.vtable

--- a/facet-diff/tests/integration/proxy_diff.rs
+++ b/facet-diff/tests/integration/proxy_diff.rs
@@ -25,7 +25,6 @@ impl OpaqueCounter {
 
 /// Proxy type that derives Facet for serialization/comparison.
 #[derive(Facet, Clone, Debug, PartialEq)]
-#[facet(auto_traits)]
 pub struct OpaqueCounterProxy {
     pub count: u64,
 }
@@ -49,7 +48,6 @@ impl TryFrom<&OpaqueCounter> for OpaqueCounterProxy {
 // =============================================================================
 
 #[derive(Facet, Clone, Debug)]
-#[facet(auto_traits)]
 pub struct StructWithOpaqueField {
     pub name: String,
     #[facet(opaque, proxy = OpaqueCounterProxy)]
@@ -136,7 +134,6 @@ fn diff_struct_with_opaque_proxy_field_both_different() {
 // =============================================================================
 
 #[derive(Facet, Clone, Debug)]
-#[facet(auto_traits)]
 #[repr(u8)]
 #[allow(dead_code)]
 pub enum EnumWithOpaqueField {
@@ -203,7 +200,6 @@ fn diff_enum_different_variants() {
 // =============================================================================
 
 #[derive(Facet, Clone, Debug)]
-#[facet(auto_traits)]
 pub struct MultipleOpaqueFields {
     #[facet(opaque, proxy = OpaqueCounterProxy)]
     pub first: OpaqueCounter,
@@ -271,7 +267,6 @@ fn diff_multiple_opaque_fields_both_different() {
 // =============================================================================
 
 #[derive(Facet, Clone, Debug)]
-#[facet(auto_traits)]
 pub struct OuterStruct {
     pub id: u32,
     pub inner: StructWithOpaqueField,

--- a/facet-reflect/tests/partial/misc.rs
+++ b/facet-reflect/tests/partial/misc.rs
@@ -672,7 +672,6 @@ fn clone_into() -> Result<(), IPanic> {
     static CLONES: AtomicU64 = AtomicU64::new(0);
 
     #[derive(Facet)]
-    #[facet(auto_traits)]
     struct Foo;
 
     impl Clone for Foo {
@@ -958,7 +957,6 @@ fn struct_field_set_twice() -> Result<(), IPanic> {
 #[test]
 fn set_default() -> Result<(), IPanic> {
     #[derive(Facet, Debug, PartialEq, Default)]
-    #[facet(auto_traits)]
     struct Sample {
         x: u32,
         y: String,
@@ -997,7 +995,6 @@ fn set_default_drops_previous() -> Result<(), IPanic> {
     static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
 
     #[derive(Facet, Debug)]
-    #[facet(auto_traits)]
     struct DropTracker {
         id: u64,
     }

--- a/facet-reflect/tests/peek/serialize.rs
+++ b/facet-reflect/tests/peek/serialize.rs
@@ -10,7 +10,6 @@ fn peek_opaque_custom_serialize() -> Result<(), IPanic> {
 
     // Proxy type that derives Facet
     #[derive(Facet, Copy, Clone)]
-    #[facet(auto_traits)]
     pub struct NotDerivingFacetProxy(u64);
 
     impl TryFrom<NotDerivingFacetProxy> for NotDerivingFacet {
@@ -28,7 +27,6 @@ fn peek_opaque_custom_serialize() -> Result<(), IPanic> {
     }
 
     #[derive(Facet)]
-    #[facet(auto_traits)]
     pub struct Container {
         #[facet(opaque, proxy = NotDerivingFacetProxy)]
         inner: NotDerivingFacet,
@@ -69,14 +67,12 @@ fn peek_opaque_custom_serialize() -> Result<(), IPanic> {
 #[test]
 fn peek_shaped_custom_serialize() -> Result<(), IPanic> {
     #[derive(Facet, Copy, Clone, Debug, Eq, PartialEq)]
-    #[facet(auto_traits)]
     pub struct Struct1 {
         val: u64,
     }
 
     // Proxy type for serialization
     #[derive(Facet)]
-    #[facet(auto_traits)]
     pub struct Struct1Proxy {
         sum: String,
     }
@@ -100,7 +96,6 @@ fn peek_shaped_custom_serialize() -> Result<(), IPanic> {
     }
 
     #[derive(Facet)]
-    #[facet(auto_traits)]
     pub struct Container {
         #[facet(opaque, proxy = Struct1Proxy)]
         inner: Struct1,
@@ -145,7 +140,6 @@ fn peek_opaque_custom_serialize_enum_tuple() -> Result<(), IPanic> {
 
     // Proxy type that derives Facet
     #[derive(Facet, Copy, Clone)]
-    #[facet(auto_traits)]
     pub struct NotDerivingFacetProxy(u64);
 
     impl TryFrom<NotDerivingFacetProxy> for NotDerivingFacet {
@@ -164,7 +158,6 @@ fn peek_opaque_custom_serialize_enum_tuple() -> Result<(), IPanic> {
 
     #[allow(dead_code)]
     #[derive(Facet)]
-    #[facet(auto_traits)]
     #[repr(u8)]
     pub enum Choices {
         Opaque(#[facet(opaque, proxy = NotDerivingFacetProxy)] NotDerivingFacet),
@@ -216,7 +209,6 @@ fn peek_opaque_custom_serialize_enum_feels() -> Result<(), IPanic> {
 
     // Proxy type that derives Facet
     #[derive(Facet, Copy, Clone)]
-    #[facet(auto_traits)]
     pub struct NotDerivingFacetProxy(u64);
 
     impl TryFrom<NotDerivingFacetProxy> for NotDerivingFacet {
@@ -235,7 +227,6 @@ fn peek_opaque_custom_serialize_enum_feels() -> Result<(), IPanic> {
 
     #[allow(dead_code)]
     #[derive(Facet)]
-    #[facet(auto_traits)]
     #[repr(u8)]
     pub enum Choices {
         Opaque {
@@ -288,14 +279,12 @@ fn peek_opaque_custom_serialize_enum_feels() -> Result<(), IPanic> {
 #[test]
 fn peek_shaped_custom_serialize_pointers() -> Result<(), IPanic> {
     #[derive(Facet, Copy, Clone, Debug, Eq, PartialEq)]
-    #[facet(auto_traits)]
     pub struct Struct1 {
         val: u64,
     }
 
     // Proxy type for serialization
     #[derive(Facet)]
-    #[facet(auto_traits)]
     pub struct ArcStruct1Proxy {
         sum: String,
     }
@@ -319,7 +308,6 @@ fn peek_shaped_custom_serialize_pointers() -> Result<(), IPanic> {
     }
 
     #[derive(Facet)]
-    #[facet(auto_traits)]
     pub struct Container {
         #[facet(opaque, proxy = ArcStruct1Proxy)]
         inner: std::sync::Arc<Struct1>,
@@ -364,7 +352,6 @@ fn peek_custom_serialize_errors() -> Result<(), IPanic> {
 
     // Proxy type that derives Facet
     #[derive(Facet, Copy, Clone)]
-    #[facet(auto_traits)]
     pub struct NotDerivingFacetProxy(u64);
 
     impl TryFrom<NotDerivingFacetProxy> for NotDerivingFacet {
@@ -386,7 +373,6 @@ fn peek_custom_serialize_errors() -> Result<(), IPanic> {
     }
 
     #[derive(Facet)]
-    #[facet(auto_traits)]
     pub struct Container {
         #[facet(opaque, proxy = NotDerivingFacetProxy)]
         inner: NotDerivingFacet,
@@ -434,7 +420,6 @@ fn peek_custom_serialize_errors() -> Result<(), IPanic> {
 fn peek_custom_serialize_zst() -> Result<(), IPanic> {
     // Proxy type for () (ZST)
     #[derive(Facet)]
-    #[facet(auto_traits)]
     pub struct UnitProxy(u64);
 
     impl TryFrom<UnitProxy> for () {
@@ -452,7 +437,6 @@ fn peek_custom_serialize_zst() -> Result<(), IPanic> {
     }
 
     #[derive(Facet)]
-    #[facet(auto_traits)]
     pub struct Container {
         #[facet(proxy = UnitProxy)]
         inner: (),

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -310,7 +310,7 @@ pub mod builtin {
             /// ```
             RecursiveType,
 
-            // Note: `traits(...)`, `auto_traits`, and `bound` are compile-time-only directives
+            // Note: `traits(...)` and `bound` are compile-time-only directives
             // processed by the derive macro. They are not stored as runtime attributes.
             // See DeclaredTraits in facet-macros-impl/src/parsed.rs for their handling.
 

--- a/facet/tests/integration/value_vtable_facts.rs
+++ b/facet/tests/integration/value_vtable_facts.rs
@@ -171,8 +171,8 @@ where
     let mut facts: BTreeSet<Fact> = BTreeSet::new();
     let shape = T::SHAPE;
 
-    // For VTableIndirect (auto_traits), the function pointers exist but may return None
-    // at runtime. We need to actually try calling them to know if the trait is supported.
+    // With auto trait detection, the optional function pointers may be None when the trait
+    // is not implemented. We need to actually try calling them to know if the trait is supported.
     let ptr1 = PtrConst::new(core::ptr::from_ref(val1));
     let ptr2 = PtrConst::new(core::ptr::from_ref(val2));
 
@@ -910,7 +910,6 @@ fn test_vecs() {
 fn test_custom_structs() {
     // Struct with no trait implementations
     #[derive(Facet)]
-    #[facet(auto_traits)]
     struct StructNoTraits {
         value: i32,
     }
@@ -922,7 +921,6 @@ fn test_custom_structs() {
 
     // Struct with Debug only
     #[derive(Facet, Debug)]
-    #[facet(auto_traits)]
     struct StructDebug {
         value: i32,
     }
@@ -934,7 +932,6 @@ fn test_custom_structs() {
 
     // Struct with Debug and PartialEq
     #[derive(Facet, Debug, PartialEq)]
-    #[facet(auto_traits)]
     struct StructDebugEq {
         value: i32,
     }
@@ -946,7 +943,6 @@ fn test_custom_structs() {
 
     // Struct with all traits
     #[derive(Facet, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
-    #[facet(auto_traits)]
     struct StructAll {
         value: i32,
     }
@@ -986,7 +982,6 @@ fn test_custom_structs() {
 fn test_tuple_structs() {
     // Tuple struct with no trait implementations
     #[derive(Facet)]
-    #[facet(auto_traits)]
     #[allow(dead_code)]
     struct TupleNoTraits(i32, String);
     check_facts(
@@ -997,7 +992,6 @@ fn test_tuple_structs() {
 
     // Tuple struct with Debug only
     #[derive(Facet, Debug)]
-    #[facet(auto_traits)]
     #[allow(dead_code)]
     struct TupleDebug(i32, String);
     check_facts(
@@ -1008,7 +1002,6 @@ fn test_tuple_structs() {
 
     // Tuple struct with EQ only
     #[derive(Facet, PartialEq)]
-    #[facet(auto_traits)]
     struct TupleEq(i32, String);
     check_facts(
         &TupleEq(42, "Hello".to_string()),
@@ -1018,7 +1011,6 @@ fn test_tuple_structs() {
 
     // Tuple struct with all traits
     #[derive(Facet, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-    #[facet(auto_traits)]
     struct TupleAll(i32, String);
     check_facts(
         &TupleAll(42, "Hello".to_string()),
@@ -1035,7 +1027,6 @@ fn test_tuple_structs() {
 #[test]
 fn test_enums() {
     #[derive(Facet, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-    #[facet(auto_traits)]
     #[repr(u8)]
     enum TestEnum {
         Variant1,
@@ -1087,7 +1078,6 @@ fn test_enums() {
 #[test]
 fn test_weird_cmp() {
     #[derive(Facet)]
-    #[facet(auto_traits)]
     struct WeirdCmp;
 
     impl PartialEq for WeirdCmp {


### PR DESCRIPTION
## Summary

Makes auto-detection of traits (Display, Debug, Hash, PartialEq, etc.) via the `impls!` macro the default behavior for non-generic types, rather than requiring an explicit `#[facet(auto_traits)]` attribute. This restores the pre-#1900 user experience where traits were detected automatically.

The `#[facet(traits(...))]` attribute remains available for explicitly declaring which traits to include in the vtable, which bypasses auto-detection entirely.

Closes #1918

## Changes

- **Remove `auto_traits` attribute** - The `#[facet(auto_traits)]` attribute and its associated `auto_traits` field have been removed from `PAttrs`
- **Add `*_opt` builder methods** - `ValueVTableBuilder` now has `display_opt`, `debug_opt`, `hash_opt`, `partial_eq_opt`, `partial_cmp_opt`, and `cmp_opt` methods that accept `Option<fn>` for cleaner auto-detection code
- **Update `should_auto()` logic** - Now returns `true` when no explicit traits are declared, making auto-detection the default
- **Non-generic types only** - Auto-detection only applies to non-generic types because function items can't reference type/lifetime parameters from the outer scope
- **Remove test annotations** - Removed unnecessary `#[facet(auto_traits)]` from test cases

## Test plan

- [x] All existing tests pass
- [x] Pre-commit hooks pass
- [ ] CI passes