### PR TITLE
Fix missing-field handling for untagged enum variants

### DIFF
--- a/facet-format/src/deserializer/eenum.rs
+++ b/facet-format/src/deserializer/eenum.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use facet_core::{Characteristic, Def, Field, StructKind, Type, UserType};
+use facet_core::{Def, Field, StructKind, Type, UserType};
 use facet_reflect::Partial;
 use facet_solver::VariantsByFormat;
 
@@ -564,10 +564,9 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                     }
 
                     let field_has_default = field.has_default();
-                    let field_type_has_default = field.shape().is(Characteristic::Default);
                     let field_is_option = matches!(field.shape().def, Def::Option(_));
 
-                    if field_has_default || field_type_has_default {
+                    if field_has_default {
                         wip = wip.set_nth_field_to_default(idx)?;
                     } else if field_is_option {
                         wip = wip.begin_nth_field(idx)?.set_default()?.end()?;
@@ -1110,10 +1109,9 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
             }
 
             let field_has_default = field.has_default();
-            let field_type_has_default = field.shape().is(Characteristic::Default);
             let field_is_option = matches!(field.shape().def, Def::Option(_));
 
-            if field_has_default || field_type_has_default {
+            if field_has_default {
                 wip = wip.set_nth_field_to_default(idx)?;
             } else if field_is_option {
                 wip = wip.begin_nth_field(idx)?.set_default()?.end()?;
@@ -1531,10 +1529,9 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                         }
 
                         let field_has_default = field.has_default();
-                        let field_type_has_default = field.shape().is(Characteristic::Default);
                         let field_is_option = matches!(field.shape().def, Def::Option(_));
 
-                        if field_has_default || field_type_has_default {
+                        if field_has_default {
                             wip = wip.set_nth_field_to_default(idx)?;
                         } else if field_is_option {
                             wip = wip.begin_nth_field(idx)?.set_default()?.end()?;

--- a/facet-json/tests/integration/issue_1989.rs
+++ b/facet-json/tests/integration/issue_1989.rs
@@ -1,0 +1,34 @@
+//! Regression test for https://github.com/facet-rs/facet/issues/1989
+//!
+//! Untagged enum struct variants must error on missing required fields.
+
+use facet::Facet;
+use facet_json::from_str;
+use facet_testhelpers::test;
+
+#[derive(Debug, Facet, PartialEq)]
+#[facet(untagged)]
+#[repr(C)]
+enum TestEnum {
+    Single(i32),
+    MinMaxStepList([i32; 3]),
+    MinMaxList([i32; 2]),
+    MinMax {
+        min: i32,
+        max: i32,
+        #[facet(default)]
+        step: Option<i32>,
+    },
+}
+
+#[test]
+fn test_issue_1989_untagged_missing_required_fields_error() {
+    let input = r#"{}"#;
+    let result: Result<TestEnum, _> = from_str(input);
+
+    assert!(
+        result.is_err(),
+        "deserializing `{{}}` should fail for missing required fields, got: {:?}",
+        result
+    );
+}

--- a/facet-json/tests/integration/mod.rs
+++ b/facet-json/tests/integration/mod.rs
@@ -10,6 +10,7 @@ mod issue_1852;
 mod issue_1896;
 mod issue_1900;
 mod issue_1904;
+mod issue_1989;
 mod issue_2004;
 mod issue_2007;
 mod issue_2010;


### PR DESCRIPTION
## Summary
Fixes untagged enum deserialization so missing required fields in struct variants are now rejected instead of being silently default-initialized from the field type.

## Changes
- Added a regression test for issue #1989 in `facet-json` covering `{}` input against an untagged enum with required fields.
- Updated enum variant default-filling logic in `facet-format` to only apply defaults for explicitly defaultable fields (`#[facet(default)]`, `Option`, or skipped-deserializing fields).
- Removed implicit fallback to type-level `Default` for missing enum-variant fields.

## Testing
- `cargo nextest run -p facet-json test_issue_1989_untagged_missing_required_fields_error`
- `cargo nextest run -p facet-json`
- `cargo check -p facet-format -p facet-json`

Fixes #1989
