### PR TITLE
Graft remaining Figue PRs

### DIFF
--- a/figue/src/help.rs
+++ b/figue/src/help.rs
@@ -2442,6 +2442,13 @@ fn write_arg_help(out: &mut String, arg: &ArgSchema, config: &HelpConfig) {
                 arg.value().type_identifier().to_uppercase()
             };
             out.push_str(&format!(" <{}>", placeholder));
+
+            // Append the default value or required text
+            if let Some(default) = arg.default() {
+                out.push_str(&format!(" [Default: `{}`]", config_value_summary(default)));
+            } else {
+                out.push_str(" [Required]")
+            }
         }
     }
 
@@ -2592,6 +2599,34 @@ mod tests {
         assert!(
             help.contains("<PATH>"),
             "help should use custom label placeholder"
+        );
+    }
+
+    #[test]
+    fn test_text_help_shows_required_and_default_meta() {
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        struct Args {
+            /// A required value.
+            #[facet(args::named)]
+            required: String,
+
+            /// A value with a default.
+            #[facet(args::named, default = "standard")]
+            mode: String,
+        }
+
+        let schema = Schema::from_shape(Args::SHAPE).unwrap();
+        let help = generate_help_for_subcommand(&schema, &[], &HelpConfig::default());
+        let help = strip_ansi_escapes::strip_str(&help);
+
+        assert!(
+            help.contains("--required <STRING> [Required]"),
+            "help should show required marker: {help}"
+        );
+        assert!(
+            help.contains("--mode <STRING> [Default: `standard`]"),
+            "help should show default marker: {help}"
         );
     }
 

--- a/figue/src/help.rs
+++ b/figue/src/help.rs
@@ -2446,7 +2446,7 @@ fn write_arg_help(out: &mut String, arg: &ArgSchema, config: &HelpConfig) {
             // Append the default value or required text
             if let Some(default) = arg.default() {
                 out.push_str(&format!(" [Default: `{}`]", config_value_summary(default)));
-            } else {
+            } else if arg.required() {
                 out.push_str(" [Required]")
             }
         }
@@ -2614,6 +2614,10 @@ mod tests {
             /// A value with a default.
             #[facet(args::named, default = "standard")]
             mode: String,
+
+            /// An optional value.
+            #[facet(args::named)]
+            maybe: Option<String>,
         }
 
         let schema = Schema::from_shape(Args::SHAPE).unwrap();
@@ -2627,6 +2631,14 @@ mod tests {
         assert!(
             help.contains("--mode <STRING> [Default: `standard`]"),
             "help should show default marker: {help}"
+        );
+        assert!(
+            help.contains("--maybe <STRING>"),
+            "help should show optional argument placeholder: {help}"
+        );
+        assert!(
+            !help.contains("--maybe <STRING> [Required]"),
+            "help should not mark optional arguments as required: {help}"
         );
     }
 

