### PR TITLE
fix(postcard): relax to_vec lifetimes to support borrowed types

### DIFF
--- a/facet-postcard/src/serialize.rs
+++ b/facet-postcard/src/serialize.rs
@@ -288,9 +288,9 @@ impl<'a> PostcardWriter<'a> for ScatterBuilder<'a> {
 /// let point = Point { x: 10, y: 20 };
 /// let bytes = to_vec(&point).unwrap();
 /// ```
-pub fn to_vec<T>(value: &T) -> Result<Vec<u8>, SerializeError>
+pub fn to_vec<'facet, T>(value: &T) -> Result<Vec<u8>, SerializeError>
 where
-    T: facet_core::Facet<'static>,
+    T: facet_core::Facet<'facet>,
 {
     let mut buffer = Vec::new();
     to_writer_fallible(value, &mut buffer)?;
@@ -335,9 +335,9 @@ where
 /// let mut writer = CustomWriter { buffer: Vec::new() };
 /// to_writer_fallible(&point, &mut writer).unwrap();
 /// ```
-pub fn to_writer_fallible<T, W>(value: &T, writer: &mut W) -> Result<(), SerializeError>
+pub fn to_writer_fallible<'facet, T, W>(value: &T, writer: &mut W) -> Result<(), SerializeError>
 where
-    T: facet_core::Facet<'static>,
+    T: facet_core::Facet<'facet>,
     W: Writer,
 {
     let peek = Peek::new(value);
@@ -434,12 +434,12 @@ pub fn peek_to_scatter_plan<'input, 'facet>(
 /// Returns an error if:
 /// - The value is not a dynamic value type
 /// - The value's structure doesn't match the target shape
-pub fn to_vec_with_shape<T>(
+pub fn to_vec_with_shape<'facet, T>(
     value: &T,
     target_shape: &'static Shape,
 ) -> Result<Vec<u8>, SerializeError>
 where
-    T: facet_core::Facet<'static>,
+    T: facet_core::Facet<'facet>,
 {
     let mut buffer = Vec::new();
     let peek = Peek::new(value);

--- a/facet-postcard/tests/integration/issue_2079.rs
+++ b/facet-postcard/tests/integration/issue_2079.rs
@@ -1,0 +1,66 @@
+use facet::Facet;
+use facet_postcard::{SerializeError, from_slice_borrowed, to_vec, to_vec_with_shape};
+
+#[derive(Debug, Facet, PartialEq)]
+struct Envelope<'a> {
+    id: u16,
+    label: &'a str,
+    payload: &'a [u8],
+}
+
+fn serialize_envelope<'a>(label: &'a str, payload: &'a [u8]) -> Vec<u8> {
+    let envelope = Envelope {
+        id: 7,
+        label,
+        payload,
+    };
+    to_vec(&envelope).expect("serialization should succeed for borrowed data")
+}
+
+fn serialize_envelope_with_shape<'a>(
+    label: &'a str,
+    payload: &'a [u8],
+) -> Result<Vec<u8>, SerializeError> {
+    let envelope = Envelope {
+        id: 7,
+        label,
+        payload,
+    };
+    to_vec_with_shape(&envelope, Envelope::SHAPE)
+}
+
+#[test]
+fn issue_2079_to_vec_accepts_non_static_borrows() {
+    facet_testhelpers::setup();
+
+    let label = String::from("transient-label");
+    let payload = vec![9_u8, 8, 7, 6, 5];
+
+    let bytes = serialize_envelope(label.as_str(), payload.as_slice());
+    let decoded: Envelope<'_> =
+        from_slice_borrowed(&bytes).expect("deserialization should succeed for borrowed fields");
+
+    assert_eq!(decoded.id, 7);
+    assert_eq!(decoded.label, label.as_str());
+    assert_eq!(decoded.payload, payload.as_slice());
+}
+
+#[test]
+fn issue_2079_to_vec_with_shape_accepts_non_static_borrows() {
+    facet_testhelpers::setup();
+
+    let label = String::from("transient-shape-label");
+    let payload = vec![1_u8, 2, 3];
+
+    let err = serialize_envelope_with_shape(label.as_str(), payload.as_slice())
+        .expect_err("typed values are not dynamic and should fail shape-based serialization");
+    match err {
+        SerializeError::Custom(message) => {
+            assert!(
+                message.contains("DynamicValue"),
+                "unexpected error: {message}"
+            );
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}

--- a/facet-postcard/tests/integration/mod.rs
+++ b/facet-postcard/tests/integration/mod.rs
@@ -5,6 +5,7 @@ mod issue_1453;
 mod issue_1474;
 mod issue_2027;
 mod issue_2065;
+mod issue_2079;
 mod jit_vec_bool;
 mod jit_vec_int;
 mod multi_tier;


### PR DESCRIPTION
## Summary
`facet_postcard::to_vec` and `to_vec_with_shape` were requiring `T: Facet<'static>`, which prevented serializing borrowed types even though serialization only reads through `Peek`.

This changes those APIs (and `to_writer_fallible`) to accept `T: Facet<'facet>` like the other format crates.

## Changes
- Update `to_vec` bound from `Facet<'static>` to `Facet<'facet>`
- Update `to_writer_fallible` bound from `Facet<'static>` to `Facet<'facet>`
- Update `to_vec_with_shape` bound from `Facet<'static>` to `Facet<'facet>`
- Add integration regression tests for issue #2079 using non-`'static` borrowed data

## Testing
- `cargo nextest run -p facet-postcard issue_2079`
- `cargo nextest run -p facet-postcard`
- `cargo check -p facet-postcard`

Fixes #2079
