### PR TITLE
Move PHON descriptors into weavy

### DIFF
--- a/phon/rust/phon-ir/src/descriptor.rs
+++ b/phon/rust/phon-ir/src/descriptor.rs
@@ -13,343 +13,56 @@
 //! for everything direct facts can't express. A node may give direct facts for
 //! one direction and a thunk for the other (`r[descriptors.encode-decode-asymmetry]`).
 //!
+//! The generic memory-descriptor vocabulary lives in `weavy`; PHON specializes it
+//! with `phon_schema::SchemaRef` so existing callers keep the same PHON-facing
+//! names while other bytecode consumers can reuse the same model.
+//!
 //! Spec: "The descriptor model" (`r[descriptors.*]`).
 
 use phon_schema::SchemaRef;
-use weavy::mem::{
-    BorrowThunks, DefaultThunk, MapThunks, OpaqueThunks, OptionThunks, PointerThunks, ResultThunks,
-    SeqThunks, SetThunks,
+
+pub use weavy::mem::{
+    Construct, FieldDefault, Layout, MapStorage, Presence, SequenceStorage, SetStorage, Tag, Thunk,
 };
 
-/// A node of the descriptor tree: the schema it realizes, its process-local
-/// memory layout, and how to read and construct it.
+/// A node of the PHON descriptor tree.
 // r[impl descriptors.separate-implementations]
 // r[impl descriptors.fact-driven]
-#[derive(Clone, Debug)]
-pub struct Descriptor {
-    /// The schema this node realizes.
-    pub schema: SchemaRef,
-    /// Process-local size and alignment.
-    pub layout: Layout,
-    /// How to read and construct this value.
-    pub access: Access,
-}
+pub type Descriptor = weavy::mem::Descriptor<SchemaRef>;
 
-/// Process-local size and alignment, in bytes.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Layout {
-    pub size: usize,
-    pub align: usize,
-}
-
-/// How a value's bytes are read and constructed.
-///
-/// Direct facts and thunk/vtable-backed forms are both descriptor mechanisms:
-/// the binding emits the form it can prove for that kind, and the engine
-/// consumes that descriptor rather than inventing missing layout facts.
+/// How a PHON value's bytes are read and constructed.
 // r[impl descriptors.encode-decode-asymmetry]
-#[derive(Clone, Debug)]
-pub enum Access {
-    /// A fixed-width scalar whose in-memory bytes equal its wire bytes (bool, the
-    /// integer and float primitives, char): copy `layout.size` bytes either
-    /// direction. Assumes host byte order matches the wire's (little-endian),
-    /// which every phon target does.
-    Scalar,
-    /// A struct or tuple: fields at fixed offsets.
-    Record(RecordAccess),
-    /// A sum type: an active variant chosen by a tag, a payload per variant.
-    Enum(EnumAccess),
-    /// none / some.
-    Option(OptionAccess),
-    /// A fixed-shape array: `count` elements inline (the product of the schema's
-    /// dimensions), `stride` apart, no allocation, direct both ways.
-    Array {
-        element: Box<Descriptor>,
-        count: usize,
-        stride: usize,
-    },
-    /// A runtime-shape tensor (ndarray and friends).
-    Tensor(TensorAccess),
-    /// A dynamic homogeneous sequence (list, set) or byte sequence
-    /// (string, bytes).
-    Sequence(SequenceAccess),
-    /// A set stored behind language-provided thunks (`HashSet<T>`,
-    /// `BTreeSet<T>`, …). The wire shape is `SchemaKind::Set`.
-    Set(SetAccess),
-    /// Key / value pairs.
-    Map(MapAccess),
-    /// A `Result<T, E>`: a thunk-driven two-armed sum (`Ok`/`Err`) whose
-    /// `repr(Rust)` layout the engine never assumes — presence and construction go
-    /// through the front-door [`ResultThunks`] vtable. On the wire it is a
-    /// two-variant enum (`r[compat.enum]`).
-    Result(ResultAccess),
-    /// An owning pointer whose wire shape is its pointee. The descriptor records
-    /// the local pointer handle layout plus thunks to borrow/construct the pointee.
-    // r[impl descriptors.thunk-binding]
-    Pointer(PointerAccess),
-    /// A `Dynamic` value: no layout to describe. The engine decodes/encodes a
-    /// `Value` through the self-describing codec and hands it over as-is.
-    Dynamic,
-    /// An opaque field (`#[facet(opaque = ...)]`): no layout to describe, no inner
-    /// schema the engine reads. The front-door-bound [`OpaqueThunks`] encode the
-    /// inner value (appended after a backpatched `u32` length) and decode it from
-    /// the borrowed span; on the wire it is a `Primitive::Bytes` run. This is how
-    /// `Channel`/`External` bindings (a local endpoint or external capability becoming
-    /// a handle) and any kind a producer can't reduce to layout facts are carried.
-    Opaque(OpaqueThunks),
-    /// A back-edge to a recursive (cyclic) schema: this position holds a value of the
-    /// schema named by this node's [`Descriptor::schema`], whose full descriptor lives
-    /// in the recursion block registry rather than being inlined here (an inlined
-    /// recursive descriptor would be infinite). The engine lowers it to a
-    /// [`MemOp::CallBlock`](crate::ir::MemOp::CallBlock) — a call into that schema's
-    /// block program, run at the current value pointer (`r[descriptors.recursion]`).
-    Recurse,
-}
+pub type Access = weavy::mem::Access<SchemaRef>;
 
