### PR TITLE
Expose const generic parameters via Shape reflection

### DIFF
--- a/facet-core/src/impls/core/array.rs
+++ b/facet-core/src/impls/core/array.rs
@@ -3,9 +3,9 @@
 use core::{cmp::Ordering, fmt};
 
 use crate::{
-    ArrayDef, ArrayVTable, Def, Facet, HashProxy, OxPtrConst, OxPtrMut, OxPtrUninit, OxRef,
-    PtrConst, PtrMut, PtrUninit, Shape, ShapeBuilder, Type, TypeNameOpts, TypeOpsIndirect,
-    TypeParam, VTableIndirect, Variance, VarianceDep, VarianceDesc,
+    ArrayDef, ArrayVTable, ConstParam, ConstParamKind, Def, Facet, HashProxy, OxPtrConst, OxPtrMut,
+    OxPtrUninit, OxRef, PtrConst, PtrMut, PtrUninit, Shape, ShapeBuilder, Type, TypeNameOpts,
+    TypeOpsIndirect, TypeParam, VTableIndirect, Variance, VarianceDep, VarianceDesc,
 };
 
 /// Extract the ArrayDef from a shape, returns None if not an array
@@ -281,6 +281,11 @@ where
             .type_params(&[TypeParam {
                 name: "T",
                 shape: T::SHAPE,
+            }])
+            .const_params(&[ConstParam {
+                name: "N",
+                value: N as u64,
+                kind: ConstParamKind::Usize,
             }])
             .inner(T::SHAPE)
             // [T; N] propagates T's variance

--- a/facet-core/src/types/shape.rs
+++ b/facet-core/src/types/shape.rs
@@ -189,6 +189,10 @@ pub struct Shape {
     /// Includes bounds and variance information.
     pub type_params: &'static [TypeParam],
 
+    /// Generic const parameters (e.g. `N` in `[T; N]`).
+    /// These are per-monomorphization values.
+    pub const_params: &'static [ConstParam],
+
     /// Doc comments from the original type definition.
     /// Collected by facet-macros; lines usually start with a space.
     pub doc: &'static [&'static str],
@@ -757,6 +761,51 @@ impl TypeParam {
     pub const fn shape(&self) -> &'static Shape {
         self.shape
     }
+}
+
+/// Value of a reflected const generic parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ConstParam {
+    /// The name of the const parameter (e.g., `N`).
+    pub name: &'static str,
+
+    /// Erased numeric value of the const parameter.
+    ///
+    /// Signed values are stored using Rust's cast semantics
+    /// (two's-complement representation in `u64`).
+    pub value: u64,
+
+    /// Primitive kind of the const parameter.
+    pub kind: ConstParamKind,
+}
+
+/// Primitive kind for reflected const generic parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ConstParamKind {
+    /// `bool`
+    Bool,
+    /// `char`
+    Char,
+    /// `u8`
+    U8,
+    /// `u16`
+    U16,
+    /// `u32`
+    U32,
+    /// `u64`
+    U64,
+    /// `usize`
+    Usize,
+    /// `i8`
+    I8,
+    /// `i16`
+    I16,
+    /// `i32`
+    I32,
+    /// `i64`
+    I64,
+    /// `isize`
+    Isize,
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/facet-core/src/types/shape/shape_builder.rs
+++ b/facet-core/src/types/shape/shape_builder.rs
@@ -1,8 +1,8 @@
 use alloc::alloc::Layout;
 
 use crate::{
-    Attr, ConstTypeId, DeclId, Def, FormatProxy, MarkerTraits, ProxyDef, Shape, ShapeFlags,
-    ShapeLayout, Type, TypeNameFn, TypeOps, TypeOpsDirect, TypeOpsIndirect, TypeParam,
+    Attr, ConstParam, ConstTypeId, DeclId, Def, FormatProxy, MarkerTraits, ProxyDef, Shape,
+    ShapeFlags, ShapeLayout, Type, TypeNameFn, TypeOps, TypeOpsDirect, TypeOpsIndirect, TypeParam,
     VTableDirect, VTableErased, VTableIndirect, VarianceDesc,
 };
 
