### PR TITLE
TypePlan: Avoid exponential blowup with branching types

### DIFF
--- a/facet-reflect/src/partial/typeplan.rs
+++ b/facet-reflect/src/partial/typeplan.rs
@@ -1028,6 +1028,15 @@ impl TypePlanBuilder {
     ) -> Result<NodeId, AllocError> {
         let type_id = shape.id;
 
+        // Reuse an already-built node when no field-level proxy makes this call
+        // site distinct. Without this, types reachable via N distinct
+        // non-cyclic paths are rebuilt N times which explodes combinatorially.
+        if field_proxies.is_none()
+            && let Some(&idx) = self.finished.get(&type_id)
+        {
+            return Ok(idx);
+        }
+
         // Check if we're currently building this type (cycle detected)
         if self.building.contains(&type_id) {
             // Create a BackRef node with just the TypeId - resolved later via lookup
@@ -2447,6 +2456,34 @@ mod tests {
             }
             other => panic!("Expected Struct, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_typeplan_structure_sharing() {
+        // Make sure that a DAG can't cause exponential type plan node growth
+        macro_rules! make_ty {
+            ($name:ident, $subty:ty) => {
+                #[derive(Facet)]
+                #[repr(u8)]
+                #[expect(dead_code)]
+                enum $name {
+                    A($subty),
+                    B($subty),
+                    C($subty),
+                    D($subty),
+                }
+            };
+        }
+        make_ty!(L1, u32);
+        make_ty!(L2, L1);
+        make_ty!(L3, L2);
+        make_ty!(L4, L3);
+
+        let plan = TypePlan::<L4>::build().expect("typeplan build");
+        let core = plan.core();
+        let node_count = core.nodes.len();
+        // Node count would be 341 without sharing:
+        assert_eq!(node_count, 5);
     }
 
     #[test]


### PR DESCRIPTION
Hi,

I ran into an hang/OOM inside of `TypePlan` in `facet-reflect` with a very complex data type (The AST from https://github.com/Mrmaxmeier/datafusion-sqlparser-rs/tree/facet).

I've added a test case that shows the problem: The TypePlan had a node for each *path* that a type was reachable from, which explodes for large type graphs.

It seems like the type plan allows de-duplicating here, and the simple fix does seem to work. Let me know if there's something more subtle to consider here.

Thanks!