### PR TITLE
Reduce monomorphization in facet-format deserializer (#1924)

### DIFF
--- a/facet-dessert/src/lib.rs
+++ b/facet-dessert/src/lib.rs
@@ -2,6 +2,9 @@
 //!
 //! This crate provides common setter functions for handling string, bytes, and scalar values
 //! when deserializing into facet types. It's used by both `facet-format` and `facet-dom`.
+//!
+//! By extracting these functions into a non-generic crate, we reduce monomorphization bloat
+//! in format deserializers. See <https://github.com/bearcove/facet/issues/1924> for details.
 
 extern crate alloc;
 

--- a/facet-format/src/deserializer/error.rs
+++ b/facet-format/src/deserializer/error.rs
@@ -3,7 +3,199 @@ extern crate alloc;
 use alloc::string::String;
 use core::fmt;
 use facet_path::Path;
-use facet_reflect::ReflectError;
+use facet_reflect::{ReflectError, Span};
+
+/// Internal error type used by parser-agnostic deserialization functions.
+///
+/// This type mirrors [`DeserializeError`] but without the generic `E` parameter,
+/// allowing large functions to be monomorphized once instead of per-parser type.
+/// The thin generic wrappers convert this to `DeserializeError<P::Error>`.
+#[derive(Debug)]
+pub enum InnerDeserializeError {
+    /// Reflection error from Partial operations.
+    Reflect {
+        /// The underlying reflection error.
+        error: ReflectError,
+        /// Source span where the error occurred (if available).
+        span: Option<Span>,
+        /// Path through the type structure where the error occurred.
+        path: Option<Path>,
+    },
+    /// Type mismatch during deserialization.
+    TypeMismatch {
+        /// The expected type or token.
+        expected: &'static str,
+        /// The actual type or token that was encountered.
+        got: String,
+        /// Source span where the mismatch occurred (if available).
+        span: Option<Span>,
+        /// Path through the type structure where the error occurred.
+        path: Option<Path>,
+    },
+    /// Unsupported type or operation.
+    Unsupported(String),
+    /// Unknown field encountered when deny_unknown_fields is set.
+    UnknownField {
+        /// The unknown field name.
+        field: String,
+        /// Source span where the unknown field was found (if available).
+        span: Option<Span>,
+        /// Path through the type structure where the error occurred.
+        path: Option<Path>,
+    },
+    /// Cannot borrow string from input (e.g., escaped string into &str).
+    CannotBorrow {
+        /// Description of why borrowing failed.
+        message: String,
+    },
+    /// Required field missing from input.
+    MissingField {
+        /// The field that is missing.
+        field: &'static str,
+        /// The type that contains the field.
+        type_name: &'static str,
+        /// Source span where the struct was being parsed (if available).
+        span: Option<Span>,
+        /// Path through the type structure where the error occurred.
+        path: Option<Path>,
+    },
+    /// Field validation failed.
+    #[cfg(feature = "validate")]
+    Validation {
+        /// The field that failed validation.
+        field: &'static str,
+        /// The validation error message.
+        message: String,
+        /// Source span where the invalid value was found.
+        span: Option<Span>,
+        /// Path through the type structure where the error occurred.
+        path: Option<Path>,
+    },
+    /// Unexpected end of input.
+    UnexpectedEof {
+        /// What was expected before EOF.
+        expected: &'static str,
+    },
+}
+
+impl InnerDeserializeError {
+    /// Convert this internal error into a `DeserializeError<E>`.
+    ///
+    /// Since `InnerDeserializeError` never contains a parser error, this conversion
+    /// is infallible and doesn't require a parser error value.
+    #[inline]
+    pub fn into_deserialize_error<E>(self) -> DeserializeError<E> {
+        match self {
+            InnerDeserializeError::Reflect { error, span, path } => {
+                DeserializeError::Reflect { error, span, path }
+            }
+            InnerDeserializeError::TypeMismatch {
+                expected,
+                got,
+                span,
+                path,
+            } => DeserializeError::TypeMismatch {
+                expected,
+                got,
+                span,
+                path,
+            },
+            InnerDeserializeError::Unsupported(msg) => DeserializeError::Unsupported(msg),
+            InnerDeserializeError::UnknownField { field, span, path } => {
+                DeserializeError::UnknownField { field, span, path }
+            }
+            InnerDeserializeError::CannotBorrow { message } => {
+                DeserializeError::CannotBorrow { message }
+            }
+            InnerDeserializeError::MissingField {
+                field,
+                type_name,
+                span,
+                path,
+            } => DeserializeError::MissingField {
+                field,
+                type_name,
+                span,
+                path,
+            },
+            #[cfg(feature = "validate")]
+            InnerDeserializeError::Validation {
+                field,
+                message,
+                span,
+                path,
+            } => DeserializeError::Validation {
+                field,
+                message,
+                span,
+                path,
+            },
+            InnerDeserializeError::UnexpectedEof { expected } => {
+                DeserializeError::UnexpectedEof { expected }
+            }
+        }
+    }
+
+    /// Create a Reflect error without span or path information.
+    #[inline]
+    pub const fn reflect(error: ReflectError) -> Self {
+        InnerDeserializeError::Reflect {
+            error,
+            span: None,
+            path: None,
+        }
+    }
+
+    /// Create a Reflect error with span information.
+    #[inline]
+    pub const fn reflect_with_span(error: ReflectError, span: Span) -> Self {
+        InnerDeserializeError::Reflect {
+            error,
+            span: Some(span),
+            path: None,
+        }
+    }
+
+    /// Create a Reflect error with span and path information.
+    #[inline]
+    pub const fn reflect_with_context(error: ReflectError, span: Option<Span>, path: Path) -> Self {
+        InnerDeserializeError::Reflect {
+            error,
+            span,
+            path: Some(path),
+        }
+    }
+}
+
+impl fmt::Display for InnerDeserializeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InnerDeserializeError::Reflect { error, .. } => write!(f, "{error}"),
+            InnerDeserializeError::TypeMismatch { expected, got, .. } => {
+                write!(f, "type mismatch: expected {expected}, got {got}")
+            }
+            InnerDeserializeError::Unsupported(msg) => write!(f, "unsupported: {msg}"),
+            InnerDeserializeError::UnknownField { field, .. } => {
+                write!(f, "unknown field: {field}")
+            }
+            InnerDeserializeError::CannotBorrow { message } => write!(f, "{message}"),
+            InnerDeserializeError::MissingField {
+                field, type_name, ..
+            } => {
+                write!(f, "missing field `{field}` in type `{type_name}`")
+            }
+            #[cfg(feature = "validate")]
+            InnerDeserializeError::Validation { field, message, .. } => {
+                write!(f, "validation failed for field `{field}`: {message}")
+            }
+            InnerDeserializeError::UnexpectedEof { expected } => {
+                write!(f, "unexpected end of input, expected {expected}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for InnerDeserializeError {}
 
 /// Error produced by the format deserializer.
 #[derive(Debug)]

--- a/facet-format/src/deserializer/setters.rs
+++ b/facet-format/src/deserializer/setters.rs
@@ -3,161 +3,209 @@ extern crate alloc;
 use std::borrow::Cow;
 
 use facet_core::ScalarType;
-use facet_reflect::{Partial, ReflectError};
+use facet_reflect::{Partial, ReflectError, Span};
 
-use crate::{DeserializeError, FormatDeserializer, FormatParser, ScalarValue};
+use crate::{
+    DeserializeError, FormatDeserializer, FormatParser, InnerDeserializeError, ScalarValue,
+};
+
+/// Set a scalar value into a `Partial`, handling type coercion.
+///
+/// This is a non-generic inner function that handles the core logic of `set_scalar`.
+/// It's extracted to reduce monomorphization bloat - each parser type only needs
+/// a thin wrapper that converts the error type.
+///
+/// Note: `ScalarValue::Str` and `ScalarValue::Bytes` cases delegate to `facet_dessert`
+/// for string/bytes handling.
+pub(crate) fn set_scalar_inner<'input, const BORROW: bool>(
+    mut wip: Partial<'input, BORROW>,
+    scalar: ScalarValue<'input>,
+    span: Option<Span>,
+) -> Result<Partial<'input, BORROW>, SetScalarResult<'input, BORROW>> {
+    let shape = wip.shape();
+    let scalar_type = shape.scalar_type();
+    let reflect_err = |e: ReflectError| InnerDeserializeError::Reflect {
+        error: e,
+        span,
+        path: None,
+    };
+
+    match scalar {
+        ScalarValue::Null => {
+            wip = wip.set_default().map_err(&reflect_err)?;
+        }
+        ScalarValue::Bool(b) => {
+            wip = wip.set(b).map_err(&reflect_err)?;
+        }
+        ScalarValue::Char(c) => {
+            wip = wip.set(c).map_err(&reflect_err)?;
+        }
+        ScalarValue::I64(n) => {
+            match scalar_type {
+                // Handle signed types
+                Some(ScalarType::I8) => wip = wip.set(n as i8).map_err(&reflect_err)?,
+                Some(ScalarType::I16) => wip = wip.set(n as i16).map_err(&reflect_err)?,
+                Some(ScalarType::I32) => wip = wip.set(n as i32).map_err(&reflect_err)?,
+                Some(ScalarType::I64) => wip = wip.set(n).map_err(&reflect_err)?,
+                Some(ScalarType::I128) => wip = wip.set(n as i128).map_err(&reflect_err)?,
+                Some(ScalarType::ISize) => wip = wip.set(n as isize).map_err(&reflect_err)?,
+                // Handle unsigned types (I64 can fit in unsigned if non-negative)
+                Some(ScalarType::U8) => wip = wip.set(n as u8).map_err(&reflect_err)?,
+                Some(ScalarType::U16) => wip = wip.set(n as u16).map_err(&reflect_err)?,
+                Some(ScalarType::U32) => wip = wip.set(n as u32).map_err(&reflect_err)?,
+                Some(ScalarType::U64) => wip = wip.set(n as u64).map_err(&reflect_err)?,
+                Some(ScalarType::U128) => wip = wip.set(n as u128).map_err(&reflect_err)?,
+                Some(ScalarType::USize) => wip = wip.set(n as usize).map_err(&reflect_err)?,
+                // Handle floats
+                Some(ScalarType::F32) => wip = wip.set(n as f32).map_err(&reflect_err)?,
+                Some(ScalarType::F64) => wip = wip.set(n as f64).map_err(&reflect_err)?,
+                // Handle String - stringify the number
+                Some(ScalarType::String) => {
+                    wip = wip
+                        .set(alloc::string::ToString::to_string(&n))
+                        .map_err(&reflect_err)?
+                }
+                _ => wip = wip.set(n).map_err(&reflect_err)?,
+            }
+        }
+        ScalarValue::U64(n) => {
+            match scalar_type {
+                // Handle unsigned types
+                Some(ScalarType::U8) => wip = wip.set(n as u8).map_err(&reflect_err)?,
+                Some(ScalarType::U16) => wip = wip.set(n as u16).map_err(&reflect_err)?,
+                Some(ScalarType::U32) => wip = wip.set(n as u32).map_err(&reflect_err)?,
+                Some(ScalarType::U64) => wip = wip.set(n).map_err(&reflect_err)?,
+                Some(ScalarType::U128) => wip = wip.set(n as u128).map_err(&reflect_err)?,
+                Some(ScalarType::USize) => wip = wip.set(n as usize).map_err(&reflect_err)?,
+                // Handle signed types (U64 can fit in signed if small enough)
+                Some(ScalarType::I8) => wip = wip.set(n as i8).map_err(&reflect_err)?,
+                Some(ScalarType::I16) => wip = wip.set(n as i16).map_err(&reflect_err)?,
+                Some(ScalarType::I32) => wip = wip.set(n as i32).map_err(&reflect_err)?,
+                Some(ScalarType::I64) => wip = wip.set(n as i64).map_err(&reflect_err)?,
+                Some(ScalarType::I128) => wip = wip.set(n as i128).map_err(&reflect_err)?,
+                Some(ScalarType::ISize) => wip = wip.set(n as isize).map_err(&reflect_err)?,
+                // Handle floats
+                Some(ScalarType::F32) => wip = wip.set(n as f32).map_err(&reflect_err)?,
+                Some(ScalarType::F64) => wip = wip.set(n as f64).map_err(&reflect_err)?,
+                // Handle String - stringify the number
+                Some(ScalarType::String) => {
+                    wip = wip
+                        .set(alloc::string::ToString::to_string(&n))
+                        .map_err(&reflect_err)?
+                }
+                _ => wip = wip.set(n).map_err(&reflect_err)?,
+            }
+        }
+        ScalarValue::U128(n) => {
+            match scalar_type {
+                Some(ScalarType::U128) => wip = wip.set(n).map_err(&reflect_err)?,
+                Some(ScalarType::I128) => wip = wip.set(n as i128).map_err(&reflect_err)?,
+                // For smaller types, truncate (caller should have used correct hint)
+                _ => wip = wip.set(n as u64).map_err(&reflect_err)?,
+            }
+        }
+        ScalarValue::I128(n) => {
+            match scalar_type {
+                Some(ScalarType::I128) => wip = wip.set(n).map_err(&reflect_err)?,
+                Some(ScalarType::U128) => wip = wip.set(n as u128).map_err(&reflect_err)?,
+                // For smaller types, truncate (caller should have used correct hint)
+                _ => wip = wip.set(n as i64).map_err(&reflect_err)?,
+            }
+        }
+        ScalarValue::F64(n) => {
+            match scalar_type {
+                Some(ScalarType::F32) => wip = wip.set(n as f32).map_err(&reflect_err)?,
+                Some(ScalarType::F64) => wip = wip.set(n).map_err(&reflect_err)?,
+                _ if shape.vtable.has_try_from() && shape.inner.is_some() => {
+                    // For opaque types with try_from (like NotNan, OrderedFloat), use
+                    // begin_inner() + set + end() to trigger conversion
+                    let inner_shape = shape.inner.unwrap();
+                    wip = wip.begin_inner().map_err(&reflect_err)?;
+                    if inner_shape.is_type::<f32>() {
+                        wip = wip.set(n as f32).map_err(&reflect_err)?;
+                    } else {
+                        wip = wip.set(n).map_err(&reflect_err)?;
+                    }
+                    wip = wip.end().map_err(&reflect_err)?;
+                }
+                _ if shape.vtable.has_parse() => {
+                    // For types that support parsing (like Decimal), convert to string
+                    // and use parse_from_str to preserve their parsing semantics
+                    wip = wip
+                        .parse_from_str(&alloc::string::ToString::to_string(&n))
+                        .map_err(&reflect_err)?;
+                }
+                _ => wip = wip.set(n).map_err(&reflect_err)?,
+            }
+        }
+        ScalarValue::Str(s) => {
+            // Try parse_from_str first if the type supports it
+            if shape.vtable.has_parse() {
+                wip = wip.parse_from_str(s.as_ref()).map_err(&reflect_err)?;
+            } else {
+                // Delegate to set_string_value - this requires the caller to handle it
+                return Err(SetScalarResult::NeedsStringValue { wip, s });
+            }
+        }
+        ScalarValue::Bytes(b) => {
+            // First try parse_from_bytes if the type supports it (e.g., UUID from 16 bytes)
+            if shape.vtable.has_parse_bytes() {
+                wip = wip.parse_from_bytes(b.as_ref()).map_err(&reflect_err)?;
+            } else {
+                // Delegate to set_bytes_value - this requires the caller to handle it
+                return Err(SetScalarResult::NeedsBytesValue { wip, b });
+            }
+        }
+        ScalarValue::Unit => {
+            // Unit value - set to default/unit value
+            wip = wip.set_default().map_err(&reflect_err)?;
+        }
+    }
+
+    Ok(wip)
+}
+
+/// Result of `set_scalar_inner` - either success, an error, or delegation to string/bytes handling.
+pub(crate) enum SetScalarResult<'input, const BORROW: bool> {
+    /// Need to call `set_string_value` with these parameters.
+    NeedsStringValue {
+        wip: Partial<'input, BORROW>,
+        s: Cow<'input, str>,
+    },
+    /// Need to call `set_bytes_value` with these parameters.
+    NeedsBytesValue {
+        wip: Partial<'input, BORROW>,
+        b: Cow<'input, [u8]>,
+    },
+    /// An error occurred.
+    Error(InnerDeserializeError),
+}
+
+impl<'input, const BORROW: bool> From<InnerDeserializeError> for SetScalarResult<'input, BORROW> {
+    fn from(e: InnerDeserializeError) -> Self {
+        SetScalarResult::Error(e)
+    }
+}
 
 impl<'input, const BORROW: bool, P> FormatDeserializer<'input, BORROW, P>
 where
     P: FormatParser<'input>,
 {
+    /// Set a scalar value into a `Partial`, handling type coercion.
+    ///
+    /// This is a thin wrapper around `set_scalar_inner` that handles the
+    /// string/bytes delegation cases and converts error types.
     pub(crate) fn set_scalar(
         &mut self,
-        mut wip: Partial<'input, BORROW>,
+        wip: Partial<'input, BORROW>,
         scalar: ScalarValue<'input>,
     ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
-        let shape = wip.shape();
-        let scalar_type = shape.scalar_type();
-        // Capture the span for error reporting - this is where the scalar value was parsed
-        let span = self.last_span;
-        let reflect_err = |e: ReflectError| DeserializeError::Reflect {
-            error: e,
-            span,
-            path: None,
-        };
-
-        match scalar {
-            ScalarValue::Null => {
-                wip = wip.set_default().map_err(&reflect_err)?;
-            }
-            ScalarValue::Bool(b) => {
-                wip = wip.set(b).map_err(&reflect_err)?;
-            }
-            ScalarValue::Char(c) => {
-                wip = wip.set(c).map_err(&reflect_err)?;
-            }
-            ScalarValue::I64(n) => {
-                match scalar_type {
-                    // Handle signed types
-                    Some(ScalarType::I8) => wip = wip.set(n as i8).map_err(&reflect_err)?,
-                    Some(ScalarType::I16) => wip = wip.set(n as i16).map_err(&reflect_err)?,
-                    Some(ScalarType::I32) => wip = wip.set(n as i32).map_err(&reflect_err)?,
-                    Some(ScalarType::I64) => wip = wip.set(n).map_err(&reflect_err)?,
-                    Some(ScalarType::I128) => wip = wip.set(n as i128).map_err(&reflect_err)?,
-                    Some(ScalarType::ISize) => wip = wip.set(n as isize).map_err(&reflect_err)?,
-                    // Handle unsigned types (I64 can fit in unsigned if non-negative)
-                    Some(ScalarType::U8) => wip = wip.set(n as u8).map_err(&reflect_err)?,
-                    Some(ScalarType::U16) => wip = wip.set(n as u16).map_err(&reflect_err)?,
-                    Some(ScalarType::U32) => wip = wip.set(n as u32).map_err(&reflect_err)?,
-                    Some(ScalarType::U64) => wip = wip.set(n as u64).map_err(&reflect_err)?,
-                    Some(ScalarType::U128) => wip = wip.set(n as u128).map_err(&reflect_err)?,
-                    Some(ScalarType::USize) => wip = wip.set(n as usize).map_err(&reflect_err)?,
-                    // Handle floats
-                    Some(ScalarType::F32) => wip = wip.set(n as f32).map_err(&reflect_err)?,
-                    Some(ScalarType::F64) => wip = wip.set(n as f64).map_err(&reflect_err)?,
-                    // Handle String - stringify the number
-                    Some(ScalarType::String) => {
-                        wip = wip
-                            .set(alloc::string::ToString::to_string(&n))
-                            .map_err(&reflect_err)?
-                    }
-                    _ => wip = wip.set(n).map_err(&reflect_err)?,
-                }
-            }
-            ScalarValue::U64(n) => {
-                match scalar_type {
-                    // Handle unsigned types
-                    Some(ScalarType::U8) => wip = wip.set(n as u8).map_err(&reflect_err)?,
-                    Some(ScalarType::U16) => wip = wip.set(n as u16).map_err(&reflect_err)?,
-                    Some(ScalarType::U32) => wip = wip.set(n as u32).map_err(&reflect_err)?,
-                    Some(ScalarType::U64) => wip = wip.set(n).map_err(&reflect_err)?,
-                    Some(ScalarType::U128) => wip = wip.set(n as u128).map_err(&reflect_err)?,
-                    Some(ScalarType::USize) => wip = wip.set(n as usize).map_err(&reflect_err)?,
-                    // Handle signed types (U64 can fit in signed if small enough)
-                    Some(ScalarType::I8) => wip = wip.set(n as i8).map_err(&reflect_err)?,
-                    Some(ScalarType::I16) => wip = wip.set(n as i16).map_err(&reflect_err)?,
-                    Some(ScalarType::I32) => wip = wip.set(n as i32).map_err(&reflect_err)?,
-                    Some(ScalarType::I64) => wip = wip.set(n as i64).map_err(&reflect_err)?,
-                    Some(ScalarType::I128) => wip = wip.set(n as i128).map_err(&reflect_err)?,
-                    Some(ScalarType::ISize) => wip = wip.set(n as isize).map_err(&reflect_err)?,
-                    // Handle floats
-                    Some(ScalarType::F32) => wip = wip.set(n as f32).map_err(&reflect_err)?,
-                    Some(ScalarType::F64) => wip = wip.set(n as f64).map_err(&reflect_err)?,
-                    // Handle String - stringify the number
-                    Some(ScalarType::String) => {
-                        wip = wip
-                            .set(alloc::string::ToString::to_string(&n))
-                            .map_err(&reflect_err)?
-                    }
-                    _ => wip = wip.set(n).map_err(&reflect_err)?,
-                }
-            }
-            ScalarValue::U128(n) => {
-                match scalar_type {
-                    Some(ScalarType::U128) => wip = wip.set(n).map_err(&reflect_err)?,
-                    Some(ScalarType::I128) => wip = wip.set(n as i128).map_err(&reflect_err)?,
-                    // For smaller types, truncate (caller should have used correct hint)
-                    _ => wip = wip.set(n as u64).map_err(&reflect_err)?,
-                }
-            }
-            ScalarValue::I128(n) => {
-                match scalar_type {
-                    Some(ScalarType::I128) => wip = wip.set(n).map_err(&reflect_err)?,
-                    Some(ScalarType::U128) => wip = wip.set(n as u128).map_err(&reflect_err)?,
-                    // For smaller types, truncate (caller should have used correct hint)
-                    _ => wip = wip.set(n as i64).map_err(&reflect_err)?,
-                }
-            }
-            ScalarValue::F64(n) => {
-                match scalar_type {
-                    Some(ScalarType::F32) => wip = wip.set(n as f32).map_err(&reflect_err)?,
-                    Some(ScalarType::F64) => wip = wip.set(n).map_err(&reflect_err)?,
-                    _ if shape.vtable.has_try_from() && shape.inner.is_some() => {
-                        // For opaque types with try_from (like NotNan, OrderedFloat), use
-                        // begin_inner() + set + end() to trigger conversion
-                        let inner_shape = shape.inner.unwrap();
-                        wip = wip.begin_inner().map_err(&reflect_err)?;
-                        if inner_shape.is_type::<f32>() {
-                            wip = wip.set(n as f32).map_err(&reflect_err)?;
-                        } else {
-                            wip = wip.set(n).map_err(&reflect_err)?;
-                        }
-                        wip = wip.end().map_err(&reflect_err)?;
-                    }
-                    _ if shape.vtable.has_parse() => {
-                        // For types that support parsing (like Decimal), convert to string
-                        // and use parse_from_str to preserve their parsing semantics
-                        wip = wip
-                            .parse_from_str(&alloc::string::ToString::to_string(&n))
-                            .map_err(&reflect_err)?;
-                    }
-                    _ => wip = wip.set(n).map_err(&reflect_err)?,
-                }
-            }
-            ScalarValue::Str(s) => {
-                // Try parse_from_str first if the type supports it
-                if shape.vtable.has_parse() {
-                    wip = wip.parse_from_str(s.as_ref()).map_err(&reflect_err)?;
-                } else {
-                    wip = self.set_string_value(wip, s)?;
-                }
-            }
-            ScalarValue::Bytes(b) => {
-                // First try parse_from_bytes if the type supports it (e.g., UUID from 16 bytes)
-                if shape.vtable.has_parse_bytes() {
-                    wip = wip.parse_from_bytes(b.as_ref()).map_err(&reflect_err)?;
-                } else {
-                    // Fall back to setting as Vec<u8>
-                    wip = wip.set(b.into_owned()).map_err(&reflect_err)?;
-                }
-            }
-            ScalarValue::Unit => {
-                // Unit value - set to default/unit value
-                wip = wip.set_default().map_err(&reflect_err)?;
-            }
+        match set_scalar_inner(wip, scalar, self.last_span) {
+            Ok(wip) => Ok(wip),
+            Err(SetScalarResult::NeedsStringValue { wip, s }) => self.set_string_value(wip, s),
+            Err(SetScalarResult::NeedsBytesValue { wip, b }) => self.set_bytes_value(wip, b),
+            Err(SetScalarResult::Error(e)) => Err(e.into_deserialize_error()),
         }
-
-        Ok(wip)
     }
 
     /// Set a string value, handling `&str`, `Cow<str>`, and `String` appropriately.

--- a/facet-format/src/lib.rs
+++ b/facet-format/src/lib.rs
@@ -54,7 +54,7 @@ mod visitor;
 #[cfg(feature = "jit")]
 pub mod jit;
 
-pub use deserializer::{DeserializeError, FormatDeserializer};
+pub use deserializer::{DeserializeError, FormatDeserializer, InnerDeserializeError};
 pub use event::{
     ContainerKind, FieldKey, FieldLocationHint, ParseEvent, ScalarValue, ValueTypeHint,
 };


### PR DESCRIPTION
## Summary

This PR addresses issue #1924 by reducing monomorphization bloat in the facet-format deserializer. The main technique is extracting non-generic inner functions that can be compiled once instead of being duplicated for each parser type.

## Changes

- **InnerDeserializeError**: Added a new enum that mirrors `DeserializeError` but without the generic `E` parameter. This allows large deserialization functions to use a non-generic error type internally, with thin wrappers converting to `DeserializeError<E>` at the API boundary.

- **set_scalar_inner()**: Extracted the core scalar-setting logic into a non-generic function. Each parser type now has a thin generic wrapper that calls this common implementation, reducing code duplication.

- **ScalarValue helpers**: Added `to_string_value()` and `to_display_string()` methods to `ScalarValue` to centralize string conversion logic and avoid duplicating it in generic contexts.

- **facet-dessert integration**: Moved string/bytes handling delegation to facet-dessert to further reduce generic code duplication.

## Test plan

- Existing tests should continue to pass
- Compile times / binary sizes for downstream crates using multiple format parsers should be reduced