### PR TITLE
Fix flattened fields in externally-tagged enum struct variants

### DIFF
--- a/facet-json/tests/integration/flatten_in_externally_tagged_enum.rs
+++ b/facet-json/tests/integration/flatten_in_externally_tagged_enum.rs
@@ -1,0 +1,66 @@
+//! Test for flattened fields in externally-tagged enum struct variants.
+//! See https://github.com/facet-rs/facet/issues/1921
+
+use facet::Facet;
+use facet_json::from_str;
+
+#[derive(Facet, Debug, PartialEq, Default)]
+struct LoggingOpts {
+    debug: bool,
+    #[facet(default)]
+    log_file: Option<String>,
+}
+
+#[derive(Facet, Debug, PartialEq, Default)]
+struct CommonOpts {
+    verbose: bool,
+    quiet: bool,
+    #[facet(flatten)]
+    logging: LoggingOpts,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+#[repr(u8)]
+enum DeepCommand {
+    Execute {
+        #[facet(flatten)]
+        common: CommonOpts,
+        target: String,
+    },
+}
+
+#[test]
+fn test_flatten_in_externally_tagged_enum_variant() {
+    // JSON with flat fields - this is what figue's ConfigValue produces
+    let json = r#"{"Execute": {"verbose": true, "debug": true, "log_file": "/var/log/app.log", "target": "my-target", "quiet": false}}"#;
+
+    let result: DeepCommand = from_str(json).expect("should deserialize");
+
+    match &result {
+        DeepCommand::Execute { common, target } => {
+            assert!(common.verbose, "verbose should be true");
+            assert!(!common.quiet, "quiet should be false");
+            assert!(common.logging.debug, "debug should be true");
+            assert_eq!(common.logging.log_file.as_deref(), Some("/var/log/app.log"));
+            assert_eq!(target, "my-target");
+        }
+    }
+}
+
+#[test]
+fn test_flatten_in_externally_tagged_enum_with_defaults() {
+    // JSON with only required fields - defaults should apply
+    let json = r#"{"Execute": {"target": "simple-target"}}"#;
+
+    let result: DeepCommand = from_str(json).expect("should deserialize");
+
+    match &result {
+        DeepCommand::Execute { common, target } => {
+            assert!(!common.verbose, "verbose should default to false");
+            assert!(!common.quiet, "quiet should default to false");
+            assert!(!common.logging.debug, "debug should default to false");
+            assert_eq!(common.logging.log_file, None);
+            assert_eq!(target, "simple-target");
+        }
+    }
+}

--- a/facet-json/tests/integration/mod.rs
+++ b/facet-json/tests/integration/mod.rs
@@ -1,4 +1,5 @@
 mod flatten_defaults;
+mod flatten_in_externally_tagged_enum;
 mod format_specific_proxy;
 mod issue_1236;
 mod issue_1721_1724;


### PR DESCRIPTION
## Summary

Flattened fields within externally-tagged enum struct variants were not being deserialized correctly. The fields were present in the input but were being skipped as "unknown fields" instead of being routed into the flattened struct.

## Changes

1. **Added deferred mode for enum variants with flattened fields** - this allows fields to be set out of order, which is required for flatten handling.

2. **Added path-based lookup using `find_field_path()`** - routes flat input fields to their correct nested location within flattened structs.

3. **Touch untouched flattened fields after the main loop** - ensures `fill_defaults` can properly initialize nested structs that had no input values provided.

## Test case

```rust
#[derive(Facet)]
struct CommonOpts {
    verbose: bool,
    quiet: bool,
    #[facet(flatten)]
    logging: LoggingOpts,
}

#[derive(Facet)]
enum DeepCommand {
    Execute {
        #[facet(flatten)]
        common: CommonOpts,
        target: String,
    },
}

// This JSON now deserializes correctly:
// {"Execute": {"verbose": true, "debug": true, "target": "my-target"}}
```

Fixes #1921