### PR TITLE
Add record byte ownership metadata

### DIFF
--- a/phon/rust/phon-engine/src/typed.rs
+++ b/phon/rust/phon-engine/src/typed.rs
@@ -2101,7 +2101,7 @@ mod tests {
     use super::*;
     use core::mem::{MaybeUninit, align_of, offset_of, size_of};
     use facet_value::{VArray, Value};
-    use phon_ir::{FieldAccess, Layout, SeqThunks, SequenceAccess};
+    use phon_ir::{FieldAccess, Layout, RecordByteOwnership, SeqThunks, SequenceAccess};
     use phon_schema::bytes::{write_i64, write_u64};
     use phon_schema::{Schema, SchemaId, SchemaRef, primitive_id};
 
@@ -2183,39 +2183,43 @@ mod tests {
     }
 
     fn narrow_native_int_descriptor(schema: SchemaId) -> Descriptor {
+        let layout = Layout {
+            size: size_of::<NarrowNativeInts>(),
+            align: align_of::<NarrowNativeInts>(),
+        };
+        let fields = vec![
+            FieldAccess {
+                offset: offset_of!(NarrowNativeInts, count),
+                descriptor: Descriptor {
+                    schema: SchemaRef::concrete(primitive_id(Primitive::U64)),
+                    layout: Layout {
+                        size: size_of::<u32>(),
+                        align: align_of::<u32>(),
+                    },
+                    access: Access::Scalar,
+                },
+                default: None,
+            },
+            FieldAccess {
+                offset: offset_of!(NarrowNativeInts, delta),
+                descriptor: Descriptor {
+                    schema: SchemaRef::concrete(primitive_id(Primitive::I64)),
+                    layout: Layout {
+                        size: size_of::<i32>(),
+                        align: align_of::<i32>(),
+                    },
+                    access: Access::Scalar,
+                },
+                default: None,
+            },
+        ];
+        let byte_ownership = RecordByteOwnership::from_record_layout(layout, &fields);
         Descriptor {
             schema: SchemaRef::concrete(schema),
-            layout: Layout {
-                size: size_of::<NarrowNativeInts>(),
-                align: align_of::<NarrowNativeInts>(),
-            },
+            layout,
             access: Access::Record(RecordAccess {
-                fields: vec![
-                    FieldAccess {
-                        offset: offset_of!(NarrowNativeInts, count),
-                        descriptor: Descriptor {
-                            schema: SchemaRef::concrete(primitive_id(Primitive::U64)),
-                            layout: Layout {
-                                size: size_of::<u32>(),
-                                align: align_of::<u32>(),
-                            },
-                            access: Access::Scalar,
-                        },
-                        default: None,
-                    },
-                    FieldAccess {
-                        offset: offset_of!(NarrowNativeInts, delta),
-                        descriptor: Descriptor {
-                            schema: SchemaRef::concrete(primitive_id(Primitive::I64)),
-                            layout: Layout {
-                                size: size_of::<i32>(),
-                                align: align_of::<i32>(),
-                            },
-                            access: Access::Scalar,
-                        },
-                        default: None,
-                    },
-                ],
+                fields,
+                byte_ownership,
                 construct: Construct::InPlace,
             }),
         }

--- a/phon/rust/phon-ir/src/descriptor.rs
+++ b/phon/rust/phon-ir/src/descriptor.rs
@@ -22,7 +22,8 @@
 use phon_schema::SchemaRef;
 
 pub use weavy::mem::{
-    Construct, FieldDefault, Layout, MapStorage, Presence, SequenceStorage, SetStorage, Tag, Thunk,
+    ByteOwner, ByteRange, Construct, FieldDefault, Layout, MapStorage, Presence,
+    RecordByteOwnership, SequenceStorage, SetStorage, Tag, Thunk,
 };
 
 /// A node of the PHON descriptor tree.

--- a/phon/rust/phon-ir/src/lib.rs
+++ b/phon/rust/phon-ir/src/lib.rs
@@ -15,9 +15,10 @@
 pub mod descriptor;
 
 pub use descriptor::{
-    Access, Construct, Descriptor, EnumAccess, FieldAccess, FieldDefault, Layout, MapAccess,
-    MapStorage, OptionAccess, PointerAccess, Presence, RecordAccess, ResultAccess, SequenceAccess,
-    SequenceStorage, SetAccess, SetStorage, Tag, TensorAccess, Thunk, VariantAccess,
+    Access, ByteOwner, ByteRange, Construct, Descriptor, EnumAccess, FieldAccess, FieldDefault,
+    Layout, MapAccess, MapStorage, OptionAccess, PointerAccess, Presence, RecordAccess,
+    RecordByteOwnership, ResultAccess, SequenceAccess, SequenceStorage, SetAccess, SetStorage, Tag,
+    TensorAccess, Thunk, VariantAccess,
 };
 
 pub mod ir;

--- a/phon/rust/phon/src/derive.rs
+++ b/phon/rust/phon/src/derive.rs
@@ -32,8 +32,9 @@ use phon_engine::{Registry, typed};
 use phon_ir::{
     Access, BorrowThunks, Construct, Descriptor, EnumAccess, FieldAccess, FieldDefault, Layout,
     Lowered, MapAccess, MapStorage, MapThunks, OpaqueThunks, OptionAccess, OptionThunks,
-    PointerAccess, PointerThunks, Presence, RecordAccess, ResultAccess, ResultThunks, SeqThunks,
-    SequenceAccess, SequenceStorage, SetAccess, SetStorage, SetThunks, Tag, VariantAccess,
+    PointerAccess, PointerThunks, Presence, RecordAccess, RecordByteOwnership, ResultAccess,
+    ResultThunks, SeqThunks, SequenceAccess, SequenceStorage, SetAccess, SetStorage, SetThunks,
+    Tag, VariantAccess,
 };
 use phon_schema::{
     Field, Primitive, Schema, SchemaId, SchemaKind, SchemaRef, Variant, VariantPayload,
@@ -828,6 +829,7 @@ fn build_descriptor(
                 // else the variant position (which is the implicit discriminant).
                 selector: v.discriminant.unwrap_or(i as i64) as u64,
                 payload: RecordAccess {
+                    byte_ownership: RecordByteOwnership::fields_only(&fields),
                     fields,
                     construct: Construct::InPlace,
                 },
@@ -862,6 +864,7 @@ fn build_descriptor(
         schema: SchemaRef::concrete(real),
         layout,
         access: Access::Record(RecordAccess {
+            byte_ownership: RecordByteOwnership::from_record_layout(layout, &accesses),
             fields: accesses,
             construct: Construct::InPlace,
         }),
@@ -2287,6 +2290,7 @@ mod tests {
     use facet::Facet;
     use facet_value::{VArray, VObject, VString, Value};
     use phon_engine::{Registry, compact, typed};
+    use phon_ir::ByteOwner;
     use phon_ir::ir::MemOp;
 
     // repr(Rust): the compiler may reorder these in memory, so the descriptor's
@@ -2362,6 +2366,48 @@ mod tests {
             )),
             "anonymous tuples must not be emitted as numeric-field structs"
         );
+    }
+
+    #[test]
+    // r[verify descriptors.fact-driven]
+    fn derived_record_descriptor_carries_explicit_padding() {
+        let d = of::<Pt>().unwrap();
+        let Access::Record(record) = &d.descriptor.access else {
+            panic!("Pt should derive as a record descriptor");
+        };
+
+        let field_bytes: usize = record
+            .byte_ownership
+            .ranges
+            .iter()
+            .filter_map(|range| match range.owner {
+                ByteOwner::Field(_) => Some(range.len),
+                ByteOwner::Padding | ByteOwner::Unknown => None,
+            })
+            .sum();
+        let padding_bytes: usize = record
+            .byte_ownership
+            .ranges
+            .iter()
+            .filter_map(|range| match range.owner {
+                ByteOwner::Padding => Some(range.len),
+                ByteOwner::Field(_) | ByteOwner::Unknown => None,
+            })
+            .sum();
+        let mut field_indices: Vec<_> = record
+            .byte_ownership
+            .ranges
+            .iter()
+            .filter_map(|range| match range.owner {
+                ByteOwner::Field(index) => Some(index),
+                ByteOwner::Padding | ByteOwner::Unknown => None,
+            })
+            .collect();
+        field_indices.sort_unstable();
+
+        assert_eq!(field_indices, [0, 1, 2, 3]);
+        assert!(padding_bytes > 0);
+        assert_eq!(field_bytes + padding_bytes, std::mem::size_of::<Pt>());
     }
 
     #[test]

--- a/weavy/src/mem.rs
+++ b/weavy/src/mem.rs
@@ -270,6 +270,12 @@ pub enum Access<SchemaRef> {
 #[derive(Clone, Debug)]
 pub struct RecordAccess<SchemaRef> {
     pub fields: Vec<FieldAccess<SchemaRef>>,
+    /// Explicit byte ownership for bytes this record descriptor can prove.
+    ///
+    /// Optimizers may only treat a gap as padding when it appears here as
+    /// [`ByteOwner::Padding`]. Missing bytes, unknown ranges, and layout facts not
+    /// represented here are barriers.
+    pub byte_ownership: RecordByteOwnership,
     pub construct: Construct,
 }
 
@@ -290,6 +296,149 @@ pub struct FieldDefault {
     pub ctx: *const (),
     /// Initialize the uninitialized field at `slot` to its default.
     pub thunk: DefaultThunk,
+}
+
+/// Proven byte ownership for a record-shaped descriptor.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RecordByteOwnership {
+    pub ranges: Vec<ByteRange>,
+}
+
+impl RecordByteOwnership {
+    /// No usable byte-ownership proof.
+    #[must_use]
+    pub fn unknown(layout_size: usize) -> Self {
+        if layout_size == 0 {
+            Self::default()
+        } else {
+            Self {
+                ranges: vec![ByteRange {
+                    offset: 0,
+                    len: layout_size,
+                    owner: ByteOwner::Unknown,
+                }],
+            }
+        }
+    }
+
+    /// Mark only field byte ranges. Gaps remain unrepresented and therefore
+    /// unknown to consumers.
+    #[must_use]
+    pub fn fields_only<SchemaRef>(fields: &[FieldAccess<SchemaRef>]) -> Self {
+        let Some(fields) = sorted_field_ranges(fields) else {
+            return Self::default();
+        };
+        Self {
+            ranges: fields
+                .into_iter()
+                .map(|field| ByteRange {
+                    offset: field.offset,
+                    len: field.len,
+                    owner: ByteOwner::Field(field.index),
+                })
+                .collect(),
+        }
+    }
+
+    /// Derive field and padding ranges for a plain record whose full layout is
+    /// known. Any overlap, out-of-bounds field, or arithmetic overflow falls back
+    /// to one unknown range for the whole layout.
+    #[must_use]
+    pub fn from_record_layout<SchemaRef>(
+        layout: Layout,
+        fields: &[FieldAccess<SchemaRef>],
+    ) -> Self {
+        let Some(fields) = sorted_field_ranges(fields) else {
+            return Self::unknown(layout.size);
+        };
+        let Some(last_end) = fields
+            .last()
+            .map_or(Some(0), |field| field.offset.checked_add(field.len))
+        else {
+            return Self::unknown(layout.size);
+        };
+        if last_end > layout.size {
+            return Self::unknown(layout.size);
+        }
+
+        let mut ranges = Vec::with_capacity(fields.len().saturating_mul(2).saturating_add(1));
+        let mut cursor = 0usize;
+        for field in fields {
+            if cursor < field.offset {
+                ranges.push(ByteRange {
+                    offset: cursor,
+                    len: field.offset - cursor,
+                    owner: ByteOwner::Padding,
+                });
+            }
+            if field.len != 0 {
+                ranges.push(ByteRange {
+                    offset: field.offset,
+                    len: field.len,
+                    owner: ByteOwner::Field(field.index),
+                });
+            }
+            cursor = field.offset + field.len;
+        }
+        if cursor < layout.size {
+            ranges.push(ByteRange {
+                offset: cursor,
+                len: layout.size - cursor,
+                owner: ByteOwner::Padding,
+            });
+        }
+        Self { ranges }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ByteRange {
+    pub offset: usize,
+    pub len: usize,
+    pub owner: ByteOwner,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ByteOwner {
+    Field(usize),
+    Padding,
+    Unknown,
+}
+
+#[derive(Clone, Copy)]
+struct FieldByteRange {
+    index: usize,
+    offset: usize,
+    len: usize,
+}
+
+fn sorted_field_ranges<SchemaRef>(
+    fields: &[FieldAccess<SchemaRef>],
+) -> Option<Vec<FieldByteRange>> {
+    let mut ranges = Vec::with_capacity(fields.len());
+    for (index, field) in fields.iter().enumerate() {
+        let len = field.descriptor.layout.size;
+        let end = field.offset.checked_add(len)?;
+        if len != 0 {
+            ranges.push(FieldByteRange {
+                index,
+                offset: field.offset,
+                len,
+            });
+        } else if end < field.offset {
+            return None;
+        }
+    }
+    ranges.sort_by_key(|range| (range.offset, range.index));
+
+    let mut prev_end = 0usize;
+    for range in &ranges {
+        if range.offset < prev_end {
+            return None;
+        }
+        prev_end = range.offset.checked_add(range.len)?;
+    }
+    Some(ranges)
 }
 
 /// How a record is built on decode.
@@ -943,6 +1092,18 @@ pub fn fuse<BlockId>(program: MemProgram<BlockId>) -> MemProgram<BlockId> {
 mod tests {
     use super::*;
 
+    fn field(offset: usize, size: usize) -> FieldAccess<()> {
+        FieldAccess {
+            offset,
+            descriptor: Descriptor {
+                schema: (),
+                layout: Layout { size, align: 1 },
+                access: Access::Scalar,
+            },
+            default: None,
+        }
+    }
+
     #[test]
     fn element_min_wire_distinguishes_zero_sized_programs() {
         assert_eq!(element_min_wire::<()>(&[]), 0);
@@ -1047,6 +1208,76 @@ mod tests {
         assert_eq!(
             array_element_offset(usize::MAX - 1, 1, 2),
             Err(LoweringError::ArrayElementOffsetOverflow)
+        );
+    }
+
+    #[test]
+    fn record_byte_ownership_marks_internal_and_tail_padding() {
+        let fields = [field(0, 4), field(8, 2)];
+        let ownership =
+            RecordByteOwnership::from_record_layout(Layout { size: 12, align: 4 }, &fields);
+
+        assert_eq!(
+            ownership.ranges,
+            [
+                ByteRange {
+                    offset: 0,
+                    len: 4,
+                    owner: ByteOwner::Field(0),
+                },
+                ByteRange {
+                    offset: 4,
+                    len: 4,
+                    owner: ByteOwner::Padding,
+                },
+                ByteRange {
+                    offset: 8,
+                    len: 2,
+                    owner: ByteOwner::Field(1),
+                },
+                ByteRange {
+                    offset: 10,
+                    len: 2,
+                    owner: ByteOwner::Padding,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn record_field_ranges_do_not_turn_gaps_into_padding() {
+        let fields = [field(0, 4), field(8, 2)];
+        let ownership = RecordByteOwnership::fields_only(&fields);
+
+        assert_eq!(
+            ownership.ranges,
+            [
+                ByteRange {
+                    offset: 0,
+                    len: 4,
+                    owner: ByteOwner::Field(0),
+                },
+                ByteRange {
+                    offset: 8,
+                    len: 2,
+                    owner: ByteOwner::Field(1),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn record_byte_ownership_falls_back_to_unknown_for_bad_ranges() {
+        let overlapping = [field(0, 8), field(4, 4)];
+        let out_of_bounds = [field(8, 8)];
+
+        assert_eq!(
+            RecordByteOwnership::from_record_layout(Layout { size: 12, align: 4 }, &overlapping),
+            RecordByteOwnership::unknown(12)
+        );
+        assert_eq!(
+            RecordByteOwnership::from_record_layout(Layout { size: 12, align: 4 }, &out_of_bounds),
+            RecordByteOwnership::unknown(12)
         );
     }
 }


### PR DESCRIPTION
Summary:
- Adds explicit record byte-ownership metadata to weavy::mem.
- Marks struct field and padding ranges only when the full record layout is known.
- Keeps enum variant payload records conservative by marking only payload fields, leaving gaps unknown.
- Re-exports the metadata through phon-ir and populates it from PHON's facet-derived descriptors without changing lowering or fusion behavior.

Testing:
- cargo fmt --check
- git diff --check
- cargo check -p weavy -p phon-ir -p phon-engine -p phon --all-targets --message-format=short
- cargo nextest list -p weavy -p phon-ir -p phon-engine -p phon
- cargo nextest run -p weavy -p phon-ir -p phon-engine -p phon
- cargo clippy -p weavy -p phon-ir -p phon-engine -p phon --all-features --all-targets --message-format=short -- -D warnings
- pre-push hook passed