### PR TITLE
fix(deserializer): support metadata containers in #[facet(other)] variants

### DIFF
--- a/facet-format/src/deserializer/mod.rs
+++ b/facet-format/src/deserializer/mod.rs
@@ -110,7 +110,7 @@
 //! ```ignore
 //! // Instead of:
 //! wip = wip.begin_field("name")?;
-//! wip = self.deserialize_into(wip, None)?;
+//! wip = self.deserialize_into(wip, MetaSource::FromEvents)?;
 //! wip = wip.end()?;
 //!
 //! // Use:
@@ -134,6 +134,7 @@ use facet_solver::{KeyResult, Schema, Solver};
 use crate::{FormatParser, ParseEvent};
 
 mod error;
+pub use entry::MetaSource;
 pub use error::*;
 
 /// Convenience setters for string etc.
@@ -261,7 +262,7 @@ impl<'parser, 'input> FormatDeserializer<'parser, 'input, true> {
     {
         let plan = TypePlan::<T>::build()?;
         let wip = plan.partial()?;
-        let partial = self.deserialize_into(wip, None)?;
+        let partial = self.deserialize_into(wip, MetaSource::FromEvents)?;
         // SpanGuard must cover build() and materialize() which can fail with ReflectError.
         // Created AFTER deserialize_into so last_span points to the final token.
         let _guard = SpanGuard::new(self.last_span);
@@ -289,7 +290,7 @@ impl<'parser, 'input> FormatDeserializer<'parser, 'input, true> {
         let plan = TypePlan::<T>::build()?;
         let wip = plan.partial()?;
         let wip = wip.begin_deferred()?;
-        let partial = self.deserialize_into(wip, None)?;
+        let partial = self.deserialize_into(wip, MetaSource::FromEvents)?;
 
         // SpanGuard must cover finish_deferred(), build() and materialize() which can fail with ReflectError.
         // Created AFTER deserialize_into so last_span points to the final token.
@@ -313,7 +314,7 @@ impl<'parser, 'input> FormatDeserializer<'parser, 'input, false> {
         #[allow(unsafe_code)]
         let wip: Partial<'input, false> = unsafe { core::mem::transmute(plan.partial_owned()?) };
 
-        let partial = self.deserialize_into(wip, None)?;
+        let partial = self.deserialize_into(wip, MetaSource::FromEvents)?;
 
         // SpanGuard must cover build() and materialize() which can fail with ReflectError.
         // Created AFTER deserialize_into so last_span points to the final token.
@@ -352,7 +353,7 @@ impl<'parser, 'input> FormatDeserializer<'parser, 'input, false> {
         #[allow(unsafe_code)]
         let wip: Partial<'input, false> = unsafe { core::mem::transmute(plan.partial_owned()?) };
         let wip = wip.begin_deferred()?;
-        let partial = self.deserialize_into(wip, None)?;
+        let partial = self.deserialize_into(wip, MetaSource::FromEvents)?;
 
         // SpanGuard must cover finish_deferred(), build() and materialize() which can fail with ReflectError.
         // Created AFTER deserialize_into so last_span points to the final token.

--- a/facet-format/src/deserializer/struct_simple.rs
+++ b/facet-format/src/deserializer/struct_simple.rs
@@ -3,7 +3,7 @@ use facet_reflect::Partial;
 
 use crate::{
     DeserializeError, DeserializeErrorKind, FormatDeserializer, ParseEventKind, ScalarValue,
-    SpanGuard, ValueMeta,
+    SpanGuard, ValueMeta, deserializer::entry::MetaSource,
 };
 
 /// Look up a field by name using precomputed TypePlan if available, otherwise linear scan.
@@ -120,7 +120,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                     if idx < struct_def.fields.len() {
                         wip = wip
                             .begin_nth_field(idx)?
-                            .with(|w| self.deserialize_into(w, None))?
+                            .with(|w| self.deserialize_into(w, MetaSource::FromEvents))?
                             .end()?;
                     }
                 }
@@ -161,7 +161,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                         let meta = meta_builder.build();
 
                         wip = wip.begin_nth_field(idx)?;
-                        wip = self.deserialize_into(wip, Some(&meta))?;
+                        wip = self.deserialize_into(wip, MetaSource::Owned(meta))?;
 
                         let _guard = SpanGuard::new(self.last_span);
                         wip = wip.end()?;

--- a/facet-format/src/deserializer/struct_with_flatten.rs
+++ b/facet-format/src/deserializer/struct_with_flatten.rs
@@ -4,6 +4,7 @@ use facet_core::{Characteristic, Def};
 use facet_reflect::{FieldCategory, FieldInfo, Partial, VariantSelection};
 use facet_solver::PathSegment;
 
+use super::entry::MetaSource;
 use super::path_navigator::PathNavigator;
 use crate::{
     DeserializeError, DeserializeErrorKind, FieldKey, FormatDeserializer, ParseEventKind,
@@ -217,7 +218,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                         } else {
                             // Regular field: deserialize into it
                             let wip = nav.take_wip();
-                            let wip = self.deserialize_into(wip, None)?;
+                            let wip = self.deserialize_into(wip, MetaSource::FromEvents)?;
                             nav.return_wip(wip);
                         }
 
@@ -316,7 +317,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
             let wip = nav.take_wip();
             let wip = wip
                 .begin_object_entry(key_name)?
-                .with(|w| self.deserialize_into(w, None))?
+                .with(|w| self.deserialize_into(w, MetaSource::FromEvents))?
                 .end()?;
             nav.return_wip(wip);
         } else {
@@ -328,7 +329,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
             let wip = wip.end()?;
             let wip = wip
                 .begin_value()?
-                .with(|w| self.deserialize_into(w, None))?
+                .with(|w| self.deserialize_into(w, MetaSource::FromEvents))?
                 .end()?;
             nav.return_wip(wip);
         }

--- a/facet-format/src/lib.rs
+++ b/facet-format/src/lib.rs
@@ -55,7 +55,7 @@ mod visitor;
 pub mod jit;
 
 pub use deserializer::{
-    DeserializeError, DeserializeErrorKind, FormatDeserializer, ParseError, SpanGuard,
+    DeserializeError, DeserializeErrorKind, FormatDeserializer, MetaSource, ParseError, SpanGuard,
 };
 pub use event::{
     ContainerKind, FieldKey, FieldLocationHint, ParseEvent, ParseEventKind, ScalarValue, ValueMeta,

--- a/facet-json/benches/typeplan_reuse.rs
+++ b/facet-json/benches/typeplan_reuse.rs
@@ -8,6 +8,7 @@
 
 use divan::{Bencher, black_box};
 use facet::Facet;
+use facet_format::MetaSource;
 use facet_json::JsonParser;
 use facet_reflect::TypePlan;
 
@@ -113,7 +114,9 @@ fn point_reused_typeplan(bencher: Bencher) {
         let partial = plan.partial_owned().unwrap();
         let mut parser = JsonParser::<true>::new(black_box(json.as_bytes()));
         let mut de = FormatDeserializer::new_owned(&mut parser);
-        let partial = de.deserialize_into(partial, None).unwrap();
+        let partial = de
+            .deserialize_into(partial, MetaSource::FromEvents)
+            .unwrap();
         let result: Point = partial.build().unwrap().materialize().unwrap();
         black_box(result)
     });
@@ -145,7 +148,9 @@ fn person_reused_typeplan(bencher: Bencher) {
         let partial = plan.partial_owned().unwrap();
         let mut parser = JsonParser::<true>::new(black_box(json.as_bytes()));
         let mut de = FormatDeserializer::new_owned(&mut parser);
-        let partial = de.deserialize_into(partial, None).unwrap();
+        let partial = de
+            .deserialize_into(partial, MetaSource::FromEvents)
+            .unwrap();
         let result: Person = partial.build().unwrap().materialize().unwrap();
         black_box(result)
     });
@@ -177,7 +182,9 @@ fn company_reused_typeplan(bencher: Bencher) {
         let partial = plan.partial_owned().unwrap();
         let mut parser = JsonParser::<true>::new(black_box(json.as_bytes()));
         let mut de = FormatDeserializer::new_owned(&mut parser);
-        let partial = de.deserialize_into(partial, None).unwrap();
+        let partial = de
+            .deserialize_into(partial, MetaSource::FromEvents)
+            .unwrap();
         let result: Company = partial.build().unwrap().materialize().unwrap();
         black_box(result)
     });
@@ -212,7 +219,9 @@ fn batch_1000_reused_typeplan(bencher: Bencher) {
             let partial = plan.partial_owned().unwrap();
             let mut parser = JsonParser::<true>::new(black_box(json.as_bytes()));
             let mut de = FormatDeserializer::new_owned(&mut parser);
-            let partial = de.deserialize_into(partial, None).unwrap();
+            let partial = de
+                .deserialize_into(partial, MetaSource::FromEvents)
+                .unwrap();
             let result: Person = partial.build().unwrap().materialize().unwrap();
             black_box(result);
         }

--- a/facet-json/src/lib.rs
+++ b/facet-json/src/lib.rs
@@ -260,7 +260,7 @@ pub fn from_str_into<'facet>(
     input: &str,
     partial: Partial<'facet, false>,
 ) -> Result<Partial<'facet, false>, DeserializeError> {
