### PR TITLE
chore: release v0.50.0-rc.0

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - bearcove-ubuntu-24.04

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-plz-release:
     name: Release-plz release
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     environment: release
     permissions:
       contents: write
@@ -22,7 +22,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Get crates.io token via OIDC
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@v1.0.4
         id: crates-io-auth
       - name: Run release-plz
         uses: release-plz/action@v0.5
@@ -34,7 +34,7 @@ jobs:
 
   release-plz-pr:
     name: Release-plz PR
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           cargo +nightly llvm-cov report --doctests --lcov --output-path coverage/lcov.info
 
       - name: ✨ Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           files: coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -162,7 +162,7 @@ jobs:
 
   semver-checks:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -179,7 +179,7 @@ jobs:
           verbose: true
 
   test-aarch64-apple-darwin:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
 
@@ -200,7 +200,7 @@ jobs:
           cargo nextest run --features ci
 
   test-aarch64-unknown-linux-gnu:
-    runs-on: ubuntu-24.04-arm
+    runs-on: bearcove-ubuntu-24.04
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-arm64
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,7 +200,7 @@ jobs:
           cargo nextest run --features ci
 
   test-aarch64-unknown-linux-gnu:
-    runs-on: bearcove-ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-arm64
     steps:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -53,7 +53,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: bearcove-ubuntu-24.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.50.0](https://github.com/facet-rs/facet/compare/facet-urlencoded-v0.46.4...facet-urlencoded-v0.50.0) - 2026-05-26
+## [0.50.0-rc.0](https://github.com/facet-rs/facet/compare/facet-urlencoded-v0.46.4...facet-urlencoded-v0.50.0-rc.0) - 2026-05-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.46.5](https://github.com/facet-rs/facet/compare/facet-urlencoded-v0.46.4...facet-urlencoded-v0.46.5) - 2026-05-26
+## [0.50.0](https://github.com/facet-rs/facet/compare/facet-urlencoded-v0.46.4...facet-urlencoded-v0.50.0) - 2026-05-26
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "autocfg",
  "bytes",
@@ -660,21 +660,21 @@ dependencies = [
 
 [[package]]
 name = "facet-default"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "facet",
 ]
 
 [[package]]
 name = "facet-error"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "facet",
 ]
 
 [[package]]
 name = "facet-macro-parse"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-types"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -692,14 +692,14 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "facet-macros-impl",
 ]
 
 [[package]]
 name = "facet-macros-impl"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "facet-path"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "facet",
  "facet-core",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "facet-pretty"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "camino",
  "facet",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "facet-reflect"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "camino",
  "eyre",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "facet-showcase"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "arborium",
  "facet",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "facet-solver"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "divan",
  "facet",
@@ -781,14 +781,14 @@ dependencies = [
 
 [[package]]
 name = "facet-testattrs"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "facet",
 ]
 
 [[package]]
 name = "facet-testhelpers"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "color-backtrace",
  "facet-testhelpers-macros",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "facet-testhelpers-macros"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "quote",
  "unsynn",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "facet-urlencoded"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "axum-core",
  "facet",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "facet-validate"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 dependencies = [
  "facet",
  "facet-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "autocfg",
  "bytes",
@@ -660,21 +660,21 @@ dependencies = [
 
 [[package]]
 name = "facet-default"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "facet",
 ]
 
 [[package]]
 name = "facet-error"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "facet",
 ]
 
 [[package]]
 name = "facet-macro-parse"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-types"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -692,14 +692,14 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "facet-macros-impl",
 ]
 
 [[package]]
 name = "facet-macros-impl"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "facet-path"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "facet",
  "facet-core",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "facet-pretty"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "camino",
  "facet",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "facet-reflect"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "camino",
  "eyre",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "facet-showcase"
