### PR TITLE
feat(facet-zod): add Zod schema generator crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-zod"
+version = "0.46.2"
+dependencies = [
+ "facet",
+ "facet-core",
+ "facet-testhelpers",
+ "insta",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
 
   # misc.
   "facet-urlencoded",
+  "facet-zod",
 
   # utilities
   "facet-path",

--- a/facet-zod/CHANGELOG.md
+++ b/facet-zod/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial release. Generate [Zod](https://zod.dev) TypeScript schemas from Rust
+  types via Facet reflection.

--- a/facet-zod/Cargo.toml
+++ b/facet-zod/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "facet-zod"
+version = "0.46.2"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Generate Zod schemas from Rust types via Facet reflection"
+keywords = ["zod", "typescript", "schema", "codegen", "facet"]
+categories = ["development-tools", "encoding"]
+homepage = "https://facet.rs"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[package.metadata."docs.rs"]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[dependencies]
+facet-core = { path = "../facet-core", version = "0.46.2" }
+
+[dev-dependencies]
+facet = { path = "../facet", features = ["all-impls"] }
+facet-testhelpers = { path = "../facet-testhelpers" }
+insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/facet-zod/README.md
+++ b/facet-zod/README.md
@@ -1,0 +1,95 @@
+# facet-zod
+
+<!-- cargo-reedme: start -->
+
+<!-- cargo-reedme: info-start
+
+    Do not edit this region by hand
+    ===============================
+
+    This region was generated from Rust documentation comments by `cargo-reedme` using this command:
+
+        cargo +nightly reedme --package facet-zod
+
+    for more info: https://github.com/nik-rev/cargo-reedme
+
+cargo-reedme: info-end -->
+
+
+[![Coverage Status](https://coveralls.io/repos/github/facet-rs/facet-zod/badge.svg?branch=main)](https://coveralls.io/github/facet-rs/facet?branch=main)
+[![crates.io](https://img.shields.io/crates/v/facet-zod.svg)](https://crates.io/crates/facet-zod)
+[![documentation](https://docs.rs/facet-zod/badge.svg)](https://docs.rs/facet-zod)
+[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/facet-zod.svg)](./LICENSE)
+[![Discord](https://img.shields.io/discord/1379550208551026748?logo=discord&label=discord)](https://discord.gg/JhD7CwCJ8F)
+
+Generate [Zod](https://zod.dev) TypeScript schemas from Rust types via Facet
+reflection.
+
+## Example
+
+```rust
+use facet::Facet;
+use facet_zod::generate;
+
+#[derive(Facet)]
+struct User {
+    name: String,
+    age: u32,
+    email: Option<String>,
+}
+
+let schema = generate::<User>();
+assert!(schema.contains("export const UserSchema = z.object({"));
+```
+
+<!-- cargo-reedme: end -->
+
+## Sponsors
+
+Thanks to all individual sponsors:
+
+<p> <a href="https://github.com/sponsors/fasterthanlime">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-light.svg" height="40" alt="GitHub Sponsors">
+</picture>
+</a> <a href="https://patreon.com/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-light.svg" height="40" alt="Patreon">
+    </picture>
+</a> </p>
+
+...along with corporate sponsors:
+
+<p> <a href="https://aws.amazon.com">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-light.svg" height="40" alt="AWS">
+</picture>
+</a> <a href="https://zed.dev">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-light.svg" height="40" alt="Zed">
+</picture>
+</a> <a href="https://depot.dev?utm_source=facet">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-light.svg" height="40" alt="Depot">
+</picture>
+</a> </p>
+
+...without whom this work could not exist.
+
+## Special thanks
+
+The facet logo was drawn by [Misiasart](https://misiasart.com/).
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/facet-rs/facet/blob/main/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/facet-rs/facet/blob/main/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/facet-zod/arborium-header.html
+++ b/facet-zod/arborium-header.html
@@ -1,0 +1,2 @@
+<!-- Rustdoc doesn't highlight some languages natively -- let's do it ourselves: https://github.com/bearcove/arborium -->
+<script defer src="https://cdn.jsdelivr.net/npm/@arborium/arborium@1/dist/arborium.iife.js"></script>

--- a/facet-zod/readme-footer.md
+++ b/facet-zod/readme-footer.md
@@ -1,0 +1,49 @@
+## Sponsors
+
+Thanks to all individual sponsors:
+
+<p> <a href="https://github.com/sponsors/fasterthanlime">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-light.svg" height="40" alt="GitHub Sponsors">
+</picture>
+</a> <a href="https://patreon.com/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-light.svg" height="40" alt="Patreon">
+    </picture>
+</a> </p>
+
+...along with corporate sponsors:
+
+<p> <a href="https://aws.amazon.com">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-light.svg" height="40" alt="AWS">
+</picture>
+</a> <a href="https://zed.dev">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-light.svg" height="40" alt="Zed">
+</picture>
+</a> <a href="https://depot.dev?utm_source=facet">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-light.svg" height="40" alt="Depot">
+</picture>
+</a> </p>
+
+...without whom this work could not exist.
+
+## Special thanks
+
+The facet logo was drawn by [Misiasart](https://misiasart.com/).
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/facet-rs/facet/blob/main/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/facet-rs/facet/blob/main/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/facet-zod/src/config.rs
+++ b/facet-zod/src/config.rs
@@ -1,0 +1,52 @@
+//! Configuration knobs for Zod schema generation.
+
+/// Controls how Rust `Option<T>` fields are mapped to Zod modifiers.
+pub enum OptionalMode {
+    /// Map to `.optional()` — value may be omitted (`undefined`).
+    Optional,
+    /// Map to `.nullable()` — value may be explicitly `null`.
+    Nullable,
+    /// Map to `.nullish()` — value may be `null` or `undefined`.
+    Nullish,
+}
+
+/// Controls whether large Rust integer types emit as `z.bigint()` or stay as `z.number().int()`.
+pub enum BigIntMode {
+    /// Always emit `z.number().int()` regardless of width.
+    Never,
+    /// Emit `z.bigint()` for integer types whose layout is 8 bytes or larger.
+    From64Bit,
+}
+
+/// Controls what `export` declarations are emitted per named schema.
+pub enum ExportStyle {
+    /// Emit both the `const ...Schema` value and the inferred `type`.
+    ConstAndType,
+    /// Emit only the `const ...Schema` value.
+    ConstOnly,
+    /// Emit only the inferred `type`.
+    TypeOnly,
+}
+
+/// Generator configuration.
+pub struct Config {
+    /// How `Option<T>` fields are rendered.
+    pub optional_mode: OptionalMode,
+    /// When to widen integer types to `z.bigint()`.
+    pub bigint_mode: BigIntMode,
+    /// Which `export` declarations to emit per named schema.
+    pub export_style: ExportStyle,
+    /// Optional header prepended to the generated file (e.g. `import { z } from 'zod';`).
+    pub header: Option<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            optional_mode: OptionalMode::Nullish,
+            bigint_mode: BigIntMode::Never,
+            export_style: ExportStyle::ConstAndType,
+            header: None,
+        }
+    }
+}

--- a/facet-zod/src/emit.rs
+++ b/facet-zod/src/emit.rs
@@ -1,0 +1,108 @@
+//! Emit Zod TypeScript source text from the intermediate [`ZodType`](crate::mapping::ZodType) tree.
+
+use crate::config::{Config, ExportStyle};
+use crate::mapping::{NamedSchema, ZodField, ZodType};
+
+/// Emit a top-level named schema declaration.
+pub fn emit_schema(schema: &NamedSchema, config: &Config) -> String {
+    let mut out = String::new();
+
+    if let Some(doc) = &schema.doc {
+        for line in doc.lines() {
+            out.push_str(&format!("/** {} */\n", line.trim()));
+        }
+    }
+
+    let type_expr = emit_type(&schema.ty);
+    let const_name = format!("{}Schema", schema.name);
+
+    match config.export_style {
+        ExportStyle::ConstAndType => {
+            out.push_str(&format!("export const {const_name} = {type_expr};\n"));
+            out.push_str(&format!(
+                "export type {} = z.infer<typeof {const_name}>;\n",
+                schema.name
+            ));
+        }
+        ExportStyle::ConstOnly => {
+            out.push_str(&format!("export const {const_name} = {type_expr};\n"));
+        }
+        ExportStyle::TypeOnly => {
+            out.push_str(&format!(
+                "export type {} = z.infer<typeof {type_expr}>;\n",
+                schema.name
+            ));
+        }
+    }
+
+    out
+}
+
+/// Emit a Zod expression for a single [`ZodType`] node.
+pub fn emit_type(ty: &ZodType) -> String {
+    match ty {
+        ZodType::String => "z.string()".into(),
+        ZodType::Number { int: true } => "z.number().int()".into(),
+        ZodType::Number { int: false } => "z.number()".into(),
+        ZodType::BigInt => "z.bigint()".into(),
+        ZodType::Boolean => "z.boolean()".into(),
+        ZodType::Unknown => "z.unknown()".into(),
+        ZodType::Never => "z.never()".into(),
+        ZodType::Undefined => "z.undefined()".into(),
+
+        ZodType::Literal(val) => {
+            if val == "true" || val == "false" {
+                format!("z.literal({val})")
+            } else {
+                format!("z.literal(\"{val}\")")
+            }
+        }
+
+        ZodType::Optional(inner) => format!("{}.optional()", emit_type(inner)),
+        ZodType::Nullable(inner) => format!("{}.nullable()", emit_type(inner)),
+        ZodType::Nullish(inner) => format!("{}.nullish()", emit_type(inner)),
+
+        ZodType::Array(elem) => format!("z.array({})", emit_type(elem)),
+
+        ZodType::Tuple(elems) => {
+            let items: Vec<String> = elems.iter().map(emit_type).collect();
+            format!("z.tuple([{}])", items.join(", "))
+        }
+
+        ZodType::Record(k, v) => format!("z.record({}, {})", emit_type(k), emit_type(v)),
+
+        ZodType::Object(fields) => emit_object(fields),
+
+        ZodType::Union(members) => {
+            let items: Vec<String> = members.iter().map(emit_type).collect();
+            format!("z.union([{}])", items.join(", "))
+        }
+
+        ZodType::Enum(variants) => {
+            let items: Vec<String> = variants.iter().map(|v| format!("\"{v}\"")).collect();
+            format!("z.enum([{}])", items.join(", "))
+        }
+
+        ZodType::Ref(name) => format!("{name}Schema"),
+        ZodType::Lazy(name) => format!("z.lazy(() => {name}Schema)"),
+    }
+}
+
+fn emit_object(fields: &[ZodField]) -> String {
+    if fields.is_empty() {
+        return "z.object({})".into();
+    }
+
+    let mut lines = Vec::new();
+    for field in fields {
+        let type_expr = emit_type(&field.ty);
+        let line = if let Some(doc) = &field.doc {
+            format!("  /** {} */\n  {}: {}", doc, field.name, type_expr)
+        } else {
+            format!("  {}: {}", field.name, type_expr)
+        };
+        lines.push(line);
+    }
+
+    format!("z.object({{\n{},\n}})", lines.join(",\n"))
+}

--- a/facet-zod/src/generator.rs
+++ b/facet-zod/src/generator.rs
@@ -1,0 +1,209 @@
+//! Top-level driver that registers root types and emits a Zod schema file.
+
+use std::collections::{HashMap, HashSet};
+
+use facet_core::*;
+use facet_core::{Facet, Shape};
+
+use crate::config::Config;
+use crate::emit::emit_schema;
+use crate::mapping::{NamedSchema, schema_name, shape_to_zod};
+
+/// Accumulates root types to emit and renders them to a single Zod source string.
+pub struct ZodGenerator {
+    roots: Vec<&'static Shape>,
+    config: Config,
+}
+
+impl ZodGenerator {
+    /// Create a new generator with [`Config::default()`].
+    pub fn new() -> Self {
+        Self {
+            roots: Vec::new(),
+            config: Config::default(),
+        }
+    }
+
+    /// Create a new generator with an explicit [`Config`].
+    pub fn with_config(config: Config) -> Self {
+        Self {
+            roots: Vec::new(),
+            config,
+        }
+    }
+
+    /// Register a root type `T`. Nested types reachable from `T` are emitted automatically.
+    pub fn add<'facet, T: Facet<'facet>>(&mut self) -> &mut Self {
+        self.roots.push(T::SHAPE);
+        self
+    }
+
+    /// Emit the final Zod source text for all registered roots.
+    pub fn emit(&self) -> String {
+        let registry = self.discover_all();
+        let sorted = toposort(&registry);
+
+        let mut out = String::new();
+
+        if let Some(header) = &self.config.header {
+            out.push_str(header);
+            if !header.ends_with('\n') {
+                out.push('\n');
+            }
+            out.push('\n');
+        }
+
+        for shape in &sorted {
+            let name = schema_name(shape);
+            let mut visiting = Vec::new();
+            let ty = shape_to_zod(shape, &self.config, &mut visiting);
+
+            let doc = if shape.doc.is_empty() {
+                None
+            } else {
+                Some(shape.doc.join("\n"))
+            };
+
+            let schema = NamedSchema { name, ty, doc };
+            out.push_str(&emit_schema(&schema, &self.config));
+            out.push('\n');
+        }
+
+        out
+    }
+
+    fn discover_all(&self) -> HashMap<ConstTypeId, &'static Shape> {
+        let mut registry = HashMap::new();
+        for shape in &self.roots {
+            discover(shape, &mut registry);
+        }
+        registry
+    }
+}
+
+impl Default for ZodGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn discover(shape: &'static Shape, registry: &mut HashMap<ConstTypeId, &'static Shape>) {
+    if is_primitive(shape) {
+        return;
+    }
+
+    if registry.contains_key(&shape.id) {
+        return;
+    }
+
+    if should_emit_named(shape) {
+        registry.insert(shape.id, shape);
+    }
+
+    for_each_child_shape(shape, |child| {
+        discover(child, registry);
+    });
+}
+
+fn for_each_child_shape(shape: &'static Shape, mut visit: impl FnMut(&'static Shape)) {
+    match &shape.def {
+        Def::Option(opt) => visit(opt.t),
+        Def::List(list) => visit(list.t),
+        Def::Set(set) => visit(set.t),
+        Def::Map(map) => {
+            visit(map.k);
+            visit(map.v);
+        }
+        Def::Array(arr) => visit(arr.t),
+        Def::Slice(slice) => visit(slice.t),
+        Def::Result(res) => {
+            visit(res.t);
+            visit(res.e);
+        }
+        Def::Pointer(ptr) => {
+            if let Some(pointee) = ptr.pointee {
+                visit(pointee);
+            }
+        }
+        _ => match &shape.ty {
+            Type::User(UserType::Struct(st)) => {
+                for field in st.fields {
+                    if !field
+                        .flags
+                        .contains(FieldFlags::SKIP | FieldFlags::SKIP_SERIALIZING)
+                    {
+                        visit(field.shape.get());
+                    }
+                }
+            }
+            Type::User(UserType::Enum(et)) => {
+                for variant in et.variants {
+                    for field in variant.data.fields {
+                        visit(field.shape.get());
+                    }
+                }
+            }
+            Type::Sequence(SequenceType::Array(arr)) => visit(arr.t),
+            Type::Sequence(SequenceType::Slice(slice)) => visit(slice.t),
+            Type::Pointer(PointerType::Reference(vp) | PointerType::Raw(vp)) => visit(vp.target),
+            _ => {}
+        },
+    }
+}
+
+fn toposort(registry: &HashMap<ConstTypeId, &'static Shape>) -> Vec<&'static Shape> {
+    let mut visited = HashSet::new();
+    let mut result = Vec::new();
+
+    for shape in registry.values() {
+        toposort_visit(shape, registry, &mut visited, &mut result);
+    }
+
+    result
+}
+
+fn toposort_visit(
+    shape: &'static Shape,
+    registry: &HashMap<ConstTypeId, &'static Shape>,
+    visited: &mut HashSet<ConstTypeId>,
+    result: &mut Vec<&'static Shape>,
+) {
+    if !visited.insert(shape.id) {
+        return;
+    }
+
+    for_each_child_shape(shape, |child| {
+        if registry.contains_key(&child.id) {
+            toposort_visit(child, registry, visited, result);
+        }
+    });
+
+    result.push(shape);
+}
+
+fn is_primitive(shape: &'static Shape) -> bool {
+    matches!(shape.def, Def::Scalar)
+        || matches!(
+            shape.ty,
+            Type::Primitive(_) | Type::Sequence(_) | Type::Pointer(_)
+        )
+}
+
+fn should_emit_named(shape: &'static Shape) -> bool {
+    let is_user_type = matches!(
+        shape.ty,
+        Type::User(UserType::Struct(_) | UserType::Enum(_))
+    );
+    let has_container_def = matches!(
+        shape.def,
+        Def::Option(_)
+            | Def::List(_)
+            | Def::Set(_)
+            | Def::Map(_)
+            | Def::Array(_)
+            | Def::Slice(_)
+            | Def::Result(_)
+            | Def::Pointer(_)
+    );
+    is_user_type && !has_container_def
+}

--- a/facet-zod/src/lib.rs
+++ b/facet-zod/src/lib.rs
@@ -1,0 +1,58 @@
+#![warn(missing_docs)]
+//!
+//! [![Coverage Status](https://coveralls.io/repos/github/facet-rs/facet-zod/badge.svg?branch=main)](https://coveralls.io/github/facet-rs/facet?branch=main)
+//! [![crates.io](https://img.shields.io/crates/v/facet-zod.svg)](https://crates.io/crates/facet-zod)
+//! [![documentation](https://docs.rs/facet-zod/badge.svg)](https://docs.rs/facet-zod)
+//! [![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/facet-zod.svg)](./LICENSE)
+//! [![Discord](https://img.shields.io/discord/1379550208551026748?logo=discord&label=discord)](https://discord.gg/JhD7CwCJ8F)
+//!
+//! Generate [Zod](https://zod.dev) TypeScript schemas from Rust types via Facet
+//! reflection.
+//!
+//! # Example
+//!
+//! ```
+//! use facet::Facet;
+//! use facet_zod::generate;
+//!
+//! #[derive(Facet)]
+//! struct User {
+//!     name: String,
+//!     age: u32,
+//!     email: Option<String>,
+//! }
+//!
+//! let schema = generate::<User>();
+//! assert!(schema.contains("export const UserSchema = z.object({"));
+//! ```
+//!
+#![doc = include_str!("../readme-footer.md")]
+
+/// Generator configuration: optional-field mapping, integer width handling,
+/// export style, and optional file header.
+pub mod config;
+/// Emit Zod source text from the intermediate [`mapping::ZodType`] tree.
+pub mod emit;
+/// Top-level [`ZodGenerator`] that walks roots, deduplicates types, and emits schemas.
+pub mod generator;
+/// Mapping from Facet `Shape`s to the intermediate `ZodType` representation.
+pub mod mapping;
+
+pub use config::Config;
+pub use generator::ZodGenerator;
+
+use facet_core::Facet;
+
+/// Generate a Zod schema string for `T` using default [`Config`].
+pub fn generate<'facet, T: Facet<'facet>>() -> String {
+    let mut generator = ZodGenerator::new();
+    generator.add::<T>();
+    generator.emit()
+}
+
+/// Generate a Zod schema string for `T` using the provided [`Config`].
+pub fn generate_with_config<'facet, T: Facet<'facet>>(config: Config) -> String {
+    let mut generator = ZodGenerator::with_config(config);
+    generator.add::<T>();
+    generator.emit()
+}

--- a/facet-zod/src/mapping.rs
+++ b/facet-zod/src/mapping.rs
@@ -1,0 +1,360 @@
+//! Intermediate Zod type representation and conversion from Facet [`Shape`](facet_core::Shape)s.
+
+use facet_core::Shape;
+use facet_core::*;
+
+use crate::config::{BigIntMode, Config};
+
+/// Intermediate representation of a Zod type, before emission to source text.
+#[derive(Debug, Clone)]
+pub enum ZodType {
+    /// `z.string()`
+    String,
+    /// `z.number()` (with optional `.int()` constraint).
+    Number {
+        /// Whether this number is constrained to integers.
+        int: bool,
+    },
+    /// `z.bigint()`
+    BigInt,
+    /// `z.boolean()`
+    Boolean,
+    /// `z.object({ ... })` with named fields.
+    Object(Vec<ZodField>),
+    /// `z.array(T)`
+    Array(Box<ZodType>),
+    /// `z.tuple([...])`
+    Tuple(Vec<ZodType>),
+    /// `z.record(K, V)`
+    Record(Box<ZodType>, Box<ZodType>),
+    /// `z.union([...])`
+    Union(Vec<ZodType>),
+    /// `z.enum([...])` — list of string literal variant names.
+    Enum(Vec<String>),
+    /// `T.optional()`
+    Optional(Box<ZodType>),
+    /// `T.nullable()`
+    Nullable(Box<ZodType>),
+    /// `T.nullish()`
+    Nullish(Box<ZodType>),
+    /// Reference to a named schema (`FooSchema`).
+    Ref(String),
+    /// `z.lazy(() => FooSchema)` — used to break recursive cycles.
+    Lazy(String),
+    /// `z.literal(...)` — string or boolean literal.
+    Literal(String),
+    /// `z.undefined()`
+    Undefined,
+    /// `z.unknown()`
+    Unknown,
+    /// `z.never()`
+    Never,
+}
+
+/// A named field on a Zod object.
+#[derive(Debug, Clone)]
+pub struct ZodField {
+    /// The field's serialized name (post-rename).
+    pub name: String,
+    /// The field's type.
+    pub ty: ZodType,
+    /// Whether the field is optional (Rust `Option` or has a default).
+    pub optional: bool,
+    /// Optional doc-comment text to emit above the field.
+    pub doc: Option<String>,
+}
+
+/// A top-level named Zod schema, ready for emission.
+#[derive(Debug, Clone)]
+pub struct NamedSchema {
+    /// The TypeScript identifier (e.g. `User`); the const is `${name}Schema`.
+    pub name: String,
+    /// The schema's type.
+    pub ty: ZodType,
+    /// Optional doc-comment text to emit above the schema.
+    pub doc: Option<String>,
+}
+
+/// Convert a Facet [`Shape`] to a [`ZodType`], inserting [`ZodType::Lazy`] for
+/// types already on the `visiting` stack to break cycles.
+pub fn shape_to_zod(
+    shape: &'static Shape,
+    config: &Config,
+    visiting: &mut Vec<ConstTypeId>,
+) -> ZodType {
+    let id = shape.id;
+
+    if visiting.contains(&id) {
+        return ZodType::Lazy(schema_name(shape));
+    }
+
+    visiting.push(id);
+    let result = shape_to_zod_inner(shape, config, visiting);
+    visiting.pop();
+    result
+}
+
+fn shape_to_zod_inner(
+    shape: &'static Shape,
+    config: &Config,
+    visiting: &mut Vec<ConstTypeId>,
+) -> ZodType {
+    match &shape.def {
+        Def::Option(opt) => {
+            let inner = shape_to_zod(opt.t, config, visiting);
+            wrap_optional(inner, config)
+        }
+        Def::List(list) => {
+            let elem = shape_to_zod(list.t, config, visiting);
+            ZodType::Array(Box::new(elem))
+        }
+        Def::Set(set) => {
+            let elem = shape_to_zod(set.t, config, visiting);
+            ZodType::Array(Box::new(elem))
+        }
+        Def::Map(map) => {
+            let k = shape_to_zod(map.k, config, visiting);
+            let v = shape_to_zod(map.v, config, visiting);
+            ZodType::Record(Box::new(k), Box::new(v))
+        }
+        Def::Array(arr) => {
+            let elem = shape_to_zod(arr.t, config, visiting);
+            ZodType::Tuple(vec![elem; arr.n])
+        }
+        Def::Slice(slice) => {
+            let elem = shape_to_zod(slice.t, config, visiting);
+            ZodType::Array(Box::new(elem))
+        }
+        Def::Result(res) => {
+            let ok = shape_to_zod(res.t, config, visiting);
+            let err = shape_to_zod(res.e, config, visiting);
+            ZodType::Union(vec![
+                ZodType::Object(vec![
+                    ZodField {
+                        name: "ok".into(),
+                        ty: ZodType::Literal("true".into()),
+                        optional: false,
+                        doc: None,
+                    },
+                    ZodField {
+                        name: "value".into(),
+                        ty: ok,
+                        optional: false,
+                        doc: None,
+                    },
+                ]),
+                ZodType::Object(vec![
+                    ZodField {
+                        name: "ok".into(),
+                        ty: ZodType::Literal("false".into()),
+                        optional: false,
+                        doc: None,
+                    },
+                    ZodField {
+                        name: "error".into(),
+                        ty: err,
+                        optional: false,
+                        doc: None,
+                    },
+                ]),
+            ])
+        }
+        Def::Pointer(ptr) => {
+            if let Some(pointee) = ptr.pointee {
+                shape_to_zod(pointee, config, visiting)
+            } else {
+                ZodType::Unknown
+            }
+        }
+        Def::Scalar => primitive_to_zod(shape, config),
+        Def::Undefined | Def::DynamicValue(_) | Def::NdArray(_) => {
+            map_by_type(shape, config, visiting)
+        }
+        _ => map_by_type(shape, config, visiting),
+    }
+}
+
+fn map_by_type(shape: &'static Shape, config: &Config, visiting: &mut Vec<ConstTypeId>) -> ZodType {
+    match &shape.ty {
+        Type::User(UserType::Struct(st)) => struct_to_zod(st, shape, config, visiting),
+        Type::User(UserType::Enum(et)) => enum_to_zod(et, shape, config, visiting),
+        Type::Primitive(_) => primitive_to_zod(shape, config),
+        Type::Sequence(SequenceType::Array(arr)) => {
+            let elem = shape_to_zod(arr.t, config, visiting);
+            ZodType::Tuple(vec![elem; arr.n])
+        }
+        Type::Sequence(SequenceType::Slice(slice)) => {
+            let elem = shape_to_zod(slice.t, config, visiting);
+            ZodType::Array(Box::new(elem))
+        }
+        Type::Pointer(PointerType::Reference(vp) | PointerType::Raw(vp)) => {
+            shape_to_zod(vp.target, config, visiting)
+        }
+        Type::Pointer(PointerType::Function(_)) => ZodType::Never,
+        _ => ZodType::Unknown,
+    }
+}
+
+fn primitive_to_zod(shape: &'static Shape, config: &Config) -> ZodType {
+    match &shape.ty {
+        Type::Primitive(PrimitiveType::Boolean) => ZodType::Boolean,
+        Type::Primitive(PrimitiveType::Textual(_)) => ZodType::String,
+        Type::Primitive(PrimitiveType::Numeric(num)) => numeric_to_zod(num, shape, config),
+        Type::Primitive(PrimitiveType::Never) => ZodType::Never,
+        _ => {
+            if shape.type_identifier == "String" || shape.type_identifier == "str" {
+                ZodType::String
+            } else {
+                ZodType::Unknown
+            }
+        }
+    }
+}
+
+fn numeric_to_zod(num: &NumericType, shape: &'static Shape, config: &Config) -> ZodType {
+    match num {
+        NumericType::Float => ZodType::Number { int: false },
+        NumericType::Integer { .. } => {
+            let is_large = match shape.layout {
+                ShapeLayout::Sized(layout) => layout.size() >= 8,
+                ShapeLayout::Unsized => false,
+            };
+            if is_large && matches!(config.bigint_mode, BigIntMode::From64Bit) {
+                ZodType::BigInt
+            } else {
+                ZodType::Number { int: true }
+            }
+        }
+    }
+}
+
+fn struct_to_zod(
+    st: &StructType,
+    shape: &'static Shape,
+    config: &Config,
+    visiting: &mut Vec<ConstTypeId>,
+) -> ZodType {
+    match st.kind {
+        StructKind::TupleStruct if st.fields.len() == 1 => {
+            if let Some(inner) = shape.inner {
+                return shape_to_zod(inner, config, visiting);
+            }
+            let field_shape = st.fields[0].shape.get();
+            shape_to_zod(field_shape, config, visiting)
+        }
+        StructKind::TupleStruct | StructKind::Tuple => {
+            let elems = st
+                .fields
+                .iter()
+                .map(|f| shape_to_zod(f.shape.get(), config, visiting))
+                .collect();
+            ZodType::Tuple(elems)
+        }
+        StructKind::Unit => ZodType::Object(vec![]),
+        StructKind::Struct => {
+            let fields = st
+                .fields
+                .iter()
+                .filter(|f| {
+                    !f.flags
+                        .contains(FieldFlags::SKIP | FieldFlags::SKIP_SERIALIZING)
+                })
+                .map(|f| field_to_zod(f, config, visiting))
+                .collect();
+            ZodType::Object(fields)
+        }
+    }
+}
+
+fn field_to_zod(
+    field: &'static Field,
+    config: &Config,
+    visiting: &mut Vec<ConstTypeId>,
+) -> ZodField {
+    let field_shape = field.shape.get();
+    let name = field.rename.unwrap_or(field.name).to_string();
+    let doc = if field.doc.is_empty() {
+        None
+    } else {
+        Some(field.doc.join("\n"))
+    };
+
+    let is_option = matches!(field_shape.def, Def::Option(_));
+    let has_default = field.has_default();
+
+    let ty = shape_to_zod(field_shape, config, visiting);
+
+    ZodField {
+        name,
+        ty,
+        optional: is_option || has_default,
+        doc,
+    }
+}
+
+fn enum_to_zod(
+    et: &EnumType,
+    _shape: &'static Shape,
+    config: &Config,
+    visiting: &mut Vec<ConstTypeId>,
+) -> ZodType {
+    let all_unit = et.variants.iter().all(|v| v.data.fields.is_empty());
+
+    if all_unit {
+        let names = et
+            .variants
+            .iter()
+            .map(|v| v.rename.unwrap_or(v.name).to_string())
+            .collect();
+        return ZodType::Enum(names);
+    }
+
+    let members: Vec<ZodType> = et
+        .variants
+        .iter()
+        .map(|v| {
+            let variant_name = v.rename.unwrap_or(v.name);
+            if v.data.fields.is_empty() {
+                ZodType::Object(vec![ZodField {
+                    name: variant_name.to_string(),
+                    ty: ZodType::Literal("true".into()),
+                    optional: false,
+                    doc: None,
+                }])
+            } else {
+                let inner = struct_to_zod(&v.data, v.data.fields[0].shape.get(), config, visiting);
+                ZodType::Object(vec![ZodField {
+                    name: variant_name.to_string(),
+                    ty: inner,
+                    optional: false,
+                    doc: None,
+                }])
+            }
+        })
+        .collect();
+
+    ZodType::Union(members)
+}
+
+fn wrap_optional(inner: ZodType, config: &Config) -> ZodType {
+    match config.optional_mode {
+        crate::config::OptionalMode::Optional => ZodType::Optional(Box::new(inner)),
+        crate::config::OptionalMode::Nullable => ZodType::Nullable(Box::new(inner)),
+        crate::config::OptionalMode::Nullish => ZodType::Nullish(Box::new(inner)),
+    }
+}
+
+/// Derive the TypeScript schema name for a given Facet [`Shape`].
+pub fn schema_name(shape: &Shape) -> String {
+    let base = shape.type_identifier.to_string();
+    if shape.type_params.is_empty() {
+        base
+    } else {
+        let params: Vec<String> = shape
+            .type_params
+            .iter()
+            .map(|tp| tp.name.to_string())
+            .collect();
+        format!("{}{}", base, params.join(""))
+    }
+}

--- a/facet-zod/tests/codegen.rs
+++ b/facet-zod/tests/codegen.rs
@@ -1,0 +1,104 @@
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use facet::Facet;
+use facet_zod::{Config, ZodGenerator, generate, generate_with_config};
+
+#[derive(Facet)]
+struct User {
+    name: String,
+    age: u32,
+    email: Option<String>,
+}
+
+#[derive(Facet)]
+struct Post {
+    title: String,
+    body: String,
+    author: User,
+    tags: Vec<String>,
+}
+
+#[derive(Facet)]
+#[repr(u8)]
+enum Status {
+    Active,
+    Inactive,
+    Banned,
+}
+
+#[derive(Facet)]
+#[repr(C)]
+enum Shape {
+    Circle { radius: f64 },
+    Rectangle { width: f64, height: f64 },
+}
+
+#[derive(Facet)]
+struct Config2 {
+    settings: HashMap<String, String>,
+    flags: Vec<bool>,
+    matrix: [u32; 3],
+}
+
+#[derive(Facet)]
+struct Wrapper(String);
+
+#[test]
+fn test_simple_struct() {
+    let output = generate::<User>();
+    insta::assert_snapshot!("simple_struct", output);
+}
+
+#[test]
+fn test_nested_struct() {
+    let mut generator = ZodGenerator::new();
+    generator.add::<Post>();
+    let output = generator.emit();
+    insta::assert_snapshot!("nested_struct", output);
+}
+
+#[test]
+fn test_unit_enum() {
+    let output = generate::<Status>();
+    insta::assert_snapshot!("unit_enum", output);
+}
+
+#[test]
+fn test_data_enum() {
+    let output = generate::<Shape>();
+    insta::assert_snapshot!("data_enum", output);
+}
+
+#[test]
+fn test_collections() {
+    let output = generate::<Config2>();
+    insta::assert_snapshot!("collections", output);
+}
+
+#[test]
+fn test_newtype() {
+    let output = generate::<Wrapper>();
+    insta::assert_snapshot!("newtype", output);
+}
+
+#[test]
+fn test_optional_mode_nullable() {
+    let config = Config {
+        optional_mode: facet_zod::config::OptionalMode::Nullable,
+        ..Config::default()
+    };
+    let output = generate_with_config::<User>(config);
+    insta::assert_snapshot!("optional_nullable", output);
+}
+
+#[test]
+fn test_with_header() {
+    let config = Config {
+        header: Some("import { z } from 'zod';".into()),
+        ..Config::default()
+    };
+    let output = generate_with_config::<User>(config);
+    insta::assert_snapshot!("with_header", output);
+}

--- a/facet-zod/tests/snapshots/codegen__collections.snap
+++ b/facet-zod/tests/snapshots/codegen__collections.snap
@@ -1,0 +1,10 @@
+---
+source: tests/codegen.rs
+expression: output
+---
+export const Config2Schema = z.object({
+  settings: z.record(z.string(), z.string()),
+  flags: z.array(z.boolean()),
+  matrix: z.tuple([z.number().int(), z.number().int(), z.number().int()]),
+});
+export type Config2 = z.infer<typeof Config2Schema>;

--- a/facet-zod/tests/snapshots/codegen__data_enum.snap
+++ b/facet-zod/tests/snapshots/codegen__data_enum.snap
@@ -1,0 +1,15 @@
+---
+source: tests/codegen.rs
+expression: output
+---
+export const ShapeSchema = z.union([z.object({
+  Circle: z.object({
+  radius: z.number(),
+}),
+}), z.object({
+  Rectangle: z.object({
+  width: z.number(),
+  height: z.number(),
+}),
+})]);
+export type Shape = z.infer<typeof ShapeSchema>;

--- a/facet-zod/tests/snapshots/codegen__nested_struct.snap
+++ b/facet-zod/tests/snapshots/codegen__nested_struct.snap
@@ -1,0 +1,22 @@
+---
+source: tests/codegen.rs
+expression: output
+---
+export const UserSchema = z.object({
+  name: z.string(),
+  age: z.number().int(),
+  email: z.string().nullish(),
+});
+export type User = z.infer<typeof UserSchema>;
+
+export const PostSchema = z.object({
+  title: z.string(),
+  body: z.string(),
+  author: z.object({
+  name: z.string(),
+  age: z.number().int(),
+  email: z.string().nullish(),
+}),
+  tags: z.array(z.string()),
+});
+export type Post = z.infer<typeof PostSchema>;

--- a/facet-zod/tests/snapshots/codegen__newtype.snap
+++ b/facet-zod/tests/snapshots/codegen__newtype.snap
@@ -1,0 +1,6 @@
+---
+source: tests/codegen.rs
+expression: output
+---
+export const WrapperSchema = z.string();
+export type Wrapper = z.infer<typeof WrapperSchema>;

--- a/facet-zod/tests/snapshots/codegen__optional_nullable.snap
+++ b/facet-zod/tests/snapshots/codegen__optional_nullable.snap
@@ -1,0 +1,10 @@
+---
+source: tests/codegen.rs
+expression: output
+---
+export const UserSchema = z.object({
+  name: z.string(),
+  age: z.number().int(),
+  email: z.string().nullable(),
+});
+export type User = z.infer<typeof UserSchema>;

--- a/facet-zod/tests/snapshots/codegen__simple_struct.snap
+++ b/facet-zod/tests/snapshots/codegen__simple_struct.snap
@@ -1,0 +1,10 @@
+---
+source: tests/codegen.rs
+expression: output
+---
+export const UserSchema = z.object({
+  name: z.string(),
+  age: z.number().int(),
+  email: z.string().nullish(),
+});
+export type User = z.infer<typeof UserSchema>;

--- a/facet-zod/tests/snapshots/codegen__unit_enum.snap
+++ b/facet-zod/tests/snapshots/codegen__unit_enum.snap
@@ -1,0 +1,6 @@
+---
+source: tests/codegen.rs
+expression: output
+---
+export const StatusSchema = z.enum(["Active", "Inactive", "Banned"]);
+export type Status = z.infer<typeof StatusSchema>;

--- a/facet-zod/tests/snapshots/codegen__with_header.snap
+++ b/facet-zod/tests/snapshots/codegen__with_header.snap
@@ -1,0 +1,12 @@
+---
+source: tests/codegen.rs
+expression: output
+---
+import { z } from 'zod';
+
+export const UserSchema = z.object({
+  name: z.string(),
+  age: z.number().int(),
+  email: z.string().nullish(),
+});
+export type User = z.infer<typeof UserSchema>;

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -80,6 +80,11 @@ version_group = "facet"
 changelog_path = "CHANGELOG.md"
 
 [[package]]
+name = "facet-zod"
+version_group = "facet"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
 name = "facet-path"
 version_group = "facet"
 changelog_path = "CHANGELOG.md"


### PR DESCRIPTION
## Summary

New workspace crate `facet-zod` that generates [Zod](https://zod.dev) TypeScript schemas from Rust types via Facet reflection.

- Maps Facet `Shape`s through an intermediate `ZodType` IR, then emits TS source
- Supports structs, tuple structs (incl. transparent newtype), unit enums (→ `z.enum`), data-bearing enums (→ tagged `z.union`), `Option<T>`, `Vec`/sets/slices, `HashMap`/`BTreeMap` (→ `z.record`), fixed arrays (→ `z.tuple`), `Result<T, E>` (→ `ok`/`error` union), references
- Configurable: `optional_mode` (`Optional`/`Nullable`/`Nullish`), `bigint_mode` (widen 64-bit ints to `z.bigint()`), `export_style` (const+type / const only / type only), optional file `header`
- Cycles broken with `z.lazy(() => …Schema)`; topo-sorted output so refs appear after defs
- Auto-discovers transitively reachable types from registered roots

## Files

- New crate at `facet-zod/` (src + tests + insta snapshots, README, CHANGELOG, readme-footer, arborium-header)
- Wired into root `Cargo.toml` workspace members and `release-plz.toml` `facet` version group

## Test plan

- [x] `cargo nextest run -p facet-zod` — 8/8 pass
- [x] `cargo clippy -p facet-zod --no-deps --all-targets -- -D warnings` — clean
- [x] `cargo test -p facet-zod --doc` — 1/1 pass
- [x] `cargo doc -p facet-zod --no-deps` — no warnings
- [x] `cargo fmt -p facet-zod --check` — clean
- [x] `scripts/readme-footer.sh check` — in sync