### PR TITLE
fix(reflect): avoid UAF when stored MapKey frame co-owns pending-entry key

### DIFF
--- a/facet-reflect/src/partial/partial_api/misc.rs
+++ b/facet-reflect/src/partial/partial_api/misc.rs
@@ -484,7 +484,17 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // If this is a MapValue/Deref/OptionSome frame, a parent tracker holds
                 // a pointer to our frame's memory (pending_entries / pending_inner). Clear
                 // that pointer before we dealloc, so the parent's deinit won't double-drop.
-                Self::sever_parent_pending_for_path(&path, self.frames_mut(), &mut stored_frames);
+                let stored_map_key_paths: ::alloc::collections::BTreeSet<Path> = stored_frames
+                    .keys()
+                    .filter(|p| matches!(p.steps.last(), Some(PathStep::MapKey(_))))
+                    .cloned()
+                    .collect();
+                Self::sever_parent_pending_for_path(
+                    &path,
+                    self.frames_mut(),
+                    &mut stored_frames,
+                    &stored_map_key_paths,
+                );
                 frame.deinit();
                 frame.dealloc();
                 // Clean up remaining stored frames safely (deepest first, clearing parent isets)
@@ -500,7 +510,17 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // If this is a MapValue/Deref/OptionSome frame, a parent tracker holds
                 // a pointer to our frame's memory (pending_entries / pending_inner). Clear
                 // that pointer before we dealloc, so the parent's deinit won't double-drop.
-                Self::sever_parent_pending_for_path(&path, self.frames_mut(), &mut stored_frames);
+                let stored_map_key_paths: ::alloc::collections::BTreeSet<Path> = stored_frames
+                    .keys()
+                    .filter(|p| matches!(p.steps.last(), Some(PathStep::MapKey(_))))
+                    .cloned()
+                    .collect();
+                Self::sever_parent_pending_for_path(
+                    &path,
+                    self.frames_mut(),
+                    &mut stored_frames,
+                    &stored_map_key_paths,
+                );
                 frame.deinit();
                 frame.dealloc();
                 // Clean up remaining stored frames safely (deepest first, clearing parent isets)
@@ -800,6 +820,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
         path: &Path,
         stack: &mut [Frame],
         stored_frames: &mut ::alloc::collections::BTreeMap<Path, Frame>,