-/// A struct or tuple: its fields at offsets, with how to construct it.
-#[derive(Clone, Debug)]
-pub struct RecordAccess {
-    pub fields: Vec<FieldAccess>,
-    pub construct: Construct,
-}
+/// A PHON struct or tuple: its fields at offsets, with how to construct it.
+pub type RecordAccess = weavy::mem::RecordAccess<SchemaRef>;
 
-/// One field: its byte offset within the record, and its descriptor.
-#[derive(Clone, Debug)]
-pub struct FieldAccess {
-    pub offset: usize,
-    pub descriptor: Descriptor,
-    /// How to write this field's default in place, for the decode-compat path when
-    /// the field is reader-only (absent from the writer). `Some` for a field the
-    /// language marks defaultable (`#[facet(default)]`, or an implicit
-    /// `Option<T>`/`None` default); `None` for a required field, whose absence from
-    /// the writer makes the schemas incompatible (`r[compat.reader-only-fields]`).
-    /// The `ctx` is the front-door-bound context the thunk understands (passed back
-    /// untouched).
-    pub default: Option<FieldDefault>,
-}
+/// One PHON field: its byte offset within the record, and its descriptor.
+pub type FieldAccess = weavy::mem::FieldAccess<SchemaRef>;
 
-/// A field's bound default-in-place operation: a [`DefaultThunk`] plus the opaque
-/// `ctx` it is called with. Used only on the decode-compat path for a reader-only
-/// field; ignored when the field is present on the wire.
-#[derive(Clone, Copy, Debug)]
-pub struct FieldDefault {
-    /// Opaque per-field context the front door binds (passed to `thunk`).
-    pub ctx: *const (),
-    /// Initialize the uninitialized field at `slot` to its default.
-    pub thunk: DefaultThunk,
-}
+/// A PHON sum type: a tag selecting the active variant, and the per-variant payloads.
+pub type EnumAccess = weavy::mem::EnumAccess<SchemaRef>;
 
-/// How a record is built on decode.
-#[derive(Clone, Debug)]
-pub enum Construct {
-    /// Decode writes each field into its offset in uninitialized storage; the
-    /// value is valid once all fields are written. Plain structs and tuples.
-    InPlace,
-    /// Decode fills a scratch buffer, then a thunk builds the real value from
-    /// it. Types with construction invariants, or languages that can't be poked
-    /// field by field.
-    Thunk(Thunk),
-}
+/// One PHON variant: its schema index, local tag selector, and payload fields.
+pub type VariantAccess = weavy::mem::VariantAccess<SchemaRef>;
 
