### PR TITLE
Import facet-axum into facet workspace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           manifest-path: Cargo.toml
           baseline-rev: origin/main
-          exclude: facet-testattrs, facet-cargo-toml
+          exclude: facet-testattrs, facet-cargo-toml, facet-axum
           verbose: true
 
   test-aarch64-apple-darwin:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,16 +210,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "axum-core"
@@ -726,6 +768,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-axum"
+version = "0.50.0-rc.0"
+dependencies = [
+ "axum",
+ "facet",
+ "facet-json",
+ "facet-msgpack",
+ "facet-postcard",
+ "facet-toml",
+ "facet-urlencoded",
+ "facet-xml",
+ "facet-yaml",
+ "tokio",
+ "tower",
+]
+
+[[package]]
 name = "facet-cargo-toml"
 version = "0.50.0-rc.0"
 dependencies = [
@@ -791,6 +850,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-dom"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8276a53156eed151697d04757835418513133d3d8e499b7e1951bc348a357c43"
+dependencies = [
+ "facet-core",
+ "facet-dessert",
+ "facet-reflect",
+ "facet-singularize",
+ "heck",
+ "owo-colors",
+]
+
+[[package]]
 name = "facet-error"
 version = "0.50.0-rc.0"
 dependencies = [
@@ -808,6 +881,22 @@ dependencies = [
  "facet-path",
  "facet-reflect",
  "facet-solver",
+]
+
+[[package]]
+name = "facet-json"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a49a07dd025d269cf0f5b63679d08d2d9ddd080a578bbe3ec58e414ede1bd5"
+dependencies = [
+ "axum-core",
+ "facet",
+ "facet-core",
+ "facet-format",
+ "facet-reflect",
+ "http",
+ "http-body-util",
+ "mime",
 ]
 
 [[package]]
@@ -848,6 +937,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-msgpack"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c447de4a761d3059615b078afc6466e85d62035bfd4a96ffd6b6f8ee659599ac"
+dependencies = [
+ "axum-core",
+ "facet-core",
+ "facet-format",
+ "facet-reflect",
+ "http",
+ "http-body-util",
+]
+
+[[package]]
 name = "facet-path"
 version = "0.50.0-rc.0"
 dependencies = [
@@ -855,6 +958,23 @@ dependencies = [
  "facet-core",
  "facet-testhelpers",
  "insta",
+]
+
+[[package]]
+name = "facet-postcard"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73808e09fce1ee54cf8e2a70fa301bcb8a1c92ffc3ea2d18ab2e83adbec1c46"
+dependencies = [
+ "axum-core",
+ "facet-core",
+ "facet-format",
+ "facet-path",
+ "facet-reflect",
+ "facet-value",
+ "http",
+ "http-body-util",
+ "tracing",
 ]
 
 [[package]]
@@ -904,6 +1024,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-singularize"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e621f8014a6cdfd8c9bf30b9102bb8746050a9c5de2cd98096d3eb69503490a3"
+
+[[package]]
 name = "facet-solver"
 version = "0.50.0-rc.0"
 dependencies = [
@@ -949,9 +1075,12 @@ version = "0.50.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91f7a7a88e9a27921bd870700681d450ab7c4bc8a2d1cd69dc2be1d36d5289a6"
 dependencies = [
+ "axum-core",
  "facet-core",
  "facet-format",
  "facet-reflect",
+ "http",
+ "http-body-util",
  "toml_parser",
 ]
 
@@ -989,6 +1118,38 @@ dependencies = [
  "facet-format",
  "facet-reflect",
  "indexmap",
+]
+
+[[package]]
+name = "facet-xml"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3208e3ab2d4c0c3beccf3d01ea0deb9a74225ff9ebd61c33f2eed432ac5400"
+dependencies = [
+ "axum-core",
+ "facet",
+ "facet-core",
+ "facet-dom",
+ "facet-reflect",
+ "http",
+ "http-body-util",
+ "quick-xml",
+]
+
+[[package]]
+name = "facet-yaml"
+version = "0.50.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1804f4e2a31984c1da1425c0ddc0845560b1280203bd54de8429d563983b293d"
+dependencies = [
+ "axum-core",
+ "facet",
+ "facet-core",
+ "facet-format",
+ "facet-reflect",
+ "http",
+ "http-body-util",
+ "saphyr-parser",
 ]
 
 [[package]]
@@ -1046,6 +1207,15 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "futures-core"
@@ -1153,6 +1323,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1374,53 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec 1.15.2",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1536,6 +1762,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,6 +2044,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quickcheck"
@@ -2134,6 +2375,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "saphyr-parser"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb771b59f6b1985d1406325ec28f97cfb14256abcec4fdfb37b36a1766d6af7"
+dependencies = [
+ "arraydeque",
+ "hashlink",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,6 +2443,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2287,6 +2549,16 @@ name = "smol_str"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -2552,6 +2824,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,6 +2877,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
 
   # misc.
   "facet-urlencoded",
+  "facet-axum",
 
   # utilities
   "facet-path",
@@ -64,17 +65,25 @@ repository = "https://github.com/facet-rs/facet"
 
 [workspace.dependencies]
 facet = { path = "facet", version = "0.50.0-rc.0" }
+facet-axum = { path = "facet-axum", version = "0.50.0-rc.0" }
 facet-core = { path = "facet-core" }
 facet-cargo-toml = { path = "facet-cargo-toml", version = "0.50.0-rc.0" }
 facet-error = { path = "facet-error", version = "0.50.0-rc.0" }
+facet-json = "0.50.0-rc.0"
+facet-msgpack = "0.50.0-rc.0"
+facet-postcard = "0.50.0-rc.0"
 facet-pretty = { path = "facet-pretty" }
 facet-reflect = { path = "facet-reflect", version = "0.50.0-rc.0" }
 facet-toml = "0.50.0-rc.0"
+facet-xml = "0.50.0-rc.0"
+facet-yaml = "0.50.0-rc.0"
+facet-urlencoded = { path = "facet-urlencoded", version = "0.50.0-rc.0" }
 facet-value = "0.50.0-rc.0"
 strid = { path = "strid", version = "11.0.0-rc.0" }
 strid-macros = { path = "strid-macros", version = "11.0.0-rc.0" }
 arborium = { version = "^2.4.5", default-features = false, features = ["lang-json"] }
 autocfg = "^1.5.0"
+axum = { version = "0.8.9", default-features = false, features = ["http1", "tokio", "json"] }
 bytes = { version = "^1.11.0", default-features = false }
 bytestring = { version = "^1.4.0", default-features = false }
 camino = "^1.2.1"
@@ -97,6 +106,8 @@ static_assertions = "^1.1.0"
 strsim = "0.11"
 tempfile = "^3.23.0"
 time = { version = "^0.3.44", features = ["formatting", "macros", "parsing"] }
+tokio = { version = "1", features = ["io-util", "rt", "rt-multi-thread"] }
+tower = { version = "0.5", default-features = false, features = ["util"] }
 tracing = { version = "^0.1.43", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "^0.3.22", default-features = false, features = ["fmt", "std"] }
 ulid = "^1.2.1"
@@ -139,7 +150,9 @@ facet-pretty = { path = "facet-pretty" }
 facet-reflect = { path = "facet-reflect" }
 facet-solver = { path = "facet-solver" }
 facet-testhelpers = { path = "facet-testhelpers" }
+facet-axum = { path = "facet-axum" }
 facet-cargo-toml = { path = "facet-cargo-toml" }
+facet-urlencoded = { path = "facet-urlencoded" }
 strid = { path = "strid" }
 strid-macros = { path = "strid-macros" }
 strid-examples = { path = "strid-examples" }

--- a/docs/content/ecosystem/_index.md
+++ b/docs/content/ecosystem/_index.md
@@ -94,7 +94,7 @@ Day-to-day ergonomics: better output, better errors, less boilerplate.
 
 | Crate | What it does | Source |
 |-------|--------------|--------|
-| [`facet-axum`](https://docs.rs/facet-axum) | [axum](https://docs.rs/axum) extractors and responses backed by facet instead of serde. | [facet-rs/facet-axum](https://github.com/facet-rs/facet-axum) |
+| [`facet-axum`](https://docs.rs/facet-axum) | [axum](https://docs.rs/axum) extractors and responses backed by facet instead of serde. [Guide](@/ecosystem/facet-axum/_index.md). | [facet-rs/facet](https://github.com/facet-rs/facet/tree/main/facet-axum) |
 | [`facet-egui`](https://docs.rs/facet-egui) | An [egui](https://www.egui.rs) inspector/editor widget for any `Facet` type — live, type-driven UI straight from a `Shape`. *Community-maintained.* | [Erik1000/facet-egui](https://github.com/Erik1000/facet-egui) |
 
 ## Building blocks

--- a/docs/content/ecosystem/facet-axum/_index.md
+++ b/docs/content/ecosystem/facet-axum/_index.md
@@ -1,0 +1,61 @@
++++
+title = "facet-axum"
+weight = 30
+insert_anchor_links = "heading"
++++
+
+`facet-axum` exposes [axum](https://docs.rs/axum) extractors and response
+types backed by Facet format crates.
+
+Use it when your request and response types already derive `Facet` and you want
+the web boundary to use the same schema as the rest of the Facet ecosystem.
+
+```rust
+use axum::{
+    Router,
+    routing::{get, post},
+};
+use facet::Facet;
+use facet_axum::{Json, Query};
+
+#[derive(Facet)]
+struct CreateUser {
+    name: String,
+    email: String,
+}
+
+#[derive(Facet)]
+struct User {
+    id: u64,
+    name: String,
+    email: String,
+}
+
+#[derive(Facet)]
+struct SearchParams {
+    q: String,
+    page: u64,
+}
+
+async fn create_user(Json(payload): Json<CreateUser>) -> Json<User> {
+    Json(User {
+        id: 1,
+        name: payload.name,
+        email: payload.email,
+    })
+}
+
+async fn search(Query(params): Query<SearchParams>) -> String {
+    format!("Searching for '{}' on page {}", params.q, params.page)
+}
+
+let app = Router::new()
+    .route("/users", post(create_user))
+    .route("/search", get(search));
+```
+
+The default features enable JSON responses/extractors and URL-encoded form/query
+extractors. Optional features expose YAML, TOML, XML, MessagePack, and Postcard
+types when the corresponding Facet format crates are enabled.
+
+Source: [`facet-axum`](https://github.com/facet-rs/facet/tree/main/facet-axum)

--- a/facet-axum/CHANGELOG.md
+++ b/facet-axum/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.43.1] - 2026-01-23
+
+### Changed
+
+- Moved to standalone repository at [facet-rs/facet-axum](https://github.com/facet-rs/facet-axum)
+- Now uses git dependencies to track facet main branch

--- a/facet-axum/Cargo.toml
+++ b/facet-axum/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "facet-axum"
+version = "0.43.1"
+edition = "2024"
+rust-version = "1.90.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/facet-rs/facet-axum"
+description = "Axum integration for Facet - extractors and responses using Facet's serialization"
+keywords = ["axum", "web", "json", "serialization", "facet"]
+categories = ["web-programming", "encoding"]
+homepage = "https://facet.rs"
+
+[features]
+default = ["json", "form"]
+json = ["facet-json/axum"]
+form = ["facet-urlencoded/axum"]
+yaml = ["facet-yaml/axum"]
+toml = ["facet-toml/axum"]
+msgpack = ["facet-msgpack/axum"]
+postcard = ["facet-postcard/axum"]
+all = ["json", "form", "yaml", "toml", "msgpack", "postcard"]
+
+[dependencies]
+facet-json = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
+facet-msgpack = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
+facet-postcard = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
+facet-toml = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
+facet-yaml = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
+facet-urlencoded = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
+
+[dev-dependencies]
+axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json"] }
+facet = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", features = ["all-impls", "doc"] }
+tokio = { version = "1", features = ["io-util", "rt", "rt-multi-thread"] }
+tower = { version = "0.5", default-features = false, features = ["util"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(facet_no_doc)"] }

--- a/facet-axum/Cargo.toml
+++ b/facet-axum/Cargo.toml
@@ -16,15 +16,17 @@ json = ["facet-json/axum"]
 form = ["facet-urlencoded/axum"]
 yaml = ["facet-yaml/axum"]
 toml = ["facet-toml/axum"]
+xml = ["facet-xml/axum"]
 msgpack = ["facet-msgpack/axum"]
 postcard = ["facet-postcard/axum"]
-all = ["json", "form", "yaml", "toml", "msgpack", "postcard"]
+all = ["json", "form", "yaml", "toml", "xml", "msgpack", "postcard"]
 
 [dependencies]
 facet-json = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
 facet-msgpack = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
 facet-postcard = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
 facet-toml = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
+facet-xml = { git = "https://github.com/facet-rs/facet-xml", branch = "main", version = "0.43.1", optional = true }
 facet-yaml = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
 facet-urlencoded = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
 

--- a/facet-axum/Cargo.toml
+++ b/facet-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-axum"
-version = "0.43.1"
+version = "0.44.0"
 edition = "2024"
 rust-version = "1.90.0"
 license = "MIT OR Apache-2.0"
@@ -22,17 +22,17 @@ postcard = ["facet-postcard/axum"]
 all = ["json", "form", "yaml", "toml", "xml", "msgpack", "postcard"]
 
 [dependencies]
-facet-json = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
-facet-msgpack = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
-facet-postcard = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
-facet-toml = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
-facet-xml = { git = "https://github.com/facet-rs/facet-xml", branch = "main", version = "0.43.1", optional = true }
-facet-yaml = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
-facet-urlencoded = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", optional = true }
+facet-json = { version = "0.44.0", optional = true }
+facet-msgpack = { version = "0.44.0", optional = true }
+facet-postcard = { version = "0.44.0", optional = true }
+facet-toml = { version = "0.44.0", optional = true }
+facet-xml = { version = "0.44.0", optional = true }
+facet-yaml = { version = "0.44.0", optional = true }
+facet-urlencoded = { version = "0.44.0", optional = true }
 
 [dev-dependencies]
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json"] }
-facet = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43.1", features = ["all-impls", "doc"] }
+facet = { version = "0.44.0", features = ["all-impls", "doc"] }
 tokio = { version = "1", features = ["io-util", "rt", "rt-multi-thread"] }
 tower = { version = "0.5", default-features = false, features = ["util"] }
 

--- a/facet-axum/Cargo.toml
+++ b/facet-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet-axum"
-version = "0.44.0"
+version = "0.50.0-rc.0"
 edition = "2024"
 rust-version = "1.90.0"
 license = "MIT OR Apache-2.0"
@@ -22,17 +22,17 @@ postcard = ["facet-postcard/axum"]
 all = ["json", "form", "yaml", "toml", "xml", "msgpack", "postcard"]
 
 [dependencies]
-facet-json = { version = "0.46.1", optional = true }
-facet-msgpack = { version = "0.46.1", optional = true }
-facet-postcard = { version = "0.46.1", optional = true }
-facet-toml = { version = "0.46.1", optional = true }
-facet-xml = { version = "0.46.0", optional = true }
-facet-yaml = { version = "0.46.1", optional = true }
-facet-urlencoded = { version = "0.46.4", optional = true }
+facet-json = { version = "0.50.0-rc.0", optional = true }
+facet-msgpack = { version = "0.50.0-rc.0", optional = true }
+facet-postcard = { version = "0.50.0-rc.0", optional = true }
+facet-toml = { version = "0.50.0-rc.0", optional = true }
+facet-xml = { version = "0.50.0-rc.0", optional = true }
+facet-yaml = { version = "0.50.0-rc.0", optional = true }
+facet-urlencoded = { version = "0.50.0-rc.0", optional = true }
 
 [dev-dependencies]
 axum = { version = "0.8.9", default-features = false, features = ["http1", "tokio", "json"] }
-facet = { version = "0.46.4", features = ["all-impls", "doc"] }
+facet = { version = "0.50.0-rc.0", features = ["all-impls", "doc"] }
 tokio = { version = "1", features = ["io-util", "rt", "rt-multi-thread"] }
 tower = { version = "0.5", default-features = false, features = ["util"] }
 

--- a/facet-axum/Cargo.toml
+++ b/facet-axum/Cargo.toml
@@ -22,17 +22,17 @@ postcard = ["facet-postcard/axum"]
 all = ["json", "form", "yaml", "toml", "xml", "msgpack", "postcard"]
 
 [dependencies]
-facet-json = { version = "0.44.0", optional = true }
-facet-msgpack = { version = "0.44.0", optional = true }
-facet-postcard = { version = "0.44.0", optional = true }
-facet-toml = { version = "0.44.0", optional = true }
-facet-xml = { version = "0.44.0", optional = true }
-facet-yaml = { version = "0.44.0", optional = true }
-facet-urlencoded = { version = "0.44.0", optional = true }
+facet-json = { version = "0.46.1", optional = true }
+facet-msgpack = { version = "0.46.1", optional = true }
+facet-postcard = { version = "0.46.1", optional = true }
+facet-toml = { version = "0.46.1", optional = true }
+facet-xml = { version = "0.46.0", optional = true }
+facet-yaml = { version = "0.46.1", optional = true }
+facet-urlencoded = { version = "0.46.4", optional = true }
 
 [dev-dependencies]
-axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json"] }
-facet = { version = "0.44.0", features = ["all-impls", "doc"] }
+axum = { version = "0.8.9", default-features = false, features = ["http1", "tokio", "json"] }
+facet = { version = "0.46.4", features = ["all-impls", "doc"] }
 tokio = { version = "1", features = ["io-util", "rt", "rt-multi-thread"] }
 tower = { version = "0.5", default-features = false, features = ["util"] }
 

--- a/facet-axum/Cargo.toml
+++ b/facet-axum/Cargo.toml
@@ -1,14 +1,20 @@
 [package]
 name = "facet-axum"
 version = "0.50.0-rc.0"
-edition = "2024"
-rust-version = "1.90.0"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/facet-rs/facet-axum"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 description = "Axum integration for Facet - extractors and responses using Facet's serialization"
+repository.workspace = true
 keywords = ["axum", "web", "json", "serialization", "facet"]
 categories = ["web-programming", "encoding"]
 homepage = "https://facet.rs"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[package.metadata."docs.rs"]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [features]
 default = ["json", "form"]
@@ -22,19 +28,19 @@ postcard = ["facet-postcard/axum"]
 all = ["json", "form", "yaml", "toml", "xml", "msgpack", "postcard"]
 
 [dependencies]
-facet-json = { version = "0.50.0-rc.0", optional = true }
-facet-msgpack = { version = "0.50.0-rc.0", optional = true }
-facet-postcard = { version = "0.50.0-rc.0", optional = true }
-facet-toml = { version = "0.50.0-rc.0", optional = true }
-facet-xml = { version = "0.50.0-rc.0", optional = true }
-facet-yaml = { version = "0.50.0-rc.0", optional = true }
-facet-urlencoded = { version = "0.50.0-rc.0", optional = true }
+facet-json = { workspace = true, optional = true }
+facet-msgpack = { workspace = true, optional = true }
+facet-postcard = { workspace = true, optional = true }
+facet-toml = { workspace = true, optional = true }
+facet-xml = { workspace = true, optional = true }
+facet-yaml = { workspace = true, optional = true }
+facet-urlencoded = { workspace = true, optional = true }
 
 [dev-dependencies]
-axum = { version = "0.8.9", default-features = false, features = ["http1", "tokio", "json"] }
-facet = { version = "0.50.0-rc.0", features = ["all-impls", "doc"] }
-tokio = { version = "1", features = ["io-util", "rt", "rt-multi-thread"] }
-tower = { version = "0.5", default-features = false, features = ["util"] }
+axum.workspace = true
+facet = { path = "../facet", features = ["all-impls", "doc"] }
+tokio.workspace = true
+tower.workspace = true
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(facet_no_doc)"] }
+[lints]
+workspace = true

--- a/facet-axum/LICENSE-APACHE
+++ b/facet-axum/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     https://www.apache.org/licenses/LICENSE-2.0
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/facet-axum/LICENSE-MIT
+++ b/facet-axum/LICENSE-MIT
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/facet-axum/README.md
+++ b/facet-axum/README.md
@@ -1,0 +1,115 @@
+# facet-axum
+
+[![crates.io](https://img.shields.io/crates/v/facet-axum.svg)](https://crates.io/crates/facet-axum)
+[![documentation](https://docs.rs/facet-axum/badge.svg)](https://docs.rs/facet-axum)
+[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/facet-axum.svg)](./LICENSE)
+[![Discord](https://img.shields.io/discord/1379550208551026748?logo=discord&label=discord)](https://discord.gg/JhD7CwCJ8F)
+
+Axum integration for Facet - extractors and responses using Facet's serialization.
+
+This crate provides Axum extractors and response types that use Facet's
+serialization instead of serde. This allows you to use Facet-derived types
+directly in your Axum handlers without needing serde derives.
+
+## Quick start
+
+```rust
+use axum::{routing::{get, post}, Router};
+use facet::Facet;
+use facet_axum::{Json, Query};
+
+#[derive(Debug, Facet)]
+struct CreateUser {
+    name: String,
+    email: String,
+}
+
+#[derive(Debug, Facet)]
+struct User {
+    id: u64,
+    name: String,
+    email: String,
+}
+
+#[derive(Debug, Facet)]
+struct SearchParams {
+    q: String,
+    page: u64,
+}
+
+async fn create_user(Json(payload): Json<CreateUser>) -> Json<User> {
+    Json(User {
+        id: 1,
+        name: payload.name,
+        email: payload.email,
+    })
+}
+
+async fn search(Query(params): Query<SearchParams>) -> String {
+    format!("Searching for '{}' on page {}", params.q, params.page)
+}
+
+let app = Router::new()
+    .route("/users", post(create_user))
+    .route("/search", get(search));
+```
+
+## Feature flags
+
+- `json` (default): Enables `Json<T>` extractor/response using `facet-json`
+- `form` (default): Enables `Form<T>` and `Query<T>` extractors using `facet-urlencoded`
+- `yaml`: Enables `Yaml<T>` extractor/response using `facet-yaml`
+- `toml`: Enables `Toml<T>` extractor/response using `facet-toml`
+- `msgpack`: Enables `MsgPack<T>` extractor/response using `facet-msgpack`
+- `postcard`: Enables `Postcard<T>` extractor/response using `facet-postcard`
+- `all`: Enables all format features
+
+## Sponsors
+
+Thanks to all individual sponsors:
+
+<p> <a href="https://github.com/sponsors/fasterthanlime">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-light.svg" height="40" alt="GitHub Sponsors">
+</picture>
+</a> <a href="https://patreon.com/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-light.svg" height="40" alt="Patreon">
+    </picture>
+</a> </p>
+
+...along with corporate sponsors:
+
+<p> <a href="https://aws.amazon.com">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-light.svg" height="40" alt="AWS">
+</picture>
+</a> <a href="https://zed.dev">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-light.svg" height="40" alt="Zed">
+</picture>
+</a> <a href="https://depot.dev?utm_source=facet">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-light.svg" height="40" alt="Depot">
+</picture>
+</a> </p>
+
+...without whom this work could not exist.
+
+## Special thanks
+
+The facet logo was drawn by [Misiasart](https://misiasart.com/).
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/facet-axum/README.md
+++ b/facet-axum/README.md
@@ -60,6 +60,7 @@ let app = Router::new()
 - `form` (default): Enables `Form<T>` and `Query<T>` extractors using `facet-urlencoded`
 - `yaml`: Enables `Yaml<T>` extractor/response using `facet-yaml`
 - `toml`: Enables `Toml<T>` extractor/response using `facet-toml`
+- `xml`: Enables `Xml<T>` extractor/response using `facet-xml`
 - `msgpack`: Enables `MsgPack<T>` extractor/response using `facet-msgpack`
 - `postcard`: Enables `Postcard<T>` extractor/response using `facet-postcard`
 - `all`: Enables all format features

--- a/facet-axum/arborium-header.html
+++ b/facet-axum/arborium-header.html
@@ -1,0 +1,2 @@
+<!-- Rustdoc doesn't highlight some languages natively -- let's do it ourselves: https://github.com/bearcove/arborium -->
+<script defer src="https://cdn.jsdelivr.net/npm/@arborium/arborium@2/dist/arborium.iife.js"></script>

--- a/facet-axum/src/lib.rs
+++ b/facet-axum/src/lib.rs
@@ -70,6 +70,10 @@ pub use facet_yaml::{Yaml, YamlRejection};
 #[cfg(feature = "toml")]
 pub use facet_toml::{Toml, TomlRejection};
 
+// Re-export XML types
+#[cfg(feature = "xml")]
+pub use facet_xml::{Xml, XmlRejection};
+
 // Re-export MessagePack types
 #[cfg(feature = "msgpack")]
 pub use facet_msgpack::{MsgPack, MsgPackRejection};

--- a/facet-axum/src/lib.rs
+++ b/facet-axum/src/lib.rs
@@ -1,0 +1,79 @@
+//! Axum integration for Facet.
+//!
+//! This crate provides Axum extractors and response types that use Facet's
+//! serialization instead of serde. This allows you to use Facet-derived types
+//! directly in your Axum handlers without needing serde derives.
+//!
+//! # Features
+//!
+//! - `json` (default): Enables `Json<T>` extractor/response using `facet-json`
+//! - `form` (default): Enables `Form<T>` and `Query<T>` extractors using `facet-urlencoded`
+//!
+//! # Example
+//!
+//! ```ignore
+//! use axum::{routing::{get, post}, Router};
+//! use facet::Facet;
+//! use facet_axum::{Json, Query};
+//!
+//! #[derive(Debug, Facet)]
+//! struct CreateUser {
+//!     name: String,
+//!     email: String,
+//! }
+//!
+//! #[derive(Debug, Facet)]
+//! struct User {
+//!     id: u64,
+//!     name: String,
+//!     email: String,
+//! }
+//!
+//! #[derive(Debug, Facet)]
+//! struct SearchParams {
+//!     q: String,
+//!     page: u64,
+//! }
+//!
+//! async fn create_user(Json(payload): Json<CreateUser>) -> Json<User> {
+//!     Json(User {
+//!         id: 1,
+//!         name: payload.name,
+//!         email: payload.email,
+//!     })
+//! }
+//!
+//! async fn search(Query(params): Query<SearchParams>) -> String {
+//!     format!("Searching for '{}' on page {}", params.q, params.page)
+//! }
+//!
+//! let app = Router::new()
+//!     .route("/users", post(create_user))
+//!     .route("/search", get(search));
+//! ```
+
+#![warn(missing_docs)]
+
+// Re-export JSON types
+#[cfg(feature = "json")]
+pub use facet_json::{Json, JsonRejection};
+
+// Re-export form/query types
+#[cfg(feature = "form")]
+pub use facet_urlencoded::{Form, FormRejection, Query, QueryRejection};
+
+// Re-export YAML types
+#[cfg(feature = "yaml")]
+pub use facet_yaml::{Yaml, YamlRejection};
+
+// Re-export TOML types
+#[cfg(feature = "toml")]
+pub use facet_toml::{Toml, TomlRejection};
+
+// Re-export MessagePack types
+#[cfg(feature = "msgpack")]
+pub use facet_msgpack::{MsgPack, MsgPackRejection};
+
+// Re-export Postcard types
+#[cfg(feature = "postcard")]
+pub use facet_postcard::{Postcard, PostcardRejection};

--- a/facet-axum/tests/integration.rs
+++ b/facet-axum/tests/integration.rs
@@ -1,0 +1,126 @@
+//! Integration tests for facet-axum.
+
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode, header},
+    routing::{get, post},
+};
+use facet::Facet;
+use facet_axum::{Form, Json, Query};
+use tower::ServiceExt;
+
+#[derive(Debug, Facet, PartialEq)]
+struct User {
+    name: String,
+    age: u64,
+}
+
+#[derive(Debug, Facet, PartialEq)]
+struct SearchParams {
+    query: String,
+    page: u64,
+}
+
+async fn echo_json(Json(user): Json<User>) -> Json<User> {
+    Json(user)
+}
+
+async fn echo_form(Form(user): Form<User>) -> String {
+    format!("name={}, age={}", user.name, user.age)
+}
+
+async fn search(Query(params): Query<SearchParams>) -> String {
+    format!("query={}, page={}", params.query, params.page)
+}
+
+fn app() -> Router {
+    Router::new()
+        .route("/json", post(echo_json))
+        .route("/form", post(echo_form))
+        .route("/search", get(search))
+}
+
+#[tokio::test]
+async fn test_json_extractor() {
+    let app = app();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/json")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"name": "Alice", "age": 30}"#))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+    assert!(body_str.contains("Alice"));
+    assert!(body_str.contains("30"));
+}
+
+#[tokio::test]
+async fn test_json_missing_content_type() {
+    let app = app();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/json")
+        .body(Body::from(r#"{"name": "Alice", "age": 30}"#))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[tokio::test]
+async fn test_form_extractor() {
+    let app = app();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/form")
+        .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(Body::from("name=Bob&age=25"))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+    assert_eq!(body_str, "name=Bob, age=25");
+}
+
+#[tokio::test]
+async fn test_query_extractor() {
+    let app = app();
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/search?query=rust&page=1")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+    assert_eq!(body_str, "query=rust, page=1");
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -80,6 +80,11 @@ version_group = "facet"
 changelog_path = "CHANGELOG.md"
 
 [[package]]
+name = "facet-axum"
+version_group = "facet"
+changelog_path = "CHANGELOG.md"
+
+[[package]]
 name = "facet-path"
 version_group = "facet"
 changelog_path = "CHANGELOG.md"


### PR DESCRIPTION
## Summary

Imports `facet-axum` into the Facet monorepo as a top-level workspace member, preserving the source repository history under `facet-axum/`.

This also wires the crate into workspace metadata, release-plz, lockfile resolution, CI semver-checks exclusions for the first monorepo baseline, and the website ecosystem docs. Most format crates remain crates.io dependencies for now because the format workspace has not landed here yet; `facet-urlencoded` is local.

The old repository redirect PR is open at https://github.com/facet-rs/facet-axum/pull/12.

## Testing

- `cargo metadata --no-deps --format-version 1`
- `cargo nextest list -p facet-axum`
- `cargo nextest run -p facet-axum` (4 passed)
- `cargo clippy -p facet-axum --all-features --all-targets --message-format=short -- -D warnings`
- `cargo doc -p facet-axum --no-deps --all-features`
