### PR TITLE
Fix facet where bounds parsing

### DIFF
--- a/facet-macro-types/src/lib.rs
+++ b/facet-macro-types/src/lib.rs
@@ -158,7 +158,7 @@ unsynn! {
         /// The `where` keyword.
         pub _kw_where: KWhere,
         /// The bounds (everything after `where`)
-        pub bounds: VerbatimUntil<Either<Comma, EndOfStream>>,
+        pub bounds: VerbatimUntil<EndOfStream>,
     }
 
     /// A namespaced attribute like `xml::element` or `xml::ns = "http://example.com"`

--- a/facet/tests/integration/derive_hashmap_key_bounds.rs
+++ b/facet/tests/integration/derive_hashmap_key_bounds.rs
@@ -1,0 +1,40 @@
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
+use facet::Facet;
+
+#[derive(Eq, PartialEq, Facet)]
+pub struct Key<I> {
+    pub a: String,
+    pub b: I,
+}
+
+impl<I: Hash> Hash for Key<I> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.a.hash(state);
+        self.b.hash(state);
+    }
+}
+
+#[derive(Facet)]
+#[facet(where I: Eq + Hash + 'static, T: 'static)]
+pub struct Container<I, T> {
+    pub data: HashMap<Key<I>, T>,
+}
+
+#[test]
+fn hashmap_key_with_custom_bounds() {
+    let mut container: Container<u32, String> = Container {
+        data: HashMap::new(),
+    };
+
+    container.data.insert(
+        Key {
+            a: "test".to_string(),
+            b: 42u32,
+        },
+        "value".to_string(),
+    );
+
+    assert_eq!(container.data.len(), 1);
+}

--- a/facet/tests/integration/mod.rs
+++ b/facet/tests/integration/mod.rs
@@ -1,6 +1,7 @@
 mod compile_tests;
 mod cycle;
 mod derive;
+mod derive_hashmap_key_bounds;
 mod derive_with_extension_attrs;
 mod empty;
 mod enums;


### PR DESCRIPTION
## Summary
Fix parsing for `#[facet(where ...)]` so comma-separated bounds are preserved.

## Changes
- Parse full `where` bounds token stream in macro types
- Add regression test for custom HashMap key bounds

## Test Plan
- [x] `cargo nextest run -p facet -E "test(hashmap_key_with_custom_bounds)"`

Closes #1969