-version = "0.43.0"
+version = "0.50.0"
 dependencies = [
  "arborium",
  "facet",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "facet-solver"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "divan",
  "facet",
@@ -781,14 +781,14 @@ dependencies = [
 
 [[package]]
 name = "facet-testattrs"
-version = "0.44.2"
+version = "0.50.0"
 dependencies = [
  "facet",
 ]
 
 [[package]]
 name = "facet-testhelpers"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "color-backtrace",
  "facet-testhelpers-macros",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "facet-testhelpers-macros"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "quote",
  "unsynn",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "facet-urlencoded"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "axum-core",
  "facet",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "facet-validate"
-version = "0.46.5"
+version = "0.50.0"
 dependencies = [
  "facet",
  "facet-core",

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-core"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-core"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/facet-core/src/types/shape.rs
+++ b/facet-core/src/types/shape.rs
@@ -269,9 +269,8 @@ pub struct Shape {
 }
 
 impl PartialOrd for Shape {
-    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.id.get().partial_cmp(&other.id.get())
+        Some(self.cmp(other))
     }
 }
 

--- a/facet-default/Cargo.toml
+++ b/facet-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-default"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,7 +15,7 @@ categories = ["rust-patterns", "development-tools"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { path = "../facet", version = "0.46.5" }
+facet = { path = "../facet", version = "0.50.0" }
 
 [dev-dependencies]
 facet = { path = "../facet" }

--- a/facet-default/Cargo.toml
+++ b/facet-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-default"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,7 +15,7 @@ categories = ["rust-patterns", "development-tools"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { path = "../facet", version = "0.50.0" }
+facet = { path = "../facet", version = "0.50.0-rc.0" }
 
 [dev-dependencies]
 facet = { path = "../facet" }

--- a/facet-error/Cargo.toml
+++ b/facet-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-error"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,7 +15,7 @@ categories = ["rust-patterns", "development-tools"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { path = "../facet", version = "0.46.5" }
+facet = { path = "../facet", version = "0.50.0" }
 
 [dev-dependencies]
 facet = { path = "../facet" }

--- a/facet-error/Cargo.toml
+++ b/facet-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-error"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,7 +15,7 @@ categories = ["rust-patterns", "development-tools"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet = { path = "../facet", version = "0.50.0" }
+facet = { path = "../facet", version = "0.50.0-rc.0" }
 
 [dev-dependencies]
 facet = { path = "../facet" }

--- a/facet-macro-parse/Cargo.toml
+++ b/facet-macro-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-macro-parse"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ homepage = "https://facet.rs"
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet-macro-types = { version = "0.46.5", path = "../facet-macro-types" }
+facet-macro-types = { version = "0.50.0", path = "../facet-macro-types" }
 proc-macro2 = "1"
 quote = { workspace = true }
 

--- a/facet-macro-parse/Cargo.toml
+++ b/facet-macro-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-macro-parse"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ homepage = "https://facet.rs"
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet-macro-types = { version = "0.50.0", path = "../facet-macro-types" }
+facet-macro-types = { version = "0.50.0-rc.0", path = "../facet-macro-types" }
 proc-macro2 = "1"
 quote = { workspace = true }
 

--- a/facet-macro-types/Cargo.toml
+++ b/facet-macro-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-macro-types"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/facet-macro-types/Cargo.toml
+++ b/facet-macro-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-macro-types"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/facet-macro-types/src/lib.rs
+++ b/facet-macro-types/src/lib.rs
@@ -9,6 +9,10 @@
 //! - RenameRule for field/variant name transformations
 //! - Helper types like LifetimeName for code generation
 
+#![expect(
+    clippy::result_large_err,
+    reason = "unsynn's Parser API intentionally returns its large Error by value; unsynn documents and allows this tradeoff in its own crate root"
+)]
 #![warn(missing_docs)]
 #![allow(uncommon_codepoints)]
 

--- a/facet-macro-types/src/lib.rs
+++ b/facet-macro-types/src/lib.rs
@@ -9,10 +9,8 @@
 //! - RenameRule for field/variant name transformations
 //! - Helper types like LifetimeName for code generation
 