-/// A sum type: a tag selecting the active variant, and the per-variant payloads.
-#[derive(Clone, Debug)]
-pub struct EnumAccess {
-    pub tag: Tag,
-    pub variants: Vec<VariantAccess>,
-}
+/// An optional PHON value: how presence is read/written, and the some-payload.
+pub type OptionAccess = weavy::mem::OptionAccess<SchemaRef>;
 
-/// How the active variant is read and set.
-#[derive(Clone, Debug)]
-pub enum Tag {
-    /// An integer discriminant `width` bytes wide at `offset`; the value read
-    /// there matches one variant's `selector`.
-    Direct { offset: usize, width: usize },
-    /// A niche: the discriminating region overlaps the payload (`Option<&T>` is
-    /// null, niche-optimized enums). Read like `Direct`, but writing it only
-    /// applies to variants that don't otherwise occupy the region.
-    Niche { offset: usize, width: usize },
-    /// The implementation determines and sets the active variant via thunks.
-    Thunk { read: Thunk, write: Thunk },
-}
+/// A dynamic homogeneous PHON sequence or byte sequence.
+pub type SequenceAccess = weavy::mem::SequenceAccess<SchemaRef>;
 
-/// One variant: its schema index, the in-memory tag value identifying it, and
-/// its payload fields.
-#[derive(Clone, Debug)]
-pub struct VariantAccess {
-    /// The schema variant index.
-    pub index: u32,
-    /// The tag value that identifies this variant in memory.
-    pub selector: u64,
-    /// The payload fields at offsets, with their own construction.
-    pub payload: RecordAccess,
-}
+/// A PHON set: its element descriptor and storage strategy.
+pub type SetAccess = weavy::mem::SetAccess<SchemaRef>;
 
-/// An optional value: how presence is read/written, and the some-payload.
-#[derive(Clone, Debug)]
-pub struct OptionAccess {
-    pub presence: Presence,
-    pub some: Box<Descriptor>,
-}
+/// A PHON result: the `Ok` and `Err` payload descriptors plus thunks.
+pub type ResultAccess = weavy::mem::ResultAccess<SchemaRef>;
 
-/// How none-vs-some is encoded in memory.
-#[derive(Clone, Debug)]
-pub enum Presence {
-    /// A dedicated tag region; `none_value` distinguishes none from some.
-    Tag {
-        offset: usize,
-        width: usize,
-        none_value: u64,
-    },
-    /// The some-payload's own bytes encode none at a pattern (null pointer, zero
-    /// of a non-zero type).
-    Niche {
-        offset: usize,
-        width: usize,
-        none_pattern: Vec<u8>,
-    },
-    /// Backend presence and construction.
-    Thunk {
-        is_some: Thunk,
-        set_none: Thunk,
-        set_some: Thunk,
-    },
-    /// Front-door-bound presence via the inner type's option vtable — the typed
-    /// path's representation, mirroring [`SequenceStorage::Vtable`]. The engine
-    /// reads presence and builds none/some through these thunks, never assuming
-    /// the in-memory niche/tag layout.
-    Vtable(OptionThunks),
-}
+/// A PHON owning pointer: its pointee descriptor and thunks.
+pub type PointerAccess = weavy::mem::PointerAccess<SchemaRef>;
 
-/// A dynamic homogeneous sequence or byte sequence: its element and storage.
-#[derive(Clone, Debug)]
-pub struct SequenceAccess {
-    pub element: Box<Descriptor>,
-    pub storage: SequenceStorage,
-}
+/// PHON key/value pairs: key and value descriptors plus map storage.
+pub type MapAccess = weavy::mem::MapAccess<SchemaRef>;
 
