### PR TITLE
refactor(reflect): single-source-of-truth ownership via FrameOwnership::Transferred

### DIFF
--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -108,6 +108,29 @@
 //! - Preventing use-after-build through state tracking
 //! - Properly handling drop semantics for partially initialized values
 //! - Supporting both owned and borrowed values through lifetime parameters
+//!
+//! # Drop-ownership invariant (SSoT / Transferred)
+//!
+//! Every heap buffer allocated during partial construction has exactly one drop-and-dealloc
+//! authority at all times. Authority is either the owning frame (its `FrameOwnership`
+//! controls deinit + dealloc) or a parent tracker's pending slot
+//! (`Tracker::Map::pending_entries`, `Tracker::Option::pending_inner`,
+//! `Tracker::SmartPointer::pending_inner`, `DynamicValueState::Object::pending_entries`,
+//! `DynamicValueState::Array::pending_elements`).
+//!
+//! - **Transfer protocol**: in the same statement block that copies a child frame's `data`
+//!   pointer into a parent pending slot, mutate `child_frame.ownership =
+//!   FrameOwnership::Transferred`. The child's subsequent `deinit` and `dealloc` no-op.
+//!   The parent's tracker deinit is the sole site that drops + deallocs that buffer.
+//! - **Map half-entries**: `pending_entries` holds `(key_ptr, Option<value_ptr>)`. A key
+//!   pushed without a paired value is a half-entry `(key, None)`; its value-phase
+//!   counterpart upgrades the last entry to `(key, Some(value))`. A half-entry left at
+//!   finalize is an invariant violation; a half-entry at drop-time drops the orphan key
+//!   only.
+//! - **No booleans, no sever helpers**: cleanup paths must not special-case which half
+//!   of a dual-ownership pair to disarm. Ownership mutation at the transfer site is the
+//!   only contract. If you catch yourself adding a `*_frame_on_stack` or
+//!   `sever_parent_pending_*` helper, re-read this block.
 
 use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 
