### PR TITLE
fix: json schema number types produces strings, not JSON numbers

### DIFF
--- a/facet-json-schema/src/lib.rs
+++ b/facet-json-schema/src/lib.rs
@@ -70,10 +70,10 @@ pub struct JsonSchema {
     pub enum_: Option<Vec<String>>,
 
     /// For numbers: minimum value
-    pub minimum: Option<i128>,
+    pub minimum: Option<i64>,
 
     /// For numbers: maximum value
-    pub maximum: Option<u128>,
+    pub maximum: Option<i64>,
 
     /// For oneOf/anyOf/allOf
     #[facet(rename = "oneOf")]
@@ -336,64 +336,17 @@ impl SchemaContext {
             "bool" => (Some(SchemaType::Boolean.into()), None, None),
 
             // Unsigned integers
-            "u8" => (
-                Some(SchemaType::Integer.into()),
-                Some(0),
-                Some(u8::MAX as u128),
-            ),
-            "u16" => (
-                Some(SchemaType::Integer.into()),
-                Some(0),
-                Some(u16::MAX as u128),
-            ),
-            "u32" => (
-                Some(SchemaType::Integer.into()),
-                Some(0),
-                Some(u32::MAX as u128),
-            ),
-            "u64" => (
-                Some(SchemaType::Integer.into()),
-                Some(0),
-                Some(u64::MAX as u128),
-            ),
-            "u128" => (Some(SchemaType::Integer.into()), Some(0), Some(u128::MAX)),
-            "usize" => (
-                Some(SchemaType::Integer.into()),
-                Some(0),
-                Some(u64::MAX as u128),
-            ),
+            "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {
+                (Some(SchemaType::Integer.into()), Some(0), None)
+            }
 
             // Signed integers
-            "i8" => (
-                Some(SchemaType::Integer.into()),
-                Some(i8::MIN as i128),
-                Some(i8::MAX as u128),
-            ),
-            "i16" => (
-                Some(SchemaType::Integer.into()),
-                Some(i16::MIN as i128),
-                Some(i16::MAX as u128),
-            ),
-            "i32" => (
-                Some(SchemaType::Integer.into()),
-                Some(i32::MIN as i128),
-                Some(i32::MAX as u128),
-            ),
-            "i64" => (
-                Some(SchemaType::Integer.into()),
-                Some(i64::MIN as i128),
-                Some(i64::MAX as u128),
-            ),
-            "i128" => (
-                Some(SchemaType::Integer.into()),
-                Some(i128::MIN),
-                Some(i128::MAX as u128),
-            ),
-            "isize" => (
-                Some(SchemaType::Integer.into()),
-                Some(i64::MIN as i128),
-                Some(i64::MAX as u128),
-            ),
+            "i8" => (Some(SchemaType::Integer.into()), Some(i8::MIN as i64), None),
+            "i16" => (Some(SchemaType::Integer.into()), Some(i16::MIN as i64), None),
+            "i32" => (Some(SchemaType::Integer.into()), Some(i32::MIN as i64), None),
+            "i64" => (Some(SchemaType::Integer.into()), Some(i64::MIN), None),
+            "i128" => (Some(SchemaType::Integer.into()), Some(i64::MIN), None),
+            "isize" => (Some(SchemaType::Integer.into()), Some(i64::MIN), None),
 
             // Floats
             "f32" | "f64" => (Some(SchemaType::Number.into()), None, None),

--- a/facet-json-schema/src/snapshots/facet_json_schema__tests__enum_with_data_rename_all.snap
+++ b/facet-json-schema/src/snapshots/facet_json_schema__tests__enum_with_data_rename_all.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-json-schema/src/lib.rs
-assertion_line: 648
 expression: schema
 ---
 {
@@ -38,8 +37,7 @@ expression: schema
             },
             "width": {
               "type": "integer",
-              "minimum": "0",
-              "maximum": "4294967295"
+              "minimum": 0
             }
           },
           "required": [

--- a/facet-json-schema/src/snapshots/facet_json_schema__tests__simple_struct.snap
+++ b/facet-json-schema/src/snapshots/facet_json_schema__tests__simple_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: facet-json-schema/src/lib.rs
-assertion_line: 567
 expression: schema
 ---
 {
@@ -8,8 +7,7 @@ expression: schema
   "properties": {
     "age": {
       "type": "integer",
-      "minimum": "0",
-      "maximum": "4294967295"
+      "minimum": 0
     },
     "name": {
       "type": "string"


### PR DESCRIPTION
This is a rebased version of #2052 on top of current `main`.

The `minimum` and `maximum` fields on `JsonSchema` were `Option<i128>` and `Option<u128>`, which facet-json serializes as strings. JSON Schema spec says these must be numbers.

Changes:
- Use `Option<i64>` for both `minimum` and `maximum` so they serialize as JSON numbers.
- Stop auto-populating `maximum` with type upper bounds (for example `u32::MAX`) to avoid noisy schema output.

Supersedes #2052.
