### PR TITLE
Fix from_value to respect rename attribute on struct fields

### DIFF
--- a/facet-value/src/deserialize.rs
+++ b/facet-value/src/deserialize.rs
@@ -579,12 +579,12 @@ fn deserialize_struct<'p>(value: &Value, partial: Partial<'p>) -> Result<Partial
     for (key, val) in obj.iter() {
         let key_str = key.as_str();
 
-        // Find matching field by name or alias
+        // Find matching field by effective_name (rename if present, else name) or alias
         let field_info = struct_def
             .fields
             .iter()
             .enumerate()
-            .find(|(_, f)| f.name == key_str || f.alias == Some(key_str));
+            .find(|(_, f)| f.effective_name() == key_str || f.alias == Some(key_str));
 
         if let Some((idx, field)) = field_info {
             partial = partial.begin_field(field.name)?;
@@ -667,11 +667,10 @@ fn deserialize_struct_with_flatten<'p>(
     for (key, val) in obj.iter() {
         let key_str = key.as_str();
 
-        // First, check for direct field match (non-flattened fields) by name or alias
-        let direct_field =
-            struct_def.fields.iter().enumerate().find(|(_, f)| {
-                !f.is_flattened() && (f.name == key_str || f.alias == Some(key_str))
-            });
+        // First, check for direct field match (non-flattened fields) by effective_name or alias
+        let direct_field = struct_def.fields.iter().enumerate().find(|(_, f)| {
+            !f.is_flattened() && (f.effective_name() == key_str || f.alias == Some(key_str))
+        });
 
         if let Some((idx, field)) = direct_field {
             partial = partial.begin_field(field.name)?;

--- a/facet-value/tests/integration/from_value.rs
+++ b/facet-value/tests/integration/from_value.rs
@@ -398,3 +398,45 @@ fn deserialize_numeric_enum_from_string() {
     let e: NumericEnum = from_value(v).unwrap();
     assert_eq!(e, NumericEnum::B);
 }
+
+#[test]
+fn deserialize_struct_with_rename() {
+    // Test that from_value respects #[facet(rename = "...")] attribute
+    // This is a regression test for https://github.com/facet-rs/facet/issues/1940
+    #[derive(Debug, Facet, PartialEq)]
+    struct Outer {
+        #[facet(rename = "other")]
+        field: String,
+    }
+
+    let v = value!({
+        "other": "hi"
+    });
+
+    let result: Outer = from_value(v).unwrap();
+    assert_eq!(result.field, "hi");
+}
+
+#[test]
+fn deserialize_struct_with_rename_and_alias() {
+    // Test that both rename and alias work together
+    #[derive(Debug, Facet, PartialEq)]
+    struct Config {
+        #[facet(rename = "primary_name", alias = "alt_name")]
+        value: String,
+    }
+
+    // Using the renamed name should work
+    let v1 = value!({
+        "primary_name": "via rename"
+    });
+    let result1: Config = from_value(v1).unwrap();
+    assert_eq!(result1.value, "via rename");
+
+    // Using the alias should also work
+    let v2 = value!({
+        "alt_name": "via alias"
+    });
+    let result2: Config = from_value(v2).unwrap();
+    assert_eq!(result2.value, "via alias");
+}


### PR DESCRIPTION
## Summary

Fixes `facet_value::from_value` to respect the `#[facet(rename = "...")]` attribute when deserializing structs. Previously, `from_value` only matched against the original field name, ignoring any rename attribute.

This is a regression fix for #1940.

## Changes

- Use `effective_name()` instead of `field.name` when matching JSON keys in `deserialize_struct` and `deserialize_struct_with_flatten`
- Add regression tests for rename attribute handling and rename + alias combinations

## Test plan

- Added `deserialize_struct_with_rename` test that verifies `#[facet(rename = "other")]` is respected
- Added `deserialize_struct_with_rename_and_alias` test that verifies both rename and alias work correctly together