### PR TITLE
Group scalar record copies in weavy

### DIFF
--- a/phon/rust/phon-engine/src/typed.rs
+++ b/phon/rust/phon-engine/src/typed.rs
@@ -27,7 +27,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use phon_ir::ir::{
     BorrowOp, BytesOp, DefaultOp, EnumOp, EnumVariantOp, Lowered, LoweringError, MapOp, MemOp,
-    MemProgram, OpaqueOp, OptionOp, PointerOp, ResultOp, SkipOp, fuse,
+    MemProgram, OpaqueOp, OptionOp, PointerOp, ResultOp, SkipOp, fuse, group_record_scalars,
     lower_fixed_array as lower_fixed_array_elements, lower_record_fields, owned_sequence_op,
     set_op,
 };
@@ -193,9 +193,12 @@ fn lower_node(d: &Descriptor, reg: &Registry, base: usize, out: &mut MemProgram)
                     return Err(CompactError::Unsupported("typed: thunk construction"));
                 }
             }
-            lower_record_fields(&ra.fields, base, out, |field, field_base, out| {
+            let mut record = Vec::new();
+            lower_record_fields(&ra.fields, base, &mut record, |field, field_base, out| {
                 lower_node(field, reg, field_base, out)
-            })
+            })?;
+            out.extend(group_record_scalars(fuse(record), &ra.byte_ownership, base));
+            Ok(())
         }
         // r[impl ir.memory]
         (Access::Sequence(seq), Resolved::Composite(SchemaKind::List { .. })) => {
@@ -314,7 +317,7 @@ fn lower_node(d: &Descriptor, reg: &Registry, base: usize, out: &mut MemProgram)
                 variants.push(EnumVariantOp {
                     wire_index: va.index,
                     selector: va.selector,
-                    payload: fuse(payload),
+                    payload: group_record_scalars(fuse(payload), &va.payload.byte_ownership, base),
                 });
             }
             out.push(MemOp::Enum(Box::new(EnumOp {
@@ -1378,6 +1381,16 @@ unsafe fn encode_program(
                 let src = unsafe { core::slice::from_raw_parts(base.add(*offset), *size) };
                 out.extend_from_slice(src);
             }
+            MemOp::ScalarRun(run) => {
+                for segment in &run.segments {
+                    pad_to(out, segment.align);
+                    // Safety: the value is valid for reads over this field's bytes.
+                    let src = unsafe {
+                        core::slice::from_raw_parts(base.add(segment.offset), segment.size)
+                    };
+                    out.extend_from_slice(src);
+                }
+            }
             MemOp::NativeInt {
                 offset,
                 mem_size,
@@ -1631,6 +1644,21 @@ unsafe fn decode_program(
                 // Safety: `base` is valid for writes over this field's bytes, and
                 // the wire bytes equal the in-memory bytes for a fixed scalar.
                 unsafe { core::ptr::copy_nonoverlapping(src.as_ptr(), base.add(*offset), *size) };
+            }
+            MemOp::ScalarRun(run) => {
+                for segment in &run.segments {
+                    skip_pad(r, segment.align)?;
+                    let src = r.read_slice(segment.size)?;
+                    // Safety: forwarded from the grouped scalar op: each segment
+                    // writes within a fixed scalar field, and gaps are untouched.
+                    unsafe {
+                        core::ptr::copy_nonoverlapping(
+                            src.as_ptr(),
+                            base.add(segment.offset),
+                            segment.size,
+                        )
+                    };
+                }
             }
             MemOp::NativeInt {
                 offset,
@@ -2160,6 +2188,13 @@ mod tests {
         delta: i32,
     }
 
+    #[repr(C)]
+    #[derive(Debug, PartialEq)]
+    struct PaddedScalars {
+        a: u32,
+        b: u64,
+    }
+
     fn narrow_native_int_schema(schema: SchemaId) -> Schema {
         Schema {
             id: schema,
@@ -2207,6 +2242,71 @@ mod tests {
                     layout: Layout {
                         size: size_of::<i32>(),
                         align: align_of::<i32>(),
+                    },
+                    access: Access::Scalar,
+                },
+                default: None,
+            },
+        ];
+        let byte_ownership = RecordByteOwnership::from_record_layout(layout, &fields);
+        Descriptor {
+            schema: SchemaRef::concrete(schema),
+            layout,
+            access: Access::Record(RecordAccess {
+                fields,
+                byte_ownership,
+                construct: Construct::InPlace,
+            }),
+        }
+    }
+
+    fn padded_scalars_schema(schema: SchemaId) -> Schema {
+        Schema {
+            id: schema,
+            type_params: Vec::new(),
+            kind: SchemaKind::Struct {
+                name: "PaddedScalars".to_string(),
+                fields: vec![
+                    Field {
+                        name: "a".to_string(),
+                        schema: SchemaRef::concrete(primitive_id(Primitive::U32)),
+                        required: true,
+                    },
+                    Field {
+                        name: "b".to_string(),
+                        schema: SchemaRef::concrete(primitive_id(Primitive::U64)),
+                        required: true,
+                    },
+                ],
+            },
+        }
+    }
+
+    fn padded_scalars_descriptor(schema: SchemaId) -> Descriptor {
+        let layout = Layout {
+            size: size_of::<PaddedScalars>(),
+            align: align_of::<PaddedScalars>(),
+        };
+        let fields = vec![
+            FieldAccess {
+                offset: offset_of!(PaddedScalars, a),
+                descriptor: Descriptor {
+                    schema: SchemaRef::concrete(primitive_id(Primitive::U32)),
+                    layout: Layout {
+                        size: size_of::<u32>(),
+                        align: align_of::<u32>(),
+                    },
+                    access: Access::Scalar,
+                },
+                default: None,
+            },
+            FieldAccess {
+                offset: offset_of!(PaddedScalars, b),
+                descriptor: Descriptor {
+                    schema: SchemaRef::concrete(primitive_id(Primitive::U64)),
+                    layout: Layout {
+                        size: size_of::<u64>(),
+                        align: align_of::<u64>(),
                     },
                     access: Access::Scalar,
                 },
@@ -2276,6 +2376,60 @@ mod tests {
         .unwrap();
         let back = unsafe { slot.assume_init() };
         assert_eq!(back, values.to_vec());
+    }
+
+    #[test]
+    fn padded_record_lowers_to_scalar_run_and_roundtrips() {
+        let schema = SchemaId(1);
+        let reg = Registry::new([padded_scalars_schema(schema)]);
+        let desc = padded_scalars_descriptor(schema);
+        let no_blocks = HashMap::new();
+        let lowered = lower_typed(&desc, &no_blocks, &reg).unwrap();
+
+        match lowered.program.as_slice() {
+            [MemOp::ScalarRun(run)] => {
+                assert_eq!(run.segments.len(), 2);
+                assert_eq!(
+                    (
+                        run.segments[0].offset,
+                        run.segments[0].size,
+                        run.segments[0].align
+                    ),
+                    (
+                        offset_of!(PaddedScalars, a),
+                        size_of::<u32>(),
+                        align_of::<u32>()
+                    )
+                );
+                assert_eq!(
+                    (
+                        run.segments[1].offset,
+                        run.segments[1].size,
+                        run.segments[1].align
+                    ),
+                    (
+                        offset_of!(PaddedScalars, b),
+                        size_of::<u64>(),
+                        align_of::<u64>()
+                    )
+                );
+            }
+            other => panic!("expected one grouped scalar run, got {other:?}"),
+        }
+
+        let value = PaddedScalars {
+            a: 0x1122_3344,
+            b: 0xAABB_CCDD_EEFF_0011,
+        };
+        let bytes = unsafe { encode_with(&lowered, core::ptr::from_ref(&value).cast::<u8>()) };
+        let mut expected = value.a.to_le_bytes().to_vec();
+        expected.extend_from_slice(&[0; 4]);
+        expected.extend_from_slice(&value.b.to_le_bytes());
+        assert_eq!(bytes, expected);
+
+        let mut slot = MaybeUninit::<PaddedScalars>::uninit();
+        unsafe { decode_with(&lowered, &bytes, slot.as_mut_ptr().cast::<u8>()) }.unwrap();
+        assert_eq!(unsafe { slot.assume_init() }, value);
     }
 
     #[test]

--- a/phon/rust/phon-ir/src/ir.rs
+++ b/phon/rust/phon-ir/src/ir.rs
@@ -30,9 +30,9 @@ use phon_schema::bytes::{Reader, skip_pad};
 use phon_schema::{DecodeError, Primitive, SchemaId, SchemaRef};
 pub use weavy::mem::{
     BorrowOp, BorrowThunks, ByteValidator, BytesOp, DefaultOp, DefaultThunk, LoweringError,
-    MapThunks, OpaqueOp, OpaqueThunks, OptionThunks, PointerThunks, ResultThunks, SeqThunks,
-    SetThunks, SkipOp, element_min_wire, lower_fixed_array, lower_record_fields, owned_sequence_op,
-    set_op,
+    MapThunks, OpaqueOp, OpaqueThunks, OptionThunks, PointerThunks, ResultThunks, ScalarRunOp,
+    ScalarSegment, SeqThunks, SetThunks, SkipOp, element_min_wire, group_record_scalars,
+    lower_fixed_array, lower_record_fields, owned_sequence_op, set_op,
 };
 
 /// A lowered decode program: a straight run of [`Op`]s executed start to finish.

--- a/phon/rust/phon-ir/src/lib.rs
+++ b/phon/rust/phon-ir/src/lib.rs
@@ -26,8 +26,8 @@ pub mod ir;
 pub use ir::{
     BorrowOp, BorrowThunks, ByteValidator, BytesOp, DefaultOp, DefaultThunk, EnumArm, EnumOp,
     EnumVariantOp, Lowered, MapOp, MapThunks, MemOp, MemProgram, Op, OpaqueOp, OpaqueThunks,
-    OptionOp, OptionThunks, PointerOp, PointerThunks, Program, ResultOp, ResultThunks, SeqOp,
-    SeqThunks, SetOp, SetThunks, SkipOp, ValueProgram,
+    OptionOp, OptionThunks, PointerOp, PointerThunks, Program, ResultOp, ResultThunks, ScalarRunOp,
+    ScalarSegment, SeqOp, SeqThunks, SetOp, SetThunks, SkipOp, ValueProgram,
 };
 
 /// Thunk bindings: resolving thunk names to process-local function pointers

--- a/phon/rust/phon-jit/src/lower.rs
+++ b/phon/rust/phon-jit/src/lower.rs
@@ -33,6 +33,10 @@ enum DecodeStep {
         stencil: unsafe fn(&mut DecodeCtx, &Imm) -> Result<(), DecodeError>,
         imm: Imm,
     },
+    ScalarRun {
+        stencil: unsafe fn(&mut DecodeCtx, &Imm) -> Result<(), DecodeError>,
+        imms: Vec<Imm>,
+    },
     Pointer {
         field_offset: usize,
         pointee_size: usize,
@@ -57,6 +61,11 @@ enum EncodeStep {
     Scalar {
         stencil: unsafe fn(&mut EncodeCtx, &Imm),
         imm: Imm,
+    },
+    /// Several fixed scalar segments, each retaining its own wire alignment.
+    ScalarRun {
+        stencil: unsafe fn(&mut EncodeCtx, &Imm),
+        imms: Vec<Imm>,
     },
     /// An owned sequence: write its `u32` count, then encode each element with the
     /// element sub-program at `data + i*stride`.
@@ -89,6 +98,14 @@ pub fn compile_decode(program: &MemProgram) -> CompiledDecode {
             } => DecodeStep::Scalar {
                 stencil: stencil::scalar_decode,
                 imm: [*offset, *size, *align],
+            },
+            MemOp::ScalarRun(run) => DecodeStep::ScalarRun {
+                stencil: stencil::scalar_decode,
+                imms: run
+                    .segments
+                    .iter()
+                    .map(|segment| [segment.offset, segment.size, segment.align])
+                    .collect(),
             },
             MemOp::NativeInt { .. } => {
                 panic!("phon-jit: native-sized integer casts are interpreter-only for now")
@@ -136,6 +153,14 @@ pub fn compile_encode(program: &MemProgram) -> CompiledEncode {
             } => EncodeStep::Scalar {
                 stencil: stencil::scalar_encode,
                 imm: [*offset, *size, *align],
+            },
+            MemOp::ScalarRun(run) => EncodeStep::ScalarRun {
+                stencil: stencil::scalar_encode,
+                imms: run
+                    .segments
+                    .iter()
+                    .map(|segment| [segment.offset, segment.size, segment.align])
+                    .collect(),
             },
             MemOp::NativeInt { .. } => {
                 panic!("phon-jit: native-sized integer casts are interpreter-only for now")
@@ -204,6 +229,13 @@ impl DecodeStep {
             DecodeStep::Scalar { stencil, imm } => {
                 // Safety: forwarded; the scalar op writes within the current base.
                 unsafe { (stencil)(ctx, imm) }
+            }
+            DecodeStep::ScalarRun { stencil, imms } => {
+                for imm in imms {
+                    // Safety: forwarded; every segment writes within a scalar field.
+                    unsafe { (stencil)(ctx, imm)? };
+                }
+                Ok(())
             }
             DecodeStep::Pointer {
                 field_offset,
@@ -280,6 +312,17 @@ impl CompiledEncode {
                     unsafe { (stencil)(&mut ctx, imm) };
                     *out = ctx.out;
                 }
+                EncodeStep::ScalarRun { stencil, imms } => {
+                    let mut ctx = EncodeCtx {
+                        out: core::mem::take(out),
+                        base,
+                    };
+                    for imm in imms {
+                        // Safety: forwarded; every segment reads within a scalar field.
+                        unsafe { (stencil)(&mut ctx, imm) };
+                    }
+                    *out = ctx.out;
+                }
                 EncodeStep::Sequence {
                     field_offset,
                     stride,
@@ -342,7 +385,7 @@ fn free_scratch(buf: *mut u8, layout: Option<std::alloc::Layout>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use phon_ir::ir::{MemOp, PointerOp};
+    use phon_ir::ir::{MemOp, PointerOp, ScalarRunOp, ScalarSegment};
 
     // A two-field value in memory: u32 at offset 0, u64 at offset 8. On the wire,
     // compact alignment puts the u32 first, pads to 8, then the u64.
@@ -381,6 +424,43 @@ mod tests {
         let mut out = Mem([0; 16]);
         unsafe { dec.run(&bytes, out.0.as_mut_ptr()) }.unwrap();
         assert_eq!(out.0, mem.0);
+    }
+
+    #[test]
+    fn scalar_run_keeps_per_segment_wire_padding() {
+        let program: MemProgram = vec![MemOp::ScalarRun(Box::new(ScalarRunOp {
+            segments: vec![
+                ScalarSegment {
+                    offset: 0,
+                    size: 4,
+                    align: 4,
+                },
+                ScalarSegment {
+                    offset: 8,
+                    size: 8,
+                    align: 8,
+                },
+            ],
+        }))];
+        let enc = compile_encode(&program);
+        let dec = compile_decode(&program);
+
+        let mut mem = Mem([0; 16]);
+        mem.0[0..4].copy_from_slice(&0x1122_3344u32.to_le_bytes());
+        mem.0[4..8].copy_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]);
+        mem.0[8..16].copy_from_slice(&0xAABB_CCDD_EEFF_0011u64.to_le_bytes());
+
+        let bytes = unsafe { enc.run(mem.0.as_ptr()) };
+        assert_eq!(bytes.len(), 16);
+        assert_eq!(&bytes[0..4], &0x1122_3344u32.to_le_bytes());
+        assert_eq!(&bytes[4..8], &[0, 0, 0, 0]);
+        assert_eq!(&bytes[8..16], &0xAABB_CCDD_EEFF_0011u64.to_le_bytes());
+
+        let mut out = Mem([0xEE; 16]);
+        unsafe { dec.run(&bytes, out.0.as_mut_ptr()) }.unwrap();
+        assert_eq!(&out.0[0..4], &mem.0[0..4]);
+        assert_eq!(&out.0[4..8], &[0xEE; 4]);
+        assert_eq!(&out.0[8..16], &mem.0[8..16]);
     }
 
     #[test]

--- a/phon/rust/phon-jit/src/native.rs
+++ b/phon/rust/phon-jit/src/native.rs
@@ -459,6 +459,27 @@ struct Chain {
     prog_index: usize,
 }
 
+fn expand_scalar_runs(program: &MemProgram) -> Option<MemProgram> {
+    if !program.iter().any(|op| matches!(op, MemOp::ScalarRun(_))) {
+        return None;
+    }
+
+    let mut out = Vec::with_capacity(program.len());
+    for op in program {
+        match op {
+            MemOp::ScalarRun(run) => {
+                out.extend(run.segments.iter().map(|segment| MemOp::Scalar {
+                    offset: segment.offset,
+                    size: segment.size,
+                    align: segment.align,
+                }));
+            }
+            other => out.push(other.clone()),
+        }
+    }
+    Some(out)
+}
+
 /// A sequence's prog slot to fill once chains are laid out and the `ExecBuf`
 /// exists: write `&seq_infos[seqinfo]` into `progs[prog_index][slot]`.
 struct SeqFixup {
@@ -736,6 +757,8 @@ impl Compiler {
     /// continuations patched to chain to the next op (the last to `done`).
     /// Recurses into sequence elements, which become their own chains.
     fn compile_chain(&mut self, program: &MemProgram) -> Chain {
+        let expanded = expand_scalar_runs(program);
+        let program = expanded.as_ref().unwrap_or(program);
         let entry = self.code.len();
         let prog_index = self.progs.len();
         self.progs.push(Vec::new());
@@ -756,6 +779,9 @@ impl Compiler {
                     p.push(*offset as u64);
                     p.push(*size as u64);
                     p.push(*align as u64);
+                }
+                MemOp::ScalarRun(_) => {
+                    unreachable!("scalar runs are expanded before native lowering")
                 }
                 MemOp::NativeInt { .. } => {
                     panic!("phon-jit: native-sized integer casts are interpreter-only for now")
@@ -1086,6 +1112,9 @@ impl Compiler {
             let next = starts.get(i + 1).copied().unwrap_or(done_start);
             let relocs = match &program[i] {
                 MemOp::Scalar { .. } => SCALAR_CONT,
+                MemOp::ScalarRun(_) => {
+                    unreachable!("scalar runs are expanded before native lowering")
+                }
                 MemOp::NativeInt { .. } => {
                     panic!("phon-jit: native-sized integer casts are interpreter-only for now")
                 }
@@ -1998,6 +2027,8 @@ impl EncCompiler {
     /// `done`, with continuations patched to chain to the next op (the last to
     /// `done`). Recurses into sequence elements, which become their own chains.
     fn compile_chain(&mut self, program: &MemProgram) -> Chain {
+        let expanded = expand_scalar_runs(program);
+        let program = expanded.as_ref().unwrap_or(program);
         let entry = self.code.len();
         let prog_index = self.progs.len();
         self.progs.push(Vec::new());
@@ -2016,6 +2047,9 @@ impl EncCompiler {
                     p.push(*offset as u64);
                     p.push(*size as u64);
                     p.push(*align as u64);
+                }
+                MemOp::ScalarRun(_) => {
+                    unreachable!("scalar runs are expanded before native lowering")
                 }
                 MemOp::NativeInt { .. } => {
                     panic!("phon-jit: native-sized integer casts are interpreter-only for now")
@@ -2282,6 +2316,9 @@ impl EncCompiler {
             let next = starts.get(i + 1).copied().unwrap_or(done_start);
             let relocs = match &program[i] {
                 MemOp::Scalar { .. } => SCALAR_ENC_CONT,
+                MemOp::ScalarRun(_) => {
+                    unreachable!("scalar runs are expanded before native lowering")
+                }
                 MemOp::NativeInt { .. } => {
                     panic!("phon-jit: native-sized integer casts are interpreter-only for now")
                 }
@@ -2677,6 +2714,7 @@ impl NativeEncode {
 mod tests {
     use super::*;
     use crate::lower::compile_decode;
+    use phon_ir::ir::{ScalarRunOp, ScalarSegment};
 
     #[test]
     fn runs_compiler_emitted_machine_code() {
@@ -3061,6 +3099,42 @@ mod tests {
         assert_eq!(&got[0..4], &0x1122_3344u32.to_le_bytes());
         assert_eq!(&got[4..8], &[0, 0, 0, 0]);
         assert_eq!(&got[8..16], &0xAABB_CCDD_EEFF_0011u64.to_le_bytes());
+    }
+
+    #[test]
+    fn jit_scalar_run_matches_threaded() {
+        let program: MemProgram = vec![MemOp::ScalarRun(Box::new(ScalarRunOp {
+            segments: vec![
+                ScalarSegment {
+                    offset: 0,
+                    size: 4,
+                    align: 4,
+                },
+                ScalarSegment {
+                    offset: 8,
+                    size: 8,
+                    align: 8,
+                },
+            ],
+        }))];
+        #[repr(C, align(8))]
+        struct Mem([u8; 16]);
+        let mut mem = Mem([0; 16]);
+        mem.0[0..4].copy_from_slice(&0x1122_3344u32.to_le_bytes());
+        mem.0[4..8].copy_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]);
+        mem.0[8..16].copy_from_slice(&0xAABB_CCDD_EEFF_0011u64.to_le_bytes());
+
+        let expected = unsafe { compile_encode(&program).run(mem.0.as_ptr()) };
+        let got = unsafe { NativeEncode::compile(&program).run(mem.0.as_ptr()) };
+        assert_eq!(got, expected);
+        assert_eq!(&got[4..8], &[0, 0, 0, 0]);
+
+        let dec = NativeDecode::compile(&program);
+        let mut out = Mem([0xEE; 16]);
+        unsafe { dec.run(&got, out.0.as_mut_ptr()) }.unwrap();
+        assert_eq!(&out.0[0..4], &mem.0[0..4]);
+        assert_eq!(&out.0[4..8], &[0xEE; 4]);
+        assert_eq!(&out.0[8..16], &mem.0[8..16]);
     }
 
     /// A wider scalar program (every fixed width, reordered offsets), encoded and

--- a/phon/rust/phon/src/lib.rs
+++ b/phon/rust/phon/src/lib.rs
@@ -435,6 +435,7 @@ pub mod api {
     fn decode_program_supported(program: &[MemOp]) -> bool {
         program.iter().all(|op| match op {
             MemOp::Scalar { .. }
+            | MemOp::ScalarRun(_)
             | MemOp::Bytes(_)
             | MemOp::Borrow(_)
             | MemOp::Default(_)
@@ -457,7 +458,7 @@ pub mod api {
     #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
     fn encode_program_supported(program: &[MemOp]) -> bool {
         program.iter().all(|op| match op {
-            MemOp::Scalar { .. } | MemOp::Bytes(_) | MemOp::Borrow(_) => true,
+            MemOp::Scalar { .. } | MemOp::ScalarRun(_) | MemOp::Bytes(_) | MemOp::Borrow(_) => true,
             MemOp::NativeInt { .. } => false,
             MemOp::Sequence(s) => encode_program_supported(&s.element),
             MemOp::Set(s) => encode_program_supported(&s.element),

--- a/vox/rust/vox-phon/src/lib.rs
+++ b/vox/rust/vox-phon/src/lib.rs
@@ -237,6 +237,7 @@ fn native_encode_supported(lowered: &Lowered) -> bool {
 fn decode_program_supported(program: &[MemOp]) -> bool {
     program.iter().all(|op| match op {
         MemOp::Scalar { .. }
+        | MemOp::ScalarRun(_)
         | MemOp::Bytes(_)
         | MemOp::Borrow(_)
         | MemOp::Default(_)
@@ -259,7 +260,7 @@ fn decode_program_supported(program: &[MemOp]) -> bool {
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn encode_program_supported(program: &[MemOp]) -> bool {
     program.iter().all(|op| match op {
-        MemOp::Scalar { .. } | MemOp::Bytes(_) | MemOp::Borrow(_) => true,
+        MemOp::Scalar { .. } | MemOp::ScalarRun(_) | MemOp::Bytes(_) | MemOp::Borrow(_) => true,
         MemOp::NativeInt { .. } => false,
         MemOp::Sequence(s) => encode_program_supported(&s.element),
         MemOp::Set(s) => encode_program_supported(&s.element),

--- a/vox/rust/vox-phon/src/schema.rs
+++ b/vox/rust/vox-phon/src/schema.rs
@@ -318,6 +318,7 @@ fn native_decode_supported(lowered: &Lowered) -> bool {
 fn decode_program_supported(program: &[MemOp]) -> bool {
     program.iter().all(|op| match op {
         MemOp::Scalar { .. }
+        | MemOp::ScalarRun(_)
         | MemOp::Bytes(_)
         | MemOp::Borrow(_)
         | MemOp::Default(_)

--- a/weavy/src/mem.rs
+++ b/weavy/src/mem.rs
@@ -389,6 +389,41 @@ impl RecordByteOwnership {
         }
         Self { ranges }
     }
+
+    /// Whether every byte in `offset..offset + len` is explicitly known padding.
+    ///
+    /// Missing ranges, unknown ranges, field ranges, and overflow are all barriers.
+    #[must_use]
+    pub fn is_padding_range(&self, offset: usize, len: usize) -> bool {
+        if len == 0 {
+            return true;
+        }
+        let Some(end) = offset.checked_add(len) else {
+            return false;
+        };
+        let mut cursor = offset;
+
+        for range in &self.ranges {
+            let Some(range_end) = range.offset.checked_add(range.len) else {
+                return false;
+            };
+            if range_end <= cursor {
+                continue;
+            }
+            if range.offset > cursor {
+                return false;
+            }
+            if range.owner != ByteOwner::Padding {
+                return false;
+            }
+            cursor = range_end.min(end);
+            if cursor == end {
+                return true;
+            }
+        }
+
+        false
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -623,6 +658,12 @@ pub enum MemOp<BlockId> {
         size: usize,
         align: usize,
     },
+    /// Copy several scalar segments in one grouped op.
+    ///
+    /// Each segment keeps its own wire alignment. Memory bytes between segments
+    /// are not read or written; this is only equivalent to the scalar stream when
+    /// those gaps are known padding or when the segments are contiguous.
+    ScalarRun(Box<ScalarRunOp>),
     /// A native-sized integer (`usize`/`isize`) whose wire primitive is fixed-width
     /// (`u64`/`i64`) on every platform.
     NativeInt {
@@ -658,6 +699,26 @@ pub enum MemOp<BlockId> {
     Opaque(Box<OpaqueOp>),
     /// A call into a recursive block program, run at `base + offset`.
     CallBlock { schema: BlockId, offset: usize },
+}
+
+/// One scalar segment inside a grouped scalar run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ScalarSegment {
+    pub offset: usize,
+    pub size: usize,
+    pub align: usize,
+}
+
+impl ScalarSegment {
+    fn end(self) -> Option<usize> {
+        self.offset.checked_add(self.size)
+    }
+}
+
+/// A scalar run preserving per-segment wire alignment.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScalarRunOp {
+    pub segments: Vec<ScalarSegment>,
 }
 
 /// A pre-built wire skeleton of a writer value, advancing the cursor only.
@@ -871,9 +932,11 @@ pub enum LoweringError {
 /// reader's remaining byte count. Every other element occupies at least one byte.
 #[must_use]
 pub fn element_min_wire<BlockId>(element: &[MemOp<BlockId>]) -> usize {
-    let zero_sized = element
-        .iter()
-        .all(|op| matches!(op, MemOp::Scalar { size: 0, .. }));
+    let zero_sized = element.iter().all(|op| match op {
+        MemOp::Scalar { size: 0, .. } => true,
+        MemOp::ScalarRun(run) => run.segments.iter().all(|segment| segment.size == 0),
+        _ => false,
+    });
     usize::from(!zero_sized)
 }
 
@@ -891,6 +954,38 @@ pub fn bulk_scalar_align<BlockId>(element: &[MemOp<BlockId>], stride: usize) -> 
         ] if *size == stride && *align != 0 && stride.is_multiple_of(*align) => Some(*align),
         _ => None,
     }
+}
+
+/// Group adjacent scalar ops inside one record when memory gaps are proven padding.
+///
+/// The optimizer is intentionally record-local: byte ownership is record-relative,
+/// and after flattening there is no way to distinguish padding from arbitrary
+/// untouched memory. A `ScalarRun` keeps each segment's wire alignment, so this
+/// does not change compact-wire padding behavior.
+#[must_use]
+pub fn group_record_scalars<BlockId>(
+    program: MemProgram<BlockId>,
+    ownership: &RecordByteOwnership,
+    record_base: usize,
+) -> MemProgram<BlockId> {
+    let mut out = Vec::with_capacity(program.len());
+    let mut run = Vec::new();
+
+    for op in program {
+        if let Some(segments) = scalar_segments(&op) {
+            if run_can_append(&run, &segments, ownership, record_base) {
+                run.extend(segments);
+            } else {
+                flush_scalar_run(&mut out, &mut run);
+                run.extend(segments);
+            }
+        } else {
+            flush_scalar_run(&mut out, &mut run);
+            out.push(op);
+        }
+    }
+    flush_scalar_run(&mut out, &mut run);
+    out
 }
 
 /// Build an owned-sequence op, using a bulk byte run when the lowered element is
@@ -945,6 +1040,82 @@ pub fn set_op<BlockId>(
         min_wire,
         thunks,
     }))
+}
+
+fn scalar_segments<BlockId>(op: &MemOp<BlockId>) -> Option<Vec<ScalarSegment>> {
+    match op {
+        MemOp::Scalar {
+            offset,
+            size,
+            align,
+        } => Some(vec![ScalarSegment {
+            offset: *offset,
+            size: *size,
+            align: *align,
+        }]),
+        MemOp::ScalarRun(run) => Some(run.segments.clone()),
+        _ => None,
+    }
+}
+
+fn run_can_append(
+    run: &[ScalarSegment],
+    next: &[ScalarSegment],
+    ownership: &RecordByteOwnership,
+    record_base: usize,
+) -> bool {
+    let (Some(last), Some(first)) = (run.last(), next.first()) else {
+        return true;
+    };
+    let Some(last_end) = last.end() else {
+        return false;
+    };
+    if first.offset < last_end {
+        return false;
+    }
+    if first.offset == last_end {
+        return true;
+    }
+    absolute_gap_is_padding(ownership, record_base, last_end, first.offset)
+}
+
+fn absolute_gap_is_padding(
+    ownership: &RecordByteOwnership,
+    record_base: usize,
+    start: usize,
+    end: usize,
+) -> bool {
+    let Some(rel_start) = start.checked_sub(record_base) else {
+        return false;
+    };
+    let Some(rel_end) = end.checked_sub(record_base) else {
+        return false;
+    };
+    if rel_end < rel_start {
+        return false;
+    }
+    ownership.is_padding_range(rel_start, rel_end - rel_start)
+}
+
+fn flush_scalar_run<BlockId>(out: &mut MemProgram<BlockId>, run: &mut Vec<ScalarSegment>) {
+    match run.len() {
+        0 => {}
+        1 => {
+            let segment = run[0];
+            out.push(MemOp::Scalar {
+                offset: segment.offset,
+                size: segment.size,
+                align: segment.align,
+            });
+        }
+        _ => {
+            out.push(MemOp::ScalarRun(Box::new(ScalarRunOp {
+                segments: core::mem::take(run),
+            })));
+            return;
+        }
+    }
+    run.clear();
 }
 
 /// Lower each record field at `base + field.offset`.
@@ -1049,6 +1220,10 @@ pub fn fuse<BlockId>(program: MemProgram<BlockId>) -> MemProgram<BlockId> {
                     });
                 }
                 wire_pos = wire_pos.map(|p| p + pad.unwrap_or(0) + size);
+            }
+            run @ MemOp::ScalarRun(_) => {
+                out.push(run);
+                wire_pos = None;
             }
             MemOp::NativeInt {
                 offset,
@@ -1279,5 +1454,111 @@ mod tests {
             RecordByteOwnership::from_record_layout(Layout { size: 12, align: 4 }, &out_of_bounds),
             RecordByteOwnership::unknown(12)
         );
+    }
+
+    #[test]
+    fn record_byte_ownership_answers_padding_ranges() {
+        let fields = [field(0, 4), field(8, 2)];
+        let ownership =
+            RecordByteOwnership::from_record_layout(Layout { size: 12, align: 4 }, &fields);
+
+        assert!(ownership.is_padding_range(4, 4));
+        assert!(ownership.is_padding_range(10, 2));
+        assert!(!ownership.is_padding_range(2, 4));
+        assert!(!ownership.is_padding_range(12, 1));
+    }
+
+    #[test]
+    fn record_scalar_grouping_crosses_explicit_padding() {
+        let fields = [field(0, 4), field(8, 2)];
+        let ownership =
+            RecordByteOwnership::from_record_layout(Layout { size: 12, align: 4 }, &fields);
+        let program = vec![
+            MemOp::<()>::Scalar {
+                offset: 16,
+                size: 4,
+                align: 4,
+            },
+            MemOp::Scalar {
+                offset: 24,
+                size: 2,
+                align: 2,
+            },
+        ];
+
+        let grouped = group_record_scalars(program, &ownership, 16);
+
+        match grouped.as_slice() {
+            [MemOp::ScalarRun(run)] => assert_eq!(
+                run.segments,
+                [
+                    ScalarSegment {
+                        offset: 16,
+                        size: 4,
+                        align: 4,
+                    },
+                    ScalarSegment {
+                        offset: 24,
+                        size: 2,
+                        align: 2,
+                    },
+                ]
+            ),
+            other => panic!("expected one scalar run, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn record_scalar_grouping_crosses_contiguous_wire_padding() {
+        let fields = [field(0, 4), field(4, 8)];
+        let ownership =
+            RecordByteOwnership::from_record_layout(Layout { size: 12, align: 8 }, &fields);
+        let program = vec![
+            MemOp::<()>::Scalar {
+                offset: 0,
+                size: 4,
+                align: 4,
+            },
+            MemOp::Scalar {
+                offset: 4,
+                size: 8,
+                align: 8,
+            },
+        ];
+
+        let grouped = group_record_scalars(program, &ownership, 0);
+
+        match grouped.as_slice() {
+            [MemOp::ScalarRun(run)] => assert_eq!(run.segments.len(), 2),
+            other => panic!("expected one scalar run, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn record_scalar_grouping_does_not_cross_unknown_gap() {
+        let fields = [field(0, 4), field(8, 2)];
+        let ownership = RecordByteOwnership::fields_only(&fields);
+        let program = vec![
+            MemOp::<()>::Scalar {
+                offset: 0,
+                size: 4,
+                align: 4,
+            },
+            MemOp::Scalar {
+                offset: 8,
+                size: 2,
+                align: 2,
+            },
+        ];
+
+        let grouped = group_record_scalars(program, &ownership, 0);
+
+        assert!(matches!(
+            grouped.as_slice(),
+            [
+                MemOp::Scalar { offset: 0, .. },
+                MemOp::Scalar { offset: 8, .. }
+            ]
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Add a shared weavy ScalarRun MemOp that groups scalar segments while preserving each segment's wire alignment.
- Use RecordByteOwnership to group normal typed PHON records across explicit padding, without treating unknown gaps as padding.
- Teach PHON interpreter, portable JIT, native copy-patch JIT expansion, and PHON/vox-phon native support checks to accept the grouped IR.

## Testing
- cargo check --all-features --all-targets --message-format=short
- cargo nextest run -p weavy -p phon-engine -p phon-jit
- cargo nextest run -p phon -p vox-phon
- cargo clippy --all-features --all-targets --message-format=short -- -D warnings