### PR TITLE
fix(facet-default): auto-convert default values via TryFrom

### DIFF
--- a/facet-default/tests/integration.rs
+++ b/facet-default/tests/integration.rs
@@ -211,3 +211,18 @@ fn test_derive_first_then_other_attrs() {
     assert_eq!(config.port, 8080);
     assert_eq!(config.host, "");
 }
+
+/// Repro for bug: `#[facet(default = "literal")]` on a String field
+/// The literal `"ha"` is a `&str`, not a `String`, so it should be auto-converted.
+#[test]
+fn test_string_literal_default() {
+    #[derive(Facet, Debug, PartialEq)]
+    #[facet(derive(Default))]
+    pub struct Blah {
+        #[facet(default = "ha")]
+        field: String,
+    }
+
+    let blah = Blah::default();
+    assert_eq!(blah.field, "ha");
+}

--- a/facet-macros-impl/src/plugin.rs
+++ b/facet-macros-impl/src/plugin.rs
@@ -1284,7 +1284,7 @@ fn emit_doc(ctx: &EvalContext<'_>, output: &mut TokenStream) {
 /// `@field_default_expr` - emit the default expression for the current field
 ///
 /// Checks for:
-/// - `#[facet(default = literal)]` (builtin) → `literal` (direct value)
+/// - `#[facet(default = literal)]` (builtin) → `literal.try_into().expect(...)` (auto-converts via TryFrom)
 /// - `#[facet(default)]` (builtin, no value) → `::core::default::Default::default()`
 /// - `#[facet(default::value = literal)]` → `literal.into()`
 /// - `#[facet(default::func = "path")]` → `path()`
@@ -1306,8 +1306,13 @@ fn emit_field_default_expr(ctx: &EvalContext<'_>, output: &mut TokenStream) {
             // #[facet(default)] without value - use Default::default()
             output.extend(quote! { ::core::default::Default::default() });
         } else {
-            // #[facet(default = value)] - emit the value directly
-            output.extend(quote! { #args });
+            // #[facet(default = value)] - emit the value with try_into for auto-conversion.
+            // .into() doesn't work here because From isn't implemented for lossy numeric
+            // conversions (e.g. From<i32> for usize). TryFrom covers both infallible
+            // conversions (via blanket impl from From) and fallible ones (e.g. i32→usize).
+            output.extend(quote! {
+                (#args).try_into().expect("facet-default: failed to convert default value to field type")
+            });
         }
         return;
     }
@@ -1367,8 +1372,13 @@ fn field_default_tokens(field: &facet_macro_parse::PStructField) -> TokenStream 
             // #[facet(default)] without value - use Default::default()
             return quote! { ::core::default::Default::default() };
         } else {
-            // #[facet(default = value)] - emit the value directly
-            return quote! { #args };
+            // #[facet(default = value)] - emit the value with try_into for auto-conversion.
+            // .into() doesn't work here because From isn't implemented for lossy numeric
+            // conversions (e.g. From<i32> for usize). TryFrom covers both infallible
+            // conversions (via blanket impl from From) and fallible ones (e.g. i32→usize).
+            return quote! {
+                (#args).try_into().expect("facet-default: failed to convert default value to field type")
+            };
         }
     }
 


### PR DESCRIPTION
## Problem

When a field has `#[facet(default = "literal")]`, the literal may be a different type than the field — e.g. `"ha"` is `&str` but the field is `String`. Previously the template system in `emit_field_default_expr` and `field_default_tokens` emitted the value verbatim, causing a type mismatch error.

## Fix

Wrap custom default expressions with `.try_into().expect(...)` instead of emitting them directly.

**Why `try_into()` rather than `.into()`:** `.into()` requires `From<Src> for Dst` which isn't implemented for lossy numeric conversions like `i32 → usize` or `i32 → u16`. `try_into()` uses `TryFrom`, which covers:

- Infallible conversions via the blanket `impl<T, U> TryFrom<U> for T where T: From<U>` (handles `&str → String`, same-type, widening numerics)
- Fallible conversions like `i32 → usize` that have explicit `TryFrom` impls

The `.expect(...)` provides a clear error message if a conversion genuinely fails at runtime (e.g., negative integer for an unsigned type).

## Changes

- **`facet-macros-impl/src/plugin.rs`** — Fixed `emit_field_default_expr` and `field_default_tokens` to emit `(#args).try_into().expect(...)`
- **`facet-default/tests/integration.rs`** — Added `test_string_literal_default` reproducer test