### PR TITLE
chore: sync all companion crates to v0.46.0 in one version group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "autocfg",
  "bytes",
@@ -587,21 +587,21 @@ dependencies = [
 
 [[package]]
 name = "facet-default"
-version = "0.44.6"
+version = "0.46.0"
 dependencies = [
  "facet",
 ]
 
 [[package]]
 name = "facet-error"
-version = "0.44.6"
+version = "0.46.0"
 dependencies = [
  "facet",
 ]
 
 [[package]]
 name = "facet-macro-parse"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-types"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -619,14 +619,14 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "facet-macros-impl",
 ]
 
 [[package]]
 name = "facet-macros-impl"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "facet-path"
-version = "0.44.5"
+version = "0.46.0"
 dependencies = [
  "facet",
  "facet-core",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "facet-pretty"
-version = "0.44.7"
+version = "0.46.0"
 dependencies = [
  "camino",
  "facet",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "facet-reflect"
-version = "0.44.6"
+version = "0.46.0"
 dependencies = [
  "camino",
  "eyre",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "facet-solver"
-version = "0.44.6"
+version = "0.46.0"
 dependencies = [
  "divan",
  "facet",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "facet-testhelpers"
-version = "0.44.3"
+version = "0.46.0"
 dependencies = [
  "color-backtrace",
  "facet-testhelpers-macros",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "facet-testhelpers-macros"
-version = "0.44.3"
+version = "0.46.0"
 dependencies = [
  "quote",
  "unsynn",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "facet-urlencoded"
-version = "0.44.6"
+version = "0.46.0"
 dependencies = [
  "axum-core",
  "facet",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "facet-validate"
-version = "0.44.6"
+version = "0.46.0"
 dependencies = [
  "facet",
  "facet-core",

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-core"
-version = "0.45.0"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/facet-default/Cargo.toml
+++ b/facet-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-default"
-version = "0.44.6"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,7 +15,7 @@ categories = ["rust-patterns", "development-tools"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { path = "../facet", version = "0.45.0" }
+facet = { path = "../facet", version = "0.46.0" }
 
 [dev-dependencies]
 facet = { path = "../facet" }

--- a/facet-error/Cargo.toml
+++ b/facet-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-error"
-version = "0.44.6"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,7 +15,7 @@ categories = ["rust-patterns", "development-tools"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { path = "../facet", version = "0.45.0" }
+facet = { path = "../facet", version = "0.46.0" }
 
 [dev-dependencies]
 facet = { path = "../facet" }

--- a/facet-macro-parse/Cargo.toml
+++ b/facet-macro-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-macro-parse"
-version = "0.45.0"
+version = "0.46.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ homepage = "https://facet.rs"
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet-macro-types = { version = "0.45.0", path = "../facet-macro-types" }
+facet-macro-types = { version = "0.46.0", path = "../facet-macro-types" }
 proc-macro2 = "1"
 quote = { workspace = true }
 

--- a/facet-macro-types/Cargo.toml
+++ b/facet-macro-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-macro-types"
-version = "0.45.0"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/facet-macros-impl/Cargo.toml
+++ b/facet-macros-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-macros-impl"
-version = "0.45.0"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -30,8 +30,8 @@ doc = []
 helpful-derive = ["dep:strsim"]
 
 [dependencies]
-facet-macro-parse = { version = "0.45.0", path = "../facet-macro-parse" }
-facet-macro-types = { version = "0.45.0", path = "../facet-macro-types" }
+facet-macro-parse = { version = "0.46.0", path = "../facet-macro-parse" }
+facet-macro-types = { version = "0.46.0", path = "../facet-macro-types" }
 proc-macro2 = "1.0.95"
 quote = { workspace = true }
 strsim = { workspace = true, optional = true }

--- a/facet-macros/Cargo.toml
+++ b/facet-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-macros"
-version = "0.45.0"
+version = "0.46.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true
@@ -31,7 +31,7 @@ doc = ["facet-macros-impl/doc"]
 helpful-derive = ["facet-macros-impl/helpful-derive"]
 
 [dependencies]
-facet-macros-impl = { version = "0.45.0", path = "../facet-macros-impl", default-features = false }
+facet-macros-impl = { version = "0.46.0", path = "../facet-macros-impl", default-features = false }
 
 # cf. https://hachyderm.io/@epage/114141126315983016
 [target.'cfg(any())'.dependencies]

--- a/facet-path/Cargo.toml
+++ b/facet-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-path"
-version = "0.44.5"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -22,7 +22,7 @@ std = ["alloc", "facet-core/std"]
 alloc = ["facet-core/alloc"]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.45.0", default-features = false }
+facet-core = { path = "../facet-core", version = "0.46.0", default-features = false }
 
 [dev-dependencies]
 facet = { path = "../facet" }

--- a/facet-pretty/Cargo.toml
+++ b/facet-pretty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-pretty"
-version = "0.44.7"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -24,8 +24,8 @@ alloc = ["facet-core/alloc", "facet-reflect/alloc"] # Enables alloc support
 camino = ["alloc", "facet-core/camino"]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.45.0" }
-facet-reflect = { path = "../facet-reflect", version = "0.44.6" }
+facet-core = { path = "../facet-core", version = "0.46.0" }
+facet-reflect = { path = "../facet-reflect", version = "0.46.0" }
 owo-colors = { version = "4", features = ["supports-colors"] }
 
 [dev-dependencies]

--- a/facet-reflect/Cargo.toml
+++ b/facet-reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-reflect"
-version = "0.44.6"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -40,8 +40,8 @@ fn-ptr = ["facet-core/fn-ptr"] # Enable Facet implementation for function pointe
 
 [dependencies]
 camino = { workspace = true, optional = true }
-facet-core = { path = "../facet-core", version = "0.45.0", default-features = false }
-facet-path = { version = "0.44.5", path = "../facet-path", default-features = false }
+facet-core = { path = "../facet-core", version = "0.46.0", default-features = false }
+facet-path = { version = "0.46.0", path = "../facet-path", default-features = false }
 hashbrown = "0.17"
 smallvec = "^2.0.0-alpha.10"
 regex = { version = "1", default-features = false, features = ["std"], optional = true }

--- a/facet-showcase/Cargo.toml
+++ b/facet-showcase/Cargo.toml
@@ -15,8 +15,8 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
 arborium = { workspace = true, features = ["lang-rust", "lang-xml", "lang-yaml"] }
-facet = { path = "../facet", version = "0.45.0", features = ["all-impls", "doc"] }
-facet-pretty = { path = "../facet-pretty", version = "0.44.7" }
+facet = { path = "../facet", version = "0.46.0", features = ["all-impls", "doc"] }
+facet-pretty = { path = "../facet-pretty", version = "0.46.0" }
 
 # Terminal colors
 owo-colors = "4"

--- a/facet-solver/Cargo.toml
+++ b/facet-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-solver"
-version = "0.44.6"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -21,8 +21,8 @@ suggestions = ["strsim", "alloc"]
 tracing = ["dep:tracing", "facet-reflect/tracing"]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.45.0", default-features = false }
-facet-reflect = { path = "../facet-reflect", version = "0.44.6", default-features = false }
+facet-core = { path = "../facet-core", version = "0.46.0", default-features = false }
+facet-reflect = { path = "../facet-reflect", version = "0.46.0", default-features = false }
 strsim = { workspace = true, optional = true }
 
 # Tracing (optional - compiles to nothing when disabled)

--- a/facet-testattrs/Cargo.toml
+++ b/facet-testattrs/Cargo.toml
@@ -9,7 +9,7 @@ description = "Test attributes for facet extension attribute testing (not publis
 publish = false
 
 [dependencies]
-facet = { path = "../facet", version = "0.45.0" }
+facet = { path = "../facet", version = "0.46.0" }
 
 [lints]
 workspace = true

--- a/facet-testhelpers-macros/Cargo.toml
+++ b/facet-testhelpers-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-testhelpers-macros"
-version = "0.44.3"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/facet-testhelpers/Cargo.toml
+++ b/facet-testhelpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-testhelpers"
-version = "0.44.3"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,7 +13,7 @@ description = "A collection of testing helpers and utilities for facet"
 [features]
 
 [dependencies]
-facet-testhelpers-macros = { version = "0.44.3", path = "../facet-testhelpers-macros" }
+facet-testhelpers-macros = { version = "0.46.0", path = "../facet-testhelpers-macros" }
 color-backtrace = { version = "0.7.2", features = ["use-btparse-crate"] }
 termcolor = "1.4"
 tracing = { workspace = true }

--- a/facet-urlencoded/Cargo.toml
+++ b/facet-urlencoded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-urlencoded"
-version = "0.44.6"
+version = "0.46.0"
 edition = "2024"
 rust-version = "1.90.0"
 license = "MIT OR Apache-2.0"
@@ -24,8 +24,8 @@ axum = ["dep:axum-core", "dep:http", "dep:http-body-util"]
 
 # Axum integration (optional)
 axum-core = { version = "0.5", default-features = false, optional = true }
-facet-core = { path = "../facet-core", version = "0.45.0" }
-facet-reflect = { path = "../facet-reflect", version = "0.44.6" }
+facet-core = { path = "../facet-core", version = "0.46.0" }
+facet-reflect = { path = "../facet-reflect", version = "0.46.0" }
 form_urlencoded = "1.2.1"
 http = { workspace = true, optional = true }
 http-body-util = { version = "0.1", default-features = false, optional = true }

--- a/facet-validate/Cargo.toml
+++ b/facet-validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-validate"
-version = "0.44.6"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -16,8 +16,8 @@ homepage = "https://facet.rs"
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.45.0" }
-facet = { path = "../facet", version = "0.45.0" }
+facet-core = { path = "../facet-core", version = "0.46.0" }
+facet = { path = "../facet", version = "0.46.0" }
 regex = { version = "1", default-features = false, features = ["std"] }
 
 [lints]

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet"
-version = "0.45.0"
+version = "0.46.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -130,9 +130,9 @@ slow-tests = []
 autocfg = { workspace = true }
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "=0.45.0", default-features = false }
-facet-macros = { path = "../facet-macros", version = "0.45.0", default-features = false }
-facet-reflect = { path = "../facet-reflect", version = "0.44.6", optional = true }
+facet-core = { path = "../facet-core", version = "=0.46.0", default-features = false }
+facet-macros = { path = "../facet-macros", version = "0.46.0", default-features = false }
+facet-reflect = { path = "../facet-reflect", version = "0.46.0", optional = true }
 static_assertions = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,6 +6,12 @@ git_release_enable = true
 
 # ============================================================================
 # Publishable packages - all synchronized versions, single changelog
+#
+# Every crate that re-exports or has facet-core in its public API must be in
+# this group. When facet-core makes a breaking change, all of these must ship
+# a new version simultaneously — otherwise consumers see a facet-core version
+# split that breaks compilation even though the dependent crate's semver looks
+# unchanged. cargo-semver-checks cannot detect this class of breakage today.
 # ============================================================================
 
 # Core
@@ -38,6 +44,58 @@ changelog_path = "CHANGELOG.md"
 
 [[package]]
 name = "facet-macro-parse"
+version_group = "facet"
+changelog_path = "CHANGELOG.md"
+
+# Reflection (re-exports facet-core types publicly)
+[[package]]
+name = "facet-reflect"
+version_group = "facet"
+changelog_path = "CHANGELOG.md"
+
+# Companion crates (depend on facet-core publicly)
+[[package]]
+name = "facet-error"
+version_group = "facet"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "facet-default"
+version_group = "facet"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "facet-solver"
+version_group = "facet"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "facet-pretty"
+version_group = "facet"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "facet-urlencoded"
+version_group = "facet"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "facet-path"
+version_group = "facet"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "facet-validate"
+version_group = "facet"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "facet-testhelpers"
+version_group = "facet"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
+name = "facet-testhelpers-macros"
 version_group = "facet"
 changelog_path = "CHANGELOG.md"
 


### PR DESCRIPTION
## Problem

The companion crates (`facet-reflect`, `facet-path`, `facet-error`, `facet-default`, `facet-solver`, `facet-pretty`, `facet-urlencoded`, `facet-validate`, `facet-testhelpers`, `facet-testhelpers-macros`) were **not** in the same `version_group` as `facet-core` and `facet` in `release-plz.toml`.

When `facet-core` bumped from `0.44` → `0.45`, those companion crates got independent patch releases (`0.44.6`, `0.44.7`, …) that internally required `facet-core 0.45.x` — a **semver violation** that `cargo-semver-checks` cannot detect, because it checks API shape, not crate identity of re-exported types.

Result: any downstream crate using both an old dep on `facet-cbor`/`moire-types`/etc. (published with `facet-core = "0.44"`) and a new dep on `facet-reflect 0.44.6` (which requires `facet-core 0.45`) ended up with two incompatible `facet_core` versions in the same build — confusing type-mismatch errors like:

```
note: two different versions of crate `facet_core` are being used
```

## Fix

1. **`release-plz.toml`**: add all publishable companion crates to the `"facet"` version group. Going forward, any change that bumps the group bumps all crates simultaneously, keeping versions consistent.

2. **Version bump**: level all companion crates from their scattered `0.44.x` / `0.45.x` values up to `0.46.0` to start from a clean, consistent baseline.

After this lands, release-plz will publish `facet-reflect 0.46.0`, `facet-path 0.46.0`, etc. all pointing to `facet-core 0.46.0`. Downstream crates that do `cargo update` will get a fully consistent tree with no split.
