### PR TITLE
Reduce facet-format recursive stack usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,6 +2101,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
+ "stacker",
  "tendril",
  "tracing",
  "zmij",

--- a/facet-format/src/deserializer/entry.rs
+++ b/facet-format/src/deserializer/entry.rs
@@ -138,20 +138,9 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
         trace!(?strategy, "deserialize_into: using precomputed strategy");
 
         match strategy {
-            Some(DeserStrategy::ContainerProxy) => {
-                // Container-level proxy - the type itself has #[facet(proxy = X)]
-                let format_ns = self.parser.format_namespace();
-                let (wip, _) =
-                    wip.begin_custom_deserialization_from_shape_with_format(format_ns)?;
-                Ok(wip.with(|w| self.deserialize_into(w, meta))?.end()?)
-            }
+            Some(DeserStrategy::ContainerProxy) => self.deserialize_container_proxy(wip, meta),
 
-            Some(DeserStrategy::FieldProxy) => {
-                // Field-level proxy - the field has #[facet(proxy = X)]
-                let format_ns = self.parser.format_namespace();
-                let wip = wip.begin_custom_deserialization_with_format(format_ns)?;
-                Ok(wip.with(|w| self.deserialize_into(w, meta))?.end()?)
-            }
+            Some(DeserStrategy::FieldProxy) => self.deserialize_field_proxy(wip, meta),
 
             Some(DeserStrategy::Pointer { .. }) => {
                 trace!("deserialize_into: dispatching to deserialize_pointer");
@@ -160,10 +149,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
 
             Some(DeserStrategy::TransparentConvert { .. }) => {
                 trace!("deserialize_into: dispatching via begin_inner (transparent convert)");
-                Ok(wip
-                    .begin_inner()?
-                    .with(|w| self.deserialize_into(w, meta))?
-                    .end()?)
+                self.deserialize_transparent_convert(wip, meta)
             }
 
             Some(DeserStrategy::Scalar {
@@ -243,107 +229,164 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                 unreachable!("deser_strategy() should resolve BackRef to target strategy")
             }
 
-            Some(DeserStrategy::Opaque) => {
-                if let Some(adapter) = shape.opaque_adapter {
-                    let trailing_opaque = wip
-                        .nearest_field()
-                        .is_some_and(|f| f.has_builtin_attr("trailing"));
+            Some(DeserStrategy::Opaque) => self.deserialize_opaque(wip),
 
-                    if self.is_non_self_describing() {
-                        let handled = if trailing_opaque {
-                            self.parser.hint_remaining_byte_sequence()
-                        } else {
-                            self.parser.hint_byte_sequence()
-                        };
-                        if !handled {
-                            self.parser.hint_scalar_type(ScalarTypeHint::Bytes);
-                        }
-                    }
+            Some(DeserStrategy::OpaquePointer) => self.unsupported_opaque_pointer(shape),
 
-                    let expected = if trailing_opaque {
-                        "remaining bytes for trailing opaque adapter"
-                    } else {
-                        "bytes for opaque adapter"
-                    };
-                    let event = self.expect_event(expected)?;
-                    let input = match event.kind {
-                        ParseEventKind::Scalar(ScalarValue::Bytes(bytes)) => {
-                            if BORROW {
-                                match bytes {
-                                    Cow::Borrowed(b) => OpaqueDeserialize::Borrowed(b),
-                                    Cow::Owned(v) => OpaqueDeserialize::Owned(v),
-                                }
-                            } else {
-                                OpaqueDeserialize::Owned(bytes.into_owned())
-                            }
-                        }
-                        _ => {
-                            return Err(self.mk_err(
-                                &wip,
-                                DeserializeErrorKind::UnexpectedToken {
-                                    expected,
-                                    got: event.kind_name().into(),
-                                },
-                            ));
-                        }
-                    };
+            // A deserialization strategy variant added since this match was written.
+            Some(_) => self.unsupported_strategy(shape),
 
-                    let adapter = *adapter;
-                    #[allow(unsafe_code)]
-                    let wip = unsafe {
-                        wip.set_from_function(move |target| {
-                            match (adapter.deserialize)(input, target) {
-                                Ok(_) => Ok(()),
-                                Err(message) => Err(ReflectErrorKind::OperationFailedOwned {
-                                    shape,
-                                    operation: format!(
-                                        "opaque adapter deserialize failed: {message}"
-                                    ),
-                                }),
-                            }
-                        })?
-                    };
-                    Ok(wip)
-                } else {
-                    Err(DeserializeErrorKind::Unsupported {
-                        message: format!(
-                            "cannot deserialize opaque type {} - add a proxy or opaque adapter",
-                            shape
-                        )
-                        .into(),
-                    }
-                    .with_span(self.last_span))
-                }
-            }
+            None => self.missing_strategy(shape),
+        }
+    }
 
-            Some(DeserStrategy::OpaquePointer) => Err(DeserializeErrorKind::Unsupported {
+    #[inline(never)]
+    fn deserialize_container_proxy(
+        &mut self,
+        wip: Partial<'input, BORROW>,
+        meta: MetaSource<'input>,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError> {
+        let format_ns = self.parser.format_namespace();
+        let (wip, _) = wip.begin_custom_deserialization_from_shape_with_format(format_ns)?;
+        Ok(wip.with(|w| self.deserialize_into(w, meta))?.end()?)
+    }
+
+    #[inline(never)]
+    fn deserialize_field_proxy(
+        &mut self,
+        wip: Partial<'input, BORROW>,
+        meta: MetaSource<'input>,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError> {
+        let format_ns = self.parser.format_namespace();
+        let wip = wip.begin_custom_deserialization_with_format(format_ns)?;
+        Ok(wip.with(|w| self.deserialize_into(w, meta))?.end()?)
+    }
+
+    #[inline(never)]
+    fn deserialize_transparent_convert(
+        &mut self,
+        wip: Partial<'input, BORROW>,
+        meta: MetaSource<'input>,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError> {
+        Ok(wip
+            .begin_inner()?
+            .with(|w| self.deserialize_into(w, meta))?
+            .end()?)
+    }
+
+    #[inline(never)]
+    fn deserialize_opaque(
+        &mut self,
+        wip: Partial<'input, BORROW>,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError> {
+        let shape = wip.shape();
+        let Some(adapter) = shape.opaque_adapter else {
+            return Err(DeserializeErrorKind::Unsupported {
                 message: format!(
-                    "cannot deserialize opaque type {} - add a proxy to make it deserializable",
+                    "cannot deserialize opaque type {} - add a proxy or opaque adapter",
                     shape
                 )
                 .into(),
             }
-            .with_span(self.last_span)),
+            .with_span(self.last_span));
+        };
 
-            // A deserialization strategy variant added since this match was written.
-            Some(_) => Err(DeserializeErrorKind::Unsupported {
-                message: format!("unsupported deserialization strategy for {:?}", shape.def).into(),
-            }
-            .with_span(self.last_span)),
+        let trailing_opaque = wip
+            .nearest_field()
+            .is_some_and(|f| f.has_builtin_attr("trailing"));
 
-            None => {
-                // This should not happen - TypePlan::build errors at allocation time for
-                // unsupported types. If we get here, something went wrong with plan tracking.
-                Err(DeserializeErrorKind::Unsupported {
-                    message: format!(
-                        "missing deserialization strategy for shape: {:?} (TypePlan bug)",
-                        shape.def
-                    )
-                    .into(),
-                }
-                .with_span(self.last_span))
+        if self.is_non_self_describing() {
+            let handled = if trailing_opaque {
+                self.parser.hint_remaining_byte_sequence()
+            } else {
+                self.parser.hint_byte_sequence()
+            };
+            if !handled {
+                self.parser.hint_scalar_type(ScalarTypeHint::Bytes);
             }
         }
+
+        let expected = if trailing_opaque {
+            "remaining bytes for trailing opaque adapter"
+        } else {
+            "bytes for opaque adapter"
+        };
+        let event = self.expect_event(expected)?;
+        let input = match event.kind {
+            ParseEventKind::Scalar(ScalarValue::Bytes(bytes)) => {
+                if BORROW {
+                    match bytes {
+                        Cow::Borrowed(b) => OpaqueDeserialize::Borrowed(b),
+                        Cow::Owned(v) => OpaqueDeserialize::Owned(v),
+                    }
+                } else {
+                    OpaqueDeserialize::Owned(bytes.into_owned())
+                }
+            }
+            _ => {
+                return Err(self.mk_err(
+                    &wip,
+                    DeserializeErrorKind::UnexpectedToken {
+                        expected,
+                        got: event.kind_name().into(),
+                    },
+                ));
+            }
+        };
+
+        let adapter = *adapter;
+        #[allow(unsafe_code)]
+        let wip = unsafe {
+            wip.set_from_function(move |target| match (adapter.deserialize)(input, target) {
+                Ok(_) => Ok(()),
+                Err(message) => Err(ReflectErrorKind::OperationFailedOwned {
+                    shape,
+                    operation: format!("opaque adapter deserialize failed: {message}"),
+                }),
+            })?
+        };
+        Ok(wip)
+    }
+
+    #[inline(never)]
+    fn unsupported_opaque_pointer(
+        &self,
+        shape: &'static Shape,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError> {
+        Err(DeserializeErrorKind::Unsupported {
+            message: format!(
+                "cannot deserialize opaque type {} - add a proxy to make it deserializable",
+                shape
+            )
+            .into(),
+        }
+        .with_span(self.last_span))
+    }
+
+    #[inline(never)]
+    fn unsupported_strategy(
+        &self,
+        shape: &'static Shape,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError> {
+        Err(DeserializeErrorKind::Unsupported {
+            message: format!("unsupported deserialization strategy for {:?}", shape.def).into(),
+        }
+        .with_span(self.last_span))
+    }
+
+    #[inline(never)]
+    fn missing_strategy(
+        &self,
+        shape: &'static Shape,
+    ) -> Result<Partial<'input, BORROW>, DeserializeError> {
+        Err(DeserializeErrorKind::Unsupported {
+            message: format!(
+                "missing deserialization strategy for shape: {:?} (TypePlan bug)",
+                shape.def
+            )
+            .into(),
+        }
+        .with_span(self.last_span))
     }
 
     /// Deserialize a metadata container (like `Spanned<T>`, `Documented<T>`).

--- a/facet-format/src/serializer.rs
+++ b/facet-format/src/serializer.rs
@@ -8,7 +8,9 @@ use core::fmt::Write as _;
 use facet_core::{
     Def, DynDateTimeKind, DynValueKind, ScalarType, Shape, StructKind, Type, UserType,
 };
-use facet_reflect::{HasFields as _, Peek, ReflectError};
+use facet_reflect::{
+    HasFields as _, Peek, PeekListLike, PeekMap, PeekOption, PeekResult, PeekSet, ReflectError,
+};
 
 use crate::ScalarValue;
 
@@ -767,65 +769,12 @@ impl<'s, S: FormatSerializer> SerializeContext<'s, S> {
                 .map_err(SerializeError::Backend);
         }
 
-        // Handle Option<T>
         if let Ok(opt) = value.into_option() {
-            return match opt.value() {
-                Some(inner) => {
-                    self.serializer
-                        .begin_option_some()
-                        .map_err(SerializeError::Backend)?;
-                    self.serialize_impl(inner)
-                }
-                None => self
-                    .serializer
-                    .serialize_none()
-                    .map_err(SerializeError::Backend),
-            };
+            return self.serialize_option(opt);
         }
 
         if let Ok(result) = value.into_result() {
-            let (variant_index, variant_name, inner) = if result.is_ok() {
-                (
-                    0,
-                    "Ok",
-                    result.ok().ok_or(SerializeError::Internal(Cow::Borrowed(
-                        "result reported Ok but value was missing",
-                    )))?,
-                )
-            } else {
-                (
-                    1,
-                    "Err",
-                    result.err().ok_or(SerializeError::Internal(Cow::Borrowed(
-                        "result reported Err but value was missing",
-                    )))?,
-                )
-            };
-
-            if self.serializer.enum_variant_encoding() == EnumVariantEncoding::Index {
-                self.serializer
-                    .begin_enum_variant(variant_index, variant_name)
-                    .map_err(SerializeError::Backend)?;
-                self.push(PathSegment::Variant(Cow::Borrowed(variant_name)));
-                let result = self.serialize_impl(inner);
-                self.pop();
-                return result;
-            }
-
-            self.serializer
-                .begin_struct()
-                .map_err(SerializeError::Backend)?;
-            self.serializer
-                .field_key(variant_name)
-                .map_err(SerializeError::Backend)?;
-            self.push(PathSegment::Variant(Cow::Borrowed(variant_name)));
-            let result = self.serialize_impl(inner);
-            self.pop();
-            result?;
-            self.serializer
-                .end_struct()
-                .map_err(SerializeError::Backend)?;
-            return Ok(());
+            return self.serialize_result(result);
         }
 
         if let Ok(dynamic) = value.into_dynamic_value() {
@@ -834,115 +783,17 @@ impl<'s, S: FormatSerializer> SerializeContext<'s, S> {
 
         match value.shape().def {
             facet_core::Def::List(_) | facet_core::Def::Array(_) | facet_core::Def::Slice(_) => {
-                let list = value.into_list_like().map_err(SerializeError::Reflect)?;
-                let len = list.len();
-
-                // Check if this is a byte sequence
-                if let Some(bytes) = list.as_bytes() {
-                    let handled = match value.shape().def {
-                        facet_core::Def::Array(_) => self
-                            .serializer
-                            .serialize_byte_array(bytes)
-                            .map_err(SerializeError::Backend)?,
-                        _ => self
-                            .serializer
-                            .serialize_byte_sequence(bytes)
-                            .map_err(SerializeError::Backend)?,
-                    };
-                    if handled {
-                        return Ok(());
-                    }
-                }
-
-                match value.shape().def {
-                    facet_core::Def::Array(_) => self
-                        .serializer
-                        .begin_seq()
-                        .map_err(SerializeError::Backend)?,
-                    _ => self
-                        .serializer
-                        .begin_seq_with_len(len)
-                        .map_err(SerializeError::Backend)?,
-                };
-                for (idx, item) in list.iter().enumerate() {
-                    self.push(PathSegment::Index(idx));
-                    self.serialize_impl(item)?;
-                    self.pop();
-                }
-                self.serializer.end_seq().map_err(SerializeError::Backend)?;
-                return Ok(());
+                return self.serialize_list_like(value);
             }
             _ => {}
         }
 
         if let Ok(map) = value.into_map() {
-            let len = map.len();
-            match self.serializer.map_encoding() {
-                MapEncoding::Pairs => {
-                    self.serializer
-                        .begin_map_with_len(len)
-                        .map_err(SerializeError::Backend)?;
-                    for (key, val) in map.iter() {
-                        self.serialize_impl(key)?;
-                        // Track map key in path
-                        let key_str = key
-                            .as_str()
-                            .map(|s| Cow::Owned(s.to_string()))
-                            .unwrap_or_else(|| Cow::Owned(alloc::format!("{}", key)));
-                        self.push(PathSegment::Field(key_str));
-                        self.serialize_impl(val)?;
-                        self.pop();
-                    }
-                    self.serializer.end_map().map_err(SerializeError::Backend)?;
-                }
-                MapEncoding::Struct => {
-                    self.serializer
-                        .begin_struct()
-                        .map_err(SerializeError::Backend)?;
-                    for (key, val) in map.iter() {
-                        if !self
-                            .serializer
-                            .serialize_map_key(key)
-                            .map_err(SerializeError::Backend)?
-                        {
-                            // Use extract_string_from_peek to handle metadata containers
-                            let key_str = if let Some(s) = extract_string_from_peek(key) {
-                                Cow::Borrowed(s)
-                            } else {
-                                Cow::Owned(alloc::format!("{}", key))
-                            };
-                            self.serializer
-                                .field_key(&key_str)
-                                .map_err(SerializeError::Backend)?;
-                        }
-                        // Use extract_string_from_peek for path tracking too
-                        let key_str = extract_string_from_peek(key)
-                            .map(|s| Cow::Owned(s.to_string()))
-                            .unwrap_or_else(|| Cow::Owned(alloc::format!("{}", key)));
-                        self.push(PathSegment::Field(key_str));
-                        self.serialize_impl(val)?;
-                        self.pop();
-                    }
-                    self.serializer
-                        .end_struct()
-                        .map_err(SerializeError::Backend)?;
-                }
-            }
-            return Ok(());
+            return self.serialize_map(map);
         }
 
         if let Ok(set) = value.into_set() {
-            let len = set.len();
-            self.serializer
-                .begin_seq_with_len(len)
-                .map_err(SerializeError::Backend)?;
-            for (idx, item) in set.iter().enumerate() {
-                self.push(PathSegment::Index(idx));
-                self.serialize_impl(item)?;
-                self.pop();
-            }
-            self.serializer.end_seq().map_err(SerializeError::Backend)?;
-            return Ok(());
+            return self.serialize_set(set);
         }
 
         if let Ok(struct_) = value.into_struct() {
@@ -954,6 +805,211 @@ impl<'s, S: FormatSerializer> SerializeContext<'s, S> {
         }
 
         Err(self.unsupported_error(value.shape(), "unsupported value kind for serialization"))
+    }
+
+    #[inline(never)]
+    fn serialize_option<'mem, 'facet>(
+        &mut self,
+        opt: PeekOption<'mem, 'facet>,
+    ) -> Result<(), SerializeError<S::Error>> {
+        match opt.value() {
+            Some(inner) => {
+                self.serializer
+                    .begin_option_some()
+                    .map_err(SerializeError::Backend)?;
+                self.serialize_impl(inner)
+            }
+            None => self
+                .serializer
+                .serialize_none()
+                .map_err(SerializeError::Backend),
+        }
+    }
+
+    #[inline(never)]
+    fn serialize_result<'mem, 'facet>(
+        &mut self,
+        result: PeekResult<'mem, 'facet>,
+    ) -> Result<(), SerializeError<S::Error>> {
+        let (variant_index, variant_name, inner) = if result.is_ok() {
+            (
+                0,
+                "Ok",
+                result.ok().ok_or(SerializeError::Internal(Cow::Borrowed(
+                    "result reported Ok but value was missing",
+                )))?,
+            )
+        } else {
+            (
+                1,
+                "Err",
+                result.err().ok_or(SerializeError::Internal(Cow::Borrowed(
+                    "result reported Err but value was missing",
+                )))?,
+            )
+        };
+
+        if self.serializer.enum_variant_encoding() == EnumVariantEncoding::Index {
+            self.serializer
+                .begin_enum_variant(variant_index, variant_name)
+                .map_err(SerializeError::Backend)?;
+            self.push(PathSegment::Variant(Cow::Borrowed(variant_name)));
+            let result = self.serialize_impl(inner);
+            self.pop();
+            return result;
+        }
+
+        self.serializer
+            .begin_struct()
+            .map_err(SerializeError::Backend)?;
+        self.serializer
+            .field_key(variant_name)
+            .map_err(SerializeError::Backend)?;
+        self.push(PathSegment::Variant(Cow::Borrowed(variant_name)));
+        let result = self.serialize_impl(inner);
+        self.pop();
+        result?;
+        self.serializer
+            .end_struct()
+            .map_err(SerializeError::Backend)?;
+        Ok(())
+    }
+
+    #[inline(never)]
+    fn serialize_list_like<'mem, 'facet>(
+        &mut self,
+        value: Peek<'mem, 'facet>,
+    ) -> Result<(), SerializeError<S::Error>> {
+        let list = value.into_list_like().map_err(SerializeError::Reflect)?;
+        self.serialize_list_like_inner(value.shape().def, list)
+    }
+
+    #[inline(never)]
+    fn serialize_list_like_inner<'mem, 'facet>(
+        &mut self,
+        def: Def,
+        list: PeekListLike<'mem, 'facet>,
+    ) -> Result<(), SerializeError<S::Error>> {
+        let len = list.len();
+
+        if let Some(bytes) = list.as_bytes() {
+            let handled = match def {
+                facet_core::Def::Array(_) => self
+                    .serializer
+                    .serialize_byte_array(bytes)
+                    .map_err(SerializeError::Backend)?,
+                _ => self
+                    .serializer
+                    .serialize_byte_sequence(bytes)
+                    .map_err(SerializeError::Backend)?,
+            };
+            if handled {
+                return Ok(());
+            }
+        }
+
+        match def {
+            facet_core::Def::Array(_) => self
+                .serializer
+                .begin_seq()
+                .map_err(SerializeError::Backend)?,
+            _ => self
+                .serializer
+                .begin_seq_with_len(len)
+                .map_err(SerializeError::Backend)?,
+        };
+        for (idx, item) in list.iter().enumerate() {
+            self.push(PathSegment::Index(idx));
+            self.serialize_impl(item)?;
+            self.pop();
+        }
+        self.serializer.end_seq().map_err(SerializeError::Backend)
+    }
+
+    #[inline(never)]
+    fn serialize_map<'mem, 'facet>(
+        &mut self,
+        map: PeekMap<'mem, 'facet>,
+    ) -> Result<(), SerializeError<S::Error>> {
+        let len = map.len();
+        match self.serializer.map_encoding() {
+            MapEncoding::Pairs => self.serialize_map_as_pairs(map, len),
+            MapEncoding::Struct => self.serialize_map_as_struct(map),
+        }
+    }
+
+    #[inline(never)]
+    fn serialize_map_as_pairs<'mem, 'facet>(
+        &mut self,
+        map: PeekMap<'mem, 'facet>,
+        len: usize,
+    ) -> Result<(), SerializeError<S::Error>> {
+        self.serializer
+            .begin_map_with_len(len)
+            .map_err(SerializeError::Backend)?;
+        for (key, val) in map.iter() {
+            self.serialize_impl(key)?;
+            let key_str = key
+                .as_str()
+                .map(|s| Cow::Owned(s.to_string()))
+                .unwrap_or_else(|| Cow::Owned(alloc::format!("{}", key)));
+            self.push(PathSegment::Field(key_str));
+            self.serialize_impl(val)?;
+            self.pop();
+        }
+        self.serializer.end_map().map_err(SerializeError::Backend)
+    }
+
+    #[inline(never)]
+    fn serialize_map_as_struct<'mem, 'facet>(
+        &mut self,
+        map: PeekMap<'mem, 'facet>,
+    ) -> Result<(), SerializeError<S::Error>> {
+        self.serializer
+            .begin_struct()
+            .map_err(SerializeError::Backend)?;
+        for (key, val) in map.iter() {
+            if !self
+                .serializer
+                .serialize_map_key(key)
+                .map_err(SerializeError::Backend)?
+            {
+                let key_str = if let Some(s) = extract_string_from_peek(key) {
+                    Cow::Borrowed(s)
+                } else {
+                    Cow::Owned(alloc::format!("{}", key))
+                };
+                self.serializer
+                    .field_key(&key_str)
+                    .map_err(SerializeError::Backend)?;
+            }
+            let key_str = extract_string_from_peek(key)
+                .map(|s| Cow::Owned(s.to_string()))
+                .unwrap_or_else(|| Cow::Owned(alloc::format!("{}", key)));
+            self.push(PathSegment::Field(key_str));
+            self.serialize_impl(val)?;
+            self.pop();
+        }
+        self.serializer
+            .end_struct()
+            .map_err(SerializeError::Backend)
+    }
+
+    #[inline(never)]
+    fn serialize_set<'mem, 'facet>(
+        &mut self,
+        set: PeekSet<'mem, 'facet>,
+    ) -> Result<(), SerializeError<S::Error>> {
+        let len = set.len();
+        self.serializer
+            .begin_seq_with_len(len)
+            .map_err(SerializeError::Backend)?;
+        for (idx, item) in set.iter().enumerate() {
+            self.push(PathSegment::Index(idx));
+            self.serialize_impl(item)?;
+            self.pop();
+        }
+        self.serializer.end_seq().map_err(SerializeError::Backend)
     }
 
     fn serialize_field_value<'mem, 'facet>(
@@ -979,157 +1035,192 @@ impl<'s, S: FormatSerializer> SerializeContext<'s, S> {
         struct_: facet_reflect::PeekStruct<'mem, 'facet>,
     ) -> Result<(), SerializeError<S::Error>> {
         let kind = struct_.ty().kind;
-        let field_mode = self.serializer.struct_field_mode();
         self.serializer
             .struct_metadata(shape)
             .map_err(SerializeError::Backend)?;
 
         if kind == StructKind::Tuple || kind == StructKind::TupleStruct {
-            let fields: alloc::vec::Vec<_> = struct_.fields_for_binary_serialize().collect();
-            let is_transparent = shape.is_transparent() && fields.len() == 1;
+            self.serialize_tuple_struct(shape, struct_)
+        } else {
+            self.serialize_named_struct(struct_)
+        }
+    }
 
-            if is_transparent {
-                let (field_item, field_value) = &fields[0];
-                self.serialize_field_value(field_item, *field_value)?;
-            } else {
-                self.serializer
-                    .begin_seq()
-                    .map_err(SerializeError::Backend)?;
-                for (idx, (field_item, field_value)) in fields.into_iter().enumerate() {
-                    self.push(PathSegment::Index(idx));
-                    self.serialize_field_value(&field_item, field_value)?;
-                    self.pop();
-                }
-                self.serializer.end_seq().map_err(SerializeError::Backend)?;
-            }
+    #[inline(never)]
+    fn serialize_tuple_struct<'mem, 'facet>(
+        &mut self,
+        shape: &'static Shape,
+        struct_: facet_reflect::PeekStruct<'mem, 'facet>,
+    ) -> Result<(), SerializeError<S::Error>> {
+        let fields: alloc::vec::Vec<_> = struct_.fields_for_binary_serialize().collect();
+        let is_transparent = shape.is_transparent() && fields.len() == 1;
+
+        if is_transparent {
+            let (field_item, field_value) = &fields[0];
+            self.serialize_field_value(field_item, *field_value)
         } else {
             self.serializer
-                .begin_struct()
+                .begin_seq()
                 .map_err(SerializeError::Backend)?;
-
-            let mut fields: alloc::vec::Vec<_> = if field_mode == StructFieldMode::Unnamed {
-                struct_.fields_for_binary_serialize().collect()
-            } else {
-                struct_.fields_for_serialize().collect()
-            };
-
-            sort_fields_if_needed(self.serializer, &mut fields);
-
-            for (field_item, field_value) in fields {
-                // Check for flattened internally-tagged enum
-                if field_item.flattened
-                    && let Some(field) = field_item.field
-                    && let shape = field.shape()
-                    && let Some(tag_key) = shape.get_tag_attr()
-                    && shape.get_content_attr().is_none()
-                {
-                    let variant_name = field_item.effective_name();
-
-                    if field_mode == StructFieldMode::Named {
-                        self.serializer
-                            .field_key(tag_key)
-                            .map_err(SerializeError::Backend)?;
-                    }
-                    self.serializer
-                        .scalar(ScalarValue::Str(Cow::Borrowed(variant_name)))
-                        .map_err(SerializeError::Backend)?;
-
-                    if let Ok(inner_struct) = field_value.into_struct() {
-                        for (inner_item, inner_value) in inner_struct.fields_for_serialize() {
-                            if field_mode == StructFieldMode::Named {
-                                self.serializer
-                                    .field_key(inner_item.effective_name())
-                                    .map_err(SerializeError::Backend)?;
-                            }
-                            self.push(PathSegment::Field(Cow::Owned(
-                                inner_item.effective_name().to_string(),
-                            )));
-                            self.serialize_field_value(&inner_item, inner_value)?;
-                            self.pop();
-                        }
-                    } else if let Ok(enum_peek) = field_value.into_enum() {
-                        for (inner_item, inner_value) in enum_peek.fields_for_serialize() {
-                            if field_mode == StructFieldMode::Named {
-                                self.serializer
-                                    .field_key(inner_item.effective_name())
-                                    .map_err(SerializeError::Backend)?;
-                            }
-                            self.push(PathSegment::Field(Cow::Owned(
-                                inner_item.effective_name().to_string(),
-                            )));
-                            self.serialize_field_value(&inner_item, inner_value)?;
-                            self.pop();
-                        }
-                    } else if matches!(field_value.shape().ty, Type::Primitive(_)) {
-                        return Err(SerializeError::Unsupported(
-                            "internally-tagged enum with scalar newtype payload cannot be \
-                             flattened; use #[facet(content = \"...\")] for adjacently-tagged \
-                             representation"
-                                .into(),
-                        ));
-                    }
-                    continue;
-                }
-
-                // Flattened externally-tagged enum fields should contribute exactly one
-                // key/value pair to the parent object. `field_item.effective_name()` is
-                // already the active variant key for flattened enum fields.
-                if field_item.flattened
-                    && {
-                        let shape = field_value.shape();
-                        shape.get_tag_attr().is_none() && shape.get_content_attr().is_none()
-                    }
-                    && let Ok(enum_peek) = field_value.into_enum()
-                {
-                    if field_mode == StructFieldMode::Named {
-                        self.serializer
-                            .field_key(field_item.effective_name())
-                            .map_err(SerializeError::Backend)?;
-                    }
-
-                    let variant = enum_peek
-                        .active_variant()
-                        .map_err(|e| SerializeError::Unsupported(Cow::Owned(e.to_string())))?;
-
-                    self.push(PathSegment::Variant(Cow::Owned(
-                        field_item.effective_name().to_string(),
-                    )));
-                    if variant.data.kind == StructKind::Unit {
-                        self.serializer
-                            .serialize_none()
-                            .map_err(SerializeError::Backend)?;
-                    } else {
-                        self.serialize_variant_after_tag(enum_peek, variant)?;
-                    }
-                    self.pop();
-                    continue;
-                }
-
-                let key_written = self
-                    .serializer
-                    .field_metadata_with_value(&field_item, field_value)
-                    .map_err(SerializeError::Backend)?;
-                if !key_written {
-                    self.serializer
-                        .field_metadata(&field_item)
-                        .map_err(SerializeError::Backend)?;
-                    if field_mode == StructFieldMode::Named {
-                        self.serializer
-                            .field_key(field_item.effective_name())
-                            .map_err(SerializeError::Backend)?;
-                    }
-                }
-                self.push(PathSegment::Field(Cow::Owned(
-                    field_item.effective_name().to_string(),
-                )));
+            for (idx, (field_item, field_value)) in fields.into_iter().enumerate() {
+                self.push(PathSegment::Index(idx));
                 self.serialize_field_value(&field_item, field_value)?;
                 self.pop();
             }
-            self.serializer
-                .end_struct()
-                .map_err(SerializeError::Backend)?;
+            self.serializer.end_seq().map_err(SerializeError::Backend)
         }
-        Ok(())
+    }
+
+    #[inline(never)]
+    fn serialize_named_struct<'mem, 'facet>(
+        &mut self,
+        struct_: facet_reflect::PeekStruct<'mem, 'facet>,
+    ) -> Result<(), SerializeError<S::Error>> {
+        let field_mode = self.serializer.struct_field_mode();
+        self.serializer
+            .begin_struct()
+            .map_err(SerializeError::Backend)?;
+
+        let mut fields: alloc::vec::Vec<_> = if field_mode == StructFieldMode::Unnamed {
+            struct_.fields_for_binary_serialize().collect()
+        } else {
+            struct_.fields_for_serialize().collect()
+        };
+
+        sort_fields_if_needed(self.serializer, &mut fields);
+
+        for (field_item, field_value) in fields {
+            if field_item.flattened {
+                self.serialize_flattened_struct_field(field_mode, field_item, field_value)?;
+            } else {
+                self.serialize_regular_struct_field(field_mode, field_item, field_value)?;
+            }
+        }
+
+        self.serializer
+            .end_struct()
+            .map_err(SerializeError::Backend)
+    }
+
+    #[inline(never)]
+    fn serialize_regular_struct_field<'mem, 'facet>(
+        &mut self,
+        field_mode: StructFieldMode,
+        field_item: facet_reflect::FieldItem,
+        field_value: Peek<'mem, 'facet>,
+    ) -> Result<(), SerializeError<S::Error>> {
+        let key_written = self
+            .serializer
+            .field_metadata_with_value(&field_item, field_value)
+            .map_err(SerializeError::Backend)?;
+        if !key_written {
+            self.serializer
+                .field_metadata(&field_item)
+                .map_err(SerializeError::Backend)?;
+            if field_mode == StructFieldMode::Named {
+                self.serializer
+                    .field_key(field_item.effective_name())
+                    .map_err(SerializeError::Backend)?;
+            }
+        }
+        self.push(PathSegment::Field(Cow::Owned(
+            field_item.effective_name().to_string(),
+        )));
+        let result = self.serialize_field_value(&field_item, field_value);
+        self.pop();
+        result
+    }
+
+    #[inline(never)]
+    fn serialize_flattened_struct_field<'mem, 'facet>(
+        &mut self,
+        field_mode: StructFieldMode,
+        field_item: facet_reflect::FieldItem,
+        field_value: Peek<'mem, 'facet>,
+    ) -> Result<(), SerializeError<S::Error>> {
+        if let Some(field) = field_item.field
+            && let shape = field.shape()
+            && let Some(tag_key) = shape.get_tag_attr()
+            && shape.get_content_attr().is_none()
+        {
+            let variant_name = field_item.effective_name();
+
+            if field_mode == StructFieldMode::Named {
+                self.serializer
+                    .field_key(tag_key)
+                    .map_err(SerializeError::Backend)?;
+            }
+            self.serializer
+                .scalar(ScalarValue::Str(Cow::Borrowed(variant_name)))
+                .map_err(SerializeError::Backend)?;
+
+            if let Ok(inner_struct) = field_value.into_struct() {
+                for (inner_item, inner_value) in inner_struct.fields_for_serialize() {
+                    if field_mode == StructFieldMode::Named {
+                        self.serializer
+                            .field_key(inner_item.effective_name())
+                            .map_err(SerializeError::Backend)?;
+                    }
+                    self.push(PathSegment::Field(Cow::Owned(
+                        inner_item.effective_name().to_string(),
+                    )));
+                    self.serialize_field_value(&inner_item, inner_value)?;
+                    self.pop();
+                }
+            } else if let Ok(enum_peek) = field_value.into_enum() {
+                for (inner_item, inner_value) in enum_peek.fields_for_serialize() {
+                    if field_mode == StructFieldMode::Named {
+                        self.serializer
+                            .field_key(inner_item.effective_name())
+                            .map_err(SerializeError::Backend)?;
+                    }
+                    self.push(PathSegment::Field(Cow::Owned(
+                        inner_item.effective_name().to_string(),
+                    )));
+                    self.serialize_field_value(&inner_item, inner_value)?;
+                    self.pop();
+                }
+            } else if matches!(field_value.shape().ty, Type::Primitive(_)) {
+                return Err(SerializeError::Unsupported(
+                    "internally-tagged enum with scalar newtype payload cannot be \
+                     flattened; use #[facet(content = \"...\")] for adjacently-tagged \
+                     representation"
+                        .into(),
+                ));
+            }
+            return Ok(());
+        }
+
+        if {
+            let shape = field_value.shape();
+            shape.get_tag_attr().is_none() && shape.get_content_attr().is_none()
+        } && let Ok(enum_peek) = field_value.into_enum()
+        {
+            if field_mode == StructFieldMode::Named {
+                self.serializer
+                    .field_key(field_item.effective_name())
+                    .map_err(SerializeError::Backend)?;
+            }
+
+            let variant = enum_peek
+                .active_variant()
+                .map_err(|e| SerializeError::Unsupported(Cow::Owned(e.to_string())))?;
+
+            self.push(PathSegment::Variant(Cow::Owned(
+                field_item.effective_name().to_string(),
+            )));
+            if variant.data.kind == StructKind::Unit {
+                self.serializer
+                    .serialize_none()
+                    .map_err(SerializeError::Backend)?;
+            } else {
+                self.serialize_variant_after_tag(enum_peek, variant)?;
+            }
+            self.pop();
+            return Ok(());
+        }
+
+        self.serialize_regular_struct_field(field_mode, field_item, field_value)
     }
 
     /// Recursively flattens a newtype variant's inner value into the current

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -62,6 +62,7 @@ facet-format-suite = { path = "../facet-format-suite", features = [
 indoc = { workspace = true }
 libtest-mimic = "0.8.1"
 smol_str = { workspace = true }
+stacker = { version = "0.1.24", default-features = false }
 
 [[test]]
 name = "format_suite"

--- a/facet-json/tests/integration/mod.rs
+++ b/facet-json/tests/integration/mod.rs
@@ -31,6 +31,7 @@ mod opaque_proxy_struct;
 mod option_enum_test;
 mod out_of_order;
 mod raw_json;
+mod recursive_stack;
 mod rename;
 mod smolstr_flatten_map;
 mod string_like_map_keys;

--- a/facet-json/tests/integration/recursive_stack.rs
+++ b/facet-json/tests/integration/recursive_stack.rs
@@ -2,6 +2,9 @@ use std::cell::RefCell;
 
 use facet::Facet;
 
+const DEFAULT_MAX_SERIALIZE_STACK_BYTES: usize = 512 * 1024;
+const DEFAULT_MAX_DESERIALIZE_STACK_BYTES: usize = 2304 * 1024;
+
 #[derive(Facet, Debug, PartialEq, Eq)]
 struct IdentityNode {
     id: u32,
@@ -184,7 +187,10 @@ fn recursive_identity_node_json_serializes() {
         "recursive JSON serialization",
         depth,
         stack_usage,
-        configured_stack_limit("FACET_RECURSIVE_STACK_MAX_SERIALIZE_BYTES", 512 * 1024),
+        configured_stack_limit(
+            "FACET_RECURSIVE_STACK_MAX_SERIALIZE_BYTES",
+            DEFAULT_MAX_SERIALIZE_STACK_BYTES,
+        ),
     );
 }
 
@@ -205,7 +211,7 @@ fn recursive_identity_node_json_deserializes() {
         stack_usage,
         configured_stack_limit(
             "FACET_RECURSIVE_STACK_MAX_DESERIALIZE_BYTES",
-            2 * 1024 * 1024,
+            DEFAULT_MAX_DESERIALIZE_STACK_BYTES,
         ),
     );
 }

--- a/facet-json/tests/integration/recursive_stack.rs
+++ b/facet-json/tests/integration/recursive_stack.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::convert::Infallible;
 
 use facet::Facet;
 
@@ -19,21 +18,17 @@ struct StackProbe;
 #[facet(transparent)]
 struct StackProbeProxy(u8);
 
-impl TryFrom<&StackProbe> for StackProbeProxy {
-    type Error = Infallible;
-
-    fn try_from(_: &StackProbe) -> Result<Self, Self::Error> {
+impl From<&StackProbe> for StackProbeProxy {
+    fn from(_: &StackProbe) -> Self {
         record_stack_sample();
-        Ok(Self(0))
+        Self(0)
     }
 }
 
-impl TryFrom<StackProbeProxy> for StackProbe {
-    type Error = Infallible;
-
-    fn try_from(_: StackProbeProxy) -> Result<Self, Self::Error> {
+impl From<StackProbeProxy> for StackProbe {
+    fn from(_: StackProbeProxy) -> Self {
         record_stack_sample();
-        Ok(Self)
+        Self
     }
 }
 
@@ -73,7 +68,7 @@ struct StackUsage {
 }
 
 thread_local! {
-    static STACK_MEASUREMENT: RefCell<Option<StackMeasurement>> = RefCell::new(None);
+    static STACK_MEASUREMENT: RefCell<Option<StackMeasurement>> = const { RefCell::new(None) };
 }
 
 fn record_stack_sample() {

--- a/facet-json/tests/integration/recursive_stack.rs
+++ b/facet-json/tests/integration/recursive_stack.rs
@@ -1,0 +1,216 @@
+use std::cell::RefCell;
+use std::convert::Infallible;
+
+use facet::Facet;
+
+#[derive(Facet, Debug, PartialEq, Eq)]
+struct IdentityNode {
+    id: u32,
+    #[facet(proxy = StackProbeProxy)]
+    probe: StackProbe,
+    #[facet(recursive_type)]
+    child: Option<Box<IdentityNode>>,
+}
+
+#[derive(Facet, Debug, PartialEq, Eq)]
+struct StackProbe;
+
+#[derive(Facet)]
+#[facet(transparent)]
+struct StackProbeProxy(u8);
+
+impl TryFrom<&StackProbe> for StackProbeProxy {
+    type Error = Infallible;
+
+    fn try_from(_: &StackProbe) -> Result<Self, Self::Error> {
+        record_stack_sample();
+        Ok(Self(0))
+    }
+}
+
+impl TryFrom<StackProbeProxy> for StackProbe {
+    type Error = Infallible;
+
+    fn try_from(_: StackProbeProxy) -> Result<Self, Self::Error> {
+        record_stack_sample();
+        Ok(Self)
+    }
+}
+
+#[derive(Debug, Default)]
+struct StackMeasurement {
+    first_remaining: Option<usize>,
+    min_remaining: usize,
+    samples: usize,
+}
+
+impl StackMeasurement {
+    fn record(&mut self, remaining: usize) {
+        self.first_remaining.get_or_insert(remaining);
+        self.min_remaining = if self.samples == 0 {
+            remaining
+        } else {
+            self.min_remaining.min(remaining)
+        };
+        self.samples += 1;
+    }
+
+    fn finish(self) -> StackUsage {
+        let first_remaining = self
+            .first_remaining
+            .expect("recursive JSON stack test did not take any stack samples");
+        StackUsage {
+            samples: self.samples,
+            bytes: first_remaining.saturating_sub(self.min_remaining),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct StackUsage {
+    samples: usize,
+    bytes: usize,
+}
+
+thread_local! {
+    static STACK_MEASUREMENT: RefCell<Option<StackMeasurement>> = RefCell::new(None);
+}
+
+fn record_stack_sample() {
+    STACK_MEASUREMENT.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        if let Some(measurement) = slot.as_mut() {
+            let remaining = stacker::remaining_stack()
+                .expect("stacker::remaining_stack is unavailable on this target");
+            measurement.record(remaining);
+        }
+    });
+}
+
+fn measure_stack_usage<T>(f: impl FnOnce() -> T) -> (T, StackUsage) {
+    STACK_MEASUREMENT.with(|slot| {
+        assert!(
+            slot.borrow().is_none(),
+            "recursive JSON stack measurement was already active"
+        );
+        *slot.borrow_mut() = Some(StackMeasurement::default());
+    });
+
+    let result = f();
+    let measurement = STACK_MEASUREMENT.with(|slot| {
+        slot.borrow_mut()
+            .take()
+            .expect("recursive JSON stack measurement disappeared")
+    });
+    (result, measurement.finish())
+}
+
+impl IdentityNode {
+    fn chain(depth: u32) -> Self {
+        let mut node = Self {
+            id: depth,
+            probe: StackProbe,
+            child: None,
+        };
+
+        for id in (0..depth).rev() {
+            node = Self {
+                id,
+                probe: StackProbe,
+                child: Some(Box::new(node)),
+            };
+        }
+
+        node
+    }
+
+    fn depth(&self) -> u32 {
+        let mut depth = 0;
+        let mut current = self;
+        while let Some(child) = current.child.as_deref() {
+            depth += 1;
+            current = child;
+        }
+        depth
+    }
+}
+
+fn expected_json(depth: u32) -> String {
+    let mut json = format!(r#"{{"id":{depth},"probe":0,"child":null}}"#);
+    for id in (0..depth).rev() {
+        json = format!(r#"{{"id":{id},"probe":0,"child":{json}}}"#);
+    }
+    json
+}
+
+fn configured_depth() -> u32 {
+    std::env::var("FACET_RECURSIVE_STACK_DEPTH")
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(23)
+}
+
+fn configured_stack_limit(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn assert_stack_usage(operation: &str, depth: u32, usage: StackUsage, max_bytes: usize) {
+    let expected_samples = depth as usize + 1;
+    assert_eq!(
+        usage.samples, expected_samples,
+        "{operation} should sample stack usage once per recursive node"
+    );
+    if depth > 0 {
+        assert!(
+            usage.bytes > 0,
+            "{operation} did not observe recursive stack growth"
+        );
+    }
+    assert!(
+        usage.bytes <= max_bytes,
+        "{operation} used {} bytes of stack for depth {depth}, above {max_bytes} bytes",
+        usage.bytes
+    );
+}
+
+#[test]
+fn recursive_identity_node_json_serializes() {
+    let depth = configured_depth();
+    let node = IdentityNode::chain(depth);
+
+    let (json, stack_usage) = measure_stack_usage(|| {
+        facet_json::to_string(&node).expect("recursive node should serialize")
+    });
+    assert_eq!(json, expected_json(depth));
+    assert_stack_usage(
+        "recursive JSON serialization",
+        depth,
+        stack_usage,
+        configured_stack_limit("FACET_RECURSIVE_STACK_MAX_SERIALIZE_BYTES", 512 * 1024),
+    );
+}
+
+#[test]
+fn recursive_identity_node_json_deserializes() {
+    let depth = configured_depth();
+    let node = IdentityNode::chain(depth);
+    let json = expected_json(depth);
+
+    let (parsed, stack_usage) = measure_stack_usage(|| {
+        facet_json::from_str::<IdentityNode>(&json).expect("recursive node should deserialize")
+    });
+    assert_eq!(parsed.depth(), depth);
+    assert_eq!(parsed, node);
+    assert_stack_usage(
+        "recursive JSON deserialization",
+        depth,
+        stack_usage,
+        configured_stack_limit(
+            "FACET_RECURSIVE_STACK_MAX_DESERIALIZE_BYTES",
+            2 * 1024 * 1024,
+        ),
+    );
+}


### PR DESCRIPTION
## Summary

- split large recursive facet-format serialization/deserialization arms into non-inlined helpers
- add a recursive facet-json roundtrip regression that samples stack usage through proxy conversions
- keep stack usage thresholds configurable through `FACET_RECURSIVE_STACK_*` environment variables

## Measurements

The measurement probe was applied to `origin/main` in a scratch tree for the base numbers.

| Path | Depth | Base | This PR |
| --- | ---: | ---: | ---: |
| serialize | 23 | 1,200,784 bytes | 370,208 bytes |
| deserialize, no `ci`/`stacker` feature | 23 | stack overflow | 1,731,440 bytes |
| deserialize, no `ci`/`stacker` feature | 20 | stack overflow | 1,505,600 bytes |
| deserialize, no `ci`/`stacker` feature | 18 | 1,791,360 bytes | 1,355,040 bytes |
| deserialize, with `ci`/`stacker` feature | 23 | 2,340,480 bytes | 1,782,960 bytes |

At matching numeric depths this is about 69% less stack for serialization and about 24% less stack for deserialization. At the default depth 23 without stack growth, base deserialization aborts before it can report a byte count; the PR branch completes.

The direct `stacker` dev-dependency in `facet-json` is only used by this integration test to call `stacker::remaining_stack()`. The production `facet-format` `stacker` feature already existed; this PR does not introduce a new production stack-growth dependency.

## Test Plan

- `cargo nextest list -p facet-json -E 'test(recursive_identity_node_json)'`
- `cargo nextest run -p facet-json -E 'test(recursive_identity_node_json)'`
- pre-push hook: clippy, docs, build tests, run tests