-#![expect(
-    clippy::result_large_err,
-    reason = "unsynn's Parser API intentionally returns its large Error by value; unsynn documents and allows this tradeoff in its own crate root"
-)]
+// unsynn's Parser API intentionally returns its large Error by value.
+#![allow(clippy::result_large_err)]
 #![warn(missing_docs)]
 #![allow(uncommon_codepoints)]
 

--- a/facet-macros-impl/Cargo.toml
+++ b/facet-macros-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-macros-impl"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -30,8 +30,8 @@ doc = []
 helpful-derive = ["dep:strsim"]
 
 [dependencies]
-facet-macro-parse = { version = "0.46.5", path = "../facet-macro-parse" }
-facet-macro-types = { version = "0.46.5", path = "../facet-macro-types" }
+facet-macro-parse = { version = "0.50.0", path = "../facet-macro-parse" }
+facet-macro-types = { version = "0.50.0", path = "../facet-macro-types" }
 proc-macro2 = "1.0.95"
 quote = { workspace = true }
 strsim = { workspace = true, optional = true }

--- a/facet-macros-impl/Cargo.toml
+++ b/facet-macros-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-macros-impl"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -30,8 +30,8 @@ doc = []
 helpful-derive = ["dep:strsim"]
 
 [dependencies]
-facet-macro-parse = { version = "0.50.0", path = "../facet-macro-parse" }
-facet-macro-types = { version = "0.50.0", path = "../facet-macro-types" }
+facet-macro-parse = { version = "0.50.0-rc.0", path = "../facet-macro-parse" }
+facet-macro-types = { version = "0.50.0-rc.0", path = "../facet-macro-types" }
 proc-macro2 = "1.0.95"
 quote = { workspace = true }
 strsim = { workspace = true, optional = true }

--- a/facet-macros-impl/src/lib.rs
+++ b/facet-macros-impl/src/lib.rs
@@ -1,7 +1,5 @@
-#![expect(
-    clippy::result_large_err,
-    reason = "unsynn's Parser API intentionally returns its large Error by value; unsynn documents and allows this tradeoff in its own crate root"
-)]
+// unsynn's Parser API intentionally returns its large Error by value.
+#![allow(clippy::result_large_err)]
 #![warn(missing_docs)]
 #![allow(uncommon_codepoints)]
 //!

--- a/facet-macros-impl/src/lib.rs
+++ b/facet-macros-impl/src/lib.rs
@@ -1,3 +1,7 @@
+#![expect(
+    clippy::result_large_err,
+    reason = "unsynn's Parser API intentionally returns its large Error by value; unsynn documents and allows this tradeoff in its own crate root"
+)]
 #![warn(missing_docs)]
 #![allow(uncommon_codepoints)]
 //!

--- a/facet-macros/Cargo.toml
+++ b/facet-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-macros"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true
@@ -31,7 +31,7 @@ doc = ["facet-macros-impl/doc"]
 helpful-derive = ["facet-macros-impl/helpful-derive"]
 
 [dependencies]
-facet-macros-impl = { version = "0.46.5", path = "../facet-macros-impl", default-features = false }
+facet-macros-impl = { version = "0.50.0", path = "../facet-macros-impl", default-features = false }
 
 # cf. https://hachyderm.io/@epage/114141126315983016
 [target.'cfg(any())'.dependencies]

--- a/facet-macros/Cargo.toml
+++ b/facet-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-macros"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true
@@ -31,7 +31,7 @@ doc = ["facet-macros-impl/doc"]
 helpful-derive = ["facet-macros-impl/helpful-derive"]
 
 [dependencies]
-facet-macros-impl = { version = "0.50.0", path = "../facet-macros-impl", default-features = false }
+facet-macros-impl = { version = "0.50.0-rc.0", path = "../facet-macros-impl", default-features = false }
 
 # cf. https://hachyderm.io/@epage/114141126315983016
 [target.'cfg(any())'.dependencies]