+        stored_map_key_paths: &::alloc::collections::BTreeSet<Path>,
     ) {
         let Some(last_step) = path.steps.last() else {
             return;
@@ -814,6 +835,31 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
         let parent_path = Path {
             shape: path.shape,
             steps: path.steps[..path.steps.len() - 1].to_vec(),
+        };
+
+        // If the failed path is a MapValue, check whether the sibling MapKey
+        // frame for this same entry index was stored in `stored_frames` at the
+        // start of cleanup. If so, that frame owns the key buffer (its deinit
+        // + dealloc will run for its own cleanup iteration) — we must pop the
+        // pending entry without dropping/deallocing the key here, otherwise
+        // we'll double-free. We consult a pre-captured snapshot because the
+        // MapKey frame may already have been removed from `stored_frames` by
+        // an earlier iteration of the cleanup loop (MapKey sorts before
+        // MapValue at equal depth).
+        //
+        // Path layout when a MapKey frame is stored in deferred mode:
+        //   parent_path + MapKey(entry_idx)   — stored MapKey frame
+        //   parent_path + MapValue(entry_idx) — the (failed) MapValue frame
+        let key_owned_by_stored_frame = if let PathStep::MapValue(entry_idx) = *last_step {
+            let mut map_key_steps = parent_path.steps.clone();
+            map_key_steps.push(PathStep::MapKey(entry_idx));
+            let map_key_path = Path {
+                shape: path.shape,
+                steps: map_key_steps,
+            };
+            stored_map_key_paths.contains(&map_key_path)
+        } else {
+            false
         };
 
         // Paths are absolute from the root; the frame at a given path lives at
@@ -838,11 +884,12 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 PathStep::MapValue(_),
             ) => {
                 // The pending entry held both (key_ptr, value_ptr). The value buffer is
-                // about to be freed by the caller via frame.dealloc(). The key buffer,
-                // however, is solely owned by this pending entry — if we just pop it
-                // without dropping, both the key's in-place contents and its allocation
-                // leak.
+                // about to be freed by the caller via frame.dealloc(). The key buffer
+                // is either solely owned by this pending entry (drop + dealloc here)
+                // or co-owned by a stored MapKey frame (pop only; that frame will
+                // handle the key).
                 if let Some((key_ptr, _value_ptr)) = pending_entries.pop()
+                    && !key_owned_by_stored_frame
                     && let Def::Map(map_def) = parent_shape.def
                 {
                     unsafe {
@@ -857,8 +904,8 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                     }
                 }
                 trace!(
-                    "sever_parent_pending_for_path: popped & dropped map pending_entry for failed MapValue at {:?}",
-                    path,
+                    "sever_parent_pending_for_path: popped map pending_entry for failed MapValue at {:?} (key_owned_by_stored_frame={})",
+                    path, key_owned_by_stored_frame,
                 );
             }
             (
@@ -919,6 +966,17 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
         mut stored_frames: ::alloc::collections::BTreeMap<Path, Frame>,
         stack: &mut [Frame],
     ) {
+        // Snapshot the set of paths whose last step is `MapKey`. A stored
+        // MapKey frame owns its key buffer, and its sibling MapValue's
+        // `sever_parent_pending_for_path` must therefore skip dropping the
+        // pending-entry key. We capture the snapshot upfront because
+        // `stored_frames` is progressively drained during cleanup.
+        let stored_map_key_paths: ::alloc::collections::BTreeSet<Path> = stored_frames
+            .keys()
+            .filter(|p| matches!(p.steps.last(), Some(PathStep::MapKey(_))))
+            .cloned()
+            .collect();
+
         // Sort by depth (deepest first) so children are processed before parents
         let mut paths: Vec<_> = stored_frames.keys().cloned().collect();
         paths.sort_by_key(|p| core::cmp::Reverse(p.steps.len()));
@@ -970,7 +1028,12 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // If this frame's buffer is also tracked by a parent Map/SmartPointer/Option
                 // pending pointer, clear that reference too — otherwise the parent will try to
                 // drop the same buffer we're about to dealloc.
-                Self::sever_parent_pending_for_path(&path, stack, &mut stored_frames);
+                Self::sever_parent_pending_for_path(
+                    &path,
+                    stack,
+                    &mut stored_frames,
+                    &stored_map_key_paths,
+                );
                 trace!("cleanup: calling deinit() on path={:?}", path,);
                 frame.deinit();
                 frame.dealloc();

--- a/facet-reflect/tests/partial/map_deferred_leak.rs
+++ b/facet-reflect/tests/partial/map_deferred_leak.rs
@@ -45,3 +45,69 @@ fn deferred_map_value_missing_required_field() {
         "expected Err from missing required field, got Ok"
     );
 }
+
+// Deeper-nested variant of the same bug: the map's value is a struct whose
+// field is an enum-variant-of-Box-of-struct-with-missing-required-field. The
+// failure unwinds several frames before `cleanup_stored_frames_on_error`
+// reaches the Map; at that point the pending map key has already been
+// committed / moved and popping + dropping it again segfaults with a bogus
+// backing pointer (observed: String data_ptr = 0x4).
+//
+// Reduced from a facet-styx schema repro involving
+//   Option<IndexMap<Documented<String>, TemplateDecl>> where
+//   TemplateDecl.syntax = SyntaxExpr::Template(Box<TemplateSyntaxDecl>).
+#[test]
+fn deferred_map_value_deep_box_enum_missing_field() {
+    #[derive(Facet, Debug)]
+    struct InnerWithRequired {
+        #[allow(dead_code)]
+        required: String,
+    }
+
+    #[derive(Facet, Debug)]
+    #[repr(u8)]
+    #[allow(dead_code)]
+    enum SyntaxExpr {
+        Template(Box<InnerWithRequired>),
+    }
+
+    #[derive(Facet, Debug)]
+    struct TemplateDecl {
+        #[allow(dead_code)]
+        syntax: SyntaxExpr,
+    }
+
+    #[derive(Facet, Debug)]
+    struct Container {
+        #[allow(dead_code)]
+        templates: HashMap<String, TemplateDecl>,
+    }
+
+    let mut partial = Partial::alloc::<Container>().unwrap();
+    partial = partial.begin_deferred().unwrap();
+
+    partial = partial.begin_field("templates").unwrap();
+    partial = partial.init_map().unwrap();
+
+    partial = partial.begin_key().unwrap();
+    partial = partial.set(String::from("ZeroOperand")).unwrap();
+    partial = partial.end().unwrap();
+
+    partial = partial.begin_value().unwrap(); // TemplateDecl
+    partial = partial.begin_field("syntax").unwrap(); // SyntaxExpr
+    partial = partial.select_variant_named("Template").unwrap();
+    partial = partial.begin_nth_field(0).unwrap(); // Box<InnerWithRequired>
+    partial = partial.begin_smart_ptr().unwrap(); // into the Box
+    // Intentionally leave `required` unset.
+    partial = partial.end().unwrap(); // end smart ptr
+    partial = partial.end().unwrap(); // end tuple-variant field
+    partial = partial.end().unwrap(); // end variant / syntax field
+    partial = partial.end().unwrap(); // end value (TemplateDecl)
+    partial = partial.end().unwrap(); // end templates field
+
+    let result = partial.finish_deferred();
+    assert!(
+        result.is_err(),
+        "expected Err from missing required field, got Ok"
+    );
+}


### PR DESCRIPTION
## Summary

`sever_parent_pending_for_path` unconditionally dropped and deallocated the Map's pending-entry key buffer when a `MapValue` frame failed. In deferred mode, though, the sibling `MapKey` frame stored in `stored_frames` also owns that buffer. `MapKey` sorts before `MapValue` at equal depth, so the cleanup loop processes the MapKey frame first (freeing the key via `frame.dealloc()`), then MapValue's `sever` pops the now-dangling `key_ptr` and calls `drop_in_place` + `dealloc` on it again — heap-use-after-free, caught by ASAN.

```
==ERROR: AddressSanitizer: heap-use-after-free on address 0x603000003048
READ / DROP at:
  sever_parent_pending_for_path            misc.rs:849
  cleanup_stored_frames_on_error           misc.rs:997
  finish_deferred                          misc.rs:507
freed by:
  cleanup_stored_frames_on_error           misc.rs:1000   (frame.dealloc on a previous iteration)
```

## Fix

Snapshot the set of paths ending in `MapKey` at the start of `cleanup_stored_frames_on_error`, pass it into `sever_parent_pending_for_path`. When the failed path is a `MapValue(idx)` and its sibling `MapKey(idx)` was in the snapshot, pop the pending entry without dropping/deallocing the key — the MapKey frame's own cleanup will handle it.

The two other callers of `sever_parent_pending_for_path` (inside `finish_deferred` itself, before the cleanup loop runs) compute the snapshot inline from the current `stored_frames` — at that point `stored_frames` hasn't been drained yet.

This builds on 0fc24a409 ("fix(reflect): drop map key when severing failed MapValue pending entry"), which fixed the case where the key buffer is solely owned by pending_entries. The new case is when the key buffer is co-owned by a stored MapKey frame.

## Repro

Non-flatten `HashMap<String, TemplateDecl>` whose value type is a struct → enum variant → `Box<InnerWithRequired>` where the innermost struct is missing a required field. The failure propagates back through several frames before triggering `cleanup_stored_frames_on_error`, at which point MapKey and MapValue are both in `stored_frames`.

Reduced from a real schema in downstream bearcove/kajit that had been SEGVing on every load.

## Test plan

- [x] new test `deferred_map_value_deep_box_enum_missing_field` — passes, expects `Err` from missing required field, no UB
- [x] all 513 facet-reflect tests pass
- [x] 126 map/deferred/option/list/smartptr tests pass under AddressSanitizer (`RUSTFLAGS=-Zsanitizer=address cargo +nightly test -Zbuild-std --target aarch64-apple-darwin`)
- [x] downstream repro (`bearcove/kajit::kajit-foundation::tests::asm_repro_schema_loads`) no longer SIGABRTs; now returns a clean "missing required field" error