### PR TITLE
facet-pretty: make the ..(x bytes).. marker be its own line

### DIFF
--- a/facet-pretty/src/printer.rs
+++ b/facet-pretty/src/printer.rs
@@ -611,8 +611,11 @@ impl PrettyPrinter {
                             if !short {
                                 writeln!(f)?;
                                 self.indent(f, format_depth + 1)?;
+                                writeln!(f, " ...({omitted} bytes)...")?;
+                                self.indent(f, format_depth + 1)?;
+                            } else {
+                                write!(f, " ...({omitted} bytes)...")?;
                             }
-                            write!(f, " ...({omitted} bytes)...")?;
 
                             // Show end
                             for (idx, item) in list.iter().enumerate().skip(total_len - end_count) {
@@ -2404,6 +2407,22 @@ mod tests {
             output
         );
         assert!(output.contains("bytes"), "should mention bytes: {}", output);
+    }
+
+    #[test]
+    fn test_max_content_formatting() {
+        let printer = PrettyPrinter::new()
+            .with_colors(ColorMode::Never)
+            .with_max_content_len(12);
+        let data: Vec<u8> = (0..50).collect();
+        let output = printer.format(&data);
+        insta::assert_snapshot!(output, @"
+        Vec<u8> [
+           00 01 02 03 04 05
+           ...(38 bytes)...
+           2c 2d 2e 2f 30 31
+        ]
+        ");
     }
 
     #[test]


### PR DESCRIPTION
It was a bit awkward before: :smile: 

```
Vec<u8> [
   89 50 4e 47 0d 0a 1a 52
   82 38 e8 e8 08 c8 60 a0
   a0 8c 83 05 bb f2 4e bd
   ...(177156 bytes)... c0 b3 37 37 04 00 00
   00 00 4c c9 ff 00 70 00
   79 17 1b 95 b8 00 00 60
]
```