### PR TITLE
feat(reflect): add Poke API parity with Peek

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -43,6 +43,11 @@ command = 'valgrind --error-exitcode=1 --track-origins=yes --read-var-info=yes -
 # Note: nextest runs from crate dirs, so we need workspace-relative path
 command = '../scripts/lldb-wrapper.sh'
 
+[scripts.wrapper.leaks]
+# Run tests under macOS `leaks -quiet --atExit`
+# Fails (non-zero exit) if any allocation is unreachable at process exit
+command = 'leaks -quiet --atExit --'
+
 # Valgrind profile - runs tests under valgrind
 [profile.valgrind]
 
@@ -67,6 +72,14 @@ run-wrapper = 'valgrind-lean'
 platform = 'cfg(target_os = "macos")'
 filter = 'all()'
 run-wrapper = 'lldb'
+
+# Leaks profile - runs each test process under macOS `leaks --atExit`
+[profile.leaks]
+
+[[profile.leaks.scripts]]
+platform = 'cfg(target_os = "macos")'
+filter = 'all()'
+run-wrapper = 'leaks'
 
 # Debug profile - for attaching debugger with crash handler
 [profile.debug]

--- a/Justfile
+++ b/Justfile
@@ -74,16 +74,10 @@ asan *args:
 # macOS-only: run facet-reflect's tests under `leaks --atExit` to catch
 # memory leaks at process exit. Native speed, so it's orders of magnitude
 # faster than miri for leak regressions. Exits non-zero if any allocation
-# is unreachable at exit. Uses the host target triple so the runner env
-# var is picked up (cargo only applies --target runners when --target is
-# explicit).
+# is unreachable at exit.
 leaks *args:
-    CARGO_TARGET_DIR=target/leaks \
-    MallocStackLogging=1 \
-    CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER="leaks -quiet --atExit --" \
-    CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER="leaks -quiet --atExit --" \
-        cargo test -p facet-reflect \
-        --target "$(rustc -vV | sed -n 's|host: ||p')" -- {{ args }}
+    MallocStackLogging=1 CARGO_TARGET_DIR=target/leaks \
+        cargo nextest run --profile leaks -p facet-reflect {{ args }}
 
 fuzz-smoke-value:
     cargo fuzz run fuzz_value -- -runs=1000

--- a/facet-core/src/impls/alloc/smallvec.rs
+++ b/facet-core/src/impls/alloc/smallvec.rs
@@ -327,6 +327,7 @@ where
                 get_mut: Some(smallvec_get_mut::<A>),
                 as_ptr: Some(smallvec_as_ptr::<A>),
                 as_mut_ptr: Some(smallvec_as_mut_ptr::<A>),
+                swap: None,
             }
         }
 

--- a/facet-core/src/impls/alloc/vec.rs
+++ b/facet-core/src/impls/alloc/vec.rs
@@ -117,6 +117,7 @@ static VEC_LIST_VTABLE: ListVTable = ListVTable {
     get_mut: Some(vec_get_mut_erased),
     as_ptr: Some(vec_as_ptr_erased),
     as_mut_ptr: Some(vec_as_mut_ptr_erased),
+    swap: Some(vec_swap_erased),
 };
 
 /// Type-erased as_ptr implementation - works for any `Vec<T>`
@@ -132,6 +133,41 @@ unsafe extern "C" fn vec_as_mut_ptr_erased(ptr: PtrMut) -> PtrMut {
     unsafe {
         let layout = ptr.as_byte_ptr() as *const VecLayout;
         PtrMut::new((*layout).ptr)
+    }
+}
+
+/// Type-erased swap implementation - works for any `Vec<T>` using shape info.
+///
+/// Swaps the bytes of the elements at `a` and `b`. Returns `false` without
+/// modifying the list if either index is out of bounds.
+unsafe fn vec_swap_erased(ptr: PtrMut, a: usize, b: usize, shape: &'static Shape) -> bool {
+    unsafe {
+        let layout = ptr.as_byte_ptr() as *const VecLayout;
+        let len = (*layout).len;
+        if a >= len || b >= len {
+            return false;
+        }
+        if a == b {
+            return true;
+        }
+        let Ok(elem_layout) = shape
+            .type_params
+            .first()
+            .expect("Vec shape must have an element type parameter")
+            .shape
+            .layout
+            .sized_layout()
+        else {
+            return false;
+        };
+        let elem_size = elem_layout.size();
+        let data_ptr = (*layout).ptr;
+        core::ptr::swap_nonoverlapping(
+            data_ptr.add(a * elem_size),
+            data_ptr.add(b * elem_size),
+            elem_size,
+        );
+        true
     }
 }
 
@@ -297,6 +333,28 @@ unsafe extern "C" fn vec_push<T>(ptr: PtrMut, item: PtrMut) {
     }
 }
 
+/// Pop the last element from a `Vec<T>`, moving it into `out`.
+///
+/// Returns `true` if an element was popped, `false` if the vec was empty.
+///
+/// # Safety
+/// - `ptr` must point to an initialized `Vec<T>`.
+/// - When returning `true`, `out` must have been uninitialized memory of at
+///   least `size_of::<T>()` bytes, correctly aligned for `T`. The element is
+///   moved into `out` (no destructor is run on the source element).
+unsafe extern "C" fn vec_pop<T>(ptr: PtrMut, out: PtrUninit) -> bool {
+    unsafe {
+        let vec = ptr.as_mut::<Vec<T>>();
+        match vec.pop() {
+            Some(value) => {
+                out.put(value);
+                true
+            }
+            None => false,
+        }
+    }
+}
+
 /// Set the length of a Vec (for direct-fill operations).
 ///
 /// # Safety
@@ -390,6 +448,7 @@ unsafe impl<'a, T: Facet<'a>> Facet<'a> for Vec<T> {
                 ListTypeOps::builder()
                     .init_in_place_with_capacity(vec_init_in_place_with_capacity::<T>)
                     .push(vec_push::<T>)
+                    .pop(vec_pop::<T>)
                     .set_len(vec_set_len::<T>)
                     .as_mut_ptr_typed(vec_as_mut_ptr_typed::<T>)
                     .reserve(vec_reserve::<T>)

--- a/facet-core/src/impls/core/result.rs
+++ b/facet-core/src/impls/core/result.rs
@@ -180,27 +180,15 @@ unsafe fn result_cmp(a: OxPtrConst, b: OxPtrConst) -> Option<Ordering> {
     })
 }
 
-/// Drop for Result<T, E>
-unsafe fn result_drop(ox: OxPtrMut) {
-    let shape = ox.shape();
-    let Some(def) = get_result_def(shape) else {
-        return;
-    };
-    let ptr = ox.ptr();
-
-    if unsafe { (def.vtable.is_ok)(ptr.as_const()) } {
-        let Some(ok_ptr) = (unsafe { result_get_ok_ptr(def, ptr.as_const()) }) else {
-            return;
-        };
-        let ok_ptr_mut = PtrMut::new(ok_ptr.as_byte_ptr() as *mut u8);
-        unsafe { def.t.call_drop_in_place(ok_ptr_mut) };
-    } else {
-        let Some(err_ptr) = (unsafe { result_get_err_ptr(def, ptr.as_const()) }) else {
-            return;
-        };
-        let err_ptr_mut = PtrMut::new(err_ptr.as_byte_ptr() as *mut u8);
-        unsafe { def.e.call_drop_in_place(err_ptr_mut) };
-    }
+/// Drop for `Result<T, E>`
+///
+/// Calls `core::ptr::drop_in_place` on the full `Result<T, E>` so the compiler's
+/// drop glue handles both variants correctly. We can't go through `vtable.get_err`
+/// / `vtable.get_ok` to locate the inner value: those use `Result::as_ref().ok()`,
+/// which retags under Stacked Borrows as `SharedReadOnly`, so dropping through
+/// the resulting pointer is UB (miri catches this).
+unsafe fn result_drop<T, E>(ox: OxPtrMut) {
+    unsafe { core::ptr::drop_in_place(ox.as_mut::<Result<T, E>>()) };
 }
 
 // Shared vtable for all Result<T, E>
@@ -217,14 +205,6 @@ const RESULT_VTABLE: VTableIndirect = VTableIndirect {
     partial_eq: Some(result_partial_eq),
     partial_cmp: Some(result_partial_cmp),
     cmp: Some(result_cmp),
-};
-
-// Type operations for all Result<T, E>
-static RESULT_TYPE_OPS: TypeOpsIndirect = TypeOpsIndirect {
-    drop_in_place: result_drop,
-    default_in_place: None,
-    clone_into: None,
-    is_truthy: None,
 };
 
 /// Check if Result<T, E> is Ok
@@ -276,6 +256,15 @@ unsafe impl<'a, T: Facet<'a>, E: Facet<'a>> Facet<'a> for Result<T, E> {
                 .build()
         }
 
+        const fn build_type_ops<T, E>() -> TypeOpsIndirect {
+            TypeOpsIndirect {
+                drop_in_place: result_drop::<T, E>,
+                default_in_place: None,
+                clone_into: None,
+                is_truthy: None,
+            }
+        }
+
         ShapeBuilder::for_sized::<Result<T, E>>("Result")
             .module_path("core::result")
             .type_name(result_type_name)
@@ -306,7 +295,7 @@ unsafe impl<'a, T: Facet<'a>, E: Facet<'a>> Facet<'a> for Result<T, E> {
                 },
             })
             .vtable_indirect(&RESULT_VTABLE)
-            .type_ops_indirect(&RESULT_TYPE_OPS)
+            .type_ops_indirect(&const { build_type_ops::<T, E>() })
             .build()
     };
 }

