### PR TITLE
Add Phon fixed-array support

### DIFF
--- a/phon/rust/phon-engine/src/typed.rs
+++ b/phon/rust/phon-engine/src/typed.rs
@@ -243,6 +243,18 @@ fn lower_node(d: &Descriptor, reg: &Registry, base: usize, out: &mut MemProgram)
         (Access::Set(set), Resolved::Composite(SchemaKind::Set { .. })) => {
             lower_set(set, reg, base, out)
         }
+        // r[impl ir.memory] — [T; N]: fixed-shape inline elements with no length prefix.
+        (
+            Access::Array {
+                element,
+                count,
+                stride,
+            },
+            Resolved::Composite(SchemaKind::Array { dimensions, .. }),
+        ) => {
+            require_fixed_array_count(*count, &dimensions)?;
+            lower_fixed_array(element, *count, *stride, reg, base, out)
+        }
         // r[impl ir.memory] — String/Bytes: a bulk contiguous byte run.
         (
             Access::Sequence(seq),
@@ -537,6 +549,29 @@ fn lower_decode_node(
             require_reader_set(&reader.schema, reg)?;
             lower_decode_set(&we, set, reg, base, out)
         }
+        // Fixed array ⋈ fixed array: dimensions match exactly; translate each element.
+        (
+            Access::Array {
+                element,
+                count,
+                stride,
+            },
+            Resolved::Composite(SchemaKind::Array {
+                element: we,
+                dimensions: wd,
+            }),
+        ) => {
+            let Resolved::Composite(SchemaKind::Array { dimensions: rd, .. }) =
+                compact::resolve(reg, &reader.schema)?
+            else {
+                return Err(incompatible("schema kinds differ"));
+            };
+            if wd != rd {
+                return Err(incompatible("array dimensions differ"));
+            }
+            require_fixed_array_count(*count, &wd)?;
+            lower_decode_fixed_array(&we, element, *count, *stride, reg, base, out)
+        }
         // String/Bytes ⋈ String/Bytes: a bulk byte run (no element translation).
         (
             Access::Sequence(seq),
@@ -687,6 +722,62 @@ fn lower_decode_sequence(
         })));
     }
     Ok(())
