### PR TITLE
refactor(reflect): single source of truth for Map pending-entry ownership

### DIFF
--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -388,6 +388,16 @@ pub(crate) struct Frame {
     pub(crate) type_plan: typeplan::NodeId,
 }
 
+/// A key/value pair queued for insertion into a Map's real container at
+/// finalization time. See the doc comment on `Tracker::Map::pending_entries`
+/// for the meaning of `owned_by_stored_frame`.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PendingMapEntry {
+    pub key_ptr: PtrUninit,
+    pub value_ptr: PtrUninit,
+    pub owned_by_stored_frame: bool,
+}
+
 #[derive(Debug)]
 pub(crate) enum Tracker {
     /// Simple scalar value - no partial initialization tracking needed.
@@ -478,8 +488,25 @@ pub(crate) enum Tracker {
         /// Pending key-value entries to be inserted on map finalization.
         /// Deferred processing requires keeping buffers alive until finish_deferred(),
         /// so we delay actual insertion until the map frame is finalized.
-        /// Each entry is (key_ptr, value_ptr) - both are initialized and owned by this tracker.
-        pending_entries: Vec<(PtrUninit, PtrUninit)>,
+        ///
+        /// Each entry carries an `owned_by_stored_frame` flag that encodes which
+        /// cleanup path has drop responsibility for the key and value buffers:
+        /// - `false`: the entry was pushed from the non-deferred completion path
+        ///   (`complete_map_value_frame`). The child key/value frames were consumed
+        ///   during their `end()` calls; the Map solely owns the buffers and is
+        ///   responsible for dropping + deallocating them on `Frame::deinit`.
+        /// - `true`: the entry was pushed from the deferred `end()` path where the
+        ///   child MapKey and/or MapValue frames are kept in `stored_frames`.
+        ///   Those stored frames own drop responsibility (they alone know the
+        ///   iset-aware partial-initialization state of their contents). The Map's
+        ///   `Frame::deinit` MUST skip such entries — dropping them here would
+        ///   double-drop once the stored frames' own `deinit`/`dealloc` runs.
+        ///
+        /// This single flag replaces the ad-hoc coordination that used to live in
+        /// `sever_parent_pending_for_path` and the `PathStep::MapValue` arm of
+        /// `impl Drop for Partial`, which both existed to remove stale entries
+        /// before the Map's wholesale drop.
+        pending_entries: Vec<PendingMapEntry>,
         /// The current entry index, used for building unique paths for deferred frame storage.
         /// Incremented each time we start a new key (in begin_key).
         /// This allows inner frames of different map entries to have distinct paths.
@@ -786,9 +813,17 @@ impl Frame {
                     };
                 }
 
-                // Clean up pending entries (key-value pairs that haven't been inserted yet)
+                // Clean up pending entries (key-value pairs that haven't been inserted yet).
+                // Skip entries owned by stored frames: those frames' own deinit/dealloc
+                // will handle the buffers (iset-aware, safe for partially-initialized
+                // contents). Dropping them here would double-free.
                 if let Def::Map(map_def) = self.allocated.shape().def {
-                    for (key_ptr, value_ptr) in pending_entries.drain(..) {
+                    for entry in pending_entries.drain(..) {
+                        if entry.owned_by_stored_frame {
+                            continue;
+                        }
+                        let key_ptr = entry.key_ptr;
+                        let value_ptr = entry.value_ptr;
                         // Drop and deallocate key
                         unsafe { map_def.k().call_drop_in_place(key_ptr.assume_init()) };
                         if let Ok(key_layout) = map_def.k().layout.sized_layout()
@@ -1373,7 +1408,7 @@ impl Frame {
     /// kept in pending_entries to allow deferred processing; now we insert them into
     /// the actual map and deallocate the temporary buffers.
     fn drain_pending_into_map(
-        pending_entries: &mut Vec<(PtrUninit, PtrUninit)>,
+        pending_entries: &mut Vec<PendingMapEntry>,
         map_def: &facet_core::MapDef,
         map_data: PtrUninit,
     ) -> Result<(), ReflectErrorKind> {
@@ -1382,7 +1417,14 @@ impl Frame {
         // SAFETY: map_data points to initialized map (is_init was true)
         let map_ptr = unsafe { map_data.assume_init() };
 
-        for (key_ptr, value_ptr) in pending_entries.drain(..) {
+        // On the happy path, `finish_deferred` has already consumed all stored
+        // frames (their `end()` moved them out of `stored_frames`), so every
+        // entry we see here points at a fully-initialized buffer that is safe
+        // to move into the real map. The `owned_by_stored_frame` flag is only
+        // consulted by `Tracker::Map::deinit` on the error / drop path.
+        for entry in pending_entries.drain(..) {
+            let key_ptr = entry.key_ptr;
+            let value_ptr = entry.value_ptr;
             // Insert the key-value pair
             unsafe {
                 insert_fn(
@@ -2229,27 +2271,13 @@ impl<'facet, const BORROW: bool> Drop for Partial<'facet, BORROW> {
                                 }
                             }
                         }
-                        Some(PathStep::MapValue(entry_idx)) => {
-                            // Map value frame - remove the entry from pending_entries.
-                            // The value is dropped by this frame's deinit.
-                            // The key is dropped by the MapKey frame's deinit (processed separately).
-                            let entry_idx = *entry_idx as usize;
-                            if let Some(parent_ptr) =
-                                find_parent_frame(&mut stored_frames, stack, &parent_path)
-                            {
-                                let parent_frame = unsafe { &mut *parent_ptr };
-                                if let Tracker::Map {
-                                    pending_entries, ..
-                                } = &mut parent_frame.tracker
-                                {
-                                    // Remove the entry at this index if it exists.
-                                    // Don't drop key/value here - they're handled by their
-                                    // respective stored frames (MapKey and MapValue).
-                                    if entry_idx < pending_entries.len() {
-                                        pending_entries.remove(entry_idx);
-                                    }
-                                }
-                            }
+                        Some(PathStep::MapValue(_)) => {
+                            // Map value frame: no-op here. The stored MapValue frame's
+                            // own `deinit` + `dealloc` (run immediately after this match)
+                            // drops and frees the value buffer, and the parent Map's
+                            // `pending_entries` entry for this path carries
+                            // `owned_by_stored_frame = true`, so `Tracker::Map::deinit`
+                            // will skip it. No need to remove the entry here.
                         }
                         Some(PathStep::Index(_)) => {
                             // List element frames with RopeSlot ownership are handled by

--- a/facet-reflect/src/partial/partial_api.rs
+++ b/facet-reflect/src/partial/partial_api.rs
@@ -8,7 +8,7 @@ use crate::{
     Guard, HeapValue, Partial, Peek, ReflectError, ReflectErrorKind,
     partial::{
         DynamicObjectInsertState, DynamicValueState, Frame, FrameMode, FrameOwnership,
-        MapInsertState, PartialState, Tracker, iset::ISet, rope::ListRope,
+        MapInsertState, PartialState, PendingMapEntry, Tracker, iset::ISet, rope::ListRope,
     },
     trace,
 };

--- a/facet-reflect/src/partial/partial_api/misc.rs
+++ b/facet-reflect/src/partial/partial_api/misc.rs
@@ -481,20 +481,11 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // Before cleanup, clear the parent's iset bit for the frame that failed.
                 // This prevents the parent from trying to drop this field when Partial is dropped.
                 Self::clear_parent_iset_for_path(&path, self.frames_mut(), &mut stored_frames);
-                // If this is a MapValue/Deref/OptionSome frame, a parent tracker holds
-                // a pointer to our frame's memory (pending_entries / pending_inner). Clear
-                // that pointer before we dealloc, so the parent's deinit won't double-drop.
-                let stored_map_key_paths: ::alloc::collections::BTreeSet<Path> = stored_frames
-                    .keys()
-                    .filter(|p| matches!(p.steps.last(), Some(PathStep::MapKey(_))))
-                    .cloned()
-                    .collect();
-                Self::sever_parent_pending_for_path(
-                    &path,
-                    self.frames_mut(),
-                    &mut stored_frames,
-                    &stored_map_key_paths,
-                );
+                // If this is a Deref/OptionSome frame, a parent tracker holds a pointer
+                // to our frame's memory (pending_inner). Clear that pointer before we
+                // dealloc, so the parent's deinit won't double-drop. MapValue is
+                // handled by `PendingMapEntry::owned_by_stored_frame` on the Map itself.
+                Self::sever_parent_pending_for_path(&path, self.frames_mut(), &mut stored_frames);
                 frame.deinit();
                 frame.dealloc();
                 // Clean up remaining stored frames safely (deepest first, clearing parent isets)
@@ -507,20 +498,11 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // Before cleanup, clear the parent's iset bit for the frame that failed.
                 // This prevents the parent from trying to drop this field when Partial is dropped.
                 Self::clear_parent_iset_for_path(&path, self.frames_mut(), &mut stored_frames);
-                // If this is a MapValue/Deref/OptionSome frame, a parent tracker holds
-                // a pointer to our frame's memory (pending_entries / pending_inner). Clear
-                // that pointer before we dealloc, so the parent's deinit won't double-drop.
-                let stored_map_key_paths: ::alloc::collections::BTreeSet<Path> = stored_frames
-                    .keys()
-                    .filter(|p| matches!(p.steps.last(), Some(PathStep::MapKey(_))))
-                    .cloned()
-                    .collect();
-                Self::sever_parent_pending_for_path(
-                    &path,
-                    self.frames_mut(),
-                    &mut stored_frames,
-                    &stored_map_key_paths,
-                );
+                // If this is a Deref/OptionSome frame, a parent tracker holds a pointer
+                // to our frame's memory (pending_inner). Clear that pointer before we
+                // dealloc, so the parent's deinit won't double-drop. MapValue is
+                // handled by `PendingMapEntry::owned_by_stored_frame` on the Map itself.
+                Self::sever_parent_pending_for_path(&path, self.frames_mut(), &mut stored_frames);
                 frame.deinit();
                 frame.dealloc();
                 // Clean up remaining stored frames safely (deepest first, clearing parent isets)
@@ -808,58 +790,35 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
     /// Sever parent/child pointer ownership when a stored child frame fails validation
     /// in `finish_deferred`.
     ///
-    /// When a child frame is stored for deferred processing, the parent may keep a
-    /// pointer to the child's buffer so it can finalize later (Map's `pending_entries`,
-    /// SmartPointer's / Option's `pending_inner`). If the child then fails validation
-    /// and its buffer is deallocated, that parent pointer would dangle and cause a
-    /// double-free when the parent is subsequently deinited.
+    /// When a child SmartPointer/Option frame is stored for deferred processing, the
+    /// parent keeps a raw `pending_inner` pointer to the child's buffer so it can
+    /// finalize later. If the child then fails validation and its buffer is deallocated,
+    /// that parent pointer would dangle and cause a double-free when the parent is
+    /// subsequently deinited. This helper clears `pending_inner` so the parent's own
+    /// cleanup leaves the buffer alone.
     ///
-    /// This helper clears the relevant parent field so the parent's own cleanup leaves
-    /// the buffer alone.
+    /// Map's `pending_entries` are handled differently — see
+    /// `PendingMapEntry::owned_by_stored_frame` and `Tracker::Map::deinit` — and are
+    /// intentionally not touched here.
     fn sever_parent_pending_for_path(
         path: &Path,
         stack: &mut [Frame],
         stored_frames: &mut ::alloc::collections::BTreeMap<Path, Frame>,
-        stored_map_key_paths: &::alloc::collections::BTreeSet<Path>,
     ) {
         let Some(last_step) = path.steps.last() else {
             return;
         };
-        if !matches!(
-            last_step,
-            PathStep::MapValue(_) | PathStep::Deref | PathStep::OptionSome
-        ) {
+        // Only Deref/OptionSome need sever handling. MapValue is handled by the
+        // `PendingMapEntry::owned_by_stored_frame` flag on the Map tracker — the
+        // Map's deinit skips the entry and the stored MapValue frame's own
+        // `deinit`/`dealloc` drops the value buffer iset-aware.
+        if !matches!(last_step, PathStep::Deref | PathStep::OptionSome) {
             return;
         }
 
         let parent_path = Path {
             shape: path.shape,
             steps: path.steps[..path.steps.len() - 1].to_vec(),
-        };
-
-        // If the failed path is a MapValue, check whether the sibling MapKey
-        // frame for this same entry index was stored in `stored_frames` at the
-        // start of cleanup. If so, that frame owns the key buffer (its deinit
-        // + dealloc will run for its own cleanup iteration) — we must pop the
-        // pending entry without dropping/deallocing the key here, otherwise
-        // we'll double-free. We consult a pre-captured snapshot because the
-        // MapKey frame may already have been removed from `stored_frames` by
-        // an earlier iteration of the cleanup loop (MapKey sorts before
-        // MapValue at equal depth).
-        //
-        // Path layout when a MapKey frame is stored in deferred mode:
-        //   parent_path + MapKey(entry_idx)   — stored MapKey frame
-        //   parent_path + MapValue(entry_idx) — the (failed) MapValue frame
-        let key_owned_by_stored_frame = if let PathStep::MapValue(entry_idx) = *last_step {
-            let mut map_key_steps = parent_path.steps.clone();
-            map_key_steps.push(PathStep::MapKey(entry_idx));
-            let map_key_path = Path {
-                shape: path.shape,
-                steps: map_key_steps,
-            };
-            stored_map_key_paths.contains(&map_key_path)
-        } else {
-            false
         };
 
         // Paths are absolute from the root; the frame at a given path lives at
@@ -874,40 +833,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
             return;
         };
 
-        let parent_shape = parent_frame.allocated.shape();
-
         match (&mut parent_frame.tracker, last_step) {
-            (
-                Tracker::Map {
-                    pending_entries, ..
-                },
-                PathStep::MapValue(_),
-            ) => {
-                // The pending entry held both (key_ptr, value_ptr). The value buffer is
-                // about to be freed by the caller via frame.dealloc(). The key buffer
-                // is either solely owned by this pending entry (drop + dealloc here)
-                // or co-owned by a stored MapKey frame (pop only; that frame will
-                // handle the key).
-                if let Some((key_ptr, _value_ptr)) = pending_entries.pop()
-                    && !key_owned_by_stored_frame
-                    && let Def::Map(map_def) = parent_shape.def
-                {
-                    unsafe {
-                        map_def.k().call_drop_in_place(key_ptr.assume_init());
-                    }
-                    if let Ok(key_layout) = map_def.k().layout.sized_layout()
-                        && key_layout.size() > 0
-                    {
-                        unsafe {
-                            ::alloc::alloc::dealloc(key_ptr.as_mut_byte_ptr(), key_layout);
-                        }
-                    }
-                }
-                trace!(
-                    "sever_parent_pending_for_path: popped map pending_entry for failed MapValue at {:?} (key_owned_by_stored_frame={})",
-                    path, key_owned_by_stored_frame,
-                );
-            }
             (
                 Tracker::SmartPointer {
                     building_inner,
@@ -966,17 +892,6 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
         mut stored_frames: ::alloc::collections::BTreeMap<Path, Frame>,
         stack: &mut [Frame],
     ) {
-        // Snapshot the set of paths whose last step is `MapKey`. A stored
-        // MapKey frame owns its key buffer, and its sibling MapValue's
-        // `sever_parent_pending_for_path` must therefore skip dropping the
-        // pending-entry key. We capture the snapshot upfront because
-        // `stored_frames` is progressively drained during cleanup.
-        let stored_map_key_paths: ::alloc::collections::BTreeSet<Path> = stored_frames
-            .keys()
-            .filter(|p| matches!(p.steps.last(), Some(PathStep::MapKey(_))))
-            .cloned()
-            .collect();
-
         // Sort by depth (deepest first) so children are processed before parents
         let mut paths: Vec<_> = stored_frames.keys().cloned().collect();
         paths.sort_by_key(|p| core::cmp::Reverse(p.steps.len()));
@@ -1025,15 +940,12 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // Before dropping this frame, clear the parent's iset bit so the
                 // parent won't try to drop this field again.
                 Self::clear_parent_iset_for_path(&path, stack, &mut stored_frames);
-                // If this frame's buffer is also tracked by a parent Map/SmartPointer/Option
-                // pending pointer, clear that reference too — otherwise the parent will try to
-                // drop the same buffer we're about to dealloc.
-                Self::sever_parent_pending_for_path(
-                    &path,
-                    stack,
-                    &mut stored_frames,
-                    &stored_map_key_paths,
-                );
+                // If this frame's buffer is also tracked by a parent SmartPointer/Option
+                // pending_inner pointer, clear that reference too — otherwise the parent
+                // will try to drop the same buffer we're about to dealloc.
+                // (Map's pending_entries are handled via
+                // `PendingMapEntry::owned_by_stored_frame`, not via sever.)
+                Self::sever_parent_pending_for_path(&path, stack, &mut stored_frames);
                 trace!("cleanup: calling deinit() on path={:?}", path,);
                 frame.deinit();
                 frame.dealloc();
@@ -1417,8 +1329,15 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 ..
             } = insert_state
         {
-            // Add the key-value pair to pending_entries
-            pending_entries.push((*key_ptr, *value_ptr));
+            // Add the key-value pair to pending_entries. This call site runs in
+            // the non-deferred completion path: both the MapKey and MapValue
+            // frames are consumed here, so the Map alone owns both buffers and
+            // is responsible for dropping + deallocating them on its own deinit.
+            pending_entries.push(PendingMapEntry {
+                key_ptr: *key_ptr,
+                value_ptr: *value_ptr,
+                owned_by_stored_frame: false,
+            });
 
             crate::trace!(
                 "complete_map_value_frame: added entry to pending_entries for {}",
@@ -1988,8 +1907,15 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                                 value_ptr: Some(value_ptr),
                                 ..
                             } => {
-                                // Add entry to pending_entries and reset to Idle
-                                pending_entries.push((*key_ptr, *value_ptr));
+                                // Deferred path: the MapValue frame (and the
+                                // already-stored MapKey frame) will be kept in
+                                // `stored_frames`. They — not the Map's deinit
+                                // — own drop responsibility for the buffers.
+                                pending_entries.push(PendingMapEntry {
+                                    key_ptr: *key_ptr,
+                                    value_ptr: *value_ptr,
+                                    owned_by_stored_frame: true,
+                                });
                                 *insert_state = MapInsertState::Idle;
                                 crate::trace!(
                                     "end(): Map added entry to pending_entries while storing value frame"
@@ -2525,8 +2451,16 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         // Instead of inserting immediately, add to pending_entries.
                         // This keeps the buffers alive for deferred processing.
                         // Actual insertion happens in require_full_initialization.
+                        //
+                        // Both the key and value frames were consumed at their
+                        // own `end()` calls (we're the non-deferred path here),
+                        // so the Map alone owns the buffers.
                         if let Some(value_ptr) = value_ptr {
-                            pending_entries.push((*key_ptr, *value_ptr));
+                            pending_entries.push(PendingMapEntry {
+                                key_ptr: *key_ptr,
+                                value_ptr: *value_ptr,
+                                owned_by_stored_frame: false,
+                            });
 
                             // Reset to idle state
                             *insert_state = MapInsertState::Idle;


### PR DESCRIPTION
## Summary

- Replace ad-hoc coordination between `Tracker::Map::pending_entries`, stored MapKey/MapValue frames in `stored_frames`, `sever_parent_pending_for_path`, and `impl Drop for Partial`'s `PathStep::MapValue` arm with a single `owned_by_stored_frame: bool` flag on each pending entry.
- Delete `sever_parent_pending_for_path`'s Map branch and its `stored_map_key_paths: &BTreeSet<Path>` parameter (added in #2163). The flag answers "who drops this key/value buffer?" at the source; Map's `deinit` consults it; no snapshot or parent-pointer disarming is needed for Map.
- `impl Drop for Partial`'s `PathStep::MapValue` arm becomes a no-op: the stored MapValue frame's own `deinit`/`dealloc` drops the value buffer iset-aware, and Map's `deinit` skips the pending entry.

Net diff: **+113 / −151 lines.**

## Motivation

Over the last few months the deferred-mode cleanup paths accumulated four targeted memory-safety fixes (`fix(reflect): drop map key when severing failed MapValue pending entry`, `fix(reflect): prevent double-free in List deinit when Vec is initialized`, `fix(reflect): drain rope before dropping Vec in List frame deinit`, and the recently merged #2163 `fix(reflect): avoid UAF when stored MapKey frame co-owns pending-entry key`). Each was locally reasonable but treated a symptom: the same raw buffer pointer was co-owned by a child `Frame` AND one or more parent-tracker pending slots, and every cleanup path had to independently disarm one side to avoid double-drop. The next nesting combination found a different unarmed pair.

This PR establishes a single invariant for the Map case: the pending entry itself records which side owns drop responsibility. No more cross-data-structure coordination for Map.

## Scope

**In scope:** Map's `pending_entries`.
**Out of scope (follow-up PRs):**
- SmartPointer's / Option's `pending_inner` (same invariant should apply — still handled by the narrowed `sever_parent_pending_for_path` for now)
- `DynamicValue` `pending_entries` / `pending_elements`
- `List` rope (downstream `bearcove/kajit`'s `asm.repr.styx` SIGABRT is via this path and is **not fixed** by this PR — the List-rope ownership coordination is a separate cleanup)

## Test plan

- [x] `cargo nextest run -p facet-reflect` — 513 / 513 pass
- [x] Full ASAN sweep: `RUSTFLAGS=\"-Zsanitizer=address\" cargo +nightly test -p facet-reflect --test main -Zbuild-std --target aarch64-apple-darwin -- --test-threads=1` — 461 / 461 pass
- [x] Downstream `bearcove/kajit` 3 existing map-repro tests pass (`asm_repro_flatten_map_missing_field`, `asm_repro_nested_failure_severs_templates_key`, `asm_repro_option_indexmap_documented_key`)
- [x] Regression tests landed in #2163 (`deferred_map_value_missing_required_field`, `deferred_map_value_deep_box_enum_missing_field`) still pass under ASAN

## Design notes

The `MapInsertState::*_frame_on_stack` / `*_frame_stored` fields are **retained**. They serve a different purpose: they disambiguate the in-progress-entry case (the Map holds a key/value pointer in `insert_state` but no pending entry yet, because the current key or value frame is still being built). `owned_by_stored_frame` addresses the completed-but-deferred-entry case. Both are necessary.

I considered introducing a `FrameOwnership::Transferred` variant, but that would require the parent to wholesale-drop partially-initialized children on error — which is UB. The iset-aware drop has to happen at the child frame; the parent just needs a \"skip me\" signal. The per-entry flag provides that signal.