### PR TITLE
Fix clippy forget_non_drop warning for custom field defaults

### DIFF
--- a/facet-macros-impl/src/process_struct.rs
+++ b/facet-macros-impl/src/process_struct.rs
@@ -1188,6 +1188,7 @@ pub(crate) fn gen_field_from_pfield(
             };
             quote! {
                 𝟋Some(𝟋DS::Custom({
+                    #[allow(clippy::forget_non_drop)]
                     unsafe fn __default(__ptr: #facet_crate::PtrUninit) -> #facet_crate::PtrMut {
                         // Helper function to get shape from a value via type inference
                         #[inline]


### PR DESCRIPTION
## Summary
This suppresses a Clippy warning emitted from `facet::Facet` derive output when `#[facet(default = ...)]` is used with a non-`Drop` type.

## Changes
- Add `#[allow(clippy::forget_non_drop)]` to the generated `__default` helper in struct field default codegen.
- Keep suppression narrowly scoped to that generated helper only.

## Testing
- cargo check -p facet-macros-impl
- cargo nextest run -p facet-macros-impl
- cargo nextest run -p facet --test main struct_with_default_field_that_has_lifetime
- Reproduced issue snippet in a temp crate with cargo clippy (warning gone)

Fixes #2067
