### PR TITLE
facet-json: configurable hex formatting for byte sequences

### DIFF
--- a/facet-json/src/lib.rs
+++ b/facet-json/src/lib.rs
@@ -67,11 +67,11 @@ pub use error::JsonError;
 pub use parser::JsonParser;
 pub use raw_json::RawJson;
 pub use serializer::{
-    JsonSerializeError, JsonSerializer, SerializeOptions, peek_to_string, peek_to_string_pretty,
-    peek_to_string_with_options, peek_to_writer_std, peek_to_writer_std_pretty,
-    peek_to_writer_std_with_options, to_string, to_string_pretty, to_string_with_options, to_vec,
-    to_vec_pretty, to_vec_with_options, to_writer_std, to_writer_std_pretty,
-    to_writer_std_with_options,
+    BytesFormat, HexBytesOptions, JsonSerializeError, JsonSerializer, SerializeOptions,
+    peek_to_string, peek_to_string_pretty, peek_to_string_with_options, peek_to_writer_std,
+    peek_to_writer_std_pretty, peek_to_writer_std_with_options, to_string, to_string_pretty,
+    to_string_with_options, to_vec, to_vec_pretty, to_vec_with_options, to_writer_std,
+    to_writer_std_pretty, to_writer_std_with_options,
 };
 
 // Re-export DeserializeError for convenience


### PR DESCRIPTION
## Summary
Add serializer-level configuration for JSON byte formatting so `Vec<u8>`, `[u8; N]`, and other byte sequences can be emitted either as numeric arrays (current behavior) or as hex strings, including optional middle truncation.

## Changes
- Add `SerializeOptions::bytes_format` with:
  - `BytesFormat::Array` (default)
  - `BytesFormat::Hex(HexBytesOptions)`
- Add helpers:
  - `bytes_as_array()`
  - `bytes_as_hex()`
  - `bytes_as_hex_with_options(...)`
- Implement byte handling in JSON serializer for both paths used by shared reflection serialization:
  - bulk byte-sequence hooks (`serialize_byte_sequence`, `serialize_byte_array`)
  - `ScalarValue::Bytes`
- Re-export new option types from `facet-json` root.
- Add tests covering:
  - default array output
  - full hex output
  - truncated hex output (`head + tail`, cut middle)
  - fixed-size byte arrays in hex mode

## Test Plan
- `cargo nextest run -p facet-json -E 'test(bytes_default_to_json_array) | test(bytes_can_serialize_as_hex_string) | test(bytes_can_serialize_as_truncated_hex_string) | test(byte_arrays_use_same_hex_mode) | test(bytes_bytes) | test(bytes_bytes_mut)'`
