### PR TITLE
Update npm package repository metadata

### DIFF
--- a/phon/typescript/packages/phon-engine/README.md
+++ b/phon/typescript/packages/phon-engine/README.md
@@ -1,0 +1,23 @@
+# @bearcove/phon-engine
+
+TypeScript engine for Phon compact encoding, compatibility planning, interpreter execution, and optional JIT compilation.
+
+## Role in the Phon stack
+
+`@bearcove/phon-engine` sits above `@bearcove/phon-schema`: it takes writer and reader schemas, builds compatibility plans, and executes those plans against compact Phon bytes.
+
+## What this package provides
+
+- Compact schema-driven encode/decode helpers
+- Writer-schema to reader-schema compatibility planning
+- Interpreter execution for compatibility plans
+- `new Function` JIT compilation with interpreter fallback
+- Typed encode/decode helpers for generated TypeScript bindings
+
+## Fits with
+
+- `@bearcove/phon-schema` for schema and Value definitions plus wire primitives
+- `@bearcove/phon` as the public front door for generated consumers
+- Vox TypeScript packages that need schema-aware binary serialization
+
+Part of the Facet workspace: <https://github.com/facet-rs/facet>

--- a/phon/typescript/packages/phon-engine/package.json
+++ b/phon/typescript/packages/phon-engine/package.json
@@ -35,8 +35,8 @@
   },
   "license": "MIT OR Apache-2.0",
   "description": "phon's TypeScript engine: compact codec, compatibility planning, interpreter, and the new Function() JIT.",
-  "repository": "https://github.com/bearcove/phon",
-  "homepage": "https://github.com/bearcove/phon",
+  "repository": "https://github.com/facet-rs/facet",
+  "homepage": "https://github.com/facet-rs/facet",
   "keywords": [
     "phon",
     "serialization",

--- a/phon/typescript/packages/phon-schema/README.md
+++ b/phon/typescript/packages/phon-schema/README.md
@@ -1,0 +1,23 @@
+# @bearcove/phon-schema
+
+TypeScript schema, value, and self-describing wire primitives for Phon.
+
+## Role in the Phon stack
+
+`@bearcove/phon-schema` defines the TypeScript representation of Phon schemas and dynamic values. It is the shared contract used by the compact engine, codegen output, and conformance tests.
+
+## What this package provides
+
+- Phon schema model types and schema registry helpers
+- Dynamic `Value` encode/decode support
+- Self-describing schema and value parsing
+- Wire primitives such as readers, byte sinks, tags, and hex helpers
+- Schema validation and alignment/minimum-size analysis
+
+## Fits with
+
+- `@bearcove/phon-engine` for compact encode/decode and compatibility planning
+- `@bearcove/phon` as the public front door for generated consumers
+- Vox TypeScript packages that share schema-derived wire contracts
+
+Part of the Facet workspace: <https://github.com/facet-rs/facet>

--- a/phon/typescript/packages/phon-schema/package.json
+++ b/phon/typescript/packages/phon-schema/package.json
@@ -35,8 +35,8 @@
   },
   "license": "MIT OR Apache-2.0",
   "description": "phon's wire contract for TypeScript: schema model, schema identity, Value, and the self-describing codec.",
-  "repository": "https://github.com/bearcove/phon",
-  "homepage": "https://github.com/bearcove/phon",
+  "repository": "https://github.com/facet-rs/facet",
+  "homepage": "https://github.com/facet-rs/facet",
   "keywords": [
     "phon",
     "serialization",

--- a/phon/typescript/packages/phon/README.md
+++ b/phon/typescript/packages/phon/README.md
@@ -1,0 +1,21 @@
+# @bearcove/phon
+
+TypeScript front door for Phon-generated bindings.
+
+## Role in the Phon stack
+
+`@bearcove/phon` is the package generated TypeScript peers should depend on when they need the stable public Phon entrypoint.
+
+## What this package provides
+
+- The top-level TypeScript package boundary for Phon consumers
+- Re-exports for the schema and engine package markers used by generated bindings
+- A stable import target for code generated from Facet-derived Phon schemas
+
+## Fits with
+
+- `@bearcove/phon-schema` for schema models, schema identity, dynamic values, and self-describing bytes
+- `@bearcove/phon-engine` for compact schema-driven encode/decode, compatibility planning, and JIT/interpreter execution
+- Vox TypeScript packages that use Phon for wire serialization
+
+Part of the Facet workspace: <https://github.com/facet-rs/facet>

--- a/phon/typescript/packages/phon/package.json
+++ b/phon/typescript/packages/phon/package.json
@@ -36,8 +36,8 @@
   },
   "license": "MIT OR Apache-2.0",
   "description": "The phon front door for TypeScript: the typed encode/decode API over codegen-emitted accessors.",
