### PR TITLE
char, unit: Expose `Clone` impl

### DIFF
--- a/facet-core/src/impls/core/char_str.rs
+++ b/facet-core/src/impls/core/char_str.rs
@@ -4,8 +4,8 @@ use crate::{
     TypeOpsIndirect, VTableIndirect, type_ops_direct, vtable_direct, vtable_indirect,
 };
 
-// TypeOps lifted out - shared static (char has Default but not Clone as Copy type)
-static CHAR_TYPE_OPS: TypeOpsDirect = type_ops_direct!(char => Default);
+// TypeOps lifted out - shared static
+static CHAR_TYPE_OPS: TypeOpsDirect = type_ops_direct!(char => Default, Clone);
 
 unsafe impl Facet<'_> for char {
     const SHAPE: &'static Shape = &const {

--- a/facet-core/src/impls/core/tuple_empty.rs
+++ b/facet-core/src/impls/core/tuple_empty.rs
@@ -3,8 +3,8 @@ use crate::{
     VTableDirect, type_ops_direct, vtable_direct,
 };
 
-// TypeOps lifted out - shared static (unit has Default but not Clone as Copy type)
-static UNIT_TYPE_OPS: TypeOpsDirect = type_ops_direct!(() => Default);
+// TypeOps lifted out - shared static
+static UNIT_TYPE_OPS: TypeOpsDirect = type_ops_direct!(() => Default, Clone);
 
 unsafe impl Facet<'_> for () {
     const SHAPE: &'static Shape = &const {


### PR DESCRIPTION
This allows calling `call_clone_into` on char and unit.

I'm not sure why the comment explicitly called out those types to not expose Clone, but other primitives like integers, floats, bool do provide it.

Thanks!