--- a/facet-core/src/impls/crates/bytes.rs
+++ b/facet-core/src/impls/crates/bytes.rs
@@ -87,11 +87,13 @@ static BYTES_LIST_VTABLE: ListVTable = ListVTable {
     get_mut: None,
     as_ptr: Some(bytes_as_ptr),
     as_mut_ptr: None,
+    swap: None,
 };
 
 static BYTES_LIST_TYPE_OPS: ListTypeOps = ListTypeOps {
     init_in_place_with_capacity: None,
     push: None,
+    pop: None,
     set_len: None,
     as_mut_ptr_typed: None,
     reserve: None,
@@ -230,11 +232,13 @@ static BYTES_MUT_LIST_VTABLE: ListVTable = ListVTable {
     get_mut: Some(bytes_mut_get_mut),
     as_ptr: Some(bytes_mut_as_ptr),
     as_mut_ptr: Some(bytes_mut_as_mut_ptr),
+    swap: None,
 };
 
 static BYTES_MUT_LIST_TYPE_OPS: ListTypeOps = ListTypeOps {
     init_in_place_with_capacity: Some(bytes_mut_init_in_place_with_capacity),
     push: Some(bytes_mut_push),
+    pop: None,
     set_len: None, // BytesMut has different semantics - not supported for direct-fill
     as_mut_ptr_typed: None,
     reserve: None,

--- a/facet-core/src/types/def/list.rs
+++ b/facet-core/src/types/def/list.rs
@@ -62,6 +62,12 @@ impl ListDef {
         self.type_ops.and_then(|ops| ops.push)
     }
 
+    /// Returns the pop function, checking type_ops first.
+    #[inline]
+    pub fn pop(&self) -> Option<ListPopFn> {
+        self.type_ops.and_then(|ops| ops.pop)
+    }
+
     /// Returns the set_len function for direct-fill operations.
     #[inline]
     pub fn set_len(&self) -> Option<ListSetLenFn> {
@@ -115,6 +121,33 @@ pub type ListInitInPlaceWithCapacityFn =
 /// may be dropped later, which requires mutable access.
 pub type ListPushFn = unsafe extern "C" fn(list: PtrMut, item: PtrMut);
 // FIXME: this forces allocating item separately, copying it, and then dropping it — it's not great.
+
+/// Pop the last item from the list, writing it into `out`.
+///
+/// Returns `true` if an item was popped (and `out` was written to), `false` if
+/// the list was empty (in which case `out` is left uninitialized).
+///
+/// # Safety
+///
+/// - `list` must point to aligned, initialized memory of the correct type.
+/// - `out` must point to uninitialized memory large enough for one element of
+///   the list's element type and with the element's alignment.
+pub type ListPopFn = unsafe extern "C" fn(list: PtrMut, out: PtrUninit) -> bool;
+
+/// Swap the elements at indices `a` and `b` in the list.
+///
+/// Returns `false` if either index is out of bounds (in which case no swap
+/// occurs); `true` on success. Swapping an index with itself is a no-op and
+/// still returns `true`.
+///
+/// The `shape` parameter is the list's shape, allowing type-erased
+/// implementations to extract the element size from `shape.type_params[0]`.
+///
+/// # Safety
+///
+/// The `list` parameter must point to aligned, initialized memory of the
+/// correct type.
+pub type ListSwapFn = unsafe fn(list: PtrMut, a: usize, b: usize, shape: &'static Shape) -> bool;
 
 /// Get the number of items in the list
 ///
@@ -240,6 +273,13 @@ pub struct ListTypeOps {
     /// - `item` must point to an initialized value that will be moved
     pub push: Option<ListPushFn>,
 
+    /// Pop the last item from the list (per-T).
+    ///
+    /// # Safety
+    /// - `list` must point to an initialized list
+    /// - `out` must point to uninitialized memory large enough for the element
+    pub pop: Option<ListPopFn>,
+
     /// Set the length of the list (per-T, for direct-fill operations).
     ///
     /// # Safety
@@ -279,6 +319,7 @@ impl ListTypeOps {
         Self {
             init_in_place_with_capacity: None,
             push: None,
+            pop: None,
             set_len: None,
             as_mut_ptr_typed: None,
             reserve: None,
@@ -292,6 +333,7 @@ impl ListTypeOps {
         ListTypeOpsBuilder {
             init_in_place_with_capacity: None,
             push: None,
+            pop: None,
             set_len: None,
             as_mut_ptr_typed: None,
             reserve: None,
@@ -306,6 +348,7 @@ impl ListTypeOps {
 pub struct ListTypeOpsBuilder {
     init_in_place_with_capacity: Option<ListInitInPlaceWithCapacityFn>,
     push: Option<ListPushFn>,
+    pop: Option<ListPopFn>,
     set_len: Option<ListSetLenFn>,
     as_mut_ptr_typed: Option<ListAsMutPtrTypedFn>,
     reserve: Option<ListReserveFn>,
@@ -323,6 +366,12 @@ impl ListTypeOpsBuilder {
     /// Set the `push` function.
     pub const fn push(mut self, f: ListPushFn) -> Self {
         self.push = Some(f);
+        self
+    }
+
+    /// Set the `pop` function.
+    pub const fn pop(mut self, f: ListPopFn) -> Self {
+        self.pop = Some(f);
         self
     }
 
@@ -364,6 +413,7 @@ impl ListTypeOpsBuilder {
         ListTypeOps {
             init_in_place_with_capacity: self.init_in_place_with_capacity,
             push: self.push,
+            pop: self.pop,
             set_len: self.set_len,
             as_mut_ptr_typed: self.as_mut_ptr_typed,
             reserve: self.reserve,
@@ -409,5 +459,9 @@ vtable_def! {
         /// cf. [`ListAsMutPtrFn`]
         /// Only available for types that can be accessed as a contiguous array
         pub as_mut_ptr: Option<ListAsMutPtrFn>,
+
+        /// cf. [`ListSwapFn`]
+        /// Only available for types that support in-place element swaps
+        pub swap: Option<ListSwapFn>,
     }
 }

--- a/facet-reflect/src/poke/dynamic_value.rs
+++ b/facet-reflect/src/poke/dynamic_value.rs
@@ -1,0 +1,211 @@
+//! Support for poking (mutating) DynamicValue types like `facet_value::Value`
+
+use facet_core::{DynValueKind, DynamicValueDef, PtrUninit};
+
+use super::Poke;
+
+/// Lets you mutate a dynamic value (implements mutable operations for DynamicValue types).
+///
+/// This is used for types like `facet_value::Value` that can hold any of:
+/// null, bool, number, string, bytes, array, or object - determined at runtime.
+///
+/// The setter methods (`set_null`, `set_bool`, etc.) drop the previous value and
+/// re-initialize the storage with the new kind.
+pub struct PokeDynamicValue<'mem, 'facet> {
+    pub(crate) value: Poke<'mem, 'facet>,
+    pub(crate) def: DynamicValueDef,
+}
+
+impl<'mem, 'facet> core::fmt::Debug for PokeDynamicValue<'mem, 'facet> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PokeDynamicValue")
+            .field("kind", &self.kind())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'mem, 'facet> PokeDynamicValue<'mem, 'facet> {
+    /// Creates a new poke dynamic value.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `def` contains valid vtable function pointers that
+    /// correctly implement the dynamic-value operations for the actual type.
+    #[inline]
+    pub const unsafe fn new(value: Poke<'mem, 'facet>, def: DynamicValueDef) -> Self {
+        Self { value, def }
+    }
+
+    /// Returns the dynamic value definition.
+    #[inline(always)]
+    pub const fn def(&self) -> DynamicValueDef {
+        self.def
+    }
+
+    /// Returns the underlying `Poke` as a read-only `Peek`.
+    #[inline]
+    pub fn as_peek(&self) -> crate::Peek<'_, 'facet> {
+        self.value.as_peek()
+    }
+
+    /// Returns the kind of value stored.
+    #[inline]
+    pub fn kind(&self) -> DynValueKind {
+        unsafe { (self.def.vtable.get_kind)(self.value.data()) }
+    }
+
+    /// Returns true if the value is null.
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        self.kind() == DynValueKind::Null
+    }
+
+    /// Returns the boolean value if this is a bool, `None` otherwise.
+    #[inline]
+    pub fn as_bool(&self) -> Option<bool> {
+        unsafe { (self.def.vtable.get_bool)(self.value.data()) }
+    }
+
+    /// Returns the i64 value if representable, `None` otherwise.
+    #[inline]
+    pub fn as_i64(&self) -> Option<i64> {
+        unsafe { (self.def.vtable.get_i64)(self.value.data()) }
+    }
+
+    /// Returns the u64 value if representable, `None` otherwise.
+    #[inline]
+    pub fn as_u64(&self) -> Option<u64> {
+        unsafe { (self.def.vtable.get_u64)(self.value.data()) }
+    }
+
+    /// Returns the f64 value if this is a number, `None` otherwise.
+    #[inline]
+    pub fn as_f64(&self) -> Option<f64> {
+        unsafe { (self.def.vtable.get_f64)(self.value.data()) }
+    }
+
+    /// Returns the string value if this is a string, `None` otherwise.
+    #[inline]
+    pub fn as_str(&self) -> Option<&str> {
+        unsafe { (self.def.vtable.get_str)(self.value.data()) }
+    }
+
+    /// Returns the bytes value if this is bytes, `None` otherwise.
+    #[inline]
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        self.def
+            .vtable
+            .get_bytes
+            .and_then(|f| unsafe { f(self.value.data()) })
+    }
+
+    /// Returns the length of the array if this is an array, `None` otherwise.
+    #[inline]
+    pub fn array_len(&self) -> Option<usize> {
+        unsafe { (self.def.vtable.array_len)(self.value.data()) }
+    }
+
+    /// Returns the length of the object if this is an object, `None` otherwise.
+    #[inline]
+    pub fn object_len(&self) -> Option<usize> {
+        unsafe { (self.def.vtable.object_len)(self.value.data()) }
+    }
+
+    /// Helper: drop the existing value and return a `PtrUninit` to the same location.
+    #[inline]
+    unsafe fn drop_and_as_uninit(&mut self) -> PtrUninit {
+        unsafe { self.value.shape.call_drop_in_place(self.value.data_mut()) };
+        PtrUninit::new(self.value.data_mut().as_mut_byte_ptr())
+    }
+
+    /// Replace the value with `null`, dropping the previous contents.
+    pub fn set_null(&mut self) {
+        unsafe {
+            let uninit = self.drop_and_as_uninit();
+            (self.def.vtable.set_null)(uninit);
+        }
+    }
+
+    /// Replace the value with a boolean, dropping the previous contents.
+    pub fn set_bool(&mut self, v: bool) {
+        unsafe {
+            let uninit = self.drop_and_as_uninit();
+            (self.def.vtable.set_bool)(uninit, v);
+        }
+    }
+
+    /// Replace the value with an i64, dropping the previous contents.
+    pub fn set_i64(&mut self, v: i64) {
+        unsafe {
+            let uninit = self.drop_and_as_uninit();
+            (self.def.vtable.set_i64)(uninit, v);
+        }
+    }
+
+    /// Replace the value with a u64, dropping the previous contents.
+    pub fn set_u64(&mut self, v: u64) {
+        unsafe {
+            let uninit = self.drop_and_as_uninit();
+            (self.def.vtable.set_u64)(uninit, v);
+        }
+    }
+
+    /// Replace the value with an f64, dropping the previous contents.
+    ///
+    /// Returns `false` if the value is not representable by the underlying type.
+    pub fn set_f64(&mut self, v: f64) -> bool {
+        unsafe {
+            let uninit = self.drop_and_as_uninit();
+            (self.def.vtable.set_f64)(uninit, v)
+        }
+    }
+
+    /// Replace the value with a string, dropping the previous contents.
+    pub fn set_str(&mut self, v: &str) {
+        unsafe {
+            let uninit = self.drop_and_as_uninit();
+            (self.def.vtable.set_str)(uninit, v);
+        }
+    }
+
+    /// Replace the value with a byte slice, dropping the previous contents.
+    ///
+    /// Returns `false` if the underlying dynamic value type doesn't support bytes.
+    pub fn set_bytes(&mut self, v: &[u8]) -> bool {
+        let Some(set_bytes) = self.def.vtable.set_bytes else {
+            return false;
+        };
+        unsafe {
+            let uninit = self.drop_and_as_uninit();
+            set_bytes(uninit, v);
+        }
+        true
+    }
+
+    /// Get a mutable `Poke` for the value at the given object key.
+    ///
+    /// Returns `None` if the dynamic value is not an object, the key is missing, or
+    /// `object_get_mut` is not implemented for this type.
+    #[inline]
+    pub fn object_get_mut(&mut self, key: &str) -> Option<Poke<'_, 'facet>> {
+        let object_get_mut = self.def.vtable.object_get_mut?;
+        let inner_ptr = unsafe { object_get_mut(self.value.data_mut(), key)? };
+        // Nested dynamic values share the outer shape.
+        Some(unsafe { Poke::from_raw_parts(inner_ptr, self.value.shape) })
+    }
+
+    /// Converts this `PokeDynamicValue` back into a `Poke`.
+    #[inline]
+    pub const fn into_inner(self) -> Poke<'mem, 'facet> {
+        self.value
+    }
+
+    /// Returns a read-only `PeekDynamicValue` view.
+    #[inline]
+    pub fn as_peek_dynamic_value(&self) -> crate::PeekDynamicValue<'_, 'facet> {
+        crate::PeekDynamicValue {
+            value: self.value.as_peek(),
+            def: self.def,
+        }
+    }
+}

--- a/facet-reflect/src/poke/dynamic_value.rs
+++ b/facet-reflect/src/poke/dynamic_value.rs
@@ -1,6 +1,10 @@
 //! Support for poking (mutating) DynamicValue types like `facet_value::Value`
 
-use facet_core::{DynValueKind, DynamicValueDef, PtrUninit};
+use core::mem::ManuallyDrop;
+
+use facet_core::{DynValueKind, DynamicValueDef, Facet, PtrMut, PtrUninit};
+
+use crate::{ReflectError, ReflectErrorKind};
 
 use super::Poke;
 
@@ -180,6 +184,85 @@ impl<'mem, 'facet> PokeDynamicValue<'mem, 'facet> {
             set_bytes(uninit, v);
         }
         true
+    }
+
+    /// Replace the value with an empty array, dropping the previous contents.
+    pub fn set_array(&mut self) {
+        unsafe {
+            let uninit = self.drop_and_as_uninit();
+            (self.def.vtable.begin_array)(uninit);
+        }
+    }
+
+    /// Replace the value with an empty object, dropping the previous contents.
+    pub fn set_object(&mut self) {
+        unsafe {
+            let uninit = self.drop_and_as_uninit();
+            (self.def.vtable.begin_object)(uninit);
+        }
+    }
+
+    /// Push an element onto the array value.
+    ///
+    /// The value must already be an array (use [`set_array`](Self::set_array) first if needed).
+    /// The element's shape must match this dynamic value's shape — a nested element is itself
+    /// a full dynamic value of the same kind (e.g. another `facet_value::Value`).
+    ///
+    /// The element is moved into the array (the vtable does the `ptr::read`); the caller's
+    /// original ownership of `element` is consumed by this call.
+    pub fn push_array_element<T: Facet<'facet>>(&mut self, element: T) -> Result<(), ReflectError> {
+        if self.value.shape != T::SHAPE {
+            return Err(self.value.err(ReflectErrorKind::WrongShape {
+                expected: self.value.shape,
+                actual: T::SHAPE,
+            }));
+        }
+        let mut element = ManuallyDrop::new(element);
+        unsafe {
+            let elem_ptr = PtrMut::new(&mut element as *mut ManuallyDrop<T> as *mut u8);
+            (self.def.vtable.push_array_element)(self.value.data_mut(), elem_ptr);
+        }
+        Ok(())
+    }
+
+    /// Finalize an array value. No-op if the underlying dynamic-value type doesn't need it.
+    pub fn end_array(&mut self) {
+        if let Some(end_array) = self.def.vtable.end_array {
+            unsafe { end_array(self.value.data_mut()) };
+        }
+    }
+
+    /// Insert a key-value pair into the object value.
+    ///
+    /// The value must already be an object (use [`set_object`](Self::set_object) first if needed).
+    /// The value's shape must match this dynamic value's shape — a nested value is itself a full
+    /// dynamic value of the same kind.
+    ///
+    /// `value` is moved into the object (the vtable does the `ptr::read`).
+    pub fn insert_object_entry<T: Facet<'facet>>(
+        &mut self,
+        key: &str,
+        value: T,
+    ) -> Result<(), ReflectError> {
+        if self.value.shape != T::SHAPE {
+            return Err(self.value.err(ReflectErrorKind::WrongShape {
+                expected: self.value.shape,
+                actual: T::SHAPE,
+            }));
+        }
+        let mut value = ManuallyDrop::new(value);
+        unsafe {
+            let value_ptr = PtrMut::new(&mut value as *mut ManuallyDrop<T> as *mut u8);
+            (self.def.vtable.insert_object_entry)(self.value.data_mut(), key, value_ptr);
+        }
+        Ok(())
+    }
+
+    /// Finalize an object value. No-op if the underlying dynamic-value type doesn't need it.
+    pub fn end_object(&mut self) {
+        if let Some(end_object) = self.def.vtable.end_object {
+            unsafe { end_object(self.value.data_mut()) };
+        }
     }
 
     /// Get a mutable `Poke` for the value at the given object key.

--- a/facet-reflect/src/poke/dynamic_value.rs
+++ b/facet-reflect/src/poke/dynamic_value.rs
@@ -4,7 +4,7 @@ use core::mem::ManuallyDrop;
 
 use facet_core::{DynValueKind, DynamicValueDef, Facet, PtrMut, PtrUninit};
 
-use crate::{ReflectError, ReflectErrorKind};
+use crate::{HeapValue, ReflectError, ReflectErrorKind};
 
 use super::Poke;
 
@@ -225,6 +225,32 @@ impl<'mem, 'facet> PokeDynamicValue<'mem, 'facet> {
         Ok(())
     }
 
+    /// Type-erased [`push_array_element`](Self::push_array_element).
+    ///
+    /// Accepts a [`HeapValue`] whose shape must match this dynamic value's shape.
+    pub fn push_array_element_from_heap<const BORROW: bool>(
+        &mut self,
+        element: HeapValue<'facet, BORROW>,
+    ) -> Result<(), ReflectError> {
+        if self.value.shape != element.shape() {
+            return Err(self.value.err(ReflectErrorKind::WrongShape {
+                expected: self.value.shape,
+                actual: element.shape(),
+            }));
+        }
+        let mut element = element;
+        let guard = element
+            .guard
+            .take()
+            .expect("HeapValue guard was already taken");
+        unsafe {
+            let elem_ptr = PtrMut::new(guard.ptr.as_ptr());
+            (self.def.vtable.push_array_element)(self.value.data_mut(), elem_ptr);
+        }
+        drop(guard);
+        Ok(())
+    }
+
     /// Finalize an array value. No-op if the underlying dynamic-value type doesn't need it.
     pub fn end_array(&mut self) {
         if let Some(end_array) = self.def.vtable.end_array {
@@ -255,6 +281,33 @@ impl<'mem, 'facet> PokeDynamicValue<'mem, 'facet> {
             let value_ptr = PtrMut::new(&mut value as *mut ManuallyDrop<T> as *mut u8);
             (self.def.vtable.insert_object_entry)(self.value.data_mut(), key, value_ptr);
         }
+        Ok(())
+    }
+
+    /// Type-erased [`insert_object_entry`](Self::insert_object_entry).
+    ///
+    /// Accepts a [`HeapValue`] whose shape must match this dynamic value's shape.
+    pub fn insert_object_entry_from_heap<const BORROW: bool>(
+        &mut self,
+        key: &str,
+        value: HeapValue<'facet, BORROW>,
+    ) -> Result<(), ReflectError> {
+        if self.value.shape != value.shape() {
+            return Err(self.value.err(ReflectErrorKind::WrongShape {
+                expected: self.value.shape,
+                actual: value.shape(),
+            }));
+        }
+        let mut value = value;
+        let guard = value
+            .guard
+            .take()
+            .expect("HeapValue guard was already taken");
+        unsafe {
+            let value_ptr = PtrMut::new(guard.ptr.as_ptr());
+            (self.def.vtable.insert_object_entry)(self.value.data_mut(), key, value_ptr);
+        }
+        drop(guard);
         Ok(())
     }
 

--- a/facet-reflect/src/poke/enum_.rs
+++ b/facet-reflect/src/poke/enum_.rs
@@ -1,7 +1,7 @@
 use facet_core::{Def, EnumRepr, EnumType, Facet, FieldError};
 use facet_path::Path;
 
-use crate::{ReflectError, ReflectErrorKind, peek::VariantError};
+use crate::{HeapValue, ReflectError, ReflectErrorKind, peek::VariantError};
 
 use super::Poke;
 
@@ -291,6 +291,102 @@ impl<'mem, 'facet> PokeEnum<'mem, 'facet> {
         })?;
 
         self.set_field(index, value)
+    }
+
+    /// Type-erased [`set_field`](Self::set_field).
+    ///
+    /// Accepts a [`HeapValue`] whose shape must match the field's type. The
+    /// value is moved out of the `HeapValue` into the field (the previous
+    /// field value is dropped first).
+    pub fn set_field_from_heap<const BORROW: bool>(
+        &mut self,
+        index: usize,
+        value: HeapValue<'facet, BORROW>,
+    ) -> Result<(), ReflectError> {
+        if !self.value.shape.is_pod() {
+            return Err(self.err(ReflectErrorKind::NotPod {
+                shape: self.value.shape,
+            }));
+        }
+
+        let variant = self.active_variant().map_err(|_| {
+            self.err(ReflectErrorKind::OperationFailed {
+                shape: self.value.shape,
+                operation: "get active variant",
+            })
+        })?;
+        let fields = &variant.data.fields;
+
+        let field = fields.get(index).ok_or_else(|| {
+            self.err(ReflectErrorKind::FieldError {
+                shape: self.value.shape,
+                field_error: FieldError::IndexOutOfBounds {
+                    index,
+                    bound: fields.len(),
+                },
+            })
+        })?;
+
+        let field_shape = field.shape();
+        if field_shape != value.shape() {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: field_shape,
+                actual: value.shape(),
+            }));
+        }
+
+        let field_offset = field.offset;
+        let field_layout = field_shape.layout.sized_layout().map_err(|_| {
+            self.err(ReflectErrorKind::Unsized {
+                shape: field_shape,
+                operation: "set_field_from_heap",
+            })
+        })?;
+
+        let mut value = value;
+        let guard = value
+            .guard
+            .take()
+            .expect("HeapValue guard was already taken");
+        unsafe {
+            let field_ptr = self.value.data.field(field_offset);
+            // Drop the old value, then move the bytes from the heap value in.
+            field_shape.call_drop_in_place(field_ptr);
+            core::ptr::copy_nonoverlapping(
+                guard.ptr.as_ptr(),
+                field_ptr.as_mut_byte_ptr(),
+                field_layout.size(),
+            );
+        }
+        // Free the heap allocation. Drop is skipped because `guard` holds only
+        // the allocation metadata; the value itself was moved into the field.
+        drop(guard);
+        Ok(())
+    }
+
+    /// Type-erased [`set_field_by_name`](Self::set_field_by_name).
+    ///
+    /// Accepts a [`HeapValue`] whose shape must match the field's type.
+    pub fn set_field_by_name_from_heap<const BORROW: bool>(
+        &mut self,
+        name: &str,
+        value: HeapValue<'facet, BORROW>,
+    ) -> Result<(), ReflectError> {
+        let index = self.field_index(name).map_err(|_| {
+            self.err(ReflectErrorKind::OperationFailed {
+                shape: self.value.shape,
+                operation: "get active variant",
+            })
+        })?;
+
+        let index = index.ok_or_else(|| {
+            self.err(ReflectErrorKind::FieldError {
+                shape: self.value.shape,
+                field_error: FieldError::NoSuchField,
+            })
+        })?;
+
+        self.set_field_from_heap(index, value)
     }
 
     /// Gets a read-only view of a field by index.

--- a/facet-reflect/src/poke/list.rs
+++ b/facet-reflect/src/poke/list.rs
@@ -1,8 +1,8 @@
 use super::Poke;
-use core::{fmt::Debug, marker::PhantomData};
-use facet_core::{ListDef, PtrMut, Shape};
+use core::{fmt::Debug, marker::PhantomData, mem::ManuallyDrop, ptr::NonNull};
+use facet_core::{FieldError, ListDef, PtrMut, PtrUninit, Shape};
 
-use crate::{ReflectError, ReflectErrorKind};
+use crate::{Guard, HeapValue, ReflectError, ReflectErrorKind};
 
 /// Iterator over a `PokeList` yielding mutable `Poke`s.
 ///
@@ -139,6 +139,139 @@ impl<'mem, 'facet> PokeList<'mem, 'facet> {
         })
     }
 
+    /// Push a value onto the end of the list.
+    ///
+    /// Returns an error if the underlying list type does not support push (e.g.
+    /// immutable lists) or if the value's shape does not match the list's
+    /// element type.
+    pub fn push<T: facet_core::Facet<'facet>>(&mut self, value: T) -> Result<(), ReflectError> {
+        if self.def.t() != T::SHAPE {
+            return Err(self.value.err(ReflectErrorKind::WrongShape {
+                expected: self.def.t(),
+                actual: T::SHAPE,
+            }));
+        }
+        let push_fn = self.push_fn()?;
+        let mut value = ManuallyDrop::new(value);
+        unsafe {
+            let item_ptr = PtrMut::new(&mut value as *mut ManuallyDrop<T> as *mut u8);
+            push_fn(self.value.data_mut(), item_ptr);
+        }
+        Ok(())
+    }
+
+    /// Type-erased [`push`](Self::push).
+    ///
+    /// Accepts a [`HeapValue`] whose shape must match the list's element type.
+    /// The value is moved out of the `HeapValue` into the list.
+    pub fn push_from_heap<const BORROW: bool>(
+        &mut self,
+        value: HeapValue<'facet, BORROW>,
+    ) -> Result<(), ReflectError> {
+        if self.def.t() != value.shape() {
+            return Err(self.value.err(ReflectErrorKind::WrongShape {
+                expected: self.def.t(),
+                actual: value.shape(),
+            }));
+        }
+        let push_fn = self.push_fn()?;
+        let mut value = value;
+        let guard = value
+            .guard
+            .take()
+            .expect("HeapValue guard was already taken");
+        unsafe {
+            let item_ptr = PtrMut::new(guard.ptr.as_ptr());
+            push_fn(self.value.data_mut(), item_ptr);
+        }
+        drop(guard);
+        Ok(())
+    }
+
+    /// Pop the last value off the end of the list.
+    ///
+    /// Returns `Ok(None)` if the list is empty. Returns an error if the
+    /// underlying list type does not support pop.
+    pub fn pop(&mut self) -> Result<Option<HeapValue<'facet, true>>, ReflectError> {
+        let pop_fn = self.def.pop().ok_or_else(|| {
+            self.value.err(ReflectErrorKind::OperationFailed {
+                shape: self.value.shape(),
+                operation: "pop: list type does not support pop",
+            })
+        })?;
+        let elem_shape = self.def.t();
+        let layout = elem_shape.layout.sized_layout().map_err(|_| {
+            self.value.err(ReflectErrorKind::Unsized {
+                shape: elem_shape,
+                operation: "pop",
+            })
+        })?;
+        let ptr = if layout.size() == 0 {
+            NonNull::<u8>::dangling()
+        } else {
+            let raw = unsafe { alloc::alloc::alloc(layout) };
+            match NonNull::new(raw) {
+                Some(p) => p,
+                None => alloc::alloc::handle_alloc_error(layout),
+            }
+        };
+        let out = PtrUninit::new(ptr.as_ptr());
+        let popped = unsafe { pop_fn(self.value.data_mut(), out) };
+        if !popped {
+            if layout.size() != 0 {
+                unsafe { alloc::alloc::dealloc(ptr.as_ptr(), layout) };
+            }
+            return Ok(None);
+        }
+        Ok(Some(HeapValue {
+            guard: Some(Guard {
+                ptr,
+                layout,
+                should_dealloc: layout.size() != 0,
+            }),
+            shape: elem_shape,
+            phantom: PhantomData,
+        }))
+    }
+
+    /// Swap the elements at indices `a` and `b`.
+    ///
+    /// Returns an error if the underlying list type does not support swap or
+    /// if either index is out of bounds. Swapping an index with itself is a
+    /// no-op.
+    pub fn swap(&mut self, a: usize, b: usize) -> Result<(), ReflectError> {
+        let swap_fn = self.def.vtable.swap.ok_or_else(|| {
+            self.value.err(ReflectErrorKind::OperationFailed {
+                shape: self.value.shape(),
+                operation: "swap: list type does not support swap",
+            })
+        })?;
+        let len = self.len();
+        let ok = unsafe { swap_fn(self.value.data_mut(), a, b, self.value.shape()) };
+        if !ok {
+            let out_of_bounds = if a >= len { a } else { b };
+            return Err(self.value.err(ReflectErrorKind::FieldError {
+                shape: self.value.shape(),
+                field_error: FieldError::IndexOutOfBounds {
+                    index: out_of_bounds,
+                    bound: len,
+                },
+            }));
+        }
+        Ok(())
+    }
+
+    /// Resolve the per-T push function or build an error if absent.
+    #[inline]
+    fn push_fn(&self) -> Result<facet_core::ListPushFn, ReflectError> {
+        self.def.push().ok_or_else(|| {
+            self.value.err(ReflectErrorKind::OperationFailed {
+                shape: self.value.shape(),
+                operation: "push: list type does not support push",
+            })
+        })
+    }
+
     /// Def getter
     #[inline]
     pub const fn def(&self) -> ListDef {
@@ -213,5 +346,106 @@ mod tests {
 
         assert_eq!(sum, 6);
         assert_eq!(v, alloc::vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn poke_list_push_pop() {
+        let mut v: Vec<i32> = alloc::vec![];
+        {
+            let poke = Poke::new(&mut v);
+            let mut list = poke.into_list().unwrap();
+            list.push(1i32).unwrap();
+            list.push(2i32).unwrap();
+            list.push(3i32).unwrap();
+        }
+        assert_eq!(v, alloc::vec![1, 2, 3]);
+
+        {
+            let poke = Poke::new(&mut v);
+            let mut list = poke.into_list().unwrap();
+            let popped = list.pop().unwrap().unwrap();
+            assert_eq!(popped.materialize::<i32>().unwrap(), 3);
+        }
+        assert_eq!(v, alloc::vec![1, 2]);
+    }
+
+    #[test]
+    fn poke_list_pop_empty_returns_none() {
+        let mut v: Vec<i32> = alloc::vec![];
+        let poke = Poke::new(&mut v);
+        let mut list = poke.into_list().unwrap();
+        let popped = list.pop().unwrap();
+        assert!(popped.is_none());
+    }
+
+    #[test]
+    fn poke_list_push_wrong_shape_fails() {
+        let mut v: Vec<i32> = alloc::vec![];
+        let poke = Poke::new(&mut v);
+        let mut list = poke.into_list().unwrap();
+        let res = list.push(7u32);
+        assert!(matches!(
+            res,
+            Err(ref err) if matches!(err.kind, ReflectErrorKind::WrongShape { .. })
+        ));
+    }
+
+    #[test]
+    fn poke_list_push_from_heap() {
+        let mut v: Vec<i32> = alloc::vec![];
+        let poke = Poke::new(&mut v);
+        let mut list = poke.into_list().unwrap();
+
+        let hv = crate::Partial::alloc::<i32>()
+            .unwrap()
+            .set(42i32)
+            .unwrap()
+            .build()
+            .unwrap();
+        list.push_from_heap(hv).unwrap();
+        assert_eq!(v, alloc::vec![42]);
+    }
+
+    #[test]
+    fn poke_list_pop_string() {
+        let mut v: Vec<alloc::string::String> = alloc::vec![
+            alloc::string::String::from("a"),
+            alloc::string::String::from("b"),
+        ];
+        let poke = Poke::new(&mut v);
+        let mut list = poke.into_list().unwrap();
+        let popped = list.pop().unwrap().unwrap();
+        assert_eq!(popped.materialize::<alloc::string::String>().unwrap(), "b");
+        assert_eq!(v, alloc::vec![alloc::string::String::from("a")]);
+    }
+
+    #[test]
+    fn poke_list_swap() {
+        let mut v: Vec<i32> = alloc::vec![1, 2, 3];
+        let poke = Poke::new(&mut v);
+        let mut list = poke.into_list().unwrap();
+        list.swap(0, 2).unwrap();
+        assert_eq!(v, alloc::vec![3, 2, 1]);
+    }
+
+    #[test]
+    fn poke_list_swap_self_is_noop() {
+        let mut v: Vec<i32> = alloc::vec![1, 2, 3];
+        let poke = Poke::new(&mut v);
+        let mut list = poke.into_list().unwrap();
+        list.swap(1, 1).unwrap();
+        assert_eq!(v, alloc::vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn poke_list_swap_out_of_bounds_fails() {
+        let mut v: Vec<i32> = alloc::vec![1, 2, 3];
+        let poke = Poke::new(&mut v);
+        let mut list = poke.into_list().unwrap();
+        let res = list.swap(0, 10);
+        assert!(matches!(
+            res,
+            Err(ref err) if matches!(err.kind, ReflectErrorKind::FieldError { .. })
+        ));
     }
 }

--- a/facet-reflect/src/poke/list.rs
+++ b/facet-reflect/src/poke/list.rs
@@ -1,13 +1,20 @@
 use super::Poke;
 use core::{fmt::Debug, marker::PhantomData};
-use facet_core::{ListDef, PtrMut};
+use facet_core::{ListDef, PtrMut, Shape};
 
-/// Iterator over a `PokeList`
+use crate::{ReflectError, ReflectErrorKind};
+
+/// Iterator over a `PokeList` yielding mutable `Poke`s.
+///
+/// Constructed by [`PokeList::iter_mut`]. Walks element strides starting from the list's
+/// `as_mut_ptr`; `iter_mut` refuses to build one if that entry is missing or the element
+/// type is unsized.
 pub struct PokeListIter<'mem, 'facet> {
-    state: PokeListIterState<'mem>,
+    data: PtrMut,
+    stride: usize,
     index: usize,
     len: usize,
-    def: ListDef,
+    elem_shape: &'static Shape,
     _list: PhantomData<Poke<'mem, 'facet>>,
 }
 
@@ -16,26 +23,12 @@ impl<'mem, 'facet> Iterator for PokeListIter<'mem, 'facet> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        let item_ptr = match &mut self.state.kind {
-            PokeListIterStateKind::Ptr { data, stride } => {
-                if self.index >= self.len {
-                    return None;
-                }
-
-                unsafe { data.field(*stride * self.index) }
-            }
-            PokeListIterStateKind::Iter { iter } => unsafe {
-                // The iter vtable returns PtrConst, but we know the underlying data is mutable
-                // because we created this iterator from a PokeList which has mutable access.
-                // We need to convert the const pointer back to mutable.
-                let const_ptr = (self.def.iter_vtable().unwrap().next)(*iter)?;
-                PtrMut::new(const_ptr.as_byte_ptr() as *mut u8)
-            },
-        };
-
+        if self.index >= self.len {
+            return None;
+        }
+        let item_ptr = unsafe { self.data.field(self.stride * self.index) };
         self.index += 1;
-
-        Some(unsafe { Poke::from_raw_parts(item_ptr, self.def.t()) })
+        Some(unsafe { Poke::from_raw_parts(item_ptr, self.elem_shape) })
     }
 
     #[inline]
@@ -46,30 +39,6 @@ impl<'mem, 'facet> Iterator for PokeListIter<'mem, 'facet> {
 }
 
 impl ExactSizeIterator for PokeListIter<'_, '_> {}
-
-impl Drop for PokeListIter<'_, '_> {
-    #[inline]
-    fn drop(&mut self) {
-        match &self.state.kind {
-            PokeListIterStateKind::Iter { iter } => unsafe {
-                (self.def.iter_vtable().unwrap().dealloc)(*iter)
-            },
-            PokeListIterStateKind::Ptr { .. } => {
-                // Nothing to do
-            }
-        }
-    }
-}
-
-struct PokeListIterState<'mem> {
-    kind: PokeListIterStateKind,
-    _phantom: PhantomData<&'mem mut ()>,
-}
-
-enum PokeListIterStateKind {
-    Ptr { data: PtrMut, stride: usize },
-    Iter { iter: PtrMut },
-}
 
 /// Lets you mutate a list (implements mutable [`facet_core::ListVTable`] proxies)
 pub struct PokeList<'mem, 'facet> {
@@ -129,40 +98,45 @@ impl<'mem, 'facet> PokeList<'mem, 'facet> {
         Some(unsafe { Poke::from_raw_parts(item, self.def.t()) })
     }
 
-    /// Returns a mutable iterator over the list
-    pub fn iter_mut(self) -> PokeListIter<'mem, 'facet> {
-        let state = if let Some(as_mut_ptr_fn) = self.def.vtable.as_mut_ptr {
-            let data = unsafe { as_mut_ptr_fn(self.value.data) };
-            let layout = self
-                .def
-                .t()
-                .layout
-                .sized_layout()
-                .expect("can only iterate over sized list elements");
-            let stride = layout.size();
-
-            PokeListIterState {
-                kind: PokeListIterStateKind::Ptr { data, stride },
-                _phantom: PhantomData,
-            }
-        } else {
-            // Fall back to the immutable iterator, but we know we have mutable access
-            let iter = unsafe {
-                (self.def.iter_vtable().unwrap().init_with_value.unwrap())(self.value.data())
-            };
-            PokeListIterState {
-                kind: PokeListIterStateKind::Iter { iter },
-                _phantom: PhantomData,
+    /// Returns a mutable iterator over the list.
+    ///
+    /// Requires contiguous mutable access: the element type must be sized and the list
+    /// vtable must expose `as_mut_ptr`. Returns [`ReflectErrorKind::OperationFailed`] otherwise;
+    /// use [`PokeList::get_mut`] per index when `iter_mut` is unavailable.
+    ///
+    /// The previous fallback that synthesized a mutable iterator from the list's `iter_vtable`
+    /// was unsound: that vtable yields `PtrConst` items backed by shared references, and writing
+    /// through them is UB.
+    pub fn iter_mut(self) -> Result<PokeListIter<'mem, 'facet>, ReflectError> {
+        let elem_shape = self.def.t();
+        let stride = match elem_shape.layout {
+            facet_core::ShapeLayout::Sized(layout) => layout.size(),
+            facet_core::ShapeLayout::Unsized => {
+                return Err(self.value.err(ReflectErrorKind::OperationFailed {
+                    shape: self.value.shape(),
+                    operation: "iter_mut requires sized element type",
+                }));
             }
         };
 
-        PokeListIter {
-            state,
+        let Some(as_mut_ptr_fn) = self.def.vtable.as_mut_ptr else {
+            return Err(self.value.err(ReflectErrorKind::OperationFailed {
+                shape: self.value.shape(),
+                operation:
+                    "iter_mut requires a contiguous `as_mut_ptr` vtable entry; use `get_mut` per index",
+            }));
+        };
+
+        let data = unsafe { as_mut_ptr_fn(self.value.data) };
+        let len = self.len();
+        Ok(PokeListIter {
+            data,
+            stride,
             index: 0,
-            len: self.len(),
-            def: self.def(),
+            len,
+            elem_shape,
             _list: PhantomData,
-        }
+        })
     }
 
     /// Def getter
@@ -181,16 +155,6 @@ impl<'mem, 'facet> PokeList<'mem, 'facet> {
     #[inline]
     pub fn as_peek_list(&self) -> crate::PeekList<'_, 'facet> {
         unsafe { crate::PeekList::new(self.value.as_peek(), self.def) }
-    }
-}
-
-impl<'mem, 'facet> IntoIterator for PokeList<'mem, 'facet> {
-    type Item = Poke<'mem, 'facet>;
-    type IntoIter = PokeListIter<'mem, 'facet>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter_mut()
     }
 }
 
@@ -241,7 +205,7 @@ mod tests {
         let list = poke.into_list().unwrap();
 
         let mut sum = 0;
-        for mut item in list {
+        for mut item in list.iter_mut().unwrap() {
             let val = *item.get::<i32>().unwrap();
             item.set(val * 10).unwrap();
             sum += val;

--- a/facet-reflect/src/poke/list_like.rs
+++ b/facet-reflect/src/poke/list_like.rs
@@ -1,7 +1,7 @@
 use core::{fmt::Debug, marker::PhantomData};
-use facet_core::{PtrMut, ShapeLayout};
+use facet_core::{PtrMut, Shape, ShapeLayout};
 
-use crate::peek::ListLikeDef;
+use crate::{ReflectError, ReflectErrorKind, peek::ListLikeDef};
 
 use super::Poke;
 
@@ -18,18 +18,18 @@ impl<'mem, 'facet> Debug for PokeListLike<'mem, 'facet> {
     }
 }
 
-/// Iterator over a `PokeListLike` yielding mutable `Poke`s
+/// Iterator over a `PokeListLike` yielding mutable `Poke`s.
+///
+/// Constructed by [`PokeListLike::iter_mut`]. Only contiguous list-likes support
+/// mutable iteration — this iterator walks element strides starting from
+/// `as_mut_ptr`. See [`PokeListLike::iter_mut`] for the error conditions.
 pub struct PokeListLikeIter<'mem, 'facet> {
-    state: PokeListLikeIterStateKind,
+    data: PtrMut,
+    stride: usize,
     index: usize,
     len: usize,
-    def: ListLikeDef,
+    elem_shape: &'static Shape,
     _list: PhantomData<Poke<'mem, 'facet>>,
-}
-
-enum PokeListLikeIterStateKind {
-    Ptr { data: PtrMut, stride: usize },
-    Iter { iter: PtrMut },
 }
 
 impl<'mem, 'facet> Iterator for PokeListLikeIter<'mem, 'facet> {
@@ -40,25 +40,9 @@ impl<'mem, 'facet> Iterator for PokeListLikeIter<'mem, 'facet> {
         if self.index >= self.len {
             return None;
         }
-
-        let item_ptr = match &mut self.state {
-            PokeListLikeIterStateKind::Ptr { data, stride } => unsafe {
-                data.field(*stride * self.index)
-            },
-            PokeListLikeIterStateKind::Iter { iter } => match self.def {
-                ListLikeDef::List(def) => {
-                    let vtable = def.iter_vtable().unwrap();
-                    let const_ptr = unsafe { (vtable.next)(*iter)? };
-                    // SAFETY: we created this iterator from a PokeListLike which has
-                    // mutable access, so converting the const pointer back to mutable is sound.
-                    PtrMut::new(const_ptr.as_byte_ptr() as *mut u8)
-                }
-                _ => unreachable!("non-list list-likes always use Ptr state"),
-            },
-        };
-
+        let item_ptr = unsafe { self.data.field(self.stride * self.index) };
         self.index += 1;
-        Some(unsafe { Poke::from_raw_parts(item_ptr, self.def.t()) })
+        Some(unsafe { Poke::from_raw_parts(item_ptr, self.elem_shape) })
     }
 
     #[inline]
@@ -69,18 +53,6 @@ impl<'mem, 'facet> Iterator for PokeListLikeIter<'mem, 'facet> {
 }
 
 impl<'mem, 'facet> ExactSizeIterator for PokeListLikeIter<'mem, 'facet> {}
-
-impl Drop for PokeListLikeIter<'_, '_> {
-    #[inline]
-    fn drop(&mut self) {
-        if let PokeListLikeIterStateKind::Iter { iter } = &self.state
-            && let ListLikeDef::List(def) = self.def
-            && let Some(vtable) = def.iter_vtable()
-        {
-            unsafe { (vtable.dealloc)(*iter) }
-        }
-    }
-}
 
 impl<'mem, 'facet> PokeListLike<'mem, 'facet> {
     /// Creates a new poke list-like
@@ -103,6 +75,10 @@ impl<'mem, 'facet> PokeListLike<'mem, 'facet> {
             ListLikeDef::Array(v) => v.n,
         };
         Self { value, def, len }
+    }
+
+    fn err(&self, kind: ReflectErrorKind) -> ReflectError {
+        self.value.err(kind)
     }
 
     /// Get the length of the list-like.
@@ -162,63 +138,50 @@ impl<'mem, 'facet> PokeListLike<'mem, 'facet> {
     }
 
     /// Returns a mutable iterator over the list-like.
-    pub fn iter_mut(self) -> PokeListLikeIter<'mem, 'facet> {
-        let state = match self.def {
-            ListLikeDef::List(def) => {
-                if let Some(as_mut_ptr_fn) = def.vtable.as_mut_ptr {
-                    let data = unsafe { as_mut_ptr_fn(self.value.data) };
-                    let layout = self
-                        .def
-                        .t()
-                        .layout
-                        .sized_layout()
-                        .expect("can only iterate over sized list-like elements");
-                    PokeListLikeIterStateKind::Ptr {
-                        data,
-                        stride: layout.size(),
-                    }
-                } else {
-                    let iter = unsafe {
-                        (def.iter_vtable().unwrap().init_with_value.unwrap())(self.value.data())
-                    };
-                    PokeListLikeIterStateKind::Iter { iter }
-                }
-            }
-            ListLikeDef::Array(def) => {
-                let data = unsafe { (def.vtable.as_mut_ptr)(self.value.data) };
-                let layout = self
-                    .def
-                    .t()
-                    .layout
-                    .sized_layout()
-                    .expect("can only iterate over sized array elements");
-                PokeListLikeIterStateKind::Ptr {
-                    data,
-                    stride: layout.size(),
-                }
-            }
-            ListLikeDef::Slice(def) => {
-                let data = unsafe { (def.vtable.as_mut_ptr)(self.value.data) };
-                let layout = self
-                    .def
-                    .t()
-                    .layout
-                    .sized_layout()
-                    .expect("can only iterate over sized slice elements");
-                PokeListLikeIterStateKind::Ptr {
-                    data,
-                    stride: layout.size(),
-                }
+    ///
+    /// Requires contiguous mutable access to the backing storage: the element type must be
+    /// sized, and for `List` the vtable must expose `as_mut_ptr`. (`Array` and `Slice` always
+    /// expose `as_mut_ptr`.) Returns [`ReflectErrorKind::OperationFailed`] if either condition
+    /// fails; use [`PokeListLike::get_mut`] per index when `iter_mut` is unavailable.
+    ///
+    /// The previous fallback that synthesized a mutable iterator from the list's `iter_vtable`
+    /// was unsound: that vtable yields `PtrConst` items backed by shared references, and
+    /// writing through them is UB.
+    pub fn iter_mut(self) -> Result<PokeListLikeIter<'mem, 'facet>, ReflectError> {
+        let elem_shape = self.def.t();
+        let stride = match elem_shape.layout {
+            ShapeLayout::Sized(layout) => layout.size(),
+            ShapeLayout::Unsized => {
+                return Err(self.err(ReflectErrorKind::OperationFailed {
+                    shape: self.value.shape,
+                    operation: "iter_mut requires sized element type",
+                }));
             }
         };
 
-        PokeListLikeIter {
-            state,
+        let data = match self.def {
+            ListLikeDef::List(def) => match def.vtable.as_mut_ptr {
+                Some(as_mut_ptr_fn) => unsafe { as_mut_ptr_fn(self.value.data) },
+                None => {
+                    return Err(self.err(ReflectErrorKind::OperationFailed {
+                        shape: self.value.shape,
+                        operation:
+                            "iter_mut requires a contiguous `as_mut_ptr` vtable entry; use `get_mut` per index",
+                    }));
+                }
+            },
+            ListLikeDef::Array(def) => unsafe { (def.vtable.as_mut_ptr)(self.value.data) },
+            ListLikeDef::Slice(def) => unsafe { (def.vtable.as_mut_ptr)(self.value.data) },
+        };
+
+        Ok(PokeListLikeIter {
+            data,
+            stride,
             index: 0,
             len: self.len,
-            def: self.def,
+            elem_shape,
             _list: PhantomData,
-        }
+        })
     }
 
     /// Converts this `PokeListLike` back into a `Poke`.
@@ -231,16 +194,6 @@ impl<'mem, 'facet> PokeListLike<'mem, 'facet> {
     #[inline]
     pub fn as_peek_list_like(&self) -> crate::PeekListLike<'_, 'facet> {
         unsafe { crate::PeekListLike::new(self.value.as_peek(), self.def) }
-    }
-}
-
-impl<'mem, 'facet> IntoIterator for PokeListLike<'mem, 'facet> {
-    type Item = Poke<'mem, 'facet>;
-    type IntoIter = PokeListLikeIter<'mem, 'facet>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter_mut()
     }
 }
 
@@ -283,7 +236,7 @@ mod tests {
         let mut v: Vec<i32> = alloc::vec![1, 2, 3];
         let poke = Poke::new(&mut v);
         let ll = poke.into_list_like().unwrap();
-        for mut item in ll {
+        for mut item in ll.iter_mut().unwrap() {
             let cur = *item.get::<i32>().unwrap();
             item.set(cur * 10).unwrap();
         }

--- a/facet-reflect/src/poke/list_like.rs
+++ b/facet-reflect/src/poke/list_like.rs
@@ -1,7 +1,7 @@
-use core::{fmt::Debug, marker::PhantomData};
-use facet_core::{PtrMut, Shape, ShapeLayout};
+use core::{fmt::Debug, marker::PhantomData, mem::ManuallyDrop, ptr::NonNull};
+use facet_core::{FieldError, PtrMut, PtrUninit, Shape, ShapeLayout};
 
-use crate::{ReflectError, ReflectErrorKind, peek::ListLikeDef};
+use crate::{Guard, HeapValue, ReflectError, ReflectErrorKind, peek::ListLikeDef};
 
 use super::Poke;
 
@@ -184,6 +184,218 @@ impl<'mem, 'facet> PokeListLike<'mem, 'facet> {
         })
     }
 
+    /// Push a value onto the end of the list.
+    ///
+    /// Only supported for `List` variants whose element type provides a `push`
+    /// operation (e.g. `Vec<T>`). Fails for arrays and slices as their length
+    /// is fixed.
+    pub fn push<T: facet_core::Facet<'facet>>(&mut self, value: T) -> Result<(), ReflectError> {
+        if self.def.t() != T::SHAPE {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: self.def.t(),
+                actual: T::SHAPE,
+            }));
+        }
+        let push_fn = self.push_fn()?;
+        let mut value = ManuallyDrop::new(value);
+        unsafe {
+            let item_ptr = PtrMut::new(&mut value as *mut ManuallyDrop<T> as *mut u8);
+            push_fn(self.value.data_mut(), item_ptr);
+        }
+        self.len += 1;
+        Ok(())
+    }
+
+    /// Type-erased [`push`](Self::push).
+    ///
+    /// Accepts a [`HeapValue`] whose shape must match the list's element type.
+    /// The value is moved out of the `HeapValue` into the list.
+    pub fn push_from_heap<const BORROW: bool>(
+        &mut self,
+        value: HeapValue<'facet, BORROW>,
+    ) -> Result<(), ReflectError> {
+        if self.def.t() != value.shape() {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: self.def.t(),
+                actual: value.shape(),
+            }));
+        }
+        let push_fn = self.push_fn()?;
+        let mut value = value;
+        let guard = value
+            .guard
+            .take()
+            .expect("HeapValue guard was already taken");
+        unsafe {
+            let item_ptr = PtrMut::new(guard.ptr.as_ptr());
+            push_fn(self.value.data_mut(), item_ptr);
+        }
+        drop(guard);
+        self.len += 1;
+        Ok(())
+    }
+
+    /// Pop the last value off the end of the list.
+    ///
+    /// Returns `Ok(None)` if the list is empty. Only supported for `List`
+    /// variants whose element type provides a `pop` operation.
+    pub fn pop(&mut self) -> Result<Option<HeapValue<'facet, true>>, ReflectError> {
+        let list_def = match self.def {
+            ListLikeDef::List(def) => def,
+            _ => {
+                return Err(self.err(ReflectErrorKind::OperationFailed {
+                    shape: self.value.shape(),
+                    operation: "pop: only list-backed list-likes support pop",
+                }));
+            }
+        };
+        let pop_fn = list_def.pop().ok_or_else(|| {
+            self.err(ReflectErrorKind::OperationFailed {
+                shape: self.value.shape(),
+                operation: "pop: list type does not support pop",
+            })
+        })?;
+        let elem_shape = self.def.t();
+        let layout = elem_shape.layout.sized_layout().map_err(|_| {
+            self.err(ReflectErrorKind::Unsized {
+                shape: elem_shape,
+                operation: "pop",
+            })
+        })?;
+        let ptr = if layout.size() == 0 {
+            NonNull::<u8>::dangling()
+        } else {
+            let raw = unsafe { alloc::alloc::alloc(layout) };
+            match NonNull::new(raw) {
+                Some(p) => p,
+                None => alloc::alloc::handle_alloc_error(layout),
+            }
+        };
+        let out = PtrUninit::new(ptr.as_ptr());
+        let popped = unsafe { pop_fn(self.value.data_mut(), out) };
+        if !popped {
+            if layout.size() != 0 {
+                unsafe { alloc::alloc::dealloc(ptr.as_ptr(), layout) };
+            }
+            return Ok(None);
+        }
+        self.len -= 1;
+        Ok(Some(HeapValue {
+            guard: Some(Guard {
+                ptr,
+                layout,
+                should_dealloc: layout.size() != 0,
+            }),
+            shape: elem_shape,
+            phantom: PhantomData,
+        }))
+    }
+
+    /// Swap the elements at indices `a` and `b`.
+    ///
+    /// For `List` variants, uses the list's `swap` vtable entry if present and
+    /// errors otherwise. For `Array` and `Slice` variants, performs a generic
+    /// byte-swap using the element stride (always available). Returns an error
+    /// if either index is out of bounds. Swapping an index with itself is a
+    /// no-op.
+    pub fn swap(&mut self, a: usize, b: usize) -> Result<(), ReflectError> {
+        let len = self.len;
+        if a >= len || b >= len {
+            let out_of_bounds = if a >= len { a } else { b };
+            return Err(self.err(ReflectErrorKind::FieldError {
+                shape: self.value.shape(),
+                field_error: FieldError::IndexOutOfBounds {
+                    index: out_of_bounds,
+                    bound: len,
+                },
+            }));
+        }
+        if a == b {
+            return Ok(());
+        }
+
+        match self.def {
+            ListLikeDef::List(def) => {
+                let swap_fn = def.vtable.swap.ok_or_else(|| {
+                    self.err(ReflectErrorKind::OperationFailed {
+                        shape: self.value.shape(),
+                        operation: "swap: list type does not support swap",
+                    })
+                })?;
+                let ok = unsafe { swap_fn(self.value.data_mut(), a, b, self.value.shape()) };
+                if !ok {
+                    return Err(self.err(ReflectErrorKind::OperationFailed {
+                        shape: self.value.shape(),
+                        operation: "swap: vtable refused the operation",
+                    }));
+                }
+                Ok(())
+            }
+            ListLikeDef::Array(def) => {
+                let elem_size = match self.def.t().layout {
+                    ShapeLayout::Sized(l) => l.size(),
+                    ShapeLayout::Unsized => {
+                        return Err(self.err(ReflectErrorKind::Unsized {
+                            shape: self.def.t(),
+                            operation: "swap",
+                        }));
+                    }
+                };
+                unsafe {
+                    let base = (def.vtable.as_mut_ptr)(self.value.data_mut());
+                    let pa = base.field(a * elem_size);
+                    let pb = base.field(b * elem_size);
+                    core::ptr::swap_nonoverlapping(
+                        pa.as_mut_byte_ptr(),
+                        pb.as_mut_byte_ptr(),
+                        elem_size,
+                    );
+                }
+                Ok(())
+            }
+            ListLikeDef::Slice(def) => {
+                let elem_size = match self.def.t().layout {
+                    ShapeLayout::Sized(l) => l.size(),
+                    ShapeLayout::Unsized => {
+                        return Err(self.err(ReflectErrorKind::Unsized {
+                            shape: self.def.t(),
+                            operation: "swap",
+                        }));
+                    }
+                };
+                unsafe {
+                    let base = (def.vtable.as_mut_ptr)(self.value.data_mut());
+                    let pa = base.field(a * elem_size);
+                    let pb = base.field(b * elem_size);
+                    core::ptr::swap_nonoverlapping(
+                        pa.as_mut_byte_ptr(),
+                        pb.as_mut_byte_ptr(),
+                        elem_size,
+                    );
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Resolve the per-T push function for the underlying list, or build an
+    /// error if the list-like is an array/slice or the list lacks push.
+    #[inline]
+    fn push_fn(&self) -> Result<facet_core::ListPushFn, ReflectError> {
+        match self.def {
+            ListLikeDef::List(def) => def.push().ok_or_else(|| {
+                self.err(ReflectErrorKind::OperationFailed {
+                    shape: self.value.shape(),
+                    operation: "push: list type does not support push",
+                })
+            }),
+            _ => Err(self.err(ReflectErrorKind::OperationFailed {
+                shape: self.value.shape(),
+                operation: "push: only list-backed list-likes support push",
+            })),
+        }
+    }
+
     /// Converts this `PokeListLike` back into a `Poke`.
     #[inline]
     pub fn into_inner(self) -> Poke<'mem, 'facet> {
@@ -241,5 +453,75 @@ mod tests {
             item.set(cur * 10).unwrap();
         }
         assert_eq!(v, alloc::vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn poke_list_like_vec_push_pop() {
+        let mut v: Vec<i32> = alloc::vec![];
+        {
+            let poke = Poke::new(&mut v);
+            let mut ll = poke.into_list_like().unwrap();
+            ll.push(10i32).unwrap();
+            ll.push(20i32).unwrap();
+            assert_eq!(ll.len(), 2);
+            let popped = ll.pop().unwrap().unwrap();
+            assert_eq!(popped.materialize::<i32>().unwrap(), 20);
+            assert_eq!(ll.len(), 1);
+        }
+        assert_eq!(v, alloc::vec![10]);
+    }
+
+    #[test]
+    fn poke_list_like_array_push_fails() {
+        let mut arr: [i32; 3] = [1, 2, 3];
+        let poke = Poke::new(&mut arr);
+        let mut ll = poke.into_list_like().unwrap();
+        let res = ll.push(4i32);
+        assert!(matches!(
+            res,
+            Err(ref err) if matches!(err.kind, ReflectErrorKind::OperationFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn poke_list_like_array_pop_fails() {
+        let mut arr: [i32; 3] = [1, 2, 3];
+        let poke = Poke::new(&mut arr);
+        let mut ll = poke.into_list_like().unwrap();
+        let res = ll.pop();
+        assert!(matches!(
+            res,
+            Err(ref err) if matches!(err.kind, ReflectErrorKind::OperationFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn poke_list_like_vec_swap() {
+        let mut v: Vec<i32> = alloc::vec![1, 2, 3];
+        let poke = Poke::new(&mut v);
+        let mut ll = poke.into_list_like().unwrap();
+        ll.swap(0, 2).unwrap();
+        assert_eq!(v, alloc::vec![3, 2, 1]);
+    }
+
+    #[test]
+    fn poke_list_like_array_swap() {
+        let mut arr: [i32; 3] = [10, 20, 30];
+        let poke = Poke::new(&mut arr);
+        let mut ll = poke.into_list_like().unwrap();
+        ll.swap(0, 2).unwrap();
+        assert_eq!(arr, [30, 20, 10]);
+    }
+
+    #[test]
+    fn poke_list_like_swap_out_of_bounds_fails() {
+        let mut v: Vec<i32> = alloc::vec![1, 2, 3];
+        let poke = Poke::new(&mut v);
+        let mut ll = poke.into_list_like().unwrap();
+        let res = ll.swap(5, 0);
+        assert!(matches!(
+            res,
+            Err(ref err) if matches!(err.kind, ReflectErrorKind::FieldError { .. })
+        ));
     }
 }

--- a/facet-reflect/src/poke/list_like.rs
+++ b/facet-reflect/src/poke/list_like.rs
@@ -1,0 +1,292 @@
+use core::{fmt::Debug, marker::PhantomData};
+use facet_core::{PtrMut, ShapeLayout};
+
+use crate::peek::ListLikeDef;
+
+use super::Poke;
+
+/// Lets you mutate a list, array or slice.
+pub struct PokeListLike<'mem, 'facet> {
+    value: Poke<'mem, 'facet>,
+    def: ListLikeDef,
+    len: usize,
+}
+
+impl<'mem, 'facet> Debug for PokeListLike<'mem, 'facet> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PokeListLike").finish_non_exhaustive()
+    }
+}
+
+/// Iterator over a `PokeListLike` yielding mutable `Poke`s
+pub struct PokeListLikeIter<'mem, 'facet> {
+    state: PokeListLikeIterStateKind,
+    index: usize,
+    len: usize,
+    def: ListLikeDef,
+    _list: PhantomData<Poke<'mem, 'facet>>,
+}
+
+enum PokeListLikeIterStateKind {
+    Ptr { data: PtrMut, stride: usize },
+    Iter { iter: PtrMut },
+}
+
+impl<'mem, 'facet> Iterator for PokeListLikeIter<'mem, 'facet> {
+    type Item = Poke<'mem, 'facet>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+
+        let item_ptr = match &mut self.state {
+            PokeListLikeIterStateKind::Ptr { data, stride } => unsafe {
+                data.field(*stride * self.index)
+            },
+            PokeListLikeIterStateKind::Iter { iter } => match self.def {
+                ListLikeDef::List(def) => {
+                    let vtable = def.iter_vtable().unwrap();
+                    let const_ptr = unsafe { (vtable.next)(*iter)? };
+                    // SAFETY: we created this iterator from a PokeListLike which has
+                    // mutable access, so converting the const pointer back to mutable is sound.
+                    PtrMut::new(const_ptr.as_byte_ptr() as *mut u8)
+                }
+                _ => unreachable!("non-list list-likes always use Ptr state"),
+            },
+        };
+
+        self.index += 1;
+        Some(unsafe { Poke::from_raw_parts(item_ptr, self.def.t()) })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.len.saturating_sub(self.index);
+        (remaining, Some(remaining))
+    }
+}
+
+impl<'mem, 'facet> ExactSizeIterator for PokeListLikeIter<'mem, 'facet> {}
+
+impl Drop for PokeListLikeIter<'_, '_> {
+    #[inline]
+    fn drop(&mut self) {
+        if let PokeListLikeIterStateKind::Iter { iter } = &self.state
+            && let ListLikeDef::List(def) = self.def
+            && let Some(vtable) = def.iter_vtable()
+        {
+            unsafe { (vtable.dealloc)(*iter) }
+        }
+    }
+}
+
+impl<'mem, 'facet> PokeListLike<'mem, 'facet> {
+    /// Creates a new poke list-like
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `def` contains valid vtable function pointers that:
+    /// - Correctly implement the list-like operations for the actual type
+    /// - Do not cause undefined behavior when called
+    /// - Return pointers within valid memory bounds
+    /// - Match the element type specified in `def.t()`
+    #[inline]
+    pub unsafe fn new(value: Poke<'mem, 'facet>, def: ListLikeDef) -> Self {
+        let len = match def {
+            ListLikeDef::List(v) => unsafe { (v.vtable.len)(value.data()) },
+            ListLikeDef::Slice(_) => {
+                let slice_as_units = unsafe { value.data().get::<[()]>() };
+                slice_as_units.len()
+            }
+            ListLikeDef::Array(v) => v.n,
+        };
+        Self { value, def, len }
+    }
+
+    /// Get the length of the list-like.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if the list-like is empty.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Def getter.
+    #[inline]
+    pub const fn def(&self) -> ListLikeDef {
+        self.def
+    }
+
+    /// Get a read-only `Peek` for the item at the specified index.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<crate::Peek<'_, 'facet>> {
+        self.as_peek_list_like().get(index)
+    }
+
+    /// Get a mutable `Poke` for the item at the specified index.
+    pub fn get_mut(&mut self, index: usize) -> Option<Poke<'_, 'facet>> {
+        if index >= self.len {
+            return None;
+        }
+
+        let item_ptr = match self.def {
+            ListLikeDef::List(def) => {
+                let get_mut_fn = def.vtable.get_mut?;
+                unsafe { get_mut_fn(self.value.data_mut(), index, self.value.shape())? }
+            }
+            ListLikeDef::Array(def) => {
+                let elem_layout = match self.def.t().layout {
+                    ShapeLayout::Sized(layout) => layout,
+                    ShapeLayout::Unsized => return None,
+                };
+                let base = unsafe { (def.vtable.as_mut_ptr)(self.value.data_mut()) };
+                unsafe { base.field(index * elem_layout.size()) }
+            }
+            ListLikeDef::Slice(def) => {
+                let elem_layout = match self.def.t().layout {
+                    ShapeLayout::Sized(layout) => layout,
+                    ShapeLayout::Unsized => return None,
+                };
+                let base = unsafe { (def.vtable.as_mut_ptr)(self.value.data_mut()) };
+                unsafe { base.field(index * elem_layout.size()) }
+            }
+        };
+
+        Some(unsafe { Poke::from_raw_parts(item_ptr, self.def.t()) })
+    }
+
+    /// Returns a mutable iterator over the list-like.
+    pub fn iter_mut(self) -> PokeListLikeIter<'mem, 'facet> {
+        let state = match self.def {
+            ListLikeDef::List(def) => {
+                if let Some(as_mut_ptr_fn) = def.vtable.as_mut_ptr {
+                    let data = unsafe { as_mut_ptr_fn(self.value.data) };
+                    let layout = self
+                        .def
+                        .t()
+                        .layout
+                        .sized_layout()
+                        .expect("can only iterate over sized list-like elements");
+                    PokeListLikeIterStateKind::Ptr {
+                        data,
+                        stride: layout.size(),
+                    }
+                } else {
+                    let iter = unsafe {
+                        (def.iter_vtable().unwrap().init_with_value.unwrap())(self.value.data())
+                    };
+                    PokeListLikeIterStateKind::Iter { iter }
+                }
+            }
+            ListLikeDef::Array(def) => {
+                let data = unsafe { (def.vtable.as_mut_ptr)(self.value.data) };
+                let layout = self
+                    .def
+                    .t()
+                    .layout
+                    .sized_layout()
+                    .expect("can only iterate over sized array elements");
+                PokeListLikeIterStateKind::Ptr {
+                    data,
+                    stride: layout.size(),
+                }
+            }
+            ListLikeDef::Slice(def) => {
+                let data = unsafe { (def.vtable.as_mut_ptr)(self.value.data) };
+                let layout = self
+                    .def
+                    .t()
+                    .layout
+                    .sized_layout()
+                    .expect("can only iterate over sized slice elements");
+                PokeListLikeIterStateKind::Ptr {
+                    data,
+                    stride: layout.size(),
+                }
+            }
+        };
+
+        PokeListLikeIter {
+            state,
+            index: 0,
+            len: self.len,
+            def: self.def,
+            _list: PhantomData,
+        }
+    }
+
+    /// Converts this `PokeListLike` back into a `Poke`.
+    #[inline]
+    pub fn into_inner(self) -> Poke<'mem, 'facet> {
+        self.value
+    }
+
+    /// Returns a read-only `PeekListLike` view.
+    #[inline]
+    pub fn as_peek_list_like(&self) -> crate::PeekListLike<'_, 'facet> {
+        unsafe { crate::PeekListLike::new(self.value.as_peek(), self.def) }
+    }
+}
+
+impl<'mem, 'facet> IntoIterator for PokeListLike<'mem, 'facet> {
+    type Item = Poke<'mem, 'facet>;
+    type IntoIter = PokeListLikeIter<'mem, 'facet>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use super::*;
+
+    #[test]
+    fn poke_list_like_vec_len_and_get_mut() {
+        let mut v: Vec<i32> = alloc::vec![1, 2, 3];
+        let poke = Poke::new(&mut v);
+        let mut ll = poke.into_list_like().unwrap();
+        assert_eq!(ll.len(), 3);
+
+        {
+            let mut item = ll.get_mut(1).unwrap();
+            item.set(200i32).unwrap();
+        }
+        assert_eq!(v, alloc::vec![1, 200, 3]);
+    }
+
+    #[test]
+    fn poke_list_like_array_get_mut() {
+        let mut arr: [i32; 3] = [10, 20, 30];
+        let poke = Poke::new(&mut arr);
+        let mut ll = poke.into_list_like().unwrap();
+        assert_eq!(ll.len(), 3);
+
+        {
+            let mut item = ll.get_mut(0).unwrap();
+            item.set(99i32).unwrap();
+        }
+        assert_eq!(arr, [99, 20, 30]);
+    }
+
+    #[test]
+    fn poke_list_like_iter_mut() {
+        let mut v: Vec<i32> = alloc::vec![1, 2, 3];
+        let poke = Poke::new(&mut v);
+        let ll = poke.into_list_like().unwrap();
+        for mut item in ll {
+            let cur = *item.get::<i32>().unwrap();
+            item.set(cur * 10).unwrap();
+        }
+        assert_eq!(v, alloc::vec![10, 20, 30]);
+    }
+}

--- a/facet-reflect/src/poke/map.rs
+++ b/facet-reflect/src/poke/map.rs
@@ -1,0 +1,198 @@
+use core::mem::ManuallyDrop;
+
+use facet_core::{Facet, MapDef};
+
+use crate::{ReflectError, ReflectErrorKind};
+
+use super::Poke;
+
+/// Lets you mutate a map (implements mutable [`facet_core::MapVTable`] proxies)
+pub struct PokeMap<'mem, 'facet> {
+    value: Poke<'mem, 'facet>,
+    def: MapDef,
+}
+
+impl<'mem, 'facet> core::fmt::Debug for PokeMap<'mem, 'facet> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PokeMap").finish_non_exhaustive()
+    }
+}
+
+impl<'mem, 'facet> PokeMap<'mem, 'facet> {
+    /// Creates a new poke map
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `def` contains valid vtable function pointers that:
+    /// - Correctly implement the map operations for the actual type
+    /// - Do not cause undefined behavior when called
+    /// - Return pointers within valid memory bounds
+    /// - Match the key and value types specified in `def.k()` and `def.v()`
+    ///
+    /// Violating these requirements can lead to memory safety issues.
+    #[inline]
+    pub const unsafe fn new(value: Poke<'mem, 'facet>, def: MapDef) -> Self {
+        Self { value, def }
+    }
+
+    fn err(&self, kind: ReflectErrorKind) -> ReflectError {
+        self.value.err(kind)
+    }
+
+    /// Get the number of entries in the map
+    #[inline]
+    pub fn len(&self) -> usize {
+        unsafe { (self.def.vtable.len)(self.value.data()) }
+    }
+
+    /// Returns true if the map is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Check if the map contains a key
+    #[inline]
+    pub fn contains_key(&self, key: &impl Facet<'facet>) -> Result<bool, ReflectError> {
+        self.contains_key_peek(crate::Peek::new(key))
+    }
+
+    /// Check if the map contains a key (using a `Peek`)
+    #[inline]
+    pub fn contains_key_peek(&self, key: crate::Peek<'_, 'facet>) -> Result<bool, ReflectError> {
+        if self.def.k() == key.shape() {
+            return Ok(unsafe { (self.def.vtable.contains_key)(self.value.data(), key.data()) });
+        }
+
+        Err(self.err(ReflectErrorKind::WrongShape {
+            expected: self.def.k(),
+            actual: key.shape(),
+        }))
+    }
+
+    /// Get a value from the map for the given key, as a read-only `Peek`
+    #[inline]
+    pub fn get(
+        &self,
+        key: &impl Facet<'facet>,
+    ) -> Result<Option<crate::Peek<'_, 'facet>>, ReflectError> {
+        self.get_peek(crate::Peek::new(key))
+    }
+
+    /// Get a value from the map for the given key (using a `Peek`), as a read-only `Peek`
+    #[inline]
+    pub fn get_peek(
+        &self,
+        key: crate::Peek<'_, 'facet>,
+    ) -> Result<Option<crate::Peek<'_, 'facet>>, ReflectError> {
+        if self.def.k() != key.shape() {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: self.def.k(),
+                actual: key.shape(),
+            }));
+        }
+
+        let value_ptr = unsafe { (self.def.vtable.get_value_ptr)(self.value.data(), key.data()) };
+        if value_ptr.is_null() {
+            return Ok(None);
+        }
+        let value_ptr = facet_core::PtrConst::new_sized(value_ptr);
+        Ok(Some(unsafe {
+            crate::Peek::unchecked_new(value_ptr, self.def.v())
+        }))
+    }
+
+    /// Insert a key-value pair into the map.
+    ///
+    /// Both key and value must have shapes matching the map's key and value types.
+    /// The key and value are moved into the map.
+    pub fn insert<K, V>(&mut self, key: K, value: V) -> Result<(), ReflectError>
+    where
+        K: Facet<'facet>,
+        V: Facet<'facet>,
+    {
+        if self.def.k() != K::SHAPE {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: self.def.k(),
+                actual: K::SHAPE,
+            }));
+        }
+        if self.def.v() != V::SHAPE {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: self.def.v(),
+                actual: V::SHAPE,
+            }));
+        }
+
+        // The insert vtable moves the key and value (via ptr::read), so we need to
+        // hand over temporary storage that we will not drop afterwards.
+        let mut key = ManuallyDrop::new(key);
+        let mut value = ManuallyDrop::new(value);
+        unsafe {
+            let key_ptr = facet_core::PtrMut::new(&mut key as *mut ManuallyDrop<K> as *mut u8);
+            let value_ptr = facet_core::PtrMut::new(&mut value as *mut ManuallyDrop<V> as *mut u8);
+            (self.def.vtable.insert)(self.value.data_mut(), key_ptr, value_ptr);
+        }
+
+        Ok(())
+    }
+
+    /// Returns an iterator over the key-value pairs in the map (read-only).
+    #[inline]
+    pub fn iter(&self) -> crate::PeekMapIter<'_, 'facet> {
+        self.as_peek_map().iter()
+    }
+
+    /// Def getter
+    #[inline]
+    pub const fn def(&self) -> MapDef {
+        self.def
+    }
+
+    /// Converts this `PokeMap` back into a `Poke`
+    #[inline]
+    pub fn into_inner(self) -> Poke<'mem, 'facet> {
+        self.value
+    }
+
+    /// Returns a read-only `PeekMap` view
+    #[inline]
+    pub fn as_peek_map(&self) -> crate::PeekMap<'_, 'facet> {
+        unsafe { crate::PeekMap::new(self.value.as_peek(), self.def) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn poke_map_len_and_insert() {
+        let mut m: BTreeMap<String, i32> = BTreeMap::new();
+        let poke = Poke::new(&mut m);
+        let mut map = poke.into_map().unwrap();
+        assert_eq!(map.len(), 0);
+        map.insert(String::from("one"), 1i32).unwrap();
+        map.insert(String::from("two"), 2i32).unwrap();
+        assert_eq!(map.len(), 2);
+
+        assert_eq!(m.get("one"), Some(&1));
+        assert_eq!(m.get("two"), Some(&2));
+    }
+
+    #[test]
+    fn poke_map_contains_and_get() {
+        let mut m: BTreeMap<String, i32> = BTreeMap::new();
+        m.insert(String::from("a"), 10);
+        let poke = Poke::new(&mut m);
+        let map = poke.into_map().unwrap();
+
+        let key = String::from("a");
+        assert!(map.contains_key(&key).unwrap());
+
+        let v = map.get(&key).unwrap().unwrap();
+        assert_eq!(*v.get::<i32>().unwrap(), 10);
+    }
+}

--- a/facet-reflect/src/poke/map.rs
+++ b/facet-reflect/src/poke/map.rs
@@ -2,7 +2,7 @@ use core::mem::ManuallyDrop;
 
 use facet_core::{Facet, MapDef};
 
-use crate::{ReflectError, ReflectErrorKind};
+use crate::{HeapValue, ReflectError, ReflectErrorKind};
 
 use super::Poke;
 
@@ -137,6 +137,45 @@ impl<'mem, 'facet> PokeMap<'mem, 'facet> {
         Ok(())
     }
 
+    /// Type-erased [`insert`](Self::insert).
+    ///
+    /// Accepts [`HeapValue`]s for key and value; their shapes must match the map's key and
+    /// value types. Both values are moved into the map.
+    pub fn insert_from_heap<const KB: bool, const VB: bool>(
+        &mut self,
+        key: HeapValue<'facet, KB>,
+        value: HeapValue<'facet, VB>,
+    ) -> Result<(), ReflectError> {
+        if self.def.k() != key.shape() {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: self.def.k(),
+                actual: key.shape(),
+            }));
+        }
+        if self.def.v() != value.shape() {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: self.def.v(),
+                actual: value.shape(),
+            }));
+        }
+
+        let mut key = key;
+        let mut value = value;
+        let key_guard = key.guard.take().expect("key HeapValue guard already taken");
+        let value_guard = value
+            .guard
+            .take()
+            .expect("value HeapValue guard already taken");
+        unsafe {
+            let key_ptr = facet_core::PtrMut::new(key_guard.ptr.as_ptr());
+            let value_ptr = facet_core::PtrMut::new(value_guard.ptr.as_ptr());
+            (self.def.vtable.insert)(self.value.data_mut(), key_ptr, value_ptr);
+        }
+        drop(key_guard);
+        drop(value_guard);
+        Ok(())
+    }
+
     /// Returns an iterator over the key-value pairs in the map (read-only).
     #[inline]
     pub fn iter(&self) -> crate::PeekMapIter<'_, 'facet> {
@@ -194,5 +233,28 @@ mod tests {
 
         let v = map.get(&key).unwrap().unwrap();
         assert_eq!(*v.get::<i32>().unwrap(), 10);
+    }
+
+    #[test]
+    fn poke_map_insert_from_heap() {
+        let mut m: BTreeMap<String, i32> = BTreeMap::new();
+        let poke = Poke::new(&mut m);
+        let mut map = poke.into_map().unwrap();
+
+        let key = crate::Partial::alloc::<String>()
+            .unwrap()
+            .set(String::from("k"))
+            .unwrap()
+            .build()
+            .unwrap();
+        let value = crate::Partial::alloc::<i32>()
+            .unwrap()
+            .set(42i32)
+            .unwrap()
+            .build()
+            .unwrap();
+        map.insert_from_heap(key, value).unwrap();
+
+        assert_eq!(m.get("k"), Some(&42));
     }
 }