-  "repository": "https://github.com/bearcove/phon",
-  "homepage": "https://github.com/bearcove/phon",
+  "repository": "https://github.com/facet-rs/facet",
+  "homepage": "https://github.com/facet-rs/facet",
   "keywords": [
     "phon",
     "serialization",

--- a/vox/typescript/packages/vox-core/README.md
+++ b/vox/typescript/packages/vox-core/README.md
@@ -18,4 +18,4 @@ Core TypeScript runtime abstractions for Vox connections, calls, and channeling.
 - `@bearcove/phon-engine` / `@bearcove/phon-schema` for serialization
 - `@bearcove/vox-tcp` and `@bearcove/vox-ws` for concrete transports
 
-Part of the Vox workspace: <https://github.com/bearcove/vox>
+Part of the Facet workspace: <https://github.com/facet-rs/facet>

--- a/vox/typescript/packages/vox-core/package.json
+++ b/vox/typescript/packages/vox-core/package.json
@@ -35,8 +35,8 @@
   },
   "license": "MIT OR Apache-2.0",
   "description": "Core protocol runtime and transport abstractions for Vox",
-  "repository": "https://github.com/bearcove/vox",
-  "homepage": "https://github.com/bearcove/vox",
+  "repository": "https://github.com/facet-rs/facet",
+  "homepage": "https://github.com/facet-rs/facet",
   "keywords": [
     "vox",
     "ipc",

--- a/vox/typescript/packages/vox-inprocess/README.md
+++ b/vox/typescript/packages/vox-inprocess/README.md
@@ -1,0 +1,21 @@
+# @bearcove/vox-inprocess
+
+In-process transport binding for Vox in TypeScript.
+
+## Role in the Vox stack
+
+`@bearcove/vox-inprocess` implements the `Link` layer without sockets, so two Vox peers can exchange binary frames inside the same JavaScript process.
+
+## What this package provides
+
+- `InProcessLink`, a `@bearcove/vox-core` `Link` implementation
+- Message queueing and close propagation between paired in-process endpoints
+- A transport useful for tests, browser/WASM integration, and embedded peer setups
+
+## Fits with
+
+- `@bearcove/vox-core` for connection/lane/call orchestration
+- `@bearcove/vox-wire` for protocol payloads
+- `@bearcove/phon-engine` / `@bearcove/phon-schema` for serialization
+
+Part of the Facet workspace: <https://github.com/facet-rs/facet>

--- a/vox/typescript/packages/vox-inprocess/package.json
+++ b/vox/typescript/packages/vox-inprocess/package.json
@@ -22,7 +22,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "dependencies": {
     "@bearcove/vox-core": "workspace:*"
@@ -41,5 +42,6 @@
     "typescript",
     "wasm",
     "in-process"
-  ]
+  ],
+  "readme": "README.md"
 }

--- a/vox/typescript/packages/vox-inprocess/package.json
+++ b/vox/typescript/packages/vox-inprocess/package.json
@@ -32,8 +32,8 @@
   },
   "license": "MIT OR Apache-2.0",
   "description": "In-process transport for vox — WASM to TypeScript communication without network",
