### PR TITLE
Add native ScalarRun stencils to phon-jit

### DIFF
--- a/phon/rust/phon-jit/build.rs
+++ b/phon/rust/phon-jit/build.rs
@@ -24,6 +24,7 @@ use copypatch::extract::{Stencil, compile_object, extract_stencil, nightly_avail
 const SYMBOLS: &[&str] = &[
     "phon_stencil_smoke",
     "phon_stencil_scalar",
+    "phon_stencil_scalar_run",
     "phon_stencil_sequence",
     "phon_stencil_bytes",
     "phon_stencil_borrow",
@@ -40,6 +41,7 @@ const SYMBOLS: &[&str] = &[
     "phon_stencil_skipwire",
     "phon_stencil_done",
     "phon_stencil_scalar_enc",
+    "phon_stencil_scalar_run_enc",
     "phon_stencil_sequence_enc",
     "phon_stencil_bytes_enc",
     "phon_stencil_option_enc",
@@ -109,6 +111,7 @@ fn emit_arm64_macos(out: &Path, generated: &Path) {
     // `phon_econt`. Each is the sole patched relocation in its stencil.
     let smoke = get("phon_stencil_smoke", "phon_cont");
     let scalar = get("phon_stencil_scalar", "phon_cont");
+    let scalar_run = get("phon_stencil_scalar_run", "phon_cont");
     let sequence = get("phon_stencil_sequence", "phon_cont");
     let bytes_dec = get("phon_stencil_bytes", "phon_cont");
     let borrow = get("phon_stencil_borrow", "phon_cont");
@@ -125,6 +128,7 @@ fn emit_arm64_macos(out: &Path, generated: &Path) {
     let skipwire = get("phon_stencil_skipwire", "phon_cont");
     let done = get("phon_stencil_done", "phon_cont");
     let scalar_enc = get("phon_stencil_scalar_enc", "phon_econt");
+    let scalar_run_enc = get("phon_stencil_scalar_run_enc", "phon_econt");
     let sequence_enc = get("phon_stencil_sequence_enc", "phon_econt");
     let bytes_enc = get("phon_stencil_bytes_enc", "phon_econt");
     let option_enc = get("phon_stencil_option_enc", "phon_econt");
@@ -160,6 +164,13 @@ fn emit_arm64_macos(out: &Path, generated: &Path) {
         &scalar,
     );
     emit_cont(&mut s, "SCALAR_CONT", "SCALAR", &scalar);
+    emit(
+        &mut s,
+        "SCALAR_RUN",
+        "`phon_stencil_scalar_run`: decode one grouped fixed-scalar run, continue.",
+        &scalar_run,
+    );
+    emit_cont(&mut s, "SCALAR_RUN_CONT", "SCALAR_RUN", &scalar_run);
     emit(
         &mut s,
         "SEQUENCE",
@@ -266,6 +277,18 @@ fn emit_arm64_macos(out: &Path, generated: &Path) {
         &scalar_enc,
     );
     emit_cont(&mut s, "SCALAR_ENC_CONT", "SCALAR_ENC", &scalar_enc);
+    emit(
+        &mut s,
+        "SCALAR_RUN_ENC",
+        "`phon_stencil_scalar_run_enc`: encode one grouped fixed-scalar run, continue.",
+        &scalar_run_enc,
+    );
+    emit_cont(
+        &mut s,
+        "SCALAR_RUN_ENC_CONT",
+        "SCALAR_RUN_ENC",
+        &scalar_run_enc,
+    );
     emit(
         &mut s,
         "SEQUENCE_ENC",

--- a/phon/rust/phon-jit/src/native.rs
+++ b/phon/rust/phon-jit/src/native.rs
@@ -35,8 +35,9 @@ use crate::stencils::{
     MAP_CONT, MAP_ENC, MAP_ENC_CONT, OPAQUE, OPAQUE_CONT, OPAQUE_ENC, OPAQUE_ENC_CONT, OPTION,
     OPTION_CONT, OPTION_ENC, OPTION_ENC_CONT, POINTER, POINTER_CONT, POINTER_ENC, POINTER_ENC_CONT,
     RESULT, RESULT_CONT, RESULT_ENC, RESULT_ENC_CONT, SCALAR, SCALAR_CONT, SCALAR_ENC,
-    SCALAR_ENC_CONT, SEQUENCE, SEQUENCE_CONT, SEQUENCE_ENC, SEQUENCE_ENC_CONT, SET, SET_CONT,
-    SET_ENC, SET_ENC_CONT, SKIPWIRE, SKIPWIRE_CONT,
+    SCALAR_ENC_CONT, SCALAR_RUN, SCALAR_RUN_CONT, SCALAR_RUN_ENC, SCALAR_RUN_ENC_CONT, SEQUENCE,
+    SEQUENCE_CONT, SEQUENCE_ENC, SEQUENCE_ENC_CONT, SET, SET_CONT, SET_ENC, SET_ENC_CONT, SKIPWIRE,
+    SKIPWIRE_CONT,
 };
 
 /// Load the smoke stencil into JIT memory and run it: `x * 3 + 1`, computed by
@@ -67,6 +68,23 @@ struct Ctx {
     error: *mut (),
     alloc: unsafe extern "C" fn(usize, usize) -> *mut u8,
     dealloc: unsafe extern "C" fn(*mut u8, usize, usize),
+}
+
+/// One scalar segment in a grouped run, matching `ScalarRunSegmentInfo` in
+/// `stencils/stencils.rs` byte for byte.
+#[repr(C)]
+struct ScalarRunSegmentInfo {
+    offset: usize,
+    size: usize,
+    align: usize,
+}
+
+/// A grouped scalar run, matching `ScalarRunInfo` in `stencils/stencils.rs` byte
+/// for byte. Reached through a `*const ScalarRunInfo` slot in the prog stream.
+#[repr(C)]
+struct ScalarRunInfo {
+    segments: *const ScalarRunSegmentInfo,
+    segment_count: usize,
 }
 
 /// A sequence op's immediates, matching `SeqInfo` in `stencils/stencils.rs` byte
@@ -391,6 +409,13 @@ pub struct NativeDecode {
     /// scalars and a `*const SeqInfo` slot per sequence. Boxed so the addresses
     /// the stencils read (and the pointers stored in `seq_infos`) stay stable.
     progs: Vec<Vec<u64>>,
+    /// One per scalar-run op: the immediates the scalar-run stencil reads through
+    /// its prog slot. Same stability contract as `seq_infos`.
+    scalar_run_infos: Vec<ScalarRunInfo>,
+    /// One segment table per scalar-run op. Each inner `Vec`'s heap buffer is
+    /// stable, so the `*const ScalarRunSegmentInfo` in `scalar_run_infos` stays
+    /// valid.
+    scalar_run_segments: Vec<Vec<ScalarRunSegmentInfo>>,
     /// One per sequence op: the immediates the sequence stencil reads through its
     /// prog slot. The `Vec`'s heap buffer is stable — built once with exact
     /// capacity, never re-grown, and a `Vec` move leaves the heap in place — so
@@ -459,25 +484,11 @@ struct Chain {
     prog_index: usize,
 }
 
-fn expand_scalar_runs(program: &MemProgram) -> Option<MemProgram> {
-    if !program.iter().any(|op| matches!(op, MemOp::ScalarRun(_))) {
-        return None;
-    }
-
-    let mut out = Vec::with_capacity(program.len());
-    for op in program {
-        match op {
-            MemOp::ScalarRun(run) => {
-                out.extend(run.segments.iter().map(|segment| MemOp::Scalar {
-                    offset: segment.offset,
-                    size: segment.size,
-                    align: segment.align,
-                }));
-            }
-            other => out.push(other.clone()),
-        }
-    }
-    Some(out)
+/// A scalar-run prog slot to fill once `scalar_run_infos` is in its final home.
+struct ScalarRunFixup {
+    prog_index: usize,
+    slot: usize,
+    runinfo: usize,
 }
 
 /// A sequence's prog slot to fill once chains are laid out and the `ExecBuf`
@@ -715,6 +726,8 @@ struct EnumInfoBuild {
 struct Compiler {
     code: Vec<u8>,
     progs: Vec<Vec<u64>>,
+    scalar_run_segments: Vec<Vec<ScalarRunSegmentInfo>>,
+    scalar_run_fixups: Vec<ScalarRunFixup>,
     seq_infos: Vec<SeqInfoBuild>,
     fixups: Vec<SeqFixup>,
     /// Built directly (no `ExecBuf`-relative fields): one per bulk byte-run op.
@@ -757,8 +770,6 @@ impl Compiler {
     /// continuations patched to chain to the next op (the last to `done`).
     /// Recurses into sequence elements, which become their own chains.
     fn compile_chain(&mut self, program: &MemProgram) -> Chain {
-        let expanded = expand_scalar_runs(program);
-        let program = expanded.as_ref().unwrap_or(program);
         let entry = self.code.len();
         let prog_index = self.progs.len();
         self.progs.push(Vec::new());
@@ -780,8 +791,26 @@ impl Compiler {
                     p.push(*size as u64);
                     p.push(*align as u64);
                 }
-                MemOp::ScalarRun(_) => {
-                    unreachable!("scalar runs are expanded before native lowering")
+                MemOp::ScalarRun(run) => {
+                    self.code.extend_from_slice(SCALAR_RUN);
+                    let slot = self.progs[prog_index].len();
+                    self.progs[prog_index].push(0);
+                    let runinfo = self.scalar_run_segments.len();
+                    self.scalar_run_segments.push(
+                        run.segments
+                            .iter()
+                            .map(|segment| ScalarRunSegmentInfo {
+                                offset: segment.offset,
+                                size: segment.size,
+                                align: segment.align,
+                            })
+                            .collect(),
+                    );
+                    self.scalar_run_fixups.push(ScalarRunFixup {
+                        prog_index,
+                        slot,
+                        runinfo,
+                    });
                 }
                 MemOp::NativeInt { .. } => {
                     panic!("phon-jit: native-sized integer casts are interpreter-only for now")
@@ -1112,9 +1141,7 @@ impl Compiler {
             let next = starts.get(i + 1).copied().unwrap_or(done_start);
             let relocs = match &program[i] {
                 MemOp::Scalar { .. } => SCALAR_CONT,
-                MemOp::ScalarRun(_) => {
-                    unreachable!("scalar runs are expanded before native lowering")
-                }
+                MemOp::ScalarRun(_) => SCALAR_RUN_CONT,
                 MemOp::NativeInt { .. } => {
                     panic!("phon-jit: native-sized integer casts are interpreter-only for now")
                 }
@@ -1165,6 +1192,8 @@ impl NativeDecode {
         let mut c = Compiler {
             code: Vec::new(),
             progs: Vec::new(),
+            scalar_run_segments: Vec::new(),
+            scalar_run_fixups: Vec::new(),
             seq_infos: Vec::new(),
             fixups: Vec::new(),
             bytes_infos: Vec::new(),
@@ -1209,6 +1238,15 @@ impl NativeDecode {
         // Box each chain's prog stream so its address is stable (the prog
         // pointers in `seq_infos` and the entry pointer alias into these).
         let progs = c.progs;
+
+        let mut scalar_run_infos: Vec<ScalarRunInfo> =
+            Vec::with_capacity(c.scalar_run_segments.len());
+        for segments in &c.scalar_run_segments {
+            scalar_run_infos.push(ScalarRunInfo {
+                segments: core::ptr::null(),
+                segment_count: segments.len(),
+            });
+        }
 
         // Materialize the `SeqInfo`s now that the code base is known. Reserve the
         // exact capacity so the `Vec` is never re-grown: its heap buffer (and thus
@@ -1412,6 +1450,8 @@ impl NativeDecode {
             buf,
             entry_prog: top.prog_index,
             progs,
+            scalar_run_infos,
+            scalar_run_segments: c.scalar_run_segments,
             seq_infos,
             // Move the byte-run infos into their final home; they carry no
             // `ExecBuf`-relative fields, so no further binding is needed.
@@ -1446,6 +1486,23 @@ impl NativeDecode {
             .collect();
         for (info, &ptr) in nd.skip_infos.iter_mut().zip(skip_op_ptrs.iter()) {
             info.skip_op = ptr;
+        }
+
+        let scalar_segment_ptrs: Vec<*const ScalarRunSegmentInfo> = nd
+            .scalar_run_segments
+            .iter()
+            .map(|segments| segments.as_ptr())
+            .collect();
+        for (info, &ptr) in nd
+            .scalar_run_infos
+            .iter_mut()
+            .zip(scalar_segment_ptrs.iter())
+        {
+            info.segments = ptr;
+        }
+        for f in &c.scalar_run_fixups {
+            let ptr: *const ScalarRunInfo = &nd.scalar_run_infos[f.runinfo];
+            nd.progs[f.prog_index][f.slot] = ptr as u64;
         }
 
         // Now that `nd.progs` is in its final home, bind the prog pointers: each
@@ -1860,6 +1917,12 @@ pub struct NativeEncode {
     /// Every chain's immediate stream: `[offset, size, align]` triples for
     /// scalars and a `*const EncSeqInfo` slot per sequence.
     progs: Vec<Vec<u64>>,
+    /// One per scalar-run op: the immediates the scalar-run stencil reads through
+    /// its prog slot. Same stability contract as `seq_infos`.
+    scalar_run_infos: Vec<ScalarRunInfo>,
+    /// One segment table per scalar-run op. Each inner `Vec`'s heap buffer is
+    /// stable for the matching `ScalarRunInfo`.
+    scalar_run_segments: Vec<Vec<ScalarRunSegmentInfo>>,
     /// One per sequence op: the immediates the sequence stencil reads through its
     /// prog slot. Built once with exact capacity, never re-grown, so the
     /// `*const EncSeqInfo` the prog stream holds stays valid.
@@ -1996,6 +2059,8 @@ struct EncEnumInfoBuild {
 struct EncCompiler {
     code: Vec<u8>,
     progs: Vec<Vec<u64>>,
+    scalar_run_segments: Vec<Vec<ScalarRunSegmentInfo>>,
+    scalar_run_fixups: Vec<ScalarRunFixup>,
     seq_infos: Vec<EncSeqInfoBuild>,
     fixups: Vec<SeqFixup>,
     /// Built directly (no `ExecBuf`-relative fields): one per bulk byte-run op.
@@ -2027,8 +2092,6 @@ impl EncCompiler {
     /// `done`, with continuations patched to chain to the next op (the last to
     /// `done`). Recurses into sequence elements, which become their own chains.
     fn compile_chain(&mut self, program: &MemProgram) -> Chain {
-        let expanded = expand_scalar_runs(program);
-        let program = expanded.as_ref().unwrap_or(program);
         let entry = self.code.len();
         let prog_index = self.progs.len();
         self.progs.push(Vec::new());
@@ -2048,8 +2111,26 @@ impl EncCompiler {
                     p.push(*size as u64);
                     p.push(*align as u64);
                 }
-                MemOp::ScalarRun(_) => {
-                    unreachable!("scalar runs are expanded before native lowering")
+                MemOp::ScalarRun(run) => {
+                    self.code.extend_from_slice(SCALAR_RUN_ENC);
+                    let slot = self.progs[prog_index].len();
+                    self.progs[prog_index].push(0);
+                    let runinfo = self.scalar_run_segments.len();
+                    self.scalar_run_segments.push(
+                        run.segments
+                            .iter()
+                            .map(|segment| ScalarRunSegmentInfo {
+                                offset: segment.offset,
+                                size: segment.size,
+                                align: segment.align,
+                            })
+                            .collect(),
+                    );
+                    self.scalar_run_fixups.push(ScalarRunFixup {
+                        prog_index,
+                        slot,
+                        runinfo,
+                    });
                 }
                 MemOp::NativeInt { .. } => {
                     panic!("phon-jit: native-sized integer casts are interpreter-only for now")
@@ -2316,9 +2397,7 @@ impl EncCompiler {
             let next = starts.get(i + 1).copied().unwrap_or(done_start);
             let relocs = match &program[i] {
                 MemOp::Scalar { .. } => SCALAR_ENC_CONT,
-                MemOp::ScalarRun(_) => {
-                    unreachable!("scalar runs are expanded before native lowering")
-                }
+                MemOp::ScalarRun(_) => SCALAR_RUN_ENC_CONT,
                 MemOp::NativeInt { .. } => {
                     panic!("phon-jit: native-sized integer casts are interpreter-only for now")
                 }
@@ -2369,6 +2448,8 @@ impl NativeEncode {
         let mut c = EncCompiler {
             code: Vec::new(),
             progs: Vec::new(),
+            scalar_run_segments: Vec::new(),
+            scalar_run_fixups: Vec::new(),
             seq_infos: Vec::new(),
             fixups: Vec::new(),
             bytes_infos: Vec::new(),
@@ -2402,6 +2483,15 @@ impl NativeEncode {
         let buf = ExecBuf::new(&c.code);
         let base = buf.as_ptr();
         let progs = c.progs;
+
+        let mut scalar_run_infos: Vec<ScalarRunInfo> =
+            Vec::with_capacity(c.scalar_run_segments.len());
+        for segments in &c.scalar_run_segments {
+            scalar_run_infos.push(ScalarRunInfo {
+                segments: core::ptr::null(),
+                segment_count: segments.len(),
+            });
+        }
 
         let mut seq_infos: Vec<EncSeqInfo> = Vec::with_capacity(c.seq_infos.len());
         for b in &c.seq_infos {
@@ -2563,6 +2653,8 @@ impl NativeEncode {
             buf,
             entry_prog: top.prog_index,
             progs,
+            scalar_run_infos,
+            scalar_run_segments: c.scalar_run_segments,
             seq_infos,
             // Move the byte-run infos into their final home; no further binding.
             bytes_infos: c.bytes_infos,
@@ -2578,6 +2670,23 @@ impl NativeEncode {
             enum_variants,
             last_size: AtomicUsize::new(0),
         };
+
+        let scalar_segment_ptrs: Vec<*const ScalarRunSegmentInfo> = ne
+            .scalar_run_segments
+            .iter()
+            .map(|segments| segments.as_ptr())
+            .collect();
+        for (info, &ptr) in ne
+            .scalar_run_infos
+            .iter_mut()
+            .zip(scalar_segment_ptrs.iter())
+        {
+            info.segments = ptr;
+        }
+        for f in &c.scalar_run_fixups {
+            let ptr: *const ScalarRunInfo = &ne.scalar_run_infos[f.runinfo];
+            ne.progs[f.prog_index][f.slot] = ptr as u64;
+        }
 
         for (b, info) in c.seq_infos.iter().zip(ne.seq_infos.iter_mut()) {
             info.element_prog = ne.progs[b.element_prog_index].as_ptr();
@@ -3125,11 +3234,14 @@ mod tests {
         mem.0[8..16].copy_from_slice(&0xAABB_CCDD_EEFF_0011u64.to_le_bytes());
 
         let expected = unsafe { compile_encode(&program).run(mem.0.as_ptr()) };
-        let got = unsafe { NativeEncode::compile(&program).run(mem.0.as_ptr()) };
+        let enc = NativeEncode::compile(&program);
+        assert_eq!(enc.progs[enc.entry_prog].len(), 1);
+        let got = unsafe { enc.run(mem.0.as_ptr()) };
         assert_eq!(got, expected);
         assert_eq!(&got[4..8], &[0, 0, 0, 0]);
 
         let dec = NativeDecode::compile(&program);
+        assert_eq!(dec.progs[dec.entry_prog].len(), 1);
         let mut out = Mem([0xEE; 16]);
         unsafe { dec.run(&got, out.0.as_mut_ptr()) }.unwrap();
         assert_eq!(&out.0[0..4], &mem.0[0..4]);

--- a/phon/rust/phon-jit/stencils/stencils.rs
+++ b/phon/rust/phon-jit/stencils/stencils.rs
@@ -59,6 +59,22 @@ pub struct Ctx {
     pub dealloc: unsafe extern "C" fn(ptr: *mut u8, size: usize, align: usize),
 }
 
+/// One fixed scalar segment in a scalar run.
+#[repr(C)]
+pub struct ScalarRunSegmentInfo {
+    pub offset: usize,
+    pub size: usize,
+    pub align: usize,
+}
+
+/// A grouped fixed-scalar run, reached through a `*const ScalarRunInfo` slot in
+/// the prog stream.
+#[repr(C)]
+pub struct ScalarRunInfo {
+    pub segments: *const ScalarRunSegmentInfo,
+    pub segment_count: usize,
+}
+
 /// A sequence op's immediates, reached through a `*const SeqInfo` slot in
 /// `Ctx.prog`. The element body is the chain entered at `element_entry`, driven
 /// by the triples at `element_prog`.
@@ -435,6 +451,56 @@ pub unsafe extern "C" fn phon_stencil_scalar(cx: *mut Ctx) {
     phon_cont(cx);
 }
 
+/// Decode a grouped run of fixed-width scalars into disjoint memory segments,
+/// then continue. Each segment keeps its own wire alignment, so padding between
+/// adjacent fields remains wire padding rather than copied memory.
+#[no_mangle]
+pub unsafe extern "C" fn phon_stencil_scalar_run(cx: *mut Ctx) {
+    let c = &mut *cx;
+    let info = &*(*c.prog as *const ScalarRunInfo);
+    c.prog = c.prog.add(1);
+
+    let mut segment_index = 0;
+    while segment_index < info.segment_count {
+        let segment = &*info.segments.add(segment_index);
+
+        let pos = (c.wire as usize) - (c.wire_start as usize);
+        let pad = segment.align.wrapping_sub(pos & (segment.align - 1)) & (segment.align - 1);
+        let src = c.wire.add(pad);
+
+        if (src as usize).wrapping_add(segment.size) > c.wire_end as usize {
+            c.status = 1;
+            return;
+        }
+
+        let dst = c.base.add(segment.offset);
+        let mut i = 0;
+        while segment.size - i >= 8 {
+            core::ptr::copy_nonoverlapping(src.add(i), dst.add(i), 8);
+            i += 8;
+        }
+        if segment.size - i >= 4 {
+            core::ptr::copy_nonoverlapping(src.add(i), dst.add(i), 4);
+            i += 4;
+        }
+        if segment.size - i >= 2 {
+            core::ptr::copy_nonoverlapping(src.add(i), dst.add(i), 2);
+            i += 2;
+        }
+        if segment.size - i >= 1 {
+            core::ptr::copy_nonoverlapping(src.add(i), dst.add(i), 1);
+        }
+
+        c.wire = src.add(segment.size);
+        segment_index += 1;
+    }
+
+    #[cfg(tailcall)]
+    become phon_cont(cx);
+    #[cfg(not(tailcall))]
+    phon_cont(cx);
+}
+
 /// Decode an owned sequence into `base + field_offset`, then continue.
 ///
 /// Reads a `u32` count (bounds-checked like `read_len`), allocates a
@@ -466,7 +532,11 @@ pub unsafe extern "C" fn phon_stencil_sequence(cx: *mut Ctx) {
     // count unbounded by the buffer, so a fixed cap applies — mirroring
     // `Reader::read_len`'s `ZST_COUNT_CAP` (1 << 24).
     let remaining = (c.wire_end as usize) - (c.wire as usize);
-    let max = if info.min_wire == 0 { 1usize << 24 } else { remaining / info.min_wire };
+    let max = if info.min_wire == 0 {
+        1usize << 24
+    } else {
+        remaining / info.min_wire
+    };
     if count > max {
         c.status = 1;
         return;
@@ -1712,6 +1782,60 @@ pub unsafe extern "C" fn phon_stencil_scalar_enc(cx: *mut EncCtx) {
     phon_econt(cx);
 }
 
+/// Encode a grouped run of fixed-width scalars, then continue. Each segment
+/// keeps its own wire alignment, and only the field bytes are read from memory.
+#[no_mangle]
+pub unsafe extern "C" fn phon_stencil_scalar_run_enc(cx: *mut EncCtx) {
+    let c = &mut *cx;
+    let info = &*(*c.prog as *const ScalarRunInfo);
+    c.prog = c.prog.add(1);
+
+    let mut segment_index = 0;
+    while segment_index < info.segment_count {
+        let segment = &*info.segments.add(segment_index);
+
+        let pad = segment.align.wrapping_sub(c.out_pos & (segment.align - 1)) & (segment.align - 1);
+        let need = c.out_pos + pad + segment.size;
+        if need > c.out_cap {
+            (c.grow)(cx, need);
+        }
+
+        let mut dst = c.out_ptr.add(c.out_pos);
+        let mut k = 0;
+        while k < pad {
+            core::ptr::write_volatile(dst, 0u8);
+            dst = dst.add(1);
+            k += 1;
+        }
+
+        let src = c.base.add(segment.offset);
+        let mut i = 0;
+        while segment.size - i >= 8 {
+            core::ptr::copy_nonoverlapping(src.add(i), dst.add(i), 8);
+            i += 8;
+        }
+        if segment.size - i >= 4 {
+            core::ptr::copy_nonoverlapping(src.add(i), dst.add(i), 4);
+            i += 4;
+        }
+        if segment.size - i >= 2 {
+            core::ptr::copy_nonoverlapping(src.add(i), dst.add(i), 2);
+            i += 2;
+        }
+        if segment.size - i >= 1 {
+            core::ptr::copy_nonoverlapping(src.add(i), dst.add(i), 1);
+        }
+
+        c.out_pos += pad + segment.size;
+        segment_index += 1;
+    }
+
+    #[cfg(tailcall)]
+    become phon_econt(cx);
+    #[cfg(not(tailcall))]
+    phon_econt(cx);
+}
+
 /// Encode an owned sequence from `base + field_offset`, then continue.
 ///
 /// Reads the element count via the `len` thunk, writes it as a `u32` (no
@@ -1780,7 +1904,8 @@ pub unsafe extern "C" fn phon_stencil_bytes_enc(cx: *mut EncCtx) {
     // Write the u32 count (no alignment padding, like `write_u32`), then pad
     // before element bytes only when there is at least one element.
     let pad = if count > 0 {
-        info.elem_align.wrapping_sub((c.out_pos + 4) & (info.elem_align - 1))
+        info.elem_align
+            .wrapping_sub((c.out_pos + 4) & (info.elem_align - 1))
             & (info.elem_align - 1)
     } else {
         0
@@ -2175,7 +2300,11 @@ pub unsafe extern "C" fn phon_stencil_enum_enc(cx: *mut EncCtx) {
         disc |= (core::ptr::read_volatile(src.add(r)) as u64) << (r * 8);
         r += 1;
     }
-    let mask = if info.tag_width >= 8 { u64::MAX } else { (1u64 << (info.tag_width * 8)) - 1 };
+    let mask = if info.tag_width >= 8 {
+        u64::MAX
+    } else {
+        (1u64 << (info.tag_width * 8)) - 1
+    };
 
     // Linear search for the matching variant (a plain loop — branches within the
     // stencil, no relocation).


### PR DESCRIPTION
Summary:
- add native decode/encode ScalarRun stencils to phon-jit
- keep ScalarRun as one native prog slot backed by a stable segment table
- remove native lowering's scalar-run expansion fallback and assert the one-slot shape in tests

Testing:
- cargo check -p phon-jit --all-features --all-targets --message-format=short
- cargo nextest run -p phon-jit -E 'test(jit_scalar_run_matches_threaded)'
- cargo nextest run -p phon-jit
- cargo check --all-features --all-targets --message-format=short
- cargo clippy --all-features --all-targets --message-format=short -- -D warnings
- cargo nextest run -p weavy -p phon-engine -p phon-jit -p phon -p vox-phon
