### PR TITLE
fix(facet-typescript): emit unit enum variants as strings in mixed tagged enums

### DIFF
--- a/facet-typescript/src/lib.rs
+++ b/facet-typescript/src/lib.rs
@@ -525,8 +525,8 @@ impl TypeScriptGenerator {
                 let variant_name = variant.effective_name();
                 match variant.data.kind {
                     StructKind::Unit => {
-                        // Unit variant as object with type discriminator
-                        variant_types.push(format!("{{ {}: \"{}\" }}", variant_name, variant_name));
+                        // Unit variant serializes as bare string, even in tagged enums.
+                        variant_types.push(format!("\"{}\"", variant_name));
                     }
                     StructKind::TupleStruct if variant.data.fields.len() == 1 => {
                         // Newtype variant: { VariantName: InnerType }
@@ -818,6 +818,23 @@ mod tests {
 
         let ts = to_typescript::<Message>();
         insta::assert_snapshot!(ts);
+    }
+
+    #[test]
+    fn test_tagged_enum_unit_and_data_variants() {
+        #[derive(Facet)]
+        #[facet(rename_all = "snake_case")]
+        #[repr(u8)]
+        #[allow(dead_code)]
+        enum ResponseStatus {
+            Pending,
+            Ok(String),
+            Error { message: String },
+            Cancelled,
+        }
+
+        let ts = to_typescript::<ResponseStatus>();
+        insta::assert_snapshot!("tagged_enum_unit_and_data_variants", ts);
     }
 
     #[test]

--- a/facet-typescript/src/snapshots/facet_typescript__tests__tagged_enum_unit_and_data_variants.snap
+++ b/facet-typescript/src/snapshots/facet_typescript__tests__tagged_enum_unit_and_data_variants.snap
@@ -1,0 +1,9 @@
+---
+source: facet-typescript/src/lib.rs
+expression: ts
+---
+export type ResponseStatus =
+  | "pending"
+  | { ok: string }
+  | { error: { message: string } }
+  | "cancelled";


### PR DESCRIPTION
## Summary
Fix `facet-typescript` enum generation for mixed tagged enums so unit variants are emitted as bare string literals, matching `facet-json` wire format.

## Changes
- Emit unit variants as `"name"` in the tagged-enum generation path (instead of `{ name: "name" }`)
- Add regression test for a `rename_all = "snake_case"` enum mixing unit, newtype, and struct variants
- Add snapshot asserting expected TypeScript output

## Test Plan
- [x] `cargo nextest run -p facet-typescript`

Closes #2055