--- a/facet-path/Cargo.toml
+++ b/facet-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-path"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -22,7 +22,7 @@ std = ["alloc", "facet-core/std"]
 alloc = ["facet-core/alloc"]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.50.0", default-features = false }
+facet-core = { path = "../facet-core", version = "0.50.0-rc.0", default-features = false }
 
 [dev-dependencies]
 facet = { path = "../facet" }

--- a/facet-path/Cargo.toml
+++ b/facet-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-path"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -22,7 +22,7 @@ std = ["alloc", "facet-core/std"]
 alloc = ["facet-core/alloc"]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.46.5", default-features = false }
+facet-core = { path = "../facet-core", version = "0.50.0", default-features = false }
 
 [dev-dependencies]
 facet = { path = "../facet" }

--- a/facet-pretty/Cargo.toml
+++ b/facet-pretty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-pretty"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -31,8 +31,8 @@ camino = ["alloc", "facet-core/camino"]
 detect-terminal-theme = ["dep:terminal-light"]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.46.5" }
-facet-reflect = { path = "../facet-reflect", version = "0.46.5" }
+facet-core = { path = "../facet-core", version = "0.50.0" }
+facet-reflect = { path = "../facet-reflect", version = "0.50.0" }
 owo-colors = { version = "4", features = ["supports-colors"] }
 
 # `terminal-light` -> `crossterm` does not compile on wasm32. The

--- a/facet-pretty/Cargo.toml
+++ b/facet-pretty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-pretty"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -31,8 +31,8 @@ camino = ["alloc", "facet-core/camino"]
 detect-terminal-theme = ["dep:terminal-light"]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.50.0" }
-facet-reflect = { path = "../facet-reflect", version = "0.50.0" }
+facet-core = { path = "../facet-core", version = "0.50.0-rc.0" }
+facet-reflect = { path = "../facet-reflect", version = "0.50.0-rc.0" }
 owo-colors = { version = "4", features = ["supports-colors"] }
 
 # `terminal-light` -> `crossterm` does not compile on wasm32. The

--- a/facet-reflect/Cargo.toml
+++ b/facet-reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-reflect"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -40,8 +40,8 @@ fn-ptr = ["facet-core/fn-ptr"] # Enable Facet implementation for function pointe
 
 [dependencies]
 camino = { workspace = true, optional = true }
-facet-core = { path = "../facet-core", version = "0.46.5", default-features = false }
-facet-path = { version = "0.46.5", path = "../facet-path", default-features = false }
+facet-core = { path = "../facet-core", version = "0.50.0", default-features = false }
+facet-path = { version = "0.50.0", path = "../facet-path", default-features = false }
 hashbrown = "0.17"
 smallvec = "^2.0.0-alpha.10"
 regex = { version = "1", default-features = false, features = ["std"], optional = true }

--- a/facet-reflect/Cargo.toml
+++ b/facet-reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-reflect"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -40,8 +40,8 @@ fn-ptr = ["facet-core/fn-ptr"] # Enable Facet implementation for function pointe
 
 [dependencies]
 camino = { workspace = true, optional = true }
-facet-core = { path = "../facet-core", version = "0.50.0", default-features = false }
-facet-path = { version = "0.50.0", path = "../facet-path", default-features = false }
+facet-core = { path = "../facet-core", version = "0.50.0-rc.0", default-features = false }
+facet-path = { version = "0.50.0-rc.0", path = "../facet-path", default-features = false }
 hashbrown = "0.17"
 smallvec = "^2.0.0-alpha.10"
 regex = { version = "1", default-features = false, features = ["std"], optional = true }

--- a/facet-showcase/Cargo.toml
+++ b/facet-showcase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-showcase"
-version = "0.43.0"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Unified showcase infrastructure for facet format crates"
@@ -15,8 +15,8 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
 arborium = { workspace = true, features = ["lang-rust", "lang-xml", "lang-yaml"] }
