### PR TITLE
perf(format): avoid boxing parser in FormatDeserializer

### DIFF
--- a/facet-asn1/src/lib.rs
+++ b/facet-asn1/src/lib.rs
@@ -95,8 +95,8 @@ where
     T: facet_core::Facet<'static>,
 {
     use facet_format::FormatDeserializer;
-    let parser = Asn1Parser::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = Asn1Parser::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     de.deserialize()
 }
 
@@ -113,7 +113,7 @@ where
     'input: 'facet,
 {
     use facet_format::FormatDeserializer;
-    let parser = Asn1Parser::new(input);
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = Asn1Parser::new(input);
+    let mut de = FormatDeserializer::new(&mut parser);
     de.deserialize()
 }

--- a/facet-asn1/tests/format_suite.rs
+++ b/facet-asn1/tests/format_suite.rs
@@ -24,8 +24,8 @@ impl FormatSuite for Asn1Slice {
         T: Facet<'static> + core::fmt::Debug,
     {
         use facet_format::FormatDeserializer;
-        let parser = Asn1Parser::new(input);
-        let mut de = FormatDeserializer::new_owned(parser);
+        let mut parser = Asn1Parser::new(input);
+        let mut de = FormatDeserializer::new_owned(&mut parser);
         de.deserialize_root::<T>()
     }
 

--- a/facet-csv/src/lib.rs
+++ b/facet-csv/src/lib.rs
@@ -57,8 +57,8 @@ where
     T: facet_core::Facet<'static>,
 {
     use facet_format::FormatDeserializer;
-    let parser = CsvParser::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = CsvParser::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     de.deserialize_root()
 }
 
@@ -87,8 +87,8 @@ where
     'input: 'facet,
 {
     use facet_format::FormatDeserializer;
-    let parser = CsvParser::new(input);
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = CsvParser::new(input);
+    let mut de = FormatDeserializer::new(&mut parser);
     de.deserialize_root()
 }
 

--- a/facet-format/src/jit/mod.rs
+++ b/facet-format/src/jit/mod.rs
@@ -618,7 +618,7 @@ where
     }
 
     // Fall back to reflection-based deserialization
-    FormatDeserializer::new(parser).deserialize()
+    FormatDeserializer::new(&mut parser).deserialize()
 }
 
 // =============================================================================
@@ -874,5 +874,5 @@ where
     }
 
     // Fall back to reflection-based deserialization
-    FormatDeserializer::new(parser).deserialize()
+    FormatDeserializer::new(&mut parser).deserialize()
 }

--- a/facet-json/src/lib.rs
+++ b/facet-json/src/lib.rs
@@ -109,8 +109,8 @@ where
 {
     use facet_format::FormatDeserializer;
     // TRUSTED_UTF8 = true: input came from &str, so it's valid UTF-8
-    let parser = JsonParser::<true>::new(input.as_bytes());
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = JsonParser::<true>::new(input.as_bytes());
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     de.deserialize_root()
 }
 
@@ -146,8 +146,8 @@ where
     T: facet_core::Facet<'static>,
 {
     use facet_format::FormatDeserializer;
-    let parser = JsonParser::<false>::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = JsonParser::<false>::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     de.deserialize_root()
 }
 
@@ -184,8 +184,8 @@ where
 {
     use facet_format::FormatDeserializer;
     // TRUSTED_UTF8 = true: input came from &str, so it's valid UTF-8
-    let parser = JsonParser::<true>::new(input.as_bytes());
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = JsonParser::<true>::new(input.as_bytes());
+    let mut de = FormatDeserializer::new(&mut parser);
     de.deserialize_root()
 }
 
@@ -221,8 +221,8 @@ where
     'input: 'facet,
 {
     use facet_format::FormatDeserializer;
-    let parser = JsonParser::<false>::new(input);
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = JsonParser::<false>::new(input);
+    let mut de = FormatDeserializer::new(&mut parser);
     de.deserialize_root()
 }
 
@@ -261,8 +261,8 @@ pub fn from_str_into<'facet>(
 ) -> Result<facet_reflect::Partial<'facet, false>, DeserializeError> {
     use facet_format::FormatDeserializer;
     // TRUSTED_UTF8 = true: input came from &str, so it's valid UTF-8
-    let parser = JsonParser::<true>::new(input.as_bytes());
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = JsonParser::<true>::new(input.as_bytes());
+    let mut de = FormatDeserializer::new_owned(&mut parser);
 
     // SAFETY: The deserializer expects Partial<'input, false> where 'input is the
     // lifetime of the JSON bytes. Since BORROW=false, no data is borrowed from the