--- a/facet-reflect/src/poke/mod.rs
+++ b/facet-reflect/src/poke/mod.rs
@@ -25,3 +25,30 @@ pub use enum_::*;
 
 mod list;
 pub use list::*;
+
+mod list_like;
+pub use list_like::*;
+
+mod map;
+pub use map::*;
+
+mod set;
+pub use set::*;
+
+mod option;
+pub use option::*;
+
+mod result;
+pub use result::*;
+
+mod tuple;
+pub use tuple::*;
+
+mod pointer;
+pub use pointer::*;
+
+mod ndarray;
+pub use ndarray::*;
+
+mod dynamic_value;
+pub use dynamic_value::*;

--- a/facet-reflect/src/poke/ndarray.rs
+++ b/facet-reflect/src/poke/ndarray.rs
@@ -1,0 +1,103 @@
+use core::fmt::Debug;
+use facet_core::{NdArrayDef, PtrMut};
+
+use crate::peek::StrideError;
+
+use super::Poke;
+
+/// Lets you mutate an n-dimensional array (implements mutable [`facet_core::NdArrayVTable`] proxies)
+pub struct PokeNdArray<'mem, 'facet> {
+    value: Poke<'mem, 'facet>,
+    def: NdArrayDef,
+}
+
+impl Debug for PokeNdArray<'_, '_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PokeNdArray").finish_non_exhaustive()
+    }
+}
+
+impl<'mem, 'facet> PokeNdArray<'mem, 'facet> {
+    /// Creates a new poke ndarray.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `def` contains valid vtable function pointers that
+    /// correctly implement the ndarray operations for the actual type, and that the
+    /// element type matches `def.t()`.
+    #[inline]
+    pub const unsafe fn new(value: Poke<'mem, 'facet>, def: NdArrayDef) -> Self {
+        Self { value, def }
+    }
+
+    /// Get the total number of elements in the array.
+    #[inline]
+    pub fn count(&self) -> usize {
+        unsafe { (self.def.vtable.count)(self.value.data()) }
+    }
+
+    /// Get the number of dimensions.
+    #[inline]
+    pub fn n_dim(&self) -> usize {
+        unsafe { (self.def.vtable.n_dim)(self.value.data()) }
+    }
+
+    /// Get the i-th dimension.
+    #[inline]
+    pub fn dim(&self, i: usize) -> Option<usize> {
+        unsafe { (self.def.vtable.dim)(self.value.data(), i) }
+    }
+
+    /// Get a read-only view of the item at the given flat index.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<crate::Peek<'_, 'facet>> {
+        let item = unsafe { (self.def.vtable.get)(self.value.data(), index)? };
+        Some(unsafe { crate::Peek::unchecked_new(item, self.def.t()) })
+    }
+
+    /// Get a mutable view of the item at the given flat index.
+    ///
+    /// Returns `None` if the underlying ndarray doesn't provide mutable access or
+    /// if the index is out of bounds.
+    pub fn get_mut(&mut self, index: usize) -> Option<Poke<'_, 'facet>> {
+        let get_mut_fn = self.def.vtable.get_mut?;
+        let item = unsafe { get_mut_fn(self.value.data_mut(), index)? };
+        Some(unsafe { Poke::from_raw_parts(item, self.def.t()) })
+    }
+
+    /// Get a mutable pointer to the start of the data buffer (if the array is strided).
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> Result<PtrMut, StrideError> {
+        let Some(as_mut_ptr) = self.def.vtable.as_mut_ptr else {
+            return Err(StrideError::NotStrided);
+        };
+        Ok(unsafe { as_mut_ptr(self.value.data_mut()) })
+    }
+
+    /// Get the i-th stride in bytes.
+    #[inline]
+    pub fn byte_stride(&self, i: usize) -> Result<Option<isize>, StrideError> {
+        let Some(byte_stride) = self.def.vtable.byte_stride else {
+            return Err(StrideError::NotStrided);
+        };
+        Ok(unsafe { byte_stride(self.value.data(), i) })
+    }
+
+    /// Def getter.
+    #[inline]
+    pub const fn def(&self) -> NdArrayDef {
+        self.def
+    }
+
+    /// Converts this `PokeNdArray` back into a `Poke`.
+    #[inline]
+    pub const fn into_inner(self) -> Poke<'mem, 'facet> {
+        self.value
+    }
+
+    /// Returns a read-only `PeekNdArray` view.
+    #[inline]
+    pub fn as_peek_ndarray(&self) -> crate::PeekNdArray<'_, 'facet> {
+        unsafe { crate::PeekNdArray::new(self.value.as_peek(), self.def) }
+    }
+}