+}
+
+fn lower_fixed_array(
+    element: &Descriptor,
+    count: usize,
+    stride: usize,
+    reg: &Registry,
+    base: usize,
+    out: &mut MemProgram,
+) -> Result<()> {
+    for i in 0..count {
+        lower_node(element, reg, array_element_offset(base, i, stride)?, out)?;
+    }
+    Ok(())
+}
+
+fn lower_decode_fixed_array(
+    writer_element: &SchemaRef,
+    element: &Descriptor,
+    count: usize,
+    stride: usize,
+    reg: &Registry,
+    base: usize,
+    out: &mut MemProgram,
+) -> Result<()> {
+    for i in 0..count {
+        lower_decode_node(
+            writer_element,
+            element,
+            reg,
+            array_element_offset(base, i, stride)?,
+            out,
+        )?;
+    }
+    Ok(())
+}
+
+fn array_element_offset(base: usize, index: usize, stride: usize) -> Result<usize> {
+    let rel = index
+        .checked_mul(stride)
+        .ok_or(CompactError::Malformed("array element offset overflow"))?;
+    base.checked_add(rel)
+        .ok_or(CompactError::Malformed("array element offset overflow"))
+}
+
+fn require_fixed_array_count(count: usize, dimensions: &[u64]) -> Result<()> {
+    let schema_count = compact::product(dimensions)?;
+    let descriptor_count = u64::try_from(count)
+        .map_err(|_| CompactError::Malformed("descriptor array length overflows u64"))?;
+    if schema_count == descriptor_count {
+        Ok(())
+    } else {
+        Err(CompactError::Malformed(
+            "descriptor/schema array length mismatch",
+        ))
+    }
 }
 
 fn lower_set(set: &SetAccess, reg: &Registry, base: usize, out: &mut MemProgram) -> Result<()> {

--- a/phon/rust/phon-engine/src/typed.rs
+++ b/phon/rust/phon-engine/src/typed.rs
@@ -732,6 +732,26 @@ fn lower_fixed_array(
     base: usize,
     out: &mut MemProgram,
 ) -> Result<()> {
+    let mut element_ops = Vec::new();
+    lower_node(element, reg, 0, &mut element_ops)?;
+    let element_ops = fuse(element_ops);
+    if let [
+        MemOp::Scalar {
+            offset: 0,
+            size,
+            align,
+        },
+    ] = element_ops.as_slice()
+        && *size == stride
+        && stride.is_multiple_of(*align)
+    {
+        out.push(MemOp::Scalar {
+            offset: base,
+            size: fixed_array_copy_size(count, stride)?,
+            align: *align,
+        });
+        return Ok(());
+    }
     for i in 0..count {
         lower_node(element, reg, array_element_offset(base, i, stride)?, out)?;
     }
@@ -747,6 +767,26 @@ fn lower_decode_fixed_array(
     base: usize,
     out: &mut MemProgram,
 ) -> Result<()> {
+    let mut element_ops = Vec::new();
+    lower_decode_node(writer_element, element, reg, 0, &mut element_ops)?;
+    let element_ops = fuse(element_ops);
+    if let [
+        MemOp::Scalar {
+            offset: 0,
+            size,
+            align,
+        },
+    ] = element_ops.as_slice()
+        && *size == stride
+        && stride.is_multiple_of(*align)
+    {
+        out.push(MemOp::Scalar {
+            offset: base,
+            size: fixed_array_copy_size(count, stride)?,
+            align: *align,
+        });
+        return Ok(());
+    }
     for i in 0..count {
         lower_decode_node(
             writer_element,
@@ -757,6 +797,12 @@ fn lower_decode_fixed_array(
         )?;
     }
     Ok(())
+}
+
+fn fixed_array_copy_size(count: usize, stride: usize) -> Result<usize> {
+    count
+        .checked_mul(stride)
+        .ok_or(CompactError::Malformed("array bulk copy size overflow"))
 }
 
 fn array_element_offset(base: usize, index: usize, stride: usize) -> Result<usize> {

--- a/phon/rust/phon/src/derive.rs
+++ b/phon/rust/phon/src/derive.rs
@@ -24,9 +24,9 @@ use std::fmt;
 use std::sync::{Arc, LazyLock, RwLock};
 
 use facet::{
-    Def, DefaultSource, EnumRepr, EnumType, Facet, KnownPointer, ListDef, MapDef, OpaqueAdapterDef,
-    OpaqueDeserialize, OpaqueSerialize, OptionDef, PointerDef, PtrConst, PtrMut, PtrUninit,
-    ResultDef, ScalarType, SetDef, Shape, StructKind, Type, UserType,
+    ArrayDef, Def, DefaultSource, EnumRepr, EnumType, Facet, KnownPointer, ListDef, MapDef,
+    OpaqueAdapterDef, OpaqueDeserialize, OpaqueSerialize, OptionDef, PointerDef, PtrConst, PtrMut,
+    PtrUninit, ResultDef, ScalarType, SetDef, Shape, StructKind, Type, UserType,
 };
 use phon_engine::{Registry, typed};
 use phon_ir::{
@@ -194,6 +194,8 @@ pub fn of_shape(shape: &'static Shape) -> Result<Derived, DeriveError> {
         b.intern_result(rd, shape)?
     } else if let Some(ld) = list_def(shape) {
         b.intern_list(ld)?
+    } else if let Some(ad) = array_def(shape) {
+        b.intern_array(ad)?
     } else if let Some(opt) = option_def(shape) {
         b.intern_option(opt)?
     } else if let Some(sd) = set_def(shape) {
@@ -204,7 +206,7 @@ pub fn of_shape(shape: &'static Shape) -> Result<Derived, DeriveError> {
         b.intern_enum(shape, et)?
     } else {
         return Err(DeriveError::Unsupported(
-            "derive root must be a struct, enum, Result, list, set, option, map, or fixed scalar so far",
+            "derive root must be a struct, enum, Result, list, array, set, option, map, or fixed scalar so far",
         ));
     };
     let by_shape = b.by_shape;
@@ -328,6 +330,9 @@ impl Builder {
         } else if let Some(list_def) = list_def(shape) {
             let key = self.intern_list(list_def)?;
             Ok(SchemaRef::concrete(SchemaId(key as u64)))
+        } else if let Some(array_def) = array_def(shape) {
+            let key = self.intern_array(array_def)?;
+            Ok(SchemaRef::concrete(SchemaId(key as u64)))
         } else if let Some(set_def) = set_def(shape) {
             let key = self.intern_set(set_def)?;
             Ok(SchemaRef::concrete(SchemaId(key as u64)))
@@ -345,7 +350,7 @@ impl Builder {
             Ok(SchemaRef::concrete(SchemaId(key as u64)))
         } else {
             Err(DeriveError::Unsupported(
-                "derive: only structs, lists, options, maps, results, enums, and fixed scalars so far",
+                "derive: only structs, lists, arrays, options, maps, results, enums, and fixed scalars so far",
             ))
         }
     }
@@ -366,6 +371,28 @@ impl Builder {
             id: SchemaId(key as u64),
             type_params: Vec::new(),
             kind: SchemaKind::List { element },
+        });
+        Ok(key)
+    }
+
+    /// Intern a fixed-size array schema (e.g. `[T; N]`), returning its provisional
+    /// key. Interned by the `ArrayDef` pointer so repeated `[T; N]` occurrences
+    /// share one schema.
+    fn intern_array(&mut self, array_def: &'static ArrayDef) -> Result<usize, DeriveError> {
+        let ptr = core::ptr::from_ref(array_def) as usize;
+        if let Some(&k) = self.by_shape.get(&ptr) {
+            return Ok(k);
+        }
+        let element = self.ref_of(array_def.t())?;
+        let key = self.protos.len();
+        self.by_shape.insert(ptr, key);
+        self.protos.push(Schema {
+            id: SchemaId(key as u64),
+            type_params: Vec::new(),
+            kind: SchemaKind::Array {
+                element,
+                dimensions: vec![array_def.n as u64],
+            },
         });
         Ok(key)
     }
@@ -685,6 +712,24 @@ fn build_descriptor(
         };
         return Ok(rec.exit(real, desc));
     }
+    if let Some(array_def) = array_def(shape) {
+        let real = real_ids[by_shape[&(core::ptr::from_ref(array_def) as usize)]];
+        let layout = Layout { size, align };
+        if let Some(d) = rec.enter(real, layout) {
+            return Ok(d);
+        }
+        let element = build_descriptor(array_def.t(), by_shape, real_ids, rec)?;
+        let desc = Descriptor {
+            schema: SchemaRef::concrete(real),
+            layout,
+            access: Access::Array {
+                stride: element.layout.size,
+                count: array_def.n,
+                element: Box::new(element),
+            },
+        };
+        return Ok(rec.exit(real, desc));
+    }
     if let Some(set_def) = set_def(shape) {
         let real = real_ids[by_shape[&(core::ptr::from_ref(set_def) as usize)]];
         let layout = Layout { size, align };
@@ -851,6 +896,14 @@ fn layout_of(shape: &Shape) -> Result<(usize, usize), DeriveError> {
 fn list_def(shape: &'static Shape) -> Option<&'static ListDef> {
     match &shape.def {
         Def::List(list_def) => Some(list_def),
+        _ => None,
+    }
+}
+
+/// The `&'static ArrayDef` behind a fixed-array shape (`[T; N]`), or `None`.
+fn array_def(shape: &'static Shape) -> Option<&'static ArrayDef> {
+    match &shape.def {
+        Def::Array(array_def) => Some(array_def),
         _ => None,
     }
 }
@@ -2417,6 +2470,91 @@ mod tests {
     struct Holder {
         items: Vec<u32>,
         tag: u32,
+    }
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct ArrayHolder {
+        items: [u32; 3],
+        tag: u8,
+    }
+
+    #[test]
+    fn fixed_array_field_derives_as_array_schema() {
+        let d = of::<ArrayHolder>().unwrap();
+        let root = d
+            .schemas
+            .iter()
+            .find(|schema| schema.id == d.root)
+            .expect("root schema should be emitted");
+        let SchemaKind::Struct { fields, .. } = &root.kind else {
+            panic!("ArrayHolder must derive as a struct schema, got {root:?}");
+        };
+        let items = fields
+            .iter()
+            .find(|field| field.name == "items")
+            .expect("items field should be present");
+        let SchemaRef::Concrete { id, args } = &items.schema else {
+            panic!("items field should reference a concrete array schema");
+        };
+        assert!(args.is_empty());
+        let array_schema = d
+            .schemas
+            .iter()
+            .find(|schema| schema.id == *id)
+            .expect("array schema should be emitted");
+        let SchemaKind::Array {
+            element,
+            dimensions,
+        } = &array_schema.kind
+        else {
+            panic!("items field must derive as SchemaKind::Array, got {array_schema:?}");
+        };
+        assert_eq!(element, &SchemaRef::concrete(primitive_id(Primitive::U32)));
+        assert_eq!(dimensions, &[3]);
+    }
+
+    #[test]
+    fn derived_fixed_array_field_typed_matches_dynamic_and_roundtrips() {
+        let d = of::<ArrayHolder>().unwrap();
+        let reg = Registry::new(d.schemas.clone());
+
+        let h = ArrayHolder {
+            items: [7, 11, 13],
+            tag: 0x55,
+        };
+        let typed_bytes = unsafe {
+            typed::encode(
+                core::ptr::from_ref(&h).cast::<u8>(),
+                &d.descriptor,
+                &d.descriptor_blocks,
+                &reg,
+            )
+        }
+        .unwrap();
+
+        let mut arr = VArray::new();
+        for &v in &h.items {
+            arr.push(Value::from(v));
+        }
+        let mut obj = VObject::new();
+        obj.insert(VString::new("items"), Value::from(arr));
+        obj.insert(VString::new("tag"), Value::from(h.tag));
+        let dyn_bytes = compact::to_bytes(&obj.into(), d.root, &reg).unwrap();
+        assert_eq!(typed_bytes, dyn_bytes);
+
+        let mut slot = std::mem::MaybeUninit::<ArrayHolder>::uninit();
+        unsafe {
+            typed::decode(
+                &typed_bytes,
+                &d.descriptor,
+                &d.descriptor_blocks,
+                &reg,
+                slot.as_mut_ptr().cast::<u8>(),
+            )
+        }
+        .unwrap();
+        let back = unsafe { slot.assume_init() };
+        assert_eq!(back, h);
     }
 
     #[test]

--- a/phon/rust/phon/src/derive.rs
+++ b/phon/rust/phon/src/derive.rs
@@ -2287,6 +2287,7 @@ mod tests {
     use facet::Facet;
     use facet_value::{VArray, VObject, VString, Value};
     use phon_engine::{Registry, compact, typed};
+    use phon_ir::ir::MemOp;
 
     // repr(Rust): the compiler may reorder these in memory, so the descriptor's
     // offsets (from facet) are not the schema/wire order. The cross-check below
@@ -2478,6 +2479,11 @@ mod tests {
         tag: u8,
     }
 
+    #[derive(Facet, Debug, PartialEq)]
+    struct ArrayOnly {
+        items: [u32; 3],
+    }
+
     #[test]
     fn fixed_array_field_derives_as_array_schema() {
         let d = of::<ArrayHolder>().unwrap();
@@ -2555,6 +2561,59 @@ mod tests {
         .unwrap();
         let back = unsafe { slot.assume_init() };
         assert_eq!(back, h);
+    }
+
+    #[test]
+    fn derived_fixed_array_of_scalars_lowers_to_one_bulk_copy() {
+        let d = of::<ArrayOnly>().unwrap();
+        let reg = Registry::new(d.schemas.clone());
+        let lowered = typed::lower_typed(&d.descriptor, &d.descriptor_blocks, &reg).unwrap();
+
+        assert!(lowered.blocks.is_empty());
+        assert_eq!(lowered.program.len(), 1);
+        assert!(matches!(
+            lowered.program.as_slice(),
+            [MemOp::Scalar {
+                offset: 0,
+                size: 12,
+                align: 4,
+            }]
+        ));
+    }
+
+    #[test]
+    // r[verify exec.jit-optional]
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    fn derived_fixed_array_jit_matches_interpreter_and_roundtrips() {
+        use phon_jit::native::{NativeDecode, NativeEncode};
+
+        let d = of::<ArrayOnly>().unwrap();
+        let reg = Registry::new(d.schemas.clone());
+        let lowered = typed::lower_typed(&d.descriptor, &d.descriptor_blocks, &reg).unwrap();
+        assert!(lowered.blocks.is_empty());
+        assert!(matches!(
+            lowered.program.as_slice(),
+            [MemOp::Scalar {
+                offset: 0,
+                size: 12,
+                align: 4,
+            }]
+        ));
+
+        let value = ArrayOnly { items: [7, 11, 13] };
+        let base = core::ptr::from_ref(&value).cast::<u8>();
+        let interp_bytes =
+            unsafe { typed::encode(base, &d.descriptor, &d.descriptor_blocks, &reg) }.unwrap();
+        let jit_bytes = unsafe { NativeEncode::compile_lowered(&lowered).run(base) };
+        assert_eq!(jit_bytes, interp_bytes);
+
+        let mut slot = std::mem::MaybeUninit::<ArrayOnly>::uninit();
+        unsafe {
+            NativeDecode::compile_lowered(&lowered).run(&jit_bytes, slot.as_mut_ptr().cast::<u8>())
+        }
+        .unwrap();
+        let back = unsafe { slot.assume_init() };
+        assert_eq!(back, value);
     }
 
     #[test]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -489,15 +489,6 @@ version_group = "ur-taking-me-with-you"
 changelog_path = "vox/rust/ur-taking-me-with-you/CHANGELOG.md"
 
 # ============================================================================
-# facet-cbor - coordinated from this monorepo, preserving its version line
-# ============================================================================
-
-[[package]]
-name = "facet-cbor"
-version_group = "facet-cbor"
-changelog_path = "vox/rust/facet-cbor/CHANGELOG.md"
-
-# ============================================================================
 # Styx packages - coordinated from this monorepo, preserving their major line
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Adds Phon support for Facet fixed-size arrays like `[u32; 3]`, including schema derivation, descriptor construction, typed encode/decode, and native-JIT coverage for the efficient scalar-array path.

This is stacked on top of #2238 (`codex/dependency-update-stack`) so the dependency update PR stays separate.

## Changes

- Derive `SchemaKind::Array` and `Access::Array` from Facet `Def::Array`.
- Lower fixed arrays through typed encode/decode, with simple scalar arrays emitted as one bulk `MemOp::Scalar` copy.
- Add fixed-array schema, dynamic-vs-typed round-trip, bulk-lowering, and macOS/aarch64 native-JIT round-trip tests.
- Remove the stale `facet-cbor` release-plz group.

## Testing

- `cargo nextest run -p phon -E 'test(fixed_array)'`
- `cargo nextest run -p phon --features jit -E 'test(fixed_array)'`
- `cargo nextest run -p phon -p phon-engine --features jit`
- `cargo check -p phon -p phon-engine --all-features --all-targets --message-format=short`
- `cargo check --all-features --all-targets --message-format=short`
- `cargo fmt --check`
- push hook: clippy/docs/build tests/run tests