### PR TITLE
fix: avoid leaking cannot-borrow error messages in format deserializer

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -4,4 +4,6 @@ disallowed-methods = [
     # Box::leak hides lifetime problems instead of solving them.
     # Use LazyLock, static variables, or restructure code to avoid needing 'static.
     { path = "std::boxed::Box::leak", reason = "Box::leak is always a bug in this codebase - use LazyLock or restructure code instead" },
+    # String::leak has the same problem: it leaks heap allocations forever.
+    { path = "alloc::string::String::leak", reason = "String::leak is always a bug in this codebase - keep errors as Cow/owned values instead" },
 ]

--- a/facet-format/src/deserializer/error.rs
+++ b/facet-format/src/deserializer/error.rs
@@ -419,7 +419,7 @@ pub enum DeserializeErrorKind {
     /// ```
     CannotBorrow {
         /// Description of why borrowing failed.
-        reason: &'static str,
+        reason: Cow<'static, str>,
     },
 
     // ============================================================

--- a/facet-format/src/deserializer/setters.rs
+++ b/facet-format/src/deserializer/setters.rs
@@ -313,9 +313,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
             facet_dessert::DessertError::CannotBorrow { message } => DeserializeError {
                 span: None,
                 path: None,
-                kind: DeserializeErrorKind::CannotBorrow {
-                    reason: message.into_owned().leak(),
-                },
+                kind: DeserializeErrorKind::CannotBorrow { reason: message },
             },
         })
     }
@@ -341,9 +339,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
             facet_dessert::DessertError::CannotBorrow { message } => DeserializeError {
                 span: None,
                 path: None,
-                kind: DeserializeErrorKind::CannotBorrow {
-                    reason: message.into_owned().leak(),
-                },
+                kind: DeserializeErrorKind::CannotBorrow { reason: message },
             },
         })
     }


### PR DESCRIPTION
## Summary
- remove intentional String leaks in format deserializer CannotBorrow error mapping
- store CannotBorrow reasons as Cow<'static, str> instead of forcing &'static str
- disallow String::leak in clippy config to prevent regressions

## Testing
- cargo check --all-features --all-targets --message-format=short
- cargo nextest run -p facet-format
- cargo nextest run -p facet-json -E 'test(/flatten/)'

Fixes #1157