### PR TITLE
Move PHON memory lowering helpers into weavy

### DIFF
--- a/phon/rust/phon-engine/src/typed.rs
+++ b/phon/rust/phon-engine/src/typed.rs
@@ -26,8 +26,10 @@ use std::alloc;
 use std::collections::{BTreeMap, HashMap};
 
 use phon_ir::ir::{
-    BorrowOp, BytesOp, DefaultOp, EnumOp, EnumVariantOp, Lowered, MapOp, MemOp, MemProgram,
-    OpaqueOp, OptionOp, PointerOp, ResultOp, SeqOp, SetOp, SkipOp, fuse,
+    BorrowOp, BytesOp, DefaultOp, EnumOp, EnumVariantOp, Lowered, LoweringError, MapOp, MemOp,
+    MemProgram, OpaqueOp, OptionOp, PointerOp, ResultOp, SkipOp, fuse,
+    lower_fixed_array as lower_fixed_array_elements, lower_record_fields, owned_sequence_op,
+    set_op,
 };
 use phon_ir::{
     Access, Construct, Descriptor, EnumAccess, MapStorage, Presence, RecordAccess, ResultAccess,
@@ -43,6 +45,19 @@ use crate::compact::{self, CompactError, Registry, Resolved, alignment, pad_to, 
 use crate::compat::{self, FieldMatch, VariantMatch, incompatible};
 
 type Result<T> = core::result::Result<T, CompactError>;
+
+impl From<LoweringError> for CompactError {
+    fn from(error: LoweringError) -> Self {
+        match error {
+            LoweringError::ArrayBulkCopySizeOverflow => {
+                CompactError::Malformed("array bulk copy size overflow")
+            }
+            LoweringError::ArrayElementOffsetOverflow => {
+                CompactError::Malformed("array element offset overflow")
+            }
+        }
+    }
+}
 
 /// The wire (and, for our targets, in-memory) size of a fixed-width scalar, or
 /// `None` for the variable-length and uninhabited primitives, which need
@@ -74,18 +89,6 @@ fn fixed_size(p: Primitive) -> Option<usize> {
 /// # Errors
 /// [`CompactError`] if a referenced schema is missing, the descriptor and schema
 /// disagree, or a kind this first cut does not handle is reached.
-/// The minimum wire bytes one owned-sequence element occupies, for the
-/// length-vs-remaining guard (`r[validate.lengths]`). `0` when the element is
-/// zero-sized (an empty / all-ZST struct encodes to nothing, so the count is
-/// unbounded by the buffer and a fixed cap applies in `read_len` / the JIT
-/// stencil); `1` otherwise. An empty program is vacuously zero-sized.
-fn elem_min_wire(element: &MemProgram) -> usize {
-    let zero_sized = element
-        .iter()
-        .all(|op| matches!(op, MemOp::Scalar { size: 0, .. }));
-    usize::from(!zero_sized)
-}
-
 // r[impl ir.memory]
 // r[impl descriptors.fact-driven]
 pub fn lower(descriptor: &Descriptor, reg: &Registry) -> Result<MemProgram> {
@@ -190,12 +193,9 @@ fn lower_node(d: &Descriptor, reg: &Registry, base: usize, out: &mut MemProgram)
                     return Err(CompactError::Unsupported("typed: thunk construction"));
                 }
             }
-            // Splice each field in wire order, folding its memory offset into the
-            // base. A field's own descriptor carries its schema and layout.
-            for fa in &ra.fields {
-                lower_node(&fa.descriptor, reg, base + fa.offset, out)?;
-            }
-            Ok(())
+            lower_record_fields(&ra.fields, base, out, |field, field_base, out| {
+                lower_node(field, reg, field_base, out)
+            })
         }
         // r[impl ir.memory]
         (Access::Sequence(seq), Resolved::Composite(SchemaKind::List { .. })) => {
@@ -209,35 +209,18 @@ fn lower_node(d: &Descriptor, reg: &Registry, base: usize, out: &mut MemProgram)
             let elem_align = seq.element.layout.align;
             let mut element = Vec::new();
             lower_node(&seq.element, reg, 0, &mut element)?;
-            let element = fuse(element);
             // Bulk-copy lowering: an element that is a single scalar covering its
             // whole size, with no inter-element wire padding, decodes/encodes as
             // ONE block copy — `Vec<u32>`, `Vec<f64>`, `Vec<u8>`, flat `repr(C)`
             // structs. Anything with structure stays a per-element sequence.
-            let bulk = matches!(
-                element.as_slice(),
-                [MemOp::Scalar { offset: 0, size, align }]
-                    if *size == stride && stride.is_multiple_of(*align)
-            );
-            if bulk {
-                out.push(MemOp::Bytes(Box::new(BytesOp {
-                    field_offset: base,
-                    stride,
-                    elem_align,
-                    validate: validate_any,
-                    thunks: *thunks,
-                })));
-            } else {
-                let min_wire = elem_min_wire(&element);
-                out.push(MemOp::Sequence(Box::new(SeqOp {
-                    field_offset: base,
-                    element,
-                    stride,
-                    elem_align,
-                    min_wire,
-                    thunks: *thunks,
-                })));
-            }
+            out.push(owned_sequence_op(
+                base,
+                element,
+                stride,
+                elem_align,
+                validate_any,
+                *thunks,
+            ));
             Ok(())
         }
         (Access::Set(set), Resolved::Composite(SchemaKind::Set { .. })) => {
@@ -322,9 +305,12 @@ fn lower_node(d: &Descriptor, reg: &Registry, base: usize, out: &mut MemProgram)
                 // The variant's fields live at base-relative offsets that already
                 // account for the discriminant (per facet); lower them as a record.
                 let mut payload = Vec::new();
-                for f in &va.payload.fields {
-                    lower_node(&f.descriptor, reg, base + f.offset, &mut payload)?;
-                }
+                lower_record_fields(
+                    &va.payload.fields,
+                    base,
+                    &mut payload,
+                    |field, field_base, out| lower_node(field, reg, field_base, out),
+                )?;
                 variants.push(EnumVariantOp {
                     wire_index: va.index,
                     selector: va.selector,
@@ -696,31 +682,14 @@ fn lower_decode_sequence(
     let elem_align = seq.element.layout.align;
     let mut element = Vec::new();
     lower_decode_node(writer_element, &seq.element, reg, 0, &mut element)?;
-    let element = fuse(element);
-    let bulk = matches!(
-        element.as_slice(),
-        [MemOp::Scalar { offset: 0, size, align }]
-            if *size == stride && stride.is_multiple_of(*align)
-    );
-    if bulk {
-        out.push(MemOp::Bytes(Box::new(BytesOp {
-            field_offset: base,
-            stride,
-            elem_align,
-            validate: validate_any,
-            thunks: *thunks,
-        })));
-    } else {
-        let min_wire = elem_min_wire(&element);
-        out.push(MemOp::Sequence(Box::new(SeqOp {
-            field_offset: base,
-            element,
-            stride,
-            elem_align,
-            min_wire,
-            thunks: *thunks,
-        })));
-    }
+    out.push(owned_sequence_op(
+        base,
+        element,
+        stride,
+        elem_align,
+        validate_any,
+        *thunks,
+    ));
     Ok(())
 }
 
@@ -732,30 +701,9 @@ fn lower_fixed_array(
     base: usize,
     out: &mut MemProgram,
 ) -> Result<()> {
-    let mut element_ops = Vec::new();
-    lower_node(element, reg, 0, &mut element_ops)?;
-    let element_ops = fuse(element_ops);
-    if let [
-        MemOp::Scalar {
-            offset: 0,
-            size,
-            align,
-        },
-    ] = element_ops.as_slice()
-        && *size == stride
-        && stride.is_multiple_of(*align)
-    {
-        out.push(MemOp::Scalar {
-            offset: base,
-            size: fixed_array_copy_size(count, stride)?,
-            align: *align,
-        });
-        return Ok(());
-    }
-    for i in 0..count {
-        lower_node(element, reg, array_element_offset(base, i, stride)?, out)?;
-    }
-    Ok(())
+    lower_fixed_array_elements(count, stride, base, out, |element_base, out| {
+        lower_node(element, reg, element_base, out)
+    })
 }
 
 fn lower_decode_fixed_array(
@@ -767,50 +715,9 @@ fn lower_decode_fixed_array(
     base: usize,
     out: &mut MemProgram,
 ) -> Result<()> {
-    let mut element_ops = Vec::new();
-    lower_decode_node(writer_element, element, reg, 0, &mut element_ops)?;
-    let element_ops = fuse(element_ops);
-    if let [
-        MemOp::Scalar {
-            offset: 0,
-            size,
-            align,
-        },
-    ] = element_ops.as_slice()
-        && *size == stride
-        && stride.is_multiple_of(*align)
-    {
-        out.push(MemOp::Scalar {
-            offset: base,
-            size: fixed_array_copy_size(count, stride)?,
-            align: *align,
-        });
-        return Ok(());
-    }
-    for i in 0..count {
-        lower_decode_node(
-            writer_element,
-            element,
-            reg,
-            array_element_offset(base, i, stride)?,
-            out,
-        )?;
-    }
-    Ok(())
-}
-
-fn fixed_array_copy_size(count: usize, stride: usize) -> Result<usize> {
-    count
-        .checked_mul(stride)
-        .ok_or(CompactError::Malformed("array bulk copy size overflow"))
-}
-
-fn array_element_offset(base: usize, index: usize, stride: usize) -> Result<usize> {
-    let rel = index
-        .checked_mul(stride)
-        .ok_or(CompactError::Malformed("array element offset overflow"))?;
-    base.checked_add(rel)
-        .ok_or(CompactError::Malformed("array element offset overflow"))
+    lower_fixed_array_elements(count, stride, base, out, |element_base, out| {
+        lower_decode_node(writer_element, element, reg, element_base, out)
+    })
 }
 
 fn require_fixed_array_count(count: usize, dimensions: &[u64]) -> Result<()> {
@@ -830,16 +737,13 @@ fn lower_set(set: &SetAccess, reg: &Registry, base: usize, out: &mut MemProgram)
     let SetStorage::Vtable(thunks) = &set.storage;
     let mut element = Vec::new();
     lower_node(&set.element, reg, 0, &mut element)?;
-    let element = fuse(element);
-    let min_wire = elem_min_wire(&element);
-    out.push(MemOp::Set(Box::new(SetOp {
-        field_offset: base,
+    out.push(set_op(
+        base,
         element,
-        elem_size: set.element.layout.size,
-        elem_align: set.element.layout.align,
-        min_wire,
-        thunks: *thunks,
-    })));
+        set.element.layout.size,
+        set.element.layout.align,
+        *thunks,
+    ));
     Ok(())
 }
 
@@ -853,16 +757,13 @@ fn lower_decode_set(
     let SetStorage::Vtable(thunks) = &set.storage;
     let mut element = Vec::new();
     lower_decode_node(writer_element, &set.element, reg, 0, &mut element)?;
-    let element = fuse(element);
-    let min_wire = elem_min_wire(&element);
-    out.push(MemOp::Set(Box::new(SetOp {
-        field_offset: base,
+    out.push(set_op(
+        base,
         element,
-        elem_size: set.element.layout.size,
-        elem_align: set.element.layout.align,
-        min_wire,
-        thunks: *thunks,
-    })));
+        set.element.layout.size,
+        set.element.layout.align,
+        *thunks,
+    ));
     Ok(())
 }
 

--- a/phon/rust/phon-ir/src/ir.rs
+++ b/phon/rust/phon-ir/src/ir.rs
@@ -29,8 +29,10 @@
 use phon_schema::bytes::{Reader, skip_pad};
 use phon_schema::{DecodeError, Primitive, SchemaId, SchemaRef};
 pub use weavy::mem::{
-    BorrowOp, BorrowThunks, ByteValidator, BytesOp, DefaultOp, DefaultThunk, MapThunks, OpaqueOp,
-    OpaqueThunks, OptionThunks, PointerThunks, ResultThunks, SeqThunks, SetThunks, SkipOp,
+    BorrowOp, BorrowThunks, ByteValidator, BytesOp, DefaultOp, DefaultThunk, LoweringError,
+    MapThunks, OpaqueOp, OpaqueThunks, OptionThunks, PointerThunks, ResultThunks, SeqThunks,
+    SetThunks, SkipOp, element_min_wire, lower_fixed_array, lower_record_fields, owned_sequence_op,
+    set_op,
 };
 
 /// A lowered decode program: a straight run of [`Op`]s executed start to finish.

--- a/weavy/src/mem.rs
+++ b/weavy/src/mem.rs
@@ -706,6 +706,168 @@ pub struct OpaqueOp {
     pub thunks: OpaqueThunks,
 }
 
+/// Errors from shape-only lowering helpers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LoweringError {
+    /// A fixed-array bulk copy would overflow `usize`.
+    ArrayBulkCopySizeOverflow,
+    /// A fixed-array element's base-relative offset would overflow `usize`.
+    ArrayElementOffsetOverflow,
+}
+
+/// The minimum wire bytes one owned-container element occupies.
+///
+/// A program made entirely of zero-sized scalar copies occupies no wire bytes,
+/// so length guards must use a fixed cap instead of deriving a cap from the
+/// reader's remaining byte count. Every other element occupies at least one byte.
+#[must_use]
+pub fn element_min_wire<BlockId>(element: &[MemOp<BlockId>]) -> usize {
+    let zero_sized = element
+        .iter()
+        .all(|op| matches!(op, MemOp::Scalar { size: 0, .. }));
+    usize::from(!zero_sized)
+}
+
+/// Return the scalar alignment when an element program can be represented as one
+/// contiguous byte run inside a sequence or fixed array.
+#[must_use]
+pub fn bulk_scalar_align<BlockId>(element: &[MemOp<BlockId>], stride: usize) -> Option<usize> {
+    match element {
+        [
+            MemOp::Scalar {
+                offset: 0,
+                size,
+                align,
+            },
+        ] if *size == stride && *align != 0 && stride.is_multiple_of(*align) => Some(*align),
+        _ => None,
+    }
+}
+
+/// Build an owned-sequence op, using a bulk byte run when the lowered element is
+/// one scalar covering the full stride.
+#[must_use]
+pub fn owned_sequence_op<BlockId>(
+    field_offset: usize,
+    element: MemProgram<BlockId>,
+    stride: usize,
+    elem_align: usize,
+    validate: ByteValidator,
+    thunks: SeqThunks,
+) -> MemOp<BlockId> {
+    let element = fuse(element);
+    if bulk_scalar_align(&element, stride).is_some() {
+        MemOp::Bytes(Box::new(BytesOp {
+            field_offset,
+            stride,
+            elem_align,
+            validate,
+            thunks,
+        }))
+    } else {
+        let min_wire = element_min_wire(&element);
+        MemOp::Sequence(Box::new(SeqOp {
+            field_offset,
+            element,
+            stride,
+            elem_align,
+            min_wire,
+            thunks,
+        }))
+    }
+}
+
+/// Build a set op from a pre-lowered element program.
+#[must_use]
+pub fn set_op<BlockId>(
+    field_offset: usize,
+    element: MemProgram<BlockId>,
+    elem_size: usize,
+    elem_align: usize,
+    thunks: SetThunks,
+) -> MemOp<BlockId> {
+    let element = fuse(element);
+    let min_wire = element_min_wire(&element);
+    MemOp::Set(Box::new(SetOp {
+        field_offset,
+        element,
+        elem_size,
+        elem_align,
+        min_wire,
+        thunks,
+    }))
+}
+
+/// Lower each record field at `base + field.offset`.
+pub fn lower_record_fields<SchemaRef, BlockId, Error>(
+    fields: &[FieldAccess<SchemaRef>],
+    base: usize,
+    out: &mut MemProgram<BlockId>,
+    mut lower_field: impl FnMut(
+        &Descriptor<SchemaRef>,
+        usize,
+        &mut MemProgram<BlockId>,
+    ) -> Result<(), Error>,
+) -> Result<(), Error> {
+    for field in fields {
+        lower_field(&field.descriptor, base + field.offset, out)?;
+    }
+    Ok(())
+}
+
+/// Lower a fixed-size inline array, collapsing it to one scalar copy when a
+/// single element is itself a full-stride scalar byte run.
+pub fn lower_fixed_array<BlockId, Error>(
+    count: usize,
+    stride: usize,
+    base: usize,
+    out: &mut MemProgram<BlockId>,
+    mut lower_element: impl FnMut(usize, &mut MemProgram<BlockId>) -> Result<(), Error>,
+) -> Result<(), Error>
+where
+    Error: From<LoweringError>,
+{
+    let mut element_ops = Vec::new();
+    lower_element(0, &mut element_ops)?;
+    let element_ops = fuse(element_ops);
+
+    if let Some(align) = bulk_scalar_align(&element_ops, stride) {
+        out.push(MemOp::Scalar {
+            offset: base,
+            size: fixed_array_copy_size(count, stride).map_err(Error::from)?,
+            align,
+        });
+        return Ok(());
+    }
+
+    for index in 0..count {
+        let offset = array_element_offset(base, index, stride).map_err(Error::from)?;
+        lower_element(offset, out)?;
+    }
+
+    Ok(())
+}
+
+/// Total byte count for a collapsed fixed-array copy.
+pub fn fixed_array_copy_size(count: usize, stride: usize) -> Result<usize, LoweringError> {
+    count
+        .checked_mul(stride)
+        .ok_or(LoweringError::ArrayBulkCopySizeOverflow)
+}
+
+/// Base-relative offset for one fixed-array element.
+pub fn array_element_offset(
+    base: usize,
+    index: usize,
+    stride: usize,
+) -> Result<usize, LoweringError> {
+    let rel = index
+        .checked_mul(stride)
+        .ok_or(LoweringError::ArrayElementOffsetOverflow)?;
+    base.checked_add(rel)
+        .ok_or(LoweringError::ArrayElementOffsetOverflow)
+}
+
 /// Coalesce adjacent scalar copies that are contiguous in both wire and memory.
 // r[impl ir.inlining]
 #[must_use]
@@ -775,4 +937,116 @@ pub fn fuse<BlockId>(program: MemProgram<BlockId>) -> MemProgram<BlockId> {
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn element_min_wire_distinguishes_zero_sized_programs() {
+        assert_eq!(element_min_wire::<()>(&[]), 0);
+        assert_eq!(
+            element_min_wire(&[MemOp::<()>::Scalar {
+                offset: 0,
+                size: 0,
+                align: 1,
+            }]),
+            0
+        );
+        assert_eq!(
+            element_min_wire(&[MemOp::<()>::Scalar {
+                offset: 0,
+                size: 4,
+                align: 4,
+            }]),
+            1
+        );
+    }
+
+    #[test]
+    fn bulk_scalar_align_requires_one_full_stride_scalar() {
+        let scalar = [MemOp::<()>::Scalar {
+            offset: 0,
+            size: 8,
+            align: 4,
+        }];
+        assert_eq!(bulk_scalar_align(&scalar, 8), Some(4));
+
+        let partial = [MemOp::<()>::Scalar {
+            offset: 0,
+            size: 4,
+            align: 4,
+        }];
+        assert_eq!(bulk_scalar_align(&partial, 8), None);
+
+        let shifted = [MemOp::<()>::Scalar {
+            offset: 4,
+            size: 4,
+            align: 4,
+        }];
+        assert_eq!(bulk_scalar_align(&shifted, 4), None);
+    }
+
+    #[test]
+    fn fixed_array_lowering_collapses_full_stride_scalar_elements() {
+        let mut out = Vec::new();
+        lower_fixed_array::<(), LoweringError>(3, 4, 16, &mut out, |base, out| {
+            out.push(MemOp::Scalar {
+                offset: base,
+                size: 4,
+                align: 4,
+            });
+            Ok(())
+        })
+        .unwrap();
+
+        match out.as_slice() {
+            [
+                MemOp::Scalar {
+                    offset,
+                    size,
+                    align,
+                },
+            ] => {
+                assert_eq!((*offset, *size, *align), (16, 12, 4));
+            }
+            other => panic!("expected one collapsed scalar op, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fixed_array_lowering_replays_structured_elements_at_checked_offsets() {
+        let mut out = Vec::new();
+        lower_fixed_array::<(), LoweringError>(2, 8, 16, &mut out, |base, out| {
+            out.push(MemOp::Scalar {
+                offset: base + 4,
+                size: 4,
+                align: 4,
+            });
+            Ok(())
+        })
+        .unwrap();
+
+        let offsets: Vec<_> = out
+            .iter()
+            .map(|op| match op {
+                MemOp::Scalar { offset, .. } => *offset,
+                other => panic!("unexpected op {other:?}"),
+            })
+            .collect();
+        assert_eq!(offsets, [20, 28]);
+    }
+
+    #[test]
+    fn fixed_array_offset_helpers_report_overflow() {
+        assert_eq!(
+            fixed_array_copy_size(usize::MAX, 2),
+            Err(LoweringError::ArrayBulkCopySizeOverflow)
+        );
+        assert_eq!(
+            array_element_offset(usize::MAX - 1, 1, 2),
+            Err(LoweringError::ArrayElementOffsetOverflow)
+        );
+    }
 }


### PR DESCRIPTION
Summary:
- Extracts shape-only typed-memory lowering helpers into weavy::mem.
- Re-exports the helpers through phon-ir so PHON keeps its IR boundary.
- Replaces duplicated PHON sequence/set/fixed-array/record lowering mechanics with the shared helpers while keeping schema resolution and compatibility matching in phon-engine.

Testing:
- cargo fmt --check
- git diff --check
- cargo check -p weavy -p phon-ir -p phon-engine -p phon --all-targets --message-format=short
- cargo nextest list -p weavy -p phon-ir -p phon-engine
- cargo nextest run -p weavy -p phon-ir -p phon-engine
- cargo nextest list -p phon
- cargo nextest run -p phon
- cargo clippy -p weavy -p phon-ir -p phon-engine -p phon --all-features --all-targets --message-format=short -- -D warnings
- pre-push hook passed