### PR TITLE
Implement dyn FormatParser for dynamic dispatch

### DIFF
--- a/facet-format/src/dyn_parser.rs
+++ b/facet-format/src/dyn_parser.rs
@@ -337,3 +337,95 @@ impl<'de, P: FormatParser<'de>> DynParser<'de> for DynParserWrapper<'de, P> {
         self.parser.format_namespace()
     }
 }
+
+// Implement FormatParser for dyn DynParser trait objects.
+//
+// This allows using `&mut dyn DynParser<'de>` wherever `P: FormatParser<'de>` is expected,
+// enabling dynamic dispatch through FormatDeserializer without code changes.
+impl<'de> FormatParser<'de> for &mut dyn DynParser<'de> {
+    type Error = DynParserError;
+
+    fn next_event(&mut self) -> Result<Option<ParseEvent<'de>>, Self::Error> {
+        DynParser::next_event(*self)
+    }
+
+    fn peek_event(&mut self) -> Result<Option<ParseEvent<'de>>, Self::Error> {
+        DynParser::peek_event(*self)
+    }
+
+    fn skip_value(&mut self) -> Result<(), Self::Error> {
+        DynParser::skip_value(*self)
+    }
+
+    fn save(&mut self) -> SavePoint {
+        DynParser::save(*self)
+    }
+
+    fn restore(&mut self, save_point: SavePoint) {
+        DynParser::restore(*self, save_point)
+    }
+
+    fn capture_raw(&mut self) -> Result<Option<&'de str>, Self::Error> {
+        DynParser::capture_raw(*self)
+    }
+
+    fn raw_capture_shape(&self) -> Option<&'static facet_core::Shape> {
+        DynParser::raw_capture_shape(*self)
+    }
+
+    fn is_self_describing(&self) -> bool {
+        DynParser::is_self_describing(*self)
+    }
+
+    fn hint_struct_fields(&mut self, num_fields: usize) {
+        DynParser::hint_struct_fields(*self, num_fields);
+    }
+
+    fn hint_scalar_type(&mut self, hint: ScalarTypeHint) {
+        DynParser::hint_scalar_type(*self, hint);
+    }
+
+    fn hint_sequence(&mut self) {
+        DynParser::hint_sequence(*self);
+    }
+
+    fn hint_byte_sequence(&mut self) -> bool {
+        DynParser::hint_byte_sequence(*self)
+    }
+
+    fn hint_array(&mut self, len: usize) {
+        DynParser::hint_array(*self, len);
+    }
+
+    fn hint_option(&mut self) {
+        DynParser::hint_option(*self);
+    }
+
+    fn hint_map(&mut self) {
+        DynParser::hint_map(*self);
+    }
+
+    fn hint_dynamic_value(&mut self) {
+        DynParser::hint_dynamic_value(*self);
+    }
+
+    fn hint_enum(&mut self, variants: &[EnumVariantHint]) {
+        DynParser::hint_enum(*self, variants);
+    }
+
+    fn hint_opaque_scalar(
+        &mut self,
+        type_identifier: &'static str,
+        shape: &'static facet_core::Shape,
+    ) -> bool {
+        DynParser::hint_opaque_scalar(*self, type_identifier, shape)
+    }
+
+    fn current_span(&self) -> Option<Span> {
+        DynParser::current_span(*self)
+    }
+
+    fn format_namespace(&self) -> Option<&'static str> {
+        DynParser::format_namespace(*self)
+    }
+}

--- a/facet-format/src/lib.rs
+++ b/facet-format/src/lib.rs
@@ -55,7 +55,10 @@ mod visitor;
 #[cfg(feature = "jit")]
 pub mod jit;
 
