### PR TITLE
 Fix missing lifetime in `generate_static_decl` for types with lifetime generics

### DIFF
--- a/facet-macros-impl/src/derive.rs
+++ b/facet-macros-impl/src/derive.rs
@@ -43,13 +43,18 @@ fn flatten_transparent_groups(input: TokenStream) -> TokenStream {
 
 /// Generate a static declaration that pre-evaluates `<T as Facet>::SHAPE`.
 /// Only emitted in release builds to avoid slowing down debug compile times.
-/// Skipped for generic types since we can't create a static for an unmonomorphized type.
+///
+/// Types with only lifetime generics (like `Holder<'a>`) get `'static` lifetimes
+/// substituted, since `SHAPE` is always `&'static Shape` regardless of the lifetime
+/// parameter. Types with type or const generics are skipped since those can't be
+/// monomorphized without knowing the concrete types.
 pub(crate) fn generate_static_decl(
     type_name: &Ident,
+    bgp_tokens: &TokenStream,
     facet_crate: &TokenStream,
     has_type_or_const_generics: bool,
 ) -> TokenStream {
-    // Can't generate a static for generic types - the type parameters aren't concrete
+    // Can't generate a static for types with type or const generics
     if has_type_or_const_generics {
         return quote! {};
     }
@@ -59,9 +64,12 @@ pub(crate) fn generate_static_decl(
 
     let static_name_ident = quote::format_ident!("{}_SHAPE", screaming_snake_name);
 
+    // Replace any lifetimes with 'static so we can generate a concrete monomorphic static
+    let bgp_static = crate::process_struct::lifetimes_to_static(bgp_tokens);
+
     quote! {
         #[cfg(not(debug_assertions))]
-        static #static_name_ident: &'static #facet_crate::Shape = <#type_name as #facet_crate::Facet>::SHAPE;
+        static #static_name_ident: &'static #facet_crate::Shape = <#type_name #bgp_static as #facet_crate::Facet #bgp_static>::SHAPE;
     }
 }
 

--- a/facet-macros-impl/src/process_enum.rs
+++ b/facet-macros-impl/src/process_enum.rs
@@ -1331,8 +1331,13 @@ pub(crate) fn process_enum(parsed: Enum) -> TokenStream {
     };
 
     // Static declaration for release builds (pre-evaluates SHAPE)
-    let static_decl =
-        crate::derive::generate_static_decl(enum_name, &facet_crate, has_type_or_const_generics);
+    let bgp_tokens = quote! { #bgp_for_vtable };
+    let static_decl = crate::derive::generate_static_decl(
+        enum_name,
+        &bgp_tokens,
+        &facet_crate,
+        has_type_or_const_generics,
+    );
 
     // Generate phantom use block for IDE hover support on attribute names.
     // This links attribute spans to facet::builtin::Attr variants.

--- a/facet-macros-impl/src/process_struct.rs
+++ b/facet-macros-impl/src/process_struct.rs
@@ -91,7 +91,7 @@ impl<'a> TraitSources<'a> {
 ///
 /// This is used when generating helper function items inside const contexts,
 /// where referencing outer lifetime parameters directly is not allowed.
-fn lifetimes_to_static(tokens: &TokenStream) -> TokenStream {
+pub(crate) fn lifetimes_to_static(tokens: &TokenStream) -> TokenStream {
     fn rewrite(stream: TokenStream) -> TokenStream {
         let mut out = TokenStream::new();
         let mut iter = stream.into_iter().peekable();
@@ -2514,8 +2514,10 @@ pub(crate) fn process_struct(parsed: Struct) -> TokenStream {
     };
 
     // Static declaration for release builds (pre-evaluates SHAPE)
+    let bgp_tokens = quote! { #bgp_for_vtable };
     let static_decl = crate::derive::generate_static_decl(
         &struct_name_ident,
+        &bgp_tokens,
         &facet_crate,
         has_type_or_const_generics,
     );

--- a/facet-reflect/tests/compile_tests/mod.rs
+++ b/facet-reflect/tests/compile_tests/mod.rs
@@ -129,10 +129,14 @@ facet-reflect = {{ path = {:?} }}
         println!("  ✓ Compilation failed as expected");
     }
 
-    // Check for expected error messages
+    // Check for expected error messages.
+    // Each string may contain " OR " to specify alternatives (one must match).
+    // Across array elements, ALL must match (AND semantics).
     let mut missing_errors = Vec::new();
     for &expected_error in test.expected_errors {
-        if !stderr_clean.contains(expected_error) {
+        let alternatives: Vec<&str> = expected_error.split(" OR ").collect();
+        let found = alternatives.iter().any(|alt| stderr_clean.contains(alt));
+        if !found {
             missing_errors.push(expected_error);
         } else {
             println!("  ✓ Found expected error: '{expected_error}'");
@@ -209,7 +213,9 @@ fn test_partial_contravariant_shrinking() {
     let test = CompilationTest {
         name: "contravariant_shrinking",
         source: include_str!("fixtures/partial_contravariant_shrinking.rs"),
-        expected_errors: &["error[E0521]: borrowed data escapes outside of function"],
+        expected_errors: &[
+            "error[E0521]: borrowed data escapes outside of function OR error: lifetime may not live long enough",
+        ],
     };
 
     run_compilation_test(&test);
@@ -221,7 +227,9 @@ fn test_partial_invariant_shrinking() {
     let test = CompilationTest {
         name: "invariant_shrinking",
         source: include_str!("fixtures/partial_invariant_shrinking.rs"),
-        expected_errors: &["error[E0521]: borrowed data escapes outside of function"],
+        expected_errors: &[
+            "error[E0521]: borrowed data escapes outside of function OR error: lifetime may not live long enough",
+        ],
     };
 
     run_compilation_test(&test);
@@ -233,7 +241,9 @@ fn test_peek_covariant_growing() {
     let test = CompilationTest {
         name: "covariant_growing",
         source: include_str!("fixtures/peek_covariant_growing.rs"),
-        expected_errors: &["error[E0521]: borrowed data escapes outside of function"],
+        expected_errors: &[
+            "error[E0521]: borrowed data escapes outside of function OR error: lifetime may not live long enough",
+        ],
     };
 
     run_compilation_test(&test);
@@ -245,7 +255,9 @@ fn test_peek_invariant_growing() {
     let test = CompilationTest {
         name: "invariant_growing",
         source: include_str!("fixtures/peek_invariant_growing.rs"),
-        expected_errors: &["error[E0521]: borrowed data escapes outside of function"],
+        expected_errors: &[
+            "error[E0521]: borrowed data escapes outside of function OR error: lifetime may not live long enough",
+        ],
     };
 
     run_compilation_test(&test);
@@ -259,9 +271,11 @@ fn test_peek_contravariant_shrinking() {
         source: include_str!("fixtures/peek_contravariant_shrinking.rs"),
         // Depending on Rust version / platform, error can be either:
         // - E0521 (borrowed data escapes) - the original invariance error
-        // - E0515 (cannot return value referencing temporary) - covariant error
+        // - "lifetime may not live long enough" - nightly/later Rust
         // Either one is acceptable as long as the code fails to compile.
-        expected_errors: &["error[E0521]: borrowed data escapes outside of function"],
+        expected_errors: &[
+            "error[E0521]: borrowed data escapes outside of function OR error: lifetime may not live long enough",
+        ],
     };
 
     run_compilation_test(&test);
@@ -273,7 +287,9 @@ fn test_peek_invariant_shrinking() {
     let test = CompilationTest {
         name: "invariant_shrinking",
         source: include_str!("fixtures/peek_invariant_shrinking.rs"),
-        expected_errors: &["error[E0521]: borrowed data escapes outside of function"],
+        expected_errors: &[
+            "error[E0521]: borrowed data escapes outside of function OR error: lifetime may not live long enough",
+        ],
     };
 
     run_compilation_test(&test);
@@ -304,7 +320,9 @@ fn test_peek_fn_ptr_ub_exploit() {
     let test = CompilationTest {
         name: "fn_ptr_ub_exploit",
         source: include_str!("fixtures/fn_ptr_ub_exploit.rs"),
-        expected_errors: &["error[E0521]: borrowed data escapes outside of function"],
+        expected_errors: &[
+            "error[E0521]: borrowed data escapes outside of function OR error: lifetime may not live long enough",
+        ],
     };
 
     run_compilation_test(&test);


### PR DESCRIPTION

The `#[derive(Facet)]` derive macro emits a cached static in release builds:

```rust
#[cfg(not(debug_assertions))]
static FOO_SHAPE: &'static ::facet::Shape = <Foo as ::facet::Facet>::SHAPE;
```

This works for concrete types, but fails for types with only lifetime generics (like `Foo<'a>`) because the bare type name is used without its lifetime parameter. The existing guard only skipped types with type or const generics — lifetime-only generics fell through the gap and produced uncompilable code.

### Fix

- `generate_static_decl` now receives the generic parameter tokens and applies the existing `lifetimes_to_static` helper to substitute lifetime params with `'static`. This is safe because `Facet::SHAPE` is `&'static Shape` regardless of the type's lifetime parameter.
- Types with type or const generics continue to be skipped, since those can't be monomorphized without knowing the concrete types.

### Before

```rust
static HOLDER_SHAPE: &'static ::facet::Shape = <Holder as ::facet::Facet>::SHAPE;
//                                                  ^^^^^^ missing lifetime
```

### After

```rust
static HOLDER_SHAPE: &'static ::facet::Shape = <Holder<'static> as ::facet::Facet<'static>>::SHAPE;
```