-facet = { path = "../facet", version = "0.46.5", features = ["all-impls", "doc"] }
-facet-pretty = { path = "../facet-pretty", version = "0.46.5" }
+facet = { path = "../facet", version = "0.50.0", features = ["all-impls", "doc"] }
+facet-pretty = { path = "../facet-pretty", version = "0.50.0" }
 
 # Terminal colors
 owo-colors = "4"

--- a/facet-showcase/Cargo.toml
+++ b/facet-showcase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-showcase"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Unified showcase infrastructure for facet format crates"
@@ -15,8 +15,8 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
 arborium = { workspace = true, features = ["lang-rust", "lang-xml", "lang-yaml"] }
-facet = { path = "../facet", version = "0.50.0", features = ["all-impls", "doc"] }
-facet-pretty = { path = "../facet-pretty", version = "0.50.0" }
+facet = { path = "../facet", version = "0.50.0-rc.0", features = ["all-impls", "doc"] }
+facet-pretty = { path = "../facet-pretty", version = "0.50.0-rc.0" }
 
 # Terminal colors
 owo-colors = "4"

--- a/facet-solver/Cargo.toml
+++ b/facet-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-solver"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -21,8 +21,8 @@ suggestions = ["strsim", "alloc"]
 tracing = ["dep:tracing", "facet-reflect/tracing"]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.46.5", default-features = false }
-facet-reflect = { path = "../facet-reflect", version = "0.46.5", default-features = false }
+facet-core = { path = "../facet-core", version = "0.50.0", default-features = false }
+facet-reflect = { path = "../facet-reflect", version = "0.50.0", default-features = false }
 strsim = { workspace = true, optional = true }
 
 # Tracing (optional - compiles to nothing when disabled)

--- a/facet-solver/Cargo.toml
+++ b/facet-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-solver"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -21,8 +21,8 @@ suggestions = ["strsim", "alloc"]
 tracing = ["dep:tracing", "facet-reflect/tracing"]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.50.0", default-features = false }
-facet-reflect = { path = "../facet-reflect", version = "0.50.0", default-features = false }
+facet-core = { path = "../facet-core", version = "0.50.0-rc.0", default-features = false }
+facet-reflect = { path = "../facet-reflect", version = "0.50.0-rc.0", default-features = false }
 strsim = { workspace = true, optional = true }
 
 # Tracing (optional - compiles to nothing when disabled)

--- a/facet-solver/src/lib.rs
+++ b/facet-solver/src/lib.rs
@@ -1619,11 +1619,11 @@ fn compute_closeness_score(
     let would_be_missing = currently_missing.saturating_sub(fields_that_would_match);
 
     // Coverage score: percentage of required fields that would be present
-    let coverage_score = if required_count > 0 {
-        ((required_count - would_be_missing) * 100) / required_count
-    } else {
-        100 // No required fields = perfect coverage
-    };
+    let coverage_score = required_count
+        .saturating_sub(would_be_missing)
+        .saturating_mul(100)
+        .checked_div(required_count)
+        .unwrap_or(100);
 
     // Penalty for truly unknown fields (no typo suggestion)
     let truly_unknown = unknown_fields.len().saturating_sub(fields_that_would_match);

--- a/facet-testattrs/Cargo.toml
+++ b/facet-testattrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-testattrs"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -9,7 +9,7 @@ description = "Test attributes for facet extension attribute testing (not publis
 publish = false
 
 [dependencies]
-facet = { path = "../facet", version = "0.50.0" }
+facet = { path = "../facet", version = "0.50.0-rc.0" }
 
 [lints]
 workspace = true

--- a/facet-testattrs/Cargo.toml
+++ b/facet-testattrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-testattrs"
-version = "0.44.2"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -9,7 +9,7 @@ description = "Test attributes for facet extension attribute testing (not publis
 publish = false
 
 [dependencies]
-facet = { path = "../facet", version = "0.46.5" }
+facet = { path = "../facet", version = "0.50.0" }
 
 [lints]
 workspace = true

--- a/facet-testhelpers-macros/Cargo.toml
+++ b/facet-testhelpers-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-testhelpers-macros"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/facet-testhelpers-macros/Cargo.toml
+++ b/facet-testhelpers-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-testhelpers-macros"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/facet-testhelpers-macros/src/lib.rs
+++ b/facet-testhelpers-macros/src/lib.rs
@@ -1,7 +1,5 @@
-#![expect(
-    clippy::result_large_err,
-    reason = "unsynn's Parser API intentionally returns its large Error by value; unsynn documents and allows this tradeoff in its own crate root"
-)]
+// unsynn's Parser API intentionally returns its large Error by value.
+#![allow(clippy::result_large_err)]
 
 use unsynn::*;
 