@@ -36,6 +36,7 @@ const EMPTY_VESSEL: Shape = Shape {
     source_line: None,
     source_column: None,
     type_params: &[],
+    const_params: &[],
     doc: &[],
     attributes: &[],
     type_tag: None,
@@ -283,6 +284,13 @@ impl ShapeBuilder {
         self
     }
 
+    /// Set the const parameters.
+    #[inline]
+    pub const fn const_params(mut self, const_params: &'static [ConstParam]) -> Self {
+        self.shape.const_params = const_params;
+        self
+    }
+
     /// Set the documentation.
     #[inline]
     pub const fn doc(mut self, doc: &'static [&'static str]) -> Self {
@@ -449,12 +457,12 @@ impl ShapeBuilder {
 
         // Handle decl_id:
         // - If already set (non-zero): use it
-        // - If not set and no type_params: auto-compute from type_identifier
-        // - If not set and has type_params and has module_path: auto-compute from parts
-        // - If not set and has type_params but no module_path: panic
+        // - If not set and no generic params: auto-compute from type_identifier
+        // - If not set and has generic params and has module_path: auto-compute from parts
+        // - If not set and has generic params but no module_path: panic
         let decl_id = if self.shape.decl_id.0 != 0 {
             self.shape.decl_id
-        } else if self.shape.type_params.is_empty() {
+        } else if self.shape.type_params.is_empty() && self.shape.const_params.is_empty() {
             // Non-generic type: auto-compute from type_identifier
             DeclId::new(crate::decl_id_hash(self.shape.type_identifier))
         } else if let Some(module_path) = self.shape.module_path {

--- a/facet-core/src/types/shape/shape_fmt.rs
+++ b/facet-core/src/types/shape/shape_fmt.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{Def, Shape, ShapeLayout, TypeParam};
+use crate::{ConstParam, Def, Shape, ShapeLayout, TypeParam};
 
 // Helper struct to format the name for display
 impl fmt::Display for Shape {
@@ -38,6 +38,7 @@ impl fmt::Debug for Shape {
             source_line: _,   // omit by default (for debugging)
             source_column: _, // omit by default (for debugging)
             type_params: _,
+            const_params: _,
             doc: _,
             attributes: _,
             type_tag: _,
@@ -65,6 +66,7 @@ impl fmt::Debug for Shape {
                 .field("def", &self.def)
                 .field("type_identifier", &self.type_identifier)
                 .field("type_params", &self.type_params)
+                .field("const_params", &self.const_params)
                 .field("doc", &self.doc)
                 .field("attributes", &self.attributes)
                 .field("type_tag", &self.type_tag)
@@ -103,6 +105,28 @@ impl fmt::Debug for Shape {
                         }
                     }
                     TypeParams(self.type_params)
+                });
+            }
+
+            if !self.const_params.is_empty() {
+                field!("const_params", "{}", {
+                    struct ConstParams<'shape>(&'shape [ConstParam]);
+                    impl core::fmt::Display for ConstParams<'_> {
+                        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                            let mut iter = self.0.iter();
+                            if let Some(first) = iter.next() {
+                                write!(f, "«({}: {:?} = {}", first.name, first.kind, first.value)?;
+                                for next in iter {
+                                    write!(f, ", {}: {:?} = {}", next.name, next.kind, next.value)?;
+                                }
+                                write!(f, ")»")?;
+                            } else {
+                                write!(f, "[]")?;
+                            }
+                            Ok(())
+                        }
+                    }
+                    ConstParams(self.const_params)
                 });
             }
 

