### PR TITLE
Improve panic msg when default conversion fails

### DIFF
--- a/facet-macros-impl/src/process_struct.rs
+++ b/facet-macros-impl/src/process_struct.rs
@@ -1124,34 +1124,22 @@ pub(crate) fn gen_field_from_pfield(
             let panic_failed = quote_spanned! { field_orig_ident_span =>
                 panic!("Field '{}' expects {}, but default function returns {}: {}",
                     #field_name,
-                    ShapePrinter(__dst_shape),
-                    ShapePrinter(__src_shape),
+                    __dst_shape,
+                    __src_shape,
                     e
                 )
             };
             let panic_unsupported = quote_spanned! { field_orig_ident_span =>
                 panic!("Field '{}' expects {}, but default function returns {}",
                     #field_name,
-                    ShapePrinter(__dst_shape),
-                    ShapePrinter(__src_shape)
+                    __dst_shape,
+                    __src_shape
                 )
             };
 
             quote! {
                 𝟋Some(𝟋DS::Custom({
                     unsafe fn __default(__ptr: #facet_crate::PtrUninit) -> #facet_crate::PtrMut {
-                        // Helper to print shapes without allocation
-                        struct ShapePrinter<'a>(&'a #facet_crate::Shape);
-                        impl<'a> core::fmt::Display for ShapePrinter<'a> {
-                            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                                if let Some(inner) = self.0.inner {
-                                    write!(f, "{}<{}>", self.0.type_identifier, ShapePrinter(inner))
-                                } else {
-                                    f.write_str(self.0.type_identifier)
-                                }
-                            }
-                        }
-
                         // Helper function to get shape from a value via type inference
                         #[inline]
                         fn __shape_of_val<'a, T: #facet_crate::Facet<'a>>(_: &T) -> &'static #facet_crate::Shape {


### PR DESCRIPTION
As a first-time user of the facet ecosystem, trying to convert an `argh` project to `figue`, I spent a somewhat embarrassingly long time trying to figure out the panic message because of my (admittedly dumb) mistake w/ default value functions. I did not open a ticket for this because I'm not even sure it qualifies as a bug, but something similar to this PR likely would have saved me quite some time and `cargo expand` invocations.

---

When a default fn is provided, and the produced default value cannot be converted into the expected type, the panic message does not make it immediately obvious where or exactly what the problem is.

This change provides:
- The correct line number for the field that failed, rather than the macro invocation line.
- A more explicit panic message displaying the found and expected types, including the inner type if present, to aid in troubleshooting.

Example 1:
```rust
use facet::Facet;

#[derive(Facet, Debug)]
struct BadOptional {
    #[facet(default = my_default_fn())]
    pub some_string: Option<String>,
}

fn my_default_fn() -> String {
    "some string".to_owned()
}

fn main() {
    let b: BadOptional = facet_json::from_str("{}").unwrap();
    println!("{b:?}");
}
```

Output:
```shell
thread 'main' (427896) panicked at src/main.rs:3:10:
type Option does not support try_from
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

New output:
```shell
thread 'main' (427647) panicked at src/main.rs:6:9:
Field 'some_string' expects Option<String>, but default function returns String
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Example 2:
```rust
use facet::Facet;

#[derive(Facet, Debug)]
struct BadOptional {
    #[facet(default = 300)]
    pub too_big: u8,
}

fn main() {
    let b: BadOptional = facet_json::from_str("{}").unwrap();
    println!("{b:?}");
}
```

Output:
```shell
thread 'main' (441067) panicked at src/main.rs:3:10:
default value conversion failed: conversion from i32 to u8 failed: value 300 out of range
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

New output:
```shell
thread 'main' (440733) panicked at src/main.rs:6:9:
Field 'too_big' expects u8, but default function returns i32: conversion from i32 to u8 failed: value 300 out of range
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

