### PR TITLE
Fix enum variant proxy deserialization in facet-value

### DIFF
--- a/facet-json/tests/issue_1661.rs
+++ b/facet-json/tests/issue_1661.rs
@@ -1,0 +1,71 @@
+//! Regression test for https://github.com/facet-rs/facet/issues/1661
+
+use facet::Facet;
+use facet_testhelpers::test;
+
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+struct IntAsObject {
+    inner: String,
+}
+
+impl TryFrom<IntAsObject> for i32 {
+    type Error = std::num::ParseIntError;
+
+    fn try_from(proxy: IntAsObject) -> Result<Self, Self::Error> {
+        proxy.inner.parse()
+    }
+}
+
+impl From<&i32> for IntAsObject {
+    fn from(value: &i32) -> Self {
+        Self {
+            inner: value.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+#[repr(u8)]
+enum ProxyEnumField {
+    Value(#[facet(proxy = IntAsObject)] i32),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+#[repr(u8)]
+enum ProxyEnumContainer {
+    Value(ProxyI32),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+#[facet(proxy = IntAsObject)]
+struct ProxyI32(i32);
+
+impl TryFrom<IntAsObject> for ProxyI32 {
+    type Error = std::num::ParseIntError;
+
+    fn try_from(proxy: IntAsObject) -> Result<Self, Self::Error> {
+        Ok(Self(proxy.inner.parse()?))
+    }
+}
+
+impl From<&ProxyI32> for IntAsObject {
+    fn from(value: &ProxyI32) -> Self {
+        Self {
+            inner: value.0.to_string(),
+        }
+    }
+}
+
+#[test]
+fn test_issue_1661_field_proxy_in_enum_variant_deserializes() {
+    let input = r#"{"Value":{"inner":"99"}}"#;
+    let got = facet_json::from_str::<ProxyEnumField>(input).expect("deserialize");
+    assert_eq!(got, ProxyEnumField::Value(99));
+}
+
+#[test]
+fn test_issue_1661_container_proxy_in_enum_variant_deserializes() {
+    let input = r#"{"Value":{"inner":"77"}}"#;
+    let got = facet_json::from_str::<ProxyEnumContainer>(input).expect("deserialize");
+    assert_eq!(got, ProxyEnumContainer::Value(ProxyI32(77)));
+}

--- a/facet-toml/tests/integration/issue_1661.rs
+++ b/facet-toml/tests/integration/issue_1661.rs
@@ -1,0 +1,78 @@
+//! Regression tests for issue #1661: proxies inside enum variants.
+
+use facet::Facet;
+
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+struct IntAsObject {
+    inner: String,
+}
+
+impl TryFrom<IntAsObject> for i32 {
+    type Error = std::num::ParseIntError;
+
+    fn try_from(proxy: IntAsObject) -> Result<Self, Self::Error> {
+        proxy.inner.parse()
+    }
+}
+
+impl From<&i32> for IntAsObject {
+    fn from(value: &i32) -> Self {
+        Self {
+            inner: value.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+#[repr(u8)]
+enum ProxyEnumField {
+    Value(#[facet(proxy = IntAsObject)] i32),
+}
+
+#[test]
+fn enum_variant_field_proxy_deserializes() {
+    let input = r#"
+[Value]
+inner = "99"
+"#;
+
+    let got = facet_toml::from_str::<ProxyEnumField>(input).expect("deserialize");
+    assert_eq!(got, ProxyEnumField::Value(99));
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+#[facet(proxy = IntAsObject)]
+struct ProxyI32(i32);
+
+impl TryFrom<IntAsObject> for ProxyI32 {
+    type Error = std::num::ParseIntError;
+
+    fn try_from(proxy: IntAsObject) -> Result<Self, Self::Error> {
+        Ok(Self(proxy.inner.parse()?))
+    }
+}
+
+impl From<&ProxyI32> for IntAsObject {
+    fn from(value: &ProxyI32) -> Self {
+        Self {
+            inner: value.0.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+#[repr(u8)]
+enum ProxyEnumContainer {
+    Value(ProxyI32),
+}
+
+#[test]
+fn enum_variant_container_proxy_deserializes() {
+    let input = r#"
+[Value]
+inner = "77"
+"#;
+
+    let got = facet_toml::from_str::<ProxyEnumContainer>(input).expect("deserialize");
+    assert_eq!(got, ProxyEnumContainer::Value(ProxyI32(77)));
+}

--- a/facet-toml/tests/integration/mod.rs
+++ b/facet-toml/tests/integration/mod.rs
@@ -1,5 +1,6 @@
 mod basic;
 mod flatten;
+mod issue_1661;
 mod issue_1995;
 mod nested_arrays;
 mod spanned;

--- a/facet-value/src/deserialize.rs
+++ b/facet-value/src/deserialize.rs
@@ -33,7 +33,8 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use facet_core::{
-    Def, Facet, NumericType, PrimitiveType, Shape, StructKind, TextualType, Type, UserType, Variant,
+    Def, Facet, Field, NumericType, PrimitiveType, Shape, StructKind, TextualType, Type, UserType,
+    Variant,
 };
 use facet_reflect::{AllocError, Partial, ReflectError, ShapeMismatchError, TypePlan};
 
@@ -996,9 +997,12 @@ fn deserialize_internally_tagged_enum<'facet>(
         StructKind::Struct => {
             // Struct variant - deserialize fields from the same object (excluding tag)
             for field in variant.data.fields.iter() {
-                if let Some(field_value) = obj.get(field.name) {
+                if let Some(field_value) = obj
+                    .get(field.effective_name())
+                    .or_else(|| field.alias.and_then(|alias| obj.get(alias)))
+                {
                     partial = partial.begin_field(field.name)?;
-                    partial = deserialize_value_into(field_value, partial)?;
+                    partial = deserialize_enum_field_value(field_value, field, partial)?;
                     partial = partial.end()?;
                 }
             }
@@ -1126,8 +1130,9 @@ fn populate_variant_from_value<'facet>(
             if num_fields == 0 {
                 // nothing to populate
             } else if num_fields == 1 {
+                let field = variant.data.fields[0];
                 partial = partial.begin_nth_field(0)?;
-                partial = deserialize_value_into(value, partial)?;
+                partial = deserialize_enum_field_value(value, &field, partial)?;
                 partial = partial.end()?;
             } else {
                 let arr = value.as_array().ok_or_else(|| {
@@ -1147,9 +1152,9 @@ fn populate_variant_from_value<'facet>(
                     }));
                 }
 
-                for (i, item) in arr.iter().enumerate() {
+                for (i, (field, item)) in variant.data.fields.iter().zip(arr.iter()).enumerate() {
                     partial = partial.begin_nth_field(i)?;
-                    partial = deserialize_value_into(item, partial)?;
+                    partial = deserialize_enum_field_value(item, field, partial)?;
                     partial = partial.end()?;
                 }
             }
@@ -1163,11 +1168,45 @@ fn populate_variant_from_value<'facet>(
             })?;
 
             for (field_key, field_val) in inner_obj.iter() {
-                partial = partial.begin_field(field_key.as_str())?;
-                partial = deserialize_value_into(field_val, partial)?;
+                let key = field_key.as_str();
+                let field = variant
+                    .data
+                    .fields
+                    .iter()
+                    .find(|f| f.effective_name() == key || f.alias == Some(key))
+                    .ok_or_else(|| {
+                        ValueError::new(ValueErrorKind::UnknownField {
+                            field: key.to_string(),
+                        })
+                    })?;
+
+                partial = partial.begin_field(field.name)?;
+                partial = deserialize_enum_field_value(field_val, field, partial)?;
                 partial = partial.end()?;
             }
         }
+    }
+
+    Ok(partial)
+}
+
+fn deserialize_enum_field_value<'facet>(
+    value: &Value,
+    field: &Field,
+    mut partial: Partial<'facet, false>,
+) -> Result<Partial<'facet, false>> {
+    #[cfg(feature = "alloc")]
+    if field.proxy_convert_in_fn().is_some() {
+        partial = partial.begin_custom_deserialization()?;
+        partial = deserialize_value_into(value, partial)?;
+        partial = partial.end()?;
+    } else {
+        partial = deserialize_value_into(value, partial)?;
+    }
+
+    #[cfg(not(feature = "alloc"))]
+    {
+        partial = deserialize_value_into(value, partial)?;
     }
 
     Ok(partial)

--- a/facet-value/tests/integration/from_value.rs
+++ b/facet-value/tests/integration/from_value.rs
@@ -163,6 +163,77 @@ fn deserialize_struct_enum() {
 }
 
 #[test]
+fn deserialize_tuple_enum_with_field_proxy() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct IntAsObject {
+        inner: String,
+    }
+
+    impl TryFrom<IntAsObject> for i32 {
+        type Error = std::num::ParseIntError;
+
+        fn try_from(proxy: IntAsObject) -> Result<Self, Self::Error> {
+            proxy.inner.parse()
+        }
+    }
+
+    impl From<&i32> for IntAsObject {
+        fn from(value: &i32) -> Self {
+            Self {
+                inner: value.to_string(),
+            }
+        }
+    }
+
+    #[derive(Debug, Facet, PartialEq)]
+    #[repr(u8)]
+    enum Message {
+        Number(#[facet(proxy = IntAsObject)] i32),
+    }
+
+    let v = value!({"Number": {"inner": "42"}});
+    let msg: Message = from_value(v).unwrap();
+    assert_eq!(msg, Message::Number(42));
+}
+
+#[test]
+fn deserialize_struct_enum_with_field_proxy() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct IntAsObject {
+        inner: String,
+    }
+
+    impl TryFrom<IntAsObject> for i32 {
+        type Error = std::num::ParseIntError;
+
+        fn try_from(proxy: IntAsObject) -> Result<Self, Self::Error> {
+            proxy.inner.parse()
+        }
+    }
+
+    impl From<&i32> for IntAsObject {
+        fn from(value: &i32) -> Self {
+            Self {
+                inner: value.to_string(),
+            }
+        }
+    }
+
+    #[derive(Debug, Facet, PartialEq)]
+    #[repr(u8)]
+    enum Message {
+        Number {
+            #[facet(proxy = IntAsObject)]
+            value: i32,
+        },
+    }
+
+    let v = value!({"Number": {"value": {"inner": "1337"}}});
+    let msg: Message = from_value(v).unwrap();
+    assert_eq!(msg, Message::Number { value: 1337 });
+}
+
+#[test]
 fn deserialize_hashmap() {
     let v = value!({
         "a": 1,


### PR DESCRIPTION
## Summary
Enum variant fields in `facet-value` deserialization were bypassing field-level proxy conversion, which caused type mismatches for proxy shapes (for example object payloads deserialized into scalar targets).

This change routes enum variant field decoding through the same proxy-aware path used by struct fields and adds regressions for JSON/TOML and `from_value`.

Fixes #1661

## Changes
- Apply proxy-aware field decoding for enum variant fields in `facet-value/src/deserialize.rs`
- Reuse field-name matching via `effective_name`/`alias` for internally-tagged enum struct variants
- Add `facet-value` regression tests for tuple and struct enum variants with field proxies
- Add format regressions:
  - `facet-json/tests/issue_1661.rs`
  - `facet-toml/tests/integration/issue_1661.rs`

## Testing
- `cargo check -p facet-value -p facet-json -p facet-toml`
- `cargo nextest run -p facet-value --test main`
- `cargo nextest run -p facet-json --test issue_1661`
- `cargo nextest run -p facet-toml --test main -E 'test(integration::issue_1661::enum_variant_field_proxy_deserializes) | test(integration::issue_1661::enum_variant_container_proxy_deserializes)'`