--- a/figue/src/schema/from_schema.rs
+++ b/figue/src/schema/from_schema.rs
@@ -573,6 +573,18 @@ fn config_struct_schema_from_shape_inner(
 
     for field in struct_type.fields {
         let field_ctx = ctx.with_field(field.name);
+        if field.flags.contains(facet_core::FieldFlags::SKIP) {
+            if field.default.is_none() {
+                return Err(SchemaError::new(
+                    field_ctx,
+                    format!(
+                        "config field `{}` is skipped but has no default value",
+                        field.name
+                    ),
+                ));
+            }
+            continue;
+        }
 
         // Handle flattened fields - recurse into the inner struct and merge fields
         if field.is_flattened() {

--- a/figue/src/schema/snapshots/figue__schema__tests__config_skipped_field_errors_when_not_defaulted.snap
+++ b/figue/src/schema/snapshots/figue__schema__tests__config_skipped_field_errors_when_not_defaulted.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/figue/src/schema/tests.rs
+source: figue/src/schema/tests.rs
 expression: stripped
 ---
 Error: config field `skipped` is skipped but has no default value
@@ -7,7 +7,7 @@ Error: config field `skipped` is skipped but has no default value
    │
  2 │ struct ArgsWithSkippedNonDefaultConfigField {
    │        ──────────────────┬─────────────────  
-   │                          ╰─────────────────── defined at crates/figue/src/schema/tests.rs:435
+   │                          ╰─────────────────── defined at figue/src/schema/tests.rs:435
    │                          │                   
    │                          ╰─────────────────── config field `skipped` is skipped but has no default value
    │ 

--- a/figue/src/schema/snapshots/figue__schema__tests__config_skipped_field_errors_when_not_defaulted.snap
+++ b/figue/src/schema/snapshots/figue__schema__tests__config_skipped_field_errors_when_not_defaulted.snap
@@ -1,0 +1,17 @@
+---
+source: crates/figue/src/schema/tests.rs
+expression: stripped
+---
+Error: config field `skipped` is skipped but has no default value
+   ╭─[ <unknown>:2:8 ]
+   │
+ 2 │ struct ArgsWithSkippedNonDefaultConfigField {
+   │        ──────────────────┬─────────────────  
+   │                          ╰─────────────────── defined at crates/figue/src/schema/tests.rs:435
+   │                          │                   
+   │                          ╰─────────────────── config field `skipped` is skipped but has no default value
+   │ 
+ 5 │ }
+   │ ┬  
+   │ ╰── end of definition
+───╯

--- a/figue/src/schema/snapshots/figue__schema__tests__config_skipped_field_is_omitted.snap
+++ b/figue/src/schema/snapshots/figue__schema__tests__config_skipped_field_is_omitted.snap
@@ -1,0 +1,30 @@
+---
+source: crates/figue/src/schema/tests.rs
+expression: "facet_json :: to_string_pretty(& value).unwrap()"
+---
+{
+  "docs": {},
+  "args": {
+    "args": {},
+    "subcommands": {}
+  },
+  "configs": [
+    {
+      "docs": {},
+      "field_name": "config",
+      "fields": {
+        "visible": {
+          "docs": {},
+          "value": {
+            "Leaf": {
+              "kind": {
+                "Scalar": "String"
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "special": {}
+}

--- a/figue/src/schema/tests.rs
+++ b/figue/src/schema/tests.rs
@@ -406,6 +406,42 @@ fn test_config_flatten_schema_builds() {
     );
 }
 
+#[test]
+fn test_config_skipped_field_is_omitted() {
+    #[derive(Facet)]
+    struct ConfigWithSkippedField {
+        visible: String,
+        #[facet(skip, default)]
+        skipped: String,
+    }
+
+    #[derive(Facet)]
+    struct ArgsWithSkippedConfigField {
+        #[facet(args::config)]
+        config: ConfigWithSkippedField,
+    }
+    assert_schema_snapshot!(Schema::from_shape(ArgsWithSkippedConfigField::SHAPE))
+}
+
+#[test]
+fn test_config_skipped_field_errors_when_not_defaulted() {
+    #[derive(Facet)]
+    struct ConfigWithSkippedNonDefaultField {
+        visible: String,
+        #[facet(skip)]
+        skipped: String,
+    }
+
+    #[derive(Facet)]
+    struct ArgsWithSkippedNonDefaultConfigField {
+        #[facet(args::config)]
+        config: ConfigWithSkippedNonDefaultField,
+    }
+    assert_schema_snapshot!(Schema::from_shape(
+        ArgsWithSkippedNonDefaultConfigField::SHAPE
+    ))
+}
+
 /// Deeply nested config flatten: common inside extended
 #[derive(Facet)]
 struct ExtendedConfig {

--- a/figue/tests/integration/snapshots/main__integration__ariadne__ariadne_missing_argument.snap
+++ b/figue/tests/integration/snapshots/main__integration__ariadne__ariadne_missing_argument.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/figue/tests/integration/ariadne.rs
+source: figue/tests/integration/ariadne.rs
 expression: ariadne_output
 ---
 main
@@ -8,7 +8,7 @@ USAGE:
     main [OPTIONS]
 
 OPTIONS:
-        --required-field <STRING>
+        --required-field <STRING> [Required]
 
 
 Error: missing required argument

--- a/figue/tests/integration/snapshots/main__integration__simple__completions_help_shows_enum_variants.snap
+++ b/figue/tests/integration/snapshots/main__integration__simple__completions_help_shows_enum_variants.snap
@@ -1,6 +1,6 @@
 ---
-source: crates/figue/tests/integration/simple.rs
-expression: "strip_ansi_escapes :: strip_str(& help.to_string())"
+source: figue/tests/integration/simple.rs
+expression: "$crate :: common :: strip_ansi(& help.to_string())"
 ---
 main
 
@@ -8,7 +8,7 @@ USAGE:
     main [OPTIONS]
 
 OPTIONS:
-        --name <STRING>
+        --name <STRING> [Required]
     -h, --[no-]help
             Show help message and exit.
         --[no-]html-help

--- a/figue/tests/integration/snapshots/main__integration__subcommand_errors__subcommand_missing_required_named.snap
+++ b/figue/tests/integration/snapshots/main__integration__subcommand_errors__subcommand_missing_required_named.snap
@@ -1,6 +1,6 @@
 ---
-source: crates/figue/tests/integration/subcommand_errors.rs
-expression: "strip_ansi_escapes :: strip_str(& err.to_string())"
+source: figue/tests/integration/subcommand_errors.rs
+expression: "$crate :: common :: strip_ansi(& err.to_string())"
 ---
 main connect
 
@@ -8,7 +8,7 @@ USAGE:
     main connect [OPTIONS]
 
 OPTIONS:
-        --url <STRING>
+        --url <STRING> [Required]
             Server URL (required)
         --timeout <U32>
             Optional timeout

--- a/figue/tests/integration/snapshots/main__integration__subcommand_errors__subcommand_mixed_missing_arguments.snap
+++ b/figue/tests/integration/snapshots/main__integration__subcommand_errors__subcommand_mixed_missing_arguments.snap
@@ -1,6 +1,6 @@
 ---
-source: crates/figue/tests/integration/subcommand_errors.rs
-expression: "strip_ansi_escapes :: strip_str(& err.to_string())"
+source: figue/tests/integration/subcommand_errors.rs
+expression: "$crate :: common :: strip_ansi(& err.to_string())"
 ---
 main deploy
 
@@ -12,7 +12,7 @@ ARGUMENTS:
             Environment to deploy to
 
 OPTIONS:
-        --region <STRING>
+        --region <STRING> [Required]
             Deployment region (required)
         --version <STRING>
             Optional version tag


### PR DESCRIPTION
## Summary

- graft bearcove/figue#106 with original authorship
- graft bearcove/figue#108 with original authorship
- adapt the help metadata change so optional arguments are not labeled required

## Test Plan

- `cargo nextest run -p figue -p figue-attrs`
- `cargo clippy -p figue -p figue-attrs --all-targets -- -D warnings --allow deprecated`
- `cargo fmt --check`