-  "repository": "https://github.com/bearcove/vox",
-  "homepage": "https://github.com/bearcove/vox",
+  "repository": "https://github.com/facet-rs/facet",
+  "homepage": "https://github.com/facet-rs/facet",
   "keywords": [
     "vox",
     "ipc",

--- a/vox/typescript/packages/vox-tcp/README.md
+++ b/vox/typescript/packages/vox-tcp/README.md
@@ -16,4 +16,4 @@ TCP transport binding for Vox in TypeScript.
 - `@bearcove/vox-core` for connection/lane/call orchestration
 - `@bearcove/vox-wire` for protocol payloads
 
-Part of the Vox workspace: <https://github.com/bearcove/vox>
+Part of the Facet workspace: <https://github.com/facet-rs/facet>

--- a/vox/typescript/packages/vox-tcp/package.json
+++ b/vox/typescript/packages/vox-tcp/package.json
@@ -34,8 +34,8 @@
   },
   "license": "MIT OR Apache-2.0",
   "description": "TCP transport implementation for the Vox protocol",
-  "repository": "https://github.com/bearcove/vox",
-  "homepage": "https://github.com/bearcove/vox",
+  "repository": "https://github.com/facet-rs/facet",
+  "homepage": "https://github.com/facet-rs/facet",
   "keywords": [
     "vox",
     "ipc",

--- a/vox/typescript/packages/vox-wire/README.md
+++ b/vox/typescript/packages/vox-wire/README.md
@@ -18,4 +18,4 @@ Wire-format types and codecs for the Vox protocol in TypeScript.
 - `@bearcove/vox-core` for runtime behavior on decoded messages
 - Transport packages that carry encoded wire frames
 
-Part of the Vox workspace: <https://github.com/bearcove/vox>
+Part of the Facet workspace: <https://github.com/facet-rs/facet>

--- a/vox/typescript/packages/vox-wire/package.json
+++ b/vox/typescript/packages/vox-wire/package.json
@@ -35,8 +35,8 @@
   },
   "license": "MIT OR Apache-2.0",
   "description": "Wire message codecs and helpers for Vox",
-  "repository": "https://github.com/bearcove/vox",
-  "homepage": "https://github.com/bearcove/vox",
+  "repository": "https://github.com/facet-rs/facet",
+  "homepage": "https://github.com/facet-rs/facet",
   "keywords": [
     "vox",
     "ipc",

--- a/vox/typescript/packages/vox-ws/README.md
+++ b/vox/typescript/packages/vox-ws/README.md
@@ -17,4 +17,4 @@ WebSocket transport binding for Vox in TypeScript.
 - `@bearcove/vox-tcp` where shared transport logic is reused
 - `@bearcove/vox-wire` for protocol message payloads
 
-Part of the Vox workspace: <https://github.com/bearcove/vox>
+Part of the Facet workspace: <https://github.com/facet-rs/facet>

--- a/vox/typescript/packages/vox-ws/package.json
+++ b/vox/typescript/packages/vox-ws/package.json
@@ -35,8 +35,8 @@
   },
   "license": "MIT OR Apache-2.0",
   "description": "WebSocket transport implementation for the Vox protocol",
-  "repository": "https://github.com/bearcove/vox",
-  "homepage": "https://github.com/bearcove/vox",
+  "repository": "https://github.com/facet-rs/facet",
+  "homepage": "https://github.com/facet-rs/facet",
   "keywords": [
     "vox",
     "ipc",


### PR DESCRIPTION
## Summary

Updates publishable Phon and Vox TypeScript package metadata now that those packages live in the Facet monorepo, and adds npm README coverage for the packages that were missing it.

## Changes

- Point `repository` and `homepage` at `https://github.com/facet-rs/facet` for publishable Phon TypeScript packages.
- Point `repository` and `homepage` at `https://github.com/facet-rs/facet` for publishable Vox TypeScript packages.
- Add npm READMEs for `@bearcove/phon`, `@bearcove/phon-engine`, `@bearcove/phon-schema`, and `@bearcove/vox-inprocess`.
- Update existing Vox npm README workspace links to the Facet monorepo.
- Include `README.md` explicitly in `@bearcove/vox-inprocess`'s packaged files.

## Test Plan

- Parsed all 8 publishable TypeScript package manifests with Node.
- Verified every publishable TypeScript package has `README.md` and includes it in `files`.
- Verified no `github.com/bearcove/vox` or `github.com/bearcove/phon` URLs remain in publishable TypeScript package manifests or npm READMEs.
- Pre-push hook passed; build/test/docs steps were skipped because no crates were affected.