--- a/facet-macros-impl/src/derive.rs
+++ b/facet-macros-impl/src/derive.rs
@@ -199,7 +199,7 @@ pub(crate) fn build_type_params_call(
                     // ignore for now
                 }
                 GenericParam::Const { .. } => {
-                    // ignore for now
+                    // handled by build_const_params_call
                 }
                 GenericParam::Type { name, .. } => {
                     let name_str = name.to_string();
@@ -218,6 +218,94 @@ pub(crate) fn build_type_params_call(
         quote! {}
     } else {
         quote! { .type_params(&[#(#type_params),*]) }
+    }
+}
+
+/// Build the `.const_params(...)` builder call, returning empty if no supported const params.
+pub(crate) fn build_const_params_call(
+    generics: Option<&GenericParams>,
+    opaque: bool,
+    facet_crate: &TokenStream,
+) -> TokenStream {
+    if opaque {
+        return quote! {};
+    }
+
+    let mut const_params = Vec::new();
+    if let Some(generics) = generics {
+        for p in generics.params.iter() {
+            if let GenericParam::Const { name, typ, .. } = &p.value {
+                let name_str = name.to_string();
+                let typ = typ.to_token_stream().to_string().replace(' ', "");
+                let primitive = typ.rsplit("::").next().unwrap_or(&typ);
+
+                let (kind, value) = match primitive {
+                    "bool" => (
+                        quote! { #facet_crate::ConstParamKind::Bool },
+                        quote! { if #name { 1u64 } else { 0u64 } },
+                    ),
+                    "char" => (
+                        quote! { #facet_crate::ConstParamKind::Char },
+                        quote! { #name as u32 as u64 },
+                    ),
+                    "u8" => (
+                        quote! { #facet_crate::ConstParamKind::U8 },
+                        quote! { #name as u64 },
+                    ),
+                    "u16" => (
+                        quote! { #facet_crate::ConstParamKind::U16 },
+                        quote! { #name as u64 },
+                    ),
+                    "u32" => (
+                        quote! { #facet_crate::ConstParamKind::U32 },
+                        quote! { #name as u64 },
+                    ),
+                    "u64" => (
+                        quote! { #facet_crate::ConstParamKind::U64 },
+                        quote! { #name as u64 },
+                    ),
+                    "usize" => (
+                        quote! { #facet_crate::ConstParamKind::Usize },
+                        quote! { #name as u64 },
+                    ),
+                    "i8" => (
+                        quote! { #facet_crate::ConstParamKind::I8 },
+                        quote! { (#name as i64) as u64 },
+                    ),
+                    "i16" => (
+                        quote! { #facet_crate::ConstParamKind::I16 },
+                        quote! { (#name as i64) as u64 },
+                    ),
+                    "i32" => (
+                        quote! { #facet_crate::ConstParamKind::I32 },
+                        quote! { (#name as i64) as u64 },
+                    ),
+                    "i64" => (
+                        quote! { #facet_crate::ConstParamKind::I64 },
+                        quote! { (#name as i64) as u64 },
+                    ),
+                    "isize" => (
+                        quote! { #facet_crate::ConstParamKind::Isize },
+                        quote! { (#name as i64) as u64 },
+                    ),
+                    _ => continue,
+                };
+
+                const_params.push(quote! {
+                    #facet_crate::ConstParam {
+                        name: #name_str,
+                        value: #value,
+                        kind: #kind,
+                    }
+                });
+            }
+        }
+    }
+
+    if const_params.is_empty() {
+        quote! {}
+    } else {
+        quote! { .const_params(&[#(#const_params),*]) }
     }
 }
 

--- a/facet-macros-impl/src/process_enum.rs
+++ b/facet-macros-impl/src/process_enum.rs
@@ -234,6 +234,7 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
         &pe.container.attrs.custom_bounds,
     );
     let type_params_call = build_type_params_call(parsed.generics.as_ref(), opaque, &facet_crate);
+    let const_params_call = build_const_params_call(parsed.generics.as_ref(), opaque, &facet_crate);
 
     // Container-level docs - returns builder call only if there are doc comments and doc feature is enabled
     #[cfg(feature = "doc")]
@@ -1257,6 +1258,7 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                     .ty(#ty_field)
                     .def(𝟋Def::Undefined)
                     #type_params_call
+                    #const_params_call
                     #type_name_call
                     #doc_call
                     #attributes_call

--- a/facet-macros-impl/src/process_struct.rs
+++ b/facet-macros-impl/src/process_struct.rs
@@ -1762,6 +1762,7 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
     };
 
     let type_params_call = build_type_params_call(parsed.generics.as_ref(), opaque, &facet_crate);
+    let const_params_call = build_const_params_call(parsed.generics.as_ref(), opaque, &facet_crate);
 
     // Static decl removed - the TYPENAME_SHAPE static was redundant since
     // <T as Facet>::SHAPE is already accessible and nobody was using the static
@@ -2340,6 +2341,7 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
                     .ty(#ty_field)
                     .def(𝟋Def::Undefined)
                     #type_params_call
+                    #const_params_call
                     #type_name_call
                     #doc_call
                     #attributes_call

--- a/facet-shapelike/src/shape_like.rs
+++ b/facet-shapelike/src/shape_like.rs
@@ -20,6 +20,8 @@ pub struct ShapeLike {
     #[facet(default, skip_unless_truthy)]
     pub type_params: Vec<TypeParamLike>,
     #[facet(default, skip_unless_truthy)]
+    pub const_params: Vec<ConstParamLike>,
+    #[facet(default, skip_unless_truthy)]
     pub doc: Vec<String>,
     #[facet(default, skip_unless_truthy)]
     pub attributes: Vec<AttrLike>,
@@ -40,6 +42,11 @@ impl From<&Shape> for ShapeLike {
             def: (&shape.def).into(),
             type_identifier: shape.type_identifier.to_string(),
             type_params: shape.type_params.iter().map(|item| (item).into()).collect(),
+            const_params: shape
+                .const_params
+                .iter()
+                .map(|item| (item).into())
+                .collect(),
             doc: shape.doc.iter().map(|s| s.to_string()).collect(),
             attributes: shape.attributes.iter().map(|item| (item).into()).collect(),
             type_tag: shape.type_tag.map(|s| s.to_string()),
@@ -61,6 +68,60 @@ impl From<&facet_core::TypeParam> for TypeParamLike {
         Self {
             name: tp.name.to_string(),
             shape: Box::new((tp.shape).into()),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub struct ConstParamLike {
+    pub name: String,
+    pub value: u64,
+    pub kind: ConstParamKindLike,
+}
+
+impl From<&facet_core::ConstParam> for ConstParamLike {
+    fn from(cp: &facet_core::ConstParam) -> Self {
+        Self {
+            name: cp.name.to_string(),
+            value: cp.value,
+            kind: cp.kind.into(),
+        }
+    }
+}
+
+#[derive(facet::Facet, Clone)]
+#[repr(C)]
+pub enum ConstParamKindLike {
+    Bool,
+    Char,
+    U8,
+    U16,
+    U32,
+    U64,
+    Usize,
+    I8,
+    I16,
+    I32,
+    I64,
+    Isize,
+}
+
+impl From<facet_core::ConstParamKind> for ConstParamKindLike {
+    fn from(kind: facet_core::ConstParamKind) -> Self {
+        match kind {
+            facet_core::ConstParamKind::Bool => Self::Bool,
+            facet_core::ConstParamKind::Char => Self::Char,
+            facet_core::ConstParamKind::U8 => Self::U8,
+            facet_core::ConstParamKind::U16 => Self::U16,
+            facet_core::ConstParamKind::U32 => Self::U32,
+            facet_core::ConstParamKind::U64 => Self::U64,
+            facet_core::ConstParamKind::Usize => Self::Usize,
+            facet_core::ConstParamKind::I8 => Self::I8,
+            facet_core::ConstParamKind::I16 => Self::I16,
+            facet_core::ConstParamKind::I32 => Self::I32,
+            facet_core::ConstParamKind::I64 => Self::I64,
+            facet_core::ConstParamKind::Isize => Self::Isize,
         }
     }
 }

--- a/facet/src/lib.rs
+++ b/facet/src/lib.rs
@@ -416,6 +416,7 @@ pub mod builtin {
             ty: crate::Type::User(crate::UserType::Opaque),
             def: crate::Def::Undefined,
             type_params: &[],
+            const_params: &[],
             doc: &[],
             attributes: &[],
             type_tag: None,

--- a/facet/tests/integration/generics.rs
+++ b/facet/tests/integration/generics.rs
@@ -1,4 +1,4 @@
-use facet::{Facet, Type, UserType};
+use facet::{ConstParamKind, Facet, Type, UserType};
 
 #[test]
 fn vec_wrapper() {
@@ -236,6 +236,36 @@ fn type_params_array_f32_12() {
     let t = &shape.type_params[0];
     assert_eq!(t.name, "T");
     assert_eq!(t.shape(), f32::SHAPE);
+    assert_eq!(shape.const_params.len(), 1);
+    let n = &shape.const_params[0];
+    assert_eq!(n.name, "N");
+    assert_eq!(n.kind, ConstParamKind::Usize);
+    assert_eq!(n.value, 12);
+}
+
+#[test]
+fn const_params_derive_struct() {
+    #[derive(Facet)]
+    struct Tx<T: 'static, const N: usize = 16> {
+        _marker: core::marker::PhantomData<T>,
+    }
+
+    let shape0 = Tx::<String, 0>::SHAPE;
+    let shape64 = Tx::<String, 64>::SHAPE;
+
+    assert_eq!(shape0.type_params.len(), 1);
+    assert_eq!(shape0.type_params[0].name, "T");
+    assert_eq!(shape0.type_params[0].shape(), String::SHAPE);
+
+    assert_eq!(shape0.const_params.len(), 1);
+    assert_eq!(shape64.const_params.len(), 1);
+
+    let n0 = &shape0.const_params[0];
+    let n64 = &shape64.const_params[0];
+    assert_eq!(n0.name, "N");
+    assert_eq!(n0.kind, ConstParamKind::Usize);
+    assert_eq!(n0.value, 0);
+    assert_eq!(n64.value, 64);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Expose const generic parameters through runtime shape reflection.

## Changes
- Added `ConstParam` and `ConstParamKind` in `facet-core`, plus `Shape::const_params`.
- Extended `ShapeBuilder` with `.const_params(...)` and treated const params as generic for `decl_id` auto-computation.
- Extended derive codegen to emit `.const_params(...)` for supported const generic primitive kinds (`bool`, `char`, `u8..u64`, `usize`, `i8..i64`, `isize`).
- Included const params in `Shape` debug formatting.
- Added const param reflection for core arrays (`[T; N]`).
- Updated `facet-shapelike` mirror types to include const params.
- Added integration coverage for derived const generics and array const params.

## Test Plan
- `cargo check`
- `cargo nextest run -p facet --test main integration::generics::`

Closes #2060
