### PR TITLE
facet-typescript: only alias non-tuple newtypes when transparent

### DIFF
--- a/facet-typescript/src/snapshots/facet_typescript__tests__non_transparent_newtype.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__non_transparent_newtype.snap
@@ -1,0 +1,9 @@
+---
+source: facet-typescript/src/lib.rs
+expression: out
+---
+export interface Envelope {
+  id: BacktraceId;
+}
+
+export type BacktraceId = [number];

--- a/facet-typescript/src/snapshots/facet_typescript__tests__transparent_newtype.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__transparent_newtype.snap
@@ -1,0 +1,7 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts
+---
+export type TransparentId = number;
+
+export type u64 = number;


### PR DESCRIPTION
## Summary

Previously any single-field tuple struct (newtype pattern) was unconditionally emitted as a TypeScript type alias to its inner type. This collapses distinct Rust types into their inner scalar, which is incorrect for non-transparent newtypes.

This removes the special-case alias path for single-field tuple structs. A non-transparent newtype now emits as a one-element array tuple (consistent with all other tuple structs). Transparent newtypes continue to collapse to the inner scalar alias, as they did before via the existing transparent handling path.

## Changes

- Remove the `StructKind::TupleStruct if fields.len() == 1` branch that unconditionally aliased single-field tuple structs
- Add snapshot test asserting a non-transparent newtype does NOT generate a scalar alias
- Add snapshot test asserting a transparent newtype DOES generate a scalar alias

## Testing

Two new insta snapshot tests cover both the fixed case and the preserved transparent behavior.