--- a/facet-testhelpers-macros/src/lib.rs
+++ b/facet-testhelpers-macros/src/lib.rs
@@ -1,3 +1,8 @@
+#![expect(
+    clippy::result_large_err,
+    reason = "unsynn's Parser API intentionally returns its large Error by value; unsynn documents and allows this tradeoff in its own crate root"
+)]
+
 use unsynn::*;
 
 keyword! {

--- a/facet-testhelpers/Cargo.toml
+++ b/facet-testhelpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-testhelpers"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,7 +13,7 @@ description = "A collection of testing helpers and utilities for facet"
 [features]
 
 [dependencies]
-facet-testhelpers-macros = { version = "0.50.0", path = "../facet-testhelpers-macros" }
+facet-testhelpers-macros = { version = "0.50.0-rc.0", path = "../facet-testhelpers-macros" }
 color-backtrace = { version = "0.7.2", features = ["use-btparse-crate"] }
 termcolor = "1.4"
 tracing = { workspace = true }

--- a/facet-testhelpers/Cargo.toml
+++ b/facet-testhelpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-testhelpers"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -13,7 +13,7 @@ description = "A collection of testing helpers and utilities for facet"
 [features]
 
 [dependencies]
-facet-testhelpers-macros = { version = "0.46.5", path = "../facet-testhelpers-macros" }
+facet-testhelpers-macros = { version = "0.50.0", path = "../facet-testhelpers-macros" }
 color-backtrace = { version = "0.7.2", features = ["use-btparse-crate"] }
 termcolor = "1.4"
 tracing = { workspace = true }

--- a/facet-urlencoded/Cargo.toml
+++ b/facet-urlencoded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-urlencoded"
-version = "0.46.5"
+version = "0.50.0"
 edition = "2024"
 rust-version = "1.90.0"
 license = "MIT OR Apache-2.0"
@@ -24,8 +24,8 @@ axum = ["dep:axum-core", "dep:http", "dep:http-body-util"]
 
 # Axum integration (optional)
 axum-core = { version = "0.5", default-features = false, optional = true }
-facet-core = { path = "../facet-core", version = "0.46.5" }
-facet-reflect = { path = "../facet-reflect", version = "0.46.5" }
+facet-core = { path = "../facet-core", version = "0.50.0" }
+facet-reflect = { path = "../facet-reflect", version = "0.50.0" }
 form_urlencoded = "1.2.1"
 http = { workspace = true, optional = true }
 http-body-util = { version = "0.1", default-features = false, optional = true }

--- a/facet-urlencoded/Cargo.toml
+++ b/facet-urlencoded/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-urlencoded"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition = "2024"
 rust-version = "1.90.0"
 license = "MIT OR Apache-2.0"
@@ -24,8 +24,8 @@ axum = ["dep:axum-core", "dep:http", "dep:http-body-util"]
 
 # Axum integration (optional)
 axum-core = { version = "0.5", default-features = false, optional = true }
-facet-core = { path = "../facet-core", version = "0.50.0" }
-facet-reflect = { path = "../facet-reflect", version = "0.50.0" }
+facet-core = { path = "../facet-core", version = "0.50.0-rc.0" }
+facet-reflect = { path = "../facet-reflect", version = "0.50.0-rc.0" }
 form_urlencoded = "1.2.1"
 http = { workspace = true, optional = true }
 http-body-util = { version = "0.1", default-features = false, optional = true }

--- a/facet-validate/Cargo.toml
+++ b/facet-validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-validate"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -16,8 +16,8 @@ homepage = "https://facet.rs"
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.46.5" }
-facet = { path = "../facet", version = "0.46.5" }
+facet-core = { path = "../facet-core", version = "0.50.0" }
+facet = { path = "../facet", version = "0.50.0" }
 regex = { version = "1", default-features = false, features = ["std"] }
 
 [lints]

--- a/facet-validate/Cargo.toml
+++ b/facet-validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-validate"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -16,8 +16,8 @@ homepage = "https://facet.rs"
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "0.50.0" }
-facet = { path = "../facet", version = "0.50.0" }
+facet-core = { path = "../facet-core", version = "0.50.0-rc.0" }
+facet = { path = "../facet", version = "0.50.0-rc.0" }
 regex = { version = "1", default-features = false, features = ["std"] }
 
 [lints]

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet"
-version = "0.46.5"
+version = "0.50.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -130,9 +130,9 @@ slow-tests = []
 autocfg = { workspace = true }
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "=0.46.5", default-features = false }
-facet-macros = { path = "../facet-macros", version = "0.46.5", default-features = false }
-facet-reflect = { path = "../facet-reflect", version = "0.46.5", optional = true }
+facet-core = { path = "../facet-core", version = "=0.50.0", default-features = false }
+facet-macros = { path = "../facet-macros", version = "0.50.0", default-features = false }
+facet-reflect = { path = "../facet-reflect", version = "0.50.0", optional = true }
 static_assertions = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet"