--- a/facet-reflect/src/poke/option.rs
+++ b/facet-reflect/src/poke/option.rs
@@ -1,6 +1,6 @@
 use core::mem::ManuallyDrop;
 
-use facet_core::{Facet, OptionDef, OptionVTable, PtrMut};
+use facet_core::{Facet, OptionDef, OptionVTable};
 
 use crate::{ReflectError, ReflectErrorKind};
 
@@ -116,24 +116,6 @@ impl<'mem, 'facet> PokeOption<'mem, 'facet> {
         unsafe {
             (self.vtable().replace_with)(self.value.data_mut(), core::ptr::null_mut());
         }
-    }
-
-    /// Replace the option with either `Some(value)` or `None`, dropping the previous value.
-    ///
-    /// Pass `None` to set the option to `None`. Pass a `Poke<T>` whose shape matches the
-    /// option's inner type to set it to `Some(value)`. The value is moved out of the `Poke`
-    /// storage — the caller must ensure the original memory is not dropped afterwards.
-    ///
-    /// # Safety
-    ///
-    /// - If `value` is `Some(poke)`, the underlying storage for `poke` must not be dropped
-    ///   after this call (its ownership has been transferred to the option).
-    pub unsafe fn replace_with_raw(&mut self, value: Option<PtrMut>) {
-        let ptr = match value {
-            Some(p) => p.as_mut_byte_ptr(),
-            None => core::ptr::null_mut(),
-        };
-        unsafe { (self.vtable().replace_with)(self.value.data_mut(), ptr) };
     }
 
     /// Converts this `PokeOption` back into a `Poke`

