### PR TITLE
Make OxPtrConst/OxPtrMut constructor invariants explicit

### DIFF
--- a/facet-core/src/impls/alloc/smallvec.rs
+++ b/facet-core/src/impls/alloc/smallvec.rs
@@ -481,9 +481,9 @@ mod tests {
         let ptr2 = PtrConst::new(&sv2 as *const _ as *const u8);
         let ptr3 = PtrConst::new(&sv3 as *const _ as *const u8);
 
-        let ox1 = OxPtrConst::new(ptr1, shape);
-        let ox2 = OxPtrConst::new(ptr2, shape);
-        let ox3 = OxPtrConst::new(ptr3, shape);
+        let ox1 = unsafe { OxPtrConst::new(ptr1, shape) };
+        let ox2 = unsafe { OxPtrConst::new(ptr2, shape) };
+        let ox3 = unsafe { OxPtrConst::new(ptr3, shape) };
 
         let result = unsafe { smallvec_partial_eq_erased(ox1, ox2) };
         assert_eq!(result, Some(true));

--- a/facet-core/src/types/builtins.rs
+++ b/facet-core/src/types/builtins.rs
@@ -70,8 +70,11 @@ pub struct OxPtrConst {
 
 impl OxPtrConst {
     /// Create a new OxPtrConst from a pointer and shape.
+    ///
+    /// # Safety
+    /// `ptr` must point to data actually described by `shape`.
     #[inline]
-    pub const fn new(ptr: PtrConst, shape: &'static Shape) -> Self {
+    pub const unsafe fn new(ptr: PtrConst, shape: &'static Shape) -> Self {
         Self { ptr, shape }
     }
 
@@ -116,8 +119,11 @@ pub struct OxPtrMut {
 
 impl OxPtrMut {
     /// Create a new OxPtrMut from a pointer and shape.
+    ///
+    /// # Safety
+    /// `ptr` must point to data actually described by `shape`.
     #[inline]
-    pub const fn new(ptr: PtrMut, shape: &'static Shape) -> Self {
+    pub const unsafe fn new(ptr: PtrMut, shape: &'static Shape) -> Self {
         Self { ptr, shape }
     }
 

--- a/facet-core/src/types/shape.rs
+++ b/facet-core/src/types/shape.rs
@@ -842,7 +842,7 @@ impl Shape {
             }
             VTableErased::Indirect(vt) => {
                 let debug_fn = vt.debug?;
-                let ox = crate::OxPtrConst::new(ptr, self);
+                let ox = unsafe { crate::OxPtrConst::new(ptr, self) };
                 unsafe { debug_fn(ox, f) }
             }
         }
@@ -865,7 +865,7 @@ impl Shape {
             }
             VTableErased::Indirect(vt) => {
                 let display_fn = vt.display?;
-                let ox = crate::OxPtrConst::new(ptr, self);
+                let ox = unsafe { crate::OxPtrConst::new(ptr, self) };
                 unsafe { display_fn(ox, f) }
             }
         }
@@ -889,7 +889,7 @@ impl Shape {
             }
             VTableErased::Indirect(vt) => {
                 let hash_fn = vt.hash?;
-                let ox = crate::OxPtrConst::new(ptr, self);
+                let ox = unsafe { crate::OxPtrConst::new(ptr, self) };
                 unsafe { hash_fn(ox, hasher) }
             }
         }
@@ -912,8 +912,8 @@ impl Shape {
             }
             VTableErased::Indirect(vt) => {
                 let eq_fn = vt.partial_eq?;
-                let ox_a = crate::OxPtrConst::new(a, self);
-                let ox_b = crate::OxPtrConst::new(b, self);
+                let ox_a = unsafe { crate::OxPtrConst::new(a, self) };
+                let ox_b = unsafe { crate::OxPtrConst::new(b, self) };
                 unsafe { eq_fn(ox_a, ox_b) }
             }
         }
@@ -936,8 +936,8 @@ impl Shape {
             }
             VTableErased::Indirect(vt) => {
                 let cmp_fn = vt.partial_cmp?;
-                let ox_a = crate::OxPtrConst::new(a, self);
-                let ox_b = crate::OxPtrConst::new(b, self);
+                let ox_a = unsafe { crate::OxPtrConst::new(a, self) };
+                let ox_b = unsafe { crate::OxPtrConst::new(b, self) };
                 unsafe { cmp_fn(ox_a, ox_b) }
             }
         }
@@ -960,8 +960,8 @@ impl Shape {
             }
             VTableErased::Indirect(vt) => {
                 let cmp_fn = vt.cmp?;
-                let ox_a = crate::OxPtrConst::new(a, self);
-                let ox_b = crate::OxPtrConst::new(b, self);
+                let ox_a = unsafe { crate::OxPtrConst::new(a, self) };
+                let ox_b = unsafe { crate::OxPtrConst::new(b, self) };
                 unsafe { cmp_fn(ox_a, ox_b) }
             }
         }
@@ -978,7 +978,7 @@ impl Shape {
                 unsafe { (ops.drop_in_place)(ptr.as_mut_byte_ptr() as *mut ()) };
             }
             TypeOps::Indirect(ops) => {
-                let ox = crate::OxPtrMut::new(ptr, self);
+                let ox = unsafe { crate::OxPtrMut::new(ptr, self) };
                 unsafe { (ops.drop_in_place)(ox) };
             }
         }
@@ -1023,7 +1023,7 @@ impl Shape {
             }
             VTableErased::Indirect(vt) => {
                 let invariants_fn = vt.invariants?;
-                let ox = crate::OxPtrConst::new(ptr, self);
+                let ox = unsafe { crate::OxPtrConst::new(ptr, self) };
                 unsafe { invariants_fn(ox) }
             }
         }
@@ -1118,7 +1118,7 @@ impl Shape {
             }
             VTableErased::Indirect(vt) => {
                 let try_borrow_fn = vt.try_borrow_inner?;
-                let ox = crate::OxPtrConst::new(ptr, self);
+                let ox = unsafe { crate::OxPtrConst::new(ptr, self) };
                 unsafe { try_borrow_fn(ox) }
             }
         }
@@ -1147,8 +1147,8 @@ impl Shape {
             }
             TypeOps::Indirect(ops) => {
                 let clone_fn = ops.clone_into?;
-                let ox_src = crate::OxPtrConst::new(src, self);
-                let ox_dst = crate::OxPtrMut::new(dst, self);
+                let ox_src = unsafe { crate::OxPtrConst::new(src, self) };
+                let ox_dst = unsafe { crate::OxPtrMut::new(dst, self) };
                 unsafe { clone_fn(ox_src, ox_dst) };
             }
         }


### PR DESCRIPTION
## Summary
`OxPtrConst::new` and `OxPtrMut::new` were safe constructors even though they rely on a caller-only invariant: the pointer must match the provided shape.

This change makes those constructors `unsafe` and updates all call sites to acknowledge the invariant explicitly.

## Changes
- Make `OxPtrConst::new` and `OxPtrMut::new` `pub const unsafe fn`
- Add safety docs stating that `ptr` must point to data described by `shape`
- Update indirect vtable/type-op call sites in `Shape` helpers to use explicit `unsafe` construction
- Update affected `smallvec` test code to use explicit `unsafe` construction

## Testing
- `cargo check`
- `cargo nextest run`

Closes #1883
