### PR TITLE
perf(format): shrink ParseEvent from 96 to 48 bytes

### DIFF
--- a/facet-format/src/deserializer/dynamic.rs
+++ b/facet-format/src/deserializer/dynamic.rs
@@ -73,7 +73,8 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                         ParseEventKind::FieldKey(field_key) => {
                             // For dynamic values, unit keys become "@"
                             field_key
-                                .name
+                                .name()
+                                .cloned()
                                 .map(|n| n.into_owned())
                                 .unwrap_or_else(|| "@".to_owned())
                         }
@@ -602,7 +603,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                 ParseEventKind::Scalar(ScalarValue::Str(s)) => s,
                 ParseEventKind::Scalar(ScalarValue::I64(i)) => Cow::Owned(i.to_string()),
                 ParseEventKind::Scalar(ScalarValue::U64(u)) => Cow::Owned(u.to_string()),
-                ParseEventKind::FieldKey(k) => k.name.unwrap_or(Cow::Borrowed("@")),
+                ParseEventKind::FieldKey(k) => k.name().cloned().unwrap_or(Cow::Borrowed("@")),
                 _ => {
                     return Err(self.mk_err(
                         &wip,

--- a/facet-format/src/deserializer/eenum.rs
+++ b/facet-format/src/deserializer/eenum.rs
@@ -284,14 +284,16 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
         // Get the variant name from the field key
         let event = self.expect_event("value")?;
         let field_key_name = match event.kind {
-            ParseEventKind::FieldKey(key) => key.name.ok_or_else(|| DeserializeError {
-                span: Some(self.last_span),
-                path: Some(wip.path()),
-                kind: DeserializeErrorKind::UnexpectedToken {
-                    expected: "variant name",
-                    got: "unit key".into(),
-                },
-            })?,
+            ParseEventKind::FieldKey(key) => {
+                key.name().cloned().ok_or_else(|| DeserializeError {
+                    span: Some(self.last_span),
+                    path: Some(wip.path()),
+                    kind: DeserializeErrorKind::UnexpectedToken {
+                        expected: "variant name",
+                        got: "unit key".into(),
+                    },
+                })?
+            }
             other => {
                 return Err(DeserializeError {
                     span: Some(self.last_span),
@@ -472,7 +474,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                 ParseEventKind::StructEnd => break,
                 ParseEventKind::FieldKey(key) => {
                     // Unit keys don't make sense for struct fields
-                    let key_name = match &key.name {
+                    let key_name = match key.name() {
                         Some(name) => name.as_ref(),
                         None => {
                             // Skip unit keys in struct context
@@ -591,7 +593,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
         // Get the variant name from FieldKey
         let field_event = self.expect_event("enum field key")?;
         let variant_name = match field_event.kind {
-            ParseEventKind::FieldKey(key) => key.name.ok_or_else(|| {
+            ParseEventKind::FieldKey(key) => key.name().cloned().ok_or_else(|| {
                 self.mk_err(
                     &wip,
                     DeserializeErrorKind::UnexpectedToken {
@@ -810,14 +812,16 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
         // Read the FieldKey with the variant name ("Ok" or "Err")
         let key_event = self.expect_event("variant key for Result")?;
         let variant_name = match key_event.kind {
-            ParseEventKind::FieldKey(key) => key.name.ok_or_else(|| DeserializeError {
-                span: Some(self.last_span),
-                path: Some(wip.path()),
-                kind: DeserializeErrorKind::UnexpectedToken {
-                    expected: "variant name",
-                    got: "unit key".into(),
-                },
-            })?,
+            ParseEventKind::FieldKey(key) => {
+                key.name().cloned().ok_or_else(|| DeserializeError {
+                    span: Some(self.last_span),
+                    path: Some(wip.path()),
+                    kind: DeserializeErrorKind::UnexpectedToken {
+                        expected: "variant name",
+                        got: "unit key".into(),
+                    },
+                })?
+            }
             _ => {
                 return Err(DeserializeError {
                     span: Some(self.last_span),
@@ -939,7 +943,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                 ParseEventKind::StructEnd => break,
                 ParseEventKind::FieldKey(key) => {
                     // Unit keys don't make sense for struct fields
-                    let key_name = match &key.name {
+                    let key_name = match key.name() {
                         Some(name) => name.as_ref(),
                         None => {
                             // Skip unit keys in struct context
@@ -1067,7 +1071,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                 ParseEventKind::StructEnd => break,
                 ParseEventKind::FieldKey(key) => {
                     // Unit keys don't make sense for adjacently tagged enums
-                    let key_name = match &key.name {
+                    let key_name = match key.name() {
                         Some(name) => name.as_ref(),
                         None => {
                             // Skip unit keys
@@ -1287,7 +1291,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                             }
                         }
                         ParseEventKind::FieldKey(key) => {
-                            let key_name = match &key.name {
+                            let key_name = match key.name() {
                                 Some(name) => name.as_ref(),
                                 None => {
                                     self.skip_value()?;

--- a/facet-format/src/deserializer/mod.rs
+++ b/facet-format/src/deserializer/mod.rs
@@ -534,15 +534,15 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
 
         // Peek to get the start offset
         let first_event = self.expect_peek("value to skip")?;
-        let start_offset = first_event.span.offset;
+        let start_offset = first_event.span.offset as usize;
         #[allow(unused_assignments)]
-        let mut end_offset = 0;
+        let mut end_offset = 0usize;
 
         let mut depth = 0i32;
         loop {
             let event = self.expect_event("value to skip")?;
             // Track the end of each event
-            end_offset = event.span.offset + event.span.len;
+            end_offset = event.span.end();
 
             match &event.kind {
                 ParseEventKind::StructStart(_) | ParseEventKind::SequenceStart(_) => {
@@ -672,7 +672,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                 crate::ParseEventKind::FieldKey(ref key) => {
                     if depth == 1 && in_struct {
                         // Top-level field - feed to solver
-                        if let Some(ref name) = key.name {
+                        if let Some(name) = key.name() {
                             match solver.see_key(name.clone()) {
                                 KeyResult::Solved(handle) => {
                                     break Some(handle);

--- a/facet-format/src/deserializer/struct_simple.rs
+++ b/facet-format/src/deserializer/struct_simple.rs
@@ -106,7 +106,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                     trace!(?key, "deserialize_struct_simple: got FieldKey");
 
                     // Unit keys don't make sense for struct fields
-                    let key_name = match &key.name {
+                    let key_name = match key.name() {
                         Some(name) => name.as_ref(),
                         None => {
                             // Skip unit keys in struct context

--- a/facet-format/src/deserializer/struct_with_flatten.rs
+++ b/facet-format/src/deserializer/struct_with_flatten.rs
@@ -145,7 +145,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                 ParseEventKind::StructEnd => break,
                 ParseEventKind::FieldKey(key) => {
                     // Unit keys don't make sense for struct fields
-                    let key_name = match &key.name {
+                    let key_name = match key.name() {
                         Some(name) => name.as_ref(),
                         None => {
                             self.skip_value()?;

--- a/facet-format/src/jit/helpers.rs
+++ b/facet-format/src/jit/helpers.rs
@@ -435,9 +435,11 @@ fn convert_event_to_raw(event: ParseEvent<'_>) -> RawEvent {
         },
         ParseEventKind::FieldKey(key) => {
             // For JIT, unit keys become empty strings (we don't have a way to represent None)
-            let (ptr, len) = match key.name {
+            let (ptr, len) = match key.name() {
                 Some(Cow::Borrowed(s)) => (s.as_ptr(), s.len()),
                 Some(Cow::Owned(s)) => {
+                    // Owned string - need to clone it for JIT to keep alive
+                    let s = s.clone();
                     // Use into_raw_parts to prevent the string from being dropped.
                     // We store the raw parts in thread-local storage and free them
                     // on the next call to next_event_wrapper.

--- a/facet-format/src/serializer.rs
+++ b/facet-format/src/serializer.rs
@@ -104,7 +104,7 @@ pub trait FormatSerializer {
     /// Formats that support tags (like Styx) should override this.
     fn emit_field_key(&mut self, key: &crate::FieldKey<'_>) -> Result<(), Self::Error> {
         // Default: ignore tag and doc, just emit the name (empty string if None)
-        let name = key.name.as_deref().unwrap_or("");
+        let name = key.name().map(|c| c.as_ref()).unwrap_or("");
         self.field_key(name)
     }
     /// End a map/object/struct.

--- a/facet-format/src/solver.rs
+++ b/facet-format/src/solver.rs
@@ -102,7 +102,7 @@ pub fn solve_variant<'de>(
             ParseEventKind::FieldKey(key) => {
                 if depth == 1 && in_struct {
                     // Top-level field - feed to solver
-                    if let Some(name) = key.name
+                    if let Some(name) = key.name().cloned()
                         && let Some(handle) = handle_key(&mut solver, name)
                     {
                         break Some(handle);

--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -159,7 +159,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                 .map_err(scan_error_to_parse_error)?;
         }
 
-        self.state.last_token_start = spanned.span.offset;
+        self.state.last_token_start = spanned.span.offset as usize;
         self.state.scanner_pos = self.scanner.pos();
 
         let kind = match spanned.token {
@@ -369,7 +369,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
             .scanner
             .next_token(self.input)
             .map_err(scan_error_to_parse_error)?;
-        let start = first.span.offset;
+        let start = first.span.offset as usize;
         self.state.scanner_pos = self.scanner.pos();
 
         match first.token {
@@ -783,7 +783,7 @@ impl<'de, const TRUSTED_UTF8: bool> FormatParser<'de> for JsonParser<'de, TRUSTE
                 .scanner
                 .next_token(self.input)
                 .map_err(scan_error_to_parse_error)?;
-            let start = first.span.offset;
+            let start = first.span.offset as usize;
             self.state.scanner_pos = self.scanner.pos();
 
             // Skip the rest of the value if it's a container

--- a/facet-toml/src/parser.rs
+++ b/facet-toml/src/parser.rs
@@ -1106,7 +1106,7 @@ value = 42
         // FieldKey("name")
         assert!(matches!(
             parser.next_event().unwrap(),
-            Some(ParseEvent { kind: ParseEventKind::FieldKey(key), .. }) if key.name.as_deref() == Some("name")
+            Some(ParseEvent { kind: ParseEventKind::FieldKey(key), .. }) if key.name().map(|c| c.as_ref()) == Some("name")
         ));
 
         // Scalar("test")
@@ -1118,7 +1118,7 @@ value = 42
         // FieldKey("value")
         assert!(matches!(
             parser.next_event().unwrap(),
-            Some(ParseEvent { kind: ParseEventKind::FieldKey(key), .. }) if key.name.as_deref() == Some("value")
+            Some(ParseEvent { kind: ParseEventKind::FieldKey(key), .. }) if key.name().map(|c| c.as_ref()) == Some("value")
         ));
 
         // Scalar(42)
@@ -1163,7 +1163,7 @@ port = 8080
             }
         ));
         assert!(
-            matches!(&events[1], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("server"))
+            matches!(&events[1], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("server"))
         );
         assert!(matches!(
             &events[2],
@@ -1173,13 +1173,13 @@ port = 8080
             }
         ));
         assert!(
-            matches!(&events[3], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("host"))
+            matches!(&events[3], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("host"))
         );
         assert!(
             matches!(&events[4], ParseEvent { kind: ParseEventKind::Scalar(ScalarValue::Str(s)), .. } if s == "localhost")
         );
         assert!(
-            matches!(&events[5], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("port"))
+            matches!(&events[5], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("port"))
         );
         assert!(matches!(
             &events[6],
@@ -1237,7 +1237,7 @@ name = "beta"
             }
         )); // root
         assert!(
-            matches!(&events[1], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("servers"))
+            matches!(&events[1], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("servers"))
         );
         assert!(matches!(
             &events[2],
@@ -1254,7 +1254,7 @@ name = "beta"
             }
         )); // element 0
         assert!(
-            matches!(&events[4], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("name"))
+            matches!(&events[4], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("name"))
         );
         assert!(
             matches!(&events[5], ParseEvent { kind: ParseEventKind::Scalar(ScalarValue::Str(s)), .. } if s == "alpha")
@@ -1276,7 +1276,7 @@ name = "beta"
 
         // Reopen servers array
         assert!(
-            matches!(&events[8], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("servers"))
+            matches!(&events[8], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("servers"))
         );
         assert!(matches!(
             &events[9],
@@ -1293,7 +1293,7 @@ name = "beta"
             }
         )); // element 1
         assert!(
-            matches!(&events[11], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("name"))
+            matches!(&events[11], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("name"))
         );
         assert!(
             matches!(&events[12], ParseEvent { kind: ParseEventKind::Scalar(ScalarValue::Str(s)), .. } if s == "beta")
@@ -1332,14 +1332,14 @@ name = "beta"
                 ..
             } = event
             {
-                if k.name.as_deref() == Some("servers") {
+                if k.name().map(|c| c.as_ref()) == Some("servers") {
                     servers_count += 1;
                     if !saw_database {
                         saw_servers_first = true;
                     } else {
                         saw_servers_second = true;
                     }
-                } else if k.name.as_deref() == Some("database") {
+                } else if k.name().map(|c| c.as_ref()) == Some("database") {
                     saw_database = true;
                 }
             }
@@ -1376,7 +1376,7 @@ y = 2
         // Count how many times we see FieldKey("bar")
         let bar_count = events
             .iter()
-            .filter(|e| matches!(e, ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("bar")))
+            .filter(|e| matches!(e, ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("bar")))
             .count();
 
         assert_eq!(bar_count, 2, "Should see bar twice (reopened)");
@@ -1403,7 +1403,7 @@ foo.bar.baz = 1
             }
         )); // root
         assert!(
-            matches!(&events[1], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("foo"))
+            matches!(&events[1], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("foo"))
         );
         assert!(matches!(
             &events[2],
@@ -1413,7 +1413,7 @@ foo.bar.baz = 1
             }
         ));
         assert!(
-            matches!(&events[3], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("bar"))
+            matches!(&events[3], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("bar"))
         );
         assert!(matches!(
             &events[4],
@@ -1423,7 +1423,7 @@ foo.bar.baz = 1
             }
         ));
         assert!(
-            matches!(&events[5], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("baz"))
+            matches!(&events[5], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("baz"))
         );
         assert!(matches!(
             &events[6],
@@ -1475,7 +1475,7 @@ server = { host = "localhost", port = 8080 }
             }
         )); // root
         assert!(
-            matches!(&events[1], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("server"))
+            matches!(&events[1], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("server"))
         );
         assert!(matches!(
             &events[2],
@@ -1485,13 +1485,13 @@ server = { host = "localhost", port = 8080 }
             }
         )); // inline table
         assert!(
-            matches!(&events[3], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("host"))
+            matches!(&events[3], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("host"))
         );
         assert!(
             matches!(&events[4], ParseEvent { kind: ParseEventKind::Scalar(ScalarValue::Str(s)), .. } if s == "localhost")
         );
         assert!(
-            matches!(&events[5], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("port"))
+            matches!(&events[5], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("port"))
         );
         assert!(matches!(
             &events[6],
@@ -1535,7 +1535,7 @@ numbers = [1, 2, 3]
             }
         )); // root
         assert!(
-            matches!(&events[1], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name.as_deref() == Some("numbers"))
+            matches!(&events[1], ParseEvent { kind: ParseEventKind::FieldKey(k), .. } if k.name().map(|c| c.as_ref()) == Some("numbers"))
         );
         assert!(matches!(
             &events[2],

--- a/facet-toml/tests/integration/spanned.rs
+++ b/facet-toml/tests/integration/spanned.rs
@@ -54,7 +54,7 @@ fn spanned_string() {
 
     // Span should be populated and point to the value
     let span = config.name.span.expect("span should be populated");
-    let spanned_text = &input[span.offset..span.offset + span.len];
+    let spanned_text = &input[span.offset as usize..span.offset as usize + span.len as usize];
     assert_eq!(spanned_text, r#""foo""#);
 }
 
@@ -86,7 +86,7 @@ fn spanned_bool() {
     assert!(config.enabled.value);
 
     let span = config.enabled.span.expect("span should be populated");
-    let spanned_text = &input[span.offset..span.offset + span.len];
+    let spanned_text = &input[span.offset as usize..span.offset as usize + span.len as usize];
     assert_eq!(spanned_text, "true");
 }
 
@@ -102,7 +102,7 @@ fn spanned_integer() {
     assert_eq!(config.version.value, 42);
 
     let span = config.version.span.expect("span should be populated");
-    let spanned_text = &input[span.offset..span.offset + span.len];
+    let spanned_text = &input[span.offset as usize..span.offset as usize + span.len as usize];
     assert_eq!(spanned_text, "42");
 }
 


### PR DESCRIPTION
## Summary

Optimize core event types for better memory efficiency:

| Type | Before | After | Reduction |
|------|--------|-------|-----------|
| Span | 16 bytes | 8 bytes | 50% |
| FieldKey | 72 bytes | 24 bytes | 67% |
| ParseEventKind | 80 bytes | 32 bytes | 60% |
| ParseEvent | 96 bytes | 48 bytes | 50% |

### Changes

**Span** now uses `u32` for offset and length instead of `usize`. This supports files up to 4GB which is sufficient for all practical use cases.

**FieldKey** is now an enum with two variants:
- `Name(Cow<str>)`: common case for JSON/YAML/TOML (24 bytes)
- `Full(Box<FullFieldKey>)`: for Styx with doc/tag metadata (8 bytes pointer)

### Benchmark Results

| Benchmark      | Before (PR #1948) | After    | Change  |
|----------------|-------------------|----------|---------|
| facet_json     | ~14.4 ms          | ~13.7 ms | **-5%** |
| facet_json_str | ~14.3 ms          | ~13.6 ms | **-5%** |
| serde_json     | 1.7 ms            | 1.7 ms   | -       |

## Test plan

- [x] All workspace tests pass (2027 tests)
- [x] Benchmarks show ~5% improvement