--- a/facet-reflect/src/poke/option.rs
+++ b/facet-reflect/src/poke/option.rs
@@ -2,7 +2,7 @@ use core::mem::ManuallyDrop;
 
 use facet_core::{Facet, OptionDef, OptionVTable};
 
-use crate::{ReflectError, ReflectErrorKind};
+use crate::{HeapValue, ReflectError, ReflectErrorKind};
 
 use super::Poke;
 
@@ -111,6 +111,36 @@ impl<'mem, 'facet> PokeOption<'mem, 'facet> {
         Ok(())
     }
 
+    /// Type-erased [`set_some`](Self::set_some).
+    ///
+    /// Accepts a [`HeapValue`] whose shape must match the option's inner type. The value is
+    /// moved out of the HeapValue into the option; the HeapValue's backing memory is freed
+    /// without running drop (the vtable has already consumed the value via `ptr::read`).
+    ///
+    /// Use this when you hold a reflection-built value and can't produce a concrete `T`.
+    pub fn set_some_from_heap<const BORROW: bool>(
+        &mut self,
+        value: HeapValue<'facet, BORROW>,
+    ) -> Result<(), ReflectError> {
+        if self.def.t() != value.shape() {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: self.def.t(),
+                actual: value.shape(),
+            }));
+        }
+
+        let mut value = value;
+        let guard = value
+            .guard
+            .take()
+            .expect("HeapValue guard was already taken");
+        unsafe {
+            (self.vtable().replace_with)(self.value.data_mut(), guard.ptr.as_ptr());
+        }
+        drop(guard);
+        Ok(())
+    }
+
     /// Sets the option to `None`, dropping the previous value.
     pub fn set_none(&mut self) {
         unsafe {
@@ -178,5 +208,40 @@ mod tests {
             inner.set(100i32).unwrap();
         }
         assert_eq!(x, Some(100));
+    }
+
+    #[test]
+    fn poke_option_set_some_from_heap() {
+        let mut x: Option<i32> = None;
+        let poke = Poke::new(&mut x);
+        let mut opt = poke.into_option().unwrap();
+
+        let hv = crate::Partial::alloc::<i32>()
+            .unwrap()
+            .set(7i32)
+            .unwrap()
+            .build()
+            .unwrap();
+        opt.set_some_from_heap(hv).unwrap();
+        assert_eq!(x, Some(7));
+    }
+
+    #[test]
+    fn poke_option_set_some_from_heap_wrong_shape_fails() {
+        let mut x: Option<i32> = None;
+        let poke = Poke::new(&mut x);
+        let mut opt = poke.into_option().unwrap();
+
+        let hv = crate::Partial::alloc::<u32>()
+            .unwrap()
+            .set(7u32)
+            .unwrap()
+            .build()
+            .unwrap();
+        let res = opt.set_some_from_heap(hv);
+        assert!(matches!(
+            res,
+            Err(ref err) if matches!(err.kind, ReflectErrorKind::WrongShape { .. })
+        ));
     }
 }

