### PR TITLE
perf(reflect): replace sorted field lookup with prefix-based buckets

### DIFF
--- a/facet-json/examples/profile_citm.rs
+++ b/facet-json/examples/profile_citm.rs
@@ -80,6 +80,8 @@ fn main() {
     ))
     .expect("citm_catalog.json not found");
 
-    let result: CitmCatalog = from_str(&json).unwrap();
-    black_box(result);
+    for _ in 0..100 {
+        let result: CitmCatalog = from_str(&json).unwrap();
+        black_box(result);
+    }
 }

--- a/facet-json/examples/profile_twitter.rs
+++ b/facet-json/examples/profile_twitter.rs
@@ -202,6 +202,8 @@ fn main() {
     let json = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../../twitter.json"))
         .expect("twitter.json not found");
 
-    let result: Twitter = from_str(&json).unwrap();
-    black_box(result);
+    for _ in 0..100 {
+        let result: Twitter = from_str(&json).unwrap();
+        black_box(result);
+    }
 }


### PR DESCRIPTION
## Summary

Replace `FieldLookup::Sorted` (binary search with full string comparisons) with `FieldLookup::PrefixBuckets` that matches the JIT's prefix-based dispatch strategy.

## How it works

1. At build time: group fields by their first 4-8 byte prefix (as little-endian u64)
2. At lookup time: compute prefix from input, binary search for bucket, linear scan within bucket

This changes field lookup from O(log n) full `memcmp` calls to O(log buckets) u64 comparisons + O(small) linear scan.

## Performance

| Benchmark | FieldLookup::find Before | After | Overall Time |
|-----------|--------------------------|-------|--------------|
| Twitter | 7.5% | **4.2%** | 5.67ms → 5.2ms (**8% faster**) |
| CITM | 1.27% | 1.18% | ~12.5ms (same) |

Twitter has deeply nested structs with many fields (e.g., `User` with ~30 fields) where prefix buckets shine. CITM has smaller structs (≤10 fields) that mostly use the `Small` linear scan path.

## Changes

- `FieldLookup::Sorted` → `FieldLookup::PrefixBuckets { prefix_len, entries, buckets }`
- Added `compute_prefix()` helper matching the JIT's approach
- Profile examples now run 100 iterations for more stable measurements