### PR TITLE
Fix internally-tagged enum newtype

### DIFF
--- a/facet-format/src/deserializer/eenum.rs
+++ b/facet-format/src/deserializer/eenum.rs
@@ -467,154 +467,242 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
             return Ok(wip);
         }
 
-        // Check if this is a single-field tuple variant containing an internally-tagged enum
-        // In this case, the inner enum's fields are flattened into the outer object
+        // Check if this is a single-field tuple (newtype) variant.
+        // The inner value's fields are flattened into the enclosing tagged object.
+        // Three cases are handled:
+        //   1. Inner value is a struct — its fields appear alongside the tag.
+        //   2. Inner value is an internally-tagged enum — its tag and fields are
+        //      flattened too (and its variants may themselves be newtypes, so we
+        //      recurse).
+        //   3. Inner value is a scalar / unsupported — error.
         if matches!(
             variant.data.kind,
             StructKind::TupleStruct | StructKind::Tuple
         ) && variant_fields.len() == 1
         {
-            let inner_shape = variant_fields[0].shape();
-            if let Some(inner_tag_key) = inner_shape.get_tag_attr()
-                && inner_shape.get_content_attr().is_none()
-            {
-                // Find the inner tag value in evidence
-                let inner_variant_name = find_tag_value(&evidence, inner_tag_key)
-                    .ok_or_else(|| {
-                        self.mk_err(
+            // Collect every tag key that appears anywhere in the newtype chain so
+            // we can skip them when reading data fields from the JSON object.
+            let mut skip_tag_keys: Vec<&'static str> = vec![tag_key];
+
+            // Walk down the newtype chain, calling begin_nth_field(0) at each
+            // level, selecting variants for internally-tagged enums, until we
+            // land on a struct or unit variant whose fields we can read directly.
+            //
+            // `depth` tracks how many begin_nth_field(0) calls we've made so we
+            // can issue the matching end() calls afterwards.
+            let mut depth: usize = 0;
+            let mut leaf_shape = variant_fields[0].shape();
+
+            loop {
+                // Case 1: inner value is a plain struct
+                if matches!(&leaf_shape.ty, Type::User(UserType::Struct(_))) {
+                    wip = wip.begin_nth_field(0)?;
+                    depth += 1;
+                    break;
+                }
+
+                // Case 2: inner value is an internally-tagged enum
+                if let Some(inner_tag_key) = leaf_shape.get_tag_attr()
+                    && leaf_shape.get_content_attr().is_none()
+                    && matches!(&leaf_shape.ty, Type::User(UserType::Enum(_)))
+                {
+                    // Reject duplicate tag key names across nesting levels —
+                    // e.g. both outer and inner enum using #[facet(tag = "type")].
+                    // With a flat JSON object we cannot distinguish which "type"
+                    // value belongs to which level.
+                    if skip_tag_keys.contains(&inner_tag_key) {
+                        for _ in 0..depth {
+                            wip = wip.end()?;
+                        }
+                        return Err(self.mk_err(
                             &wip,
-                            DeserializeErrorKind::MissingField {
-                                field: inner_tag_key,
-                                container_shape: inner_shape,
+                            DeserializeErrorKind::Unsupported {
+                                message: format!(
+                                    "nested internally-tagged enums use the same tag key \"{}\"; \
+                                     this is ambiguous when flattened into a single object",
+                                    inner_tag_key
+                                )
+                                .into(),
                             },
-                        )
-                    })?
-                    .to_string();
+                        ));
+                    }
 
-                // Begin the tuple field (field 0)
-                wip = wip.begin_nth_field(0)?;
+                    skip_tag_keys.push(inner_tag_key);
 
-                // Select the inner variant
-                wip = wip.select_variant_named(&inner_variant_name)?;
-
-                // Get the inner variant info
-                let inner_variant = wip.selected_variant().ok_or_else(|| DeserializeError {
-                    span: Some(self.last_span),
-                    path: Some(wip.path()),
-                    kind: DeserializeErrorKind::UnexpectedToken {
-                        expected: "selected inner variant",
-                        got: "no variant selected".into(),
-                    },
-                })?;
-
-                let inner_variant_fields = inner_variant.data.fields;
-
-                // Process all fields for the inner enum
-                loop {
-                    let event = self.expect_event("value")?;
-                    match event.kind {
-                        ParseEventKind::StructEnd => break,
-                        ParseEventKind::FieldKey(key) => {
-                            let key_name = match key.name() {
-                                Some(name) => name.as_ref(),
-                                None => {
-                                    self.skip_value()?;
-                                    continue;
-                                }
-                            };
-
-                            // Skip outer and inner tag fields
-                            if key_name == tag_key || key_name == inner_tag_key {
-                                self.skip_value()?;
-                                continue;
-                            }
-
-                            // Look up field in the inner variant
-                            let inner_variant_plan = wip.selected_variant_plan().unwrap();
-                            if let Some(idx) = inner_variant_plan
-                                .field_lookup
-                                .find(key_name, wip.type_plan_core())
-                            {
-                                wip = wip
-                                    .begin_nth_field(idx)?
-                                    .with(|w| self.deserialize_into(w, MetaSource::FromEvents))?
-                                    .end()?;
-                            } else {
-                                // Unknown field - skip
-                                self.skip_value()?;
-                            }
-                        }
-                        other => {
-                            return Err(DeserializeError {
-                                span: Some(self.last_span),
-                                path: Some(wip.path()),
-                                kind: DeserializeErrorKind::UnexpectedToken {
-                                    expected: "field key or struct end",
-                                    got: other.kind_name().into(),
+                    let inner_variant_name = find_tag_value(&evidence, inner_tag_key)
+                        .ok_or_else(|| {
+                            self.mk_err(
+                                &wip,
+                                DeserializeErrorKind::MissingField {
+                                    field: inner_tag_key,
+                                    container_shape: leaf_shape,
                                 },
-                            });
+                            )
+                        })?
+                        .to_string();
+
+                    wip = wip.begin_nth_field(0)?;
+                    depth += 1;
+
+                    wip = wip.select_variant_named(&inner_variant_name)?;
+
+                    let inner_variant = wip.selected_variant().ok_or_else(|| DeserializeError {
+                        span: Some(self.last_span),
+                        path: Some(wip.path()),
+                        kind: DeserializeErrorKind::UnexpectedToken {
+                            expected: "selected inner variant",
+                            got: "no variant selected".into(),
+                        },
+                    })?;
+
+                    match inner_variant.data.kind {
+                        StructKind::Unit => {
+                            // Unit variant — no fields to read, just consume the
+                            // remaining JSON object entries and return.
+                            break;
+                        }
+                        StructKind::Struct => {
+                            // Struct variant — read its fields below.
+                            break;
+                        }
+                        StructKind::TupleStruct | StructKind::Tuple => {
+                            // Another newtype — continue drilling down.
+                            if inner_variant.data.fields.len() != 1 {
+                                // Unwind depth before returning error
+                                for _ in 0..depth {
+                                    wip = wip.end()?;
+                                }
+                                return Err(self.mk_err(
+                                    &wip,
+                                    DeserializeErrorKind::Unsupported {
+                                        message: "internally tagged tuple variants with multiple fields are not supported".into(),
+                                    },
+                                ));
+                            }
+                            leaf_shape = inner_variant.data.fields[0].shape();
+                            continue;
                         }
                     }
                 }
 
-                // Apply defaults for missing inner fields
-                for (idx, field) in inner_variant_fields.iter().enumerate() {
-                    if wip.is_field_set(idx)? {
-                        continue;
-                    }
+                // Case 3: scalar or other non-flattenable type — error
+                // Unwind depth before returning error
+                for _ in 0..depth {
+                    wip = wip.end()?;
+                }
+                return Err(self.mk_err(
+                    &wip,
+                    DeserializeErrorKind::Unsupported {
+                        message: "internally-tagged enum with scalar newtype payload cannot be flattened; use #[facet(content = \"...\")] for adjacently-tagged representation".into(),
+                    },
+                ));
+            }
 
-                    let field_has_default = field.has_default();
-                    let field_is_option = matches!(field.shape().def, Def::Option(_));
+            // Now `wip` points at the leaf type (a struct, a struct variant of
+            // an enum, or a unit variant). Read the JSON object's remaining
+            // fields into it.
+            wip = self.read_tagged_object_fields(wip, &skip_tag_keys)?;
 
-                    if field_has_default {
-                        wip = wip.set_nth_field_to_default(idx)?;
-                    } else if field_is_option {
-                        wip = wip.begin_nth_field(idx)?.set_default()?.end()?;
-                    } else if field.should_skip_deserializing() {
-                        wip = wip.set_nth_field_to_default(idx)?;
-                    }
-                    // Note: don't error on missing required fields here - let the outer
-                    // build() call handle that with proper error messages
+            // Determine the leaf's fields for default-filling.
+            let leaf_fields: &[Field] = if let Some(v) = wip.selected_variant() {
+                v.data.fields
+            } else if let Type::User(UserType::Struct(s)) = &wip.shape().ty {
+                s.fields
+            } else {
+                &[]
+            };
+
+            // Apply defaults for missing leaf fields
+            for (idx, field) in leaf_fields.iter().enumerate() {
+                if wip.is_field_set(idx)? {
+                    continue;
                 }
 
-                // End the tuple field
-                wip = wip.end()?;
+                let field_has_default = field.has_default();
+                let field_is_option = matches!(field.shape().def, Def::Option(_));
 
-                return Ok(wip);
+                if field_has_default {
+                    wip = wip.set_nth_field_to_default(idx)?;
+                } else if field_is_option {
+                    wip = wip.begin_nth_field(idx)?.set_default()?.end()?;
+                } else if field.should_skip_deserializing() {
+                    wip = wip.set_nth_field_to_default(idx)?;
+                }
             }
+
+            // Unwind all the begin_nth_field(0) calls
+            for _ in 0..depth {
+                wip = wip.end()?;
+            }
+
+            return Ok(wip);
         }
 
-        // Use precomputed has_flatten from VariantPlanMeta
-        let has_flatten = wip.selected_variant_plan().unwrap().has_flatten;
+        wip = self.read_tagged_object_fields(wip, &[tag_key])?;
+
+        // Defaults for missing fields are applied automatically by facet-reflect's
+        // fill_defaults() when build() or end() is called.
+
+        Ok(wip)
+    }
+
+    /// Read fields from a JSON object into `wip`, skipping any keys in `skip_keys`.
+    ///
+    /// This is the shared field-reading loop used by both the newtype and struct
+    /// variant paths in `deserialize_enum_internally_tagged`. It handles:
+    /// - Simple field lookup via `FieldLookup`
+    /// - `#[facet(flatten)]` via recursive `find_field_path`
+    ///
+    /// Expects the parser to be positioned inside an open struct (after StructStart).
+    /// Consumes events up to and including StructEnd.
+    fn read_tagged_object_fields(
+        &mut self,
+        mut wip: Partial<'input, BORROW>,
+        skip_keys: &[&str],
+    ) -> Result<Partial<'input, BORROW>, DeserializeError> {
+        // Determine the current fields for flatten lookup
+        let fields: &[Field] = if let Some(v) = wip.selected_variant() {
+            v.data.fields
+        } else if let Type::User(UserType::Struct(s)) = &wip.shape().ty {
+            s.fields
+        } else {
+            &[]
+        };
+
+        // Check if the current type has flattened fields
+        let has_flatten = if let Some(vp) = wip.selected_variant_plan() {
+            vp.has_flatten
+        } else if let Some(sp) = wip.struct_plan() {
+            sp.has_flatten
+        } else {
+            false
+        };
 
         // Track currently open path segments for flatten handling: (field_name, is_option)
         let mut open_segments: Vec<(&str, bool)> = Vec::new();
 
-        // Process all fields (they can come in any order now)
         loop {
             let event = self.expect_event("value")?;
             match event.kind {
                 ParseEventKind::StructEnd => break,
                 ParseEventKind::FieldKey(key) => {
-                    // Unit keys don't make sense for struct fields
                     let key_name = match key.name() {
                         Some(name) => name.as_ref(),
                         None => {
-                            // Skip unit keys in struct context
                             self.skip_value()?;
                             continue;
                         }
                     };
 
-                    // Skip the tag field - already used
-                    if key_name == tag_key {
+                    // Skip tag fields - already consumed
+                    if skip_keys.contains(&key_name) {
                         self.skip_value()?;
                         continue;
                     }
 
                     if has_flatten {
-                        // Use path-based lookup for variants with flattened fields
-                        if let Some(path) = find_field_path(variant_fields, key_name) {
+                        // Use path-based lookup for types with flattened fields
+                        if let Some(path) = find_field_path(fields, key_name) {
                             // Find common prefix with currently open segments
                             let common_len = open_segments
                                 .iter()
@@ -658,12 +746,15 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                         }
                     } else {
                         // Simple case: direct field lookup using precomputed FieldLookup
-                        let variant_plan = wip.selected_variant_plan().unwrap();
+                        let found_idx = if let Some(vp) = wip.selected_variant_plan() {
+                            vp.field_lookup.find(key_name, wip.type_plan_core())
+                        } else if let Some(sp) = wip.struct_plan() {
+                            sp.field_lookup.find(key_name, wip.type_plan_core())
+                        } else {
+                            None
+                        };
 
-                        if let Some(idx) = variant_plan
-                            .field_lookup
-                            .find(key_name, wip.type_plan_core())
-                        {
+                        if let Some(idx) = found_idx {
                             wip = wip
                                 .begin_nth_field(idx)?
                                 .with(|w| self.deserialize_into(w, MetaSource::FromEvents))?
@@ -694,9 +785,6 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
             }
             wip = wip.end()?;
         }
-
-        // Defaults for missing fields are applied automatically by facet-reflect's
-        // fill_defaults() when build() or end() is called.
 
         Ok(wip)
     }

--- a/facet-format/src/serializer.rs
+++ b/facet-format/src/serializer.rs
@@ -1125,6 +1125,145 @@ impl<'s, S: FormatSerializer> SerializeContext<'s, S> {
         Ok(())
     }
 
+    /// Recursively flattens a newtype variant's inner value into the current
+    /// JSON object that already has `begin_struct` and the outer tag written.
+    ///
+    /// Three cases:
+    /// 1. Inner value is a **struct** → emit its fields directly.
+    /// 2. Inner value is an **internally-tagged enum** → emit its tag, then
+    ///    handle its active variant (which may itself be a newtype, so recurse).
+    /// 3. Inner value is a **scalar / unsupported type** → error, because
+    ///    scalars cannot be flattened into an object.
+    fn serialize_flattened_newtype_value<'mem, 'facet>(
+        &mut self,
+        value: Peek<'mem, 'facet>,
+        used_tag_keys: &[&str],
+    ) -> Result<(), SerializeError<S::Error>> {
+        let shape = value.shape();
+        let field_mode = self.serializer.struct_field_mode();
+
+        // Case 1: plain struct — flatten its fields into the enclosing object
+        if let Ok(struct_) = value.into_struct() {
+            let mut fields: alloc::vec::Vec<_> = if field_mode == StructFieldMode::Unnamed {
+                struct_.fields_for_binary_serialize().collect()
+            } else {
+                struct_.fields_for_serialize().collect()
+            };
+            sort_fields_if_needed(self.serializer, &mut fields);
+            for (field_item, field_value) in fields {
+                self.serializer
+                    .field_metadata(&field_item)
+                    .map_err(SerializeError::Backend)?;
+                if field_mode == StructFieldMode::Named {
+                    self.serializer
+                        .field_key(field_item.effective_name())
+                        .map_err(SerializeError::Backend)?;
+                }
+                self.push(PathSegment::Field(Cow::Owned(
+                    field_item.effective_name().to_string(),
+                )));
+                self.serialize_field_value(&field_item, field_value)?;
+                self.pop();
+            }
+            return Ok(());
+        }
+
+        // Case 2: internally-tagged enum — write its tag, then handle its variant
+        if let Some(inner_tag) = shape.get_tag_attr()
+            && shape.get_content_attr().is_none()
+            && let Ok(inner_enum) = value.into_enum()
+        {
+            // Reject duplicate tag key names across nesting levels —
+            // e.g. both outer and inner enum using #[facet(tag = "type")].
+            // With a flat JSON object we cannot distinguish which "type"
+            // value belongs to which level.
+            if used_tag_keys.contains(&inner_tag) {
+                return Err(SerializeError::Unsupported(
+                    format!(
+                        "nested internally-tagged enums use the same tag key \"{}\"; \
+                         this is ambiguous when flattened into a single object",
+                        inner_tag
+                    )
+                    .into(),
+                ));
+            }
+
+            let inner_variant = inner_enum
+                .active_variant()
+                .map_err(|e| SerializeError::Unsupported(Cow::Owned(e.to_string())))?;
+
+            // Write the inner enum's tag
+            self.serializer
+                .field_key(inner_tag)
+                .map_err(SerializeError::Backend)?;
+            self.serializer
+                .scalar(ScalarValue::Str(Cow::Borrowed(
+                    inner_variant.effective_name(),
+                )))
+                .map_err(SerializeError::Backend)?;
+
+            self.push(PathSegment::Variant(Cow::Borrowed(
+                inner_variant.effective_name(),
+            )));
+
+            match inner_variant.data.kind {
+                StructKind::Unit => {}
+                StructKind::Struct => {
+                    let mut inner_fields: alloc::vec::Vec<_> =
+                        if field_mode == StructFieldMode::Unnamed {
+                            inner_enum.fields_for_binary_serialize().collect()
+                        } else {
+                            inner_enum.fields_for_serialize().collect()
+                        };
+                    sort_fields_if_needed(self.serializer, &mut inner_fields);
+
+                    for (field_item, field_value) in inner_fields {
+                        self.serializer
+                            .field_metadata(&field_item)
+                            .map_err(SerializeError::Backend)?;
+                        if field_mode == StructFieldMode::Named {
+                            self.serializer
+                                .field_key(field_item.effective_name())
+                                .map_err(SerializeError::Backend)?;
+                        }
+                        self.push(PathSegment::Field(Cow::Owned(
+                            field_item.effective_name().to_string(),
+                        )));
+                        self.serialize_field_value(&field_item, field_value)?;
+                        self.pop();
+                    }
+                }
+                StructKind::TupleStruct | StructKind::Tuple => {
+                    // Inner variant is itself a newtype — recurse
+                    if inner_variant.data.fields.len() != 1 {
+                        self.pop();
+                        return Err(SerializeError::Unsupported(Cow::Borrowed(
+                            "internally tagged tuple variants with multiple fields are not supported",
+                        )));
+                    }
+                    let nested_value = inner_enum
+                        .field(0)
+                        .map_err(|e| SerializeError::Unsupported(Cow::Owned(e.to_string())))?
+                        .expect("single-field tuple variant should have field 0");
+                    let mut inner_used_tag_keys = alloc::vec::Vec::from(used_tag_keys);
+                    inner_used_tag_keys.push(inner_tag);
+                    self.serialize_flattened_newtype_value(nested_value, &inner_used_tag_keys)?;
+                }
+            }
+
+            self.pop();
+            return Ok(());
+        }
+
+        // Case 3: scalar or other non-flattenable type
+        Err(SerializeError::Unsupported(
+            "internally-tagged enum with scalar newtype payload cannot be \
+             flattened; use #[facet(content = \"...\")] for adjacently-tagged \
+             representation"
+                .into(),
+        ))
+    }
+
     fn serialize_discriminant<'mem, 'facet>(
         &mut self,
         enum_: facet_reflect::PeekEnum<'mem, 'facet>,
@@ -1286,93 +1425,23 @@ impl<'s, S: FormatSerializer> SerializeContext<'s, S> {
                         }
                     }
                     StructKind::TupleStruct | StructKind::Tuple => {
-                        // Single-field tuple variants containing an internally-tagged enum
-                        // get flattened: their inner enum's tag and fields merge into this object
+                        // Single-field tuple (newtype) variants get flattened into the
+                        // enclosing tagged object. The inner value may be a struct, an
+                        // internally-tagged enum, or a chain of newtype wrappers around
+                        // one of those — we handle all cases recursively.
                         if variant.data.fields.len() != 1 {
                             self.pop();
                             return Err(SerializeError::Unsupported(Cow::Borrowed(
-                                "internally tagged tuple variants are not supported",
+                                "internally tagged tuple variants with multiple fields are not supported",
                             )));
                         }
-
-                        let inner_shape = variant.data.fields[0].shape();
-                        let inner_tag = match inner_shape.get_tag_attr() {
-                            Some(tag) if inner_shape.get_content_attr().is_none() => tag,
-                            _ => {
-                                self.pop();
-                                return Err(SerializeError::Unsupported(Cow::Borrowed(
-                                    "internally tagged tuple variants are not supported",
-                                )));
-                            }
-                        };
 
                         let inner_value = enum_
                             .field(0)
                             .map_err(|e| SerializeError::Unsupported(Cow::Owned(e.to_string())))?
                             .expect("single-field tuple variant should have field 0");
 
-                        let inner_enum = inner_value.into_enum().map_err(|_| {
-                            SerializeError::Unsupported(Cow::Borrowed(
-                                "internally tagged tuple variant field is not an enum",
-                            ))
-                        })?;
-
-                        let inner_variant = inner_enum
-                            .active_variant()
-                            .map_err(|e| SerializeError::Unsupported(Cow::Owned(e.to_string())))?;
-
-                        // Write the inner enum's tag
-                        self.serializer
-                            .field_key(inner_tag)
-                            .map_err(SerializeError::Backend)?;
-                        self.serializer
-                            .scalar(ScalarValue::Str(Cow::Borrowed(
-                                inner_variant.effective_name(),
-                            )))
-                            .map_err(SerializeError::Backend)?;
-
-                        // Write the inner enum's fields
-                        self.push(PathSegment::Variant(Cow::Borrowed(
-                            inner_variant.effective_name(),
-                        )));
-
-                        match inner_variant.data.kind {
-                            StructKind::Unit => {}
-                            StructKind::Struct => {
-                                let mut inner_fields: alloc::vec::Vec<_> =
-                                    if field_mode == StructFieldMode::Unnamed {
-                                        inner_enum.fields_for_binary_serialize().collect()
-                                    } else {
-                                        inner_enum.fields_for_serialize().collect()
-                                    };
-                                sort_fields_if_needed(self.serializer, &mut inner_fields);
-
-                                for (field_item, field_value) in inner_fields {
-                                    self.serializer
-                                        .field_metadata(&field_item)
-                                        .map_err(SerializeError::Backend)?;
-                                    if field_mode == StructFieldMode::Named {
-                                        self.serializer
-                                            .field_key(field_item.effective_name())
-                                            .map_err(SerializeError::Backend)?;
-                                    }
-                                    self.push(PathSegment::Field(Cow::Owned(
-                                        field_item.effective_name().to_string(),
-                                    )));
-                                    self.serialize_field_value(&field_item, field_value)?;
-                                    self.pop();
-                                }
-                            }
-                            StructKind::TupleStruct | StructKind::Tuple => {
-                                self.pop();
-                                self.pop();
-                                return Err(SerializeError::Unsupported(Cow::Borrowed(
-                                    "nested internally tagged tuple variants are not supported",
-                                )));
-                            }
-                        }
-
-                        self.pop();
+                        self.serialize_flattened_newtype_value(inner_value, &[tag_key])?;
                     }
                 }
                 self.pop();

--- a/facet-json/tests/issue_2124.rs
+++ b/facet-json/tests/issue_2124.rs
@@ -1,0 +1,563 @@
+//! Regression test for https://github.com/facet-rs/facet/issues/2124
+//!
+//! Internally-tagged enums with newtype variants wrapping structs or other
+//! tagged enums fail to serialize/deserialize.
+
+use facet::Facet;
+use facet_testhelpers::test;
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+pub struct Filter {
+    pub name: String,
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "add_type")]
+#[repr(C)]
+pub enum AddOp {
+    Full,
+    Filtered { filter: Filter },
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "inner_type")]
+#[repr(C)]
+pub enum Inner {
+    Include(AddOp),
+    Exclude(Filter),
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "outer_type")]
+#[repr(C)]
+pub enum Outer {
+    Nested(Inner),
+    Simple { value: f64 },
+}
+
+// ---------------------------------------------------------------------------
+// Newtype variant wrapping a plain struct
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_issue_2124_inner_exclude() {
+    let expected = Inner::Exclude(Filter { name: "x".into() });
+
+    // Roundtrip
+    let json = facet_json::to_string(&expected).unwrap();
+    let back: Inner = facet_json::from_str(&json).unwrap();
+    assert_eq!(expected, back);
+
+    // Deserialize from known JSON
+    let back: Inner = facet_json::from_str(r#"{"inner_type":"Exclude","name":"x"}"#).unwrap();
+    assert_eq!(expected, back);
+}
+
+// ---------------------------------------------------------------------------
+// Newtype wrapping a tagged enum (two levels of tags)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_issue_2124_inner_include_full() {
+    let expected = Inner::Include(AddOp::Full);
+
+    let json = facet_json::to_string(&expected).unwrap();
+    let back: Inner = facet_json::from_str(&json).unwrap();
+    assert_eq!(expected, back);
+
+    let back: Inner =
+        facet_json::from_str(r#"{"inner_type":"Include","add_type":"Full"}"#).unwrap();
+    assert_eq!(expected, back);
+}
+
+#[test]
+fn test_issue_2124_inner_include_filtered() {
+    let expected = Inner::Include(AddOp::Filtered {
+        filter: Filter { name: "f".into() },
+    });
+
+    let json = facet_json::to_string(&expected).unwrap();
+    let back: Inner = facet_json::from_str(&json).unwrap();
+    assert_eq!(expected, back);
+
+    let back: Inner = facet_json::from_str(
+        r#"{"inner_type":"Include","add_type":"Filtered","filter":{"name":"f"}}"#,
+    )
+    .unwrap();
+    assert_eq!(expected, back);
+}
+
+// ---------------------------------------------------------------------------
+// Three levels of tags (outer → inner → add_type)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_issue_2124_outer_nested_include_filtered() {
+    let expected = Outer::Nested(Inner::Include(AddOp::Filtered {
+        filter: Filter { name: "f".into() },
+    }));
+
+    let json = facet_json::to_string(&expected).unwrap();
+    let back: Outer = facet_json::from_str(&json).unwrap();
+    assert_eq!(expected, back);
+
+    let back: Outer = facet_json::from_str(
+        r#"{"outer_type":"Nested","inner_type":"Include","add_type":"Filtered","filter":{"name":"f"}}"#,
+    )
+    .unwrap();
+    assert_eq!(expected, back);
+}
+
+#[test]
+fn test_issue_2124_outer_nested_exclude() {
+    let expected = Outer::Nested(Inner::Exclude(Filter {
+        name: "gone".into(),
+    }));
+
+    let json = facet_json::to_string(&expected).unwrap();
+    let back: Outer = facet_json::from_str(&json).unwrap();
+    assert_eq!(expected, back);
+
+    let back: Outer =
+        facet_json::from_str(r#"{"outer_type":"Nested","inner_type":"Exclude","name":"gone"}"#)
+            .unwrap();
+    assert_eq!(expected, back);
+}
+
+#[test]
+fn test_issue_2124_outer_simple() {
+    // Struct variant (not a newtype) — should already work, included for completeness.
+    let expected = Outer::Simple { value: 1.5 };
+
+    let json = facet_json::to_string(&expected).unwrap();
+    let back: Outer = facet_json::from_str(&json).unwrap();
+    assert_eq!(expected, back);
+
+    let back: Outer = facet_json::from_str(r#"{"outer_type":"Simple","value":1.5}"#).unwrap();
+    assert_eq!(expected, back);
+}
+
+// ---------------------------------------------------------------------------
+// Three-level nesting: Top(tagged) → Middle(tagged newtype) → Config(struct)
+// ---------------------------------------------------------------------------
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+pub struct Config {
+    pub enabled: bool,
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "level2")]
+#[repr(C)]
+pub enum Middle {
+    Wrap(Config),
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "level1")]
+#[repr(C)]
+pub enum Top {
+    Deep(Middle),
+}
+
+#[test]
+fn test_issue_2124_three_level_nesting() {
+    let expected = Top::Deep(Middle::Wrap(Config { enabled: true }));
+
+    let json = facet_json::to_string(&expected).unwrap();
+    let back: Top = facet_json::from_str(&json).unwrap();
+    assert_eq!(expected, back);
+
+    let back: Top =
+        facet_json::from_str(r#"{"level1":"Deep","level2":"Wrap","enabled":true}"#).unwrap();
+    assert_eq!(expected, back);
+}
+
+// ---------------------------------------------------------------------------
+// Mixed variant kinds: unit + struct + newtype in one tagged enum
+// ---------------------------------------------------------------------------
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "kind")]
+#[repr(C)]
+pub enum Mixed {
+    Unit,
+    Named { x: i32 },
+    Newtype(Filter),
+}
+
+#[test]
+fn test_issue_2124_mixed_variants() {
+    // Unit and Named variants should already work; Newtype is the new case.
+    let cases: Vec<(Mixed, &str)> = vec![
+        (Mixed::Unit, r#"{"kind":"Unit"}"#),
+        (Mixed::Named { x: 42 }, r#"{"kind":"Named","x":42}"#),
+        (
+            Mixed::Newtype(Filter { name: "abc".into() }),
+            r#"{"kind":"Newtype","name":"abc"}"#,
+        ),
+    ];
+
+    for (expected, known_json) in cases {
+        let json = facet_json::to_string(&expected).unwrap();
+        let back: Mixed = facet_json::from_str(&json).unwrap();
+        assert_eq!(expected, back);
+
+        let back: Mixed = facet_json::from_str(known_json).unwrap();
+        assert_eq!(expected, back);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Newtype wrapping a struct with optional fields (defaults must apply)
+// ---------------------------------------------------------------------------
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+pub struct OptFields {
+    pub required: String,
+    pub optional: Option<i32>,
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "t")]
+#[repr(C)]
+pub enum WithOpt {
+    Val(OptFields),
+}
+
+// ---------------------------------------------------------------------------
+// Regression test: newtype wrapping a struct with #[facet(flatten)].
+// Previously the newtype deserialization path used `field_lookup.find()` (a
+// flat name→index lookup) which did not recurse into flattened sub-structs.
+// Fixed by extracting `read_tagged_object_fields` which uses `find_field_path`
+// when `has_flatten` is set.
+// ---------------------------------------------------------------------------
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+pub struct GeoCoords {
+    pub lat: f64,
+    pub lng: f64,
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+pub struct Location {
+    pub label: String,
+    #[facet(flatten)]
+    pub coords: GeoCoords,
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "type")]
+#[repr(C)]
+pub enum Place {
+    /// Newtype variant wrapping a struct that has a flattened field.
+    /// JSON: {"type":"Pin","label":"HQ","lat":1.0,"lng":2.0}
+    Pin(Location),
+    /// Struct variant for comparison.
+    Inline {
+        label: String,
+        #[facet(flatten)]
+        coords: GeoCoords,
+    },
+}
+
+#[test]
+fn test_issue_2124_newtype_with_flatten_struct_variant_works() {
+    // Struct variant with flatten — this already works via the has_flatten /
+    // find_field_path code path. Included to contrast with the newtype case.
+    let expected = Place::Inline {
+        label: "HQ".into(),
+        coords: GeoCoords { lat: 1.0, lng: 2.0 },
+    };
+
+    let json = facet_json::to_string(&expected).unwrap();
+    let back: Place = facet_json::from_str(&json).unwrap();
+    assert_eq!(expected, back);
+
+    let back: Place =
+        facet_json::from_str(r#"{"type":"Inline","label":"HQ","lat":1.0,"lng":2.0}"#).unwrap();
+    assert_eq!(expected, back);
+}
+
+#[test]
+fn test_issue_2124_newtype_with_flatten() {
+    // Newtype variant wrapping a struct with #[facet(flatten)].
+    let expected = Place::Pin(Location {
+        label: "HQ".into(),
+        coords: GeoCoords { lat: 1.0, lng: 2.0 },
+    });
+
+    let json = facet_json::to_string(&expected).unwrap();
+    let back: Place = facet_json::from_str(&json).unwrap();
+    assert_eq!(expected, back);
+
+    let back: Place =
+        facet_json::from_str(r#"{"type":"Pin","label":"HQ","lat":1.0,"lng":2.0}"#).unwrap();
+    assert_eq!(expected, back);
+}
+
+// ---------------------------------------------------------------------------
+// Regression test: newtype wrapping an internally-tagged enum whose struct
+// variant has #[facet(flatten)]. Same root cause as above, also fixed by the
+// shared `read_tagged_object_fields` helper.
+// ---------------------------------------------------------------------------
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+pub struct Metadata {
+    pub author: String,
+    pub version: u32,
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "kind")]
+#[repr(C)]
+pub enum Document {
+    Report {
+        title: String,
+        #[facet(flatten)]
+        meta: Metadata,
+    },
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "wrapper")]
+#[repr(C)]
+pub enum Envelope {
+    Doc(Document),
+}
+
+#[test]
+fn test_issue_2124_newtype_inner_enum_with_flatten() {
+    // Two-level newtype: Envelope(tagged) → Document(tagged) → Report { flatten }
+    let expected = Envelope::Doc(Document::Report {
+        title: "Annual".into(),
+        meta: Metadata {
+            author: "Alice".into(),
+            version: 3,
+        },
+    });
+
+    let json = facet_json::to_string(&expected).unwrap();
+    let back: Envelope = facet_json::from_str(&json).unwrap();
+    assert_eq!(expected, back);
+
+    let back: Envelope = facet_json::from_str(
+        r#"{"wrapper":"Doc","kind":"Report","title":"Annual","author":"Alice","version":3}"#,
+    )
+    .unwrap();
+    assert_eq!(expected, back);
+}
+
+// ---------------------------------------------------------------------------
+// Duplicate tag keys across nesting levels must produce a clear error
+// ---------------------------------------------------------------------------
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "type")]
+#[repr(C)]
+pub enum InnerSameTag {
+    A { x: i32 },
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "type")]
+#[repr(C)]
+pub enum OuterSameTag {
+    Wrap(InnerSameTag),
+}
+
+#[test]
+fn test_issue_2124_duplicate_tag_key_serialize_error() {
+    // Both enums use #[facet(tag = "type")]. When flattened into a single
+    // object the two "type" keys are ambiguous — serialization must fail.
+    let value = OuterSameTag::Wrap(InnerSameTag::A { x: 1 });
+    let result = facet_json::to_string(&value);
+    assert!(
+        result.is_err(),
+        "expected error for duplicate tag key, got: {result:?}"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("same tag key"),
+        "error should mention 'same tag key', got: {err}"
+    );
+}
+
+#[test]
+fn test_issue_2124_duplicate_tag_key_deserialize_error() {
+    // Attempting to deserialize a JSON object where both nesting levels share
+    // the same tag key must fail with a clear error.
+    let json = r#"{"type":"Wrap","type":"A","x":1}"#;
+    let result = facet_json::from_str::<OuterSameTag>(json);
+    assert!(
+        result.is_err(),
+        "expected error for duplicate tag key, got: {result:?}"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("same tag key"),
+        "error should mention 'same tag key', got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Flattened field name equals tag key — the field is silently shadowed
+// ---------------------------------------------------------------------------
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+pub struct HasTypeField {
+    /// This field has the same name as the tag key used by the wrapping enum.
+    pub kind: String,
+    pub other: i32,
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(tag = "kind")]
+#[repr(C)]
+pub enum TagCollidesWithField {
+    Wrap(HasTypeField),
+}
+
+#[test]
+fn test_issue_2124_field_name_equals_tag_key_roundtrip() {
+    // The struct field `kind` collides with the enum's tag key `kind`.
+    // During serialization the tag is written first, then the struct's fields
+    // are flattened — producing two `kind` entries in the JSON object.
+    let value = TagCollidesWithField::Wrap(HasTypeField {
+        kind: "should_be_lost".into(),
+        other: 42,
+    });
+
+    let json = facet_json::to_string(&value).unwrap();
+    // The JSON will contain two "kind" keys — the tag and the field.
+    assert!(
+        json.contains(r#""kind":"Wrap"#),
+        "tag must be present: {json}"
+    );
+
+    // Deserializing back fails: the tag skip logic swallows all "kind" keys,
+    // so the required struct field is never populated → missing field error.
+    let result = facet_json::from_str::<TagCollidesWithField>(&json);
+    assert!(
+        result.is_err(),
+        "should error because the struct field is shadowed by the tag key"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("kind"),
+        "error should mention the missing field 'kind', got: {err}"
+    );
+}
+
+#[test]
+fn test_issue_2124_field_name_equals_tag_key_deser_from_known() {
+    // Explicit JSON where the struct's `kind` field appears (after the tag).
+    // The deserializer skips all occurrences of the tag key, so the required
+    // field is never set — resulting in a missing-field error.
+    let json = r#"{"kind":"Wrap","kind":"hello","other":99}"#;
+    let result = facet_json::from_str::<TagCollidesWithField>(json);
+    assert!(
+        result.is_err(),
+        "should error because the struct field is shadowed by the tag key"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("kind"),
+        "error should mention the missing field 'kind', got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unknown fields in the newtype-chain path (without flatten)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_issue_2124_unknown_fields_skipped_in_newtype() {
+    // Extra/unknown keys in the JSON should be silently skipped when
+    // deserializing through a newtype chain (no #[facet(flatten)]).
+    let json = r#"{"inner_type":"Exclude","name":"x","unknown_key":"ignored","another":123}"#;
+    let back: Inner = facet_json::from_str(json).unwrap();
+    assert_eq!(back, Inner::Exclude(Filter { name: "x".into() }));
+}
+
+#[test]
+fn test_issue_2124_unknown_fields_skipped_in_nested_newtype() {
+    // Three-level nesting with unknown fields scattered in the JSON object.
+    let json = r#"{"outer_type":"Nested","bogus":true,"inner_type":"Include","add_type":"Full","extra":"nope"}"#;
+    let back: Outer = facet_json::from_str(json).unwrap();
+    assert_eq!(back, Outer::Nested(Inner::Include(AddOp::Full)));
+}
+
+// ---------------------------------------------------------------------------
+// Unknown fields in the newtype-chain path (with flatten)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_issue_2124_unknown_fields_skipped_with_flatten_newtype() {
+    // Place::Pin is a newtype wrapping Location which has #[facet(flatten)].
+    // Unknown keys should be silently skipped.
+    let json = r#"{"type":"Pin","label":"HQ","lat":1.0,"lng":2.0,"unknown":"skip_me"}"#;
+    let back: Place = facet_json::from_str(json).unwrap();
+    assert_eq!(
+        back,
+        Place::Pin(Location {
+            label: "HQ".into(),
+            coords: GeoCoords { lat: 1.0, lng: 2.0 },
+        })
+    );
+}
+
+#[test]
+fn test_issue_2124_unknown_fields_skipped_with_flatten_nested_enum() {
+    // Envelope::Doc is a newtype wrapping Document (tagged enum) whose
+    // Report variant has #[facet(flatten)]. Unknown keys should be skipped.
+    let json = r#"{"wrapper":"Doc","kind":"Report","title":"Annual","author":"Alice","version":3,"junk":false}"#;
+    let back: Envelope = facet_json::from_str(json).unwrap();
+    assert_eq!(
+        back,
+        Envelope::Doc(Document::Report {
+            title: "Annual".into(),
+            meta: Metadata {
+                author: "Alice".into(),
+                version: 3,
+            },
+        })
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Newtype wrapping a struct with optional fields (defaults must apply)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_issue_2124_newtype_optional_fields() {
+    let cases: Vec<(WithOpt, &str)> = vec![
+        (
+            WithOpt::Val(OptFields {
+                required: "hi".into(),
+                optional: None,
+            }),
+            r#"{"t":"Val","required":"hi","optional":null}"#,
+        ),
+        (
+            WithOpt::Val(OptFields {
+                required: "hi".into(),
+                optional: Some(7),
+            }),
+            r#"{"t":"Val","required":"hi","optional":7}"#,
+        ),
+    ];
+
+    for (expected, known_json) in cases {
+        let json = facet_json::to_string(&expected).unwrap();
+        let back: WithOpt = facet_json::from_str(&json).unwrap();
+        assert_eq!(expected, back);
+
+        let back: WithOpt = facet_json::from_str(known_json).unwrap();
+        assert_eq!(expected, back);
+    }
+}


### PR DESCRIPTION
Refactor internally-tagged enum deserialization to properly handle nested newtype chains and fix error handling for ambiguous duplicate tag keys and unsupported scalar newtype flattening.

Added regression test for issue 2124 in facet-json/tests/issue_2124.rs as well as related tests to check the new code.

Fixes #2124 