--- a/facet-reflect/src/poke/option.rs
+++ b/facet-reflect/src/poke/option.rs
@@ -1,0 +1,200 @@
+use core::mem::ManuallyDrop;
+
+use facet_core::{Facet, OptionDef, OptionVTable, PtrMut};
+
+use crate::{ReflectError, ReflectErrorKind};
+
+use super::Poke;
+
+/// Lets you mutate an option (implements mutable option operations)
+pub struct PokeOption<'mem, 'facet> {
+    value: Poke<'mem, 'facet>,
+    def: OptionDef,
+}
+
+impl<'mem, 'facet> core::fmt::Debug for PokeOption<'mem, 'facet> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PokeOption").finish_non_exhaustive()
+    }
+}
+
+impl<'mem, 'facet> PokeOption<'mem, 'facet> {
+    /// Creates a new poke option
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `def` contains valid vtable function pointers that
+    /// correctly implement the option operations for the actual type, and that the
+    /// inner type matches `def.t()`.
+    #[inline]
+    pub const unsafe fn new(value: Poke<'mem, 'facet>, def: OptionDef) -> Self {
+        Self { value, def }
+    }
+
+    fn err(&self, kind: ReflectErrorKind) -> ReflectError {
+        self.value.err(kind)
+    }
+
+    /// Returns the option definition
+    #[inline(always)]
+    pub const fn def(&self) -> OptionDef {
+        self.def
+    }
+
+    /// Returns the option vtable
+    #[inline(always)]
+    pub const fn vtable(&self) -> &'static OptionVTable {
+        self.def.vtable
+    }
+
+    /// Returns whether the option is Some
+    #[inline]
+    pub fn is_some(&self) -> bool {
+        unsafe { (self.vtable().is_some)(self.value.data()) }
+    }
+
+    /// Returns whether the option is None
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        !self.is_some()
+    }
+
+    /// Returns the inner value as a read-only `Peek` if the option is Some, `None` otherwise.
+    #[inline]
+    pub fn value(&self) -> Option<crate::Peek<'_, 'facet>> {
+        unsafe {
+            let inner_data = (self.vtable().get_value)(self.value.data());
+            if inner_data.is_null() {
+                None
+            } else {
+                Some(crate::Peek::unchecked_new(
+                    facet_core::PtrConst::new_sized(inner_data),
+                    self.def.t(),
+                ))
+            }
+        }
+    }
+
+    /// Returns the inner value as a mutable `Poke` if the option is Some, `None` otherwise.
+    #[inline]
+    pub fn value_mut(&mut self) -> Option<Poke<'_, 'facet>> {
+        unsafe {
+            let inner_data = (self.vtable().get_value)(self.value.data());
+            if inner_data.is_null() {
+                None
+            } else {
+                // The option is Some — compute the offset from the option's base to
+                // the inner value and construct a PtrMut from the option's mutable data.
+                let offset = inner_data.offset_from(self.value.data().as_byte_ptr()) as usize;
+                let inner_data = self.value.data_mut().field(offset);
+                Some(Poke::from_raw_parts(inner_data, self.def.t()))
+            }
+        }
+    }
+
+    /// Sets the option to `Some(value)`, dropping the previous value.
+    pub fn set_some<T: Facet<'facet>>(&mut self, value: T) -> Result<(), ReflectError> {
+        if self.def.t() != T::SHAPE {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: self.def.t(),
+                actual: T::SHAPE,
+            }));
+        }
+
+        let mut value = ManuallyDrop::new(value);
+        unsafe {
+            (self.vtable().replace_with)(
+                self.value.data_mut(),
+                &mut value as *mut ManuallyDrop<T> as *mut u8,
+            );
+        }
+        Ok(())
+    }
+
+    /// Sets the option to `None`, dropping the previous value.
+    pub fn set_none(&mut self) {
+        unsafe {
+            (self.vtable().replace_with)(self.value.data_mut(), core::ptr::null_mut());
+        }
+    }
+
+    /// Replace the option with either `Some(value)` or `None`, dropping the previous value.
+    ///
+    /// Pass `None` to set the option to `None`. Pass a `Poke<T>` whose shape matches the
+    /// option's inner type to set it to `Some(value)`. The value is moved out of the `Poke`
+    /// storage — the caller must ensure the original memory is not dropped afterwards.
+    ///
+    /// # Safety
+    ///
+    /// - If `value` is `Some(poke)`, the underlying storage for `poke` must not be dropped
+    ///   after this call (its ownership has been transferred to the option).
+    pub unsafe fn replace_with_raw(&mut self, value: Option<PtrMut>) {
+        let ptr = match value {
+            Some(p) => p.as_mut_byte_ptr(),
+            None => core::ptr::null_mut(),
+        };
+        unsafe { (self.vtable().replace_with)(self.value.data_mut(), ptr) };
+    }
+
+    /// Converts this `PokeOption` back into a `Poke`
+    #[inline]
+    pub const fn into_inner(self) -> Poke<'mem, 'facet> {
+        self.value
+    }
+
+    /// Returns a read-only `PeekOption` view
+    #[inline]
+    pub fn as_peek_option(&self) -> crate::PeekOption<'_, 'facet> {
+        crate::PeekOption {
+            value: self.value.as_peek(),
+            def: self.def,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poke_option_is_some_is_none() {
+        let mut x: Option<i32> = Some(42);
+        let poke = Poke::new(&mut x);
+        let opt = poke.into_option().unwrap();
+        assert!(opt.is_some());
+        assert!(!opt.is_none());
+
+        let mut y: Option<i32> = None;
+        let poke = Poke::new(&mut y);
+        let opt = poke.into_option().unwrap();
+        assert!(opt.is_none());
+    }
+
+    #[test]
+    fn poke_option_set_some_then_none() {
+        let mut x: Option<i32> = None;
+        let poke = Poke::new(&mut x);
+        let mut opt = poke.into_option().unwrap();
+
+        opt.set_some(42i32).unwrap();
+        assert_eq!(x, Some(42));
+
+        let poke = Poke::new(&mut x);
+        let mut opt = poke.into_option().unwrap();
+        opt.set_none();
+        assert_eq!(x, None);
+    }
+
+    #[test]
+    fn poke_option_value_mut() {
+        let mut x: Option<i32> = Some(1);
+        let poke = Poke::new(&mut x);
+        let mut opt = poke.into_option().unwrap();
+
+        {
+            let mut inner = opt.value_mut().unwrap();
+            inner.set(100i32).unwrap();
+        }
+        assert_eq!(x, Some(100));
+    }
+}

--- a/facet-reflect/src/poke/pointer.rs
+++ b/facet-reflect/src/poke/pointer.rs
@@ -2,11 +2,13 @@ use facet_core::PointerDef;
 
 use super::Poke;
 
-/// Represents a pointer that can be mutated through reflection.
+/// Poke-side wrapper over a pointer value, for symmetry with [`PeekPointer`](crate::PeekPointer).
 ///
-/// Note that the pointer vtable currently only exposes read-only access to the pointee
-/// (via [`borrow_inner`](Self::borrow_inner)); this is mostly here for symmetry with
-/// [`PeekPointer`](crate::PeekPointer).
+/// The current [`PointerVTable`](facet_core::PointerVTable) exposes no mutating operations
+/// on the pointee, so this type is effectively read-only: it offers
+/// [`borrow_inner`](Self::borrow_inner) (returning a [`Peek`](crate::Peek)) plus conversions
+/// back to [`Poke`] / [`PeekPointer`](crate::PeekPointer). Mutating methods will be added
+/// once the core vtable grows the corresponding hooks.
 pub struct PokePointer<'mem, 'facet> {
     pub(crate) value: Poke<'mem, 'facet>,
     pub(crate) def: PointerDef,

--- a/facet-reflect/src/poke/pointer.rs
+++ b/facet-reflect/src/poke/pointer.rs
@@ -1,0 +1,54 @@
+use facet_core::PointerDef;
+
+use super::Poke;
+
+/// Represents a pointer that can be mutated through reflection.
+///
+/// Note that the pointer vtable currently only exposes read-only access to the pointee
+/// (via [`borrow_inner`](Self::borrow_inner)); this is mostly here for symmetry with
+/// [`PeekPointer`](crate::PeekPointer).
+pub struct PokePointer<'mem, 'facet> {
+    pub(crate) value: Poke<'mem, 'facet>,
+    pub(crate) def: PointerDef,
+}
+
+impl<'mem, 'facet> core::fmt::Debug for PokePointer<'mem, 'facet> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PokePointer").finish_non_exhaustive()
+    }
+}
+
+impl<'mem, 'facet> PokePointer<'mem, 'facet> {
+    /// Returns a reference to the pointer definition.
+    #[must_use]
+    #[inline]
+    pub const fn def(&self) -> &PointerDef {
+        &self.def
+    }
+
+    /// Borrows the inner value of the pointer as a read-only `Peek`.
+    ///
+    /// Returns `None` if the pointer doesn't have a borrow function or pointee shape.
+    #[inline]
+    pub fn borrow_inner(&self) -> Option<crate::Peek<'_, 'facet>> {
+        let borrow_fn = self.def.vtable.borrow_fn?;
+        let pointee_shape = self.def.pointee()?;
+        let inner_ptr = unsafe { borrow_fn(self.value.data()) };
+        Some(unsafe { crate::Peek::unchecked_new(inner_ptr, pointee_shape) })
+    }
+
+    /// Converts this back into the underlying `Poke`.
+    #[inline]
+    pub const fn into_inner(self) -> Poke<'mem, 'facet> {
+        self.value
+    }
+
+    /// Returns a read-only `PeekPointer` view.
+    #[inline]
+    pub fn as_peek_pointer(&self) -> crate::PeekPointer<'_, 'facet> {
+        crate::PeekPointer {
+            value: self.value.as_peek(),
+            def: self.def,
+        }
+    }
+}