-/// A set: its element descriptor and storage strategy.
-#[derive(Clone, Debug)]
-pub struct SetAccess {
-    pub element: Box<Descriptor>,
-    pub storage: SetStorage,
-}
-
-/// How a set's elements are read and constructed in memory.
-#[derive(Clone, Debug)]
-pub enum SetStorage {
-    // r[impl descriptors.thunk-binding]
-    /// An owned set reached through the front door's bound set vtable
-    /// (`HashSet<T>`, `BTreeSet<T>`, …), whose in-memory layout the engine does
-    /// not assume. The typed path's owned-set representation, mirroring
-    /// [`SequenceStorage::Vtable`] and [`MapStorage::Vtable`]
-    /// (`r[descriptors.thunk-binding]`).
-    Vtable(SetThunks),
-}
-
-/// How a sequence's elements are stored in memory.
-// r[impl descriptors.borrowed]
-#[derive(Clone, Debug)]
-pub enum SequenceStorage {
-    /// Owned contiguous run: `(ptr, len, capacity)` at offsets, elements
-    /// `element.layout` stride apart. Encode reads ptr+len and walks. Decode
-    /// calls `allocate`, writes the elements, then writes the triple.
-    /// `Vec<T>`, `String`.
-    Owned {
-        ptr_offset: usize,
-        len_offset: usize,
-        /// `None` for owned-without-capacity, e.g. `Box<[T]>`.
-        cap_offset: Option<usize>,
-        allocate: Thunk,
-    },
-    /// Borrowed contiguous run: `(ptr, len)` at offsets, no capacity, no
-    /// allocation. Decode points `ptr` into the input (or a decode-scoped arena)
-    /// and writes `len`. `&str`, `&[u8]`, `&[T]` for scalar `T`.
-    Borrowed {
-        ptr_offset: usize,
-        len_offset: usize,
-    },
-    /// Non-flat storage: length and per-element access go through thunks (linked
-    /// lists, copy-on-write buffers, anything not a contiguous run).
-    Thunk { len: Thunk, get: Thunk, push: Thunk },
-    /// An owned contiguous sequence reached through the front door's bound list
-    /// vtable (`Vec<T>`, `String`), whose `(ptr, len, cap)` layout the engine does
-    /// not assume. The typed path's owned-sequence representation
-    /// (`r[descriptors.thunk-binding]`).
-    Vtable(SeqThunks),
-    /// A BORROWED, zero-copy contiguous byte run reached through the front door's
-    /// bound borrow thunks (`&str`, `&[u8]`), whose fat-pointer layout the engine
-    /// does not assume. Decode writes a fat pointer INTO the reader's input buffer
-    /// (no allocation, no copy); the decoded value borrows the input. The typed
-    /// path's borrowed-leaf representation, mirroring [`Vtable`](Self::Vtable) but
-    /// thunk-built rather than allocated. Distinct from the layout-fact
-    /// [`Borrowed`](Self::Borrowed), which carries raw `(ptr, len)` offsets
-    /// (`r[descriptors.thunk-binding]`).
-    BorrowedVtable(BorrowThunks),
-}
-
-/// A `Result<T, E>`: the `Ok` and `Err` payload descriptors and the vtable that
-/// reads which arm is active and builds it (the engine never assumes the
-/// `repr(Rust)` layout).
-#[derive(Clone, Debug)]
-pub struct ResultAccess {
-    pub ok: Box<Descriptor>,
-    pub err: Box<Descriptor>,
-    pub thunks: ResultThunks,
-}
-
-/// An owning pointer: its pointee descriptor and the vtable used to borrow and
-/// construct the pointer handle.
-// r[impl descriptors.thunk-binding]
-#[derive(Clone, Debug)]
-pub struct PointerAccess {
-    pub pointee: Box<Descriptor>,
-    pub thunks: PointerThunks,
-}
-
-/// Key/value pairs: the key and value descriptors and how the map is stored.
-#[derive(Clone, Debug)]
-pub struct MapAccess {
-    pub key: Box<Descriptor>,
-    pub value: Box<Descriptor>,
-    pub storage: MapStorage,
-}
-
-/// How a map's entries are read and constructed in memory.
-#[derive(Clone, Debug)]
-pub enum MapStorage {
-    /// Named same-language thunks: `len` (entry count, encode), `iterate` (yield
-    /// `(key, value)` pairs, encode), `insert` (a decoded pair, decode). The
-    /// spec'd, binding-resolved representation.
-    Thunk {
-        len: Thunk,
-        iterate: Thunk,
-        insert: Thunk,
-    },
-    /// An owned map reached through the front door's bound map vtable
-    /// (`BTreeMap<K, V>`, `HashMap<K, V>`, …), whose in-memory layout the engine
-    /// does not assume. The typed path's owned-map representation, mirroring
-    /// [`SequenceStorage::Vtable`] (`r[descriptors.thunk-binding]`).
-    Vtable(MapThunks),
-}
-
-/// A runtime-shape tensor.
-#[derive(Clone, Debug)]
-pub struct TensorAccess {
-    pub element: Box<Descriptor>,
-    /// Encode: read the dimension sizes.
-    pub shape: Thunk,
-    /// The flat row-major elements; `Borrowed` when contiguous.
-    pub data: SequenceStorage,
-    /// Decode: give the filled flat data its shape.
-    pub reshape: Thunk,
-}
-
-/// A named function the implementation provides. A thunk names a function; it
-/// does not carry one. Before building an encoder or decoder, the caller supplies
-/// a binding from thunk names to process-local function pointers
-/// (`r[descriptors.thunk-binding]`).
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Thunk {
-    /// Resolved to a function pointer by the binding.
-    pub name: String,
-}
+/// A PHON runtime-shape tensor.
+pub type TensorAccess = weavy::mem::TensorAccess<SchemaRef>;

