### PR TITLE
Enable TOML struct-level default coverage in deferred mode

### DIFF
--- a/facet-toml/tests/format_suite.rs
+++ b/facet-toml/tests/format_suite.rs
@@ -117,8 +117,11 @@ impl FormatSuite for TomlSlice {
 
     fn attr_default_struct() -> CaseSpec {
         // message is missing, should use String::default() (empty string)
-        // TOML requires deferred mode to handle missing fields with defaults
-        CaseSpec::skip("struct-level defaults require deferred deserialization mode")
+        CaseSpec::from_str(indoc!(
+            r#"
+            count = 123
+        "#
+        ))
     }
 
     fn attr_default_function() -> CaseSpec {

--- a/facet-toml/tests/integration/basic.rs
+++ b/facet-toml/tests/integration/basic.rs
@@ -860,6 +860,29 @@ fn test_root_struct_deserialize_container_defaults() {
     );
 }
 
+#[test]
+fn test_root_struct_deserialize_container_defaults_partial_fields() {
+    #[derive(Debug, Facet, PartialEq, Default)]
+    #[facet(default)]
+    struct Root {
+        count: i32,
+        message: String,
+    }
+
+    assert_eq!(
+        facet_toml::from_str::<Root>(
+            r#"
+            count = 123
+            "#
+        )
+        .unwrap(),
+        Root {
+            count: 123,
+            message: String::default(),
+        },
+    );
+}
+
 // ============================================================================
 // IP address tests
 // ============================================================================


### PR DESCRIPTION
## Summary
Enable TOML coverage for struct-level `#[facet(default)]` in deferred deserialization.

## Changes
- Unskip and enable `attr::default_struct` in `facet-toml` format suite with partial input (`count = 123`).
- Add integration regression test for container-level defaults when one field is provided and one is missing.

## Testing
- cargo check -p facet-toml
- cargo nextest run -p facet-toml

Fixes #1660
