### PR TITLE
Clean release-plz Cargo.lock side effects

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,11 +24,16 @@ jobs:
       - name: Get crates.io token via OIDC
         uses: rust-lang/crates-io-auth-action@v1.0.4
         id: crates-io-auth
+      - name: Install release-plz cargo wrapper
+        run: |
+          cp scripts/release-plz-cargo.sh "$RUNNER_TEMP/release-plz-cargo.sh"
+          chmod +x "$RUNNER_TEMP/release-plz-cargo.sh"
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
           command: release
         env:
+          CARGO: ${{ runner.temp }}/release-plz-cargo.sh
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
@@ -49,9 +54,14 @@ jobs:
           persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Install release-plz cargo wrapper
+        run: |
+          cp scripts/release-plz-cargo.sh "$RUNNER_TEMP/release-plz-cargo.sh"
+          chmod +x "$RUNNER_TEMP/release-plz-cargo.sh"
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:
+          CARGO: ${{ runner.temp }}/release-plz-cargo.sh
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/release-plz-cargo.sh
+++ b/scripts/release-plz-cargo.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -u
+
+real_cargo="${RELEASE_PLZ_REAL_CARGO:-cargo}"
+
+"$real_cargo" "$@"
+status=$?
+
+if [[ "${1:-}" == "package" ]]; then
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+  if [[ -n "$repo_root" ]]; then
+    git -C "$repo_root" status --porcelain=v1 -z --untracked-files=all -- ':(glob)**/Cargo.lock' |
+      while IFS= read -r -d '' entry; do
+        path="${entry:3}"
+
+        if [[ "$path" == "Cargo.lock" ]]; then
+          continue
+        fi
+
+        if git -C "$repo_root" ls-files --error-unmatch -- "$path" >/dev/null 2>&1; then
+          git -C "$repo_root" restore --worktree -- "$path"
+        else
+          rm -f -- "$repo_root/$path"
+        fi
+      done
+  fi
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary

Fixes the remaining release-plz failure after removing nested workspace lockfiles. release-plz still compares against historical published source revisions, and those revisions can contain nested `Cargo.lock` files that `cargo package` dirties before release-plz checks back out to `main`.

This adds a release-plz-only cargo wrapper that cleans nested `Cargo.lock` side effects after `cargo package`, while deliberately leaving the root `Cargo.lock` alone.

## Changes

- Add `scripts/release-plz-cargo.sh`.
- Wire both release-plz jobs to install that wrapper into `$RUNNER_TEMP`.
- Set `CARGO` to the temp wrapper path for both `release` and `release-pr`.
- Clean any nested `Cargo.lock` that `cargo package` modifies or creates:
  - tracked nested lockfiles are restored from the current checkout
  - untracked nested lockfiles are removed
  - root `Cargo.lock` is never touched

## Verification

- `bash -n scripts/release-plz-cargo.sh`
- `actionlint .github/workflows/release-plz.yml`
- Focused repro now passes:
  - `CARGO=/private/tmp/release-plz-cargo.sh release-plz update --config release-plz.toml --package phon-schema`
- Full temp-clone repro now passes:
  - `CARGO=/private/tmp/release-plz-cargo-full.sh release-plz update --config release-plz.toml`
