### PR TITLE
Allow non-String key types for catch-all maps in solver

### DIFF
--- a/facet-toml/tests/integration/issue_1995.rs
+++ b/facet-toml/tests/integration/issue_1995.rs
@@ -60,3 +60,45 @@ fn other_variant_with_metadata_container() {
         _ => panic!("Expected EqBare variant (other fallback), got {:?}", value),
     }
 }
+
+/// A strongly-typed string wrapper (like ColumnName from strid).
+/// This is a newtype that wraps String but is not itself a String.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Facet)]
+#[facet(transparent)]
+#[repr(transparent)]
+pub struct ColumnName(String);
+
+impl ColumnName {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+/// WHERE clause using ColumnName as the key type instead of String.
+#[derive(Debug, Facet)]
+pub struct WhereWithColumnName {
+    #[facet(flatten)]
+    pub filters: HashMap<ColumnName, FilterValue>,
+}
+
+#[test]
+fn flatten_hashmap_with_newtype_key() {
+    // Same as above but using ColumnName (a transparent newtype around String) as the key
+    let input = r#"id = "$id""#;
+    let result: WhereWithColumnName = toml::from_str(input).unwrap();
+
+    assert_eq!(result.filters.len(), 1);
+    let key = ColumnName::new("id");
+    let value = result.filters.get(&key).expect("should have 'id' key");
+
+    match value {
+        FilterValue::EqBare(meta) => {
+            assert_eq!(meta.value, "$id");
+            assert!(
+                meta.span.is_some(),
+                "span should be populated for #[facet(other)] variant"
+            );
+        }
+        _ => panic!("Expected EqBare variant (other fallback), got {:?}", value),
+    }
+}


### PR DESCRIPTION
## Summary

The solver was overly restrictive, requiring map keys to be `String` or metadata containers wrapping `String` for catch-all (flattened) maps. However, the actual key type compatibility is the deserializer's concern, not the solver's.

## Changes

- Removed key type validation from the solver's catch-all map handling
- Any map type can now serve as a catch-all - whether the key type can be deserialized from field name strings is the deserializer's problem
- Added test case demonstrating `HashMap<ColumnName, FilterValue>` where `ColumnName` is a `#[facet(transparent)]` newtype around `String`

## Testing

Added `flatten_hashmap_with_newtype_key` test in `facet-toml/tests/integration/issue_1995.rs` that verifies transparent newtypes work as map keys for flattened maps.