-pub use deserializer::{DeserializeError, FormatDeserializer, InnerDeserializeError};
+pub use deserializer::{
+    DeserializeError, DynDeserializeError, DynDeserializer, DynDeserializerOwned,
+    FormatDeserializer, InnerDeserializeError,
+};
 pub use dyn_parser::{DynParser, DynParserError, DynParserWrapper, DynResult};
 pub use event::{
     ContainerKind, FieldKey, FieldLocationHint, ParseEvent, ScalarValue, ValueTypeHint,

--- a/facet-json/tests/integration/dyn_dispatch.rs
+++ b/facet-json/tests/integration/dyn_dispatch.rs
@@ -1,0 +1,125 @@
+//! Tests for dynamic dispatch deserializer.
+//!
+//! Verifies that `&mut dyn DynParser` can be used with `FormatDeserializer`
+//! to reduce monomorphization.
+
+use facet::Facet;
+use facet_format::{DynDeserializeError, DynParser, FormatDeserializer};
+use facet_json::JsonParser;
+
+#[derive(Debug, PartialEq, Facet)]
+struct Person {
+    name: String,
+    age: u32,
+}
+
+#[test]
+fn dyn_dispatch_basic() {
+    let input = r#"{"name": "Alice", "age": 30}"#;
+
+    // Create a concrete parser
+    let mut parser = JsonParser::new(input.as_bytes());
+
+    // Erase to dyn DynParser
+    let dyn_parser: &mut dyn DynParser = &mut parser;
+
+    // Use the dyn parser with FormatDeserializer
+    let mut de = FormatDeserializer::new(dyn_parser);
+
+    let person: Result<Person, DynDeserializeError> = de.deserialize();
+    let person = person.expect("deserialization should succeed");
+
+    assert_eq!(person.name, "Alice");
+    assert_eq!(person.age, 30);
+}
+
+#[derive(Debug, PartialEq, Facet)]
+struct Nested {
+    inner: Person,
+    tag: String,
+}
+
+#[test]
+fn dyn_dispatch_nested() {
+    let input = r#"{"inner": {"name": "Bob", "age": 25}, "tag": "test"}"#;
+
+    let mut parser = JsonParser::new(input.as_bytes());
+    let dyn_parser: &mut dyn DynParser = &mut parser;
+    let mut de = FormatDeserializer::new(dyn_parser);
+
+    let nested: Result<Nested, DynDeserializeError> = de.deserialize();
+    let nested = nested.expect("deserialization should succeed");
+
+    assert_eq!(nested.inner.name, "Bob");
+    assert_eq!(nested.inner.age, 25);
+    assert_eq!(nested.tag, "test");
+}
+
+#[derive(Debug, PartialEq, Facet)]
+struct WithVec {
+    items: Vec<i32>,
+}
+
+#[test]
+fn dyn_dispatch_vec() {
+    let input = r#"{"items": [1, 2, 3, 4, 5]}"#;
+
+    let mut parser = JsonParser::new(input.as_bytes());
+    let dyn_parser: &mut dyn DynParser = &mut parser;
+    let mut de = FormatDeserializer::new(dyn_parser);
+
+    let result: Result<WithVec, DynDeserializeError> = de.deserialize();
+    let result = result.expect("deserialization should succeed");
+
+    assert_eq!(result.items, vec![1, 2, 3, 4, 5]);
+}
+
+#[derive(Debug, PartialEq, Facet)]
+#[facet(tag = "type")]
+#[repr(C)]
+enum Message {
+    Text { content: String },
+    Number { value: i32 },
+}
+
+#[test]
+fn dyn_dispatch_enum() {
+    let input = r#"{"type": "Text", "content": "hello"}"#;
+
+    let mut parser = JsonParser::new(input.as_bytes());
+    let dyn_parser: &mut dyn DynParser = &mut parser;
+    let mut de = FormatDeserializer::new(dyn_parser);
+
+    let msg: Result<Message, DynDeserializeError> = de.deserialize();
+    let msg = msg.expect("deserialization should succeed");
+
+    assert_eq!(
+        msg,
+        Message::Text {
+            content: "hello".to_string()
+        }
+    );
+}
+
+/// Helper function that demonstrates using dyn dispatch in a generic context.
+///
+/// This function only needs one monomorphization regardless of how many
+/// parser types call it.
+fn deserialize_with_dyn<'de, T: facet_core::Facet<'de>>(
+    parser: &mut dyn DynParser<'de>,
+) -> Result<T, DynDeserializeError> {
+    let mut de = FormatDeserializer::new(parser);
+    de.deserialize()
+}
+
+#[test]
+fn dyn_dispatch_helper_function() {
+    let input = r#"{"name": "Charlie", "age": 35}"#;
+    let mut parser = JsonParser::new(input.as_bytes());
+
+    // Call through a helper that uses dyn dispatch internally
+    let person: Person = deserialize_with_dyn(&mut parser).expect("should work");
+
+    assert_eq!(person.name, "Charlie");
+    assert_eq!(person.age, 35);
+}

--- a/facet-json/tests/integration/mod.rs
+++ b/facet-json/tests/integration/mod.rs
@@ -1,3 +1,4 @@
+mod dyn_dispatch;
 mod flatten_defaults;
 mod flatten_in_externally_tagged_enum;
 mod format_specific_proxy;


### PR DESCRIPTION
## Summary

Add `FormatParser` impl for `&mut dyn DynParser<'de>`, enabling dynamic dispatch through `FormatDeserializer` without code duplication.

This allows using a single monomorphization of `FormatDeserializer` with any format parser at runtime, reducing binary size when multiple formats are used.

## New exports

- `DynDeserializer`: type alias for `FormatDeserializer` with dyn dispatch
- `DynDeserializerOwned`: same but produces owned strings  
- `DynDeserializeError`: error type for dyn dispatch

## Usage

```rust
use facet_format::{DynDeserializer, DynParser, FormatDeserializer};

let input = r#"{"name": "Alice"}"#;
let mut parser = JsonParser::new(input.as_bytes());
let dyn_parser: &mut dyn DynParser = &mut parser;
let mut de: DynDeserializer = FormatDeserializer::new(dyn_parser);
let value: MyStruct = de.deserialize().unwrap();
```

## Tradeoffs

- **Pros**: Reduces monomorphization bloat (one copy instead of N copies for N formats)
- **Cons**: Dynamic dispatch overhead (likely negligible), parser errors are stringified

Closes #1938