### PR TITLE
feat(crates): add facet-lua

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,6 +1213,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-lua"
+version = "0.44.1"
+dependencies = [
+ "facet",
+ "facet-core",
+ "facet-format",
+ "facet-format-suite",
+ "facet-reflect",
+ "insta",
+ "libtest-mimic",
+]
+
+[[package]]
 name = "facet-macro-parse"
 version = "0.44.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
   "facet-json-schema",
   "facet-typescript",
   "facet-python",
+  "facet-lua",
 ]
 exclude = [
   # proto-attr experiment uses nightly features

--- a/facet-lua/Cargo.toml
+++ b/facet-lua/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "facet-lua"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Generate Lua type annotations and serialize values to Lua table syntax"
+keywords = ["lua", "codegen", "serialization", "facet", "types"]
+categories = ["development-tools", "encoding"]
+homepage = "https://facet.rs"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[package.metadata."docs.rs"]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[dependencies]
+facet-core = { path = "../facet-core", version = "0.44.1" }
+facet-format = { path = "../facet-format", version = "0.44.1", default-features = false }
+facet-reflect = { path = "../facet-reflect", version = "0.44.1" }
+
+[dev-dependencies]
+facet = { path = "../facet", features = ["all-impls", "net", "iddqd"] }
+facet-format = { path = "../facet-format", features = ["net"] }
+facet-format-suite = { path = "../facet-format-suite", features = ["net"] }
+insta = { workspace = true }
+libtest-mimic = "0.8"
+
+[[test]]
+name = "format_suite"
+harness = false
+
+[features]
+default = []
+std = []
+net = ["facet-format/net", "facet-core/net"]
+
+# iddqd support
+iddqd = ["facet/iddqd"]
+
+# yoke support
+yoke = ["facet/yoke", "facet-format-suite/yoke"]
+
+[lints]
+workspace = true

--- a/facet-lua/src/annotations.rs
+++ b/facet-lua/src/annotations.rs
@@ -1,0 +1,960 @@
+//! Generate LuaLS type annotations from facet type metadata.
+
+extern crate alloc;
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt::Write;
+
+use facet_core::{Def, Facet, Field, Shape, StructKind, Type, UserType};
+
+/// Generate LuaLS annotations for a single type.
+pub fn to_lua_annotations<T: Facet<'static>>() -> String {
+    let mut generator = LuaGenerator::new();
+    generator.add_shape(T::SHAPE);
+    generator.finish()
+}
+
+/// Generator for LuaLS type annotations.
+pub struct LuaGenerator {
+    /// Generated type definitions, keyed by type name for sorting
+    generated: BTreeMap<String, String>,
+    /// Types queued for generation
+    queue: Vec<&'static Shape>,
+    /// Set of type identifiers already seen (to avoid infinite recursion)
+    seen: BTreeSet<String>,
+}
+
+impl Default for LuaGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LuaGenerator {
+    /// Create a new Lua annotation generator.
+    pub const fn new() -> Self {
+        Self {
+            generated: BTreeMap::new(),
+            queue: Vec::new(),
+            seen: BTreeSet::new(),
+        }
+    }
+
+    /// Add a type to generate.
+    pub fn add_type<T: Facet<'static>>(&mut self) {
+        self.add_shape(T::SHAPE);
+    }
+
+    /// Add a shape to generate.
+    pub fn add_shape(&mut self, shape: &'static Shape) {
+        if !self.seen.contains(shape.type_identifier) {
+            self.queue.push(shape);
+        }
+    }
+
+    /// Finish generation and return the Lua annotation code.
+    pub fn finish(mut self) -> String {
+        // Process queue until empty
+        while let Some(shape) = self.queue.pop() {
+            if self.seen.contains(shape.type_identifier) {
+                continue;
+            }
+            self.seen.insert(shape.type_identifier.to_string());
+            self.generate_shape(shape);
+        }
+
+        // Collect all generated code in sorted order
+        let mut output = String::new();
+        let mut first = true;
+        for code in self.generated.values() {
+            if !first {
+                output.push('\n');
+            }
+            first = false;
+            output.push_str(code);
+        }
+        output
+    }
+
+    fn generate_shape(&mut self, shape: &'static Shape) {
+        let mut output = String::new();
+
+        // Handle transparent wrappers - generate a type alias to the inner type
+        if let Some(inner) = shape.inner {
+            // type_for_shape handles queuing user types that need generation;
+            // no explicit add_shape needed (avoids leaking aliases like `String`)
+            let inner_type = self.type_for_shape(inner);
+            write_doc_comment(&mut output, shape.doc);
+            writeln!(output, "---@alias {} {}", shape.type_identifier, inner_type).unwrap();
+            self.generated
+                .insert(shape.type_identifier.to_string(), output);
+            return;
+        }
+
+        match &shape.ty {
+            Type::User(UserType::Struct(st)) => {
+                self.generate_struct(&mut output, shape, st.fields, st.kind);
+            }
+            Type::User(UserType::Enum(en)) => {
+                self.generate_enum(&mut output, shape, en);
+            }
+            _ => {
+                // For other types, generate a type alias
+                let type_str = self.type_for_shape(shape);
+                write_doc_comment(&mut output, shape.doc);
+                writeln!(output, "---@alias {} {}", shape.type_identifier, type_str).unwrap();
+            }
+        }
+
+        self.generated
+            .insert(shape.type_identifier.to_string(), output);
+    }
+
+    fn generate_struct(
+        &mut self,
+        output: &mut String,
+        shape: &'static Shape,
+        fields: &'static [Field],
+        kind: StructKind,
+    ) {
+        match kind {
+            StructKind::Unit => {
+                write_doc_comment(output, shape.doc);
+                // Unit structs map to nil
+                writeln!(output, "---@alias {} nil", shape.type_identifier).unwrap();
+            }
+            StructKind::TupleStruct | StructKind::Tuple if fields.is_empty() => {
+                write_doc_comment(output, shape.doc);
+                writeln!(output, "---@alias {} nil", shape.type_identifier).unwrap();
+            }
+            StructKind::TupleStruct if fields.len() == 1 => {
+                // Newtype: alias to inner type
+                let inner_type = self.type_for_shape(fields[0].shape.get());
+                write_doc_comment(output, shape.doc);
+                writeln!(output, "---@alias {} {}", shape.type_identifier, inner_type).unwrap();
+            }
+            StructKind::TupleStruct | StructKind::Tuple => {
+                // Tuple struct: use indexed table type for positional info
+                write_doc_comment(output, shape.doc);
+                let tuple_type = self.tuple_type_string(fields);
+                writeln!(output, "---@alias {} {}", shape.type_identifier, tuple_type).unwrap();
+            }
+            StructKind::Struct => {
+                self.generate_class(output, shape, fields);
+            }
+        }
+    }
+
+    fn generate_class(
+        &mut self,
+        output: &mut String,
+        shape: &'static Shape,
+        fields: &'static [Field],
+    ) {
+        write_doc_comment(output, shape.doc);
+        self.write_class_fields(output, shape.type_identifier, fields);
+    }
+
+    /// Generate a named class definition and insert it into `generated`.
+    fn generate_named_class(&mut self, class_name: &str, fields: &'static [Field]) {
+        let mut class_output = String::new();
+        self.write_class_fields(&mut class_output, class_name, fields);
+        self.generated.insert(class_name.to_string(), class_output);
+    }
+
+    /// Write `---@class Name` header followed by `---@field` lines for visible fields.
+    fn write_class_fields(
+        &mut self,
+        output: &mut String,
+        class_name: &str,
+        fields: &'static [Field],
+    ) {
+        writeln!(output, "---@class {}", class_name).unwrap();
+        for field in fields {
+            if field.flags.contains(facet_core::FieldFlags::SKIP) {
+                continue;
+            }
+            let (type_string, optional) = self.field_type_info(field);
+            let name = field.effective_name();
+            for line in field.doc {
+                write!(output, "---").unwrap();
+                output.push_str(line);
+                output.push('\n');
+            }
+            if optional {
+                writeln!(output, "---@field {}? {}", name, type_string).unwrap();
+            } else {
+                writeln!(output, "---@field {} {}", name, type_string).unwrap();
+            }
+        }
+    }
+
+    /// Get the Lua type string and optional status for a field.
+    fn field_type_info(&mut self, field: &Field) -> (String, bool) {
+        if let Def::Option(opt) = &field.shape.get().def {
+            (self.type_for_shape(opt.t), true)
+        } else {
+            (self.type_for_shape(field.shape.get()), false)
+        }
+    }
+
+    /// Build a Lua indexed table type for a tuple: `{ [1]: T1, [2]: T2 }`.
+    fn tuple_type_string(&mut self, fields: &[Field]) -> String {
+        let parts: Vec<String> = fields
+            .iter()
+            .enumerate()
+            .map(|(i, f)| format!("[{}]: {}", i + 1, self.type_for_shape(f.shape.get())))
+            .collect();
+        format!("{{ {} }}", parts.join(", "))
+    }
+
+    fn generate_enum(
+        &mut self,
+        output: &mut String,
+        shape: &'static Shape,
+        enum_type: &facet_core::EnumType,
+    ) {
+        let tag = shape.get_tag_attr();
+        let content = shape.get_content_attr();
+        let is_numeric = shape.is_numeric();
+        let is_untagged = shape.is_untagged();
+
+        write_doc_comment(output, shape.doc);
+
+        if is_numeric && tag.is_none() {
+            // Numeric enum: serializes as integer discriminant
+            writeln!(output, "---@alias {} integer", shape.type_identifier).unwrap();
+        } else if is_untagged {
+            self.generate_untagged_enum(output, shape, enum_type);
+        } else {
+            match (tag, content) {
+                (Some(tag_key), Some(content_key)) => {
+                    self.generate_adjacently_tagged_enum(
+                        output,
+                        shape,
+                        enum_type,
+                        tag_key,
+                        content_key,
+                    );
+                }
+                (Some(tag_key), None) => {
+                    self.generate_internally_tagged_enum(output, shape, enum_type, tag_key);
+                }
+                _ => {
+                    // Externally tagged (default)
+                    self.generate_externally_tagged_enum(output, shape, enum_type);
+                }
+            }
+        }
+    }
+
+    fn generate_externally_tagged_enum(
+        &mut self,
+        output: &mut String,
+        shape: &'static Shape,
+        enum_type: &facet_core::EnumType,
+    ) {
+        let all_unit = enum_type
+            .variants
+            .iter()
+            .all(|v| matches!(v.data.kind, StructKind::Unit));
+
+        if all_unit {
+            self.write_string_literal_alias(output, shape, enum_type);
+        } else {
+            let mut variant_types = Vec::new();
+            for variant in enum_type.variants {
+                let vtype = self.generate_external_variant(shape, variant);
+                variant_types.push((vtype, variant.doc));
+            }
+
+            self.write_alias_variants(output, shape.type_identifier, &variant_types);
+        }
+    }
+
+    /// Generate a single externally-tagged variant. Returns the type reference.
+    fn generate_external_variant(
+        &mut self,
+        parent_shape: &'static Shape,
+        variant: &facet_core::Variant,
+    ) -> String {
+        let variant_name = variant.effective_name();
+
+        match variant.data.kind {
+            StructKind::Unit => {
+                format!("\"{}\"", variant_name)
+            }
+            StructKind::TupleStruct if variant.data.fields.len() == 1 => {
+                // Newtype variant: { VariantName = value }
+                let class_name = format!("{}.{}", parent_shape.type_identifier, variant_name);
+                let inner_type = self.type_for_shape(variant.data.fields[0].shape.get());
+
+                let mut class_output = String::new();
+                write_doc_comment(&mut class_output, variant.doc);
+                writeln!(class_output, "---@class {}", class_name).unwrap();
+                writeln!(class_output, "---@field {} {}", variant_name, inner_type).unwrap();
+                self.generated.insert(class_name.clone(), class_output);
+
+                class_name
+            }
+            StructKind::TupleStruct => {
+                // Multi-field tuple variant: { VariantName = { [1]=v1, [2]=v2 } }
+                let class_name = format!("{}.{}", parent_shape.type_identifier, variant_name);
+                let tuple_type = self.tuple_type_string(variant.data.fields);
+
+                let mut class_output = String::new();
+                write_doc_comment(&mut class_output, variant.doc);
+                writeln!(class_output, "---@class {}", class_name).unwrap();
+                writeln!(class_output, "---@field {} {}", variant_name, tuple_type).unwrap();
+                self.generated.insert(class_name.clone(), class_output);
+
+                class_name
+            }
+            _ => {
+                // Struct variant: { VariantName = { field1=v1, ... } }
+                let class_name = format!("{}.{}", parent_shape.type_identifier, variant_name);
+                let data_class_name = format!("{}._", class_name);
+
+                // Outer wrapper class
+                let mut class_output = String::new();
+                write_doc_comment(&mut class_output, variant.doc);
+                writeln!(class_output, "---@class {}", class_name).unwrap();
+                writeln!(
+                    class_output,
+                    "---@field {} {}",
+                    variant_name, data_class_name
+                )
+                .unwrap();
+                self.generated.insert(class_name.clone(), class_output);
+
+                // Inner data class
+                self.generate_named_class(&data_class_name, variant.data.fields);
+
+                class_name
+            }
+        }
+    }
+
+    fn generate_internally_tagged_enum(
+        &mut self,
+        output: &mut String,
+        shape: &'static Shape,
+        enum_type: &facet_core::EnumType,
+        tag_key: &str,
+    ) {
+        let mut variant_types = Vec::new();
+
+        for variant in enum_type.variants {
+            let vtype = self.generate_internal_variant(shape, variant, tag_key);
+            variant_types.push((vtype, variant.doc));
+        }
+
+        self.write_alias_variants(output, shape.type_identifier, &variant_types);
+    }
+
+    /// Generate a single internally-tagged variant. Returns the type reference.
+    fn generate_internal_variant(
+        &mut self,
+        parent_shape: &'static Shape,
+        variant: &facet_core::Variant,
+        tag_key: &str,
+    ) -> String {
+        let variant_name = variant.effective_name();
+        let class_name = format!("{}.{}", parent_shape.type_identifier, variant_name);
+
+        let mut class_output = String::new();
+        write_doc_comment(&mut class_output, variant.doc);
+        writeln!(class_output, "---@class {}", class_name).unwrap();
+        // Tag field with literal string type
+        writeln!(class_output, "---@field {} \"{}\"", tag_key, variant_name).unwrap();
+
+        match variant.data.kind {
+            StructKind::Unit => {
+                // Just the tag field
+            }
+            StructKind::TupleStruct if variant.data.fields.len() == 1 => {
+                // Internally-tagged newtype with struct inner: fields get flattened
+                let inner_shape = variant.data.fields[0].shape.get();
+                if let Type::User(UserType::Struct(st)) = &inner_shape.ty {
+                    for field in st.fields {
+                        if field.flags.contains(facet_core::FieldFlags::SKIP) {
+                            continue;
+                        }
+                        let (type_string, optional) = self.field_type_info(field);
+                        let name = field.effective_name();
+                        if optional {
+                            writeln!(class_output, "---@field {}? {}", name, type_string).unwrap();
+                        } else {
+                            writeln!(class_output, "---@field {} {}", name, type_string).unwrap();
+                        }
+                    }
+                }
+            }
+            _ => {
+                // Struct variant: flatten all fields alongside the tag
+                for field in variant.data.fields {
+                    if field.flags.contains(facet_core::FieldFlags::SKIP) {
+                        continue;
+                    }
+                    let (type_string, optional) = self.field_type_info(field);
+                    let name = field.effective_name();
+                    if optional {
+                        writeln!(class_output, "---@field {}? {}", name, type_string).unwrap();
+                    } else {
+                        writeln!(class_output, "---@field {} {}", name, type_string).unwrap();
+                    }
+                }
+            }
+        }
+
+        self.generated.insert(class_name.clone(), class_output);
+        class_name
+    }
+
+    fn generate_adjacently_tagged_enum(
+        &mut self,
+        output: &mut String,
+        shape: &'static Shape,
+        enum_type: &facet_core::EnumType,
+        tag_key: &str,
+        content_key: &str,
+    ) {
+        let mut variant_types = Vec::new();
+
+        for variant in enum_type.variants {
+            let vtype = self.generate_adjacent_variant(shape, variant, tag_key, content_key);
+            variant_types.push((vtype, variant.doc));
+        }
+
+        self.write_alias_variants(output, shape.type_identifier, &variant_types);
+    }
+
+    /// Generate a single adjacently-tagged variant. Returns the type reference.
+    fn generate_adjacent_variant(
+        &mut self,
+        parent_shape: &'static Shape,
+        variant: &facet_core::Variant,
+        tag_key: &str,
+        content_key: &str,
+    ) -> String {
+        let variant_name = variant.effective_name();
+        let class_name = format!("{}.{}", parent_shape.type_identifier, variant_name);
+
+        let mut class_output = String::new();
+        write_doc_comment(&mut class_output, variant.doc);
+        writeln!(class_output, "---@class {}", class_name).unwrap();
+        // Tag field with literal string type
+        writeln!(class_output, "---@field {} \"{}\"", tag_key, variant_name).unwrap();
+
+        match variant.data.kind {
+            StructKind::Unit => {
+                // Just the tag field, no content
+            }
+            StructKind::TupleStruct if variant.data.fields.len() == 1 => {
+                // Content is the single inner value
+                let inner_type = self.type_for_shape(variant.data.fields[0].shape.get());
+                writeln!(class_output, "---@field {} {}", content_key, inner_type).unwrap();
+            }
+            StructKind::TupleStruct => {
+                // Content is a tuple
+                let tuple_type = self.tuple_type_string(variant.data.fields);
+                writeln!(class_output, "---@field {} {}", content_key, tuple_type).unwrap();
+            }
+            _ => {
+                // Content is a struct — generate inner class
+                let data_class_name = format!("{}._", class_name);
+                writeln!(
+                    class_output,
+                    "---@field {} {}",
+                    content_key, data_class_name
+                )
+                .unwrap();
+                self.generate_named_class(&data_class_name, variant.data.fields);
+            }
+        }
+
+        self.generated.insert(class_name.clone(), class_output);
+        class_name
+    }
+
+    fn generate_untagged_enum(
+        &mut self,
+        output: &mut String,
+        shape: &'static Shape,
+        enum_type: &facet_core::EnumType,
+    ) {
+        let mut variant_types = Vec::new();
+
+        for variant in enum_type.variants {
+            let vtype = self.generate_untagged_variant(shape, variant);
+            variant_types.push((vtype, variant.doc));
+        }
+
+        self.write_alias_variants(output, shape.type_identifier, &variant_types);
+    }
+
+    /// Generate a single untagged variant type. Returns the type reference.
+    fn generate_untagged_variant(
+        &mut self,
+        parent_shape: &'static Shape,
+        variant: &facet_core::Variant,
+    ) -> String {
+        match variant.data.kind {
+            StructKind::Unit => "nil".to_string(),
+            StructKind::TupleStruct if variant.data.fields.len() == 1 => {
+                self.type_for_shape(variant.data.fields[0].shape.get())
+            }
+            StructKind::TupleStruct => self.tuple_type_string(variant.data.fields),
+            _ => {
+                // Struct variant: generate a class for the fields
+                let variant_name = variant.effective_name();
+                let class_name = format!("{}.{}", parent_shape.type_identifier, variant_name);
+                self.generate_named_class(&class_name, variant.data.fields);
+                class_name
+            }
+        }
+    }
+
+    /// Write a string literal alias for an all-unit enum.
+    fn write_string_literal_alias(
+        &self,
+        output: &mut String,
+        shape: &'static Shape,
+        enum_type: &facet_core::EnumType,
+    ) {
+        let has_docs = enum_type.variants.iter().any(|v| !v.doc.is_empty());
+
+        if has_docs {
+            writeln!(output, "---@alias {}", shape.type_identifier).unwrap();
+            for variant in enum_type.variants {
+                let variant_name = variant.effective_name();
+                write!(output, "---| \"{}\"", variant_name).unwrap();
+                if !variant.doc.is_empty() {
+                    let doc_text: Vec<&str> = variant.doc.iter().map(|s| s.trim()).collect();
+                    write!(output, " # {}", doc_text.join(" ")).unwrap();
+                }
+                output.push('\n');
+            }
+        } else {
+            let variants: Vec<String> = enum_type
+                .variants
+                .iter()
+                .map(|v| format!("\"{}\"", v.effective_name()))
+                .collect();
+            writeln!(
+                output,
+                "---@alias {} {}",
+                shape.type_identifier,
+                variants.join(" | ")
+            )
+            .unwrap();
+        }
+    }
+
+    /// Write an alias as a union of variant types, using multi-line form when docs are present.
+    fn write_alias_variants(
+        &self,
+        output: &mut String,
+        type_name: &str,
+        variants: &[(String, &[&str])],
+    ) {
+        let has_docs = variants.iter().any(|(_, doc)| !doc.is_empty());
+
+        if has_docs {
+            writeln!(output, "---@alias {}", type_name).unwrap();
+            for (vtype, doc) in variants {
+                write!(output, "---| {}", vtype).unwrap();
+                if !doc.is_empty() {
+                    let doc_text: Vec<&str> = doc.iter().map(|s| s.trim()).collect();
+                    write!(output, " # {}", doc_text.join(" ")).unwrap();
+                }
+                output.push('\n');
+            }
+        } else {
+            let type_strs: Vec<&str> = variants.iter().map(|(t, _)| t.as_str()).collect();
+            writeln!(output, "---@alias {} {}", type_name, type_strs.join(" | ")).unwrap();
+        }
+    }
+
+    fn type_for_shape(&mut self, shape: &'static Shape) -> String {
+        // Check Def first - these take precedence over transparent wrappers
+        match &shape.def {
+            Def::Scalar => self.scalar_type(shape),
+            Def::Option(opt) => {
+                format!("{}?", self.type_for_shape(opt.t))
+            }
+            Def::List(list) => {
+                format!("{}[]", self.type_for_shape(list.t))
+            }
+            Def::Array(arr) => {
+                format!("{}[]", self.type_for_shape(arr.t))
+            }
+            Def::Set(set) => {
+                format!("{}[]", self.type_for_shape(set.t))
+            }
+            Def::Map(map) => {
+                format!(
+                    "table<{}, {}>",
+                    self.type_for_shape(map.k),
+                    self.type_for_shape(map.v)
+                )
+            }
+            Def::Pointer(ptr) => match ptr.pointee {
+                Some(pointee) => self.type_for_shape(pointee),
+                None => "any".to_string(),
+            },
+            Def::Undefined => {
+                // User-defined types - queue for generation and return name
+                match &shape.ty {
+                    Type::User(UserType::Struct(st)) => {
+                        // Handle tuples specially - inline them
+                        if st.kind == StructKind::Tuple {
+                            if st.fields.is_empty() {
+                                "nil".to_string()
+                            } else if st.fields.len() == 1 {
+                                self.type_for_shape(st.fields[0].shape.get())
+                            } else {
+                                self.tuple_type_string(st.fields)
+                            }
+                        } else {
+                            self.add_shape(shape);
+                            shape.type_identifier.to_string()
+                        }
+                    }
+                    Type::User(UserType::Enum(_)) => {
+                        self.add_shape(shape);
+                        shape.type_identifier.to_string()
+                    }
+                    _ => self.inner_type_or_any(shape),
+                }
+            }
+            _ => self.inner_type_or_any(shape),
+        }
+    }
+
+    /// Get the inner type for transparent wrappers, or "any" as fallback.
+    fn inner_type_or_any(&mut self, shape: &'static Shape) -> String {
+        match shape.inner {
+            Some(inner) => self.type_for_shape(inner),
+            None => "any".to_string(),
+        }
+    }
+
+    /// Get the Lua type for a scalar shape.
+    fn scalar_type(&self, shape: &'static Shape) -> String {
+        match shape.type_identifier {
+            // Strings
+            "String" | "str" | "&str" | "Cow" => "string".to_string(),
+
+            // Booleans
+            "bool" => "boolean".to_string(),
+
+            // Integers
+            "u8" | "u16" | "u32" | "u64" | "u128" | "usize" | "i8" | "i16" | "i32" | "i64"
+            | "i128" | "isize" => "integer".to_string(),
+
+            // Floats
+            "f32" | "f64" => "number".to_string(),
+
+            // Char as string
+            "char" => "string".to_string(),
+
+            // Unknown scalar
+            _ => "any".to_string(),
+        }
+    }
+}
+
+/// Write a doc comment as LuaLS comment.
+fn write_doc_comment(output: &mut String, doc: &[&str]) {
+    let additional: usize = doc.iter().map(|line| 3 + line.len() + 1).sum();
+    output.reserve(additional);
+    for line in doc {
+        output.push_str("---");
+        output.push_str(line);
+        output.push('\n');
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use facet::Facet;
+
+    #[test]
+    fn test_simple_struct() {
+        #[derive(Facet)]
+        struct User {
+            name: String,
+            age: u32,
+        }
+
+        let lua = to_lua_annotations::<User>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_optional_field() {
+        #[derive(Facet)]
+        struct Config {
+            required: String,
+            optional: Option<String>,
+        }
+
+        let lua = to_lua_annotations::<Config>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_simple_enum() {
+        #[derive(Facet)]
+        #[repr(u8)]
+        enum Status {
+            Active,
+            Inactive,
+            Pending,
+        }
+
+        let lua = to_lua_annotations::<Status>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_vec() {
+        #[derive(Facet)]
+        struct Data {
+            items: Vec<String>,
+        }
+
+        let lua = to_lua_annotations::<Data>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_nested_types() {
+        #[derive(Facet)]
+        struct Inner {
+            value: i32,
+        }
+
+        #[derive(Facet)]
+        struct Outer {
+            inner: Inner,
+            name: String,
+        }
+
+        let lua = to_lua_annotations::<Outer>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_unit_struct() {
+        #[derive(Facet)]
+        struct Empty;
+
+        let lua = to_lua_annotations::<Empty>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_tuple_struct() {
+        #[derive(Facet)]
+        struct Point(f32, f64);
+
+        let lua = to_lua_annotations::<Point>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_newtype_struct() {
+        #[derive(Facet)]
+        struct UserId(u64);
+
+        let lua = to_lua_annotations::<UserId>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_hashmap() {
+        use std::collections::HashMap;
+
+        #[derive(Facet)]
+        struct Registry {
+            entries: HashMap<String, i32>,
+        }
+
+        let lua = to_lua_annotations::<Registry>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_mixed_enum_variants() {
+        #[derive(Facet)]
+        #[repr(C)]
+        #[allow(dead_code)]
+        enum Event {
+            /// Unit variant
+            Empty,
+            /// Newtype variant
+            Id(u64),
+            /// Struct variant
+            Data { name: String, value: f64 },
+        }
+
+        let lua = to_lua_annotations::<Event>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_transparent_wrapper() {
+        #[derive(Facet)]
+        #[facet(transparent)]
+        struct UserId(String);
+
+        let lua = to_lua_annotations::<UserId>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_transparent_wrapper_with_inner_type() {
+        #[derive(Facet)]
+        struct Inner {
+            value: i32,
+        }
+
+        #[derive(Facet)]
+        #[facet(transparent)]
+        struct Wrapper(Inner);
+
+        let lua = to_lua_annotations::<Wrapper>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_struct_with_tuple_field() {
+        #[derive(Facet)]
+        struct Container {
+            coordinates: (i32, i32),
+        }
+
+        let lua = to_lua_annotations::<Container>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_enum_rename_all_snake_case() {
+        #[derive(Facet)]
+        #[facet(rename_all = "snake_case")]
+        #[repr(u8)]
+        enum ValidationErrorCode {
+            CircularDependency,
+            InvalidNaming,
+            UnknownRequirement,
+        }
+
+        let lua = to_lua_annotations::<ValidationErrorCode>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_enum_struct_variant() {
+        #[derive(Facet)]
+        #[repr(C)]
+        #[allow(dead_code)]
+        enum Message {
+            TextMessage { content: String },
+            ImageUpload { url: String, width: u32 },
+        }
+
+        let lua = to_lua_annotations::<Message>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_multi_type_generation() {
+        #[derive(Facet)]
+        struct User {
+            name: String,
+            age: u32,
+        }
+
+        #[derive(Facet)]
+        #[repr(u8)]
+        enum Role {
+            Admin,
+            User,
+        }
+
+        let mut generator = LuaGenerator::new();
+        generator.add_type::<User>();
+        generator.add_type::<Role>();
+        let lua = generator.finish();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_internally_tagged_enum() {
+        #[derive(Facet)]
+        #[facet(tag = "type")]
+        #[repr(C)]
+        #[allow(dead_code)]
+        enum Request {
+            Ping,
+            Echo { message: String },
+        }
+
+        let lua = to_lua_annotations::<Request>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_adjacently_tagged_enum() {
+        #[derive(Facet)]
+        #[facet(tag = "t", content = "c")]
+        #[repr(C)]
+        #[allow(dead_code)]
+        enum Action {
+            Stop,
+            Move(f64),
+            Resize { width: u32, height: u32 },
+        }
+
+        let lua = to_lua_annotations::<Action>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_untagged_enum() {
+        #[derive(Facet)]
+        #[facet(untagged)]
+        #[repr(C)]
+        #[allow(dead_code)]
+        enum Value {
+            Text(String),
+            Number(f64),
+            Flag(bool),
+        }
+
+        let lua = to_lua_annotations::<Value>();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_enum_with_variant_docs() {
+        #[derive(Facet)]
+        #[repr(u8)]
+        enum Color {
+            /// The color red
+            Red,
+            /// The color green
+            Green,
+            /// The color blue
+            Blue,
+        }
+
+        let lua = to_lua_annotations::<Color>();
+        insta::assert_snapshot!(lua);
+    }
+}

--- a/facet-lua/src/consts.rs
+++ b/facet-lua/src/consts.rs
@@ -1,0 +1,41 @@
+//! Shared Lua syntax tokens and helpers used by both the parser and serializer.
+
+/// Lua `nil` keyword.
+pub(crate) const KW_NIL: &[u8] = b"nil";
+/// Lua `true` keyword.
+pub(crate) const KW_TRUE: &[u8] = b"true";
+/// Lua `false` keyword.
+pub(crate) const KW_FALSE: &[u8] = b"false";
+/// Lua positive infinity literal.
+pub(crate) const MATH_HUGE: &[u8] = b"math.huge";
+/// Lua NaN literal (`0/0`).
+pub(crate) const NAN_LITERAL: &[u8] = b"0/0";
+
+/// Lua reserved keywords, sorted alphabetically for binary search.
+pub(crate) const LUA_KEYWORDS: &[&str] = &[
+    "and", "break", "do", "else", "elseif", "end", "false", "for", "function", "goto", "if", "in",
+    "local", "nil", "not", "or", "repeat", "return", "then", "true", "until", "while",
+];
+
+/// Check if a string is a Lua reserved keyword.
+pub(crate) fn is_lua_keyword(name: &str) -> bool {
+    LUA_KEYWORDS.binary_search(&name).is_ok()
+}
+
+/// Check if a string is a valid Lua identifier (alphanumeric/underscore, not a keyword).
+pub(crate) fn is_lua_identifier(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    let mut chars = s.chars();
+    let first = chars.next().unwrap();
+    if !first.is_ascii_alphabetic() && first != '_' {
+        return false;
+    }
+    for c in chars {
+        if !c.is_ascii_alphanumeric() && c != '_' {
+            return false;
+        }
+    }
+    !is_lua_keyword(s)
+}

--- a/facet-lua/src/lib.rs
+++ b/facet-lua/src/lib.rs
@@ -1,0 +1,1637 @@
+//! Generate LuaLS type annotations, serialize values to Lua table syntax,
+//! and parse Lua table syntax back into Rust values.
+//!
+//! This crate provides three complementary features:
+//! - **Annotations**: Generate LuaLS `---@class` / `---@alias` annotations from type metadata
+//! - **Serialization**: Serialize Rust values to Lua table constructor syntax
+//! - **Deserialization**: Parse Lua table constructor syntax back into Rust values
+//!
+//! # Example
+//!
+//! ```
+//! use facet::Facet;
+//! use facet_lua::{to_lua_annotations, to_string_pretty, to_lua_annotated, from_str};
+//!
+//! #[derive(Facet, Debug, PartialEq)]
+//! struct User {
+//!     name: String,
+//!     age: u32,
+//! }
+//!
+//! // Generate just the annotations
+//! let annotations = to_lua_annotations::<User>();
+//! assert!(annotations.contains("---@class User"));
+//!
+//! // Serialize a value
+//! let user = User { name: "Alice".into(), age: 30 };
+//! let lua = to_string_pretty(&user).unwrap();
+//! assert!(lua.contains("name"));
+//!
+//! // Parse it back
+//! let parsed: User = from_str(&lua).unwrap();
+//! assert_eq!(parsed.name, "Alice");
+//! assert_eq!(parsed.age, 30);
+//!
+//! // Combined: annotations + typed local variable
+//! let annotated = to_lua_annotated(&user, "user").unwrap();
+//! assert!(annotated.contains("---@class User"));
+//! assert!(annotated.contains("---@type User"));
+//! assert!(annotated.contains("local user ="));
+//! ```
+//!
+//! # Lua syntax coverage
+//!
+//! The parser accepts a broad subset of Lua table syntax:
+//! - Table constructors with `,` or `;` separators
+//! - Bare identifier keys, bracket keys (`["key"]`), and long-bracket keys
+//! - Double-quoted, single-quoted, and long-bracket strings (`[[...]]`, `[=[...]=]`)
+//! - All standard string escapes: `\n`, `\t`, `\r`, `\a`, `\b`, `\f`, `\v`, `\\`, `\"`, `\'`
+//! - Extended escapes: `\xNN` (hex), `\u{XXXX}` (Unicode), `\z` (whitespace skip), `\ddd` (decimal)
+//! - Decimal and hex integer literals (`0xFF`)
+//! - Decimal floats with scientific notation (`1.5e3`) and hex floats (`0x1.8p1`)
+//! - Special floats: `math.huge`, `-math.huge`, `0/0`
+//! - Line comments (`--`) and block comments (`--[[ ]]`, `--[=[ ]=]`)
+//! - Function values are skipped (deserialized as `nil`)
+
+// Note: unsafe code is used for lifetime transmutes in from_str_into
+// when BORROW=false, mirroring the approach used in facet-json.
+
+extern crate alloc;
+
+mod annotations;
+pub(crate) mod consts;
+mod parser;
+pub(crate) mod scanner;
+mod serializer;
+
+pub use annotations::{LuaGenerator, to_lua_annotations};
+pub use parser::LuaParser;
+pub use serializer::{
+    LuaSerializeError, LuaSerializer, SerializeOptions, to_string, to_string_pretty,
+    to_string_with_options, to_vec, to_vec_pretty, to_vec_with_options, to_writer_std,
+    to_writer_std_pretty, to_writer_std_with_options,
+};
+
+use facet_reflect::Partial;
+
+// Re-export DeserializeError for convenience
+pub use facet_format::DeserializeError;
+
+/// Convert a UTF-8 validation error into a `DeserializeError` with context.
+fn utf8_parse_error(input: &[u8], e: core::str::Utf8Error) -> DeserializeError {
+    let mut context = [0u8; 16];
+    let context_len = e.valid_up_to().min(16);
+    context[..context_len].copy_from_slice(&input[..context_len]);
+    facet_format::DeserializeErrorKind::InvalidUtf8 {
+        context,
+        context_len: context_len as u8,
+    }
+    .with_span(facet_reflect::Span::new(e.valid_up_to(), 1))
+}
+
+/// Deserialize a value from a Lua table string into an owned type.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_lua::from_str;
+///
+/// #[derive(Facet, Debug, PartialEq)]
+/// struct User {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// let lua = r#"{name = "Alice", age = 30}"#;
+/// let user: User = from_str(lua).unwrap();
+/// assert_eq!(user.name, "Alice");
+/// assert_eq!(user.age, 30);
+/// ```
+pub fn from_str<T>(input: &str) -> Result<T, DeserializeError>
+where
+    T: facet_core::Facet<'static>,
+{
+    use facet_format::FormatDeserializer;
+    let mut parser = LuaParser::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
+    de.deserialize_root()
+}
+
+/// Deserialize a value from Lua table bytes into an owned type.
+///
+/// # Errors
+///
+/// Returns an error if the input is not valid UTF-8 or if deserialization fails.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_lua::from_slice;
+///
+/// #[derive(Facet, Debug, PartialEq)]
+/// struct User {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// let lua = b"{name = \"Alice\", age = 30}";
+/// let user: User = from_slice(lua).unwrap();
+/// assert_eq!(user.name, "Alice");
+/// assert_eq!(user.age, 30);
+/// ```
+pub fn from_slice<T>(input: &[u8]) -> Result<T, DeserializeError>
+where
+    T: facet_core::Facet<'static>,
+{
+    let s = core::str::from_utf8(input).map_err(|e| utf8_parse_error(input, e))?;
+    from_str(s)
+}
+
+/// Deserialize a value from a Lua table string, allowing zero-copy borrowing.
+///
+/// This variant requires the input to outlive the result (`'input: 'facet`),
+/// enabling zero-copy deserialization of string fields as `&str` or `Cow<str>`.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_lua::from_str_borrowed;
+///
+/// #[derive(Facet, Debug, PartialEq)]
+/// struct Person<'a> {
+///     name: &'a str,
+///     age: u32,
+/// }
+///
+/// let lua = r#"{name = "Alice", age = 30}"#;
+/// let person: Person = from_str_borrowed(lua).unwrap();
+/// assert_eq!(person.name, "Alice");
+/// assert_eq!(person.age, 30);
+/// ```
+pub fn from_str_borrowed<'input, 'facet, T>(input: &'input str) -> Result<T, DeserializeError>
+where
+    T: facet_core::Facet<'facet>,
+    'input: 'facet,
+{
+    use facet_format::FormatDeserializer;
+    let mut parser = LuaParser::new(input);
+    let mut de = FormatDeserializer::new(&mut parser);
+    de.deserialize_root()
+}
+
+/// Deserialize a value from Lua table bytes, allowing zero-copy borrowing.
+///
+/// This variant requires the input to outlive the result (`'input: 'facet`),
+/// enabling zero-copy deserialization of string fields as `&str` or `Cow<str>`.
+///
+/// # Errors
+///
+/// Returns an error if the input is not valid UTF-8 or if deserialization fails.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_lua::from_slice_borrowed;
+///
+/// #[derive(Facet, Debug, PartialEq)]
+/// struct Person<'a> {
+///     name: &'a str,
+///     age: u32,
+/// }
+///
+/// let lua = b"{name = \"Alice\", age = 30}";
+/// let person: Person = from_slice_borrowed(lua).unwrap();
+/// assert_eq!(person.name, "Alice");
+/// assert_eq!(person.age, 30);
+/// ```
+pub fn from_slice_borrowed<'input, 'facet, T>(input: &'input [u8]) -> Result<T, DeserializeError>
+where
+    T: facet_core::Facet<'facet>,
+    'input: 'facet,
+{
+    let s = core::str::from_utf8(input).map_err(|e| utf8_parse_error(input, e))?;
+    from_str_borrowed(s)
+}
+
+/// Deserialize Lua from a string into an existing Partial.
+///
+/// This is useful for reflection-based deserialization where you don't have
+/// a concrete type `T` at compile time, only its Shape metadata. The Partial
+/// must already be allocated for the target type.
+///
+/// This version produces owned strings (no borrowing from input).
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_lua::from_str_into;
+/// use facet_reflect::Partial;
+///
+/// #[derive(Facet, Debug, PartialEq)]
+/// struct User {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// let lua = r#"{name = "Alice", age = 30}"#;
+/// let partial = Partial::alloc_owned::<User>().unwrap();
+/// let partial = from_str_into(lua, partial).unwrap();
+/// let value = partial.build().unwrap();
+/// let user: User = value.materialize().unwrap();
+/// assert_eq!(user.name, "Alice");
+/// assert_eq!(user.age, 30);
+/// ```
+pub fn from_str_into<'facet>(
+    input: &str,
+    partial: Partial<'facet, false>,
+) -> Result<Partial<'facet, false>, DeserializeError> {
+    use facet_format::{FormatDeserializer, MetaSource};
+    let mut parser = LuaParser::new(input);
+    let mut de = FormatDeserializer::new_owned(&mut parser);
+
+    // SAFETY: The deserializer expects Partial<'input, false> where 'input is the
+    // lifetime of the Lua bytes. Since BORROW=false, no data is borrowed from the
+    // input, so the actual 'facet lifetime of the Partial is independent of 'input.
+    // We transmute to satisfy the type system, then transmute back after deserialization.
+    #[allow(unsafe_code)]
+    let partial: Partial<'_, false> =
+        unsafe { core::mem::transmute::<Partial<'facet, false>, Partial<'_, false>>(partial) };
+
+    let partial = de.deserialize_into(partial, MetaSource::FromEvents)?;
+
+    // SAFETY: Same reasoning - no borrowed data since BORROW=false.
+    #[allow(unsafe_code)]
+    let partial: Partial<'facet, false> =
+        unsafe { core::mem::transmute::<Partial<'_, false>, Partial<'facet, false>>(partial) };
+
+    Ok(partial)
+}
+
+/// Deserialize Lua from bytes into an existing Partial.
+///
+/// This is useful for reflection-based deserialization where you don't have
+/// a concrete type `T` at compile time, only its Shape metadata.
+///
+/// This version produces owned strings (no borrowing from input).
+///
+/// # Errors
+///
+/// Returns an error if the input is not valid UTF-8 or if deserialization fails.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_lua::from_slice_into;
+/// use facet_reflect::Partial;
+///
+/// #[derive(Facet, Debug, PartialEq)]
+/// struct User {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// let lua = b"{name = \"Alice\", age = 30}";
+/// let partial = Partial::alloc_owned::<User>().unwrap();
+/// let partial = from_slice_into(lua, partial).unwrap();
+/// let value = partial.build().unwrap();
+/// let user: User = value.materialize().unwrap();
+/// assert_eq!(user.name, "Alice");
+/// assert_eq!(user.age, 30);
+/// ```
+pub fn from_slice_into<'facet>(
+    input: &[u8],
+    partial: Partial<'facet, false>,
+) -> Result<Partial<'facet, false>, DeserializeError> {
+    let s = core::str::from_utf8(input).map_err(|e| utf8_parse_error(input, e))?;
+    from_str_into(s, partial)
+}
+
+/// Deserialize Lua from a string into an existing Partial, allowing zero-copy borrowing.
+///
+/// This variant requires the input to outlive the Partial's lifetime (`'input: 'facet`),
+/// enabling zero-copy deserialization of string fields as `&str` or `Cow<str>`.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_lua::from_str_into_borrowed;
+/// use facet_reflect::Partial;
+///
+/// #[derive(Facet, Debug, PartialEq)]
+/// struct Person<'a> {
+///     name: &'a str,
+///     age: u32,
+/// }
+///
+/// let lua = r#"{name = "Alice", age = 30}"#;
+/// let partial = Partial::alloc::<Person>().unwrap();
+/// let partial = from_str_into_borrowed(lua, partial).unwrap();
+/// let value = partial.build().unwrap();
+/// let person: Person = value.materialize().unwrap();
+/// assert_eq!(person.name, "Alice");
+/// assert_eq!(person.age, 30);
+/// ```
+pub fn from_str_into_borrowed<'input, 'facet>(
+    input: &'input str,
+    partial: Partial<'facet, true>,
+) -> Result<Partial<'facet, true>, DeserializeError>
+where
+    'input: 'facet,
+{
+    use facet_format::{FormatDeserializer, MetaSource};
+    let mut parser = LuaParser::new(input);
+    let mut de = FormatDeserializer::new(&mut parser);
+    de.deserialize_into(partial, MetaSource::FromEvents)
+}
+
+/// Deserialize Lua from bytes into an existing Partial, allowing zero-copy borrowing.
+///
+/// This variant requires the input to outlive the Partial's lifetime (`'input: 'facet`),
+/// enabling zero-copy deserialization of string fields as `&str` or `Cow<str>`.
+///
+/// # Errors
+///
+/// Returns an error if the input is not valid UTF-8 or if deserialization fails.
+///
+/// # Example
+///
+/// ```
+/// use facet::Facet;
+/// use facet_lua::from_slice_into_borrowed;
+/// use facet_reflect::Partial;
+///
+/// #[derive(Facet, Debug, PartialEq)]
+/// struct Person<'a> {
+///     name: &'a str,
+///     age: u32,
+/// }
+///
+/// let lua = b"{name = \"Alice\", age = 30}";
+/// let partial = Partial::alloc::<Person>().unwrap();
+/// let partial = from_slice_into_borrowed(lua, partial).unwrap();
+/// let value = partial.build().unwrap();
+/// let person: Person = value.materialize().unwrap();
+/// assert_eq!(person.name, "Alice");
+/// assert_eq!(person.age, 30);
+/// ```
+pub fn from_slice_into_borrowed<'input, 'facet>(
+    input: &'input [u8],
+    partial: Partial<'facet, true>,
+) -> Result<Partial<'facet, true>, DeserializeError>
+where
+    'input: 'facet,
+{
+    let s = core::str::from_utf8(input).map_err(|e| utf8_parse_error(input, e))?;
+    from_str_into_borrowed(s, partial)
+}
+
+/// Generate LuaLS annotations followed by a typed local variable with the serialized value.
+///
+/// Output format:
+/// ```lua
+/// ---@class MyType
+/// ---@field name string
+///
+/// ---@type MyType
+/// local var_name = {
+///     name = "value",
+/// }
+/// ```
+pub fn to_lua_annotated<T>(
+    value: &T,
+    var_name: &str,
+) -> Result<String, facet_format::SerializeError<LuaSerializeError>>
+where
+    T: facet_core::Facet<'static>,
+{
+    let annotations = to_lua_annotations::<T>();
+    let serialized = to_string_pretty(value)?;
+
+    let type_identifier = T::SHAPE.type_identifier;
+    let mut output = String::new();
+    output.push_str("---@meta\n\n");
+    output.push_str(&annotations);
+    output.push('\n');
+    use core::fmt::Write;
+    writeln!(output, "---@type {}", type_identifier).unwrap();
+    writeln!(output, "local {} = {}", var_name, serialized).unwrap();
+    Ok(output)
+}
+
+#[cfg(test)]
+mod parser_tests {
+    use super::*;
+    use facet::Facet;
+    use std::collections::BTreeMap;
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct User {
+        name: String,
+        age: u32,
+    }
+
+    #[test]
+    fn test_roundtrip_simple_struct() {
+        let user = User {
+            name: "Alice".to_string(),
+            age: 30,
+        };
+        let lua = to_string(&user).unwrap();
+        let parsed: User = from_str(&lua).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_roundtrip_pretty_struct() {
+        let user = User {
+            name: "Alice".to_string(),
+            age: 30,
+        };
+        let lua = to_string_pretty(&user).unwrap();
+        let parsed: User = from_str(&lua).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_parse_struct_from_string() {
+        let parsed: User = from_str(r#"{name = "Alice", age = 30}"#).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_parse_vec_string() {
+        let parsed: Vec<String> = from_str(r#"{"a", "b", "c"}"#).unwrap();
+        assert_eq!(parsed, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_parse_vec_int() {
+        let parsed: Vec<i32> = from_str(r#"{1, 2, 3}"#).unwrap();
+        assert_eq!(parsed, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_roundtrip_nested_struct() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Inner {
+            value: i32,
+        }
+        #[derive(Facet, Debug, PartialEq)]
+        struct Outer {
+            inner: Inner,
+            name: String,
+        }
+
+        let outer = Outer {
+            inner: Inner { value: 42 },
+            name: "test".to_string(),
+        };
+        let lua = to_string_pretty(&outer).unwrap();
+        let parsed: Outer = from_str(&lua).unwrap();
+        assert_eq!(parsed.inner.value, 42);
+        assert_eq!(parsed.name, "test");
+    }
+
+    #[test]
+    fn test_roundtrip_optional_none() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Config {
+            required: String,
+            optional: Option<String>,
+        }
+
+        let config = Config {
+            required: "yes".to_string(),
+            optional: None,
+        };
+        let lua = to_string_pretty(&config).unwrap();
+        let parsed: Config = from_str(&lua).unwrap();
+        assert_eq!(parsed.required, "yes");
+        assert_eq!(parsed.optional, None);
+    }
+
+    #[test]
+    fn test_roundtrip_optional_some() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Config {
+            required: String,
+            optional: Option<String>,
+        }
+
+        let config = Config {
+            required: "yes".to_string(),
+            optional: Some("value".to_string()),
+        };
+        let lua = to_string_pretty(&config).unwrap();
+        let parsed: Config = from_str(&lua).unwrap();
+        assert_eq!(parsed.required, "yes");
+        assert_eq!(parsed.optional, Some("value".to_string()));
+    }
+
+    #[test]
+    fn test_parse_special_floats() {
+        #[derive(Facet, Debug)]
+        struct Floats {
+            pos_inf: f64,
+            neg_inf: f64,
+            nan: f64,
+        }
+
+        let lua = r#"{pos_inf = math.huge, neg_inf = -math.huge, nan = 0/0}"#;
+        let parsed: Floats = from_str(lua).unwrap();
+        assert!(parsed.pos_inf.is_infinite() && parsed.pos_inf.is_sign_positive());
+        assert!(parsed.neg_inf.is_infinite() && parsed.neg_inf.is_sign_negative());
+        assert!(parsed.nan.is_nan());
+    }
+
+    #[test]
+    fn test_roundtrip_special_floats() {
+        #[derive(Facet, Debug)]
+        struct Floats {
+            pos_inf: f64,
+            neg_inf: f64,
+            nan: f64,
+        }
+
+        let floats = Floats {
+            pos_inf: f64::INFINITY,
+            neg_inf: f64::NEG_INFINITY,
+            nan: f64::NAN,
+        };
+        let lua = to_string(&floats).unwrap();
+        let parsed: Floats = from_str(&lua).unwrap();
+        assert!(parsed.pos_inf.is_infinite() && parsed.pos_inf.is_sign_positive());
+        assert!(parsed.neg_inf.is_infinite() && parsed.neg_inf.is_sign_negative());
+        assert!(parsed.nan.is_nan());
+    }
+
+    #[test]
+    fn test_roundtrip_btreemap() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Registry {
+            entries: BTreeMap<String, i32>,
+        }
+
+        let mut entries = BTreeMap::new();
+        entries.insert("alpha".to_string(), 1);
+        entries.insert("beta".to_string(), 2);
+
+        let registry = Registry { entries };
+        let lua = to_string_pretty(&registry).unwrap();
+        let parsed: Registry = from_str(&lua).unwrap();
+        assert_eq!(parsed.entries.get("alpha"), Some(&1));
+        assert_eq!(parsed.entries.get("beta"), Some(&2));
+    }
+
+    #[test]
+    fn test_roundtrip_enum_unit_variant() {
+        #[derive(Facet, Debug, PartialEq)]
+        #[repr(u8)]
+        enum Status {
+            Active,
+            #[allow(dead_code)]
+            Inactive,
+        }
+
+        let status = Status::Active;
+        let lua = to_string(&status).unwrap();
+        let parsed: Status = from_str(&lua).unwrap();
+        assert_eq!(parsed, Status::Active);
+    }
+
+    #[test]
+    fn test_roundtrip_booleans() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Flags {
+            a: bool,
+            b: bool,
+        }
+
+        let flags = Flags { a: true, b: false };
+        let lua = to_string(&flags).unwrap();
+        let parsed: Flags = from_str(&lua).unwrap();
+        assert_eq!(parsed, flags);
+    }
+
+    #[test]
+    fn test_roundtrip_string_escapes() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Text {
+            content: String,
+        }
+
+        let text = Text {
+            content: "hello \"world\"\nnew\tline\\backslash".to_string(),
+        };
+        let lua = to_string(&text).unwrap();
+        let parsed: Text = from_str(&lua).unwrap();
+        assert_eq!(parsed.content, text.content);
+    }
+
+    #[test]
+    fn test_roundtrip_struct_with_vec() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Data {
+            items: Vec<String>,
+        }
+
+        let data = Data {
+            items: vec!["hello".to_string(), "world".to_string()],
+        };
+        let lua = to_string_pretty(&data).unwrap();
+        let parsed: Data = from_str(&lua).unwrap();
+        assert_eq!(parsed.items, data.items);
+    }
+
+    #[test]
+    fn test_parse_empty_table_as_struct() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Empty {}
+
+        let parsed: Empty = from_str("{}").unwrap();
+        let _ = parsed;
+    }
+
+    #[test]
+    fn test_parse_trailing_comma() {
+        let parsed: User = from_str(r#"{name = "Alice", age = 30,}"#).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_parse_negative_integer() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: i32,
+        }
+        let parsed: Val = from_str("{x = -42}").unwrap();
+        assert_eq!(parsed.x, -42);
+    }
+
+    #[test]
+    fn test_parse_float() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: f64,
+        }
+        let parsed: Val = from_str("{x = 3.125}").unwrap();
+        assert!((parsed.x - 3.125).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_zero() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: i32,
+            y: f64,
+        }
+        let parsed: Val = from_str("{x = 0, y = 0.0}").unwrap();
+        assert_eq!(parsed.x, 0);
+        assert_eq!(parsed.y, 0.0);
+    }
+
+    #[test]
+    fn test_parse_zero_in_seq() {
+        let parsed: Vec<i32> = from_str("{0, 1, 0}").unwrap();
+        assert_eq!(parsed, vec![0, 1, 0]);
+    }
+
+    #[test]
+    fn test_parse_bracket_key() {
+        let parsed: BTreeMap<String, i32> =
+            from_str(r#"{["hello world"] = 1, ["foo bar"] = 2}"#).unwrap();
+        assert_eq!(parsed.get("hello world"), Some(&1));
+        assert_eq!(parsed.get("foo bar"), Some(&2));
+    }
+
+    #[test]
+    fn test_error_unterminated_string() {
+        let result = from_str::<User>(r#"{name = "Alice}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_error_missing_closing_brace() {
+        let result = from_str::<User>(r#"{name = "Alice", age = 30"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_slice() {
+        let lua = b"{name = \"Alice\", age = 30}";
+        let user: User = from_slice(lua).unwrap();
+        assert_eq!(user.name, "Alice");
+        assert_eq!(user.age, 30);
+    }
+
+    #[test]
+    fn test_from_slice_invalid_utf8() {
+        let bad = b"{name = \xff}";
+        let result = from_slice::<User>(bad);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_single_quoted_string() {
+        let parsed: User = from_str("{name = 'Alice', age = 30}").unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_parse_single_quoted_with_escape() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Text {
+            content: String,
+        }
+        let parsed: Text = from_str(r#"{content = 'it\'s a test'}"#).unwrap();
+        assert_eq!(parsed.content, "it's a test");
+    }
+
+    #[test]
+    fn test_parse_with_line_comment() {
+        let lua = r#"{
+            -- this is a comment
+            name = "Alice", -- inline comment
+            age = 30
+        }"#;
+        let parsed: User = from_str(lua).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_parse_with_block_comment() {
+        let lua = r#"{
+            --[[ this is a
+            block comment ]]
+            name = "Alice",
+            age = 30
+        }"#;
+        let parsed: User = from_str(lua).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_parse_long_string() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Text {
+            content: String,
+        }
+        let parsed: Text = from_str("{content = [[hello world]]}").unwrap();
+        assert_eq!(parsed.content, "hello world");
+    }
+
+    #[test]
+    fn test_parse_long_string_with_level() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Text {
+            content: String,
+        }
+        let parsed: Text = from_str("{content = [==[contains ]] and [[ brackets]==]}").unwrap();
+        assert_eq!(parsed.content, "contains ]] and [[ brackets");
+    }
+
+    #[test]
+    fn test_parse_long_string_strips_leading_newline() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Text {
+            content: String,
+        }
+        let parsed: Text = from_str("{content = [[\nhello]]}").unwrap();
+        assert_eq!(parsed.content, "hello");
+    }
+
+    #[test]
+    fn test_parse_long_string_in_sequence() {
+        let parsed: Vec<String> = from_str("{[[first]], [[second]]}").unwrap();
+        assert_eq!(parsed, vec!["first", "second"]);
+    }
+
+    #[test]
+    fn test_parse_leveled_block_comment() {
+        let lua = r#"{
+            --[=[ this contains ]] and [[ ]=]
+            name = "Alice",
+            age = 30
+        }"#;
+        let parsed: User = from_str(lua).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_parse_escape_bell_backspace_formfeed_vtab() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Text {
+            content: String,
+        }
+        let parsed: Text = from_str(r#"{content = "\a\b\f\v"}"#).unwrap();
+        assert_eq!(parsed.content, "\x07\x08\x0C\x0B");
+    }
+
+    #[test]
+    fn test_parse_unicode_escape() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Text {
+            content: String,
+        }
+        let parsed: Text = from_str(r#"{content = "\u{48}\u{65}\u{6C}\u{6C}\u{6F}"}"#).unwrap();
+        assert_eq!(parsed.content, "Hello");
+    }
+
+    #[test]
+    fn test_parse_unicode_escape_emoji() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Text {
+            content: String,
+        }
+        let parsed: Text = from_str(r#"{content = "\u{1F980}"}"#).unwrap();
+        assert_eq!(parsed.content, "🦀");
+    }
+
+    #[test]
+    fn test_parse_z_escape() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Text {
+            content: String,
+        }
+        let lua = "{content = \"hello\\z\n    world\"}";
+        let parsed: Text = from_str(lua).unwrap();
+        assert_eq!(parsed.content, "helloworld");
+    }
+
+    #[test]
+    fn test_skip_function_value() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Config {
+            name: String,
+            callback: Option<String>,
+        }
+        let lua = r#"{
+            name = "test",
+            callback = function(x) return x + 1 end
+        }"#;
+        let parsed: Config = from_str(lua).unwrap();
+        assert_eq!(parsed.name, "test");
+        assert_eq!(parsed.callback, None);
+    }
+
+    #[test]
+    fn test_skip_nested_function() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Config {
+            name: String,
+            handler: Option<String>,
+        }
+        let lua = r#"{
+            name = "test",
+            handler = function()
+                local inner = function() return 1 end
+                if true then
+                    for i = 1, 10 do
+                        print(i)
+                    end
+                end
+                return inner()
+            end
+        }"#;
+        let parsed: Config = from_str(lua).unwrap();
+        assert_eq!(parsed.name, "test");
+        assert_eq!(parsed.handler, None);
+    }
+
+    #[test]
+    fn test_parse_semicolon_separator_struct() {
+        let parsed: User = from_str(r#"{name = "Alice"; age = 30}"#).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_parse_semicolon_separator_seq() {
+        let parsed: Vec<i32> = from_str("{1; 2; 3}").unwrap();
+        assert_eq!(parsed, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_parse_mixed_separators() {
+        let parsed: User = from_str(r#"{name = "Alice", age = 30; }"#).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_parse_hex_integer() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: u32,
+        }
+        let parsed: Val = from_str("{x = 0xFF}").unwrap();
+        assert_eq!(parsed.x, 255);
+    }
+
+    #[test]
+    fn test_parse_hex_integer_uppercase() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: u32,
+        }
+        let parsed: Val = from_str("{x = 0X1A}").unwrap();
+        assert_eq!(parsed.x, 26);
+    }
+
+    #[test]
+    fn test_parse_negative_hex() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: i32,
+        }
+        let parsed: Val = from_str("{x = -0x10}").unwrap();
+        assert_eq!(parsed.x, -16);
+    }
+
+    #[test]
+    fn test_parse_negative_hex_i64_min() {
+        // -0x8000000000000000 == i64::MIN — tests the overflow edge case
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: i64,
+        }
+        let parsed: Val = from_str("{x = -0x8000000000000000}").unwrap();
+        assert_eq!(parsed.x, i64::MIN);
+    }
+
+    #[test]
+    fn test_parse_negative_hex_large() {
+        // -0xFFFFFFFFFFFFFFFF is too large for i64, should promote to i128
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: i128,
+        }
+        let parsed: Val = from_str("{x = -0xFFFFFFFFFFFFFFFF}").unwrap();
+        assert_eq!(parsed.x, -(0xFFFFFFFFFFFFFFFFi128));
+    }
+
+    #[test]
+    fn test_parse_hex_float() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: f64,
+        }
+        // 0x1.8p1 = 1.5 * 2^1 = 3.0
+        let parsed: Val = from_str("{x = 0x1.8p1}").unwrap();
+        assert_eq!(parsed.x, 3.0);
+    }
+
+    #[test]
+    fn test_parse_hex_float_no_frac() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: f64,
+        }
+        // 0xAp2 = 10 * 2^2 = 40.0
+        let parsed: Val = from_str("{x = 0xAp2}").unwrap();
+        assert_eq!(parsed.x, 40.0);
+    }
+
+    #[test]
+    fn test_parse_hex_float_negative_exp() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: f64,
+        }
+        // 0x1p-2 = 1 * 2^-2 = 0.25
+        let parsed: Val = from_str("{x = 0x1p-2}").unwrap();
+        assert_eq!(parsed.x, 0.25);
+    }
+
+    #[test]
+    fn test_parse_negative_hex_float() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: f64,
+        }
+        // -0x1.8p1 = -3.0
+        let parsed: Val = from_str("{x = -0x1.8p1}").unwrap();
+        assert_eq!(parsed.x, -3.0);
+    }
+
+    #[test]
+    fn test_parse_hex_float_dot_only() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Val {
+            x: f64,
+        }
+        // 0x1.8 = 1.5 (no exponent, implicit p0)
+        let parsed: Val = from_str("{x = 0x1.8}").unwrap();
+        assert_eq!(parsed.x, 1.5);
+    }
+
+    #[test]
+    fn test_parse_hex_escape_in_string() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Text {
+            content: String,
+        }
+        let parsed: Text = from_str(r#"{content = "\x48\x65\x6C\x6Co"}"#).unwrap();
+        assert_eq!(parsed.content, "Hello");
+    }
+
+    #[test]
+    fn test_parse_hex_escape_control_char() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Text {
+            content: String,
+        }
+        let parsed: Text = from_str(r#"{content = "tab\x09here"}"#).unwrap();
+        assert_eq!(parsed.content, "tab\there");
+    }
+
+    #[test]
+    fn test_skip_function_with_strings() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Config {
+            name: String,
+            init: Option<String>,
+        }
+        let lua = r#"{
+            name = "test",
+            init = function()
+                local s = "contains end keyword"
+                return s
+            end
+        }"#;
+        let parsed: Config = from_str(lua).unwrap();
+        assert_eq!(parsed.name, "test");
+        assert_eq!(parsed.init, None);
+    }
+
+    #[test]
+    fn test_skip_function_among_other_fields() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Config {
+            name: String,
+            on_click: Option<String>,
+            enabled: bool,
+        }
+        let lua = r#"{
+            name = "button",
+            on_click = function(self) self:activate() end,
+            enabled = true
+        }"#;
+        let parsed: Config = from_str(lua).unwrap();
+        assert_eq!(parsed.name, "button");
+        assert_eq!(parsed.on_click, None);
+        assert_eq!(parsed.enabled, true);
+    }
+
+    #[test]
+    fn test_skip_function_in_sequence() {
+        let lua = r#"{"hello", function() end, "world"}"#;
+        let parsed: Vec<Option<String>> = from_str(lua).unwrap();
+        assert_eq!(
+            parsed,
+            vec![Some("hello".to_string()), None, Some("world".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_roundtrip_with_function_field() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Config {
+            name: String,
+            hook: Option<String>,
+        }
+        // Parse Lua with function → hook becomes None
+        let lua = r#"{name = "test", hook = function() return 1 end}"#;
+        let parsed: Config = from_str(lua).unwrap();
+        assert_eq!(parsed.hook, None);
+
+        // Serialize back → hook is omitted (no function in output)
+        let serialized = to_string(&parsed).unwrap();
+        assert!(!serialized.contains("function"));
+        assert!(serialized.contains("name"));
+
+        // Re-parse the serialized output
+        let reparsed: Config = from_str(&serialized).unwrap();
+        assert_eq!(reparsed, parsed);
+    }
+
+    // ── Number edge cases ──────────────────────────────────────────
+
+    #[test]
+    fn test_parse_i64_min() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct S {
+            x: i64,
+        }
+        let s: S = from_str("{x = -9223372036854775808}").unwrap();
+        assert_eq!(s.x, i64::MIN);
+    }
+
+    #[test]
+    fn test_parse_u64_max() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct S {
+            x: u64,
+        }
+        let s: S = from_str("{x = 18446744073709551615}").unwrap();
+        assert_eq!(s.x, u64::MAX);
+    }
+
+    #[test]
+    fn test_parse_negative_zero() {
+        #[derive(Facet, Debug)]
+        struct S {
+            x: f64,
+        }
+        let s: S = from_str("{x = -0.0}").unwrap();
+        assert!(s.x.is_sign_negative());
+        assert_eq!(s.x, 0.0);
+    }
+
+    #[test]
+    fn test_parse_scientific_notation() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct S {
+            a: f64,
+            b: f64,
+            c: f64,
+        }
+        let s: S = from_str("{a = 1e10, b = 1.5e-3, c = 1E+5}").unwrap();
+        assert_eq!(s.a, 1e10);
+        assert_eq!(s.b, 1.5e-3);
+        assert_eq!(s.c, 1E+5);
+    }
+
+    #[test]
+    fn test_roundtrip_large_integers() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Signed {
+            x: i64,
+        }
+        #[derive(Facet, Debug, PartialEq)]
+        struct Unsigned {
+            x: u64,
+        }
+        let orig_signed = Signed { x: i64::MIN };
+        let lua = to_string(&orig_signed).unwrap();
+        let parsed: Signed = from_str(&lua).unwrap();
+        assert_eq!(parsed, orig_signed);
+
+        let orig_unsigned = Unsigned { x: u64::MAX };
+        let lua = to_string(&orig_unsigned).unwrap();
+        let parsed: Unsigned = from_str(&lua).unwrap();
+        assert_eq!(parsed, orig_unsigned);
+    }
+
+    #[test]
+    fn test_roundtrip_scientific_notation_float() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct S {
+            x: f64,
+        }
+        let orig = S { x: 1e10_f64 };
+        let lua = to_string(&orig).unwrap();
+        let parsed: S = from_str(&lua).unwrap();
+        assert_eq!(parsed, orig);
+    }
+
+    // ── String edge cases ──────────────────────────────────────────
+
+    #[test]
+    fn test_parse_empty_string() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct S {
+            name: String,
+        }
+        let s: S = from_str(r#"{name = ""}"#).unwrap();
+        assert_eq!(s.name, "");
+    }
+
+    #[test]
+    fn test_roundtrip_empty_string() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct S {
+            name: String,
+        }
+        let orig = S {
+            name: String::new(),
+        };
+        let lua = to_string(&orig).unwrap();
+        let parsed: S = from_str(&lua).unwrap();
+        assert_eq!(parsed, orig);
+    }
+
+    #[test]
+    fn test_parse_decimal_escape() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct S {
+            content: String,
+        }
+        let s: S = from_str(r#"{content = "\065\066\067"}"#).unwrap();
+        assert_eq!(s.content, "ABC");
+    }
+
+    #[test]
+    fn test_roundtrip_null_byte() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct S {
+            content: String,
+        }
+        let orig = S {
+            content: String::from("hello\0world"),
+        };
+        let lua = to_string(&orig).unwrap();
+        let parsed: S = from_str(&lua).unwrap();
+        assert_eq!(parsed, orig);
+    }
+
+    #[test]
+    fn test_roundtrip_control_chars() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct S {
+            content: String,
+        }
+        let orig = S {
+            content: String::from("\x01\x02\x1F"),
+        };
+        let lua = to_string(&orig).unwrap();
+        let parsed: S = from_str(&lua).unwrap();
+        assert_eq!(parsed, orig);
+    }
+
+    #[test]
+    fn test_parse_single_quoted_bracket_key() {
+        let m: BTreeMap<String, i32> = from_str("{['hello world'] = 1}").unwrap();
+        assert_eq!(m.get("hello world"), Some(&1));
+    }
+
+    #[test]
+    fn test_parse_keyword_bracket_keys() {
+        let m: BTreeMap<String, i32> =
+            from_str(r#"{["end"] = 1, ["function"] = 2, ["for"] = 3}"#).unwrap();
+        assert_eq!(m.get("end"), Some(&1));
+        assert_eq!(m.get("function"), Some(&2));
+        assert_eq!(m.get("for"), Some(&3));
+    }
+
+    // ── Structure edge cases ───────────────────────────────────────
+
+    #[test]
+    fn test_parse_empty_table_is_struct_not_vec() {
+        // In Lua, `{}` is ambiguous — could be empty struct or empty sequence.
+        // We parse it as a struct (matching JSON `{}` behavior), so deserializing
+        // as Vec will fail.
+        let result = from_str::<Vec<i32>>("{}");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_roundtrip_empty_vec() {
+        // Empty Vec serializes as `{}`, which parses back as struct, not sequence.
+        // This is a known limitation of Lua's single-table-constructor syntax.
+        #[derive(Facet, Debug, PartialEq)]
+        struct Data {
+            items: Vec<String>,
+        }
+        let data = Data { items: vec![] };
+        let lua = to_string(&data).unwrap();
+        assert_eq!(lua, "{items={}}");
+        // Roundtrip fails because inner `{}` is parsed as struct, not sequence.
+        let result = from_str::<Data>(&lua);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_nested_vec() {
+        let parsed: Vec<Vec<i32>> = from_str("{{1, 2}, {3, 4}}").unwrap();
+        assert_eq!(parsed, vec![vec![1, 2], vec![3, 4]]);
+    }
+
+    #[test]
+    fn test_roundtrip_nested_vec() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Data {
+            matrix: Vec<Vec<i32>>,
+        }
+        let data = Data {
+            matrix: vec![vec![1, 2], vec![3, 4]],
+        };
+        let lua = to_string_pretty(&data).unwrap();
+        let parsed: Data = from_str(&lua).unwrap();
+        assert_eq!(parsed, data);
+    }
+
+    #[test]
+    fn test_parse_deeply_nested_struct() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Inner {
+            value: i32,
+        }
+        #[derive(Facet, Debug, PartialEq)]
+        struct Middle {
+            inner: Inner,
+            label: String,
+        }
+        #[derive(Facet, Debug, PartialEq)]
+        struct Outer {
+            middle: Middle,
+            active: bool,
+        }
+        let lua = r#"{
+            middle = {
+                inner = {value = 99},
+                label = "hello"
+            },
+            active = true
+        }"#;
+        let parsed: Outer = from_str(lua).unwrap();
+        assert_eq!(parsed.middle.inner.value, 99);
+        assert_eq!(parsed.middle.label, "hello");
+        assert!(parsed.active);
+    }
+
+    #[test]
+    fn test_roundtrip_deeply_nested() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Inner {
+            value: i32,
+        }
+        #[derive(Facet, Debug, PartialEq)]
+        struct Middle {
+            inner: Inner,
+            label: String,
+        }
+        #[derive(Facet, Debug, PartialEq)]
+        struct Outer {
+            middle: Middle,
+            active: bool,
+        }
+        let outer = Outer {
+            middle: Middle {
+                inner: Inner { value: 99 },
+                label: "hello".to_string(),
+            },
+            active: true,
+        };
+        let lua = to_string_pretty(&outer).unwrap();
+        let parsed: Outer = from_str(&lua).unwrap();
+        assert_eq!(parsed, outer);
+    }
+
+    #[test]
+    fn test_roundtrip_keyword_map_keys() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Data {
+            counts: BTreeMap<String, i32>,
+        }
+        let mut counts = BTreeMap::new();
+        counts.insert("end".to_string(), 1);
+        counts.insert("function".to_string(), 2);
+        counts.insert("for".to_string(), 3);
+        counts.insert("while".to_string(), 4);
+        counts.insert("nil".to_string(), 5);
+        counts.insert("true".to_string(), 6);
+        let data = Data { counts };
+        let lua = to_string_pretty(&data).unwrap();
+        // Keywords must use bracket notation
+        assert!(lua.contains(r#"["end"]"#));
+        assert!(lua.contains(r#"["function"]"#));
+        assert!(lua.contains(r#"["for"]"#));
+        assert!(lua.contains(r#"["while"]"#));
+        assert!(lua.contains(r#"["nil"]"#));
+        assert!(lua.contains(r#"["true"]"#));
+        let parsed: Data = from_str(&lua).unwrap();
+        assert_eq!(parsed, data);
+    }
+
+    #[test]
+    fn test_roundtrip_char_field() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct CharVal {
+            c: char,
+        }
+        let val = CharVal { c: 'A' };
+        let lua = to_string(&val).unwrap();
+        let parsed: CharVal = from_str(&lua).unwrap();
+        assert_eq!(parsed, val);
+    }
+
+    #[test]
+    fn test_roundtrip_tuple_struct() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Pair(i32, i32);
+
+        let pair = Pair(10, 20);
+        let lua = to_string(&pair).unwrap();
+        let parsed: Pair = from_str(&lua).unwrap();
+        assert_eq!(parsed, pair);
+    }
+
+    // ── Comment edge cases ─────────────────────────────────────────
+
+    #[test]
+    fn test_parse_comment_between_key_and_equals() {
+        let lua = r#"{name --[[comment]]= "Alice", age = 30}"#;
+        let parsed: User = from_str(lua).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_parse_comment_between_equals_and_value() {
+        let lua = r#"{name = --[[x]] "Alice", age = 30}"#;
+        let parsed: User = from_str(lua).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_parse_comment_before_closing_brace() {
+        let lua = "{name = \"Alice\", age = 30 --trailing\n}";
+        let parsed: User = from_str(lua).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    #[test]
+    fn test_parse_comment_only_lines() {
+        let lua = r#"{
+            -- comment before first field
+            name = "Alice",
+            -- comment between fields
+            -- another comment
+            age = 30
+            -- comment after last field
+        }"#;
+        let parsed: User = from_str(lua).unwrap();
+        assert_eq!(parsed.name, "Alice");
+        assert_eq!(parsed.age, 30);
+    }
+
+    // ── Error cases ────────────────────────────────────────────────
+
+    #[test]
+    fn test_error_empty_input() {
+        let result = from_str::<User>("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_error_whitespace_only() {
+        let result = from_str::<User>("   \n\t  ");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_error_missing_equals() {
+        let result = from_str::<User>(r#"{name "Alice"}"#);
+        assert!(result.is_err());
+    }
+
+    // ── Root scalar parsing ────────────────────────────────────────
+
+    #[test]
+    fn test_parse_bare_integer_root() {
+        let parsed: u32 = from_str("42").unwrap();
+        assert_eq!(parsed, 42);
+    }
+
+    #[test]
+    fn test_parse_bare_string_root() {
+        let parsed: String = from_str(r#""hello""#).unwrap();
+        assert_eq!(parsed, "hello");
+    }
+
+    #[test]
+    fn test_parse_bare_bool_root() {
+        let parsed: bool = from_str("true").unwrap();
+        assert!(parsed);
+    }
+
+    #[test]
+    fn test_parse_bare_nil_root() {
+        let parsed: Option<String> = from_str("nil").unwrap();
+        assert_eq!(parsed, None);
+    }
+
+    // ── Roundtrip edge cases ───────────────────────────────────────
+
+    #[test]
+    fn test_roundtrip_option_option() {
+        #[derive(Facet, Debug, PartialEq)]
+        struct Wrap {
+            x: Option<Option<i32>>,
+        }
+        // Some(Some(42)) roundtrips cleanly
+        let w = Wrap { x: Some(Some(42)) };
+        let lua = to_string(&w).unwrap();
+        let parsed: Wrap = from_str(&lua).unwrap();
+        assert_eq!(parsed, w);
+
+        // None serializes as nil and roundtrips to None
+        let w_none = Wrap { x: None };
+        let lua_none = to_string(&w_none).unwrap();
+        let parsed_none: Wrap = from_str(&lua_none).unwrap();
+        assert_eq!(parsed_none.x, None);
+
+        // Some(None) also serializes as nil, so it roundtrips to None (lossy)
+        let w_some_none = Wrap { x: Some(None) };
+        let lua_some_none = to_string(&w_some_none).unwrap();
+        let parsed_some_none: Wrap = from_str(&lua_some_none).unwrap();
+        assert_eq!(parsed_some_none.x, None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use facet::Facet;
+
+    #[test]
+    fn test_to_lua_annotated() {
+        #[derive(Facet)]
+        struct User {
+            name: String,
+            age: u32,
+        }
+
+        let user = User {
+            name: "DT".to_string(),
+            age: 25,
+        };
+        let lua = to_lua_annotated(&user, "user").unwrap();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_to_lua_annotated_nested() {
+        #[derive(Facet)]
+        struct Address {
+            street: String,
+            city: String,
+        }
+
+        #[derive(Facet)]
+        struct Person {
+            name: String,
+            address: Address,
+        }
+
+        let person = Person {
+            name: "Alice".to_string(),
+            address: Address {
+                street: "123 Main St".to_string(),
+                city: "Springfield".to_string(),
+            },
+        };
+        let lua = to_lua_annotated(&person, "person").unwrap();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_to_lua_annotated_with_option() {
+        #[derive(Facet)]
+        struct Config {
+            host: String,
+            port: Option<u16>,
+        }
+
+        let config = Config {
+            host: "localhost".to_string(),
+            port: Some(8080),
+        };
+        let lua = to_lua_annotated(&config, "config").unwrap();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_to_lua_annotated_with_vec() {
+        #[derive(Facet)]
+        struct Settings {
+            name: String,
+            tags: Vec<String>,
+        }
+
+        let settings = Settings {
+            name: "test".to_string(),
+            tags: vec!["a".to_string(), "b".to_string()],
+        };
+        let lua = to_lua_annotated(&settings, "settings").unwrap();
+        insta::assert_snapshot!(lua);
+    }
+}

--- a/facet-lua/src/parser.rs
+++ b/facet-lua/src/parser.rs
@@ -1,0 +1,1288 @@
+//! Parse Lua table constructor syntax into Rust values.
+
+extern crate alloc;
+
+use alloc::borrow::Cow;
+use alloc::collections::VecDeque;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use facet_format::{
+    ContainerKind, DeserializeErrorKind, FieldKey, FieldLocationHint, FormatParser, ParseError,
+    ParseEvent, ParseEventKind, SavePoint, ScalarValue,
+};
+use facet_reflect::Span;
+
+use crate::consts;
+use crate::scanner::{
+    BLOCK_OPENERS, HexExtent, ValueStart, find_long_bracket_close, match_long_bracket_open,
+    simple_escape, skip_ws, utf8_char_len,
+};
+
+/// A parser for Lua table constructor syntax.
+///
+/// Parses the subset of Lua that [`LuaSerializer`](crate::LuaSerializer) produces,
+/// plus common Lua extensions:
+/// - Table constructors: `{ ... }`
+/// - Struct fields: `ident = value` or `["string"] = value`
+/// - Sequence elements: bare values separated by `,`
+/// - Scalars: `nil`, `true`/`false`, integers, floats, quoted strings, long strings
+/// - Hex integers: `0xFF`, `0X1A` and hex floats: `0x1.8p1`
+/// - Special floats: `math.huge`, `-math.huge`, `0/0`
+/// - String escapes: `\n`, `\t`, `\a`, `\b`, `\f`, `\v`, `\xNN`, `\u{XXXX}`, `\z`, `\ddd`
+/// - Separators: `,` and `;`
+/// - Comments: `-- line` and `--[[ block ]]`
+pub struct LuaParser<'de> {
+    input: &'de [u8],
+    pos: usize,
+    state: ParserState<'de>,
+    save_counter: u64,
+    saved_states: Vec<(u64, ParserState<'de>, usize)>,
+}
+
+#[derive(Clone)]
+struct ParserState<'de> {
+    stack: Vec<ContextState>,
+    event_peek: Option<ParseEvent<'de>>,
+    root_started: bool,
+    root_complete: bool,
+    last_token_start: usize,
+}
+
+#[derive(Debug, Clone)]
+enum ContextState {
+    Struct(StructState),
+    Seq(SeqState),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StructState {
+    /// Expecting a field key or `}`
+    KeyOrEnd,
+    /// Expecting the value for the current field (after `key =`)
+    Value,
+    /// Expecting `,` or `}`
+    CommaOrEnd,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SeqState {
+    /// Expecting a value or `}`
+    ValueOrEnd,
+    /// Expecting `,` or `}`
+    CommaOrEnd,
+}
+
+impl<'de> LuaParser<'de> {
+    /// Create a new Lua parser from a string slice.
+    pub fn new(input: &'de str) -> Self {
+        Self {
+            input: input.as_bytes(),
+            pos: 0,
+            state: ParserState {
+                stack: Vec::new(),
+                event_peek: None,
+                root_started: false,
+                root_complete: false,
+                last_token_start: 0,
+            },
+            save_counter: 0,
+            saved_states: Vec::new(),
+        }
+    }
+
+    fn skip_whitespace(&mut self) {
+        self.pos = skip_ws(self.input, self.pos);
+    }
+
+    fn peek_byte(&self) -> Option<u8> {
+        self.input.get(self.pos).copied()
+    }
+
+    fn advance(&mut self) -> Option<u8> {
+        let b = self.input.get(self.pos).copied()?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn expect_byte(&mut self, expected: u8, label: &'static str) -> Result<(), ParseError> {
+        match self.advance() {
+            Some(b) if b == expected => Ok(()),
+            Some(b) => Err(self.error(DeserializeErrorKind::UnexpectedChar {
+                ch: b as char,
+                expected: label,
+            })),
+            None => Err(self.error(DeserializeErrorKind::UnexpectedEof { expected: label })),
+        }
+    }
+
+    fn starts_with(&self, s: &[u8]) -> bool {
+        self.input[self.pos..].starts_with(s)
+    }
+
+    fn peek_ahead(&self, offset: usize) -> Option<u8> {
+        self.input.get(self.pos + offset).copied()
+    }
+
+    fn span_at(&self, offset: usize, len: usize) -> Span {
+        Span::new(offset, len)
+    }
+
+    fn current_span_pos(&self) -> Span {
+        Span::new(self.pos, 0)
+    }
+
+    fn error(&self, kind: DeserializeErrorKind) -> ParseError {
+        ParseError::new(self.current_span_pos(), kind)
+    }
+
+    fn err_invalid_value(&self, start: usize, message: &'static str) -> ParseError {
+        ParseError::new(
+            self.span_at(start, self.pos - start),
+            DeserializeErrorKind::InvalidValue {
+                message: message.into(),
+            },
+        )
+    }
+
+    fn err_unexpected_byte(&self, expected: &'static str) -> ParseError {
+        match self.peek_byte() {
+            Some(b) => ParseError::new(
+                self.span_at(self.pos, 1),
+                DeserializeErrorKind::UnexpectedChar {
+                    ch: b as char,
+                    expected,
+                },
+            ),
+            None => self.error(DeserializeErrorKind::UnexpectedEof { expected }),
+        }
+    }
+
+    fn parse_hex_digits_as_u64(
+        &self,
+        from: usize,
+        to: usize,
+        span_start: usize,
+    ) -> Result<u64, ParseError> {
+        if from == to {
+            return Ok(0);
+        }
+        let s = core::str::from_utf8(&self.input[from..to]).map_err(|_| {
+            ParseError::new(
+                self.span_at(from, to - from),
+                DeserializeErrorKind::InvalidUtf8 {
+                    context: [0u8; 16],
+                    context_len: 0,
+                },
+            )
+        })?;
+        u64::from_str_radix(s, 16)
+            .map_err(|_| self.err_invalid_value(span_start, "invalid hex digits"))
+    }
+
+    /// Parse a quoted Lua string (double or single quotes). Returns borrowed if no escapes.
+    fn parse_quoted_string(&mut self) -> Result<Cow<'de, str>, ParseError> {
+        let quote_pos = self.pos;
+        let quote_char = self.advance().ok_or_else(|| {
+            self.error(DeserializeErrorKind::UnexpectedEof { expected: "string" })
+        })?;
+        debug_assert!(quote_char == b'"' || quote_char == b'\'');
+        let start = self.pos;
+
+        let (end, has_escapes) = self.scan_string_extent(quote_char, quote_pos)?;
+
+        if !has_escapes {
+            let s = core::str::from_utf8(&self.input[start..end]).map_err(|_| {
+                ParseError::new(
+                    self.span_at(start, end - start),
+                    DeserializeErrorKind::InvalidUtf8 {
+                        context: [0u8; 16],
+                        context_len: 0,
+                    },
+                )
+            })?;
+            self.pos = end + 1;
+            return Ok(Cow::Borrowed(s));
+        }
+
+        self.pos = start;
+        let buf = self.decode_string_escapes(end)?;
+        self.pos = end + 1;
+        Ok(Cow::Owned(buf))
+    }
+
+    /// Scan forward to find the closing quote, returning `(end_pos, has_escapes)`.
+    /// Advances past escape sequences without decoding them.
+    fn scan_string_extent(
+        &self,
+        quote_char: u8,
+        quote_pos: usize,
+    ) -> Result<(usize, bool), ParseError> {
+        let mut scan = self.pos;
+        let mut has_escapes = false;
+
+        loop {
+            if scan >= self.input.len() {
+                return Err(ParseError::new(
+                    self.span_at(quote_pos, scan - quote_pos),
+                    DeserializeErrorKind::UnexpectedEof {
+                        expected: "closing quote",
+                    },
+                ));
+            }
+            match self.input[scan] {
+                b if b == quote_char => return Ok((scan, has_escapes)),
+                b'\\' => {
+                    has_escapes = true;
+                    scan += 1;
+                    if scan >= self.input.len() {
+                        return Err(ParseError::new(
+                            self.span_at(quote_pos, scan - quote_pos),
+                            DeserializeErrorKind::UnexpectedEof {
+                                expected: "escape character",
+                            },
+                        ));
+                    }
+                    scan = self.scan_past_escape(scan);
+                }
+                _ => scan += 1,
+            }
+        }
+    }
+
+    /// Starting right after the `\`, advance `scan` past one escape sequence.
+    /// Does not validate — that happens in the decode pass.
+    fn scan_past_escape(&self, scan: usize) -> usize {
+        match self.input[scan] {
+            b'x' => {
+                // \xNN — always exactly 2 hex digits
+                let mut p = scan + 1;
+                if p + 1 < self.input.len()
+                    && self.input[p].is_ascii_hexdigit()
+                    && self.input[p + 1].is_ascii_hexdigit()
+                {
+                    p += 2;
+                } else {
+                    p += 1; // will error during decode pass
+                }
+                p
+            }
+            b'u' if self.input.get(scan + 1).copied() == Some(b'{') => {
+                // \u{XXXX}
+                let mut p = scan + 2;
+                while p < self.input.len() && self.input[p].is_ascii_hexdigit() {
+                    p += 1;
+                }
+                if p < self.input.len() && self.input[p] == b'}' {
+                    p += 1;
+                }
+                p
+            }
+            b'z' => {
+                // \z skip following whitespace
+                let mut p = scan + 1;
+                while p < self.input.len() && matches!(self.input[p], b' ' | b'\t' | b'\n' | b'\r')
+                {
+                    p += 1;
+                }
+                p
+            }
+            d if d.is_ascii_digit() => {
+                // \ddd — up to 3 decimal digits
+                let mut p = scan + 1;
+                if p < self.input.len() && self.input[p].is_ascii_digit() {
+                    p += 1;
+                    if p < self.input.len() && self.input[p].is_ascii_digit() {
+                        p += 1;
+                    }
+                }
+                p
+            }
+            _ => scan + 1,
+        }
+    }
+
+    /// Decode the escape sequences between `self.pos` and `end`, returning the owned string.
+    fn decode_string_escapes(&mut self, end: usize) -> Result<String, ParseError> {
+        let mut buf = String::new();
+        while self.pos < end {
+            if self.input[self.pos] == b'\\' {
+                self.pos += 1;
+                self.decode_one_escape(&mut buf, end)?;
+            } else {
+                self.push_utf8_char(&mut buf, end)?;
+            }
+        }
+        Ok(buf)
+    }
+
+    /// Decode a single escape sequence (positioned right after the `\`).
+    fn decode_one_escape(&mut self, buf: &mut String, end: usize) -> Result<(), ParseError> {
+        let esc = self.input[self.pos];
+        if let Some(ch) = simple_escape(esc) {
+            buf.push(ch);
+            self.pos += 1;
+            return Ok(());
+        }
+        match esc {
+            b'x' => self.decode_hex_escape(buf, end),
+            b'u' if self.input.get(self.pos + 1).copied() == Some(b'{') => {
+                self.decode_unicode_escape(buf, end)
+            }
+            b'z' => {
+                self.pos += 1;
+                while self.pos < end && matches!(self.input[self.pos], b' ' | b'\t' | b'\n' | b'\r')
+                {
+                    self.pos += 1;
+                }
+                Ok(())
+            }
+            b'0' if self.pos + 1 >= end || !self.input[self.pos + 1].is_ascii_digit() => {
+                buf.push('\0');
+                self.pos += 1;
+                Ok(())
+            }
+            d if d.is_ascii_digit() => self.decode_decimal_escape(buf, end),
+            _ => Err(self.err_invalid_value(self.pos, "unknown escape sequence")),
+        }
+    }
+
+    /// Decode `\xNN` hex escape.
+    fn decode_hex_escape(&mut self, buf: &mut String, end: usize) -> Result<(), ParseError> {
+        self.pos += 1; // skip 'x'
+        if self.pos + 1 >= end
+            || !self.input[self.pos].is_ascii_hexdigit()
+            || !self.input[self.pos + 1].is_ascii_hexdigit()
+        {
+            return Err(ParseError::new(
+                self.span_at(self.pos - 2, 4),
+                DeserializeErrorKind::InvalidValue {
+                    message: "\\x requires exactly 2 hex digits".into(),
+                },
+            ));
+        }
+        let hi = (self.input[self.pos] as char).to_digit(16).unwrap() as u8;
+        let lo = (self.input[self.pos + 1] as char).to_digit(16).unwrap() as u8;
+        buf.push((hi * 16 + lo) as char);
+        self.pos += 2;
+        Ok(())
+    }
+
+    /// Decode `\u{XXXX}` unicode escape.
+    fn decode_unicode_escape(&mut self, buf: &mut String, end: usize) -> Result<(), ParseError> {
+        self.pos += 2; // skip 'u{'
+        let hex_start = self.pos;
+        while self.pos < end && self.input[self.pos].is_ascii_hexdigit() {
+            self.pos += 1;
+        }
+        if self.pos >= end || self.input[self.pos] != b'}' {
+            return Err(ParseError::new(
+                self.span_at(hex_start - 3, self.pos - hex_start + 3),
+                DeserializeErrorKind::InvalidValue {
+                    message: "\\u{} requires hex digits and closing '}'".into(),
+                },
+            ));
+        }
+        let hex_str = core::str::from_utf8(&self.input[hex_start..self.pos]).unwrap();
+        let val = u32::from_str_radix(hex_str, 16)
+            .map_err(|_| self.err_invalid_value(hex_start, "invalid unicode escape"))?;
+        let c = char::from_u32(val)
+            .ok_or_else(|| self.err_invalid_value(hex_start, "invalid unicode code point"))?;
+        buf.push(c);
+        self.pos += 1; // skip '}'
+        Ok(())
+    }
+
+    /// Decode `\ddd` decimal escape (1-3 digits).
+    fn decode_decimal_escape(&mut self, buf: &mut String, end: usize) -> Result<(), ParseError> {
+        let d = self.input[self.pos];
+        let mut val: u32 = (d - b'0') as u32;
+        self.pos += 1;
+        if self.pos < end && self.input[self.pos].is_ascii_digit() {
+            val = val * 10 + (self.input[self.pos] - b'0') as u32;
+            self.pos += 1;
+            if self.pos < end && self.input[self.pos].is_ascii_digit() {
+                val = val * 10 + (self.input[self.pos] - b'0') as u32;
+                self.pos += 1;
+            }
+        }
+        let c = char::from_u32(val)
+            .ok_or_else(|| self.err_invalid_value(self.pos - 1, "invalid decimal escape value"))?;
+        buf.push(c);
+        Ok(())
+    }
+
+    /// Push one UTF-8 character from `self.pos` into `buf`.
+    fn push_utf8_char(&mut self, buf: &mut String, end: usize) -> Result<(), ParseError> {
+        let char_end = self.pos + utf8_char_len(self.input[self.pos]);
+        if char_end > end {
+            return Err(self.invalid_utf8_at(self.pos));
+        }
+        let s = core::str::from_utf8(&self.input[self.pos..char_end])
+            .map_err(|_| self.invalid_utf8_at(self.pos))?;
+        buf.push_str(s);
+        self.pos = char_end;
+        Ok(())
+    }
+
+    fn invalid_utf8_at(&self, pos: usize) -> ParseError {
+        ParseError::new(
+            self.span_at(pos, 1),
+            DeserializeErrorKind::InvalidUtf8 {
+                context: [0u8; 16],
+                context_len: 0,
+            },
+        )
+    }
+
+    /// Parse a long bracket string `[=*[...]=*]`. Always borrows from input.
+    fn parse_long_string(&mut self) -> Result<Cow<'de, str>, ParseError> {
+        let start = self.pos;
+        let level = match_long_bracket_open(self.input, self.pos).ok_or_else(|| {
+            self.error(DeserializeErrorKind::UnexpectedToken {
+                got: "'['".into(),
+                expected: "long string opening bracket",
+            })
+        })?;
+        let opener_len = 2 + level; // `[` + `=`*level + `[`
+        let body_start = self.pos + opener_len;
+
+        // Skip leading newline (Lua spec: first newline after opener is ignored)
+        let content_start = if self.input.get(body_start).copied() == Some(b'\n') {
+            body_start + 1
+        } else if self.input.get(body_start).copied() == Some(b'\r') {
+            if self.input.get(body_start + 1).copied() == Some(b'\n') {
+                body_start + 2
+            } else {
+                body_start + 1
+            }
+        } else {
+            body_start
+        };
+
+        let close_pos =
+            find_long_bracket_close(self.input, body_start, level).ok_or_else(|| {
+                ParseError::new(
+                    self.span_at(start, self.input.len() - start),
+                    DeserializeErrorKind::UnexpectedEof {
+                        expected: "closing long bracket",
+                    },
+                )
+            })?;
+
+        // Content ends at the `]` of the closing bracket
+        let content_end = close_pos - 2 - level;
+        self.pos = close_pos;
+
+        let s = core::str::from_utf8(&self.input[content_start..content_end]).map_err(|_| {
+            ParseError::new(
+                self.span_at(content_start, content_end - content_start),
+                DeserializeErrorKind::InvalidUtf8 {
+                    context: [0u8; 16],
+                    context_len: 0,
+                },
+            )
+        })?;
+        Ok(Cow::Borrowed(s))
+    }
+
+    /// Parse any Lua string: quoted (`"..."` / `'...'`) or long bracket (`[[...]]`).
+    fn parse_string(&mut self) -> Result<Cow<'de, str>, ParseError> {
+        match self.peek_byte() {
+            Some(b'"') | Some(b'\'') => self.parse_quoted_string(),
+            Some(b'[') => self.parse_long_string(),
+            _ => Err(self.err_unexpected_byte("string")),
+        }
+    }
+
+    fn parse_number(&mut self, negative: bool) -> Result<ScalarValue<'de>, ParseError> {
+        if self.pos + 1 < self.input.len()
+            && self.input[self.pos] == b'0'
+            && (self.input[self.pos + 1] == b'x' || self.input[self.pos + 1] == b'X')
+        {
+            self.parse_hex_number(negative)
+        } else {
+            self.parse_decimal_number(negative)
+        }
+    }
+
+    /// Parse a hex integer (`0xFF`) or hex float (`0x1.8p1`).
+    fn parse_hex_number(&mut self, negative: bool) -> Result<ScalarValue<'de>, ParseError> {
+        let start = self.pos;
+        self.pos += 2; // skip "0x"
+        let hex_start = self.pos;
+
+        while self.pos < self.input.len() && self.input[self.pos].is_ascii_hexdigit() {
+            self.pos += 1;
+        }
+        let int_end = self.pos;
+
+        let has_dot = self.pos < self.input.len() && self.input[self.pos] == b'.';
+        if has_dot {
+            self.pos += 1;
+            while self.pos < self.input.len() && self.input[self.pos].is_ascii_hexdigit() {
+                self.pos += 1;
+            }
+        }
+        let frac_end = self.pos;
+
+        let has_exp = self.pos < self.input.len() && matches!(self.input[self.pos], b'p' | b'P');
+        if has_exp {
+            self.pos += 1;
+            if self.pos < self.input.len() && matches!(self.input[self.pos], b'+' | b'-') {
+                self.pos += 1;
+            }
+            if self.pos >= self.input.len() || !self.input[self.pos].is_ascii_digit() {
+                return Err(self.err_invalid_value(start, "expected digits after exponent"));
+            }
+            while self.pos < self.input.len() && self.input[self.pos].is_ascii_digit() {
+                self.pos += 1;
+            }
+        }
+
+        if int_end == hex_start && !has_dot {
+            return Err(self.err_invalid_value(start, "expected hex digits after 0x"));
+        }
+
+        if has_dot || has_exp {
+            let ext = HexExtent {
+                start,
+                hex_start,
+                int_end,
+                frac_end,
+                has_dot,
+                has_exp,
+            };
+            return self.parse_hex_float_value(&ext, negative);
+        }
+
+        // Plain hex integer
+        let val = self.parse_hex_digits_as_u64(hex_start, int_end, start)?;
+        if negative {
+            if val <= i64::MAX as u64 {
+                Ok(ScalarValue::I64(-(val as i64)))
+            } else if val == i64::MAX as u64 + 1 {
+                Ok(ScalarValue::I64(i64::MIN))
+            } else {
+                Ok(ScalarValue::I128(-(val as i128)))
+            }
+        } else {
+            Ok(ScalarValue::U64(val))
+        }
+    }
+
+    /// Compute the value of a hex float once the extent has been scanned.
+    fn parse_hex_float_value(
+        &self,
+        ext: &HexExtent,
+        negative: bool,
+    ) -> Result<ScalarValue<'de>, ParseError> {
+        let int_part = self.parse_hex_digits_as_u64(ext.hex_start, ext.int_end, ext.start)?;
+        let frac_val = if ext.has_dot {
+            let frac_start = ext.int_end + 1; // skip '.'
+            let frac_len = ext.frac_end - frac_start;
+            if frac_len == 0 {
+                0.0
+            } else {
+                let frac_int = self.parse_hex_digits_as_u64(frac_start, ext.frac_end, ext.start)?;
+                frac_int as f64 / 16_f64.powi(frac_len as i32)
+            }
+        } else {
+            0.0
+        };
+        let exp = if ext.has_exp {
+            let exp_str =
+                core::str::from_utf8(&self.input[ext.frac_end + 1..self.pos]).unwrap_or("0");
+            exp_str
+                .parse::<i32>()
+                .map_err(|_| self.err_invalid_value(ext.start, "invalid hex float exponent"))?
+        } else {
+            0
+        };
+        let val = (int_part as f64 + frac_val) * 2_f64.powi(exp);
+        Ok(ScalarValue::F64(if negative { -val } else { val }))
+    }
+
+    /// Parse a decimal integer or float.
+    fn parse_decimal_number(&mut self, negative: bool) -> Result<ScalarValue<'de>, ParseError> {
+        let start = self.pos;
+        let mut has_dot = false;
+        let mut has_e = false;
+
+        while self.pos < self.input.len() {
+            match self.input[self.pos] {
+                b'0'..=b'9' => self.pos += 1,
+                b'.' => {
+                    has_dot = true;
+                    self.pos += 1;
+                }
+                b'e' | b'E' => {
+                    has_e = true;
+                    self.pos += 1;
+                    if self.pos < self.input.len()
+                        && (self.input[self.pos] == b'+' || self.input[self.pos] == b'-')
+                    {
+                        self.pos += 1;
+                    }
+                }
+                _ => break,
+            }
+        }
+
+        let num_str = core::str::from_utf8(&self.input[start..self.pos]).map_err(|_| {
+            ParseError::new(
+                self.span_at(start, self.pos - start),
+                DeserializeErrorKind::InvalidUtf8 {
+                    context: [0u8; 16],
+                    context_len: 0,
+                },
+            )
+        })?;
+
+        if has_dot || has_e {
+            let val: f64 = num_str
+                .parse()
+                .map_err(|_| self.err_invalid_value(start, "invalid float"))?;
+            return Ok(ScalarValue::F64(if negative { -val } else { val }));
+        }
+
+        if negative {
+            return self.parse_negative_integer(num_str, start);
+        }
+
+        if let Ok(val) = num_str.parse::<u64>() {
+            return Ok(ScalarValue::U64(val));
+        }
+        if let Ok(val) = num_str.parse::<i64>() {
+            return Ok(ScalarValue::I64(val));
+        }
+        if let Ok(val) = num_str.parse::<u128>() {
+            return Ok(ScalarValue::U128(val));
+        }
+        if let Ok(val) = num_str.parse::<i128>() {
+            return Ok(ScalarValue::I128(val));
+        }
+        Err(self.err_invalid_value(start, "integer out of range"))
+    }
+
+    /// Parse unsigned digits as a negative integer, avoiding format!() allocation.
+    /// Handles the i64::MIN edge case where the unsigned magnitude doesn't fit in i64.
+    fn parse_negative_integer(
+        &self,
+        num_str: &str,
+        start: usize,
+    ) -> Result<ScalarValue<'de>, ParseError> {
+        if let Ok(val) = num_str.parse::<u64>() {
+            // val == i64::MAX + 1 is the i64::MIN magnitude
+            if val <= i64::MAX as u64 {
+                return Ok(ScalarValue::I64(-(val as i64)));
+            }
+            if val == i64::MAX as u64 + 1 {
+                return Ok(ScalarValue::I64(i64::MIN));
+            }
+            // Doesn't fit in i64, use i128
+            return Ok(ScalarValue::I128(-(val as i128)));
+        }
+        if let Ok(val) = num_str.parse::<u128>() {
+            if val <= i128::MAX as u128 {
+                return Ok(ScalarValue::I128(-(val as i128)));
+            }
+            if val == i128::MAX as u128 + 1 {
+                return Ok(ScalarValue::I128(i128::MIN));
+            }
+        }
+        Err(self.err_invalid_value(start, "integer out of range"))
+    }
+
+    fn parse_identifier(&mut self) -> Result<&'de str, ParseError> {
+        let start = self.pos;
+        if self.pos >= self.input.len()
+            || (!self.input[self.pos].is_ascii_alphabetic() && self.input[self.pos] != b'_')
+        {
+            return Err(self.err_unexpected_byte("identifier"));
+        }
+        self.pos += 1;
+        while self.pos < self.input.len()
+            && (self.input[self.pos].is_ascii_alphanumeric() || self.input[self.pos] == b'_')
+        {
+            self.pos += 1;
+        }
+        core::str::from_utf8(&self.input[start..self.pos]).map_err(|_| {
+            ParseError::new(
+                self.span_at(start, self.pos - start),
+                DeserializeErrorKind::InvalidUtf8 {
+                    context: [0u8; 16],
+                    context_len: 0,
+                },
+            )
+        })
+    }
+
+    /// After consuming `{`, peek ahead to decide struct vs sequence.
+    fn peek_table_is_struct(&self) -> bool {
+        let p = skip_ws(self.input, self.pos);
+
+        if p >= self.input.len() {
+            return true; // EOF → will error later
+        }
+
+        match self.input[p] {
+            b'}' => true, // empty table → struct
+            b'[' => {
+                // `["key"] = ...` or `['key'] = ...` → struct key
+                // `[[long string]]` as first element → sequence
+                let next = self.input.get(p + 1).copied();
+                matches!(next, Some(b'"') | Some(b'\''))
+            }
+            b if b.is_ascii_alphabetic() || b == b'_' => {
+                // Scan the identifier
+                let mut p = p + 1;
+                while p < self.input.len()
+                    && (self.input[p].is_ascii_alphanumeric() || self.input[p] == b'_')
+                {
+                    p += 1;
+                }
+
+                let p = skip_ws(self.input, p);
+
+                // If followed by `=` (but not `==`), it's a struct field
+                if p < self.input.len() && self.input[p] == b'=' {
+                    !(p + 1 < self.input.len() && self.input[p + 1] == b'=')
+                } else {
+                    false // bare value → sequence
+                }
+            }
+            _ => false, // number, string, `-`, etc. → sequence
+        }
+    }
+
+    /// Returns true if `self.pos` is at the start of a string literal
+    /// (quoted or long bracket).
+    fn at_string_start(&self) -> bool {
+        match self.peek_byte() {
+            Some(b'"') | Some(b'\'') => true,
+            Some(b'[') => match_long_bracket_open(self.input, self.pos).is_some(),
+            _ => false,
+        }
+    }
+
+    fn parse_value(&mut self) -> Result<ParseEvent<'de>, ParseError> {
+        self.skip_whitespace();
+        self.state.last_token_start = self.pos;
+        self.state.root_started = true;
+        let span_start = self.pos;
+
+        match self.classify_value()? {
+            ValueStart::String => {
+                let s = self.parse_string()?;
+                let span = self.span_at(span_start, self.pos - span_start);
+                self.finish_value_in_parent();
+                Ok(ParseEvent::new(
+                    ParseEventKind::Scalar(ScalarValue::Str(s)),
+                    span,
+                ))
+            }
+            ValueStart::Table => {
+                self.pos += 1;
+                let span = self.span_at(span_start, 1);
+                if self.peek_table_is_struct() {
+                    self.state
+                        .stack
+                        .push(ContextState::Struct(StructState::KeyOrEnd));
+                    Ok(ParseEvent::new(
+                        ParseEventKind::StructStart(ContainerKind::Object),
+                        span,
+                    ))
+                } else {
+                    self.state
+                        .stack
+                        .push(ContextState::Seq(SeqState::ValueOrEnd));
+                    Ok(ParseEvent::new(
+                        ParseEventKind::SequenceStart(ContainerKind::Array),
+                        span,
+                    ))
+                }
+            }
+            ValueStart::Negative => {
+                self.pos += 1;
+                self.skip_whitespace();
+                if self.starts_with(consts::MATH_HUGE) {
+                    self.pos += consts::MATH_HUGE.len();
+                    let span = self.span_at(span_start, self.pos - span_start);
+                    self.finish_value_in_parent();
+                    return Ok(ParseEvent::new(
+                        ParseEventKind::Scalar(ScalarValue::F64(f64::NEG_INFINITY)),
+                        span,
+                    ));
+                }
+                if self.peek_byte().is_some_and(|b| b.is_ascii_digit()) {
+                    let scalar = self.parse_number(true)?;
+                    let span = self.span_at(span_start, self.pos - span_start);
+                    self.finish_value_in_parent();
+                    return Ok(ParseEvent::new(ParseEventKind::Scalar(scalar), span));
+                }
+                Err(ParseError::new(
+                    self.span_at(span_start, 1),
+                    DeserializeErrorKind::UnexpectedToken {
+                        got: "'-'".into(),
+                        expected: "number or 'math.huge'",
+                    },
+                ))
+            }
+            ValueStart::NaN => {
+                self.pos += 3;
+                let span = self.span_at(span_start, 3);
+                self.finish_value_in_parent();
+                Ok(ParseEvent::new(
+                    ParseEventKind::Scalar(ScalarValue::F64(f64::NAN)),
+                    span,
+                ))
+            }
+            ValueStart::Number => {
+                let scalar = self.parse_number(false)?;
+                let span = self.span_at(span_start, self.pos - span_start);
+                self.finish_value_in_parent();
+                Ok(ParseEvent::new(ParseEventKind::Scalar(scalar), span))
+            }
+            ValueStart::Identifier => self.parse_keyword_or_ident_value(span_start),
+        }
+    }
+
+    /// Dispatch an identifier-starting value: keywords (`nil`, `true`, `false`, `math.huge`,
+    /// `function`) or bare identifiers treated as strings.
+    fn parse_keyword_or_ident_value(
+        &mut self,
+        span_start: usize,
+    ) -> Result<ParseEvent<'de>, ParseError> {
+        let ident = self.parse_identifier()?;
+        let span = self.span_at(span_start, self.pos - span_start);
+        let scalar = match ident {
+            "nil" => ScalarValue::Null,
+            "true" => ScalarValue::Bool(true),
+            "false" => ScalarValue::Bool(false),
+            "math" => {
+                self.expect_byte(b'.', "'.'")?;
+                let rest = self.parse_identifier()?;
+                if rest != "huge" {
+                    return Err(self.err_invalid_value(span_start, "expected math.huge"));
+                }
+                let span = self.span_at(span_start, self.pos - span_start);
+                self.finish_value_in_parent();
+                return Ok(ParseEvent::new(
+                    ParseEventKind::Scalar(ScalarValue::F64(f64::INFINITY)),
+                    span,
+                ));
+            }
+            "function" => {
+                self.skip_function_body()?;
+                let span = self.span_at(span_start, self.pos - span_start);
+                self.finish_value_in_parent();
+                return Ok(ParseEvent::new(
+                    ParseEventKind::Scalar(ScalarValue::Null),
+                    span,
+                ));
+            }
+            _ => ScalarValue::Str(Cow::Borrowed(ident)),
+        };
+        self.finish_value_in_parent();
+        Ok(ParseEvent::new(ParseEventKind::Scalar(scalar), span))
+    }
+
+    fn finish_value_in_parent(&mut self) {
+        match self.state.stack.last_mut() {
+            Some(ContextState::Struct(state)) => *state = StructState::CommaOrEnd,
+            Some(ContextState::Seq(state)) => *state = SeqState::CommaOrEnd,
+            None if self.state.root_started => self.state.root_complete = true,
+            _ => {}
+        }
+    }
+
+    /// Classify what kind of value token is next (after whitespace is skipped).
+    fn classify_value(&self) -> Result<ValueStart, ParseError> {
+        if self.at_string_start() {
+            return Ok(ValueStart::String);
+        }
+        match self.peek_byte() {
+            None => Err(ParseError::new(
+                self.current_span_pos(),
+                DeserializeErrorKind::UnexpectedEof { expected: "value" },
+            )),
+            Some(b'{') => Ok(ValueStart::Table),
+            Some(b'-') => Ok(ValueStart::Negative),
+            Some(b'0') if self.peek_ahead(1) == Some(b'/') && self.peek_ahead(2) == Some(b'0') => {
+                Ok(ValueStart::NaN)
+            }
+            Some(b) if b.is_ascii_digit() => Ok(ValueStart::Number),
+            Some(b) if b.is_ascii_alphabetic() || b == b'_' => Ok(ValueStart::Identifier),
+            Some(b) => Err(ParseError::new(
+                self.span_at(self.pos, 1),
+                DeserializeErrorKind::UnexpectedChar {
+                    ch: b as char,
+                    expected: "value",
+                },
+            )),
+        }
+    }
+
+    /// Consume `}` and return the appropriate end event for the current container.
+    fn close_container(&mut self) -> ParseEvent<'de> {
+        let span = self.span_at(self.pos, 1);
+        self.pos += 1;
+        let end_kind = match self.state.stack.pop() {
+            Some(ContextState::Struct(_)) => ParseEventKind::StructEnd,
+            Some(ContextState::Seq(_)) => ParseEventKind::SequenceEnd,
+            None => unreachable!("close_container called without container on stack"),
+        };
+        self.finish_value_in_parent();
+        ParseEvent::new(end_kind, span)
+    }
+
+    /// Handle the `CommaOrEnd` state for both struct and sequence containers.
+    /// Returns `Ok(None)` when a separator was consumed (caller should continue),
+    /// `Ok(Some(event))` when the container was closed.
+    fn consume_separator_or_close(&mut self) -> Result<Option<ParseEvent<'de>>, ParseError> {
+        self.skip_whitespace();
+        match self.peek_byte() {
+            Some(b',' | b';') => {
+                self.pos += 1;
+                match self.state.stack.last_mut() {
+                    Some(ContextState::Struct(state)) => *state = StructState::KeyOrEnd,
+                    Some(ContextState::Seq(state)) => *state = SeqState::ValueOrEnd,
+                    _ => {}
+                }
+                Ok(None)
+            }
+            Some(b'}') => Ok(Some(self.close_container())),
+            Some(b) => Err(ParseError::new(
+                self.current_span_pos(),
+                DeserializeErrorKind::UnexpectedChar {
+                    ch: b as char,
+                    expected: "',', ';', or '}'",
+                },
+            )),
+            None => Err(self.error(DeserializeErrorKind::UnexpectedEof {
+                expected: "',', ';', or '}'",
+            })),
+        }
+    }
+
+    fn parse_field_key(&mut self) -> Result<ParseEvent<'de>, ParseError> {
+        self.skip_whitespace();
+        let span_start = self.pos;
+
+        let key: Cow<'de, str> = if self.peek_byte() == Some(b'[') {
+            self.pos += 1;
+            let s = self.parse_string()?;
+            self.skip_whitespace();
+            self.expect_byte(b']', "']'")?;
+            s
+        } else {
+            let ident = self.parse_identifier()?;
+            Cow::Borrowed(ident)
+        };
+
+        let span = self.span_at(span_start, self.pos - span_start);
+
+        self.skip_whitespace();
+        self.expect_byte(b'=', "'='")?;
+
+        // Transition to expecting the field value
+        if let Some(ContextState::Struct(state)) = self.state.stack.last_mut() {
+            *state = StructState::Value;
+        }
+
+        Ok(ParseEvent::new(
+            ParseEventKind::FieldKey(FieldKey::new(key, FieldLocationHint::KeyValue)),
+            span,
+        ))
+    }
+
+    fn produce_event(&mut self) -> Result<Option<ParseEvent<'de>>, ParseError> {
+        loop {
+            self.skip_whitespace();
+
+            match self.state.stack.last().cloned() {
+                None if self.state.root_complete => return Ok(None),
+                None => return self.parse_value().map(Some),
+                Some(ContextState::Struct(struct_state)) => {
+                    if let Some(event) = self.produce_struct_event(struct_state)? {
+                        return Ok(Some(event));
+                    }
+                }
+                Some(ContextState::Seq(seq_state)) => {
+                    if let Some(event) = self.produce_seq_event(seq_state)? {
+                        return Ok(Some(event));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns `Ok(None)` when a separator was consumed (caller should loop again).
+    fn produce_struct_event(
+        &mut self,
+        struct_state: StructState,
+    ) -> Result<Option<ParseEvent<'de>>, ParseError> {
+        match struct_state {
+            StructState::KeyOrEnd => {
+                self.skip_whitespace();
+                match self.peek_byte() {
+                    Some(b'}') => Ok(Some(self.close_container())),
+                    Some(_) => self.parse_field_key().map(Some),
+                    None => Err(self.error(DeserializeErrorKind::UnexpectedEof {
+                        expected: "field name or '}'",
+                    })),
+                }
+            }
+            StructState::Value => self.parse_value().map(Some),
+            StructState::CommaOrEnd => self.consume_separator_or_close(),
+        }
+    }
+
+    /// Returns `Ok(None)` when a separator was consumed (caller should loop again).
+    fn produce_seq_event(
+        &mut self,
+        seq_state: SeqState,
+    ) -> Result<Option<ParseEvent<'de>>, ParseError> {
+        match seq_state {
+            SeqState::ValueOrEnd => {
+                self.skip_whitespace();
+                match self.peek_byte() {
+                    Some(b'}') => Ok(Some(self.close_container())),
+                    Some(_) => self.parse_value().map(Some),
+                    None => Err(self.error(DeserializeErrorKind::UnexpectedEof {
+                        expected: "value or '}'",
+                    })),
+                }
+            }
+            SeqState::CommaOrEnd => self.consume_separator_or_close(),
+        }
+    }
+
+    fn skip_value_raw(&mut self) -> Result<(), ParseError> {
+        self.skip_whitespace();
+        match self.classify_value()? {
+            ValueStart::String => {
+                self.parse_string()?;
+                Ok(())
+            }
+            ValueStart::Table => {
+                self.pos += 1;
+                self.skip_table_contents()
+            }
+            ValueStart::Negative => {
+                self.pos += 1;
+                self.skip_whitespace();
+                if self.starts_with(consts::MATH_HUGE) {
+                    self.pos += consts::MATH_HUGE.len();
+                } else {
+                    self.parse_number(true)?;
+                }
+                Ok(())
+            }
+            ValueStart::NaN => {
+                self.pos += 3;
+                Ok(())
+            }
+            ValueStart::Number => {
+                self.parse_number(false)?;
+                Ok(())
+            }
+            ValueStart::Identifier => {
+                let ident = self.parse_identifier()?;
+                match ident {
+                    "math" => {
+                        self.expect_byte(b'.', "'.'")?;
+                        self.parse_identifier()?;
+                    }
+                    "function" => {
+                        self.skip_function_body()?;
+                    }
+                    _ => {}
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Skip a function body: everything from after `function` to the matching `end`.
+    /// Handles nested blocks (`function`, `if`, `for`, `while` ... `end`)
+    /// and `repeat` ... `until`.
+    fn skip_function_body(&mut self) -> Result<(), ParseError> {
+        let start = self.pos;
+        let mut depth: usize = 1; // we're already inside one `function`
+
+        while depth > 0 {
+            self.skip_whitespace();
+
+            if self.at_string_start() {
+                self.parse_string()?;
+                continue;
+            }
+
+            match self.peek_byte() {
+                Some(b) if b.is_ascii_alphabetic() || b == b'_' => {
+                    let ident = self.parse_identifier()?;
+                    if BLOCK_OPENERS.contains(&ident) {
+                        depth += 1;
+                    } else if ident == "repeat" {
+                        // repeat...until doesn't use `end`, but can nest blocks
+                        depth += 1;
+                    } else if ident == "until" {
+                        // closes a `repeat` block
+                        depth -= 1;
+                    } else if ident == "end" {
+                        depth -= 1;
+                    }
+                }
+                Some(b'{') => {
+                    self.pos += 1;
+                    self.skip_table_contents()?;
+                }
+                Some(_) => {
+                    self.pos += 1;
+                }
+                None => {
+                    return Err(ParseError::new(
+                        self.span_at(start, self.pos - start),
+                        DeserializeErrorKind::UnexpectedEof {
+                            expected: "'end' to close function",
+                        },
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Skip table contents — assumes `{` already consumed.
+    fn skip_table_contents(&mut self) -> Result<(), ParseError> {
+        let mut depth: usize = 1;
+        while depth > 0 {
+            self.skip_whitespace();
+            if self.at_string_start() {
+                self.parse_string()?;
+                continue;
+            }
+            match self.peek_byte() {
+                Some(b'{') => {
+                    self.pos += 1;
+                    depth += 1;
+                }
+                Some(b'}') => {
+                    self.pos += 1;
+                    depth -= 1;
+                }
+                Some(_) => {
+                    self.pos += 1;
+                }
+                None => {
+                    return Err(self.error(DeserializeErrorKind::UnexpectedEof { expected: "'}'" }));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'de> FormatParser<'de> for LuaParser<'de> {
+    fn next_event(&mut self) -> Result<Option<ParseEvent<'de>>, ParseError> {
+        if let Some(event) = self.state.event_peek.take() {
+            return Ok(Some(event));
+        }
+        self.produce_event()
+    }
+
+    fn next_events(
+        &mut self,
+        buf: &mut VecDeque<ParseEvent<'de>>,
+        limit: usize,
+    ) -> Result<usize, ParseError> {
+        if limit == 0 {
+            return Ok(0);
+        }
+        let mut count = 0;
+        if let Some(event) = self.state.event_peek.take() {
+            buf.push_back(event);
+            count += 1;
+        }
+        while count < limit {
+            match self.produce_event()? {
+                Some(event) => {
+                    buf.push_back(event);
+                    count += 1;
+                }
+                None => break,
+            }
+        }
+        Ok(count)
+    }
+
+    fn peek_event(&mut self) -> Result<Option<ParseEvent<'de>>, ParseError> {
+        if let Some(event) = self.state.event_peek.clone() {
+            return Ok(Some(event));
+        }
+        let event = self.produce_event()?;
+        if let Some(ref e) = event {
+            self.state.event_peek = Some(e.clone());
+        }
+        Ok(event)
+    }
+
+    fn save(&mut self) -> SavePoint {
+        self.save_counter += 1;
+        self.saved_states
+            .push((self.save_counter, self.state.clone(), self.pos));
+        SavePoint(self.save_counter)
+    }
+
+    fn restore(&mut self, save_point: SavePoint) {
+        if let Some(idx) = self
+            .saved_states
+            .iter()
+            .position(|(id, _, _)| *id == save_point.0)
+        {
+            let (_, saved_state, saved_pos) = self.saved_states.remove(idx);
+            self.state = saved_state;
+            self.pos = saved_pos;
+        }
+    }
+
+    fn skip_value(&mut self) -> Result<(), ParseError> {
+        // Handle the case where peek_event was called before skip_value
+        if let Some(event) = self.state.event_peek.take() {
+            // When peeking a StructStart/SequenceStart, parse_value already pushed
+            // to self.state.stack. Skip the container contents and pop the entry.
+            match event.kind {
+                ParseEventKind::StructStart(_) | ParseEventKind::SequenceStart(_) => {
+                    let res = self.skip_table_contents();
+                    self.state.stack.pop();
+                    res?;
+                    self.finish_value_in_parent();
+                }
+                _ => {
+                    // Scalar or other event — already fully consumed during peek.
+                    // parse_value already called finish_value_in_parent for scalars.
+                }
+            }
+            return Ok(());
+        }
+        self.skip_value_raw()?;
+        self.finish_value_in_parent();
+        Ok(())
+    }
+
+    fn format_namespace(&self) -> Option<&'static str> {
+        Some("lua")
+    }
+
+    fn input(&self) -> Option<&'de [u8]> {
+        Some(self.input)
+    }
+
+    fn current_span(&self) -> Option<Span> {
+        let offset = self.state.last_token_start;
+        let len = self.pos.saturating_sub(offset);
+        Some(Span::new(offset, len))
+    }
+}

--- a/facet-lua/src/scanner.rs
+++ b/facet-lua/src/scanner.rs
@@ -1,0 +1,121 @@
+//! Low-level scanning utilities for Lua table constructor syntax.
+//!
+//! This module contains token-boundary finding, whitespace/comment skipping,
+//! escape lookup, and value classification — all stateless functions and types
+//! that the parser uses without semantic interpretation.
+
+/// Keywords that open a block requiring a matching `end`.
+/// Note: `do` is intentionally excluded — in `for/while ... do ... end`, the
+/// `for`/`while` already counts as the opener. Standalone `do...end` blocks
+/// in table constructors are vanishingly rare.
+pub(crate) const BLOCK_OPENERS: &[&str] = &["function", "if", "for", "while"];
+
+/// Count the `=` signs in a long-bracket opener starting at `input[pos]`.
+/// Returns `Some(level)` if `input[pos..]` starts with `[=*[`, else `None`.
+pub(crate) fn match_long_bracket_open(input: &[u8], pos: usize) -> Option<usize> {
+    if input.get(pos).copied() != Some(b'[') {
+        return None;
+    }
+    let mut p = pos + 1;
+    while p < input.len() && input[p] == b'=' {
+        p += 1;
+    }
+    if input.get(p).copied() == Some(b'[') {
+        Some(p - pos - 1) // number of '=' signs
+    } else {
+        None
+    }
+}
+
+/// Find the end of a long-bracket string/comment body.
+/// `pos` should point just past the opening `[=*[`.
+/// Returns the position just past the closing `]=*]`.
+pub(crate) fn find_long_bracket_close(input: &[u8], mut pos: usize, level: usize) -> Option<usize> {
+    while pos < input.len() {
+        if input[pos] == b']' {
+            let mut eq = 0;
+            while pos + 1 + eq < input.len() && input[pos + 1 + eq] == b'=' {
+                eq += 1;
+            }
+            if eq == level && input.get(pos + 1 + eq).copied() == Some(b']') {
+                return Some(pos + 2 + level);
+            }
+        }
+        pos += 1;
+    }
+    None
+}
+
+/// Skip whitespace and comments starting at `pos`. Returns the new position.
+pub(crate) fn skip_ws(input: &[u8], mut pos: usize) -> usize {
+    while pos < input.len() {
+        match input[pos] {
+            b' ' | b'\t' | b'\n' | b'\r' => pos += 1,
+            b'-' if input.get(pos + 1).copied() == Some(b'-') => {
+                pos += 2;
+                // Block comment: --[=*[...]=*]
+                if let Some(level) = match_long_bracket_open(input, pos) {
+                    let opener_len = 2 + level; // `[` + `=`*level + `[`
+                    pos = find_long_bracket_close(input, pos + opener_len, level)
+                        .unwrap_or(input.len());
+                } else {
+                    // Line comment: skip to end of line
+                    while pos < input.len() && input[pos] != b'\n' {
+                        pos += 1;
+                    }
+                }
+            }
+            _ => break,
+        }
+    }
+    pos
+}
+
+/// Look up a simple single-character Lua escape sequence.
+pub(crate) fn simple_escape(b: u8) -> Option<char> {
+    match b {
+        b'"' | b'\'' | b'\\' => Some(b as char),
+        b'n' => Some('\n'),
+        b'r' => Some('\r'),
+        b't' => Some('\t'),
+        b'a' => Some('\x07'),
+        b'b' => Some('\x08'),
+        b'f' => Some('\x0C'),
+        b'v' => Some('\x0B'),
+        _ => None,
+    }
+}
+
+/// Determine the expected byte length of a UTF-8 character from its leading byte.
+pub(crate) fn utf8_char_len(b: u8) -> usize {
+    if b < 0x80 {
+        1
+    } else if b < 0xE0 {
+        2
+    } else if b < 0xF0 {
+        3
+    } else {
+        4
+    }
+}
+
+/// Byte ranges for a scanned hex number (before value computation).
+pub(crate) struct HexExtent {
+    pub start: usize,
+    pub hex_start: usize,
+    pub int_end: usize,
+    pub frac_end: usize,
+    pub has_dot: bool,
+    pub has_exp: bool,
+}
+
+/// Classification of the next value token, used to DRY the dispatch
+/// between `parse_value` and `skip_value_raw`.
+pub(crate) enum ValueStart {
+    String,
+    Table,
+    Negative,
+    NaN,
+    Number,
+    Identifier,
+}

--- a/facet-lua/src/serializer.rs
+++ b/facet-lua/src/serializer.rs
@@ -1,0 +1,591 @@
+//! Serialize Rust values to Lua table constructor syntax.
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use facet_core::Facet;
+use facet_format::{FormatSerializer, ScalarValue, SerializeError, serialize_root};
+use facet_reflect::Peek;
+
+use crate::consts::{self, is_lua_identifier};
+
+/// Options for Lua serialization.
+#[derive(Debug, Clone)]
+pub struct SerializeOptions {
+    /// Whether to pretty-print with indentation (default: false)
+    pub pretty: bool,
+
+    /// Indentation string for pretty-printing (default: "    ")
+    pub indent: &'static str,
+}
+
+impl Default for SerializeOptions {
+    fn default() -> Self {
+        Self {
+            pretty: false,
+            indent: "    ",
+        }
+    }
+}
+
+impl SerializeOptions {
+    /// Create new default options (compact output).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enable pretty-printing with default indentation.
+    pub const fn pretty(mut self) -> Self {
+        self.pretty = true;
+        self
+    }
+
+    /// Set a custom indentation string (implies pretty-printing).
+    pub const fn indent(mut self, indent: &'static str) -> Self {
+        self.indent = indent;
+        self.pretty = true;
+        self
+    }
+}
+
+/// Lua-specific serialization error.
+#[derive(Debug)]
+pub struct LuaSerializeError {
+    msg: &'static str,
+}
+
+impl core::fmt::Display for LuaSerializeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.msg)
+    }
+}
+
+impl std::error::Error for LuaSerializeError {}
+
+#[derive(Debug, Clone, Copy)]
+enum Ctx {
+    Struct { first: bool },
+    Seq { first: bool },
+}
+
+/// Lua table serializer with configurable formatting options.
+pub struct LuaSerializer {
+    out: Vec<u8>,
+    stack: Vec<Ctx>,
+    options: SerializeOptions,
+}
+
+impl LuaSerializer {
+    /// Create a new Lua serializer with default (compact) options.
+    pub fn new() -> Self {
+        Self::with_options(SerializeOptions::default())
+    }
+
+    /// Create a new Lua serializer with the given options.
+    pub const fn with_options(options: SerializeOptions) -> Self {
+        Self {
+            out: Vec::new(),
+            stack: Vec::new(),
+            options,
+        }
+    }
+
+    /// Consume the serializer and return the output bytes.
+    pub fn finish(self) -> Vec<u8> {
+        self.out
+    }
+
+    /// Current nesting depth (for indentation).
+    const fn depth(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// Write a newline and indentation if in pretty mode.
+    fn write_indent(&mut self) {
+        if self.options.pretty {
+            self.out.push(b'\n');
+            for _ in 0..self.depth() {
+                self.out.extend_from_slice(self.options.indent.as_bytes());
+            }
+        }
+    }
+
+    fn before_value(&mut self) -> Result<(), LuaSerializeError> {
+        match self.stack.last_mut() {
+            Some(Ctx::Seq { first }) => {
+                if !*first {
+                    self.out.push(b',');
+                }
+                *first = false;
+                self.write_indent();
+            }
+            Some(Ctx::Struct { .. }) => {
+                // struct values are separated by `field_key`
+            }
+            None => {}
+        }
+        Ok(())
+    }
+
+    /// Write a Lua string with proper escaping.
+    fn write_lua_string(&mut self, s: &str) {
+        self.out.push(b'"');
+        for c in s.chars() {
+            self.write_lua_escaped_char(c);
+        }
+        self.out.push(b'"');
+    }
+
+    #[inline]
+    fn write_lua_escaped_char(&mut self, c: char) {
+        match c {
+            '"' => self.out.extend_from_slice(b"\\\""),
+            '\\' => self.out.extend_from_slice(b"\\\\"),
+            '\n' => self.out.extend_from_slice(b"\\n"),
+            '\r' => self.out.extend_from_slice(b"\\r"),
+            '\t' => self.out.extend_from_slice(b"\\t"),
+            '\0' => self.out.extend_from_slice(b"\\0"),
+            c if c.is_ascii_control() => {
+                // Lua uses \ddd decimal escaping for control chars (0–31)
+                let b = c as u8;
+                self.out.push(b'\\');
+                if b >= 100 {
+                    self.out.push(b'0' + b / 100);
+                }
+                if b >= 10 {
+                    self.out.push(b'0' + (b / 10) % 10);
+                }
+                self.out.push(b'0' + b % 10);
+            }
+            c if c.is_ascii() => {
+                self.out.push(c as u8);
+            }
+            c => {
+                let mut buf = [0u8; 4];
+                let len = c.encode_utf8(&mut buf).len();
+                self.out.extend_from_slice(&buf[..len]);
+            }
+        }
+    }
+}
+
+impl Default for LuaSerializer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FormatSerializer for LuaSerializer {
+    type Error = LuaSerializeError;
+
+    fn begin_struct(&mut self) -> Result<(), Self::Error> {
+        self.before_value()?;
+        self.out.push(b'{');
+        self.stack.push(Ctx::Struct { first: true });
+        Ok(())
+    }
+
+    fn field_key(&mut self, key: &str) -> Result<(), Self::Error> {
+        match self.stack.last_mut() {
+            Some(Ctx::Struct { first }) => {
+                if !*first {
+                    self.out.push(b',');
+                }
+                *first = false;
+                self.write_indent();
+                // Lua field syntax: key = value
+                // If key is a valid Lua identifier, use bare name; otherwise use ["key"]
+                if is_lua_identifier(key) {
+                    self.out.extend_from_slice(key.as_bytes());
+                } else {
+                    self.out.push(b'[');
+                    self.write_lua_string(key);
+                    self.out.push(b']');
+                }
+                if self.options.pretty {
+                    self.out.extend_from_slice(b" = ");
+                } else {
+                    self.out.extend_from_slice(b"=");
+                }
+                Ok(())
+            }
+            _ => Err(LuaSerializeError {
+                msg: "field_key called outside of a struct",
+            }),
+        }
+    }
+
+    fn end_struct(&mut self) -> Result<(), Self::Error> {
+        match self.stack.pop() {
+            Some(Ctx::Struct { first }) => {
+                if !first {
+                    // Add trailing comma in pretty mode
+                    if self.options.pretty {
+                        self.out.push(b',');
+                    }
+                    self.write_indent();
+                }
+                self.out.push(b'}');
+                Ok(())
+            }
+            _ => Err(LuaSerializeError {
+                msg: "end_struct called without matching begin_struct",
+            }),
+        }
+    }
+
+    fn begin_seq(&mut self) -> Result<(), Self::Error> {
+        self.before_value()?;
+        self.out.push(b'{');
+        self.stack.push(Ctx::Seq { first: true });
+        Ok(())
+    }
+
+    fn end_seq(&mut self) -> Result<(), Self::Error> {
+        match self.stack.pop() {
+            Some(Ctx::Seq { first }) => {
+                if !first {
+                    if self.options.pretty {
+                        self.out.push(b',');
+                    }
+                    self.write_indent();
+                }
+                self.out.push(b'}');
+                Ok(())
+            }
+            _ => Err(LuaSerializeError {
+                msg: "end_seq called without matching begin_seq",
+            }),
+        }
+    }
+
+    fn scalar(&mut self, scalar: ScalarValue<'_>) -> Result<(), Self::Error> {
+        self.before_value()?;
+        match scalar {
+            ScalarValue::Null | ScalarValue::Unit => self.out.extend_from_slice(consts::KW_NIL),
+            ScalarValue::Bool(v) => {
+                if v {
+                    self.out.extend_from_slice(consts::KW_TRUE)
+                } else {
+                    self.out.extend_from_slice(consts::KW_FALSE)
+                }
+            }
+            ScalarValue::Char(c) => {
+                self.out.push(b'"');
+                self.write_lua_escaped_char(c);
+                self.out.push(b'"');
+            }
+            ScalarValue::I64(v) => {
+                self.out.extend_from_slice(v.to_string().as_bytes());
+            }
+            ScalarValue::U64(v) => {
+                self.out.extend_from_slice(v.to_string().as_bytes());
+            }
+            ScalarValue::I128(v) => {
+                self.out.extend_from_slice(v.to_string().as_bytes());
+            }
+            ScalarValue::U128(v) => {
+                self.out.extend_from_slice(v.to_string().as_bytes());
+            }
+            ScalarValue::F64(v) => {
+                if v.is_nan() {
+                    self.out.extend_from_slice(consts::NAN_LITERAL);
+                } else if v.is_infinite() {
+                    if v.is_sign_positive() {
+                        self.out.extend_from_slice(consts::MATH_HUGE);
+                    } else {
+                        self.out.push(b'-');
+                        self.out.extend_from_slice(consts::MATH_HUGE);
+                    }
+                } else {
+                    self.out.extend_from_slice(v.to_string().as_bytes());
+                }
+            }
+            ScalarValue::Str(s) => self.write_lua_string(&s),
+            ScalarValue::Bytes(_) => {
+                return Err(LuaSerializeError {
+                    msg: "bytes serialization unsupported for lua",
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn format_namespace(&self) -> Option<&'static str> {
+        Some("lua")
+    }
+}
+
+/// Serialize a value to a Lua table string.
+pub fn to_string<'facet, T>(value: &T) -> Result<String, SerializeError<LuaSerializeError>>
+where
+    T: Facet<'facet> + ?Sized,
+{
+    let mut serializer = LuaSerializer::new();
+    serialize_root(&mut serializer, Peek::new(value))?;
+    let bytes = serializer.finish();
+    Ok(String::from_utf8(bytes).expect("Lua output should always be valid UTF-8"))
+}
+
+/// Serialize a value to a pretty-printed Lua table string.
+pub fn to_string_pretty<'facet, T>(value: &T) -> Result<String, SerializeError<LuaSerializeError>>
+where
+    T: Facet<'facet> + ?Sized,
+{
+    let mut serializer = LuaSerializer::with_options(SerializeOptions::default().pretty());
+    serialize_root(&mut serializer, Peek::new(value))?;
+    let bytes = serializer.finish();
+    Ok(String::from_utf8(bytes).expect("Lua output should always be valid UTF-8"))
+}
+
+/// Serialize a value to a Lua table string with custom options.
+pub fn to_string_with_options<'facet, T>(
+    value: &T,
+    options: &SerializeOptions,
+) -> Result<String, SerializeError<LuaSerializeError>>
+where
+    T: Facet<'facet> + ?Sized,
+{
+    let mut serializer = LuaSerializer::with_options(options.clone());
+    serialize_root(&mut serializer, Peek::new(value))?;
+    let bytes = serializer.finish();
+    Ok(String::from_utf8(bytes).expect("Lua output should always be valid UTF-8"))
+}
+
+/// Serialize a value to Lua table bytes.
+pub fn to_vec<'facet, T>(value: &T) -> Result<Vec<u8>, SerializeError<LuaSerializeError>>
+where
+    T: Facet<'facet> + ?Sized,
+{
+    to_vec_with_options(value, &SerializeOptions::default())
+}
+
+/// Serialize a value to pretty-printed Lua table bytes.
+pub fn to_vec_pretty<'facet, T>(value: &T) -> Result<Vec<u8>, SerializeError<LuaSerializeError>>
+where
+    T: Facet<'facet> + ?Sized,
+{
+    to_vec_with_options(value, &SerializeOptions::default().pretty())
+}
+
+/// Serialize a value to Lua table bytes with custom options.
+pub fn to_vec_with_options<'facet, T>(
+    value: &T,
+    options: &SerializeOptions,
+) -> Result<Vec<u8>, SerializeError<LuaSerializeError>>
+where
+    T: Facet<'facet> + ?Sized,
+{
+    let mut serializer = LuaSerializer::with_options(options.clone());
+    serialize_root(&mut serializer, Peek::new(value))?;
+    Ok(serializer.finish())
+}
+
+/// Serialize a value to a `std::io::Write` writer as Lua table syntax.
+pub fn to_writer_std<'facet, W, T>(writer: W, value: &T) -> std::io::Result<()>
+where
+    W: std::io::Write,
+    T: Facet<'facet> + ?Sized,
+{
+    to_writer_std_with_options(writer, value, &SerializeOptions::default())
+}
+
+/// Serialize a value to a `std::io::Write` writer as pretty-printed Lua table syntax.
+pub fn to_writer_std_pretty<'facet, W, T>(writer: W, value: &T) -> std::io::Result<()>
+where
+    W: std::io::Write,
+    T: Facet<'facet> + ?Sized,
+{
+    to_writer_std_with_options(writer, value, &SerializeOptions::default().pretty())
+}
+
+/// Serialize a value to a `std::io::Write` writer as Lua table syntax with custom options.
+pub fn to_writer_std_with_options<'facet, W, T>(
+    mut writer: W,
+    value: &T,
+    options: &SerializeOptions,
+) -> std::io::Result<()>
+where
+    W: std::io::Write,
+    T: Facet<'facet> + ?Sized,
+{
+    let bytes =
+        to_vec_with_options(value, options).map_err(|e| std::io::Error::other(e.to_string()))?;
+    writer.write_all(&bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use facet::Facet;
+
+    #[test]
+    fn test_simple_struct() {
+        #[derive(Facet)]
+        struct User {
+            name: String,
+            age: u32,
+        }
+
+        let user = User {
+            name: "Alice".to_string(),
+            age: 30,
+        };
+        let lua = to_string(&user).unwrap();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_simple_struct_pretty() {
+        #[derive(Facet)]
+        struct User {
+            name: String,
+            age: u32,
+        }
+
+        let user = User {
+            name: "Alice".to_string(),
+            age: 30,
+        };
+        let lua = to_string_pretty(&user).unwrap();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_nested_struct() {
+        #[derive(Facet)]
+        struct Inner {
+            value: i32,
+        }
+
+        #[derive(Facet)]
+        struct Outer {
+            inner: Inner,
+            name: String,
+        }
+
+        let outer = Outer {
+            inner: Inner { value: 42 },
+            name: "test".to_string(),
+        };
+        let lua = to_string_pretty(&outer).unwrap();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_vec() {
+        #[derive(Facet)]
+        struct Data {
+            items: Vec<String>,
+        }
+
+        let data = Data {
+            items: vec!["hello".to_string(), "world".to_string()],
+        };
+        let lua = to_string_pretty(&data).unwrap();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_optional_field() {
+        #[derive(Facet)]
+        struct Config {
+            required: String,
+            optional: Option<String>,
+        }
+
+        let config = Config {
+            required: "yes".to_string(),
+            optional: None,
+        };
+        let lua = to_string_pretty(&config).unwrap();
+        insta::assert_snapshot!("optional_none", lua);
+
+        let config_some = Config {
+            required: "yes".to_string(),
+            optional: Some("value".to_string()),
+        };
+        let lua_some = to_string_pretty(&config_some).unwrap();
+        insta::assert_snapshot!("optional_some", lua_some);
+    }
+
+    #[test]
+    fn test_bool_and_numbers() {
+        #[derive(Facet)]
+        struct Mixed {
+            flag: bool,
+            count: u64,
+            score: f64,
+        }
+
+        let mixed = Mixed {
+            flag: true,
+            count: 42,
+            score: 3.125,
+        };
+        let lua = to_string_pretty(&mixed).unwrap();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_string_escaping() {
+        #[derive(Facet)]
+        struct Text {
+            content: String,
+        }
+
+        let text = Text {
+            content: "hello \"world\"\nnew\tline\\backslash".to_string(),
+        };
+        let lua = to_string(&text).unwrap();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_hashmap() {
+        use std::collections::BTreeMap;
+
+        #[derive(Facet)]
+        struct Registry {
+            entries: BTreeMap<String, i32>,
+        }
+
+        let mut entries = BTreeMap::new();
+        entries.insert("alpha".to_string(), 1);
+        entries.insert("beta".to_string(), 2);
+
+        let registry = Registry { entries };
+        let lua = to_string_pretty(&registry).unwrap();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_enum_unit_variant() {
+        #[derive(Facet)]
+        #[repr(u8)]
+        enum Status {
+            Active,
+            #[allow(dead_code)]
+            Inactive,
+        }
+
+        let status = Status::Active;
+        let lua = to_string(&status).unwrap();
+        insta::assert_snapshot!(lua);
+    }
+
+    #[test]
+    fn test_compact_output() {
+        #[derive(Facet)]
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        let point = Point { x: 10, y: 20 };
+        let lua = to_string(&point).unwrap();
+        insta::assert_snapshot!(lua);
+    }
+}

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__adjacently_tagged_enum.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__adjacently_tagged_enum.snap
@@ -1,0 +1,20 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias Action Action.Stop | Action.Move | Action.Resize
+
+---@class Action.Move
+---@field t "Move"
+---@field c number
+
+---@class Action.Resize
+---@field t "Resize"
+---@field c Action.Resize._
+
+---@class Action.Resize._
+---@field width integer
+---@field height integer
+
+---@class Action.Stop
+---@field t "Stop"

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__enum_rename_all_snake_case.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__enum_rename_all_snake_case.snap
@@ -1,0 +1,5 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias ValidationErrorCode "circular_dependency" | "invalid_naming" | "unknown_requirement"

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__enum_struct_variant.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__enum_struct_variant.snap
@@ -1,0 +1,18 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias Message Message.TextMessage | Message.ImageUpload
+
+---@class Message.ImageUpload
+---@field ImageUpload Message.ImageUpload._
+
+---@class Message.ImageUpload._
+---@field url string
+---@field width integer
+
+---@class Message.TextMessage
+---@field TextMessage Message.TextMessage._
+
+---@class Message.TextMessage._
+---@field content string

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__enum_with_variant_docs.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__enum_with_variant_docs.snap
@@ -1,0 +1,8 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias Color
+---| "Red" # The color red
+---| "Green" # The color green
+---| "Blue" # The color blue

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__hashmap.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__hashmap.snap
@@ -1,0 +1,6 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@class Registry
+---@field entries table<string, integer>

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__internally_tagged_enum.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__internally_tagged_enum.snap
@@ -1,0 +1,12 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias Request Request.Ping | Request.Echo
+
+---@class Request.Echo
+---@field type "Echo"
+---@field message string
+
+---@class Request.Ping
+---@field type "Ping"

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__mixed_enum_variants.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__mixed_enum_variants.snap
@@ -1,0 +1,20 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias Event
+---| "Empty" # Unit variant
+---| Event.Id # Newtype variant
+---| Event.Data # Struct variant
+
+--- Struct variant
+---@class Event.Data
+---@field Data Event.Data._
+
+---@class Event.Data._
+---@field name string
+---@field value number
+
+--- Newtype variant
+---@class Event.Id
+---@field Id integer

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__multi_type_generation.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__multi_type_generation.snap
@@ -1,0 +1,9 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias Role "Admin" | "User"
+
+---@class User
+---@field name string
+---@field age integer

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__nested_types.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__nested_types.snap
@@ -1,0 +1,10 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@class Inner
+---@field value integer
+
+---@class Outer
+---@field inner Inner
+---@field name string

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__newtype_struct.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__newtype_struct.snap
@@ -1,0 +1,5 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias UserId integer

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__optional_field.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__optional_field.snap
@@ -1,0 +1,7 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@class Config
+---@field required string
+---@field optional? string

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__simple_enum.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__simple_enum.snap
@@ -1,0 +1,5 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias Status "Active" | "Inactive" | "Pending"

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__simple_struct.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__simple_struct.snap
@@ -1,0 +1,7 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@class User
+---@field name string
+---@field age integer

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__struct_with_tuple_field.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__struct_with_tuple_field.snap
@@ -1,0 +1,6 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@class Container
+---@field coordinates { [1]: integer, [2]: integer }

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__transparent_wrapper.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__transparent_wrapper.snap
@@ -1,0 +1,5 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias UserId string

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__transparent_wrapper_with_inner_type.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__transparent_wrapper_with_inner_type.snap
@@ -1,0 +1,8 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@class Inner
+---@field value integer
+
+---@alias Wrapper Inner

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__tuple_struct.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__tuple_struct.snap
@@ -1,0 +1,5 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias Point { [1]: number, [2]: number }

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__unit_struct.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__unit_struct.snap
@@ -1,0 +1,5 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias Empty nil

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__untagged_enum.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__untagged_enum.snap
@@ -1,0 +1,5 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@alias Value string | number | boolean

--- a/facet-lua/src/snapshots/facet_lua__annotations__tests__vec.snap
+++ b/facet-lua/src/snapshots/facet_lua__annotations__tests__vec.snap
@@ -1,0 +1,6 @@
+---
+source: facet-lua/src/annotations.rs
+expression: lua
+---
+---@class Data
+---@field items string[]

--- a/facet-lua/src/snapshots/facet_lua__serializer__tests__bool_and_numbers.snap
+++ b/facet-lua/src/snapshots/facet_lua__serializer__tests__bool_and_numbers.snap
@@ -1,0 +1,9 @@
+---
+source: facet-lua/src/serializer.rs
+expression: lua
+---
+{
+    flag = true,
+    count = 42,
+    score = 3.125,
+}

--- a/facet-lua/src/snapshots/facet_lua__serializer__tests__compact_output.snap
+++ b/facet-lua/src/snapshots/facet_lua__serializer__tests__compact_output.snap
@@ -1,0 +1,5 @@
+---
+source: facet-lua/src/serializer.rs
+expression: lua
+---
+{x=10,y=20}

--- a/facet-lua/src/snapshots/facet_lua__serializer__tests__enum_unit_variant.snap
+++ b/facet-lua/src/snapshots/facet_lua__serializer__tests__enum_unit_variant.snap
@@ -1,0 +1,5 @@
+---
+source: facet-lua/src/serializer.rs
+expression: lua
+---
+"Active"

--- a/facet-lua/src/snapshots/facet_lua__serializer__tests__hashmap.snap
+++ b/facet-lua/src/snapshots/facet_lua__serializer__tests__hashmap.snap
@@ -1,0 +1,10 @@
+---
+source: facet-lua/src/serializer.rs
+expression: lua
+---
+{
+    entries = {
+        alpha = 1,
+        beta = 2,
+    },
+}

--- a/facet-lua/src/snapshots/facet_lua__serializer__tests__nested_struct.snap
+++ b/facet-lua/src/snapshots/facet_lua__serializer__tests__nested_struct.snap
@@ -1,0 +1,10 @@
+---
+source: facet-lua/src/serializer.rs
+expression: lua
+---
+{
+    inner = {
+        value = 42,
+    },
+    name = "test",
+}

--- a/facet-lua/src/snapshots/facet_lua__serializer__tests__optional_none.snap
+++ b/facet-lua/src/snapshots/facet_lua__serializer__tests__optional_none.snap
@@ -1,0 +1,8 @@
+---
+source: facet-lua/src/serializer.rs
+expression: lua
+---
+{
+    required = "yes",
+    optional = nil,
+}

--- a/facet-lua/src/snapshots/facet_lua__serializer__tests__optional_some.snap
+++ b/facet-lua/src/snapshots/facet_lua__serializer__tests__optional_some.snap
@@ -1,0 +1,8 @@
+---
+source: facet-lua/src/serializer.rs
+expression: lua_some
+---
+{
+    required = "yes",
+    optional = "value",
+}

--- a/facet-lua/src/snapshots/facet_lua__serializer__tests__simple_struct.snap
+++ b/facet-lua/src/snapshots/facet_lua__serializer__tests__simple_struct.snap
@@ -1,0 +1,5 @@
+---
+source: facet-lua/src/serializer.rs
+expression: lua
+---
+{name="Alice",age=30}

--- a/facet-lua/src/snapshots/facet_lua__serializer__tests__simple_struct_pretty.snap
+++ b/facet-lua/src/snapshots/facet_lua__serializer__tests__simple_struct_pretty.snap
@@ -1,0 +1,8 @@
+---
+source: facet-lua/src/serializer.rs
+expression: lua
+---
+{
+    name = "Alice",
+    age = 30,
+}

--- a/facet-lua/src/snapshots/facet_lua__serializer__tests__string_escaping.snap
+++ b/facet-lua/src/snapshots/facet_lua__serializer__tests__string_escaping.snap
@@ -1,0 +1,5 @@
+---
+source: facet-lua/src/serializer.rs
+expression: lua
+---
+{content="hello \"world\"\nnew\tline\\backslash"}

--- a/facet-lua/src/snapshots/facet_lua__serializer__tests__vec.snap
+++ b/facet-lua/src/snapshots/facet_lua__serializer__tests__vec.snap
@@ -1,0 +1,10 @@
+---
+source: facet-lua/src/serializer.rs
+expression: lua
+---
+{
+    items = {
+        "hello",
+        "world",
+    },
+}

--- a/facet-lua/src/snapshots/facet_lua__tests__to_lua_annotated.snap
+++ b/facet-lua/src/snapshots/facet_lua__tests__to_lua_annotated.snap
@@ -1,0 +1,15 @@
+---
+source: facet-lua/src/lib.rs
+expression: lua
+---
+---@meta
+
+---@class User
+---@field name string
+---@field age integer
+
+---@type User
+local user = {
+    name = "DT",
+    age = 25,
+}

--- a/facet-lua/src/snapshots/facet_lua__tests__to_lua_annotated_nested.snap
+++ b/facet-lua/src/snapshots/facet_lua__tests__to_lua_annotated_nested.snap
@@ -1,0 +1,22 @@
+---
+source: facet-lua/src/lib.rs
+expression: lua
+---
+---@meta
+
+---@class Address
+---@field street string
+---@field city string
+
+---@class Person
+---@field name string
+---@field address Address
+
+---@type Person
+local person = {
+    name = "Alice",
+    address = {
+        street = "123 Main St",
+        city = "Springfield",
+    },
+}

--- a/facet-lua/src/snapshots/facet_lua__tests__to_lua_annotated_with_option.snap
+++ b/facet-lua/src/snapshots/facet_lua__tests__to_lua_annotated_with_option.snap
@@ -1,0 +1,15 @@
+---
+source: facet-lua/src/lib.rs
+expression: lua
+---
+---@meta
+
+---@class Config
+---@field host string
+---@field port? integer
+
+---@type Config
+local config = {
+    host = "localhost",
+    port = 8080,
+}

--- a/facet-lua/src/snapshots/facet_lua__tests__to_lua_annotated_with_vec.snap
+++ b/facet-lua/src/snapshots/facet_lua__tests__to_lua_annotated_with_vec.snap
@@ -1,0 +1,18 @@
+---
+source: facet-lua/src/lib.rs
+expression: lua
+---
+---@meta
+
+---@class Settings
+---@field name string
+---@field tags string[]
+
+---@type Settings
+local settings = {
+    name = "test",
+    tags = {
+        "a",
+        "b",
+    },
+}

--- a/facet-lua/tests/format_suite.rs
+++ b/facet-lua/tests/format_suite.rs
@@ -1,0 +1,558 @@
+#![forbid(unsafe_code)]
+
+use facet::Facet;
+use facet_format::{DeserializeError, FormatDeserializer};
+use facet_format_suite::{CaseOutcome, CaseSpec, FormatSuite, all_cases};
+use facet_lua::{LuaParser, to_vec};
+use libtest_mimic::{Arguments, Failed, Trial};
+
+struct LuaSlice;
+
+impl FormatSuite for LuaSlice {
+    type Error = DeserializeError;
+
+    fn format_name() -> &'static str {
+        "facet-lua/slice"
+    }
+
+    fn highlight_language() -> Option<&'static str> {
+        Some("lua")
+    }
+
+    fn deserialize<T>(input: &[u8]) -> Result<T, Self::Error>
+    where
+        T: Facet<'static> + core::fmt::Debug,
+    {
+        let s = core::str::from_utf8(input).map_err(|e| {
+            let mut context = [0u8; 16];
+            let context_len = e.valid_up_to().min(16);
+            context[..context_len].copy_from_slice(&input[..context_len]);
+            facet_format::DeserializeErrorKind::InvalidUtf8 {
+                context,
+                context_len: context_len as u8,
+            }
+            .with_span(facet_reflect::Span::new(e.valid_up_to(), 1))
+        })?;
+        let mut parser = LuaParser::new(s);
+        let mut de = FormatDeserializer::new_owned(&mut parser);
+        de.deserialize_root::<T>()
+    }
+
+    fn serialize<T>(value: &T) -> Option<Result<Vec<u8>, String>>
+    where
+        for<'facet> T: Facet<'facet>,
+        T: core::fmt::Debug,
+    {
+        Some(to_vec(value).map_err(|e| e.to_string()))
+    }
+
+    // ── Core cases ──
+
+    fn struct_single_field() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "facet"}"#)
+    }
+
+    fn sequence_numbers() -> CaseSpec {
+        CaseSpec::from_str("{1, 2, 3}")
+    }
+
+    fn sequence_mixed_scalars() -> CaseSpec {
+        CaseSpec::from_str("{-1, 4.625, nil, true}")
+    }
+
+    fn struct_nested() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"{id = 42, child = {code = "alpha", active = true}, tags = {"core", "json"}}"#,
+        )
+    }
+
+    fn enum_complex() -> CaseSpec {
+        CaseSpec::from_str(r#"{Label = {name = "facet", level = 7}}"#)
+    }
+
+    // ── Attribute cases ──
+
+    fn attr_rename_field() -> CaseSpec {
+        CaseSpec::from_str(r#"{userName = "alice", age = 30}"#)
+    }
+
+    fn attr_rename_all_camel() -> CaseSpec {
+        CaseSpec::from_str(r#"{firstName = "Jane", lastName = "Doe", isActive = true}"#)
+    }
+
+    fn attr_default_field() -> CaseSpec {
+        CaseSpec::from_str(r#"{required = "present"}"#)
+    }
+
+    fn attr_default_struct() -> CaseSpec {
+        CaseSpec::from_str(r#"{count = 123}"#)
+    }
+
+    fn attr_default_function() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "hello"}"#)
+    }
+
+    fn option_none() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "test"}"#)
+    }
+
+    fn option_some() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "test", nickname = "nick"}"#)
+    }
+
+    fn option_null() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "test", nickname = nil}"#)
+            .without_roundtrip("nil serializes as missing field, not explicit nil")
+    }
+
+    fn attr_skip_serializing() -> CaseSpec {
+        CaseSpec::from_str(r#"{visible = "shown"}"#)
+    }
+
+    fn attr_skip_serializing_if() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "test"}"#)
+    }
+
+    fn attr_skip() -> CaseSpec {
+        CaseSpec::from_str(r#"{visible = "data"}"#)
+    }
+
+    // ── Enum tagging cases ──
+
+    fn enum_internally_tagged() -> CaseSpec {
+        CaseSpec::from_str(r#"{type = "Circle", radius = 5.0}"#)
+    }
+
+    fn enum_adjacently_tagged() -> CaseSpec {
+        CaseSpec::from_str(r#"{t = "Message", c = "hello"}"#)
+    }
+
+    // ── Advanced cases ──
+
+    fn struct_flatten() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "point", x = 10, y = 20}"#)
+    }
+
+    fn transparent_newtype() -> CaseSpec {
+        CaseSpec::from_str(r#"{id = 42, name = "alice"}"#)
+    }
+
+    // ── Error cases ──
+
+    fn deny_unknown_fields() -> CaseSpec {
+        CaseSpec::expect_error(r#"{foo = "abc", bar = 42, baz = true}"#, "unknown field")
+    }
+
+    fn error_type_mismatch_string_to_int() -> CaseSpec {
+        CaseSpec::expect_error(r#"{value = "not_a_number"}"#, "failed to parse")
+    }
+
+    fn error_type_mismatch_object_to_array() -> CaseSpec {
+        CaseSpec::expect_error(
+            r#"{items = {wrong = "structure"}}"#,
+            "got object, expected array",
+        )
+    }
+
+    fn error_missing_required_field() -> CaseSpec {
+        CaseSpec::expect_error(r#"{name = "Alice", age = 30}"#, "missing field")
+    }
+
+    // ── Alias cases ──
+
+    fn attr_alias() -> CaseSpec {
+        CaseSpec::from_str(r#"{old_name = "value", count = 5}"#)
+            .without_roundtrip("alias is only for deserialization, serializes as new_name")
+    }
+
+    fn attr_rename_vs_alias_precedence() -> CaseSpec {
+        CaseSpec::from_str(r#"{officialName = "test", id = 1}"#)
+    }
+
+    fn attr_rename_all_kebab() -> CaseSpec {
+        CaseSpec::from_str(r#"{["first-name"] = "John", ["last-name"] = "Doe", ["user-id"] = 42}"#)
+    }
+
+    fn attr_rename_all_screaming() -> CaseSpec {
+        CaseSpec::from_str(r#"{API_KEY = "secret-123", MAX_RETRY_COUNT = 5}"#)
+    }
+
+    fn attr_rename_unicode() -> CaseSpec {
+        // Unicode keys use ["key"] bracket syntax in Lua
+        CaseSpec::from_str(r#"{["🎉"] = "party"}"#)
+    }
+
+    fn attr_rename_special_chars() -> CaseSpec {
+        CaseSpec::from_str(r#"{["@type"] = "node"}"#)
+    }
+
+    // ── Proxy cases ──
+
+    fn proxy_container() -> CaseSpec {
+        CaseSpec::from_str(r#""42""#)
+    }
+
+    fn proxy_field_level() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "test", count = "100"}"#)
+    }
+
+    fn proxy_validation_error() -> CaseSpec {
+        CaseSpec::expect_error(r#""not_a_number""#, "invalid digit")
+    }
+
+    fn proxy_with_option() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "test", count = "42"}"#)
+    }
+
+    fn proxy_with_enum() -> CaseSpec {
+        CaseSpec::from_str(r#"{Value = "99"}"#)
+    }
+
+    fn proxy_with_transparent() -> CaseSpec {
+        CaseSpec::from_str(r#""42""#)
+    }
+
+    fn opaque_proxy() -> CaseSpec {
+        CaseSpec::from_str(r#"{value = {inner = 42}}"#).with_partial_eq()
+    }
+
+    fn opaque_proxy_option() -> CaseSpec {
+        CaseSpec::from_str(r#"{value = {inner = 99}}"#).with_partial_eq()
+    }
+
+    fn transparent_multilevel() -> CaseSpec {
+        CaseSpec::from_str("42")
+    }
+
+    fn transparent_option() -> CaseSpec {
+        CaseSpec::from_str("99")
+    }
+
+    fn transparent_nonzero() -> CaseSpec {
+        CaseSpec::from_str("42")
+    }
+
+    fn flatten_optional_some() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "test", version = 1, author = "alice"}"#)
+    }
+
+    fn flatten_optional_none() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "test"}"#)
+    }
+
+    fn flatten_overlapping_fields_error() -> CaseSpec {
+        CaseSpec::expect_error(
+            r#"{field_a = "a", field_b = "b", shared = 1}"#,
+            "Duplicate field",
+        )
+    }
+
+    fn flatten_multilevel() -> CaseSpec {
+        CaseSpec::from_str(r#"{top_field = "top", mid_field = 42, deep_field = 100}"#)
+    }
+
+    fn flatten_multiple_enums() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"{name = "service", Password = {password = "secret"}, Tcp = {port = 8080}}"#,
+        )
+        .without_roundtrip("serialization of flattened enums not yet supported")
+    }
+
+    // ── Scalar cases ──
+
+    fn scalar_bool() -> CaseSpec {
+        CaseSpec::from_str(r#"{yes = true, no = false}"#)
+    }
+
+    fn scalar_integers() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"{signed_8 = -128, unsigned_8 = 255, signed_32 = -2147483648, unsigned_32 = 4294967295, signed_64 = -9223372036854775808, unsigned_64 = 18446744073709551615}"#,
+        )
+    }
+
+    fn scalar_floats() -> CaseSpec {
+        CaseSpec::from_str(r#"{float_32 = 1.5, float_64 = 2.25}"#)
+    }
+
+    fn scalar_floats_scientific() -> CaseSpec {
+        CaseSpec::from_str(r#"{large = 1.23e10, small = -4.56e-7, positive_exp = 5e3}"#)
+    }
+
+    // ── Network type cases ──
+
+    fn net_ip_addr_v4() -> CaseSpec {
+        CaseSpec::from_str(r#"{addr = "192.168.1.1"}"#)
+    }
+
+    fn net_ip_addr_v6() -> CaseSpec {
+        CaseSpec::from_str(r#"{addr = "2001:db8::1"}"#)
+    }
+
+    fn net_ipv4_addr() -> CaseSpec {
+        CaseSpec::from_str(r#"{addr = "127.0.0.1"}"#)
+    }
+
+    fn net_ipv6_addr() -> CaseSpec {
+        CaseSpec::from_str(r#"{addr = "::1"}"#)
+    }
+
+    fn net_socket_addr_v4() -> CaseSpec {
+        CaseSpec::from_str(r#"{addr = "192.168.1.1:8080"}"#)
+    }
+
+    fn net_socket_addr_v6() -> CaseSpec {
+        CaseSpec::from_str(r#"{addr = "[2001:db8::1]:443"}"#)
+    }
+
+    fn net_socket_addr_v4_explicit() -> CaseSpec {
+        CaseSpec::from_str(r#"{addr = "10.0.0.1:3000"}"#)
+    }
+
+    fn net_socket_addr_v6_explicit() -> CaseSpec {
+        CaseSpec::from_str(r#"{addr = "[fe80::1]:9000"}"#)
+    }
+
+    // ── Collection cases ──
+
+    fn map_string_keys() -> CaseSpec {
+        CaseSpec::from_str(r#"{data = {alpha = 1, beta = 2}}"#)
+    }
+
+    fn tuple_simple() -> CaseSpec {
+        CaseSpec::from_str(r#"{triple = {"hello", 42, true}}"#)
+    }
+
+    fn tuple_nested() -> CaseSpec {
+        CaseSpec::from_str(r#"{outer = {{1, 2}, {"test", true}}}"#)
+    }
+
+    fn tuple_empty() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "test", empty = {}}"#)
+            .without_roundtrip("empty tuple serialization format mismatch")
+    }
+
+    fn tuple_single_element() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "test", single = {42}}"#)
+    }
+
+    fn tuple_struct_variant() -> CaseSpec {
+        CaseSpec::from_str(r#"{Pair = {"test", 42}}"#)
+    }
+
+    fn tuple_newtype_variant() -> CaseSpec {
+        CaseSpec::from_str(r#"{Some = 99}"#)
+    }
+
+    // ── Enum variant cases ──
+
+    fn enum_unit_variant() -> CaseSpec {
+        CaseSpec::from_str(r#""Active""#)
+    }
+
+    fn numeric_enum() -> CaseSpec {
+        CaseSpec::from_str("1")
+    }
+
+    fn signed_numeric_enum() -> CaseSpec {
+        CaseSpec::from_str("-1")
+    }
+
+    fn inferred_numeric_enum() -> CaseSpec {
+        CaseSpec::from_str(r#""0""#)
+    }
+
+    fn enum_untagged() -> CaseSpec {
+        CaseSpec::from_str(r#"{x = 10, y = 20}"#)
+    }
+
+    fn enum_variant_rename() -> CaseSpec {
+        CaseSpec::from_str(r#""enabled""#)
+    }
+
+    fn untagged_with_null() -> CaseSpec {
+        CaseSpec::from_str("nil")
+            .without_roundtrip("unit variant serializes to variant name, not nil")
+    }
+
+    fn untagged_newtype_variant() -> CaseSpec {
+        CaseSpec::from_str(r#""test""#)
+    }
+
+    fn untagged_as_field() -> CaseSpec {
+        CaseSpec::from_str(r#"{name = "test", value = 42}"#)
+    }
+
+    fn untagged_unit_only() -> CaseSpec {
+        CaseSpec::from_str(r#""Alpha""#)
+    }
+
+    // ── Smart pointer cases ──
+
+    fn box_wrapper() -> CaseSpec {
+        CaseSpec::from_str(r#"{inner = 42}"#)
+    }
+
+    fn arc_wrapper() -> CaseSpec {
+        CaseSpec::from_str(r#"{inner = 42}"#)
+    }
+
+    fn rc_wrapper() -> CaseSpec {
+        CaseSpec::from_str(r#"{inner = 42}"#)
+    }
+
+    fn box_str() -> CaseSpec {
+        CaseSpec::from_str(r#"{inner = "hello world"}"#)
+    }
+
+    fn arc_str() -> CaseSpec {
+        CaseSpec::from_str(r#"{inner = "hello world"}"#)
+    }
+
+    fn rc_str() -> CaseSpec {
+        CaseSpec::from_str(r#"{inner = "hello world"}"#)
+    }
+
+    fn arc_slice() -> CaseSpec {
+        CaseSpec::from_str(r#"{inner = {1, 2, 3, 4}}"#)
+    }
+
+    // ── Set cases ──
+
+    fn set_btree() -> CaseSpec {
+        CaseSpec::from_str(r#"{items = {"alpha", "beta", "gamma"}}"#)
+    }
+
+    // ── Extended numeric cases ──
+
+    fn scalar_integers_16() -> CaseSpec {
+        CaseSpec::from_str(r#"{signed_16 = -32768, unsigned_16 = 65535}"#)
+    }
+
+    fn scalar_integers_128() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"{signed_128 = -170141183460469231731687303715884105728, unsigned_128 = 340282366920938463463374607431768211455}"#,
+        )
+        .without_roundtrip("i128/u128 serialize as strings, not native Lua numbers")
+    }
+
+    fn scalar_integers_size() -> CaseSpec {
+        CaseSpec::from_str(r#"{signed_size = -1000, unsigned_size = 2000}"#)
+    }
+
+    // ── NonZero cases ──
+
+    fn nonzero_integers() -> CaseSpec {
+        CaseSpec::from_str(r#"{nz_u32 = 42, nz_i64 = -100}"#)
+    }
+
+    fn nonzero_integers_extended() -> CaseSpec {
+        CaseSpec::from_str(
+            r#"{nz_u8 = 255, nz_i8 = -128, nz_u16 = 65535, nz_i16 = -32768, nz_u128 = 1, nz_i128 = -1, nz_usize = 1000, nz_isize = -500}"#,
+        )
+        .without_roundtrip("i128/u128 serialize as strings, not native Lua numbers")
+    }
+
+    // ── Borrowed string cases ──
+
+    fn cow_str() -> CaseSpec {
+        CaseSpec::from_str(r#"{owned = "hello world", message = "borrowed"}"#)
+    }
+
+    // ── Bytes/binary data cases ──
+
+    fn bytes_vec_u8() -> CaseSpec {
+        CaseSpec::from_str(r#"{data = {0, 128, 255, 42}}"#)
+    }
+
+    // ── Fixed-size array cases ──
+
+    fn array_fixed_size() -> CaseSpec {
+        CaseSpec::from_str(r#"{values = {1, 2, 3}}"#)
+    }
+
+    // ── Unknown field handling cases ──
+
+    fn skip_unknown_fields() -> CaseSpec {
+        CaseSpec::from_str(r#"{unknown = "ignored", known = "value"}"#)
+            .without_roundtrip("unknown field is not preserved")
+    }
+
+    // ── String escape cases ──
+
+    fn string_escapes() -> CaseSpec {
+        CaseSpec::from_str(r#"{text = "line1\nline2\ttab\"quote\\backslash"}"#)
+    }
+
+    fn string_escapes_extended() -> CaseSpec {
+        // Lua uses \ddd decimal escapes for control chars
+        CaseSpec::from_str(
+            r#"{backspace = "hello\8world", formfeed = "page\12break", carriage_return = "line\rreturn", control_char = "\1"}"#,
+        )
+    }
+
+    // ── Unit type cases ──
+
+    fn unit_struct() -> CaseSpec {
+        CaseSpec::from_str(r#"{}"#)
+    }
+
+    // ── Newtype cases ──
+
+    fn newtype_u64() -> CaseSpec {
+        CaseSpec::from_str(r#"{value = 42}"#)
+    }
+
+    fn newtype_string() -> CaseSpec {
+        CaseSpec::from_str(r#"{value = "hello"}"#)
+    }
+
+    // ── Char cases ──
+
+    fn char_scalar() -> CaseSpec {
+        CaseSpec::from_str(r#"{letter = "A", emoji = "🦀"}"#)
+    }
+
+    // ── HashSet cases ──
+
+    fn hashset() -> CaseSpec {
+        CaseSpec::from_str(r#"{items = {"alpha", "beta"}}"#)
+    }
+
+    // ── Nested collection cases ──
+
+    fn vec_nested() -> CaseSpec {
+        CaseSpec::from_str(r#"{matrix = {{1, 2}, {3, 4, 5}}}"#)
+    }
+
+    // ── Duration case ──
+
+    fn std_duration() -> CaseSpec {
+        CaseSpec::from_str(r#"{duration = {3600, 500000000}}"#)
+    }
+}
+
+fn main() {
+    use std::sync::Arc;
+
+    let args = Arguments::from_args();
+    let cases: Vec<Arc<_>> = all_cases::<LuaSlice>().into_iter().map(Arc::new).collect();
+
+    let mut trials: Vec<Trial> = Vec::new();
+
+    for case in &cases {
+        let name = format!("{}::{}", LuaSlice::format_name(), case.id);
+        let skip_reason = case.skip_reason();
+        let case = Arc::clone(case);
+        let mut trial = Trial::test(name, move || match case.run() {
+            CaseOutcome::Passed => Ok(()),
+            CaseOutcome::Skipped(_) => Ok(()),
+            CaseOutcome::Failed(msg) => Err(Failed::from(msg)),
+        });
+        if skip_reason.is_some() {
+            trial = trial.with_ignored_flag(true);
+        }
+        trials.push(trial);
+    }
+
+    libtest_mimic::run(&args, trials).exit()
+}


### PR DESCRIPTION
Closes #2049.

New facet-lua crate — serialize to Lua table syntax, parse it back, and generate LuaLS type annotations.

- Lua 5.4 table constructor coverage
- Types tested against LuaLS CLI on snapshot files.
- Serializer: structs as {key = value}, sequences as {value, value}, Lua string escaping, math.huge/0/0 for special floats, auto-bracketed keyword keys
- Parser: quoted + long-bracket strings, all Lua escapes, hex integers/floats, comments, semicolons, bracket keys, function(...)end skipping
- Annotations: ---@class/---@alias with all enum tagging modes, doc comments, rename_all

Known limitation: empty {} parses as struct, not sequence (Lua table ambiguity).