### PR TITLE
fix(derive): handle empty tuple enum variants

### DIFF
--- a/facet-macros-impl/src/process_enum.rs
+++ b/facet-macros-impl/src/process_enum.rs
@@ -637,12 +637,17 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
                                 quote! { #field_ident: #typ }
                             })
                             .collect();
+                        // Handle empty fields case explicitly (e.g., Variant())
+                        let struct_fields = if fields_with_types.is_empty() {
+                            quote! { _phantom: #phantom_data }
+                        } else {
+                            quote! { #(#fields_with_types),*, _phantom: #phantom_data }
+                        };
                         shadow_defs.push(quote! {
                             #[repr(C)]
                             #[allow(non_snake_case, dead_code)]
                             struct #shadow_struct_name #bgp_with_bounds #where_clauses {
-                                #(#fields_with_types),* ,
-                                _phantom: #phantom_data
+                                #struct_fields
                             }
                         });
                         let field_defs: Vec<TokenStream> = fields

--- a/facet/tests/integration/enums.rs
+++ b/facet/tests/integration/enums.rs
@@ -410,4 +410,63 @@ fn enum_with_multiple_generics_c() {
     }
 }
 
-// testing
+// Regression test for https://github.com/facet-rs/facet/issues/1991
+#[test]
+fn enum_with_empty_tuple_variant_repr_c() {
+    #[derive(Debug, Facet)]
+    #[repr(C)]
+    #[allow(dead_code)]
+    enum EmptyTupleEnum {
+        Unit,
+        EmptyTuple(),
+        NonEmpty(u32),
+    }
+
+    let shape = EmptyTupleEnum::SHAPE;
+    assert_eq!(format!("{shape}"), "EmptyTupleEnum");
+
+    if let Type::User(UserType::Enum(enum_def)) = shape.ty {
+        assert_eq!(enum_def.variants.len(), 3);
+
+        assert_eq!(enum_def.variants[0].name, "Unit");
+        assert_eq!(enum_def.variants[0].data.fields.len(), 0);
+
+        assert_eq!(enum_def.variants[1].name, "EmptyTuple");
+        assert_eq!(enum_def.variants[1].data.fields.len(), 0);
+
+        assert_eq!(enum_def.variants[2].name, "NonEmpty");
+        assert_eq!(enum_def.variants[2].data.fields.len(), 1);
+    } else {
+        panic!("Expected Enum definition");
+    }
+}
+
+#[test]
+fn enum_with_empty_tuple_variant_repr_u8() {
+    #[derive(Debug, Facet)]
+    #[repr(u8)]
+    #[allow(dead_code)]
+    enum EmptyTupleEnumU8 {
+        Unit,
+        EmptyTuple(),
+        NonEmpty(u32),
+    }
+
+    let shape = EmptyTupleEnumU8::SHAPE;
+    assert_eq!(format!("{shape}"), "EmptyTupleEnumU8");
+
+    if let Type::User(UserType::Enum(enum_def)) = shape.ty {
+        assert_eq!(enum_def.variants.len(), 3);
+
+        assert_eq!(enum_def.variants[0].name, "Unit");
+        assert_eq!(enum_def.variants[0].data.fields.len(), 0);
+
+        assert_eq!(enum_def.variants[1].name, "EmptyTuple");
+        assert_eq!(enum_def.variants[1].data.fields.len(), 0);
+
+        assert_eq!(enum_def.variants[2].name, "NonEmpty");
+        assert_eq!(enum_def.variants[2].data.fields.len(), 1);
+    } else {
+        panic!("Expected Enum definition");
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `#[derive(Facet)]` failing on enums with empty tuple variants like `Variant()`
- The C-repr shadow struct template produced a leading comma when the fields list was empty, causing "expected identifier, found `,`"
- Handle the empty case explicitly, matching the pattern already used for struct variants

## Test plan
- [x] Added regression tests for `#[repr(C)]` and `#[repr(u8)]` enums with empty tuple variants
- [x] All 187 `facet` crate tests pass

Closes #1991