### PR TITLE
Add Poke::into_peek for consuming conversion to Peek

### DIFF
--- a/facet-reflect/src/poke/value.rs
+++ b/facet-reflect/src/poke/value.rs
@@ -214,9 +214,15 @@ impl<'mem, 'facet> Poke<'mem, 'facet> {
         Ok(())
     }
 
-    /// Converts this `Poke` into a read-only `Peek`.
+    /// Borrows this `Poke` as a read-only `Peek`.
     #[inline]
     pub fn as_peek(&self) -> crate::Peek<'_, 'facet> {
+        unsafe { crate::Peek::unchecked_new(self.data.as_const(), self.shape) }
+    }
+
+    /// Consumes this `Poke`, returning a read-only `Peek` with the same `'mem` lifetime.
+    #[inline]
+    pub fn into_peek(self) -> crate::Peek<'mem, 'facet> {
         unsafe { crate::Peek::unchecked_new(self.data.as_const(), self.shape) }
     }
 


### PR DESCRIPTION
## Summary

Adds `Poke::into_peek`, which consumes a `Poke` and returns a `Peek` carrying the original `'mem` lifetime. This complements the existing `as_peek`, which borrows the `Poke` and ties the `Peek` to the borrow's shorter lifetime. Also fixes the `as_peek` doc comment to say "borrows" instead of "converts".

## Changes

- Add `Poke::into_peek(self) -> Peek<'mem, 'facet>` method
- Fix `as_peek` doc comment: "Borrows this Poke as a read-only Peek"

## Testing

Existing tests continue to pass. The new method is a thin wrapper over the same `Peek::unchecked_new` used by `as_peek`.

Closes #2062