-    use facet_format::FormatDeserializer;
+    use facet_format::{FormatDeserializer, MetaSource};
     // TRUSTED_UTF8 = true: input came from &str, so it's valid UTF-8
     let mut parser = JsonParser::<true>::new(input.as_bytes());
     let mut de = FormatDeserializer::new_owned(&mut parser);
@@ -273,7 +273,7 @@ pub fn from_str_into<'facet>(
     let partial: Partial<'_, false> =
         unsafe { core::mem::transmute::<Partial<'facet, false>, Partial<'_, false>>(partial) };
 
-    let partial = de.deserialize_into(partial, None)?;
+    let partial = de.deserialize_into(partial, MetaSource::FromEvents)?;
 
     // SAFETY: Same reasoning - no borrowed data since BORROW=false.
     #[allow(unsafe_code)]
@@ -316,7 +316,7 @@ pub fn from_slice_into<'facet>(
     input: &[u8],
     partial: Partial<'facet, false>,
 ) -> Result<Partial<'facet, false>, DeserializeError> {
-    use facet_format::FormatDeserializer;
+    use facet_format::{FormatDeserializer, MetaSource};
     let mut parser = JsonParser::<false>::new(input);
     let mut de = FormatDeserializer::new_owned(&mut parser);
 
@@ -328,7 +328,7 @@ pub fn from_slice_into<'facet>(
     let partial: Partial<'_, false> =
         unsafe { core::mem::transmute::<Partial<'facet, false>, Partial<'_, false>>(partial) };
 
