### PR TITLE
Drop broken pagefind resources

### DIFF
--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -9,7 +9,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Recursive:slnt,wght,CASL,CRSV,MONO@-15..0,300..1000,0..1,0..1,0..1&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/main.css">
-    <link rel="stylesheet" href="/pagefind/pagefind-ui.css">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" href="/favicon.png">
@@ -82,7 +81,6 @@
         </div>
     </footer>
 
-    <script src="/pagefind/pagefind-ui.js"></script>
     <script>
     document.addEventListener('DOMContentLoaded', () => {
         // Build TOC from showcase scenario headers


### PR DESCRIPTION
`pagefind-ui.css` and `pagefind-ui.js` were not served on live doc. pagefind does not seem to be used as there is no `pagefind-modal` in the code.