@@ -324,8 +324,8 @@ pub fn from_slice_into<'facet>(
     partial: facet_reflect::Partial<'facet, false>,
 ) -> Result<facet_reflect::Partial<'facet, false>, DeserializeError> {
     use facet_format::FormatDeserializer;
-    let parser = JsonParser::<false>::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = JsonParser::<false>::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
 
     // SAFETY: The deserializer expects Partial<'input, false> where 'input is the
     // lifetime of the JSON bytes. Since BORROW=false, no data is borrowed from the
@@ -391,8 +391,8 @@ where
 {
     use facet_format::FormatDeserializer;
     // TRUSTED_UTF8 = true: input came from &str, so it's valid UTF-8
-    let parser = JsonParser::<true>::new(input.as_bytes());
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = JsonParser::<true>::new(input.as_bytes());
+    let mut de = FormatDeserializer::new(&mut parser);
     de.deserialize_into(partial)
 }
 
@@ -433,7 +433,7 @@ where
     'input: 'facet,
 {
     use facet_format::FormatDeserializer;
-    let parser = JsonParser::<false>::new(input);
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = JsonParser::<false>::new(input);
+    let mut de = FormatDeserializer::new(&mut parser);
     de.deserialize_into(partial)
 }

--- a/facet-json/tests/format_suite.rs
+++ b/facet-json/tests/format_suite.rs
@@ -24,8 +24,8 @@ impl FormatSuite for JsonSlice {
     where
         T: Facet<'static> + core::fmt::Debug,
     {
-        let parser = JsonParser::<false>::new(input);
-        let mut de = FormatDeserializer::new_owned(parser);
+        let mut parser = JsonParser::<false>::new(input);
+        let mut de = FormatDeserializer::new_owned(&mut parser);
         de.deserialize_root::<T>()
     }
 

--- a/facet-json/tests/integration/flatten_defaults.rs
+++ b/facet-json/tests/integration/flatten_defaults.rs
@@ -21,8 +21,8 @@ struct FlattenOuter {
 fn flatten_default_field_missing_format_deserializer() {
     let input = br#"{"foo":1}"#;
 
-    let parser = JsonParser::<false>::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = JsonParser::<false>::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     let value: FlattenOuter = de
         .deserialize_root()
         .expect("format deserializer should fill defaults inside flatten");

--- a/facet-json/tests/integration/jit_deserialize.rs
+++ b/facet-json/tests/integration/jit_deserialize.rs
@@ -317,11 +317,11 @@ fn test_cursor_coherency_after_tier1_struct() {
     // Parse JSON array where each element should use JIT
     // Then verify cursor is at correct position after each element
     let json = br#"[{"name": "Alice", "age": 30, "active": true}, {"name": "Bob", "age": 25, "active": false}]"#;
-    let parser = JsonParser::<false>::new(json);
+    let mut parser = JsonParser::<false>::new(json);
 
     // Parse the entire Vec<SimpleStruct> using the standard deserializer
     // This exercises cursor coherency internally as it parses each struct
-    let result: Vec<SimpleStruct> = FormatDeserializer::new(parser).deserialize().unwrap();
+    let result: Vec<SimpleStruct> = FormatDeserializer::new(&mut parser).deserialize().unwrap();
 
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].name, "Alice");
@@ -339,9 +339,9 @@ fn test_cursor_coherency_struct_then_more() {
 
     // Parse nested array of structs - verifies cursor is correct after each struct
     let json = br#"[[1, 2], [3, 4, 5], [6]]"#;
-    let parser = JsonParser::<false>::new(json);
+    let mut parser = JsonParser::<false>::new(json);
 
-    let result: Vec<Vec<i64>> = FormatDeserializer::new(parser).deserialize().unwrap();
+    let result: Vec<Vec<i64>> = FormatDeserializer::new(&mut parser).deserialize().unwrap();
 
     assert_eq!(result, vec![vec![1, 2], vec![3, 4, 5], vec![6]]);
 }
@@ -361,9 +361,9 @@ fn test_cursor_coherency_tier2_vec() {
     // The "numbers" field may use Tier-2, "name" uses standard parsing
     // This tests that cursor is correct after Tier-2 Vec parsing
     let json = br#"{"numbers": [1, 2, 3], "name": "test"}"#;
-    let parser = JsonParser::<false>::new(json);
+    let mut parser = JsonParser::<false>::new(json);
 
-    let result: WithVec = FormatDeserializer::new(parser).deserialize().unwrap();
+    let result: WithVec = FormatDeserializer::new(&mut parser).deserialize().unwrap();
 
     assert_eq!(result.numbers, vec![1, 2, 3]);
     assert_eq!(result.name, "test");
@@ -382,9 +382,9 @@ fn test_cursor_coherency_tier2_vec_bool_in_struct() {
     }
 
     let json = br#"{"flags": [true, false, true], "label": "test", "count": 42}"#;
-    let parser = JsonParser::<false>::new(json);
+    let mut parser = JsonParser::<false>::new(json);
 
-    let result: FlagsAndName = FormatDeserializer::new(parser).deserialize().unwrap();
+    let result: FlagsAndName = FormatDeserializer::new(&mut parser).deserialize().unwrap();
 
     assert_eq!(result.flags, vec![true, false, true]);
     assert_eq!(result.label, "test");
@@ -404,9 +404,9 @@ fn test_cursor_coherency_multiple_vecs() {
     }
 
     let json = br#"{"bools": [true, false], "nums": [1, 2, 3], "strs": ["a", "b"]}"#;
-    let parser = JsonParser::<false>::new(json);
+    let mut parser = JsonParser::<false>::new(json);
 
-    let result: MultiVec = FormatDeserializer::new(parser).deserialize().unwrap();
+    let result: MultiVec = FormatDeserializer::new(&mut parser).deserialize().unwrap();
 
     assert_eq!(result.bools, vec![true, false]);
     assert_eq!(result.nums, vec![1, 2, 3]);
@@ -426,9 +426,9 @@ fn test_cursor_coherency_empty_arrays() {
     }
 
     let json = br#"{"empty": [], "name": "test", "more": [true]}"#;
-    let parser = JsonParser::<false>::new(json);
+    let mut parser = JsonParser::<false>::new(json);
 
-    let result: WithEmpty = FormatDeserializer::new(parser).deserialize().unwrap();
+    let result: WithEmpty = FormatDeserializer::new(&mut parser).deserialize().unwrap();
 
     assert_eq!(result.empty, Vec::<i64>::new());
     assert_eq!(result.name, "test");
@@ -448,9 +448,9 @@ fn test_cursor_coherency_nested_mixed() {
     }
 
     let json = br#"[{"id": 1, "tags": ["a", "b"]}, {"id": 2, "tags": ["c"]}]"#;
-    let parser = JsonParser::<false>::new(json);
+    let mut parser = JsonParser::<false>::new(json);
 
-    let result: Vec<Item> = FormatDeserializer::new(parser).deserialize().unwrap();
+    let result: Vec<Item> = FormatDeserializer::new(&mut parser).deserialize().unwrap();
 
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].id, 1);

--- a/facet-json/tests/integration/nested_flatten_map.rs
+++ b/facet-json/tests/integration/nested_flatten_map.rs
@@ -25,8 +25,8 @@ struct Outer {
 fn nested_flatten_map_captures_unknown_fields() {
     let input = br#"{"known_field":"hello","unknown1":"value1","unknown2":"value2"}"#;
 
-    let parser = JsonParser::<false>::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = JsonParser::<false>::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     let value: Outer = de
         .deserialize_root()
         .expect("should deserialize with nested flatten map");
@@ -55,8 +55,8 @@ fn nested_flatten_map_captures_unknown_fields() {
 fn nested_flatten_map_empty_if_no_unknown() {
     let input = br#"{"known_field":"hello"}"#;
 
-    let parser = JsonParser::<false>::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = JsonParser::<false>::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     let value: Outer = de
         .deserialize_root()
         .expect("should deserialize with no unknown fields");

--- a/facet-json/tests/integration/out_of_order.rs
+++ b/facet-json/tests/integration/out_of_order.rs
@@ -20,8 +20,8 @@ pub enum AdjacentlyTagged {
 fn test_internally_tagged_out_of_order() {
     // Tag comes AFTER the other field - this should work now!
     let json = br#"{"radius": 5.0, "type": "Circle"}"#;
-    let parser = JsonParser::<false>::new(json);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = JsonParser::<false>::new(json);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     let result: InternallyTagged = de.deserialize_root().expect("should deserialize");
     assert_eq!(result, InternallyTagged::Circle { radius: 5.0 });
 }
@@ -30,8 +30,8 @@ fn test_internally_tagged_out_of_order() {
 fn test_adjacently_tagged_out_of_order() {
     // Content comes BEFORE the tag - this should work now!
     let json = br#"{"c": "hello", "t": "Message"}"#;
-    let parser = JsonParser::<false>::new(json);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = JsonParser::<false>::new(json);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     let result: AdjacentlyTagged = de.deserialize_root().expect("should deserialize");
     assert_eq!(result, AdjacentlyTagged::Message("hello".into()));
 }

--- a/facet-msgpack/src/lib.rs
+++ b/facet-msgpack/src/lib.rs
@@ -101,8 +101,8 @@ where
     T: facet_core::Facet<'static>,
 {
     use facet_format::FormatDeserializer;
-    let parser = MsgPackParser::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = MsgPackParser::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     de.deserialize()
 }
 
@@ -139,8 +139,8 @@ where
     'input: 'facet,
 {
     use facet_format::FormatDeserializer;
-    let parser = MsgPackParser::new(input);
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = MsgPackParser::new(input);
+    let mut de = FormatDeserializer::new(&mut parser);
     de.deserialize()
 }
 
@@ -179,8 +179,8 @@ pub fn from_slice_into<'facet>(
     partial: facet_reflect::Partial<'facet, false>,
 ) -> Result<facet_reflect::Partial<'facet, false>, DeserializeError> {
     use facet_format::FormatDeserializer;
-    let parser = MsgPackParser::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = MsgPackParser::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
 
     // SAFETY: The deserializer expects Partial<'input, false> where 'input is the
     // lifetime of the MsgPack bytes. Since BORROW=false, no data is borrowed from the
@@ -246,7 +246,7 @@ where
     'input: 'facet,
 {
     use facet_format::FormatDeserializer;
-    let parser = MsgPackParser::new(input);
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = MsgPackParser::new(input);
+    let mut de = FormatDeserializer::new(&mut parser);
     de.deserialize_into(partial)
 }

--- a/facet-msgpack/tests/format_suite.rs
+++ b/facet-msgpack/tests/format_suite.rs
@@ -24,8 +24,8 @@ impl FormatSuite for MsgPackSlice {
         T: Facet<'static> + core::fmt::Debug,
     {
         use facet_format::FormatDeserializer;
-        let parser = MsgPackParser::new(input);
-        let mut de = FormatDeserializer::new_owned(parser);
+        let mut parser = MsgPackParser::new(input);
+        let mut de = FormatDeserializer::new_owned(&mut parser);
         de.deserialize_root::<T>()
     }
 

--- a/facet-postcard/src/lib.rs
+++ b/facet-postcard/src/lib.rs
@@ -103,8 +103,8 @@ where
     T: facet_core::Facet<'static>,
 {
     use facet_format::FormatDeserializer;
-    let parser = PostcardParser::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = PostcardParser::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     de.deserialize()
 }
 
@@ -141,8 +141,8 @@ where
     'input: 'facet,
 {
     use facet_format::FormatDeserializer;
-    let parser = PostcardParser::new(input);
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = PostcardParser::new(input);
+    let mut de = FormatDeserializer::new(&mut parser);
     de.deserialize()
 }
 
@@ -181,8 +181,8 @@ pub fn from_slice_into<'facet>(
     partial: facet_reflect::Partial<'facet, false>,
 ) -> Result<facet_reflect::Partial<'facet, false>, DeserializeError> {
     use facet_format::FormatDeserializer;
-    let parser = PostcardParser::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = PostcardParser::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
 
     // SAFETY: The deserializer expects Partial<'input, false> where 'input is the
     // lifetime of the postcard bytes. Since BORROW=false, no data is borrowed from the
@@ -248,7 +248,7 @@ where
     'input: 'facet,
 {
     use facet_format::FormatDeserializer;
-    let parser = PostcardParser::new(input);
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = PostcardParser::new(input);
+    let mut de = FormatDeserializer::new(&mut parser);
     de.deserialize_into(partial)
 }

--- a/facet-postcard/src/shape_deser.rs
+++ b/facet-postcard/src/shape_deser.rs
@@ -36,8 +36,8 @@ pub fn from_slice_with_shape(
     input: &[u8],
     source_shape: &'static Shape,
 ) -> Result<Value, DeserializeError> {
-    let parser = PostcardParser::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = PostcardParser::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     de.deserialize_with_shape(source_shape)
 }
 

--- a/facet-postcard/tests/integration/multi_tier.rs
+++ b/facet-postcard/tests/integration/multi_tier.rs
@@ -25,8 +25,8 @@ mod tier_helpers {
     where
         T: Facet<'de>,
     {
-        let parser = PostcardParser::new(input);
-        let mut de = FormatDeserializer::new(parser);
+        let mut parser = PostcardParser::new(input);
+        let mut de = FormatDeserializer::new(&mut parser);
         de.deserialize()
     }
 

--- a/facet-toml/src/lib.rs
+++ b/facet-toml/src/lib.rs
@@ -81,8 +81,8 @@ where
     T: facet_core::Facet<'static>,
 {
     use facet_format::FormatDeserializer;
-    let parser = TomlParser::new(input)?;
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = TomlParser::new(input)?;
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     // TOML requires deferred mode to handle table reopening
     de.deserialize_deferred()
 }
@@ -167,8 +167,8 @@ where
     'input: 'facet,
 {
     use facet_format::FormatDeserializer;
-    let parser = TomlParser::new(input)?;
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = TomlParser::new(input)?;
+    let mut de = FormatDeserializer::new(&mut parser);
     // TOML requires deferred mode to handle table reopening
     de.deserialize_deferred()
 }

--- a/facet-toml/tests/format_suite.rs
+++ b/facet-toml/tests/format_suite.rs
@@ -26,8 +26,8 @@ impl FormatSuite for TomlSlice {
         T: Facet<'static> + core::fmt::Debug,
     {
         let input_str = std::str::from_utf8(input).expect("input should be valid UTF-8");
-        let parser = TomlParser::new(input_str)?;
-        let mut de = FormatDeserializer::new_owned(parser);
+        let mut parser = TomlParser::new(input_str)?;
+        let mut de = FormatDeserializer::new_owned(&mut parser);
         de.deserialize_deferred::<T>()
     }
 

--- a/facet-xdr/src/lib.rs
+++ b/facet-xdr/src/lib.rs
@@ -78,8 +78,8 @@ where
     T: facet_core::Facet<'static>,
 {
     use facet_format::FormatDeserializer;
-    let parser = XdrParser::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = XdrParser::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     de.deserialize()
 }
 
@@ -115,7 +115,7 @@ where
     'input: 'facet,
 {
     use facet_format::FormatDeserializer;
-    let parser = XdrParser::new(input);
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = XdrParser::new(input);
+    let mut de = FormatDeserializer::new(&mut parser);
     de.deserialize()
 }

--- a/facet-yaml/src/lib.rs
+++ b/facet-yaml/src/lib.rs
@@ -78,8 +78,8 @@ where
     T: facet_core::Facet<'static>,
 {
     use facet_format::FormatDeserializer;
-    let parser = YamlParser::new(input);
-    let mut de = FormatDeserializer::new_owned(parser);
+    let mut parser = YamlParser::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
     de.deserialize_root()
 }
 
@@ -118,8 +118,8 @@ where
     'input: 'facet,
 {
     use facet_format::FormatDeserializer;
-    let parser = YamlParser::new(input);
-    let mut de = FormatDeserializer::new(parser);
+    let mut parser = YamlParser::new(input);
+    let mut de = FormatDeserializer::new(&mut parser);
     de.deserialize_root()
 }
 

--- a/facet-yaml/tests/format_suite.rs
+++ b/facet-yaml/tests/format_suite.rs
@@ -26,8 +26,8 @@ impl FormatSuite for YamlSlice {
         T: Facet<'static> + core::fmt::Debug,
     {
         let input_str = std::str::from_utf8(input).expect("input should be valid UTF-8");
-        let parser = YamlParser::new(input_str);
-        let mut de = FormatDeserializer::new_owned(parser);
+        let mut parser = YamlParser::new(input_str);
+        let mut de = FormatDeserializer::new_owned(&mut parser);
         de.deserialize_root::<T>()
     }
 


### PR DESCRIPTION
## Summary

Changes `FormatDeserializer` to accept a borrowed mutable reference (`&'parser mut dyn FormatParser<'input>`) instead of boxing the parser. This eliminates a heap allocation per deserialization call.

## Changes

- Replace `Box<dyn FormatParser>` with `&'parser mut dyn FormatParser` in `FormatDeserializer`
- Remove `into_inner()` method (deserializer no longer owns the parser)
- Update all format crates (json, yaml, toml, msgpack, postcard, csv, asn1, xdr) to pass `&mut parser` instead of `parser`
- Update all tests to match new API

## Testing

All pre-push hooks pass (clippy, build tests).