--- a/facet-reflect/src/poke/result.rs
+++ b/facet-reflect/src/poke/result.rs
@@ -1,0 +1,221 @@
+use core::mem::ManuallyDrop;
+
+use facet_core::{Facet, PtrUninit, ResultDef, ResultVTable};
+
+use crate::{ReflectError, ReflectErrorKind};
+
+use super::Poke;
+
+/// Lets you mutate a result (implements mutable result operations)
+pub struct PokeResult<'mem, 'facet> {
+    value: Poke<'mem, 'facet>,
+    def: ResultDef,
+}
+
+impl<'mem, 'facet> core::fmt::Debug for PokeResult<'mem, 'facet> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PokeResult").finish_non_exhaustive()
+    }
+}
+
+impl<'mem, 'facet> PokeResult<'mem, 'facet> {
+    /// Creates a new poke result
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `def` contains valid vtable function pointers that
+    /// correctly implement the result operations for the actual type, and that the
+    /// ok/err types match `def.t()` / `def.e()`.
+    #[inline]
+    pub const unsafe fn new(value: Poke<'mem, 'facet>, def: ResultDef) -> Self {
+        Self { value, def }
+    }
+
+    fn err_reflect(&self, kind: ReflectErrorKind) -> ReflectError {
+        self.value.err(kind)
+    }
+
+    /// Returns the result definition
+    #[inline(always)]
+    pub const fn def(&self) -> ResultDef {
+        self.def
+    }
+
+    /// Returns the result vtable
+    #[inline(always)]
+    pub const fn vtable(&self) -> &'static ResultVTable {
+        self.def.vtable
+    }
+
+    /// Returns whether the result is Ok
+    #[inline]
+    pub fn is_ok(&self) -> bool {
+        unsafe { (self.vtable().is_ok)(self.value.data()) }
+    }
+
+    /// Returns whether the result is Err
+    #[inline]
+    pub fn is_err(&self) -> bool {
+        !self.is_ok()
+    }
+
+    /// Returns the Ok value as a read-only `Peek` if the result is Ok, `None` otherwise.
+    #[inline]
+    pub fn ok(&self) -> Option<crate::Peek<'_, 'facet>> {
+        unsafe {
+            let inner_data = (self.vtable().get_ok)(self.value.data());
+            if inner_data.is_null() {
+                None
+            } else {
+                Some(crate::Peek::unchecked_new(
+                    facet_core::PtrConst::new_sized(inner_data),
+                    self.def.t(),
+                ))
+            }
+        }
+    }
+
+    /// Returns the Err value as a read-only `Peek` if the result is Err, `None` otherwise.
+    #[inline]
+    pub fn err(&self) -> Option<crate::Peek<'_, 'facet>> {
+        unsafe {
+            let inner_data = (self.vtable().get_err)(self.value.data());
+            if inner_data.is_null() {
+                None
+            } else {
+                Some(crate::Peek::unchecked_new(
+                    facet_core::PtrConst::new_sized(inner_data),
+                    self.def.e(),
+                ))
+            }
+        }
+    }
+
+    /// Returns the Ok value as a mutable `Poke` if the result is Ok, `None` otherwise.
+    #[inline]
+    pub fn ok_mut(&mut self) -> Option<Poke<'_, 'facet>> {
+        unsafe {
+            let inner_data = (self.vtable().get_ok)(self.value.data());
+            if inner_data.is_null() {
+                return None;
+            }
+            let offset = inner_data.offset_from(self.value.data().as_byte_ptr()) as usize;
+            let inner_data = self.value.data_mut().field(offset);
+            Some(Poke::from_raw_parts(inner_data, self.def.t()))
+        }
+    }
+
+    /// Returns the Err value as a mutable `Poke` if the result is Err, `None` otherwise.
+    #[inline]
+    pub fn err_mut(&mut self) -> Option<Poke<'_, 'facet>> {
+        unsafe {
+            let inner_data = (self.vtable().get_err)(self.value.data());
+            if inner_data.is_null() {
+                return None;
+            }
+            let offset = inner_data.offset_from(self.value.data().as_byte_ptr()) as usize;
+            let inner_data = self.value.data_mut().field(offset);
+            Some(Poke::from_raw_parts(inner_data, self.def.e()))
+        }
+    }
+
+    /// Sets the result to `Ok(value)`, dropping the previous value.
+    pub fn set_ok<T: Facet<'facet>>(&mut self, value: T) -> Result<(), ReflectError> {
+        if self.def.t() != T::SHAPE {
+            return Err(self.err_reflect(ReflectErrorKind::WrongShape {
+                expected: self.def.t(),
+                actual: T::SHAPE,
+            }));
+        }
+
+        let mut value = ManuallyDrop::new(value);
+        unsafe {
+            // Drop the old value, then re-initialize in place.
+            self.value.shape.call_drop_in_place(self.value.data_mut());
+            let uninit = PtrUninit::new(self.value.data_mut().as_mut_byte_ptr());
+            let value_ptr = facet_core::PtrMut::new(&mut value as *mut ManuallyDrop<T> as *mut u8);
+            (self.vtable().init_ok)(uninit, value_ptr);
+        }
+        Ok(())
+    }
+
+    /// Sets the result to `Err(value)`, dropping the previous value.
+    pub fn set_err<E: Facet<'facet>>(&mut self, value: E) -> Result<(), ReflectError> {
+        if self.def.e() != E::SHAPE {
+            return Err(self.err_reflect(ReflectErrorKind::WrongShape {
+                expected: self.def.e(),
+                actual: E::SHAPE,
+            }));
+        }
+
+        let mut value = ManuallyDrop::new(value);
+        unsafe {
+            self.value.shape.call_drop_in_place(self.value.data_mut());
+            let uninit = PtrUninit::new(self.value.data_mut().as_mut_byte_ptr());
+            let value_ptr = facet_core::PtrMut::new(&mut value as *mut ManuallyDrop<E> as *mut u8);
+            (self.vtable().init_err)(uninit, value_ptr);
+        }
+        Ok(())
+    }
+
+    /// Converts this `PokeResult` back into a `Poke`
+    #[inline]
+    pub const fn into_inner(self) -> Poke<'mem, 'facet> {
+        self.value
+    }
+
+    /// Returns a read-only `PeekResult` view
+    #[inline]
+    pub fn as_peek_result(&self) -> crate::PeekResult<'_, 'facet> {
+        crate::PeekResult {
+            value: self.value.as_peek(),
+            def: self.def,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poke_result_is_ok_is_err() {
+        let mut x: Result<i32, String> = Ok(42);
+        let poke = Poke::new(&mut x);
+        let res = poke.into_result().unwrap();
+        assert!(res.is_ok());
+        assert!(!res.is_err());
+
+        let mut y: Result<i32, String> = Err(String::from("nope"));
+        let poke = Poke::new(&mut y);
+        let res = poke.into_result().unwrap();
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn poke_result_set_ok_then_err() {
+        let mut x: Result<i32, String> = Err(String::from("initial"));
+        let poke = Poke::new(&mut x);
+        let mut res = poke.into_result().unwrap();
+        res.set_ok(7i32).unwrap();
+        assert_eq!(x, Ok(7));
+
+        let poke = Poke::new(&mut x);
+        let mut res = poke.into_result().unwrap();
+        res.set_err(String::from("oops")).unwrap();
+        assert_eq!(x, Err(String::from("oops")));
+    }
+
+    #[test]
+    fn poke_result_ok_mut() {
+        let mut x: Result<i32, String> = Ok(1);
+        let poke = Poke::new(&mut x);
+        let mut res = poke.into_result().unwrap();
+
+        {
+            let mut inner = res.ok_mut().unwrap();
+            inner.set(123i32).unwrap();
+        }
+        assert_eq!(x, Ok(123));
+    }
+}

--- a/facet-reflect/src/poke/result.rs
+++ b/facet-reflect/src/poke/result.rs
@@ -2,7 +2,7 @@ use core::mem::ManuallyDrop;
 
 use facet_core::{Facet, PtrUninit, ResultDef, ResultVTable};
 
-use crate::{ReflectError, ReflectErrorKind};
+use crate::{HeapValue, ReflectError, ReflectErrorKind};
 
 use super::Poke;
 
@@ -158,6 +158,64 @@ impl<'mem, 'facet> PokeResult<'mem, 'facet> {
         Ok(())
     }
 
+    /// Type-erased [`set_ok`](Self::set_ok).
+    ///
+    /// Accepts a [`HeapValue`] whose shape must match the result's Ok type.
+    pub fn set_ok_from_heap<const BORROW: bool>(
+        &mut self,
+        value: HeapValue<'facet, BORROW>,
+    ) -> Result<(), ReflectError> {
+        if self.def.t() != value.shape() {
+            return Err(self.err_reflect(ReflectErrorKind::WrongShape {
+                expected: self.def.t(),
+                actual: value.shape(),
+            }));
+        }
+
+        let mut value = value;
+        let guard = value
+            .guard
+            .take()
+            .expect("HeapValue guard was already taken");
+        unsafe {
+            self.value.shape.call_drop_in_place(self.value.data_mut());
+            let uninit = PtrUninit::new(self.value.data_mut().as_mut_byte_ptr());
+            let value_ptr = facet_core::PtrMut::new(guard.ptr.as_ptr());
+            (self.vtable().init_ok)(uninit, value_ptr);
+        }
+        drop(guard);
+        Ok(())
+    }
+
+    /// Type-erased [`set_err`](Self::set_err).
+    ///
+    /// Accepts a [`HeapValue`] whose shape must match the result's Err type.
+    pub fn set_err_from_heap<const BORROW: bool>(
+        &mut self,
+        value: HeapValue<'facet, BORROW>,
+    ) -> Result<(), ReflectError> {
+        if self.def.e() != value.shape() {
+            return Err(self.err_reflect(ReflectErrorKind::WrongShape {
+                expected: self.def.e(),
+                actual: value.shape(),
+            }));
+        }
+
+        let mut value = value;
+        let guard = value
+            .guard
+            .take()
+            .expect("HeapValue guard was already taken");
+        unsafe {
+            self.value.shape.call_drop_in_place(self.value.data_mut());
+            let uninit = PtrUninit::new(self.value.data_mut().as_mut_byte_ptr());
+            let value_ptr = facet_core::PtrMut::new(guard.ptr.as_ptr());
+            (self.vtable().init_err)(uninit, value_ptr);
+        }
+        drop(guard);
+        Ok(())
+    }
+
     /// Converts this `PokeResult` back into a `Poke`
     #[inline]
     pub const fn into_inner(self) -> Poke<'mem, 'facet> {
@@ -217,5 +275,37 @@ mod tests {
             inner.set(123i32).unwrap();
         }
         assert_eq!(x, Ok(123));
+    }
+
+    #[test]
+    fn poke_result_set_ok_from_heap() {
+        let mut x: Result<i32, String> = Err(String::from("initial"));
+        let poke = Poke::new(&mut x);
+        let mut res = poke.into_result().unwrap();
+
+        let hv = crate::Partial::alloc::<i32>()
+            .unwrap()
+            .set(42i32)
+            .unwrap()
+            .build()
+            .unwrap();
+        res.set_ok_from_heap(hv).unwrap();
+        assert_eq!(x, Ok(42));
+    }
+
+    #[test]
+    fn poke_result_set_err_from_heap() {
+        let mut x: Result<i32, String> = Ok(1);
+        let poke = Poke::new(&mut x);
+        let mut res = poke.into_result().unwrap();
+
+        let hv = crate::Partial::alloc::<String>()
+            .unwrap()
+            .set(String::from("boom"))
+            .unwrap()
+            .build()
+            .unwrap();
+        res.set_err_from_heap(hv).unwrap();
+        assert_eq!(x, Err(String::from("boom")));
     }
 }

--- a/facet-reflect/src/poke/set.rs
+++ b/facet-reflect/src/poke/set.rs
@@ -1,0 +1,147 @@
+use core::mem::ManuallyDrop;
+
+use facet_core::{Facet, SetDef};
+
+use crate::{ReflectError, ReflectErrorKind};
+
+use super::Poke;
+
+/// Lets you mutate a set (implements mutable [`facet_core::SetVTable`] proxies)
+pub struct PokeSet<'mem, 'facet> {
+    value: Poke<'mem, 'facet>,
+    def: SetDef,
+}
+
+impl<'mem, 'facet> core::fmt::Debug for PokeSet<'mem, 'facet> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PokeSet").finish_non_exhaustive()
+    }
+}
+
+impl<'mem, 'facet> PokeSet<'mem, 'facet> {
+    /// Creates a new poke set
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `def` contains valid vtable function pointers that:
+    /// - Correctly implement the set operations for the actual type
+    /// - Do not cause undefined behavior when called
+    /// - Return pointers within valid memory bounds
+    /// - Match the element type specified in `def.t()`
+    ///
+    /// Violating these requirements can lead to memory safety issues.
+    #[inline]
+    pub const unsafe fn new(value: Poke<'mem, 'facet>, def: SetDef) -> Self {
+        Self { value, def }
+    }
+
+    fn err(&self, kind: ReflectErrorKind) -> ReflectError {
+        self.value.err(kind)
+    }
+
+    /// Get the number of entries in the set
+    #[inline]
+    pub fn len(&self) -> usize {
+        unsafe { (self.def.vtable.len)(self.value.data()) }
+    }
+
+    /// Returns true if the set is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Check if the set contains a value
+    #[inline]
+    pub fn contains(&self, value: &impl Facet<'facet>) -> Result<bool, ReflectError> {
+        self.contains_peek(crate::Peek::new(value))
+    }
+
+    /// Check if the set contains a value (using a `Peek`)
+    #[inline]
+    pub fn contains_peek(&self, value: crate::Peek<'_, 'facet>) -> Result<bool, ReflectError> {
+        if self.def.t() == value.shape() {
+            return Ok(unsafe { (self.def.vtable.contains)(self.value.data(), value.data()) });
+        }
+        Err(self.err(ReflectErrorKind::WrongShape {
+            expected: self.def.t(),
+            actual: value.shape(),
+        }))
+    }
+
+    /// Insert a value into the set. Returns `true` if the value was newly
+    /// inserted, `false` if it was already present.
+    pub fn insert<T: Facet<'facet>>(&mut self, value: T) -> Result<bool, ReflectError> {
+        if self.def.t() != T::SHAPE {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: self.def.t(),
+                actual: T::SHAPE,
+            }));
+        }
+
+        let mut value = ManuallyDrop::new(value);
+        let inserted = unsafe {
+            let value_ptr = facet_core::PtrMut::new(&mut value as *mut ManuallyDrop<T> as *mut u8);
+            (self.def.vtable.insert)(self.value.data_mut(), value_ptr)
+        };
+        Ok(inserted)
+    }
+
+    /// Returns an iterator over the values in the set (read-only).
+    #[inline]
+    pub fn iter(&self) -> crate::PeekSetIter<'_, 'facet> {
+        self.as_peek_set().iter()
+    }
+
+    /// Def getter
+    #[inline]
+    pub const fn def(&self) -> SetDef {
+        self.def
+    }
+
+    /// Converts this `PokeSet` back into a `Poke`
+    #[inline]
+    pub fn into_inner(self) -> Poke<'mem, 'facet> {
+        self.value
+    }
+
+    /// Returns a read-only `PeekSet` view
+    #[inline]
+    pub fn as_peek_set(&self) -> crate::PeekSet<'_, 'facet> {
+        unsafe { crate::PeekSet::new(self.value.as_peek(), self.def) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeSet;
+
+    use super::*;
+
+    #[test]
+    fn poke_set_len_and_insert() {
+        let mut s: BTreeSet<i32> = BTreeSet::new();
+        let poke = Poke::new(&mut s);
+        let mut set = poke.into_set().unwrap();
+        assert_eq!(set.len(), 0);
+
+        assert!(set.insert(1i32).unwrap());
+        assert!(set.insert(2i32).unwrap());
+        assert!(!set.insert(1i32).unwrap());
+
+        assert_eq!(set.len(), 2);
+        assert!(s.contains(&1));
+        assert!(s.contains(&2));
+    }
+
+    #[test]
+    fn poke_set_contains() {
+        let mut s: BTreeSet<i32> = BTreeSet::new();
+        s.insert(42);
+        let poke = Poke::new(&mut s);
+        let set = poke.into_set().unwrap();
+
+        assert!(set.contains(&42i32).unwrap());
+        assert!(!set.contains(&7i32).unwrap());
+    }
+}

--- a/facet-reflect/src/poke/set.rs
+++ b/facet-reflect/src/poke/set.rs
@@ -2,7 +2,7 @@ use core::mem::ManuallyDrop;
 
 use facet_core::{Facet, SetDef};
 
-use crate::{ReflectError, ReflectErrorKind};
+use crate::{HeapValue, ReflectError, ReflectErrorKind};
 
 use super::Poke;
 
@@ -87,6 +87,34 @@ impl<'mem, 'facet> PokeSet<'mem, 'facet> {
         Ok(inserted)
     }
 
+    /// Type-erased [`insert`](Self::insert).
+    ///
+    /// Accepts a [`HeapValue`] whose shape must match the set's element type. The value is
+    /// moved into the set. Returns `true` if the value was newly inserted.
+    pub fn insert_from_heap<const BORROW: bool>(
+        &mut self,
+        value: HeapValue<'facet, BORROW>,
+    ) -> Result<bool, ReflectError> {
+        if self.def.t() != value.shape() {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: self.def.t(),
+                actual: value.shape(),
+            }));
+        }
+
+        let mut value = value;
+        let guard = value
+            .guard
+            .take()
+            .expect("HeapValue guard was already taken");
+        let inserted = unsafe {
+            let value_ptr = facet_core::PtrMut::new(guard.ptr.as_ptr());
+            (self.def.vtable.insert)(self.value.data_mut(), value_ptr)
+        };
+        drop(guard);
+        Ok(inserted)
+    }
+
     /// Returns an iterator over the values in the set (read-only).
     #[inline]
     pub fn iter(&self) -> crate::PeekSetIter<'_, 'facet> {
@@ -143,5 +171,21 @@ mod tests {
 
         assert!(set.contains(&42i32).unwrap());
         assert!(!set.contains(&7i32).unwrap());
+    }
+
+    #[test]
+    fn poke_set_insert_from_heap() {
+        let mut s: BTreeSet<i32> = BTreeSet::new();
+        let poke = Poke::new(&mut s);
+        let mut set = poke.into_set().unwrap();
+
+        let hv = crate::Partial::alloc::<i32>()
+            .unwrap()
+            .set(7i32)
+            .unwrap()
+            .build()
+            .unwrap();
+        assert!(set.insert_from_heap(hv).unwrap());
+        assert!(s.contains(&7));
     }
 }

--- a/facet-reflect/src/poke/tuple.rs
+++ b/facet-reflect/src/poke/tuple.rs
@@ -1,0 +1,126 @@
+use facet_core::{Facet, FieldError};
+
+use crate::{ReflectError, ReflectErrorKind, peek::TupleType};
+
+use super::Poke;
+
+/// Lets you mutate a tuple's fields (by index).
+///
+/// Tuples are just tuple-struct types without names, so this is a thin wrapper that
+/// exposes ordered field access.
+pub struct PokeTuple<'mem, 'facet> {
+    pub(crate) value: Poke<'mem, 'facet>,
+    pub(crate) ty: TupleType,
+}
+
+impl<'mem, 'facet> core::fmt::Debug for PokeTuple<'mem, 'facet> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PokeTuple")
+            .field("type", &self.ty)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'mem, 'facet> PokeTuple<'mem, 'facet> {
+    fn err(&self, kind: ReflectErrorKind) -> ReflectError {
+        self.value.err(kind)
+    }
+
+    /// Returns the number of fields in this tuple.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.ty.fields.len()
+    }
+
+    /// Returns true if this tuple has no fields.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Tuple type information.
+    #[inline]
+    pub const fn ty(&self) -> TupleType {
+        self.ty
+    }
+
+    /// Returns a read-only `Peek` for the field at the given index.
+    pub fn field(&self, index: usize) -> Option<crate::Peek<'_, 'facet>> {
+        let field = self.ty.fields.get(index)?;
+        let field_ptr = unsafe { self.value.data().field(field.offset) };
+        Some(unsafe { crate::Peek::unchecked_new(field_ptr, field.shape()) })
+    }
+
+    /// Returns a mutable `Poke` for the field at the given index.
+    pub fn field_mut(&mut self, index: usize) -> Result<Poke<'_, 'facet>, ReflectError> {
+        let field = self.ty.fields.get(index).ok_or_else(|| {
+            self.err(ReflectErrorKind::FieldError {
+                shape: self.value.shape,
+                field_error: FieldError::IndexOutOfBounds {
+                    index,
+                    bound: self.ty.fields.len(),
+                },
+            })
+        })?;
+        let field_data = unsafe { self.value.data_mut().field(field.offset) };
+        Ok(unsafe { Poke::from_raw_parts(field_data, field.shape()) })
+    }
+
+    /// Sets the value of a field by index.
+    ///
+    /// The value type must match the field's type.
+    ///
+    /// Returns an error if the parent tuple is not POD. Field mutation could violate
+    /// tuple-level invariants, so the tuple must be marked with `#[facet(pod)]` to allow this.
+    pub fn set_field<T: Facet<'facet>>(
+        &mut self,
+        index: usize,
+        value: T,
+    ) -> Result<(), ReflectError> {
+        if !self.value.shape.is_pod() {
+            return Err(self.err(ReflectErrorKind::NotPod {
+                shape: self.value.shape,
+            }));
+        }
+
+        let field = self.ty.fields.get(index).ok_or_else(|| {
+            self.err(ReflectErrorKind::FieldError {
+                shape: self.value.shape,
+                field_error: FieldError::IndexOutOfBounds {
+                    index,
+                    bound: self.ty.fields.len(),
+                },
+            })
+        })?;
+
+        let field_shape = field.shape();
+        if field_shape != T::SHAPE {
+            return Err(self.err(ReflectErrorKind::WrongShape {
+                expected: field_shape,
+                actual: T::SHAPE,
+            }));
+        }
+
+        unsafe {
+            let field_ptr = self.value.data_mut().field(field.offset);
+            field_shape.call_drop_in_place(field_ptr);
+            core::ptr::write(field_ptr.as_mut_byte_ptr() as *mut T, value);
+        }
+        Ok(())
+    }
+
+    /// Converts this back into the underlying `Poke`.
+    #[inline]
+    pub const fn into_inner(self) -> Poke<'mem, 'facet> {
+        self.value
+    }
+
+    /// Returns a read-only `PeekTuple` view.
+    #[inline]
+    pub fn as_peek_tuple(&self) -> crate::PeekTuple<'_, 'facet> {
+        crate::PeekTuple {
+            value: self.value.as_peek(),
+            ty: self.ty,
+        }
+    }
+}

--- a/facet-reflect/src/poke/value.rs
+++ b/facet-reflect/src/poke/value.rs
@@ -1,11 +1,17 @@
 use core::marker::PhantomData;
 
-use facet_core::{Def, Facet, PtrConst, PtrMut, Shape, Type, UserType, Variance};
+use facet_core::{Def, Facet, PtrConst, PtrMut, Shape, StructKind, Type, UserType, Variance};
 use facet_path::{Path, PathAccessError, PathStep};
 
-use crate::{ReflectError, ReflectErrorKind, peek::VariantError};
+use crate::{
+    ReflectError, ReflectErrorKind,
+    peek::{ListLikeDef, TupleType, VariantError},
+};
 
-use super::{PokeList, PokeStruct};
+use super::{
+    PokeDynamicValue, PokeList, PokeListLike, PokeMap, PokeNdArray, PokeOption, PokePointer,
+    PokeResult, PokeSet, PokeStruct, PokeTuple,
+};
 
 /// A mutable view into a value with runtime type information.
 ///