-    let partial = de.deserialize_into(partial, None)?;
+    let partial = de.deserialize_into(partial, MetaSource::FromEvents)?;
 
     // SAFETY: Same reasoning - no borrowed data since BORROW=false.
     #[allow(unsafe_code)]
@@ -374,11 +374,11 @@ pub fn from_str_into_borrowed<'input, 'facet>(
 where
     'input: 'facet,
 {
-    use facet_format::FormatDeserializer;
+    use facet_format::{FormatDeserializer, MetaSource};
     // TRUSTED_UTF8 = true: input came from &str, so it's valid UTF-8
     let mut parser = JsonParser::<true>::new(input.as_bytes());
     let mut de = FormatDeserializer::new(&mut parser);
-    de.deserialize_into(partial, None)
+    de.deserialize_into(partial, MetaSource::FromEvents)
 }
 
 /// Deserialize JSON from bytes into an existing Partial, allowing zero-copy borrowing.
@@ -417,8 +417,8 @@ pub fn from_slice_into_borrowed<'input, 'facet>(
 where
     'input: 'facet,
 {
-    use facet_format::FormatDeserializer;
+    use facet_format::{FormatDeserializer, MetaSource};
     let mut parser = JsonParser::<false>::new(input);
     let mut de = FormatDeserializer::new(&mut parser);
-    de.deserialize_into(partial, None)
+    de.deserialize_into(partial, MetaSource::FromEvents)
 }

--- a/facet-msgpack/src/lib.rs
+++ b/facet-msgpack/src/lib.rs
@@ -178,7 +178,7 @@ pub fn from_slice_into<'facet>(
     input: &[u8],
     partial: facet_reflect::Partial<'facet, false>,
 ) -> Result<facet_reflect::Partial<'facet, false>, DeserializeError> {
-    use facet_format::FormatDeserializer;
+    use facet_format::{FormatDeserializer, MetaSource};
     let mut parser = MsgPackParser::new(input);
     let mut de = FormatDeserializer::new_owned(&mut parser);
 
@@ -194,7 +194,7 @@ pub fn from_slice_into<'facet>(
         >(partial)
     };
 
-    let partial = de.deserialize_into(partial, None)?;
+    let partial = de.deserialize_into(partial, MetaSource::FromEvents)?;
 
     // SAFETY: Same reasoning - no borrowed data since BORROW=false.
     #[allow(unsafe_code)]
@@ -245,8 +245,8 @@ pub fn from_slice_into_borrowed<'input, 'facet>(
 where
     'input: 'facet,
 {
-    use facet_format::FormatDeserializer;
+    use facet_format::{FormatDeserializer, MetaSource};
     let mut parser = MsgPackParser::new(input);
     let mut de = FormatDeserializer::new(&mut parser);
-    de.deserialize_into(partial, None)
+    de.deserialize_into(partial, MetaSource::FromEvents)
 }

--- a/facet-postcard/src/lib.rs
+++ b/facet-postcard/src/lib.rs
@@ -180,7 +180,7 @@ pub fn from_slice_into<'facet>(
     input: &[u8],
     partial: facet_reflect::Partial<'facet, false>,
 ) -> Result<facet_reflect::Partial<'facet, false>, DeserializeError> {
