### PR TITLE
Fix borrowed &[T] pointer deserialization path (issue #2098)

### DIFF
--- a/facet-format/src/deserializer/pointer.rs
+++ b/facet-format/src/deserializer/pointer.rs
@@ -148,6 +148,55 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
             }
         }
 
+        // Generic shared slice references (`&[T]`) can only be borrowed directly when empty.
+        // Non-empty values would require allocating backing storage that outlives the result.
+        if let Def::Pointer(ptr_def) = shape.def
+            && matches!(ptr_def.known, Some(KnownPointer::SharedReference))
+            && let Some(pointee) = ptr_def.pointee()
+            && matches!(pointee.def, Def::Slice(_))
+        {
+            if !BORROW {
+                return Err(self.mk_err(
+                    &wip,
+                    DeserializeErrorKind::CannotBorrow {
+                        reason:
+                            "cannot deserialize into &[T] when borrowing is disabled; use Vec<T> instead"
+                                .into(),
+                    },
+                ));
+            }
+
+            if self.is_non_self_describing() {
+                self.parser.hint_sequence();
+            }
+            let event = self.expect_event("sequence for &[T]")?;
+            let _guard = SpanGuard::new(self.last_span);
+            if !matches!(event.kind, ParseEventKind::SequenceStart(_)) {
+                return Err(self.mk_err(
+                    &wip,
+                    DeserializeErrorKind::UnexpectedToken {
+                        expected: "sequence start for &[T]",
+                        got: event.kind_name().into(),
+                    },
+                ));
+            }
+
+            let next = self.expect_peek("value")?;
+            if matches!(next.kind, ParseEventKind::SequenceEnd) {
+                self.expect_event("value")?;
+                return wip.set_empty_shared_slice().map_err(Into::into);
+            }
+
+            return Err(self.mk_err(
+                &wip,
+                DeserializeErrorKind::CannotBorrow {
+                    reason:
+                        "cannot deserialize non-empty &[T] by borrowing from input; use Vec<T> or a shape-based Partial workflow"
+                            .into(),
+                },
+            ));
+        }
+
         // Regular smart pointer (Box, Arc, Rc)
         let _guard = SpanGuard::new(self.last_span);
         wip = wip.begin_smart_ptr()?;

--- a/facet-postcard/tests/integration/issue_2098.rs
+++ b/facet-postcard/tests/integration/issue_2098.rs
@@ -1,0 +1,59 @@
+use facet::Facet;
+use facet_format::DeserializeErrorKind;
+use facet_postcard::{from_slice_borrowed, to_vec};
+
+#[repr(u8)]
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+enum BorrowedValue<'a> {
+    Str(&'a str) = 0,
+    Bytes(&'a [u8]) = 1,
+    U64(u64) = 2,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+struct Entry<'a> {
+    key: &'a str,
+    value: BorrowedValue<'a>,
+    flags: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+struct Message<'a> {
+    id: u32,
+    entries: &'a [Entry<'a>],
+}
+
+#[test]
+fn issue_2098_borrowed_slice_of_structs_empty() {
+    facet_testhelpers::setup();
+
+    let msg = Message {
+        id: 1,
+        entries: &[],
+    };
+    let bytes = to_vec(&msg).expect("serialize");
+    let decoded: Message<'_> = from_slice_borrowed(&bytes).expect("deserialize");
+
+    assert_eq!(decoded, msg);
+}
+
+#[test]
+fn issue_2098_borrowed_slice_of_structs_non_empty() {
+    facet_testhelpers::setup();
+
+    let entries = [Entry {
+        key: "x",
+        value: BorrowedValue::Str("hello"),
+        flags: 7,
+    }];
+    let msg = Message {
+        id: 1,
+        entries: &entries,
+    };
+    let bytes = to_vec(&msg).expect("serialize");
+    let err = from_slice_borrowed::<Message<'_>>(&bytes).expect_err("should fail with clear error");
+    assert!(matches!(
+        err.kind,
+        DeserializeErrorKind::CannotBorrow { .. }
+    ));
+}

--- a/facet-postcard/tests/integration/mod.rs
+++ b/facet-postcard/tests/integration/mod.rs
@@ -7,6 +7,7 @@ mod issue_1474;
 mod issue_2027;
 mod issue_2065;
 mod issue_2079;
+mod issue_2098;
 mod jit_vec_bool;
 mod jit_vec_int;
 mod multi_tier;

--- a/facet-reflect/src/partial/partial_api/set.rs
+++ b/facet-reflect/src/partial/partial_api/set.rs
@@ -1,10 +1,59 @@
 use super::*;
-use facet_core::{Def, DynDateTimeKind, NumericType, PrimitiveType, Type};
+use facet_core::{Def, DynDateTimeKind, KnownPointer, NumericType, PrimitiveType, Type};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `Set` and set helpers
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
+    /// Set a shared slice reference (`&[T]`) to an empty slice without knowing `T` at compile time.
+    ///
+    /// This writes a valid wide reference with len=0 and a suitably aligned dangling data pointer.
+    pub fn set_empty_shared_slice(mut self) -> Result<Self, ReflectError> {
+        let shape = self.frames().last().unwrap().allocated.shape();
+        let align = match shape.def {
+            Def::Pointer(ptr_def)
+                if matches!(ptr_def.known, Some(KnownPointer::SharedReference)) =>
+            {
+                let Some(pointee) = ptr_def.pointee() else {
+                    return Err(self.err(ReflectErrorKind::OperationFailed {
+                        shape,
+                        operation: "shared reference pointer missing pointee shape",
+                    }));
+                };
+                let Def::Slice(slice_def) = pointee.def else {
+                    return Err(self.err(ReflectErrorKind::OperationFailed {
+                        shape,
+                        operation: "set_empty_shared_slice requires a slice pointee",
+                    }));
+                };
+                slice_def
+                    .t
+                    .layout
+                    .sized_layout()
+                    .map_or(1, |l| l.align().max(1))
+            }
+            _ => {
+                return Err(self.err(ReflectErrorKind::OperationFailed {
+                    shape,
+                    operation: "set_empty_shared_slice requires a shared slice reference",
+                }));
+            }
+        };
+
+        let fr = self.frames_mut().last_mut().unwrap();
+        fr.deinit_for_replace();
+
+        // For len=0, any non-null aligned pointer is valid.
+        let data_ptr = align as *const u8 as usize;
+        unsafe {
+            let dst = fr.data.as_mut_byte_ptr() as *mut [usize; 2];
+            core::ptr::write(dst, [data_ptr, 0]);
+            fr.mark_as_init();
+        }
+
+        Ok(self)
+    }
+
     /// Sets a value wholesale into the current frame.
     ///
     /// If the current frame was already initialized, the previous value is


### PR DESCRIPTION
## Summary
Fixes deserialization for borrowed shared slices (`&[T]`) to avoid the misleading smart-pointer error path.

## Changes
- Add dedicated handling for `&[T]` in pointer deserialization.
- Allow empty borrowed shared slices to deserialize successfully.
- Return a clear `CannotBorrow` error for non-empty generic `&[T]` (instead of `push_smart_ptr` incompatibility).
- Add regression coverage for issue #2098 in `facet-postcard` integration tests.

## Test Plan
- [x] `cargo nextest run -p facet-postcard issue_2098 --failure-output immediate --success-output never`
- [x] `cargo nextest run -p facet-postcard --failure-output immediate --success-output never`

Fixes #2098