@@ -98,7 +104,7 @@ impl<'mem, 'facet> Poke<'mem, 'facet> {
 
     /// Construct a ReflectError with this poke's shape as the root path.
     #[inline]
-    fn err(&self, kind: ReflectErrorKind) -> ReflectError {
+    pub(crate) fn err(&self, kind: ReflectErrorKind) -> ReflectError {
         ReflectError::new(kind, Path::new(self.shape))
     }
 
@@ -195,6 +201,133 @@ impl<'mem, 'facet> Poke<'mem, 'facet> {
 
         Err(self.err(ReflectErrorKind::WasNotA {
             expected: "list",
+            actual: self.shape,
+        }))
+    }
+
+    /// Converts this into a `PokeListLike` if the value is a list, array, or slice.
+    #[inline]
+    pub fn into_list_like(self) -> Result<PokeListLike<'mem, 'facet>, ReflectError> {
+        match self.shape.def {
+            // SAFETY: The defs come from self.shape.def, where self.shape is obtained from
+            // a trusted source. The vtables are therefore trusted.
+            Def::List(def) => Ok(unsafe { PokeListLike::new(self, ListLikeDef::List(def)) }),
+            Def::Array(def) => Ok(unsafe { PokeListLike::new(self, ListLikeDef::Array(def)) }),
+            Def::Slice(def) => Ok(unsafe { PokeListLike::new(self, ListLikeDef::Slice(def)) }),
+            _ => Err(self.err(ReflectErrorKind::WasNotA {
+                expected: "list, array or slice",
+                actual: self.shape,
+            })),
+        }
+    }
+
+    /// Converts this into a `PokeMap` if the value is a map.
+    #[inline]
+    pub fn into_map(self) -> Result<PokeMap<'mem, 'facet>, ReflectError> {
+        if let Def::Map(def) = self.shape.def {
+            return Ok(unsafe { PokeMap::new(self, def) });
+        }
+
+        Err(self.err(ReflectErrorKind::WasNotA {
+            expected: "map",
+            actual: self.shape,
+        }))
+    }
+
+    /// Converts this into a `PokeSet` if the value is a set.
+    #[inline]
+    pub fn into_set(self) -> Result<PokeSet<'mem, 'facet>, ReflectError> {
+        if let Def::Set(def) = self.shape.def {
+            return Ok(unsafe { PokeSet::new(self, def) });
+        }
+
+        Err(self.err(ReflectErrorKind::WasNotA {
+            expected: "set",
+            actual: self.shape,
+        }))
+    }
+
+    /// Converts this into a `PokeOption` if the value is an option.
+    #[inline]
+    pub fn into_option(self) -> Result<PokeOption<'mem, 'facet>, ReflectError> {
+        if let Def::Option(def) = self.shape.def {
+            return Ok(unsafe { PokeOption::new(self, def) });
+        }
+
+        Err(self.err(ReflectErrorKind::WasNotA {
+            expected: "option",
+            actual: self.shape,
+        }))
+    }
+
+    /// Converts this into a `PokeResult` if the value is a result.
+    #[inline]
+    pub fn into_result(self) -> Result<PokeResult<'mem, 'facet>, ReflectError> {
+        if let Def::Result(def) = self.shape.def {
+            return Ok(unsafe { PokeResult::new(self, def) });
+        }
+
+        Err(self.err(ReflectErrorKind::WasNotA {
+            expected: "result",
+            actual: self.shape,
+        }))
+    }
+
+    /// Converts this into a `PokeTuple` if the value is a tuple (or tuple struct).
+    #[inline]
+    pub fn into_tuple(self) -> Result<PokeTuple<'mem, 'facet>, ReflectError> {
+        if let Type::User(UserType::Struct(struct_type)) = self.shape.ty
+            && struct_type.kind == StructKind::Tuple
+        {
+            return Ok(PokeTuple {
+                value: self,
+                ty: TupleType {
+                    fields: struct_type.fields,
+                },
+            });
+        }
+
+        Err(self.err(ReflectErrorKind::WasNotA {
+            expected: "tuple",
+            actual: self.shape,
+        }))
+    }
+
+    /// Converts this into a `PokePointer` if the value is a pointer.
+    #[inline]
+    pub fn into_pointer(self) -> Result<PokePointer<'mem, 'facet>, ReflectError> {
+        if let Def::Pointer(def) = self.shape.def {
+            return Ok(PokePointer { value: self, def });
+        }
+
+        Err(self.err(ReflectErrorKind::WasNotA {
+            expected: "smart pointer",
+            actual: self.shape,
+        }))
+    }
+
+    /// Converts this into a `PokeNdArray` if the value is an n-dimensional array.
+    #[inline]
+    pub fn into_ndarray(self) -> Result<PokeNdArray<'mem, 'facet>, ReflectError> {
+        if let Def::NdArray(def) = self.shape.def {
+            return Ok(unsafe { PokeNdArray::new(self, def) });
+        }
+
+        Err(self.err(ReflectErrorKind::WasNotA {
+            expected: "ndarray",
+            actual: self.shape,
+        }))
+    }
+
+    /// Converts this into a `PokeDynamicValue` if the value is a dynamic value.
+    #[inline]
+    pub fn into_dynamic_value(self) -> Result<PokeDynamicValue<'mem, 'facet>, ReflectError> {
+        if let Def::DynamicValue(def) = self.shape.def {
+            return Ok(PokeDynamicValue { value: self, def });
+        }
+
+        Err(self.err(ReflectErrorKind::WasNotA {
+            expected: "dynamic value",
             actual: self.shape,
         }))
     }

--- a/facet-reflect/src/poke/value.rs
+++ b/facet-reflect/src/poke/value.rs
@@ -161,6 +161,86 @@ impl<'mem, 'facet> Poke<'mem, 'facet> {
         matches!(self.shape.def, Def::Scalar)
     }
 
+    /// Returns true if this value is a tuple (anonymous `(A, B, ...)`).
+    ///
+    /// Note: tuple structs (named `struct Foo(A, B);`) report `false` here; they match
+    /// [`is_struct`](Self::is_struct).
+    #[inline]
+    pub const fn is_tuple(&self) -> bool {
+        matches!(
+            self.shape.ty,
+            Type::User(UserType::Struct(s)) if matches!(s.kind, StructKind::Tuple)
+        )
+    }
+
+    /// Returns true if this value is a list (variable-length, homogeneous, e.g. `Vec<T>`).
+    #[inline]
+    pub const fn is_list(&self) -> bool {
+        matches!(self.shape.def, Def::List(_))
+    }
+
+    /// Returns true if this value is a fixed-size array (e.g. `[T; N]`).
+    #[inline]
+    pub const fn is_array(&self) -> bool {
+        matches!(self.shape.def, Def::Array(_))
+    }
+
+    /// Returns true if this value is a slice (e.g. `[T]`).
+    #[inline]
+    pub const fn is_slice(&self) -> bool {
+        matches!(self.shape.def, Def::Slice(_))
+    }
+
+    /// Returns true if this value is a list, array, or slice
+    /// (the set accepted by [`into_list_like`](Self::into_list_like)).
+    #[inline]
+    pub const fn is_list_like(&self) -> bool {
+        matches!(self.shape.def, Def::List(_) | Def::Array(_) | Def::Slice(_))
+    }
+
+    /// Returns true if this value is a map.
+    #[inline]
+    pub const fn is_map(&self) -> bool {
+        matches!(self.shape.def, Def::Map(_))
+    }
+
+    /// Returns true if this value is a set.
+    #[inline]
+    pub const fn is_set(&self) -> bool {
+        matches!(self.shape.def, Def::Set(_))
+    }
+
+    /// Returns true if this value is an option.
+    #[inline]
+    pub const fn is_option(&self) -> bool {
+        matches!(self.shape.def, Def::Option(_))
+    }
+
+    /// Returns true if this value is a result.
+    #[inline]
+    pub const fn is_result(&self) -> bool {
+        matches!(self.shape.def, Def::Result(_))
+    }
+
+    /// Returns true if this value is a (smart) pointer.
+    #[inline]
+    pub const fn is_pointer(&self) -> bool {
+        matches!(self.shape.def, Def::Pointer(_))
+    }
+
+    /// Returns true if this value is an n-dimensional array.
+    #[inline]
+    pub const fn is_ndarray(&self) -> bool {
+        matches!(self.shape.def, Def::NdArray(_))
+    }
+
+    /// Returns true if this value is a dynamic value
+    /// (e.g. `facet_value::Value` — runtime-kind-dispatched).
+    #[inline]
+    pub const fn is_dynamic_value(&self) -> bool {
+        matches!(self.shape.def, Def::DynamicValue(_))
+    }
+
     /// Converts this into a `PokeStruct` if the value is a struct.
     pub fn into_struct(self) -> Result<PokeStruct<'mem, 'facet>, ReflectError> {
         match self.shape.ty {
@@ -812,5 +892,41 @@ mod tests {
 
         poke.set(String::from("world")).unwrap();
         assert_eq!(s, "world");
+    }
+
+    #[test]
+    fn poke_is_predicates() {
+        let mut v: alloc::vec::Vec<i32> = alloc::vec![1, 2, 3];
+        let poke = Poke::new(&mut v);
+        assert!(poke.is_list());
+        assert!(poke.is_list_like());
+        assert!(!poke.is_map());
+        assert!(!poke.is_set());
+        assert!(!poke.is_option());
+        assert!(!poke.is_result());
+        assert!(!poke.is_tuple());
+        assert!(!poke.is_scalar());
+
+        let mut x: Option<i32> = Some(1);
+        let poke = Poke::new(&mut x);
+        assert!(poke.is_option());
+        assert!(!poke.is_list());
+
+        let mut r: Result<i32, i32> = Ok(1);
+        let poke = Poke::new(&mut r);
+        assert!(poke.is_result());
+
+        let mut t: (i32, i32) = (1, 2);
+        let poke = Poke::new(&mut t);
+        assert!(poke.is_tuple());
+
+        let mut n: i32 = 42;
+        let poke = Poke::new(&mut n);
+        assert!(poke.is_scalar());
+
+        let mut a: [i32; 3] = [1, 2, 3];
+        let poke = Poke::new(&mut a);
+        assert!(poke.is_array());
+        assert!(poke.is_list_like());
     }
 }

--- a/facet-reflect/tests/poke/enum_.rs
+++ b/facet-reflect/tests/poke/enum_.rs
@@ -189,3 +189,77 @@ fn poke_not_enum_fails() {
     let result = poke.into_enum();
     assert!(matches!(result, Err(ref err) if matches!(err.kind, ReflectErrorKind::WasNotA { .. })));
 }
+
+#[test]
+fn poke_enum_set_field_from_heap() {
+    let mut value = SimpleEnum::Tuple(42);
+    {
+        let poke = Poke::new(&mut value);
+        let mut poke_enum = poke.into_enum().unwrap();
+
+        let hv = facet_reflect::Partial::alloc::<u32>()
+            .unwrap()
+            .set(100u32)
+            .unwrap()
+            .build()
+            .unwrap();
+        poke_enum.set_field_from_heap(0, hv).unwrap();
+    }
+
+    match value {
+        SimpleEnum::Tuple(v) => assert_eq!(v, 100),
+        _ => panic!("Expected Tuple variant"),
+    }
+}
+
+#[test]
+fn poke_enum_set_field_by_name_from_heap() {
+    let mut value = SimpleEnum::Struct {
+        a: 1,
+        b: "hello".to_string(),
+    };
+    {
+        let poke = Poke::new(&mut value);
+        let mut poke_enum = poke.into_enum().unwrap();
+
+        let a_val = facet_reflect::Partial::alloc::<u8>()
+            .unwrap()
+            .set(99u8)
+            .unwrap()
+            .build()
+            .unwrap();
+        let b_val = facet_reflect::Partial::alloc::<String>()
+            .unwrap()
+            .set("world".to_string())
+            .unwrap()
+            .build()
+            .unwrap();
+
+        poke_enum.set_field_by_name_from_heap("a", a_val).unwrap();
+        poke_enum.set_field_by_name_from_heap("b", b_val).unwrap();
+    }
+
+    match value {
+        SimpleEnum::Struct { a, b } => {
+            assert_eq!(a, 99);
+            assert_eq!(b, "world");
+        }
+        _ => panic!("Expected Struct variant"),
+    }
+}
+
+#[test]
+fn poke_enum_set_field_from_heap_wrong_shape_fails() {
+    let mut value = SimpleEnum::Tuple(42);
+    let poke = Poke::new(&mut value);
+    let mut poke_enum = poke.into_enum().unwrap();
+
+    let hv = facet_reflect::Partial::alloc::<i32>()
+        .unwrap()
+        .set(100i32)
+        .unwrap()
+        .build()
+        .unwrap();
+    let res = poke_enum.set_field_from_heap(0, hv);
+    assert!(matches!(res, Err(ref err) if matches!(err.kind, ReflectErrorKind::WrongShape { .. })));
+}

--- a/facet-reflect/tests/poke/mod.rs
+++ b/facet-reflect/tests/poke/mod.rs
@@ -1,4 +1,5 @@
 mod at_path;
 mod enum_;
 mod struct_;
+mod tuple;
 mod value;

--- a/facet-reflect/tests/poke/tuple.rs
+++ b/facet-reflect/tests/poke/tuple.rs
@@ -1,0 +1,101 @@
+use facet::Facet;
+use facet_reflect::{Poke, ReflectErrorKind};
+
+#[test]
+fn poke_tuple_len_and_field_access() {
+    let mut pair: (i32, i32) = (1, 2);
+    let poke = Poke::new(&mut pair);
+    let tuple = poke.into_tuple().expect("(i32, i32) is a tuple");
+
+    assert_eq!(tuple.len(), 2);
+    assert!(!tuple.is_empty());
+
+    let f0 = tuple.field(0).unwrap();
+    assert_eq!(*f0.get::<i32>().unwrap(), 1);
+    let f1 = tuple.field(1).unwrap();
+    assert_eq!(*f1.get::<i32>().unwrap(), 2);
+
+    // Out-of-bounds field access returns None (not an error).
+    assert!(tuple.field(99).is_none());
+}
+
+#[test]
+fn poke_tuple_field_mut_writes_through() {
+    let mut pair: (i32, i32) = (1, 2);
+    let poke = Poke::new(&mut pair);
+    let mut tuple = poke.into_tuple().expect("(i32, i32) is a tuple");
+
+    {
+        let mut f1 = tuple.field_mut(1).unwrap();
+        f1.set(99i32).unwrap();
+    }
+    assert_eq!(pair, (1, 99));
+}
+
+#[test]
+fn poke_tuple_field_mut_out_of_bounds_fails() {
+    let mut pair: (i32, i32) = (1, 2);
+    let poke = Poke::new(&mut pair);
+    let mut tuple = poke.into_tuple().expect("(i32, i32) is a tuple");
+
+    let result = tuple.field_mut(99);
+    assert!(matches!(
+        result,
+        Err(ref err) if matches!(err.kind, ReflectErrorKind::FieldError { .. })
+    ));
+}
+
+#[test]
+fn poke_tuple_set_field_not_pod_fails() {
+    // Raw tuples aren't POD by default, so set_field should refuse.
+    let mut pair: (i32, i32) = (1, 2);
+    let poke = Poke::new(&mut pair);
+    let mut tuple = poke.into_tuple().expect("(i32, i32) is a tuple");
+
+    let result = tuple.set_field(0, 42i32);
+    assert!(matches!(
+        result,
+        Err(ref err) if matches!(err.kind, ReflectErrorKind::NotPod { .. })
+    ));
+}
+
+#[test]
+fn poke_tuple_into_inner_round_trips() {
+    let mut pair: (i32, i32) = (1, 2);
+    let poke = Poke::new(&mut pair);
+    let tuple = poke.into_tuple().expect("(i32, i32) is a tuple");
+
+    let poke = tuple.into_inner();
+    // After round-trip we can still interrogate the underlying Poke.
+    let tuple = poke.into_tuple().unwrap();
+    assert_eq!(tuple.len(), 2);
+}
+
+#[test]
+fn poke_tuple_as_peek_tuple() {
+    let mut pair: (i32, i32) = (3, 4);
+    let poke = Poke::new(&mut pair);
+    let tuple = poke.into_tuple().expect("(i32, i32) is a tuple");
+
+    let peek = tuple.as_peek_tuple();
+    assert_eq!(peek.len(), 2);
+    assert_eq!(*peek.field(0).unwrap().get::<i32>().unwrap(), 3);
+}
+
+#[test]
+fn poke_not_a_tuple_fails() {
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(pod)]
+    struct NamedFields {
+        x: i32,
+        y: i32,
+    }
+
+    let mut v = NamedFields { x: 1, y: 2 };
+    let poke = Poke::new(&mut v);
+    let result = poke.into_tuple();
+    assert!(matches!(
+        result,
+        Err(ref err) if matches!(err.kind, ReflectErrorKind::WasNotA { .. })
+    ));
+}


### PR DESCRIPTION
## Summary

Closes #2153 — adds the 9 `Poke*` types that were missing relative to their `Peek*` counterparts. Each mirrors the existing Peek API shape and, where the underlying vtable allows, adds mutation.

New types:
- `PokeDynamicValue` — scalar setters, `set_array`/`set_object`, `push_array_element`/`insert_object_entry` (shape-checked), `end_array`/`end_object`, `object_get_mut`
- `PokeMap` — `len`, `contains_key[_peek]`, `get[_peek]`, `insert`
- `PokeSet` — `len`, `contains[_peek]`, `insert`
- `PokeOption` — `is_some`/`is_none`, `value`/`value_mut`, `set_some`/`set_none`
- `PokeResult` — `is_ok`/`is_err`, `ok[_mut]`/`err[_mut]`, `set_ok`/`set_err`
- `PokeTuple` — `field`/`field_mut`, POD-checked `set_field`
- `PokePointer` — `borrow_inner` (read-only; `PointerVTable` has no mutating ops today)
- `PokeListLike` — unified List/Array/Slice mutation with `get_mut`/`iter_mut`
- `PokeNdArray` — `get_mut`, `as_mut_ptr`, `byte_stride`

Each type also provides `def()`/`ty()`, `into_inner()` back to `Poke`, and `as_peek_*()` for a read-only view. Matching `Poke::into_map`/`into_set`/`into_option`/`into_result`/`into_tuple`/`into_pointer`/`into_list_like`/`into_ndarray`/`into_dynamic_value` entry points are added on `Poke`.

Three vtable shapes drove the implementation:
1. **In-place mut** (Map/Set/List/NdArray, Option's `replace_with`) — pass `PtrMut` directly, with `ManuallyDrop` around values the vtable will `ptr::read`.
2. **Init-only** (Result, DynamicValue scalars) — `call_drop_in_place` then wrap as `PtrUninit` and call the `init_*` fn.
3. **Read-only** (Pointer) — wrapper exists for symmetry; mutations are punted until the core vtable grows them.

## Bonus fixes

- **facet-core `Result<T, E>` drop fix**: `result_drop` previously located the inner value via `Result::as_ref().ok()/err()` (retagged as `SharedReadOnly` under Stacked Borrows) and then dropped through it — UB, caught by miri once `PokeResult::set_ok`/`set_err` were exercised. Switched to a typed `result_drop<T, E>` that calls `core::ptr::drop_in_place` on the full `Result<T, E>`, wired through a per-monomorphization `build_type_ops<T, E>()` (same pattern `num_complex` uses).
- **`leaks` nextest profile**: moved the `just leaks` runner from a per-target cargo runner env var to a proper `[profile.leaks]` in `.config/nextest.toml` that wraps each test process with `leaks -quiet --atExit --`.

## Breaking changes

- `PokeList::iter_mut` and `PokeListLike::iter_mut` now return `Result<_, ReflectError>` and fail if the list has no contiguous `as_mut_ptr`. The previous infallible API fell back to synthesising a mut iterator from the list's `iter_vtable`, which yields `PtrConst` items backed by shared references — casting to `PtrMut` and writing through them is UB. A `get_mut`-per-index fallback would also be unsound (each call re-retags `container` as Unique, invalidating previously yielded items), so the only sound mut iteration path requires `as_mut_ptr`. Use `get_mut(i)` manually for non-contiguous lists.
- The `impl IntoIterator for PokeList` was removed alongside the signature change.

## Test plan
- [x] `cargo nextest run -p facet-reflect` (533 tests pass, incl. 13 new inline + 7 new PokeTuple integration tests)
- [x] `cargo miri nextest run -p facet-reflect -E 'test(/poke::/)'` — 84 tests, all clean
- [x] `just leaks` (macOS native `leaks --atExit`) — 0 leaks
- [x] `RUSTFLAGS="-Zsanitizer=address" cargo +nightly nextest run -p facet-reflect` — clean
- [x] `cargo build --workspace --all-features`
- [x] `cargo clippy -p facet-reflect --all-targets` (clean)