### PR TITLE
fix(reflect): prevent double-free in List deinit when Vec is initialized

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -71,6 +71,20 @@ asan *args:
         --target "$(rustc -vV | sed -n 's|host: ||p')" \
         -p facet-reflect {{ args }}
 
+# macOS-only: run facet-reflect's tests under `leaks --atExit` to catch
+# memory leaks at process exit. Native speed, so it's orders of magnitude
+# faster than miri for leak regressions. Exits non-zero if any allocation
+# is unreachable at exit. Uses the host target triple so the runner env
+# var is picked up (cargo only applies --target runners when --target is
+# explicit).
+leaks *args:
+    CARGO_TARGET_DIR=target/leaks \
+    MallocStackLogging=1 \
+    CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER="leaks -quiet --atExit --" \
+    CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER="leaks -quiet --atExit --" \
+        cargo test -p facet-reflect \
+        --target "$(rustc -vV | sed -n 's|host: ||p')" -- {{ args }}
+
 fuzz-smoke-value:
     cargo fuzz run fuzz_value -- -runs=1000
 

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -746,27 +746,30 @@ impl Frame {
                 }
             }
             Tracker::List { rope, .. } => {
-                // Drop the initialized List
+                // Drain any rope elements first. `is_init` only indicates that the Vec
+                // has been allocated (via `init_in_place_with_capacity`); elements pushed
+                // via `begin_list_item` live in the rope until `drain_rope_into_vec` moves
+                // them into the Vec. A successful drain leaves `rope = None` (via `.take()`),
+                // so if we see `rope = Some(..)` here the elements inside were never moved
+                // into the Vec and they're still owned by the rope. Drop them now.
+                if let Some(mut rope) = rope.take()
+                    && let Def::List(list_def) = self.allocated.shape().def
+                {
+                    let element_shape = list_def.t;
+                    unsafe {
+                        rope.drain_into(|ptr| {
+                            element_shape.call_drop_in_place(PtrMut::new(ptr.as_ptr()));
+                        });
+                    }
+                }
+
+                // Now drop the Vec (and whatever elements it already owns).
                 if self.is_init {
                     unsafe {
                         self.allocated
                             .shape()
                             .call_drop_in_place(self.data.assume_init())
                     };
-                    // The Vec was built and owns all elements — do NOT drain the rope,
-                    // as its data has already been moved into the Vec.
-                } else {
-                    // Vec was never built. Drop any elements still in the rope.
-                    if let Some(mut rope) = rope.take()
-                        && let Def::List(list_def) = self.allocated.shape().def
-                    {
-                        let element_shape = list_def.t;
-                        unsafe {
-                            rope.drain_into(|ptr| {
-                                element_shape.call_drop_in_place(PtrMut::new(ptr.as_ptr()));
-                            });
-                        }
-                    }
                 }
             }
             Tracker::Map {
@@ -2290,7 +2293,6 @@ impl<'facet, const BORROW: bool> Drop for Partial<'facet, BORROW> {
                     _ => {}
                 }
             }
-
 
             frame.deinit();
             frame.dealloc();

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -753,17 +753,19 @@ impl Frame {
                             .shape()
                             .call_drop_in_place(self.data.assume_init())
                     };
-                }
-
-                // Drop any elements still in the rope (not yet drained into Vec)
-                if let Some(mut rope) = rope.take()
-                    && let Def::List(list_def) = self.allocated.shape().def
-                {
-                    let element_shape = list_def.t;
-                    unsafe {
-                        rope.drain_into(|ptr| {
-                            element_shape.call_drop_in_place(PtrMut::new(ptr.as_ptr()));
-                        });
+                    // The Vec was built and owns all elements — do NOT drain the rope,
+                    // as its data has already been moved into the Vec.
+                } else {
+                    // Vec was never built. Drop any elements still in the rope.
+                    if let Some(mut rope) = rope.take()
+                        && let Def::List(list_def) = self.allocated.shape().def
+                    {
+                        let element_shape = list_def.t;
+                        unsafe {
+                            rope.drain_into(|ptr| {
+                                element_shape.call_drop_in_place(PtrMut::new(ptr.as_ptr()));
+                            });
+                        }
                     }
                 }
             }
@@ -2288,6 +2290,7 @@ impl<'facet, const BORROW: bool> Drop for Partial<'facet, BORROW> {
                     _ => {}
                 }
             }
+
 
             frame.deinit();
             frame.dealloc();


### PR DESCRIPTION
## Summary

- When a `Tracker::List` frame has `is_init=true` (the Vec was successfully built from rope elements) and the rope still has chunk data, `Frame::deinit()` would drop the Vec via `call_drop_in_place` (dropping all elements), then drain the rope and drop those same elements again — a **double-free / use-after-free**.
- Fix: only drain the rope when `is_init=false` (Vec was never built). When `is_init=true`, the Vec owns all elements and its drop handles cleanup.

## Reproducer

Deserialize a type containing `Vec<T>` inside a map value where a later map entry fails mid-deserialization. The error cleanup path triggers `Partial::drop`, which pops frames and calls `deinit()` on the List frame — hitting the double-free.

Concrete example: a styx schema with `IndexMap<K, V>` where `V` contains `Vec<SyntaxExpr>`, and a later map entry's value fails to parse. The first entries' Vec fields are initialized (`is_init=true`) but the rope chunks haven't been cleared.

## Test plan

- [ ] Verify with valgrind that the double-free on `Vec<T>` elements is gone
- [ ] Existing tests pass (this only changes the error/cleanup path, not the happy path)