-version = "0.50.0"
+version = "0.50.0-rc.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -130,9 +130,9 @@ slow-tests = []
 autocfg = { workspace = true }
 
 [dependencies]
-facet-core = { path = "../facet-core", version = "=0.50.0", default-features = false }
-facet-macros = { path = "../facet-macros", version = "0.50.0", default-features = false }
-facet-reflect = { path = "../facet-reflect", version = "0.50.0", optional = true }
+facet-core = { path = "../facet-core", version = "=0.50.0-rc.0", default-features = false }
+facet-macros = { path = "../facet-macros", version = "0.50.0-rc.0", default-features = false }
+facet-reflect = { path = "../facet-reflect", version = "0.50.0-rc.0", optional = true }
 static_assertions = { workspace = true, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Summary:
- Set every facet workspace crate to 0.50.0-rc.0 via release-plz set-version, one crate at a time.
- Update internal facet dependency requirements and Cargo.lock to match the RC.
- Move remaining x86 Linux workflows, including release, semver-checks, and Pages deploy, to bearcove-ubuntu-24.04.
- Keep Linux ARM on GitHub's ubuntu-24.04-arm runner because Bearcove has no ARM workers yet.
- Add actionlint config for the Bearcove runner label and update CI actions that were stale or Node 20-sensitive.
- Fix local Rust 1.96.0 clippy failures exposed by the pre-push hook; use allow rather than expect for unsynn parser macro result_large_err because the lint fires across toolchains inconsistently.

Testing:
- actionlint
- Recursive action runtime scan: no Node 20 actions, including nested composite actions
- cargo check --workspace --features ci --locked
- cargo clippy --workspace --all-features --all-targets --keep-going -- -D warnings --allow deprecated
- cargo nextest list -p facet-core -p facet-solver
- cargo nextest run -p facet-core -p facet-solver
- git diff --check
- Normal git push pre-push hook passed