### PR TITLE
docs: document trailing and opaque adapter attributes

### DIFF
--- a/docs/content/reference/attributes/_index.md
+++ b/docs/content/reference/attributes/_index.md
@@ -269,6 +269,51 @@ which keeps `Poke::get_mut` sound.
 
 **When `assert_same!` encounters an opaque type**, it returns `Sameness::Opaque` — you cannot structurally compare opaque values.
 
+#### Opaque adapter (`#[facet(opaque = AdapterType)]`)
+
+For container-level opaque types, you can provide an adapter instead of using `proxy`. This gives explicit control over how opaque bytes are mapped during serialization and deserialization.
+
+```rust,noexec
+use facet::{Facet, FacetOpaqueAdapter, OpaqueDeserialize, OpaqueSerialize, PtrConst};
+
+#[derive(Facet)]
+#[facet(opaque = PayloadAdapter)]
+struct Payload<'a>(&'a [u8]);
+
+struct PayloadAdapter;
+
+impl FacetOpaqueAdapter for PayloadAdapter {
+    type Error = String;
+    type SendValue<'a> = Payload<'a>;
+    type RecvValue<'de> = Payload<'de>;
+
+    fn serialize_map(value: &Self::SendValue<'_>) -> OpaqueSerialize {
+        OpaqueSerialize {
+            ptr: PtrConst::new(&value.0 as *const &[u8]),
+            shape: <&[u8] as Facet>::SHAPE,
+        }
+    }
+
+    fn deserialize_build<'de>(
+        input: OpaqueDeserialize<'de>,
+    ) -> Result<Self::RecvValue<'de>, Self::Error> {
+        Ok(match input {
+            OpaqueDeserialize::Borrowed(bytes) => Payload(bytes),
+            OpaqueDeserialize::Owned(_) => {
+                return Err("expected borrowed bytes".to_string());
+            }
+        })
+    }
+}
+```
+
+Rules and notes:
+
+1. `#[facet(opaque = ...)]` is currently container-level only (not supported on fields).
+2. The adapter type must implement `FacetOpaqueAdapter`.
+3. This is an alternative to `proxy` for opaque values.
+4. `#[facet(trailing)]` accepts either a field marked `#[facet(opaque)]` or a field type whose shape has a container-level opaque adapter.
+
 ### `pod`
 
 Mark a type as Plain Old Data. POD types have no invariants — any combination of valid field values produces a valid instance. This enables safe mutation through reflection.
@@ -748,8 +793,7 @@ Mark an opaque field as structurally trailing in its container. Formats that sup
 struct Packet {
     tag: u8,
     len: u16,
-    #[facet(trailing)]
-    #[facet(opaque)]
+    #[facet(opaque, trailing)]
     payload: Vec<u8>,
 }
 ```


### PR DESCRIPTION
## Summary
Document opaque trailing fields and container-level opaque adapters in the attributes reference.

## Changes
- Updated `trailing` docs to show combined attribute syntax: `#[facet(opaque, trailing)]`.
- Added an `Opaque adapter` subsection documenting `#[facet(opaque = AdapterType)]` and `FacetOpaqueAdapter`.
- Documented key rules and how this interacts with `trailing`.

## Testing
- Docs-only change.
- Pre-commit/captain checks passed on commit and push.
