### PR TITLE
Handle NaN and infinity as null in JSON serializer

### DIFF
--- a/facet-json/src/serializer.rs
+++ b/facet-json/src/serializer.rs
@@ -358,11 +358,15 @@ impl FormatSerializer for JsonSerializer {
                 self.out.extend_from_slice(v.to_string().as_bytes());
             }
             ScalarValue::F64(v) => {
-                #[cfg(feature = "fast")]
-                self.out
-                    .extend_from_slice(zmij::Buffer::new().format(v).as_bytes());
-                #[cfg(not(feature = "fast"))]
-                self.out.extend_from_slice(v.to_string().as_bytes());
+                if v.is_nan() || v.is_infinite() {
+                    self.out.extend_from_slice(b"null");
+                } else {
+                    #[cfg(feature = "fast")]
+                    self.out
+                        .extend_from_slice(zmij::Buffer::new().format(v).as_bytes());
+                    #[cfg(not(feature = "fast"))]
+                    self.out.extend_from_slice(v.to_string().as_bytes());
+                }
             }
             ScalarValue::Str(s) => self.write_json_string(&s),
             ScalarValue::Bytes(_) => {

--- a/facet-json/tests/integration/mod.rs
+++ b/facet-json/tests/integration/mod.rs
@@ -10,6 +10,7 @@ mod issue_1896;
 mod issue_1900;
 mod issue_1904;
 mod jit_deserialize;
+mod nan_infinity;
 mod nested_flatten_map;
 mod opaque_proxy_enum;
 mod opaque_proxy_struct;

--- a/facet-json/tests/integration/nan_infinity.rs
+++ b/facet-json/tests/integration/nan_infinity.rs
@@ -1,0 +1,44 @@
+//! Test for NaN and Infinity float serialization.
+//!
+//! JSON does not support NaN or Infinity values. Per serde's behavior,
+//! these should serialize as `null`.
+
+use facet::Facet;
+
+#[derive(Debug, Facet)]
+struct Container {
+    value: f64,
+}
+
+#[derive(Debug, Facet)]
+struct ContainerF32 {
+    value: f32,
+}
+
+#[test]
+fn test_nan_serializes_as_null() {
+    let container = Container { value: f64::NAN };
+    let json = facet_json::to_string(&container).unwrap();
+
+    assert_eq!(json, r#"{"value":null}"#, "NaN should serialize as null");
+}
+
+#[test]
+fn test_positive_infinity_serializes_as_null() {
+    let container = Container {
+        value: f64::INFINITY,
+    };
+    let json = facet_json::to_string(&container).unwrap();
+
+    assert_eq!(
+        json, r#"{"value":null}"#,
+        "Positive infinity should serialize as null"
+    );
+}
+
+#[test]
+fn test_f32_nan_serializes_as_null() {
+    let container = ContainerF32 { value: f32::NAN };
+    let json = facet_json::to_string(&container).unwrap();
+    assert_eq!(json, r#"{"value":null}"#);
+}


### PR DESCRIPTION
This to generate valid json documents and be consistent with serde. (Nan is not valid jso)