### PR TITLE
fix(core): make ownership transfer explicit in list/slice push vtables

### DIFF
--- a/facet-core/src/impls/alloc/arc.rs
+++ b/facet-core/src/impls/alloc/arc.rs
@@ -101,7 +101,7 @@ fn slice_builder_new<'a, U: Facet<'a>>() -> PtrMut {
     PtrMut::new(raw as *mut u8)
 }
 
-unsafe fn slice_builder_push<'a, U: Facet<'a>>(builder: PtrMut, item: PtrConst) {
+unsafe fn slice_builder_push<'a, U: Facet<'a>>(builder: PtrMut, item: PtrMut) {
     unsafe {
         let vec = builder.as_mut::<Vec<U>>();
         let value = item.read::<U>();
@@ -787,8 +787,8 @@ mod tests {
         let push_fn = slice_builder_vtable.push_fn;
         let values = [1i32, 2, 3, 4, 5];
         for &value in &values {
-            let value_copy = value;
-            let value_ptr = PtrConst::new(&value_copy);
+            let mut value_copy = value;
+            let value_ptr = PtrMut::new(&mut value_copy);
             unsafe { push_fn(builder_ptr, value_ptr) };
         }
 
@@ -837,8 +837,8 @@ mod tests {
         let push_fn = slice_builder_vtable.push_fn;
         let strings = ["hello", "world", "test"];
         for &s in &strings {
-            let value = ManuallyDrop::new(String::from(s));
-            let value_ptr = PtrConst::new(&value);
+            let mut value = ManuallyDrop::new(String::from(s));
+            let value_ptr = PtrMut::new(&mut value);
             unsafe { push_fn(builder_ptr, value_ptr) };
         }
 

--- a/facet-core/src/impls/alloc/boxed.rs
+++ b/facet-core/src/impls/alloc/boxed.rs
@@ -138,7 +138,7 @@ fn box_slice_builder_new<'a, U: Facet<'a>>() -> PtrMut {
     PtrMut::new(raw as *mut u8)
 }
 
-unsafe fn box_slice_builder_push<'a, U: Facet<'a>>(builder: PtrMut, item: PtrConst) {
+unsafe fn box_slice_builder_push<'a, U: Facet<'a>>(builder: PtrMut, item: PtrMut) {
     unsafe {
         let vec = builder.as_mut::<Vec<U>>();
         let value = item.read::<U>();
@@ -400,8 +400,8 @@ mod tests {
         let push_fn = slice_builder_vtable.push_fn;
         let values: [u8; 5] = [1, 2, 3, 4, 5];
         for &value in &values {
-            let value_copy = value;
-            let value_ptr = PtrConst::new(&value_copy);
+            let mut value_copy = value;
+            let value_ptr = PtrMut::new(&mut value_copy);
             unsafe { push_fn(builder_ptr, value_ptr) };
         }
 

--- a/facet-core/src/impls/alloc/rc.rs
+++ b/facet-core/src/impls/alloc/rc.rs
@@ -262,7 +262,7 @@ fn slice_builder_new<'a, U: Facet<'a>>() -> PtrMut {
     PtrMut::new(unsafe { NonNull::new_unchecked(raw as *mut u8) }.as_ptr())
 }
 
-fn slice_builder_push<'a, U: Facet<'a>>(builder: PtrMut, item: PtrConst) {
+fn slice_builder_push<'a, U: Facet<'a>>(builder: PtrMut, item: PtrMut) {
     unsafe {
         let vec = builder.as_mut::<Vec<U>>();
         let value = item.read::<U>();

--- a/facet-core/src/impls/alloc/smallvec.rs
+++ b/facet-core/src/impls/alloc/smallvec.rs
@@ -217,7 +217,7 @@ unsafe fn smallvec_init_in_place_with_capacity<A: Array>(
     unsafe { uninit.put(SmallVec::<A>::with_capacity(capacity)) }
 }
 
-unsafe fn smallvec_push<A: Array>(ptr: PtrMut, item: PtrConst) {
+unsafe fn smallvec_push<A: Array>(ptr: PtrMut, item: PtrMut) {
     unsafe {
         let sv = ptr.as_mut::<SmallVec<A>>();
         let item = item.read::<A::Item>();

--- a/facet-core/src/impls/alloc/vec.rs
+++ b/facet-core/src/impls/alloc/vec.rs
@@ -286,7 +286,7 @@ unsafe fn vec_init_in_place_with_capacity<T>(uninit: PtrUninit, capacity: usize)
     unsafe { uninit.put(Vec::<T>::with_capacity(capacity)) }
 }
 
-unsafe fn vec_push<T>(ptr: PtrMut, item: PtrConst) {
+unsafe fn vec_push<T>(ptr: PtrMut, item: PtrMut) {
     unsafe {
         let vec = ptr.as_mut::<Vec<T>>();
         let item = item.read::<T>();

--- a/facet-core/src/impls/crates/bytes.rs
+++ b/facet-core/src/impls/crates/bytes.rs
@@ -202,7 +202,7 @@ unsafe fn bytes_mut_init_in_place_with_capacity(data: PtrUninit, capacity: usize
     unsafe { data.put(BytesMut::with_capacity(capacity)) }
 }
 
-unsafe fn bytes_mut_push(ptr: PtrMut, item: PtrConst) {
+unsafe fn bytes_mut_push(ptr: PtrMut, item: PtrMut) {
     unsafe {
         let bytes = ptr.as_mut::<BytesMut>();
         let item = item.read::<u8>();

--- a/facet-core/src/types/def/list.rs
+++ b/facet-core/src/types/def/list.rs
@@ -110,7 +110,9 @@ pub type ListInitInPlaceWithCapacityFn = unsafe fn(list: PtrUninit, capacity: us
 /// The `list` parameter must point to aligned, initialized memory of the correct type.
 /// `item` is moved out of (with [`core::ptr::read`]) — it should be deallocated afterwards (e.g.
 /// with [`core::mem::forget`]) but NOT dropped.
-pub type ListPushFn = unsafe fn(list: PtrMut, item: PtrConst);
+/// Note: `item` must be PtrMut (not PtrConst) because ownership is transferred and the value
+/// may be dropped later, which requires mutable access.
+pub type ListPushFn = unsafe fn(list: PtrMut, item: PtrMut);
 // FIXME: this forces allocating item separately, copying it, and then dropping it — it's not great.
 
 /// Get the number of items in the list

--- a/facet-core/src/types/def/pointer.rs
+++ b/facet-core/src/types/def/pointer.rs
@@ -223,7 +223,10 @@ pub type SliceBuilderNewFn = fn() -> PtrMut;
 ///
 /// Item must point to a valid value of type `U` and must be initialized.
 /// Function is infallible as it uses the global allocator.
-pub type SliceBuilderPushFn = unsafe fn(builder: PtrMut, item: PtrConst);
+/// `item` is moved out of (with [`core::ptr::read`]) — it should be deallocated afterwards
+/// but NOT dropped.
+/// Note: `item` must be PtrMut (not PtrConst) because ownership is transferred.
+pub type SliceBuilderPushFn = unsafe fn(builder: PtrMut, item: PtrMut);
 
 /// Converts a slice builder into a pointer. This takes ownership of the builder
 /// and frees the backing storage.

--- a/facet-format/src/jit/helpers.rs
+++ b/facet-format/src/jit/helpers.rs
@@ -1707,7 +1707,7 @@ pub unsafe extern "C" fn jit_deserialize_list_by_shape(
         }
 
         // Push element to Vec
-        let elem_ptr = facet_core::PtrConst::new(elem_ptr);
+        let elem_ptr = facet_core::PtrMut::new(elem_ptr);
         unsafe { push_fn(out_mut, elem_ptr) };
     }
 

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -1354,7 +1354,7 @@ impl Frame {
             rope.drain_into(|element_ptr| {
                 push_fn(
                     facet_core::PtrMut::new(list_ptr.as_mut_byte_ptr()),
-                    facet_core::PtrConst::new(element_ptr.as_ptr()),
+                    facet_core::PtrMut::new(element_ptr.as_ptr()),
                 );
             });
         }

--- a/facet-reflect/src/partial/partial_api/misc.rs
+++ b/facet-reflect/src/partial/partial_api/misc.rs
@@ -1141,10 +1141,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
 
             // Use push to add element to the list
             unsafe {
-                push_fn(
-                    PtrMut::new(list_frame.data.as_mut_byte_ptr()),
-                    element_ptr.into(),
-                );
+                push_fn(PtrMut::new(list_frame.data.as_mut_byte_ptr()), element_ptr);
             }
 
             crate::trace!(
@@ -1179,7 +1176,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
             unsafe {
                 (vtable.push_fn)(
                     PtrMut::new(builder_ptr.as_mut_byte_ptr()),
-                    PtrConst::new(element_frame.data.as_byte_ptr()),
+                    PtrMut::new(element_frame.data.as_mut_byte_ptr()),
                 );
             }
 
@@ -2307,7 +2304,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                             unsafe {
                                 push_fn(
                                     PtrMut::new(parent_frame.data.as_mut_byte_ptr()),
-                                    element_ptr.into(),
+                                    element_ptr,
                                 );
                             }
 
@@ -2622,7 +2619,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                     crate::trace!("Pushing element to slice builder");
                     unsafe {
                         let parent_ptr = parent_frame.data.assume_init();
-                        (vtable.push_fn)(parent_ptr, element_ptr.into());
+                        (vtable.push_fn)(parent_ptr, element_ptr);
                     }
 
                     popped_frame.tracker = Tracker::Scalar;


### PR DESCRIPTION
## Summary
This updates ownership-transferring vtable push hooks to use mutable pointers consistently, aligning the API with actual move semantics.

## Changes
- Change `ListPushFn` and `SliceBuilderPushFn` to accept `PtrMut` instead of `PtrConst`
- Update all affected implementations and call sites in `facet-core`, `facet-format`, and `facet-reflect`
- Update slice-builder tests to pass mutable pointers for moved values
- Clarify safety docs around ownership transfer in vtable type definitions

## Testing
- `cargo check`
- `cargo nextest run`

Fixes #1167
