### PR TITLE
Add Partial::alloc_shape_owned for type-erased owned allocation

### DIFF
--- a/facet-reflect/src/partial/partial_api/alloc.rs
+++ b/facet-reflect/src/partial/partial_api/alloc.rs
@@ -44,6 +44,25 @@ impl Partial<'static, false> {
     pub fn alloc_owned<T: Facet<'static>>() -> Result<Self, AllocError> {
         TypePlan::<T>::build()?.partial_owned()
     }
+
+    /// Create a new owned Partial from a shape.
+    ///
+    /// This allocates memory for a value described by the shape and returns a `Partial`
+    /// that can be used to initialize it incrementally. The resulting value will be
+    /// fully owned ('static lifetime).
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the shape is valid and corresponds to a real type.
+    /// Using an incorrect or maliciously crafted shape can lead to undefined behavior
+    /// when materializing values.
+    #[inline]
+    pub unsafe fn alloc_shape_owned(shape: &'static facet_core::Shape) -> Result<Self, AllocError> {
+        // SAFETY: caller guarantees shape is valid
+        let plan = unsafe { TypePlanCore::from_shape(shape)? };
+        let root_id = plan.root_id();
+        create_partial_internal::<false>(plan, root_id)
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Adds `Partial::alloc_shape_owned` to restore symmetry with the borrowing API:

| Mode | With type T | With shape |
|------|-------------|------------|
| borrowing | `alloc<T>()` | `alloc_shape(shape)` |
| owned | `alloc_owned<T>()` | **`alloc_shape_owned(shape)`** ← new |

This method was accidentally dropped during the TypePlan refactor (#1968).

## Use case

Needed for type-erased deserialization where you have a `&'static Shape` but no concrete type `T`, and need an owned `HeapValue<'static, false>` result (e.g., picante's persistent cache).