### PR TITLE
Box inner closures in run_deserialize_coro to reduce monomorphization

### DIFF
--- a/facet-format/src/deserializer/dynamic.rs
+++ b/facet-format/src/deserializer/dynamic.rs
@@ -374,9 +374,10 @@ where
         wip: Partial<'input, BORROW>,
         enum_def: &'static facet_core::EnumType,
     ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
-        run_deserialize_coro(self, |yielder| {
-            deserialize_enum_dynamic_inner(yielder, wip, enum_def)
-        })
+        run_deserialize_coro(
+            self,
+            Box::new(move |yielder| deserialize_enum_dynamic_inner(yielder, wip, enum_def)),
+        )
     }
 
     pub(crate) fn deserialize_scalar_dynamic(

--- a/facet-format/src/deserializer/struct_with_flatten.rs
+++ b/facet-format/src/deserializer/struct_with_flatten.rs
@@ -551,8 +551,9 @@ where
         &mut self,
         wip: Partial<'input, BORROW>,
     ) -> Result<Partial<'input, BORROW>, DeserializeError<P::Error>> {
-        run_deserialize_coro(self, |yielder| {
-            deserialize_struct_with_flatten_inner(yielder, wip)
-        })
+        run_deserialize_coro(
+            self,
+            Box::new(move |yielder| deserialize_struct_with_flatten_inner(yielder, wip)),
+        )
     }
 }


### PR DESCRIPTION
## Summary

By boxing the inner function passed to `run_deserialize_coro`, we type-erase the closure type `F`. This reduces monomorphization from `P × F` (88 copies) to just `P` (8 copies).

## Measurements from dodeca binary

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| `run_deserialize_coro::{{closure}}` | 45k × 88 | 4k × 8 | -90% |
| Total LLVM IR | 2.37M | 2.32M | -58k |

## Changes

- Added `BoxedInnerFn` type alias for the boxed closure type
- Changed `run_deserialize_coro` to take `BoxedInnerFn` instead of generic `F`
- Updated all call sites to use `Box::new(move |yielder| ...)`
- Changed `tag_key` and `content_key` parameters to `&'static str` (they come from shape metadata which is always static)

## Test plan

- [x] All existing tests pass
- [x] Measured LLVM IR reduction in downstream project