### PR TITLE
fix(toml): re-enable multiple flattened enum deserialization case

### DIFF
--- a/facet-toml/tests/format_suite.rs
+++ b/facet-toml/tests/format_suite.rs
@@ -364,8 +364,10 @@ impl FormatSuite for TomlSlice {
     }
 
     fn flatten_multiple_enums() -> CaseSpec {
-        // Multiple flattened enums require solver support that isn't working properly
-        CaseSpec::skip("multiple flattened enums solver not supported")
+        CaseSpec::from_str(
+            "name = \"service\"\n\n[Password]\npassword = \"secret\"\n\n[Tcp]\nport = 8080",
+        )
+        .without_roundtrip("serialization of flattened enums not yet supported")
     }
 
     // -- Scalar cases --

--- a/facet-toml/tests/integration/flatten.rs
+++ b/facet-toml/tests/integration/flatten.rs
@@ -150,3 +150,50 @@ fn flatten_with_single_key_works() {
     assert_eq!(result.item.len(), 1);
     assert_eq!(result.item[0].nested_item.extra.len(), 1);
 }
+
+#[derive(Facet, Debug, PartialEq)]
+struct MultiFlattenServiceConfig {
+    name: String,
+    #[facet(flatten)]
+    auth: MultiFlattenAuthMethod,
+    #[facet(flatten)]
+    transport: MultiFlattenTransport,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+#[repr(u8)]
+enum MultiFlattenAuthMethod {
+    Password { password: String },
+    Token { token: String },
+}
+
+#[derive(Facet, Debug, PartialEq)]
+#[repr(u8)]
+enum MultiFlattenTransport {
+    Tcp { port: u16 },
+    Unix { path: String },
+}
+
+#[test]
+fn flatten_multiple_enums_resolves_all_table_headers() {
+    let toml = r#"
+name = "service"
+
+[Password]
+password = "secret"
+
+[Tcp]
+port = 8080
+"#;
+
+    let config: MultiFlattenServiceConfig = facet_toml::from_str(toml).unwrap();
+    assert_eq!(config.name, "service");
+    assert!(matches!(
+        config.auth,
+        MultiFlattenAuthMethod::Password { password } if password == "secret"
+    ));
+    assert!(matches!(
+        config.transport,
+        MultiFlattenTransport::Tcp { port } if port == 8080
+    ));
+}


### PR DESCRIPTION
## Summary
Re-enables TOML coverage for the multiple flattened enums scenario that issue #1659 reports.
Adds a focused TOML integration regression using `[Password]` and `[Tcp]` tables to verify deserialization resolves both flattened enum selections together.

## Changes
- Replace the skipped `flatten_multiple_enums` TOML format-suite case with a real input fixture.
- Mark the case as deserialize-only (`without_roundtrip`) because flattened enum serialization parity is still pending.
- Add `flatten_multiple_enums_resolves_all_table_headers` integration test in `facet-toml/tests/integration/flatten.rs`.

## Testing
- `cargo check -p facet-toml`
- `cargo nextest run -p facet-toml`

Fixes #1659