--- a/weavy/src/lib.rs
+++ b/weavy/src/lib.rs
@@ -1,10 +1,10 @@
 //! Shared lowered-program substrate for interpreters and copy-and-patch backends.
 //!
-//! `weavy` deliberately knows nothing about schemas, parsers, memory layouts, or
-//! value models. A caller brings its own op enum and semantics; `weavy` provides
-//! the common carrier: flat programs, named blocks for recursive plans, and a
-//! small call-stack runner that keeps program execution out of the Rust call
-//! stack. Native copy-and-patch backends can use the same program/block shape.
+//! `weavy` stays format-agnostic: callers bring schema identities, parsers, and
+//! value models. The crate provides the shared carrier for lowered programs
+//! (flat programs, named blocks, and a small call-stack runner), plus the generic
+//! typed-memory descriptor/op vocabulary in [`mem`]. Native copy-and-patch
+//! backends can use the same program/block shape.
 
 pub mod mem;
 

--- a/weavy/src/mem.rs
+++ b/weavy/src/mem.rs
@@ -210,6 +210,254 @@ pub struct OpaqueThunks {
         unsafe extern "C" fn(ctx: *const (), bytes: *const u8, len: usize, slot: *mut u8) -> bool,
 }
 
+/// A caller-local descriptor tree: schema identity, process-local memory layout,
+/// and the access strategy for reading or constructing the value.
+#[derive(Clone, Debug)]
+pub struct Descriptor<SchemaRef> {
+    /// The caller's schema reference for this value.
+    pub schema: SchemaRef,
+    /// Process-local size and alignment.
+    pub layout: Layout,
+    /// How to read and construct this value.
+    pub access: Access<SchemaRef>,
+}
+
+/// Process-local size and alignment, in bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Layout {
+    pub size: usize,
+    pub align: usize,
+}
+
+/// How a value's bytes are read and constructed.
+#[derive(Clone, Debug)]
+pub enum Access<SchemaRef> {
+    /// A fixed-width scalar whose in-memory bytes equal its wire bytes.
+    Scalar,
+    /// A struct or tuple: fields at fixed offsets.
+    Record(RecordAccess<SchemaRef>),
+    /// A sum type: an active variant chosen by a tag, with a payload per variant.
+    Enum(EnumAccess<SchemaRef>),
+    /// none / some.
+    Option(OptionAccess<SchemaRef>),
+    /// A fixed-shape array: `count` elements inline, `stride` apart.
+    Array {
+        element: Box<Descriptor<SchemaRef>>,
+        count: usize,
+        stride: usize,
+    },
+    /// A runtime-shape tensor.
+    Tensor(TensorAccess<SchemaRef>),
+    /// A dynamic homogeneous sequence or byte sequence.
+    Sequence(SequenceAccess<SchemaRef>),
+    /// A set stored behind caller-provided thunks.
+    Set(SetAccess<SchemaRef>),
+    /// Key / value pairs.
+    Map(MapAccess<SchemaRef>),
+    /// A result-like two-armed sum whose local layout is thunk-driven.
+    Result(ResultAccess<SchemaRef>),
+    /// An owning pointer whose wire shape is its pointee.
+    Pointer(PointerAccess<SchemaRef>),
+    /// A dynamic self-describing value owned by the caller.
+    Dynamic,
+    /// An opaque value whose inner encoding is delegated to caller thunks.
+    Opaque(OpaqueThunks),
+    /// A back-edge to a recursive schema block.
+    Recurse,
+}
+
+/// A struct or tuple: its fields at offsets, with how to construct it.
+#[derive(Clone, Debug)]
+pub struct RecordAccess<SchemaRef> {
+    pub fields: Vec<FieldAccess<SchemaRef>>,
+    pub construct: Construct,
+}
+
+/// One field: its byte offset within the record, and its descriptor.
+#[derive(Clone, Debug)]
+pub struct FieldAccess<SchemaRef> {
+    pub offset: usize,
+    pub descriptor: Descriptor<SchemaRef>,
+    /// How to write this field's default in place when a reader-only field is
+    /// absent from the wire.
+    pub default: Option<FieldDefault>,
+}
+
+/// A field's bound default-in-place operation.
+#[derive(Clone, Copy, Debug)]
+pub struct FieldDefault {
+    /// Opaque per-field context the front door binds.
+    pub ctx: *const (),
+    /// Initialize the uninitialized field at `slot` to its default.
+    pub thunk: DefaultThunk,
+}
+
+/// How a record is built on decode.
+#[derive(Clone, Debug)]
+pub enum Construct {
+    /// Decode writes each field into its offset in uninitialized storage.
+    InPlace,
+    /// Decode fills a scratch buffer, then a thunk builds the real value from it.
+    Thunk(Thunk),
+}
+
+/// A sum type: a tag selecting the active variant, and the per-variant payloads.
+#[derive(Clone, Debug)]
+pub struct EnumAccess<SchemaRef> {
+    pub tag: Tag,
+    pub variants: Vec<VariantAccess<SchemaRef>>,
+}
+
+/// How the active variant is read and set.
+#[derive(Clone, Debug)]
+pub enum Tag {
+    /// An integer discriminant `width` bytes wide at `offset`.
+    Direct { offset: usize, width: usize },
+    /// A niche where the discriminating region overlaps payload bytes.
+    Niche { offset: usize, width: usize },
+    /// Caller-defined tag operations.
+    Thunk { read: Thunk, write: Thunk },
+}
+
+/// One variant: its schema index, local tag selector, and payload fields.
+#[derive(Clone, Debug)]
+pub struct VariantAccess<SchemaRef> {
+    pub index: u32,
+    pub selector: u64,
+    pub payload: RecordAccess<SchemaRef>,
+}
+
+/// An optional value: how presence is read/written, and the some-payload.
+#[derive(Clone, Debug)]
+pub struct OptionAccess<SchemaRef> {
+    pub presence: Presence,
+    pub some: Box<Descriptor<SchemaRef>>,
+}
+
+/// How none-vs-some is encoded in memory.
+#[derive(Clone, Debug)]
+pub enum Presence {
+    /// A dedicated tag region.
+    Tag {
+        offset: usize,
+        width: usize,
+        none_value: u64,
+    },
+    /// The some-payload's own bytes encode none at a pattern.
+    Niche {
+        offset: usize,
+        width: usize,
+        none_pattern: Vec<u8>,
+    },
+    /// Caller-defined presence operations.
+    Thunk {
+        is_some: Thunk,
+        set_none: Thunk,
+        set_some: Thunk,
+    },
+    /// Front-door-bound presence via an option vtable.
+    Vtable(OptionThunks),
+}
+
+/// A dynamic homogeneous sequence or byte sequence: its element and storage.
+#[derive(Clone, Debug)]
+pub struct SequenceAccess<SchemaRef> {
+    pub element: Box<Descriptor<SchemaRef>>,
+    pub storage: SequenceStorage,
+}
+
+/// A set: its element descriptor and storage strategy.
+#[derive(Clone, Debug)]
+pub struct SetAccess<SchemaRef> {
+    pub element: Box<Descriptor<SchemaRef>>,
+    pub storage: SetStorage,
+}
+
+/// How a set's elements are read and constructed in memory.
+#[derive(Clone, Debug)]
+pub enum SetStorage {
+    /// Front-door-bound set operations.
+    Vtable(SetThunks),
+}
+
+/// How a sequence's elements are stored in memory.
+#[derive(Clone, Debug)]
+pub enum SequenceStorage {
+    /// Owned contiguous run with explicit local handle offsets.
+    Owned {
+        ptr_offset: usize,
+        len_offset: usize,
+        cap_offset: Option<usize>,
+        allocate: Thunk,
+    },
+    /// Borrowed contiguous run with explicit local handle offsets.
+    Borrowed {
+        ptr_offset: usize,
+        len_offset: usize,
+    },
+    /// Non-flat storage through caller-provided operations.
+    Thunk { len: Thunk, get: Thunk, push: Thunk },
+    /// An owned contiguous sequence reached through front-door-bound thunks.
+    Vtable(SeqThunks),
+    /// A borrowed, zero-copy contiguous byte run reached through bound thunks.
+    BorrowedVtable(BorrowThunks),
+}
+
+/// A result-like value: ok/err payload descriptors and local operations.
+#[derive(Clone, Debug)]
+pub struct ResultAccess<SchemaRef> {
+    pub ok: Box<Descriptor<SchemaRef>>,
+    pub err: Box<Descriptor<SchemaRef>>,
+    pub thunks: ResultThunks,
+}
+
+/// An owning pointer: its pointee descriptor and local operations.
+#[derive(Clone, Debug)]
+pub struct PointerAccess<SchemaRef> {
+    pub pointee: Box<Descriptor<SchemaRef>>,
+    pub thunks: PointerThunks,
+}
+
+/// Key/value pairs: the key and value descriptors and how the map is stored.
+#[derive(Clone, Debug)]
+pub struct MapAccess<SchemaRef> {
+    pub key: Box<Descriptor<SchemaRef>>,
+    pub value: Box<Descriptor<SchemaRef>>,
+    pub storage: MapStorage,
+}
+
+/// How a map's entries are read and constructed in memory.
+#[derive(Clone, Debug)]
+pub enum MapStorage {
+    /// Named same-language thunks.
+    Thunk {
+        len: Thunk,
+        iterate: Thunk,
+        insert: Thunk,
+    },
+    /// Front-door-bound map operations.
+    Vtable(MapThunks),
+}
+
+/// A runtime-shape tensor.
+#[derive(Clone, Debug)]
+pub struct TensorAccess<SchemaRef> {
+    pub element: Box<Descriptor<SchemaRef>>,
+    /// Encode: read the dimension sizes.
+    pub shape: Thunk,
+    /// The flat row-major elements.
+    pub data: SequenceStorage,
+    /// Decode: give the filled flat data its shape.
+    pub reshape: Thunk,
+}
+
+/// A named function the implementation provides.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Thunk {
+    /// Resolved to a function pointer by the binding.
+    pub name: String,
+}
+
 /// A typed memory program whose block calls use caller-defined block ids.
 // r[impl ir.one-vocabulary]
 pub type MemProgram<BlockId> = crate::Program<MemOp<BlockId>>;


### PR DESCRIPTION
Summary:
- Moves the generic memory descriptor/access vocabulary from phon-ir into weavy::mem.
- Keeps phon-ir's PHON-facing names as SchemaRef-specialized aliases and re-exports.
- Updates weavy crate docs so it is described as format-agnostic, with shared typed-memory vocabulary.

Testing:
- cargo fmt --check
- git diff --check
- cargo check -p weavy -p phon-ir -p phon-engine -p phon --all-targets --message-format=short
- cargo nextest list -p weavy -p phon-ir -p phon-engine
- cargo nextest run -p weavy -p phon-ir -p phon-engine
- cargo clippy -p weavy -p phon-ir -p phon-engine -p phon --all-features --all-targets --message-format=short -- -D warnings
- pre-push hook passed