-    use facet_format::FormatDeserializer;
+    use facet_format::{FormatDeserializer, MetaSource};
     let mut parser = PostcardParser::new(input);
     let mut de = FormatDeserializer::new_owned(&mut parser);
 
@@ -196,7 +196,7 @@ pub fn from_slice_into<'facet>(
         >(partial)
     };
 
-    let partial = de.deserialize_into(partial, None)?;
+    let partial = de.deserialize_into(partial, MetaSource::FromEvents)?;
 
     // SAFETY: Same reasoning - no borrowed data since BORROW=false.
     #[allow(unsafe_code)]
@@ -247,8 +247,8 @@ pub fn from_slice_into_borrowed<'input, 'facet>(
 where
     'input: 'facet,
 {
-    use facet_format::FormatDeserializer;
+    use facet_format::{FormatDeserializer, MetaSource};
     let mut parser = PostcardParser::new(input);
     let mut de = FormatDeserializer::new(&mut parser);
-    de.deserialize_into(partial, None)
+    de.deserialize_into(partial, MetaSource::FromEvents)
 }

--- a/facet-toml/tests/integration/issue_1995.rs
+++ b/facet-toml/tests/integration/issue_1995.rs
@@ -1,0 +1,62 @@
+//! Tests for issue #1995: #[facet(other)] variants don't support metadata containers
+//!
+//! When using `#[facet(other)]` as a catch-all variant in an externally-tagged enum,
+//! metadata containers like `Meta<T>` should be supported so that span information is preserved.
+
+use facet::Facet;
+use facet_reflect::Span;
+use facet_toml as toml;
+use std::collections::HashMap;
+
+/// A value with source span information.
+#[derive(Debug, Clone, Facet)]
+#[facet(metadata_container)]
+pub struct Meta<T> {
+    pub value: T,
+    #[facet(metadata = "span")]
+    pub span: Option<Span>,
+}
+
+/// An externally-tagged enum with a catch-all variant that uses a metadata container.
+#[derive(Debug, Facet)]
+#[facet(rename_all = "kebab-case")]
+#[repr(u8)]
+#[allow(dead_code)]
+pub enum FilterValue {
+    /// NULL check
+    Null,
+    /// Greater than
+    Gt(Vec<Meta<String>>),
+    /// Equality - bare scalar fallback (unknown variant names fall through here)
+    #[facet(other)]
+    EqBare(Meta<String>),
+}
+
+/// WHERE clause - filter conditions.
+#[derive(Debug, Facet)]
+pub struct Where {
+    #[facet(flatten)]
+    pub filters: HashMap<String, FilterValue>,
+}
+
+#[test]
+fn other_variant_with_metadata_container() {
+    // Input: {id = "$id"} - "id" is not a known variant, so falls through to EqBare
+    // The value "$id" should be wrapped in Meta<String> with span info
+    let input = r#"id = "$id""#;
+    let result: Where = toml::from_str(input).unwrap();
+
+    assert_eq!(result.filters.len(), 1);
+    let value = result.filters.get("id").expect("should have 'id' key");
+
+    match value {
+        FilterValue::EqBare(meta) => {
+            assert_eq!(meta.value, "$id");
+            assert!(
+                meta.span.is_some(),
+                "span should be populated for #[facet(other)] variant"
+            );
+        }
+        _ => panic!("Expected EqBare variant (other fallback), got {:?}", value),
+    }
+}

--- a/facet-toml/tests/integration/mod.rs
+++ b/facet-toml/tests/integration/mod.rs
@@ -1,5 +1,6 @@
 mod basic;
 mod flatten;
+mod issue_1995;
 mod nested_arrays;
 mod spanned;
 mod tables;


### PR DESCRIPTION
## Summary

Fixes #1995. When using `#[facet(other)]` as a catch-all variant in an externally-tagged enum, metadata containers like `Meta<String>` now correctly receive span information.

The fix replaces `Option<&ValueMeta>` with a `MetaSource` enum that explicitly tracks where metadata should come from during deserialization. For scalar values in "other" variants, instead of consuming the event and directly setting the string value, we now leave the event unconsumed and call `deserialize_into` with `MetaSource::FromEvents`, allowing metadata containers to read the span information fresh from the event.

## Changes

- Introduced `MetaSource` enum with three variants:
  - `Explicit(&ValueMeta)` - use borrowed metadata from outer context
  - `Owned(ValueMeta)` - use locally-constructed metadata  
  - `FromEvents` - read fresh metadata from the events being parsed
- Updated all `deserialize_into` call sites across facet-format, facet-json, facet-msgpack, facet-postcard
- Fixed the scalar handling in eenum.rs for "other" variants to not consume the event prematurely
- Added test case `issue_1995.rs` demonstrating the fix

## Test plan

- [x] Existing tests pass
- [x] New test `other_variant_with_metadata_container` verifies span is populated