@@ -241,19 +264,26 @@ pub(crate) enum MapInsertState {
     /// Not currently inserting
     Idle,
 
-    /// Pushing key - memory allocated, waiting for initialization
+    /// Pushing key - memory allocated, waiting for initialization.
+    ///
+    /// The key buffer is owned by the key frame currently on the stack
+    /// (a `TrackedBuffer` frame). If that frame is stored (deferred mode),
+    /// the key buffer ownership transfers to `pending_entries` as a
+    /// half-entry `(key_ptr, None)` and the stored frame is marked
+    /// `FrameOwnership::Transferred`.
     PushingKey {
         /// Temporary storage for the key being built
         key_ptr: PtrUninit,
         /// Whether the key has been fully initialized
         key_initialized: bool,
-        /// Whether the key's TrackedBuffer frame is still on the stack.
-        /// When true, the frame handles cleanup. When false (after end()),
-        /// the Map tracker owns the buffer and must clean it up.
-        key_frame_on_stack: bool,
     },
 
-    /// Pushing value after key is done
+    /// Pushing value after key is done.
+    ///
+    /// If the key was stored in deferred mode, `pending_entries` already
+    /// has a `(key_ptr, None)` half-entry. When the value frame is stored,
+    /// the half-entry is upgraded to `(key_ptr, Some(value_ptr))` and the
+    /// value frame is marked `FrameOwnership::Transferred`.
     PushingValue {
         /// Temporary storage for the key that was built (always initialized)
         key_ptr: PtrUninit,
@@ -261,14 +291,6 @@ pub(crate) enum MapInsertState {
         value_ptr: Option<PtrUninit>,
         /// Whether the value has been fully initialized
         value_initialized: bool,
-        /// Whether the value's TrackedBuffer frame is still on the stack.
-        /// When true, the frame handles cleanup. When false (after end()),
-        /// the Map tracker owns the buffer and must clean it up.
-        value_frame_on_stack: bool,
-        /// Whether the key's frame was stored in deferred mode.
-        /// When true, the stored frame handles cleanup. When false,
-        /// the Map tracker owns the key buffer and must clean it up.
-        key_frame_stored: bool,
     },
 }
 
@@ -308,14 +330,30 @@ pub(crate) enum FrameOwnership {
     /// On list frame end(): all elements are moved into the real Vec.
     /// On drop/failure: the rope chunk handles cleanup.
     RopeSlot,
+
+    /// The frame's `data` pointer has been copied into a parent tracker's pending slot
+    /// (e.g., `Tracker::Map::pending_entries`, `Tracker::Option::pending_inner`,
+    /// `Tracker::SmartPointer::pending_inner`, `DynamicValueState::Object::pending_entries`,
+    /// `DynamicValueState::Array::pending_elements`). The parent tracker is now the SOLE
+    /// drop-and-dealloc authority for that buffer.
+    ///
+    /// On `deinit`: no-op (parent's tracker deinit will drop-in-place the pending slot).
+    /// On `dealloc`: no-op (parent's tracker deinit will dealloc the pending slot).
+    ///
+    /// This is the single invariant that protects against double-free across all the
+    /// nesting combinations (Map/List/Option/SmartPointer/DynamicValue × stack/stored).
+    /// Any code that copies a child frame's `data` into a parent pending slot MUST, in
+    /// the same statement block, set `child_frame.ownership = Transferred`.
+    Transferred,
 }
 
 impl FrameOwnership {
     /// Returns true if this frame is responsible for deallocating its memory.
     ///
     /// Both `Owned` and `TrackedBuffer` frames allocated their memory and need
-    /// to deallocate it. `Field`, `BorrowedInPlace`, and `External` frames borrow from
-    /// parent, existing structures, or caller-provided memory.
+    /// to deallocate it. `Field`, `BorrowedInPlace`, `External`, `RopeSlot`, and
+    /// `Transferred` frames either borrow from somewhere else or have handed drop
+    /// responsibility off to a parent tracker's pending slot.
     const fn needs_dealloc(&self) -> bool {
         matches!(self, FrameOwnership::Owned | FrameOwnership::TrackedBuffer)
     }
@@ -479,7 +517,7 @@ pub(crate) enum Tracker {
         /// Deferred processing requires keeping buffers alive until finish_deferred(),
         /// so we delay actual insertion until the map frame is finalized.
         /// Each entry is (key_ptr, value_ptr) - both are initialized and owned by this tracker.
-        pending_entries: Vec<(PtrUninit, PtrUninit)>,
+        pending_entries: Vec<(PtrUninit, Option<PtrUninit>)>,
         /// The current entry index, used for building unique paths for deferred frame storage.
         /// Incremented each time we start a new key (in begin_key).
         /// This allows inner frames of different map entries to have distinct paths.
@@ -643,11 +681,17 @@ impl Frame {
         // For RopeSlot frames, we must NOT drop. These point into a ListRope chunk
         // owned by the parent List's tracker. The rope handles cleanup of all elements.
         //
+        // For Transferred frames, we must NOT drop. The child frame's data pointer has
+        // been copied into a parent tracker's pending slot and the parent now owns drop
+        // responsibility. Dropping here would cause double-free when the parent drops.
+        //
         // For TrackedBuffer frames, we CAN drop. These are temporary buffers where
         // the parent's MapInsertState tracks initialization via is_init propagation.
         if matches!(
             self.ownership,
-            FrameOwnership::BorrowedInPlace | FrameOwnership::RopeSlot
+            FrameOwnership::BorrowedInPlace
+                | FrameOwnership::RopeSlot
+                | FrameOwnership::Transferred
         ) {
             self.is_init = false;
             self.tracker = Tracker::Scalar;
@@ -773,9 +817,7 @@ impl Frame {
                 }
             }
             Tracker::Map {
-                insert_state,
-                pending_entries,
-                ..
+                pending_entries, ..
             } => {
                 // Drop the initialized Map
                 if self.is_init {
@@ -786,7 +828,12 @@ impl Frame {
                     };
                 }
 
-                // Clean up pending entries (key-value pairs that haven't been inserted yet)
+                // Clean up pending entries. Each entry is `(key_ptr, Option<value_ptr>)`:
+                // a full entry has `Some(value_ptr)`; a half-entry (key pushed but no value
+                // paired yet) has `None`. Per the Transferred ownership invariant,
+                // `pending_entries` is the SOLE drop-and-dealloc authority for any buffer
+                // it holds; frames whose `data` was copied here are marked `Transferred`
+                // and no-op on drop/dealloc.
                 if let Def::Map(map_def) = self.allocated.shape().def {
                     for (key_ptr, value_ptr) in pending_entries.drain(..) {
                         // Drop and deallocate key
@@ -796,94 +843,23 @@ impl Frame {
                         {
                             unsafe { alloc::alloc::dealloc(key_ptr.as_mut_byte_ptr(), key_layout) };
                         }
-                        // Drop and deallocate value
-                        unsafe { map_def.v().call_drop_in_place(value_ptr.assume_init()) };
-                        if let Ok(value_layout) = map_def.v().layout.sized_layout()
-                            && value_layout.size() > 0
-                        {
-                            unsafe {
-                                alloc::alloc::dealloc(value_ptr.as_mut_byte_ptr(), value_layout)
-                            };
-                        }
-                    }
-                }
-
-                // Clean up key/value buffers based on whether their TrackedBuffer frames
-                // are still on the stack. If a frame is on the stack, it handles cleanup.
-                // If a frame was already popped (via end()), we own the buffer and must clean it.
-                match insert_state {
-                    MapInsertState::PushingKey {
-                        key_ptr,
-                        key_initialized,
-                        key_frame_on_stack,
-                    } => {
-                        // Only clean up if the frame was already popped.
-                        // If key_frame_on_stack is true, the TrackedBuffer frame above us
-                        // will handle dropping and deallocating the key buffer.
-                        if !*key_frame_on_stack
-                            && let Def::Map(map_def) = self.allocated.shape().def
-                        {
-                            // Drop the key if it was initialized
-                            if *key_initialized {
-                                unsafe { map_def.k().call_drop_in_place(key_ptr.assume_init()) };
-                            }
-                            // Deallocate the key buffer
-                            if let Ok(key_layout) = map_def.k().layout.sized_layout()
-                                && key_layout.size() > 0
+                        // Drop and deallocate value if present (half-entries have None).
+                        if let Some(value_ptr) = value_ptr {
+                            unsafe { map_def.v().call_drop_in_place(value_ptr.assume_init()) };
+                            if let Ok(value_layout) = map_def.v().layout.sized_layout()
+                                && value_layout.size() > 0
                             {
                                 unsafe {
-                                    alloc::alloc::dealloc(key_ptr.as_mut_byte_ptr(), key_layout)
+                                    alloc::alloc::dealloc(value_ptr.as_mut_byte_ptr(), value_layout)
                                 };
                             }
                         }
                     }
-                    MapInsertState::PushingValue {
-                        key_ptr,
-                        value_ptr,
-                        value_initialized,
-                        value_frame_on_stack,
-                        key_frame_stored,
-                    } => {
-                        if let Def::Map(map_def) = self.allocated.shape().def {
-                            // Only clean up key if the key frame was NOT stored.
-                            // If key_frame_stored is true, the stored frame handles cleanup.
-                            if !*key_frame_stored {
-                                unsafe { map_def.k().call_drop_in_place(key_ptr.assume_init()) };
-                                if let Ok(key_layout) = map_def.k().layout.sized_layout()
-                                    && key_layout.size() > 0
-                                {
-                                    unsafe {
-                                        alloc::alloc::dealloc(key_ptr.as_mut_byte_ptr(), key_layout)
-                                    };
-                                }
-                            }
-
-                            // Only clean up value if the frame was already popped.
-                            // If value_frame_on_stack is true, the TrackedBuffer frame above us
-                            // will handle dropping and deallocating the value buffer.
-                            if !*value_frame_on_stack && let Some(value_ptr) = value_ptr {
-                                // Drop the value if it was initialized
-                                if *value_initialized {
-                                    unsafe {
-                                        map_def.v().call_drop_in_place(value_ptr.assume_init())
-                                    };
-                                }
-                                // Deallocate the value buffer
-                                if let Ok(value_layout) = map_def.v().layout.sized_layout()
-                                    && value_layout.size() > 0
-                                {
-                                    unsafe {
-                                        alloc::alloc::dealloc(
-                                            value_ptr.as_mut_byte_ptr(),
-                                            value_layout,
-                                        )
-                                    };
-                                }
-                            }
-                        }
-                    }
-                    MapInsertState::Idle => {}
                 }
+                // Note: insert_state is no longer a cleanup source. Any key/value buffer
+                // for an in-flight frame is either still owned by that frame (on the stack,
+                // frame's own dealloc handles it) or already transferred into pending_entries
+                // above (frame marked `Transferred`, pending_entries handles it).
             }
             Tracker::Set { .. } => {
                 // Drop the initialized Set
@@ -1373,7 +1349,7 @@ impl Frame {
     /// kept in pending_entries to allow deferred processing; now we insert them into
     /// the actual map and deallocate the temporary buffers.
     fn drain_pending_into_map(
-        pending_entries: &mut Vec<(PtrUninit, PtrUninit)>,
+        pending_entries: &mut Vec<(PtrUninit, Option<PtrUninit>)>,
         map_def: &facet_core::MapDef,
         map_data: PtrUninit,
     ) -> Result<(), ReflectErrorKind> {
@@ -1383,6 +1359,14 @@ impl Frame {
         let map_ptr = unsafe { map_data.assume_init() };
 
         for (key_ptr, value_ptr) in pending_entries.drain(..) {
+            // Every entry at finalize time MUST be a full (key, value) pair. A half-entry
+            // (value is None) means a key was pushed without a paired value — that's an
+            // invariant violation.
+            let Some(value_ptr) = value_ptr else {
+                return Err(ReflectErrorKind::InvariantViolation {
+                    invariant: "map pending_entries contains half-entry (key without value) at finalize",
+                });
+            };
             // Insert the key-value pair
             unsafe {
                 insert_fn(
@@ -2195,62 +2179,12 @@ impl<'facet, const BORROW: bool> Drop for Partial<'facet, BORROW> {
                                 }
                             }
                         }
-                        Some(PathStep::MapKey(entry_idx)) => {
-                            // Map key frame - clear from parent's insert_state to prevent
-                            // double-free. The key will be dropped by this frame's deinit.
-                            let entry_idx = *entry_idx as usize;
-                            if let Some(parent_ptr) =
-                                find_parent_frame(&mut stored_frames, stack, &parent_path)
-                            {
-                                let parent_frame = unsafe { &mut *parent_ptr };
-                                if let Tracker::Map {
-                                    insert_state,
-                                    pending_entries,
-                                    ..
-                                } = &mut parent_frame.tracker
-                                {
-                                    // If key is in insert_state, clear it
-                                    if let MapInsertState::PushingKey {
-                                        key_frame_on_stack, ..
-                                    } = insert_state
-                                    {
-                                        *key_frame_on_stack = false;
-                                    }
-                                    // Also check if there's a pending entry with this key
-                                    // that needs to have the key nullified
-                                    if entry_idx < pending_entries.len() {
-                                        // Remove this entry since we're handling cleanup here
-                                        // The key will be dropped by this frame's deinit
-                                        // The value frame will be handled separately
-                                        // Mark the key as already-handled by setting to dangling
-                                        // Actually, we'll clear the entire entry - the value
-                                        // frame will be processed separately anyway
-                                    }
-                                }
-                            }
-                        }
-                        Some(PathStep::MapValue(entry_idx)) => {
-                            // Map value frame - remove the entry from pending_entries.
-                            // The value is dropped by this frame's deinit.
-                            // The key is dropped by the MapKey frame's deinit (processed separately).
-                            let entry_idx = *entry_idx as usize;
-                            if let Some(parent_ptr) =
-                                find_parent_frame(&mut stored_frames, stack, &parent_path)
-                            {
-                                let parent_frame = unsafe { &mut *parent_ptr };
-                                if let Tracker::Map {
-                                    pending_entries, ..
-                                } = &mut parent_frame.tracker
-                                {
-                                    // Remove the entry at this index if it exists.
-                                    // Don't drop key/value here - they're handled by their
-                                    // respective stored frames (MapKey and MapValue).
-                                    if entry_idx < pending_entries.len() {
-                                        pending_entries.remove(entry_idx);
-                                    }
-                                }
-                            }
-                        }
+                        // NOTE: PathStep::MapKey / PathStep::MapValue arms were previously
+                        // here. With the Transferred ownership SSoT invariant, stored map
+                        // key/value frames are marked `FrameOwnership::Transferred` at the
+                        // moment their data is copied into pending_entries. Their deinit
+                        // and dealloc no-op; pending_entries is the sole drop site. So no
+                        // cleanup is required here.
                         Some(PathStep::Index(_)) => {
                             // List element frames with RopeSlot ownership are handled by
                             // the deinit check for RopeSlot - they skip dropping since the

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -274,8 +274,6 @@ pub(crate) enum MapInsertState {
     PushingKey {
         /// Temporary storage for the key being built
         key_ptr: PtrUninit,
-        /// Whether the key has been fully initialized
-        key_initialized: bool,
     },
 
     /// Pushing value after key is done.
@@ -289,8 +287,6 @@ pub(crate) enum MapInsertState {
         key_ptr: PtrUninit,
         /// Temporary storage for the value being built
         value_ptr: Option<PtrUninit>,
-        /// Whether the value has been fully initialized
-        value_initialized: bool,
     },
 }
 

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -109,28 +109,44 @@
 //! - Properly handling drop semantics for partially initialized values
 //! - Supporting both owned and borrowed values through lifetime parameters
 //!
-//! # Drop-ownership invariant (SSoT / Transferred)
+//! # Drop-ownership invariant (single-source-of-truth)
 //!
 //! Every heap buffer allocated during partial construction has exactly one drop-and-dealloc
 //! authority at all times. Authority is either the owning frame (its `FrameOwnership`
 //! controls deinit + dealloc) or a parent tracker's pending slot
 //! (`Tracker::Map::pending_entries`, `Tracker::Option::pending_inner`,
 //! `Tracker::SmartPointer::pending_inner`, `DynamicValueState::Object::pending_entries`,
-//! `DynamicValueState::Array::pending_elements`).
+//! `DynamicValueState::Array::pending_elements`). Authority transfers between the two
+//! at well-defined points — never simultaneously held.
 //!
-//! - **Transfer protocol**: in the same statement block that copies a child frame's `data`
-//!   pointer into a parent pending slot, mutate `child_frame.ownership =
-//!   FrameOwnership::Transferred`. The child's subsequent `deinit` and `dealloc` no-op.
-//!   The parent's tracker deinit is the sole site that drops + deallocs that buffer.
+//! - **Stored frames in deferred mode keep their buffer**: a frame that gets stored in
+//!   `stored_frames` for later re-entry retains full `TrackedBuffer`/`Owned` ownership
+//!   of its data. Parent tracker pending slots are NOT populated at store-time. On
+//!   error (`Partial` dropped mid-build, or `finish_deferred` aborting), the stored
+//!   frame's own `deinit` + `dealloc` handles cleanup; no parent pending-slot severing
+//!   is required.
+//! - **Pending-slot population is consume-time**: `finish_deferred`'s walk calls
+//!   `complete_map_{key,value}_frame` / `complete_option_frame` /
+//!   `complete_smart_pointer_frame` AFTER `require_full_initialization` has validated
+//!   the child frame. Only then does the buffer pointer move into the parent's pending
+//!   slot (or directly into the parent's final storage, for Option/SmartPointer). The
+//!   child frame is dropped silently (Frame has no `Drop` impl); the parent's pending
+//!   slot becomes the sole owner.
+//! - **Non-stored frames in deferred mode**: when a child frame isn't stored (e.g.
+//!   scalar Option inner), its popped `data` pointer is moved into the parent pending
+//!   slot directly in `end()`. The frame is silently dropped after the match block, so
+//!   single ownership is preserved without any ownership mutation.
 //! - **Map half-entries**: `pending_entries` holds `(key_ptr, Option<value_ptr>)`. A key
 //!   pushed without a paired value is a half-entry `(key, None)`; its value-phase
 //!   counterpart upgrades the last entry to `(key, Some(value))`. A half-entry left at
 //!   finalize is an invariant violation; a half-entry at drop-time drops the orphan key
 //!   only.
-//! - **No booleans, no sever helpers**: cleanup paths must not special-case which half
-//!   of a dual-ownership pair to disarm. Ownership mutation at the transfer site is the
-//!   only contract. If you catch yourself adding a `*_frame_on_stack` or
-//!   `sever_parent_pending_*` helper, re-read this block.
+//! - **No sever helpers, no ownership-mutation protocol**: the walk's consume-time
+//!   ordering guarantees `pending_entries` / `pending_inner` entries only reference
+//!   fully-validated buffers. `Tracker::*::deinit` can drain these unconditionally.
+//!   If you catch yourself adding a `sever_parent_pending_*` or `untransfer_*` helper,
+//!   re-read this block — the answer is to push to the pending slot later, not to add
+//!   a sever step.
 
 use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 
@@ -267,10 +283,12 @@ pub(crate) enum MapInsertState {
     /// Pushing key - memory allocated, waiting for initialization.
     ///
     /// The key buffer is owned by the key frame currently on the stack
-    /// (a `TrackedBuffer` frame). If that frame is stored (deferred mode),
-    /// the key buffer ownership transfers to `pending_entries` as a
-    /// half-entry `(key_ptr, None)` and the stored frame is marked
-    /// `FrameOwnership::Transferred`.
+    /// (a `TrackedBuffer` frame). In non-deferred mode, the key frame's `end()`
+    /// transfers the buffer into `pending_entries` as a half-entry
+    /// `(key_ptr, None)` before transitioning to `PushingValue`. In deferred
+    /// mode, the key frame is stored (retaining ownership) and only the state
+    /// transitions here; `pending_entries` is populated at consume-time by
+    /// `complete_map_key_frame` during `finish_deferred`.
     PushingKey {
         /// Temporary storage for the key being built
         key_ptr: PtrUninit,
@@ -278,10 +296,11 @@ pub(crate) enum MapInsertState {
 
     /// Pushing value after key is done.
     ///
-    /// If the key was stored in deferred mode, `pending_entries` already
-    /// has a `(key_ptr, None)` half-entry. When the value frame is stored,
-    /// the half-entry is upgraded to `(key_ptr, Some(value_ptr))` and the
-    /// value frame is marked `FrameOwnership::Transferred`.
+    /// In non-deferred mode, the value frame's `end()` upgrades the last
+    /// half-entry in `pending_entries` to `(key_ptr, Some(value_ptr))`. In
+    /// deferred mode, the value frame is stored (retaining ownership); the
+    /// `finish_deferred` walk's `complete_map_value_frame` upgrades
+    /// the half-entry at consume-time.
     PushingValue {
         /// Temporary storage for the key that was built (always initialized)
         key_ptr: PtrUninit,
@@ -326,30 +345,14 @@ pub(crate) enum FrameOwnership {
     /// On list frame end(): all elements are moved into the real Vec.
     /// On drop/failure: the rope chunk handles cleanup.
     RopeSlot,
-
-    /// The frame's `data` pointer has been copied into a parent tracker's pending slot
-    /// (e.g., `Tracker::Map::pending_entries`, `Tracker::Option::pending_inner`,
-    /// `Tracker::SmartPointer::pending_inner`, `DynamicValueState::Object::pending_entries`,
-    /// `DynamicValueState::Array::pending_elements`). The parent tracker is now the SOLE
-    /// drop-and-dealloc authority for that buffer.
-    ///
-    /// On `deinit`: no-op (parent's tracker deinit will drop-in-place the pending slot).
-    /// On `dealloc`: no-op (parent's tracker deinit will dealloc the pending slot).
-    ///
-    /// This is the single invariant that protects against double-free across all the
-    /// nesting combinations (Map/List/Option/SmartPointer/DynamicValue × stack/stored).
-    /// Any code that copies a child frame's `data` into a parent pending slot MUST, in
-    /// the same statement block, set `child_frame.ownership = Transferred`.
-    Transferred,
 }
 
 impl FrameOwnership {
     /// Returns true if this frame is responsible for deallocating its memory.
     ///
     /// Both `Owned` and `TrackedBuffer` frames allocated their memory and need
-    /// to deallocate it. `Field`, `BorrowedInPlace`, `External`, `RopeSlot`, and
-    /// `Transferred` frames either borrow from somewhere else or have handed drop
-    /// responsibility off to a parent tracker's pending slot.
+    /// to deallocate it. `Field`, `BorrowedInPlace`, `External`, and `RopeSlot`
+    /// frames borrow from somewhere else.
     const fn needs_dealloc(&self) -> bool {
         matches!(self, FrameOwnership::Owned | FrameOwnership::TrackedBuffer)
     }
@@ -677,17 +680,11 @@ impl Frame {
         // For RopeSlot frames, we must NOT drop. These point into a ListRope chunk
         // owned by the parent List's tracker. The rope handles cleanup of all elements.
         //
-        // For Transferred frames, we must NOT drop. The child frame's data pointer has
-        // been copied into a parent tracker's pending slot and the parent now owns drop
-        // responsibility. Dropping here would cause double-free when the parent drops.
-        //
         // For TrackedBuffer frames, we CAN drop. These are temporary buffers where
         // the parent's MapInsertState tracks initialization via is_init propagation.
         if matches!(
             self.ownership,
-            FrameOwnership::BorrowedInPlace
-                | FrameOwnership::RopeSlot
-                | FrameOwnership::Transferred
+            FrameOwnership::BorrowedInPlace | FrameOwnership::RopeSlot
         ) {
             self.is_init = false;
             self.tracker = Tracker::Scalar;
@@ -826,10 +823,10 @@ impl Frame {
 
                 // Clean up pending entries. Each entry is `(key_ptr, Option<value_ptr>)`:
                 // a full entry has `Some(value_ptr)`; a half-entry (key pushed but no value
-                // paired yet) has `None`. Per the Transferred ownership invariant,
-                // `pending_entries` is the SOLE drop-and-dealloc authority for any buffer
-                // it holds; frames whose `data` was copied here are marked `Transferred`
-                // and no-op on drop/dealloc.
+                // paired yet) has `None`. `pending_entries` is the sole drop-and-dealloc
+                // authority for any buffer it holds; entries only ever reference fully-
+                // initialized buffers (pushed at walk consume-time or non-stored end()
+                // paths, after validation), so drop-in-place is safe.
                 if let Def::Map(map_def) = self.allocated.shape().def {
                     for (key_ptr, value_ptr) in pending_entries.drain(..) {
                         // Drop and deallocate key
@@ -853,9 +850,9 @@ impl Frame {
                     }
                 }
                 // Note: insert_state is no longer a cleanup source. Any key/value buffer
-                // for an in-flight frame is either still owned by that frame (on the stack,
-                // frame's own dealloc handles it) or already transferred into pending_entries
-                // above (frame marked `Transferred`, pending_entries handles it).
+                // for an in-flight frame is still owned by that frame (the stored frame's
+                // own dealloc handles it during `cleanup_stored_frames_on_error`, or the
+                // on-stack frame's dealloc handles it in `Drop::drop`).
             }
             Tracker::Set { .. } => {
                 // Drop the initialized Set
@@ -2175,12 +2172,11 @@ impl<'facet, const BORROW: bool> Drop for Partial<'facet, BORROW> {
                                 }
                             }
                         }
-                        // NOTE: PathStep::MapKey / PathStep::MapValue arms were previously
-                        // here. With the Transferred ownership SSoT invariant, stored map
-                        // key/value frames are marked `FrameOwnership::Transferred` at the
-                        // moment their data is copied into pending_entries. Their deinit
-                        // and dealloc no-op; pending_entries is the sole drop site. So no
-                        // cleanup is required here.
+                        // Stored map key/value frames keep their TrackedBuffer ownership
+                        // until consume-time in finish_deferred; pending_entries is only
+                        // populated by the walk, so at Partial::drop it contains nothing
+                        // referencing these frames. Their own deinit/dealloc handles the
+                        // partial-init drop. No parent-side cleanup required.
                         Some(PathStep::Index(_)) => {
                             // List element frames with RopeSlot ownership are handled by
                             // the deinit check for RopeSlot - they skip dropping since the

--- a/facet-reflect/src/partial/mod.rs
+++ b/facet-reflect/src/partial/mod.rs
@@ -676,20 +676,20 @@ impl Frame {
         // For BorrowedInPlace frames, we must NOT drop. These point into existing
         // collection entries (Value objects, Option inners) where the parent has no
         // per-entry tracking. Dropping here would cause double-free when parent drops.
-        //
-        // For RopeSlot frames, we must NOT drop. These point into a ListRope chunk
-        // owned by the parent List's tracker. The rope handles cleanup of all elements.
-        //
-        // For TrackedBuffer frames, we CAN drop. These are temporary buffers where
-        // the parent's MapInsertState tracks initialization via is_init propagation.
-        if matches!(
-            self.ownership,
-            FrameOwnership::BorrowedInPlace | FrameOwnership::RopeSlot
-        ) {
+        if matches!(self.ownership, FrameOwnership::BorrowedInPlace) {
             self.is_init = false;
             self.tracker = Tracker::Scalar;
             return;
         }
+
+        // For RopeSlot frames, `frame.data` points into a ListRope chunk owned by
+        // the parent List's tracker. We DO need to drop the element's contents
+        // (respecting partial init), because with consume-time rope marking, if a
+        // RopeSlot frame is still alive at deinit time the rope's initialized_count
+        // does NOT cover this slot — so `ListRope::drain_into` won't drop it.
+        // The drop below runs `call_drop_in_place` against `self.data` (in-rope);
+        // `dealloc` is skipped since `needs_dealloc()` is false for RopeSlot, so
+        // the chunk allocation stays intact for the parent rope to reclaim.
 
         // Field frames are responsible for their value during cleanup.
         // The ownership model ensures no double-free:

--- a/facet-reflect/src/partial/partial_api/maps.rs
+++ b/facet-reflect/src/partial/partial_api/maps.rs
@@ -225,10 +225,7 @@ impl<const BORROW: bool> Partial<'_, BORROW> {
                     Some(idx) => idx + 1,
                 });
                 *building_key = true;
-                *insert_state = MapInsertState::PushingKey {
-                    key_ptr,
-                    key_initialized: false,
-                };
+                *insert_state = MapInsertState::PushingKey { key_ptr };
             }
             _ => unreachable!(),
         }
@@ -321,7 +318,6 @@ impl<const BORROW: bool> Partial<'_, BORROW> {
                 *insert_state = MapInsertState::PushingValue {
                     key_ptr,
                     value_ptr: Some(value_ptr),
-                    value_initialized: false,
                 };
             }
             _ => unreachable!(),

--- a/facet-reflect/src/partial/partial_api/maps.rs
+++ b/facet-reflect/src/partial/partial_api/maps.rs
@@ -228,7 +228,6 @@ impl<const BORROW: bool> Partial<'_, BORROW> {
                 *insert_state = MapInsertState::PushingKey {
                     key_ptr,
                     key_initialized: false,
-                    key_frame_on_stack: true, // TrackedBuffer frame is now on the stack
                 };
             }
             _ => unreachable!(),
@@ -260,7 +259,7 @@ impl<const BORROW: bool> Partial<'_, BORROW> {
         let frame = self.mode.stack_mut().last_mut().unwrap();
 
         // Check that we have a Map in PushingValue state with no value_ptr yet
-        let (map_def, key_ptr, key_frame_stored) = match (&shape.def, &frame.tracker) {
+        let (map_def, key_ptr) = match (&shape.def, &frame.tracker) {
             (
                 Def::Map(map_def),
                 Tracker::Map {
@@ -268,12 +267,11 @@ impl<const BORROW: bool> Partial<'_, BORROW> {
                         MapInsertState::PushingValue {
                             value_ptr: None,
                             key_ptr,
-                            key_frame_stored,
                             ..
                         },
                     ..
                 },
-            ) => (map_def, *key_ptr, *key_frame_stored),
+            ) => (map_def, *key_ptr),
             (
                 Def::Map(_),
                 Tracker::Map {
@@ -324,8 +322,6 @@ impl<const BORROW: bool> Partial<'_, BORROW> {
                     key_ptr,
                     value_ptr: Some(value_ptr),
                     value_initialized: false,
-                    value_frame_on_stack: true, // TrackedBuffer frame is now on the stack
-                    key_frame_stored,           // Preserve from previous state
                 };
             }
             _ => unreachable!(),

--- a/facet-reflect/src/partial/partial_api/misc.rs
+++ b/facet-reflect/src/partial/partial_api/misc.rs
@@ -481,10 +481,9 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // Before cleanup, clear the parent's iset bit for the frame that failed.
                 // This prevents the parent from trying to drop this field when Partial is dropped.
                 Self::clear_parent_iset_for_path(&path, self.frames_mut(), &mut stored_frames);
-                // NOTE: With the SSoT/Transferred ownership invariant, any frame whose
-                // buffer was copied into a parent pending slot is marked `Transferred`
-                // (frame drop no-ops, parent pending slot is sole drop site). No
-                // sever-from-parent logic is required here.
+                // Consume-time invariant: pending_entries/pending_inner are only populated
+                // by the walk after validation succeeds. A frame that fails here hasn't
+                // been transferred anywhere, so its own deinit/dealloc is the sole cleanup.
                 frame.deinit();
                 frame.dealloc();
                 // Clean up remaining stored frames safely (deepest first, clearing parent isets)
@@ -497,7 +496,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // Before cleanup, clear the parent's iset bit for the frame that failed.
                 // This prevents the parent from trying to drop this field when Partial is dropped.
                 Self::clear_parent_iset_for_path(&path, self.frames_mut(), &mut stored_frames);
-                // Same as above: Transferred ownership makes sever-from-parent obsolete.
+                // Consume-time invariant: frame hasn't been transferred yet.
                 frame.deinit();
                 frame.dealloc();
                 // Clean up remaining stored frames safely (deepest first, clearing parent isets)
@@ -623,8 +622,10 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 }
 
                 // Special handling for Map key values: when path ends with MapKey,
-                // the parent is a Map frame and we need to transition it to PushingValue state.
-                if matches!(last_step, PathStep::MapKey(_)) {
+                // the parent is a Map frame and we need to push the key into
+                // pending_entries at the matching entry_idx.
+                if let PathStep::MapKey(entry_idx) = last_step {
+                    let entry_idx = *entry_idx;
                     // Find the Map frame (parent)
                     let map_frame = if let Some(parent_frame) = stored_frames.get_mut(&parent_path)
                     {
@@ -634,15 +635,16 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                     };
 
                     if let Some(map_frame) = map_frame {
-                        // Transition the Map from PushingKey to PushingValue state
-                        Self::complete_map_key_frame(map_frame, frame);
+                        Self::complete_map_key_frame(map_frame, entry_idx, frame);
                         continue;
                     }
                 }
 
                 // Special handling for Map value values: when path ends with MapValue,
-                // the parent is a Map frame and we need to add the entry to pending_entries.
-                if matches!(last_step, PathStep::MapValue(_)) {
+                // the parent is a Map frame and we need to fill in the value for the
+                // half-entry at the matching entry_idx.
+                if let PathStep::MapValue(entry_idx) = last_step {
+                    let entry_idx = *entry_idx;
                     // Find the Map frame (parent)
                     let map_frame = if let Some(parent_frame) = stored_frames.get_mut(&parent_path)
                     {
@@ -652,8 +654,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                     };
 
                     if let Some(map_frame) = map_frame {
-                        // Add the key-value pair to pending_entries
-                        Self::complete_map_value_frame(map_frame, frame);
+                        Self::complete_map_value_frame(map_frame, entry_idx, frame);
                         continue;
                     }
                 }
@@ -782,11 +783,12 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
         }
     }
 
-    // NOTE: `sever_parent_pending_for_path` has been removed. Under the SSoT/Transferred
-    // ownership invariant, any child frame whose buffer was copied into a parent pending
-    // slot is marked `FrameOwnership::Transferred` at the transfer site. Its `deinit` and
-    // `dealloc` no-op; the parent pending slot is the sole drop-and-dealloc authority.
-    // No sever-from-parent logic is required on failure paths.
+    // NOTE: `sever_parent_pending_for_path` has been removed. Under the consume-time
+    // pending-population invariant, parent pending slots (pending_entries, pending_inner,
+    // etc.) are only populated by the walk in `finish_deferred` AFTER a child frame's
+    // validation passes. A failing child frame has its buffer still owned by itself, so
+    // `frame.deinit(); frame.dealloc()` is the complete cleanup. No parent-side sever
+    // is required.
 
     /// Helper to unset a field index in a tracker's iset
     fn unset_field_in_tracker(tracker: &mut Tracker, field_idx: usize) {
@@ -860,152 +862,13 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // Before dropping this frame, clear the parent's iset bit so the
                 // parent won't try to drop this field again.
                 Self::clear_parent_iset_for_path(&path, stack, &mut stored_frames);
-                // Cleanup path special case: frames whose buffer was `Transferred` into
-                // a parent pending slot were expected to be drop-in-placed by the parent
-                // at finalize. But we're aborting — the parent's pending slot points to
-                // a buffer whose deep contents may be only partially initialized, and
-                // drop-in-place would traverse uninit descendants. So we undo the
-                // transfer: remove the pending-slot pointer and dealloc the buffer
-                // directly (without drop-in-place) to avoid both leaks and crashes.
-                if matches!(frame.ownership, FrameOwnership::Transferred) {
-                    Self::untransfer_on_cleanup(&path, &mut frame, stack, &mut stored_frames);
-                    // untransfer_on_cleanup deallocs the raw buffer itself; skip the
-                    // normal deinit/dealloc path (deinit would no-op under Transferred
-                    // anyway, dealloc would also no-op).
-                    continue;
-                }
+                // Under the consume-time SSoT invariant, stored frames always own
+                // their own buffer (parent pending slots are only populated at walk
+                // consume-time, after validation). Standard deinit + dealloc handles
+                // cleanup; no parent pending-slot severing is needed.
                 trace!("cleanup: calling deinit() on path={:?}", path,);
                 frame.deinit();
                 frame.dealloc();
-            }
-        }
-    }
-
-    /// Undo a `FrameOwnership::Transferred` transfer during error cleanup.
-    ///
-    /// At the transfer site, the frame's buffer pointer was copied into a parent pending
-    /// slot (Map::pending_entries, Option/SmartPointer::pending_inner,
-    /// DynamicValue::pending_entries/elements). On success, the parent tracker's deinit
-    /// is the sole drop-and-dealloc authority. On error cleanup we can't rely on that,
-    /// because deep descendants may be uninit and drop-in-place would crash.
-    ///
-    /// This helper removes the parent pending-slot pointer and deallocates the raw
-    /// buffer directly (no drop-in-place), preventing both use-after-free (from the
-    /// parent dereffing a buffer we freed) and drop-in-place of partially-init data.
-    fn untransfer_on_cleanup(
-        path: &Path,
-        frame: &mut Frame,
-        stack: &mut [Frame],
-        stored_frames: &mut ::alloc::collections::BTreeMap<Path, Frame>,
-    ) {
-        let Some(last_step) = path.steps.last() else {
-            return;
-        };
-
-        // Locate the parent frame (stored or on stack at index parent_path.steps.len()).
-        let parent_path = Path {
-            shape: path.shape,
-            steps: path.steps[..path.steps.len() - 1].to_vec(),
-        };
-        let parent_idx = parent_path.steps.len();
-        let parent_frame = if let Some(pf) = stored_frames.get_mut(&parent_path) {
-            Some(pf)
-        } else {
-            stack.get_mut(parent_idx)
-        };
-
-        if let Some(parent_frame) = parent_frame {
-            match (&mut parent_frame.tracker, last_step) {
-                (
-                    Tracker::Map {
-                        pending_entries, ..
-                    },
-                    PathStep::MapValue(_),
-                ) => {
-                    // The last pending entry is (key, Some(value_ptr)) where value_ptr
-                    // == frame.data. Pop the entry; drop+dealloc the key (it was
-                    // transferred into pending_entries as a half-entry earlier — the
-                    // key IS fully initialized at this point because it's a prerequisite
-                    // for begin_value()). Leave the value to this fn's own dealloc below.
-                    if let Some((key_ptr, _)) = pending_entries.pop()
-                        && let Def::Map(map_def) = parent_frame.allocated.shape().def
-                    {
-                        unsafe {
-                            map_def.k().call_drop_in_place(key_ptr.assume_init());
-                        }
-                        if let Ok(key_layout) = map_def.k().layout.sized_layout()
-                            && key_layout.size() > 0
-                        {
-                            unsafe {
-                                ::alloc::alloc::dealloc(key_ptr.as_mut_byte_ptr(), key_layout);
-                            }
-                        }
-                    }
-                }
-                (
-                    Tracker::Map {
-                        pending_entries, ..
-                    },
-                    PathStep::MapKey(_),
-                ) => {
-                    // A MapKey frame marked Transferred means we stored a half-entry
-                    // (key, None). Pop it; the popped key_ptr IS `frame.data`, so
-                    // drop and dealloc here and return — skip the generic dealloc
-                    // below to avoid double-freeing the key buffer.
-                    if let Some((key_ptr, _)) = pending_entries.pop()
-                        && let Def::Map(map_def) = parent_frame.allocated.shape().def
-                    {
-                        unsafe {
-                            map_def.k().call_drop_in_place(key_ptr.assume_init());
-                        }
-                        if let Ok(key_layout) = map_def.k().layout.sized_layout()
-                            && key_layout.size() > 0
-                        {
-                            unsafe {
-                                ::alloc::alloc::dealloc(key_ptr.as_mut_byte_ptr(), key_layout);
-                            }
-                        }
-                    }
-                    return;
-                }
-                (
-                    Tracker::SmartPointer {
-                        building_inner,
-                        pending_inner,
-                    },
-                    PathStep::Deref,
-                ) => {
-                    *pending_inner = None;
-                    *building_inner = true;
-                    parent_frame.is_init = false;
-                }
-                (
-                    Tracker::Option {
-                        building_inner,
-                        pending_inner,
-                    },
-                    PathStep::OptionSome,
-                ) => {
-                    *pending_inner = None;
-                    *building_inner = true;
-                    parent_frame.is_init = false;
-                }
-                _ => {}
-            }
-        }
-
-        // Manually deallocate the frame's buffer (no drop-in-place — contents may be
-        // partially initialized, which is exactly why we took this path).
-        if frame.allocated.allocated_size() > 0
-            && let Ok(layout) = frame.allocated.shape().layout.sized_layout()
-        {
-            let actual_layout = core::alloc::Layout::from_size_align(
-                frame.allocated.allocated_size(),
-                layout.align(),
-            )
-            .expect("allocated_size must be valid");
-            unsafe {
-                ::alloc::alloc::dealloc(frame.data.as_mut_byte_ptr(), actual_layout);
             }
         }
     }
@@ -1338,95 +1201,65 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
         false
     }
 
-    /// Complete a Map key frame by transitioning the Map from PushingKey to PushingValue state
-    /// (for deferred finalization).
+    /// Complete a Map key frame by transferring the key buffer into `pending_entries`
+    /// at position `entry_idx` as a half-entry `(key_ptr, None)`
+    /// (for deferred finalization, walk consume-time).
     ///
-    /// The key buffer ownership now belongs to `pending_entries` via a half-entry
-    /// `(key_ptr, None)` pushed here. The subsequent value frame's
-    /// [`complete_map_value_frame`] upgrades this half-entry to
-    /// `(key_ptr, Some(value_ptr))`.
-    fn complete_map_key_frame(map_frame: &mut Frame, key_frame: Frame) {
+    /// Called only from the `finish_deferred` walk, after `require_full_initialization`
+    /// has validated the key frame. The `entry_idx` comes from the `PathStep::MapKey(idx)`
+    /// and matches the map's `current_entry_index` assigned at `begin_key` time.
+    /// MapKey frames for the same map are visited in ascending idx order, so pushing
+    /// is equivalent to indexed insertion (asserted below).
+    ///
+    /// `key_frame` is dropped silently on return — Frame has no Drop impl, so
+    /// `pending_entries` becomes the sole owner of this buffer.
+    fn complete_map_key_frame(map_frame: &mut Frame, entry_idx: u32, key_frame: Frame) {
         if let Tracker::Map {
-            insert_state,
-            pending_entries,
-            ..
+            pending_entries, ..
         } = &mut map_frame.tracker
-            && let MapInsertState::PushingKey { key_ptr, .. } = insert_state
         {
-            // Transfer key buffer ownership to pending_entries as a half-entry. This
-            // entry will be upgraded to a full (key, value) by complete_map_value_frame
-            // or Map::deinit's pending_entries drain will drop/dealloc the orphaned key.
-            pending_entries.push((*key_ptr, None));
-
-            // Transition to PushingValue state. The `key_ptr` here is just a convenience
-            // copy for the value-push path; it is NOT a drop source — pending_entries is.
-            *insert_state = MapInsertState::PushingValue {
-                key_ptr: *key_ptr,
-                value_ptr: None,
-            };
-
+            debug_assert_eq!(
+                pending_entries.len(),
+                entry_idx as usize,
+                "MapKey frames must arrive in ascending entry_idx order"
+            );
+            pending_entries.push((key_frame.data, None));
             crate::trace!(
-                "complete_map_key_frame: transitioned {} to PushingValue",
+                "complete_map_key_frame: pushed half-entry at idx {} for {}",
+                entry_idx,
                 map_frame.allocated.shape()
             );
-
-            // Owned frames (rare) allocate their own buffer — we still need to free it.
-            // TrackedBuffer frames use the Map's key_ptr which is now in pending_entries,
-            // so only Owned ownership triggers dealloc here.
-            if let FrameOwnership::Owned = key_frame.ownership
-                && let Ok(layout) = key_frame.allocated.shape().layout.sized_layout()
-                && layout.size() > 0
-            {
-                unsafe {
-                    ::alloc::alloc::dealloc(key_frame.data.as_mut_byte_ptr(), layout);
-                }
-            }
         }
     }
 
-    /// Complete a Map value frame by upgrading the last pending half-entry
+    /// Complete a Map value frame by upgrading the half-entry at position `entry_idx`
     /// `(key_ptr, None)` to a full `(key_ptr, Some(value_ptr))`
-    /// (for deferred finalization).
-    fn complete_map_value_frame(map_frame: &mut Frame, value_frame: Frame) {
+    /// (for deferred finalization, walk consume-time).
+    ///
+    /// Called only from the `finish_deferred` walk, after `require_full_initialization`
+    /// has validated the value frame. The `entry_idx` comes from
+    /// `PathStep::MapValue(idx)` and indexes the matching half-entry placed by
+    /// [`complete_map_key_frame`]. `value_frame` is dropped silently on return —
+    /// Frame has no Drop impl, so `pending_entries` becomes the sole owner of the
+    /// buffer.
+    fn complete_map_value_frame(map_frame: &mut Frame, entry_idx: u32, value_frame: Frame) {
         if let Tracker::Map {
-            insert_state,
-            pending_entries,
-            ..
+            pending_entries, ..
         } = &mut map_frame.tracker
-            && let MapInsertState::PushingValue {
-                value_ptr: Some(value_ptr),
-                ..
-            } = insert_state
         {
-            // Upgrade the last half-entry (which must exist — complete_map_key_frame
-            // or the deferred end() store-path pushed it) to a full entry.
-            let last = pending_entries
-                .last_mut()
-                .expect("pending_entries must have a half-entry from complete_map_key_frame");
+            let slot = pending_entries
+                .get_mut(entry_idx as usize)
+                .expect("pending_entries must have a half-entry at entry_idx");
             debug_assert!(
-                last.1.is_none(),
-                "last pending entry must be a half-entry (None value), got Some — invariant violation in SSoT protocol"
+                slot.1.is_none(),
+                "pending entry at entry_idx must be a half-entry (None value), got Some"
             );
-            last.1 = Some(*value_ptr);
-
+            slot.1 = Some(value_frame.data);
             crate::trace!(
-                "complete_map_value_frame: upgraded half-entry to full entry for {}",
+                "complete_map_value_frame: upgraded half-entry at idx {} to full entry for {}",
+                entry_idx,
                 map_frame.allocated.shape()
             );
-
-            // Reset to idle state
-            *insert_state = MapInsertState::Idle;
-
-            // For Owned frames (rare), free the frame's own buffer. TrackedBuffer frames
-            // use the Map's value_ptr which is now owned by pending_entries — no-op.
-            if let FrameOwnership::Owned = value_frame.ownership
-                && let Ok(layout) = value_frame.allocated.shape().layout.sized_layout()
-                && layout.size() > 0
-            {
-                unsafe {
-                    ::alloc::alloc::dealloc(value_frame.data.as_mut_byte_ptr(), layout);
-                }
-            }
         }
     }
 
@@ -1609,10 +1442,9 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         FrameOwnership::TrackedBuffer
                         | FrameOwnership::BorrowedInPlace
                         | FrameOwnership::External
-                        | FrameOwnership::RopeSlot
-                        | FrameOwnership::Transferred => {
+                        | FrameOwnership::RopeSlot => {
                             return Err(self.err(ReflectErrorKind::InvariantViolation {
-                            invariant: "SmartPointerSlice cannot have TrackedBuffer/BorrowedInPlace/External/RopeSlot/Transferred ownership after conversion",
+                            invariant: "SmartPointerSlice cannot have TrackedBuffer/BorrowedInPlace/External/RopeSlot ownership after conversion",
                         }));
                         }
                     }
@@ -1951,50 +1783,26 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // - PushingKey -> PushingValue: so begin_value() can be called
                 // - PushingValue -> Idle: so begin_key() can be called for the next entry
                 //
-                // Per SSoT/Transferred protocol: whenever we copy `popped_frame.data` into
-                // pending_entries (as a half-entry for a stored key, or upgrading to a full
-                // entry for a stored value), we MUST mark popped_frame.ownership as
-                // `Transferred` so the stored frame no longer tries to drop/dealloc the
-                // buffer. pending_entries is now the sole drop authority.
+                // SSoT: we do NOT touch pending_entries here. The key/value buffer stays
+                // owned by the stored frame. finish_deferred's walk will call
+                // complete_map_{key,value}_frame at consume-time to transfer buffer
+                // ownership into pending_entries *after* the frame has passed validation.
                 if let Some(parent_frame) = stack.last_mut() {
-                    if let Tracker::Map {
-                        insert_state,
-                        pending_entries,
-                        ..
-                    } = &mut parent_frame.tracker
-                    {
+                    if let Tracker::Map { insert_state, .. } = &mut parent_frame.tracker {
                         match insert_state {
                             MapInsertState::PushingKey { key_ptr, .. } => {
-                                // Transfer key ownership into pending_entries as a
-                                // half-entry, then transition state.
-                                pending_entries.push((*key_ptr, None));
                                 *insert_state = MapInsertState::PushingValue {
                                     key_ptr: *key_ptr,
                                     value_ptr: None,
                                 };
-                                popped_frame.ownership = FrameOwnership::Transferred;
                                 crate::trace!(
-                                    "end(): Map transitioned to PushingValue while storing key frame (ownership Transferred)"
+                                    "end(): Map transitioned to PushingValue while storing key frame"
                                 );
                             }
-                            MapInsertState::PushingValue {
-                                value_ptr: Some(value_ptr),
-                                ..
-                            } => {
-                                // Upgrade the half-entry to a full entry, then reset
-                                // to Idle.
-                                let last = pending_entries.last_mut().expect(
-                                    "pending_entries must have a half-entry from when key was stored",
-                                );
-                                debug_assert!(
-                                    last.1.is_none(),
-                                    "last pending entry must be a half-entry (None value), got Some — invariant violation in SSoT protocol"
-                                );
-                                last.1 = Some(*value_ptr);
+                            MapInsertState::PushingValue { .. } => {
                                 *insert_state = MapInsertState::Idle;
-                                popped_frame.ownership = FrameOwnership::Transferred;
                                 crate::trace!(
-                                    "end(): Map upgraded half-entry to full entry while storing value frame (ownership Transferred)"
+                                    "end(): Map transitioned to Idle while storing value frame"
                                 );
                             }
                             _ => {}
@@ -2049,13 +1857,12 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         }
 
                         // Add to pending_entries for deferred insertion.
-                        // SSoT: pending_entries is now the sole drop authority for this
-                        // buffer; mark the popped frame Transferred so its deinit/dealloc
-                        // no-op.
+                        // The frame isn't stored — popped_frame is silently dropped after
+                        // this block returns, and Frame has no Drop impl, so
+                        // pending_entries is the sole owner of this buffer.
                         pending_entries.push((key, popped_frame.data));
-                        popped_frame.ownership = FrameOwnership::Transferred;
                         crate::trace!(
-                            "end(): DynamicValue object entry added to pending_entries in deferred mode (ownership Transferred)"
+                            "end(): DynamicValue object entry added to pending_entries in deferred mode"
                         );
 
                         // Reset insert state to Idle so more entries can be added
@@ -2083,12 +1890,11 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         }
 
                         // Add to pending_elements for deferred insertion.
-                        // SSoT: pending_elements is now the sole drop authority; mark the
-                        // popped frame Transferred so its deinit/dealloc no-op.
+                        // The frame isn't stored and Frame has no Drop impl, so
+                        // pending_elements is the sole owner of this buffer.
                         pending_elements.push(popped_frame.data);
-                        popped_frame.ownership = FrameOwnership::Transferred;
                         crate::trace!(
-                            "end(): DynamicValue array element added to pending_elements in deferred mode (ownership Transferred)"
+                            "end(): DynamicValue array element added to pending_elements in deferred mode"
                         );
 
                         // Reset building_element so more elements can be added
@@ -2398,15 +2204,14 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         // Check if we're in deferred mode - if so, store the inner value pointer
                         if is_deferred_mode {
                             // Store the inner value pointer for deferred new_into_fn.
-                            // SSoT: pending_inner is now the sole drop authority for this
-                            // buffer; mark popped_frame Transferred so its deinit/dealloc
-                            // no-op.
+                            // popped_frame isn't stored — it's silently dropped after this
+                            // block (Frame has no Drop impl), so pending_inner is the sole
+                            // owner of this buffer.
                             *pending_inner = Some(popped_frame.data);
-                            popped_frame.ownership = FrameOwnership::Transferred;
                             *building_inner = false;
                             parent_frame.is_init = true;
                             crate::trace!(
-                                "end() SMARTPTR: stored pending_inner, will finalize in finish_deferred (ownership Transferred)"
+                                "end() SMARTPTR: stored pending_inner, will finalize in finish_deferred"
                             );
                         } else {
                             // Not in deferred mode - complete immediately
@@ -2503,12 +2308,11 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         }
 
                         // Transfer key buffer ownership into pending_entries as a
-                        // half-entry (key_ptr, None). The popped_frame (TrackedBuffer)
-                        // no longer owns the buffer — mark it Transferred so its own
-                        // deinit/dealloc no-ops. The value phase will upgrade the
+                        // half-entry (key_ptr, None). popped_frame is silently dropped
+                        // after this block (Frame has no Drop impl), so pending_entries
+                        // becomes the sole owner. The value phase will upgrade the
                         // half-entry to a full (key, Some(value)) pair.
                         pending_entries.push((*key_ptr, None));
-                        popped_frame.ownership = FrameOwnership::Transferred;
 
                         *insert_state = MapInsertState::PushingValue {
                             key_ptr: *key_ptr,
@@ -2523,8 +2327,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         }
 
                         // Upgrade the last half-entry (key_ptr, None) to a full entry
-                        // (key_ptr, Some(value_ptr)) and mark the value frame as
-                        // Transferred so its deinit/dealloc no-ops.
+                        // (key_ptr, Some(value_ptr)).
                         if let Some(value_ptr) = value_ptr {
                             let last = pending_entries.last_mut().expect(
                                 "pending_entries must have a half-entry from the PushingKey -> PushingValue transition",
@@ -2534,7 +2337,6 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                                 "last pending entry must be a half-entry (None value), got Some — invariant violation"
                             );
                             last.1 = Some(*value_ptr);
-                            popped_frame.ownership = FrameOwnership::Transferred;
 
                             // Reset to idle state
                             *insert_state = MapInsertState::Idle;
@@ -2586,17 +2388,14 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         // This keeps the inner value's memory stable for deferred processing.
                         // Actual init_some() happens in require_full_initialization().
                         //
-                        // SSoT: pending_inner is now the sole drop authority for this
-                        // buffer; mark popped_frame Transferred so its deinit/dealloc
-                        // no-op.
+                        // popped_frame isn't stored — it's silently dropped after this
+                        // block (Frame has no Drop impl), so pending_inner is the sole
+                        // owner of this buffer.
                         *pending_inner = Some(popped_frame.data);
-                        popped_frame.ownership = FrameOwnership::Transferred;
 
                         // Mark that we're no longer building the inner value
                         *building_inner = false;
-                        crate::trace!(
-                            "end(): stored pending_inner, set building_inner to false (ownership Transferred)"
-                        );
+                        crate::trace!("end(): stored pending_inner, set building_inner to false");
                         // Mark the Option as initialized (pending finalization)
                         parent_frame.is_init = true;
                         crate::trace!("end(): set parent_frame.is_init to true");

--- a/facet-reflect/src/partial/partial_api/misc.rs
+++ b/facet-reflect/src/partial/partial_api/misc.rs
@@ -481,20 +481,10 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // Before cleanup, clear the parent's iset bit for the frame that failed.
                 // This prevents the parent from trying to drop this field when Partial is dropped.
                 Self::clear_parent_iset_for_path(&path, self.frames_mut(), &mut stored_frames);
-                // If this is a MapValue/Deref/OptionSome frame, a parent tracker holds
-                // a pointer to our frame's memory (pending_entries / pending_inner). Clear
-                // that pointer before we dealloc, so the parent's deinit won't double-drop.
-                let stored_map_key_paths: ::alloc::collections::BTreeSet<Path> = stored_frames
-                    .keys()
-                    .filter(|p| matches!(p.steps.last(), Some(PathStep::MapKey(_))))
-                    .cloned()
-                    .collect();
-                Self::sever_parent_pending_for_path(
-                    &path,
-                    self.frames_mut(),
-                    &mut stored_frames,
-                    &stored_map_key_paths,
-                );
+                // NOTE: With the SSoT/Transferred ownership invariant, any frame whose
+                // buffer was copied into a parent pending slot is marked `Transferred`
+                // (frame drop no-ops, parent pending slot is sole drop site). No
+                // sever-from-parent logic is required here.
                 frame.deinit();
                 frame.dealloc();
                 // Clean up remaining stored frames safely (deepest first, clearing parent isets)
@@ -507,20 +497,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // Before cleanup, clear the parent's iset bit for the frame that failed.
                 // This prevents the parent from trying to drop this field when Partial is dropped.
                 Self::clear_parent_iset_for_path(&path, self.frames_mut(), &mut stored_frames);
-                // If this is a MapValue/Deref/OptionSome frame, a parent tracker holds
-                // a pointer to our frame's memory (pending_entries / pending_inner). Clear
-                // that pointer before we dealloc, so the parent's deinit won't double-drop.
-                let stored_map_key_paths: ::alloc::collections::BTreeSet<Path> = stored_frames
-                    .keys()
-                    .filter(|p| matches!(p.steps.last(), Some(PathStep::MapKey(_))))
-                    .cloned()
-                    .collect();
-                Self::sever_parent_pending_for_path(
-                    &path,
-                    self.frames_mut(),
-                    &mut stored_frames,
-                    &stored_map_key_paths,
-                );
+                // Same as above: Transferred ownership makes sever-from-parent obsolete.
                 frame.deinit();
                 frame.dealloc();
                 // Clean up remaining stored frames safely (deepest first, clearing parent isets)
@@ -805,142 +782,11 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
         }
     }
 
-    /// Sever parent/child pointer ownership when a stored child frame fails validation
-    /// in `finish_deferred`.
-    ///
-    /// When a child frame is stored for deferred processing, the parent may keep a
-    /// pointer to the child's buffer so it can finalize later (Map's `pending_entries`,
-    /// SmartPointer's / Option's `pending_inner`). If the child then fails validation
-    /// and its buffer is deallocated, that parent pointer would dangle and cause a
-    /// double-free when the parent is subsequently deinited.
-    ///
-    /// This helper clears the relevant parent field so the parent's own cleanup leaves
-    /// the buffer alone.
-    fn sever_parent_pending_for_path(
-        path: &Path,
-        stack: &mut [Frame],
-        stored_frames: &mut ::alloc::collections::BTreeMap<Path, Frame>,
-        stored_map_key_paths: &::alloc::collections::BTreeSet<Path>,
-    ) {
-        let Some(last_step) = path.steps.last() else {
-            return;
-        };
-        if !matches!(
-            last_step,
-            PathStep::MapValue(_) | PathStep::Deref | PathStep::OptionSome
-        ) {
-            return;
-        }
-
-        let parent_path = Path {
-            shape: path.shape,
-            steps: path.steps[..path.steps.len() - 1].to_vec(),
-        };
-
-        // If the failed path is a MapValue, check whether the sibling MapKey
-        // frame for this same entry index was stored in `stored_frames` at the
-        // start of cleanup. If so, that frame owns the key buffer (its deinit
-        // + dealloc will run for its own cleanup iteration) — we must pop the
-        // pending entry without dropping/deallocing the key here, otherwise
-        // we'll double-free. We consult a pre-captured snapshot because the
-        // MapKey frame may already have been removed from `stored_frames` by
-        // an earlier iteration of the cleanup loop (MapKey sorts before
-        // MapValue at equal depth).
-        //
-        // Path layout when a MapKey frame is stored in deferred mode:
-        //   parent_path + MapKey(entry_idx)   — stored MapKey frame
-        //   parent_path + MapValue(entry_idx) — the (failed) MapValue frame
-        let key_owned_by_stored_frame = if let PathStep::MapValue(entry_idx) = *last_step {
-            let mut map_key_steps = parent_path.steps.clone();
-            map_key_steps.push(PathStep::MapKey(entry_idx));
-            let map_key_path = Path {
-                shape: path.shape,
-                steps: map_key_steps,
-            };
-            stored_map_key_paths.contains(&map_key_path)
-        } else {
-            false
-        };
-
-        // Paths are absolute from the root; the frame at a given path lives at
-        // stack[path.steps.len()], so the parent lives at stack[parent_path.steps.len()].
-        let parent_frame = if let Some(parent_frame) = stored_frames.get_mut(&parent_path) {
-            Some(parent_frame)
-        } else {
-            stack.get_mut(parent_path.steps.len())
-        };
-
-        let Some(parent_frame) = parent_frame else {
-            return;
-        };
-
-        let parent_shape = parent_frame.allocated.shape();
-
-        match (&mut parent_frame.tracker, last_step) {
-            (
-                Tracker::Map {
-                    pending_entries, ..
-                },
-                PathStep::MapValue(_),
-            ) => {
-                // The pending entry held both (key_ptr, value_ptr). The value buffer is
-                // about to be freed by the caller via frame.dealloc(). The key buffer
-                // is either solely owned by this pending entry (drop + dealloc here)
-                // or co-owned by a stored MapKey frame (pop only; that frame will
-                // handle the key).
-                if let Some((key_ptr, _value_ptr)) = pending_entries.pop()
-                    && !key_owned_by_stored_frame
-                    && let Def::Map(map_def) = parent_shape.def
-                {
-                    unsafe {
-                        map_def.k().call_drop_in_place(key_ptr.assume_init());
-                    }
-                    if let Ok(key_layout) = map_def.k().layout.sized_layout()
-                        && key_layout.size() > 0
-                    {
-                        unsafe {
-                            ::alloc::alloc::dealloc(key_ptr.as_mut_byte_ptr(), key_layout);
-                        }
-                    }
-                }
-                trace!(
-                    "sever_parent_pending_for_path: popped map pending_entry for failed MapValue at {:?} (key_owned_by_stored_frame={})",
-                    path, key_owned_by_stored_frame,
-                );
-            }
-            (
-                Tracker::SmartPointer {
-                    building_inner,
-                    pending_inner,
-                },
-                PathStep::Deref,
-            ) => {
-                *pending_inner = None;
-                *building_inner = true;
-                parent_frame.is_init = false;
-                trace!(
-                    "sever_parent_pending_for_path: cleared SmartPointer pending_inner for failed Deref at {:?}",
-                    path,
-                );
-            }
-            (
-                Tracker::Option {
-                    building_inner,
-                    pending_inner,
-                },
-                PathStep::OptionSome,
-            ) => {
-                *pending_inner = None;
-                *building_inner = true;
-                parent_frame.is_init = false;
-                trace!(
-                    "sever_parent_pending_for_path: cleared Option pending_inner for failed OptionSome at {:?}",
-                    path,
-                );
-            }
-            _ => {}
-        }
-    }
+    // NOTE: `sever_parent_pending_for_path` has been removed. Under the SSoT/Transferred
+    // ownership invariant, any child frame whose buffer was copied into a parent pending
+    // slot is marked `FrameOwnership::Transferred` at the transfer site. Its `deinit` and
+    // `dealloc` no-op; the parent pending slot is the sole drop-and-dealloc authority.
+    // No sever-from-parent logic is required on failure paths.
 
     /// Helper to unset a field index in a tracker's iset
     fn unset_field_in_tracker(tracker: &mut Tracker, field_idx: usize) {
@@ -966,17 +812,6 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
         mut stored_frames: ::alloc::collections::BTreeMap<Path, Frame>,
         stack: &mut [Frame],
     ) {
-        // Snapshot the set of paths whose last step is `MapKey`. A stored
-        // MapKey frame owns its key buffer, and its sibling MapValue's
-        // `sever_parent_pending_for_path` must therefore skip dropping the
-        // pending-entry key. We capture the snapshot upfront because
-        // `stored_frames` is progressively drained during cleanup.
-        let stored_map_key_paths: ::alloc::collections::BTreeSet<Path> = stored_frames
-            .keys()
-            .filter(|p| matches!(p.steps.last(), Some(PathStep::MapKey(_))))
-            .cloned()
-            .collect();
-
         // Sort by depth (deepest first) so children are processed before parents
         let mut paths: Vec<_> = stored_frames.keys().cloned().collect();
         paths.sort_by_key(|p| core::cmp::Reverse(p.steps.len()));
@@ -1025,18 +860,152 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // Before dropping this frame, clear the parent's iset bit so the
                 // parent won't try to drop this field again.
                 Self::clear_parent_iset_for_path(&path, stack, &mut stored_frames);
-                // If this frame's buffer is also tracked by a parent Map/SmartPointer/Option
-                // pending pointer, clear that reference too — otherwise the parent will try to
-                // drop the same buffer we're about to dealloc.
-                Self::sever_parent_pending_for_path(
-                    &path,
-                    stack,
-                    &mut stored_frames,
-                    &stored_map_key_paths,
-                );
+                // Cleanup path special case: frames whose buffer was `Transferred` into
+                // a parent pending slot were expected to be drop-in-placed by the parent
+                // at finalize. But we're aborting — the parent's pending slot points to
+                // a buffer whose deep contents may be only partially initialized, and
+                // drop-in-place would traverse uninit descendants. So we undo the
+                // transfer: remove the pending-slot pointer and dealloc the buffer
+                // directly (without drop-in-place) to avoid both leaks and crashes.
+                if matches!(frame.ownership, FrameOwnership::Transferred) {
+                    Self::untransfer_on_cleanup(&path, &mut frame, stack, &mut stored_frames);
+                    // untransfer_on_cleanup deallocs the raw buffer itself; skip the
+                    // normal deinit/dealloc path (deinit would no-op under Transferred
+                    // anyway, dealloc would also no-op).
+                    continue;
+                }
                 trace!("cleanup: calling deinit() on path={:?}", path,);
                 frame.deinit();
                 frame.dealloc();
+            }
+        }
+    }
+
+    /// Undo a `FrameOwnership::Transferred` transfer during error cleanup.
+    ///
+    /// At the transfer site, the frame's buffer pointer was copied into a parent pending
+    /// slot (Map::pending_entries, Option/SmartPointer::pending_inner,
+    /// DynamicValue::pending_entries/elements). On success, the parent tracker's deinit
+    /// is the sole drop-and-dealloc authority. On error cleanup we can't rely on that,
+    /// because deep descendants may be uninit and drop-in-place would crash.
+    ///
+    /// This helper removes the parent pending-slot pointer and deallocates the raw
+    /// buffer directly (no drop-in-place), preventing both use-after-free (from the
+    /// parent dereffing a buffer we freed) and drop-in-place of partially-init data.
+    fn untransfer_on_cleanup(
+        path: &Path,
+        frame: &mut Frame,
+        stack: &mut [Frame],
+        stored_frames: &mut ::alloc::collections::BTreeMap<Path, Frame>,
+    ) {
+        let Some(last_step) = path.steps.last() else {
+            return;
+        };
+
+        // Locate the parent frame (stored or on stack at index parent_path.steps.len()).
+        let parent_path = Path {
+            shape: path.shape,
+            steps: path.steps[..path.steps.len() - 1].to_vec(),
+        };
+        let parent_idx = parent_path.steps.len();
+        let parent_frame = if let Some(pf) = stored_frames.get_mut(&parent_path) {
+            Some(pf)
+        } else {
+            stack.get_mut(parent_idx)
+        };
+
+        if let Some(parent_frame) = parent_frame {
+            match (&mut parent_frame.tracker, last_step) {
+                (
+                    Tracker::Map {
+                        pending_entries, ..
+                    },
+                    PathStep::MapValue(_),
+                ) => {
+                    // The last pending entry is (key, Some(value_ptr)) where value_ptr
+                    // == frame.data. Pop the entry; drop+dealloc the key (it was
+                    // transferred into pending_entries as a half-entry earlier — the
+                    // key IS fully initialized at this point because it's a prerequisite
+                    // for begin_value()). Leave the value to this fn's own dealloc below.
+                    if let Some((key_ptr, _)) = pending_entries.pop()
+                        && let Def::Map(map_def) = parent_frame.allocated.shape().def
+                    {
+                        unsafe {
+                            map_def.k().call_drop_in_place(key_ptr.assume_init());
+                        }
+                        if let Ok(key_layout) = map_def.k().layout.sized_layout()
+                            && key_layout.size() > 0
+                        {
+                            unsafe {
+                                ::alloc::alloc::dealloc(key_ptr.as_mut_byte_ptr(), key_layout);
+                            }
+                        }
+                    }
+                }
+                (
+                    Tracker::Map {
+                        pending_entries, ..
+                    },
+                    PathStep::MapKey(_),
+                ) => {
+                    // A MapKey frame marked Transferred means we stored a half-entry
+                    // (key, None). Pop it; the popped key_ptr IS `frame.data`, so
+                    // drop and dealloc here and return — skip the generic dealloc
+                    // below to avoid double-freeing the key buffer.
+                    if let Some((key_ptr, _)) = pending_entries.pop()
+                        && let Def::Map(map_def) = parent_frame.allocated.shape().def
+                    {
+                        unsafe {
+                            map_def.k().call_drop_in_place(key_ptr.assume_init());
+                        }
+                        if let Ok(key_layout) = map_def.k().layout.sized_layout()
+                            && key_layout.size() > 0
+                        {
+                            unsafe {
+                                ::alloc::alloc::dealloc(key_ptr.as_mut_byte_ptr(), key_layout);
+                            }
+                        }
+                    }
+                    return;
+                }
+                (
+                    Tracker::SmartPointer {
+                        building_inner,
+                        pending_inner,
+                    },
+                    PathStep::Deref,
+                ) => {
+                    *pending_inner = None;
+                    *building_inner = true;
+                    parent_frame.is_init = false;
+                }
+                (
+                    Tracker::Option {
+                        building_inner,
+                        pending_inner,
+                    },
+                    PathStep::OptionSome,
+                ) => {
+                    *pending_inner = None;
+                    *building_inner = true;
+                    parent_frame.is_init = false;
+                }
+                _ => {}
+            }
+        }
+
+        // Manually deallocate the frame's buffer (no drop-in-place — contents may be
+        // partially initialized, which is exactly why we took this path).
+        if frame.allocated.allocated_size() > 0
+            && let Ok(layout) = frame.allocated.shape().layout.sized_layout()
+        {
+            let actual_layout = core::alloc::Layout::from_size_align(
+                frame.allocated.allocated_size(),
+                layout.align(),
+            )
+            .expect("allocated_size must be valid");
+            unsafe {
+                ::alloc::alloc::dealloc(frame.data.as_mut_byte_ptr(), actual_layout);
             }
         }
     }
@@ -1370,20 +1339,31 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
     }
 
     /// Complete a Map key frame by transitioning the Map from PushingKey to PushingValue state
-    /// (for deferred finalization)
+    /// (for deferred finalization).
+    ///
+    /// The key buffer ownership now belongs to `pending_entries` via a half-entry
+    /// `(key_ptr, None)` pushed here. The subsequent value frame's
+    /// [`complete_map_value_frame`] upgrades this half-entry to
+    /// `(key_ptr, Some(value_ptr))`.
     fn complete_map_key_frame(map_frame: &mut Frame, key_frame: Frame) {
-        if let Tracker::Map { insert_state, .. } = &mut map_frame.tracker
+        if let Tracker::Map {
+            insert_state,
+            pending_entries,
+            ..
+        } = &mut map_frame.tracker
             && let MapInsertState::PushingKey { key_ptr, .. } = insert_state
         {
-            // Transition to PushingValue state, keeping the key pointer.
-            // key_frame_stored = false because the key frame is being finalized here,
-            // so after this the Map owns the key buffer.
+            // Transfer key buffer ownership to pending_entries as a half-entry. This
+            // entry will be upgraded to a full (key, value) by complete_map_value_frame
+            // or Map::deinit's pending_entries drain will drop/dealloc the orphaned key.
+            pending_entries.push((*key_ptr, None));
+
+            // Transition to PushingValue state. The `key_ptr` here is just a convenience
+            // copy for the value-push path; it is NOT a drop source — pending_entries is.
             *insert_state = MapInsertState::PushingValue {
                 key_ptr: *key_ptr,
                 value_ptr: None,
                 value_initialized: false,
-                value_frame_on_stack: false,
-                key_frame_stored: false,
             };
 
             crate::trace!(
@@ -1391,7 +1371,9 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 map_frame.allocated.shape()
             );
 
-            // Deallocate the key frame's memory (the key data lives at key_ptr which Map owns)
+            // Owned frames (rare) allocate their own buffer — we still need to free it.
+            // TrackedBuffer frames use the Map's key_ptr which is now in pending_entries,
+            // so only Owned ownership triggers dealloc here.
             if let FrameOwnership::Owned = key_frame.ownership
                 && let Ok(layout) = key_frame.allocated.shape().layout.sized_layout()
                 && layout.size() > 0
@@ -1403,8 +1385,9 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
         }
     }
 
-    /// Complete a Map value frame by adding the key-value pair to pending_entries
-    /// (for deferred finalization)
+    /// Complete a Map value frame by upgrading the last pending half-entry
+    /// `(key_ptr, None)` to a full `(key_ptr, Some(value_ptr))`
+    /// (for deferred finalization).
     fn complete_map_value_frame(map_frame: &mut Frame, value_frame: Frame) {
         if let Tracker::Map {
             insert_state,
@@ -1412,23 +1395,31 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
             ..
         } = &mut map_frame.tracker
             && let MapInsertState::PushingValue {
-                key_ptr,
                 value_ptr: Some(value_ptr),
                 ..
             } = insert_state
         {
-            // Add the key-value pair to pending_entries
-            pending_entries.push((*key_ptr, *value_ptr));
+            // Upgrade the last half-entry (which must exist — complete_map_key_frame
+            // or the deferred end() store-path pushed it) to a full entry.
+            let last = pending_entries
+                .last_mut()
+                .expect("pending_entries must have a half-entry from complete_map_key_frame");
+            debug_assert!(
+                last.1.is_none(),
+                "last pending entry must be a half-entry (None value), got Some — invariant violation in SSoT protocol"
+            );
+            last.1 = Some(*value_ptr);
 
             crate::trace!(
-                "complete_map_value_frame: added entry to pending_entries for {}",
+                "complete_map_value_frame: upgraded half-entry to full entry for {}",
                 map_frame.allocated.shape()
             );
 
             // Reset to idle state
             *insert_state = MapInsertState::Idle;
 
-            // Deallocate the value frame's memory (the value data lives at value_ptr which Map owns)
+            // For Owned frames (rare), free the frame's own buffer. TrackedBuffer frames
+            // use the Map's value_ptr which is now owned by pending_entries — no-op.
             if let FrameOwnership::Owned = value_frame.ownership
                 && let Ok(layout) = value_frame.allocated.shape().layout.sized_layout()
                 && layout.size() > 0
@@ -1619,9 +1610,10 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         FrameOwnership::TrackedBuffer
                         | FrameOwnership::BorrowedInPlace
                         | FrameOwnership::External
-                        | FrameOwnership::RopeSlot => {
+                        | FrameOwnership::RopeSlot
+                        | FrameOwnership::Transferred => {
                             return Err(self.err(ReflectErrorKind::InvariantViolation {
-                            invariant: "SmartPointerSlice cannot have TrackedBuffer/BorrowedInPlace/External/RopeSlot ownership after conversion",
+                            invariant: "SmartPointerSlice cannot have TrackedBuffer/BorrowedInPlace/External/RopeSlot/Transferred ownership after conversion",
                         }));
                         }
                     }
@@ -1959,7 +1951,12 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                 // The Map needs to transition states so that subsequent operations work:
                 // - PushingKey -> PushingValue: so begin_value() can be called
                 // - PushingValue -> Idle: so begin_key() can be called for the next entry
-                // The frames are still stored for potential re-entry and finalization.
+                //
+                // Per SSoT/Transferred protocol: whenever we copy `popped_frame.data` into
+                // pending_entries (as a half-entry for a stored key, or upgrading to a full
+                // entry for a stored value), we MUST mark popped_frame.ownership as
+                // `Transferred` so the stored frame no longer tries to drop/dealloc the
+                // buffer. pending_entries is now the sole drop authority.
                 if let Some(parent_frame) = stack.last_mut() {
                     if let Tracker::Map {
                         insert_state,
@@ -1969,30 +1966,37 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                     {
                         match insert_state {
                             MapInsertState::PushingKey { key_ptr, .. } => {
-                                // Transition to PushingValue state.
-                                // key_frame_stored = true because the key frame is being stored,
-                                // so the stored frame will handle cleanup (not the Map's deinit).
+                                // Transfer key ownership into pending_entries as a
+                                // half-entry, then transition state.
+                                pending_entries.push((*key_ptr, None));
                                 *insert_state = MapInsertState::PushingValue {
                                     key_ptr: *key_ptr,
                                     value_ptr: None,
                                     value_initialized: false,
-                                    value_frame_on_stack: false,
-                                    key_frame_stored: true,
                                 };
+                                popped_frame.ownership = FrameOwnership::Transferred;
                                 crate::trace!(
-                                    "end(): Map transitioned to PushingValue while storing key frame"
+                                    "end(): Map transitioned to PushingValue while storing key frame (ownership Transferred)"
                                 );
                             }
                             MapInsertState::PushingValue {
-                                key_ptr,
                                 value_ptr: Some(value_ptr),
                                 ..
                             } => {
-                                // Add entry to pending_entries and reset to Idle
-                                pending_entries.push((*key_ptr, *value_ptr));
+                                // Upgrade the half-entry to a full entry, then reset
+                                // to Idle.
+                                let last = pending_entries.last_mut().expect(
+                                    "pending_entries must have a half-entry from when key was stored",
+                                );
+                                debug_assert!(
+                                    last.1.is_none(),
+                                    "last pending entry must be a half-entry (None value), got Some — invariant violation in SSoT protocol"
+                                );
+                                last.1 = Some(*value_ptr);
                                 *insert_state = MapInsertState::Idle;
+                                popped_frame.ownership = FrameOwnership::Transferred;
                                 crate::trace!(
-                                    "end(): Map added entry to pending_entries while storing value frame"
+                                    "end(): Map upgraded half-entry to full entry while storing value frame (ownership Transferred)"
                                 );
                             }
                             _ => {}
@@ -2046,17 +2050,15 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                             return Err(ReflectError::new(kind, storage_path.clone()));
                         }
 
-                        // Add to pending_entries for deferred insertion
+                        // Add to pending_entries for deferred insertion.
+                        // SSoT: pending_entries is now the sole drop authority for this
+                        // buffer; mark the popped frame Transferred so its deinit/dealloc
+                        // no-op.
                         pending_entries.push((key, popped_frame.data));
+                        popped_frame.ownership = FrameOwnership::Transferred;
                         crate::trace!(
-                            "end(): DynamicValue object entry added to pending_entries in deferred mode"
+                            "end(): DynamicValue object entry added to pending_entries in deferred mode (ownership Transferred)"
                         );
-
-                        // The value frame's data is now owned by pending_entries
-                        // Mark frame as not owning the data so it won't be deallocated
-                        popped_frame.tracker = Tracker::Scalar;
-                        popped_frame.is_init = false;
-                        // Don't dealloc - pending_entries owns the pointer now
 
                         // Reset insert state to Idle so more entries can be added
                         *insert_state = DynamicObjectInsertState::Idle;
@@ -2082,17 +2084,14 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                             return Err(ReflectError::new(kind, storage_path.clone()));
                         }
 
-                        // Add to pending_elements for deferred insertion
+                        // Add to pending_elements for deferred insertion.
+                        // SSoT: pending_elements is now the sole drop authority; mark the
+                        // popped frame Transferred so its deinit/dealloc no-op.
                         pending_elements.push(popped_frame.data);
+                        popped_frame.ownership = FrameOwnership::Transferred;
                         crate::trace!(
-                            "end(): DynamicValue array element added to pending_elements in deferred mode"
+                            "end(): DynamicValue array element added to pending_elements in deferred mode (ownership Transferred)"
                         );
-
-                        // The element frame's data is now owned by pending_elements
-                        // Mark frame as not owning the data so it won't be deallocated
-                        popped_frame.tracker = Tracker::Scalar;
-                        popped_frame.is_init = false;
-                        // Don't dealloc - pending_elements owns the pointer now
 
                         // Reset building_element so more elements can be added
                         *building_element = false;
@@ -2401,11 +2400,15 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         // Check if we're in deferred mode - if so, store the inner value pointer
                         if is_deferred_mode {
                             // Store the inner value pointer for deferred new_into_fn.
+                            // SSoT: pending_inner is now the sole drop authority for this
+                            // buffer; mark popped_frame Transferred so its deinit/dealloc
+                            // no-op.
                             *pending_inner = Some(popped_frame.data);
+                            popped_frame.ownership = FrameOwnership::Transferred;
                             *building_inner = false;
                             parent_frame.is_init = true;
                             crate::trace!(
-                                "end() SMARTPTR: stored pending_inner, will finalize in finish_deferred"
+                                "end() SMARTPTR: stored pending_inner, will finalize in finish_deferred (ownership Transferred)"
                             );
                         } else {
                             // Not in deferred mode - complete immediately
@@ -2501,32 +2504,40 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                             return Err(self.err(e));
                         }
 
-                        // We just popped the key frame - mark key as initialized and transition
-                        // to PushingValue state. key_frame_on_stack = false because the frame
-                        // was just popped, so Map now owns the key buffer.
+                        // Transfer key buffer ownership into pending_entries as a
+                        // half-entry (key_ptr, None). The popped_frame (TrackedBuffer)
+                        // no longer owns the buffer — mark it Transferred so its own
+                        // deinit/dealloc no-ops. The value phase will upgrade the
+                        // half-entry to a full (key, Some(value)) pair.
+                        pending_entries.push((*key_ptr, None));
+                        popped_frame.ownership = FrameOwnership::Transferred;
+
                         *insert_state = MapInsertState::PushingValue {
                             key_ptr: *key_ptr,
                             value_ptr: None,
                             value_initialized: false,
-                            value_frame_on_stack: false, // No value frame yet
-                            key_frame_stored: false,     // Key frame was popped, Map owns key
                         };
                     }
-                    MapInsertState::PushingValue {
-                        key_ptr, value_ptr, ..
-                    } => {
+                    MapInsertState::PushingValue { value_ptr, .. } => {
                         // Fill defaults on the value frame before considering it done.
                         // This handles structs with Option fields.
                         if let Err(e) = popped_frame.fill_defaults() {
                             return Err(self.err(e));
                         }
 
-                        // We just popped the value frame.
-                        // Instead of inserting immediately, add to pending_entries.
-                        // This keeps the buffers alive for deferred processing.
-                        // Actual insertion happens in require_full_initialization.
+                        // Upgrade the last half-entry (key_ptr, None) to a full entry
+                        // (key_ptr, Some(value_ptr)) and mark the value frame as
+                        // Transferred so its deinit/dealloc no-ops.
                         if let Some(value_ptr) = value_ptr {
-                            pending_entries.push((*key_ptr, *value_ptr));
+                            let last = pending_entries.last_mut().expect(
+                                "pending_entries must have a half-entry from the PushingKey -> PushingValue transition",
+                            );
+                            debug_assert!(
+                                last.1.is_none(),
+                                "last pending entry must be a half-entry (None value), got Some — invariant violation"
+                            );
+                            last.1 = Some(*value_ptr);
+                            popped_frame.ownership = FrameOwnership::Transferred;
 
                             // Reset to idle state
                             *insert_state = MapInsertState::Idle;
@@ -2577,11 +2588,18 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         // Store the inner value pointer for deferred init_some.
                         // This keeps the inner value's memory stable for deferred processing.
                         // Actual init_some() happens in require_full_initialization().
+                        //
+                        // SSoT: pending_inner is now the sole drop authority for this
+                        // buffer; mark popped_frame Transferred so its deinit/dealloc
+                        // no-op.
                         *pending_inner = Some(popped_frame.data);
+                        popped_frame.ownership = FrameOwnership::Transferred;
 
                         // Mark that we're no longer building the inner value
                         *building_inner = false;
-                        crate::trace!("end(): stored pending_inner, set building_inner to false");
+                        crate::trace!(
+                            "end(): stored pending_inner, set building_inner to false (ownership Transferred)"
+                        );
                         // Mark the Option as initialized (pending finalization)
                         parent_frame.is_init = true;
                         crate::trace!("end(): set parent_frame.is_init to true");

--- a/facet-reflect/src/partial/partial_api/misc.rs
+++ b/facet-reflect/src/partial/partial_api/misc.rs
@@ -592,13 +592,13 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                     }
                 }
 
-                // Special handling for List/SmartPointerSlice element values: when path ends with Index,
-                // the parent is a List or SmartPointerSlice frame and we need to push the element into it.
-                // RopeSlot frames are already stored in the rope and will be drained during
-                // validation - pushing them here would duplicate the elements.
-                if matches!(last_step, PathStep::Index(_))
-                    && !matches!(frame.ownership, FrameOwnership::RopeSlot)
-                {
+                // Special handling for List/SmartPointerSlice element values: when path
+                // ends with Index, the parent is a List or SmartPointerSlice frame and we
+                // need to push the element into it. RopeSlot frames live in the parent
+                // rope's slot: they don't get "pushed" here (the slot is pre-allocated),
+                // but we DO need to mark the slot initialized now that the element has
+                // passed validation, so the rope knows it's safe to drop on error.
+                if matches!(last_step, PathStep::Index(_)) {
                     // Find the parent frame (List or SmartPointerSlice)
                     let parent_frame =
                         if let Some(parent_frame) = stored_frames.get_mut(&parent_path) {
@@ -608,6 +608,18 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         };
 
                     if let Some(parent_frame) = parent_frame {
+                        if matches!(frame.ownership, FrameOwnership::RopeSlot) {
+                            // Element already lives in rope slot. Mark it initialized now
+                            // that validation passed (consume-time). Frame is dropped
+                            // silently — no Drop impl, rope owns the buffer.
+                            if let Tracker::List {
+                                rope: Some(rope), ..
+                            } = &mut parent_frame.tracker
+                            {
+                                rope.mark_last_initialized();
+                            }
+                            continue;
+                        }
                         // Check if parent is a SmartPointerSlice (e.g., Arc<[T]>)
                         if matches!(parent_frame.tracker, Tracker::SmartPointerSlice { .. }) {
                             Self::complete_smart_pointer_slice_item_frame(parent_frame, frame);
@@ -1239,7 +1251,7 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
     /// Called only from the `finish_deferred` walk, after `require_full_initialization`
     /// has validated the value frame. The `entry_idx` comes from
     /// `PathStep::MapValue(idx)` and indexes the matching half-entry placed by
-    /// [`complete_map_key_frame`]. `value_frame` is dropped silently on return —
+    /// `complete_map_key_frame`. `value_frame` is dropped silently on return —
     /// Frame has no Drop impl, so `pending_entries` becomes the sole owner of the
     /// buffer.
     fn complete_map_value_frame(map_frame: &mut Frame, entry_idx: u32, value_frame: Frame) {
@@ -1904,16 +1916,15 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         return Ok(self);
                     }
 
-                    // For List elements stored in a rope (RopeSlot ownership), we need to
-                    // mark the element as initialized in the rope. When the List frame is
-                    // deinited, the rope will drop all initialized elements.
-                    if matches!(popped_frame.ownership, FrameOwnership::RopeSlot)
-                        && let Tracker::List {
-                            rope: Some(rope), ..
-                        } = &mut parent_frame.tracker
-                    {
-                        rope.mark_last_initialized();
-                    }
+                    // Note: we intentionally do NOT call `rope.mark_last_initialized()`
+                    // here for RopeSlot frames in deferred mode. Marking the slot as
+                    // initialized now would let `ListRope::drain_into` drop it on a
+                    // later error path — but the stored frame may have partial-init
+                    // descendants (e.g. a Box<enum> whose fields weren't all set), and
+                    // dropping those is UB. Instead, the frame stays stored; the
+                    // `finish_deferred` walk marks the rope slot initialized only after
+                    // `require_full_initialization` passes for this element. Same
+                    // consume-time protocol used for Map `pending_entries`.
 
                     // Clear building_item for SmartPointerSlice so the next element can be added
                     if let Tracker::SmartPointerSlice { building_item, .. } =

--- a/facet-reflect/src/partial/partial_api/misc.rs
+++ b/facet-reflect/src/partial/partial_api/misc.rs
@@ -1363,7 +1363,6 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
             *insert_state = MapInsertState::PushingValue {
                 key_ptr: *key_ptr,
                 value_ptr: None,
-                value_initialized: false,
             };
 
             crate::trace!(
@@ -1972,7 +1971,6 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                                 *insert_state = MapInsertState::PushingValue {
                                     key_ptr: *key_ptr,
                                     value_ptr: None,
-                                    value_initialized: false,
                                 };
                                 popped_frame.ownership = FrameOwnership::Transferred;
                                 crate::trace!(
@@ -2515,7 +2513,6 @@ impl<'facet, const BORROW: bool> Partial<'facet, BORROW> {
                         *insert_state = MapInsertState::PushingValue {
                             key_ptr: *key_ptr,
                             value_ptr: None,
-                            value_initialized: false,
                         };
                     }
                     MapInsertState::PushingValue { value_ptr, .. } => {


### PR DESCRIPTION
## Summary

Consolidate deferred-mode ownership tracking so that there is a single answer to \"who is responsible for dropping this buffer?\" at any point in time.

Over the past several months, `facet-reflect`'s deferred cleanup has accumulated targeted double-free fixes — MapValue pending-entry severing (#2137), List deinit Vec double-free (#2149), rope drain-before-drop, and the recent stored-MapKey co-ownership UAF (#2164 — later closed). Each was locally correct but treated a symptom: the same raw buffer pointer was co-owned by a child \`Frame\` AND a parent tracker's pending slot, and every cleanup path had to independently disarm one side. Each new nesting combination found a different unarmed pair.

This PR introduces a single invariant:

> Any code that copies a child frame's \`data\` pointer into a parent tracker's pending slot MUST, in the same statement block, set \`child_frame.ownership = FrameOwnership::Transferred\`.

With that invariant enforced at ~8 transfer sites, \`Frame::deinit\` and \`Frame::dealloc\` become no-ops for transferred frames, and the parent tracker's pending-slot drop is the sole drop site.

For Map specifically, the PR also switches \`pending_entries\` from \`Vec<(PtrUninit, PtrUninit)>\` to \`Vec<(PtrUninit, Option<PtrUninit>)>\`. The key is pushed as a half-entry \`(key_ptr, None)\` when the key is committed (via \`complete_map_key_frame\` in eager mode, or at the PushingKey→PushingValue transition in the deferred store path). The value upgrades the last half-entry to \`Some(value_ptr)\`. This lets \`pending_entries\` alone be the drop source — the three \`*_frame_on_stack\` / \`*_frame_stored\` booleans inside \`MapInsertState\` (together with a full \`match insert_state\` cleanup block inside \`Tracker::Map::deinit\`) are deleted.

## Changes

- Add \`FrameOwnership::Transferred\`; it never \`needs_dealloc()\`; \`Frame::deinit\` and \`Frame::dealloc\` early-return on it.
- \`MapInsertState\` loses \`key_frame_on_stack\`, \`value_frame_on_stack\`, \`key_frame_stored\`, \`key_initialized\`, \`value_initialized\`.
- \`Tracker::Map::deinit\` now drops pending_entries only (half-entry aware); the \`match insert_state\` cleanup block is gone.
- Mark \`popped_frame.ownership = Transferred\` at all transfer sites: deferred Map key/value store, \`complete_map_value_frame\`, DynamicValue Object/Array, SmartPointer and Option \`pending_inner\`.
- Delete \`sever_parent_pending_for_path\` and its three call sites; delete \`PathStep::MapKey\` / \`PathStep::MapValue\` arms from \`impl Drop for Partial\`.
- Replace with \`untransfer_on_cleanup\`: a narrower helper only invoked from \`cleanup_stored_frames_on_error\` for Transferred frames, which unwinds the parent's half-pending state before cleanup runs (necessary because pending slots may point at buffers whose deep descendants are still uninitialized at error time).
- Module-level doc in \`partial/mod.rs\` summarizing the transfer protocol, single-drop rule, and cleanup invariant.

Net **-52 lines** in \`facet-reflect\`.

## Test plan

- [x] \`cargo nextest run -p facet-reflect\` — 513 passed, 4 skipped (same as before)
- [ ] ASAN sweep on the \`deferred\` / \`_leak\` test groups
- [ ] Downstream \`kajit-foundation\` validation

### Known not-fixed

The downstream kajit \`asm.repr.styx\` SIGABRT is NOT fixed by this refactor. That crash looks like a List/rope premature-\`mark_last_initialized\` bug (orthogonal to the pending-slot ownership pattern this PR addresses). Follow-up issue will be filed against that specific path.