### PR TITLE
Report and aggregate PHON JIT shape stats

### DIFF
--- a/phon/rust/phon-ir/src/ir.rs
+++ b/phon/rust/phon-ir/src/ir.rs
@@ -29,10 +29,11 @@
 use phon_schema::bytes::{Reader, skip_pad};
 use phon_schema::{DecodeError, Primitive, SchemaId, SchemaRef};
 pub use weavy::mem::{
-    BorrowOp, BorrowThunks, ByteValidator, BytesOp, DefaultOp, DefaultThunk, LoweringError,
-    MapThunks, OpaqueOp, OpaqueThunks, OptionThunks, PointerThunks, ResultThunks, ScalarRunOp,
-    ScalarSegment, SeqThunks, SetThunks, SkipOp, element_min_wire, group_record_scalars,
-    lower_fixed_array, lower_record_fields, owned_sequence_op, set_op,
+    BorrowOp, BorrowThunks, ByteValidator, BytesOp, DefaultOp, DefaultThunk,
+    LoweredMemProgramStats, LoweringError, MapThunks, MemProgramStats, OpaqueOp, OpaqueThunks,
+    OptionThunks, PointerThunks, ResultThunks, ScalarRunOp, ScalarSegment, SeqThunks, SetThunks,
+    SkipOp, element_min_wire, group_record_scalars, lower_fixed_array, lower_record_fields,
+    lowered_mem_program_stats, mem_program_stats, owned_sequence_op, set_op,
 };
 
 /// A lowered decode program: a straight run of [`Op`]s executed start to finish.

--- a/phon/rust/phon-ir/src/lib.rs
+++ b/phon/rust/phon-ir/src/lib.rs
@@ -25,9 +25,10 @@ pub mod ir;
 
 pub use ir::{
     BorrowOp, BorrowThunks, ByteValidator, BytesOp, DefaultOp, DefaultThunk, EnumArm, EnumOp,
-    EnumVariantOp, Lowered, MapOp, MapThunks, MemOp, MemProgram, Op, OpaqueOp, OpaqueThunks,
-    OptionOp, OptionThunks, PointerOp, PointerThunks, Program, ResultOp, ResultThunks, ScalarRunOp,
-    ScalarSegment, SeqOp, SeqThunks, SetOp, SetThunks, SkipOp, ValueProgram,
+    EnumVariantOp, Lowered, LoweredMemProgramStats, MapOp, MapThunks, MemOp, MemProgram,
+    MemProgramStats, Op, OpaqueOp, OpaqueThunks, OptionOp, OptionThunks, PointerOp, PointerThunks,
+    Program, ResultOp, ResultThunks, ScalarRunOp, ScalarSegment, SeqOp, SeqThunks, SetOp,
+    SetThunks, SkipOp, ValueProgram, lowered_mem_program_stats, mem_program_stats,
 };
 
 /// Thunk bindings: resolving thunk names to process-local function pointers

--- a/phon/rust/phon-jit/src/native.rs
+++ b/phon/rust/phon-jit/src/native.rs
@@ -397,12 +397,26 @@ unsafe extern "C" fn jit_read_value(
     }
 }
 
+/// Shape and code-layout counts for a compiled native copy-and-patch program.
+///
+/// `stencil_count` includes the terminal `done` stencil emitted for each chain.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NativeProgramStats {
+    pub chain_count: usize,
+    pub stencil_count: usize,
+    pub prog_slot_count: usize,
+    pub scalar_run_count: usize,
+    pub scalar_run_segment_count: usize,
+}
+
 /// A JIT-compiled decoder for a [`MemProgram`]: a `MAP_JIT` page of copied
 /// stencils with their continuations patched to chain, ending at `done`. Scalars
 /// chain straight through; an owned sequence runs its element body as a
 /// separately compiled chain it calls once per element (`r[ir.stencils]`).
 pub struct NativeDecode {
     buf: ExecBuf,
+    stencil_count: usize,
     /// Index into `progs` of the top-level chain's immediate stream.
     entry_prog: usize,
     /// Every chain's immediate stream: `[offset, size, align]` triples for
@@ -726,6 +740,7 @@ struct EnumInfoBuild {
 struct Compiler {
     code: Vec<u8>,
     progs: Vec<Vec<u64>>,
+    stencil_count: usize,
     scalar_run_segments: Vec<Vec<ScalarRunSegmentInfo>>,
     scalar_run_fixups: Vec<ScalarRunFixup>,
     seq_infos: Vec<SeqInfoBuild>,
@@ -1133,6 +1148,7 @@ impl Compiler {
         }
         let done_start = self.code.len();
         self.code.extend_from_slice(DONE);
+        self.stencil_count += program.len() + 1;
 
         // Patch every op's continuation branches to the following op (last ->
         // `done`). Scalar and sequence stencils both reach the next op through a
@@ -1192,6 +1208,7 @@ impl NativeDecode {
         let mut c = Compiler {
             code: Vec::new(),
             progs: Vec::new(),
+            stencil_count: 0,
             scalar_run_segments: Vec::new(),
             scalar_run_fixups: Vec::new(),
             seq_infos: Vec::new(),
@@ -1448,6 +1465,7 @@ impl NativeDecode {
 
         let mut nd = NativeDecode {
             buf,
+            stencil_count: c.stencil_count,
             entry_prog: top.prog_index,
             progs,
             scalar_run_infos,
@@ -1625,6 +1643,18 @@ impl NativeDecode {
         }
 
         nd
+    }
+
+    /// Return shape and code-layout counts for this compiled decoder.
+    #[must_use]
+    pub fn stats(&self) -> NativeProgramStats {
+        NativeProgramStats {
+            chain_count: self.progs.len(),
+            stencil_count: self.stencil_count,
+            prog_slot_count: self.progs.iter().map(Vec::len).sum(),
+            scalar_run_count: self.scalar_run_infos.len(),
+            scalar_run_segment_count: self.scalar_run_segments.iter().map(Vec::len).sum(),
+        }
     }
 
     /// Decode `bytes` into the value at `base`, rejecting trailing bytes.
@@ -1912,6 +1942,7 @@ unsafe extern "C" fn jit_write_value(value: *const u8, out: *mut Vec<u8>) {
 /// runs its element body as a separately compiled chain it calls once per element.
 pub struct NativeEncode {
     buf: ExecBuf,
+    stencil_count: usize,
     /// Index into `progs` of the top-level chain's immediate stream.
     entry_prog: usize,
     /// Every chain's immediate stream: `[offset, size, align]` triples for
@@ -2059,6 +2090,7 @@ struct EncEnumInfoBuild {
 struct EncCompiler {
     code: Vec<u8>,
     progs: Vec<Vec<u64>>,
+    stencil_count: usize,
     scalar_run_segments: Vec<Vec<ScalarRunSegmentInfo>>,
     scalar_run_fixups: Vec<ScalarRunFixup>,
     seq_infos: Vec<EncSeqInfoBuild>,
@@ -2392,6 +2424,7 @@ impl EncCompiler {
         }
         let done_start = self.code.len();
         self.code.extend_from_slice(DONE_ENC);
+        self.stencil_count += program.len() + 1;
 
         for (i, &op_start) in starts.iter().enumerate() {
             let next = starts.get(i + 1).copied().unwrap_or(done_start);
@@ -2448,6 +2481,7 @@ impl NativeEncode {
         let mut c = EncCompiler {
             code: Vec::new(),
             progs: Vec::new(),
+            stencil_count: 0,
             scalar_run_segments: Vec::new(),
             scalar_run_fixups: Vec::new(),
             seq_infos: Vec::new(),
@@ -2651,6 +2685,7 @@ impl NativeEncode {
 
         let mut ne = NativeEncode {
             buf,
+            stencil_count: c.stencil_count,
             entry_prog: top.prog_index,
             progs,
             scalar_run_infos,
@@ -2783,6 +2818,18 @@ impl NativeEncode {
         }
 
         ne
+    }
+
+    /// Return shape and code-layout counts for this compiled encoder.
+    #[must_use]
+    pub fn stats(&self) -> NativeProgramStats {
+        NativeProgramStats {
+            chain_count: self.progs.len(),
+            stencil_count: self.stencil_count,
+            prog_slot_count: self.progs.iter().map(Vec::len).sum(),
+            scalar_run_count: self.scalar_run_infos.len(),
+            scalar_run_segment_count: self.scalar_run_segments.iter().map(Vec::len).sum(),
+        }
     }
 
     /// Encode the value at `base` into compact bytes.
@@ -3235,13 +3282,23 @@ mod tests {
 
         let expected = unsafe { compile_encode(&program).run(mem.0.as_ptr()) };
         let enc = NativeEncode::compile(&program);
-        assert_eq!(enc.progs[enc.entry_prog].len(), 1);
+        let enc_stats = enc.stats();
+        assert_eq!(enc_stats.chain_count, 1);
+        assert_eq!(enc_stats.stencil_count, 2);
+        assert_eq!(enc_stats.prog_slot_count, 1);
+        assert_eq!(enc_stats.scalar_run_count, 1);
+        assert_eq!(enc_stats.scalar_run_segment_count, 2);
         let got = unsafe { enc.run(mem.0.as_ptr()) };
         assert_eq!(got, expected);
         assert_eq!(&got[4..8], &[0, 0, 0, 0]);
 
         let dec = NativeDecode::compile(&program);
-        assert_eq!(dec.progs[dec.entry_prog].len(), 1);
+        let dec_stats = dec.stats();
+        assert_eq!(dec_stats.chain_count, 1);
+        assert_eq!(dec_stats.stencil_count, 2);
+        assert_eq!(dec_stats.prog_slot_count, 1);
+        assert_eq!(dec_stats.scalar_run_count, 1);
+        assert_eq!(dec_stats.scalar_run_segment_count, 2);
         let mut out = Mem([0xEE; 16]);
         unsafe { dec.run(&got, out.0.as_mut_ptr()) }.unwrap();
         assert_eq!(&out.0[0..4], &mem.0[0..4]);

--- a/phon/rust/phon/src/lib.rs
+++ b/phon/rust/phon/src/lib.rs
@@ -26,9 +26,9 @@ pub mod api {
 
     use facet::Facet;
     use phon_engine::{CompactError, Registry, typed};
-    use phon_ir::Lowered;
     #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
     use phon_ir::MemOp;
+    use phon_ir::{Lowered, LoweredMemProgramStats, lowered_mem_program_stats};
     use phon_schema::DecodeError;
 
     use crate::derive::{self, DeriveError};
@@ -93,6 +93,41 @@ pub mod api {
     pub struct JitFallbackReport {
         pub decode: Vec<JitFallbackRecord>,
         pub encode: Vec<JitFallbackRecord>,
+    }
+
+    /// Shape and code-layout counts for a compiled native JIT program.
+    #[non_exhaustive]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct NativeJitStats {
+        pub chain_count: usize,
+        pub stencil_count: usize,
+        pub prog_slot_count: usize,
+        pub scalar_run_count: usize,
+        pub scalar_run_segment_count: usize,
+    }
+
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    impl From<phon_jit::native::NativeProgramStats> for NativeJitStats {
+        fn from(value: phon_jit::native::NativeProgramStats) -> Self {
+            Self {
+                chain_count: value.chain_count,
+                stencil_count: value.stencil_count,
+                prog_slot_count: value.prog_slot_count,
+                scalar_run_count: value.scalar_run_count,
+                scalar_run_segment_count: value.scalar_run_segment_count,
+            }
+        }
+    }
+
+    /// Lowered shape plus optional native JIT code-layout stats for a codec.
+    ///
+    /// This is diagnostics only. It does not change encode/decode dispatch.
+    #[non_exhaustive]
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub struct JitShapeReport {
+        pub lowered: LoweredMemProgramStats,
+        pub decode_native: Option<NativeJitStats>,
+        pub encode_native: Option<NativeJitStats>,
     }
 
     /// One fallback record scoped to a Vox method root.
@@ -274,6 +309,30 @@ pub mod api {
             #[cfg(not(all(feature = "jit", target_os = "macos", target_arch = "aarch64")))]
             {
                 report
+            }
+        }
+
+        /// Report the lowered IR shape and, when compiled, the native JIT shape.
+        ///
+        /// This is strict diagnostics only. It does not change whether encode or
+        /// decode run with the native JIT or the interpreter.
+        pub fn jit_shape_report(&self) -> JitShapeReport {
+            let lowered = lowered_mem_program_stats(&self.lowered);
+            #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+            {
+                JitShapeReport {
+                    lowered,
+                    decode_native: self.native_decode.as_ref().map(|jit| jit.stats().into()),
+                    encode_native: self.native_encode.as_ref().map(|jit| jit.stats().into()),
+                }
+            }
+            #[cfg(not(all(feature = "jit", target_os = "macos", target_arch = "aarch64")))]
+            {
+                JitShapeReport {
+                    lowered,
+                    decode_native: None,
+                    encode_native: None,
+                }
             }
         }
 
@@ -586,16 +645,29 @@ mod tests {
     #[test]
     fn api_roundtrips_and_reports_supported_backend() {
         let codec = api::Codec::<ApiMsg>::new().unwrap();
+        let shape = codec.jit_shape_report();
+        assert_eq!(shape.lowered.block_count, 0);
+        assert!(shape.lowered.total.op_count > 0);
         #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
         {
             assert!(codec.decode_uses_native_jit());
             assert!(codec.encode_uses_native_jit());
             assert!(codec.jit_fallback_report().is_empty());
+            let decode_native = shape.decode_native.expect("native decode stats");
+            let encode_native = shape.encode_native.expect("native encode stats");
+            assert!(decode_native.chain_count > 0);
+            assert!(decode_native.stencil_count >= shape.lowered.total.op_count);
+            assert!(decode_native.prog_slot_count > 0);
+            assert!(encode_native.chain_count > 0);
+            assert!(encode_native.stencil_count >= shape.lowered.total.op_count);
+            assert!(encode_native.prog_slot_count > 0);
         }
         #[cfg(not(all(feature = "jit", target_os = "macos", target_arch = "aarch64")))]
         {
             assert!(!codec.decode_uses_native_jit());
             assert!(!codec.encode_uses_native_jit());
+            assert!(shape.decode_native.is_none());
+            assert!(shape.encode_native.is_none());
             let report = codec.jit_fallback_report();
             assert!(!report.decode.is_empty());
             assert!(!report.encode.is_empty());

--- a/phon/rust/phon/src/lib.rs
+++ b/phon/rust/phon/src/lib.rs
@@ -106,6 +106,17 @@ pub mod api {
         pub scalar_run_segment_count: usize,
     }
 
+    impl NativeJitStats {
+        /// Add another native program counter into this one.
+        pub fn accumulate(&mut self, other: Self) {
+            self.chain_count += other.chain_count;
+            self.stencil_count += other.stencil_count;
+            self.prog_slot_count += other.prog_slot_count;
+            self.scalar_run_count += other.scalar_run_count;
+            self.scalar_run_segment_count += other.scalar_run_segment_count;
+        }
+    }
+
     #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
     impl From<phon_jit::native::NativeProgramStats> for NativeJitStats {
         fn from(value: phon_jit::native::NativeProgramStats) -> Self {
@@ -130,6 +141,34 @@ pub mod api {
         pub encode_native: Option<NativeJitStats>,
     }
 
+    /// One shape record scoped to a Vox method root.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub struct MethodJitShapeRecord {
+        pub method: String,
+        pub phase: String,
+        pub lowered: LoweredMemProgramStats,
+        pub decode_native: Option<NativeJitStats>,
+        pub encode_native: Option<NativeJitStats>,
+    }
+
+    /// Aggregated shape totals for a method-scoped surface report.
+    #[non_exhaustive]
+    #[derive(Clone, Debug, Default, PartialEq, Eq)]
+    pub struct MethodJitShapeSummary {
+        pub root_count: usize,
+        pub lowered: LoweredMemProgramStats,
+        pub decode_native: NativeJitStats,
+        pub encode_native: NativeJitStats,
+        pub decode_native_count: usize,
+        pub encode_native_count: usize,
+    }
+
+    /// Method-scoped shape report for service-surface audits.
+    #[derive(Clone, Debug, Default, PartialEq, Eq)]
+    pub struct MethodJitShapeReport {
+        pub records: Vec<MethodJitShapeRecord>,
+    }
+
     /// One fallback record scoped to a Vox method root.
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub struct MethodJitFallbackRecord {
@@ -149,6 +188,65 @@ pub mod api {
     impl MethodJitFallbackReport {
         pub fn is_empty(&self) -> bool {
             self.records.is_empty()
+        }
+    }
+
+    impl MethodJitShapeReport {
+        pub fn is_empty(&self) -> bool {
+            self.records.is_empty()
+        }
+
+        pub fn extend(&mut self, other: Self) {
+            self.records.extend(other.records);
+        }
+
+        pub fn summary(&self) -> MethodJitShapeSummary {
+            let mut summary = MethodJitShapeSummary {
+                root_count: self.records.len(),
+                ..MethodJitShapeSummary::default()
+            };
+            for record in &self.records {
+                summary.lowered.accumulate(record.lowered);
+                if let Some(decode_native) = record.decode_native {
+                    summary.decode_native.accumulate(decode_native);
+                    summary.decode_native_count += 1;
+                }
+                if let Some(encode_native) = record.encode_native {
+                    summary.encode_native.accumulate(encode_native);
+                    summary.encode_native_count += 1;
+                }
+            }
+            summary
+        }
+    }
+
+    impl JitShapeReport {
+        pub fn new(
+            lowered: LoweredMemProgramStats,
+            decode_native: Option<NativeJitStats>,
+            encode_native: Option<NativeJitStats>,
+        ) -> Self {
+            Self {
+                lowered,
+                decode_native,
+                encode_native,
+            }
+        }
+
+        pub fn scoped(
+            self,
+            method: impl Into<String>,
+            phase: impl Into<String>,
+        ) -> MethodJitShapeReport {
+            MethodJitShapeReport {
+                records: vec![MethodJitShapeRecord {
+                    method: method.into(),
+                    phase: phase.into(),
+                    lowered: self.lowered,
+                    decode_native: self.decode_native,
+                    encode_native: self.encode_native,
+                }],
+            }
         }
     }
 

--- a/phon/rust/phon/tests/bee_surface.rs
+++ b/phon/rust/phon/tests/bee_surface.rs
@@ -1,5 +1,5 @@
 use facet::Facet;
-use phon::api::{Codec, MethodJitFallbackReport};
+use phon::api::{Codec, MethodJitShapeReport};
 
 #[derive(Debug, Clone, Facet)]
 struct RepoFile {
@@ -195,22 +195,31 @@ struct ImeContextLostArgs {
     had_marked_text: bool,
 }
 
-fn report_for<'facet, T>(method: &str, phase: &str) -> MethodJitFallbackReport
-where
-    T: Facet<'facet>,
-{
-    Codec::<T>::new()
-        .expect("Bee surface shape should lower")
-        .jit_fallback_report()
-        .scoped(method, phase)
-}
-
 #[track_caller]
-fn audit<'facet, T>(method: &str, phase: &str)
+fn audit<'facet, T>(method: &str, phase: &str) -> MethodJitShapeReport
 where
     T: Facet<'facet>,
 {
-    let report = report_for::<T>(method, phase);
+    let codec = Codec::<T>::new().expect("Bee surface shape should lower");
+    let shape = codec.jit_shape_report().scoped(method, phase);
+    assert_eq!(shape.records.len(), 1);
+    let shape_record = &shape.records[0];
+    assert_eq!(shape_record.method, method);
+    assert_eq!(shape_record.phase, phase);
+
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    {
+        assert!(shape_record.decode_native.is_some());
+        assert!(shape_record.encode_native.is_some());
+    }
+
+    #[cfg(not(all(feature = "jit", target_os = "macos", target_arch = "aarch64")))]
+    {
+        assert!(shape_record.decode_native.is_none());
+        assert!(shape_record.encode_native.is_none());
+    }
+
+    let report = codec.jit_fallback_report().scoped(method, phase);
     for record in &report.records {
         assert_eq!(record.method, method);
         assert_eq!(record.phase, phase);
@@ -227,6 +236,39 @@ where
 
     #[cfg(not(all(feature = "jit", target_os = "macos", target_arch = "aarch64")))]
     assert!(!report.is_empty());
+
+    shape
+}
+
+#[track_caller]
+fn assert_surface_shape_summary(report: &MethodJitShapeReport) {
+    assert!(!report.is_empty());
+    let summary = report.summary();
+    assert_eq!(summary.root_count, report.records.len());
+    assert!(summary.lowered.total.op_count > 0);
+    assert!(summary.lowered.total.scalar_op_count > 0);
+
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    {
+        assert_eq!(summary.decode_native_count, summary.root_count);
+        assert_eq!(summary.encode_native_count, summary.root_count);
+        assert!(summary.decode_native.stencil_count >= summary.lowered.total.op_count);
+        assert!(summary.encode_native.stencil_count >= summary.lowered.total.op_count);
+    }
+
+    #[cfg(not(all(feature = "jit", target_os = "macos", target_arch = "aarch64")))]
+    {
+        assert_eq!(summary.decode_native_count, 0);
+        assert_eq!(summary.encode_native_count, 0);
+    }
+}
+
+macro_rules! audit_roots {
+    ($($ty:ty, $method:literal, $phase:literal;)+) => {{
+        let mut surface = MethodJitShapeReport::default();
+        $(surface.extend(audit::<$ty>($method, $phase));)+
+        surface
+    }};
 }
 
 #[test]
@@ -258,69 +300,56 @@ fn bee_engine_roots_are_auditable() {
         4
     );
 
-    audit::<ModelArgs>("requiredDownloads", "args");
-    audit::<Vec<RepoDownload>>("requiredDownloads", "response");
-
-    audit::<LoadEngineArgs>("loadEngine", "args");
-    audit::<Result<bool, BeeError>>("loadEngine", "response");
-
-    audit::<CreateSessionArgs>("createSession", "args");
-    audit::<Result<String, BeeError>>("createSession", "response");
-
-    audit::<FeedArgs>("feed", "args");
-    audit::<Result<Option<FeedResult>, BeeError>>("feed", "response");
-
-    audit::<FinishSessionArgs>("finishSession", "args");
-    audit::<Result<FeedResult, BeeError>>("finishSession", "response");
-
-    audit::<SetLanguageArgs>("setLanguage", "args");
-    audit::<Result<bool, BeeError>>("setLanguage", "response");
-
-    audit::<TranscribeSamplesArgs>("transcribeSamples", "args");
-    audit::<Result<String, BeeError>>("transcribeSamples", "response");
-
-    audit::<EmptyArgs>("getStats", "args");
-    audit::<EngineStats>("getStats", "response");
-
-    audit::<CorrectLoadArgs>("correctLoad", "args");
-    audit::<Result<bool, BeeError>>("correctLoad", "response");
-
-    audit::<CorrectTeachArgs>("correctTeach", "args");
-    audit::<Result<bool, BeeError>>("correctTeach", "response");
-
-    audit::<EmptyArgs>("correctSave", "args");
-    audit::<Result<bool, BeeError>>("correctSave", "response");
+    let surface = audit_roots! {
+        ModelArgs, "requiredDownloads", "args";
+        Vec<RepoDownload>, "requiredDownloads", "response";
+        LoadEngineArgs, "loadEngine", "args";
+        Result<bool, BeeError>, "loadEngine", "response";
+        CreateSessionArgs, "createSession", "args";
+        Result<String, BeeError>, "createSession", "response";
+        FeedArgs, "feed", "args";
+        Result<Option<FeedResult>, BeeError>, "feed", "response";
+        FinishSessionArgs, "finishSession", "args";
+        Result<FeedResult, BeeError>, "finishSession", "response";
+        SetLanguageArgs, "setLanguage", "args";
+        Result<bool, BeeError>, "setLanguage", "response";
+        TranscribeSamplesArgs, "transcribeSamples", "args";
+        Result<String, BeeError>, "transcribeSamples", "response";
+        EmptyArgs, "getStats", "args";
+        EngineStats, "getStats", "response";
+        CorrectLoadArgs, "correctLoad", "args";
+        Result<bool, BeeError>, "correctLoad", "response";
+        CorrectTeachArgs, "correctTeach", "args";
+        Result<bool, BeeError>, "correctTeach", "response";
+        EmptyArgs, "correctSave", "args";
+        Result<bool, BeeError>, "correctSave", "response";
+    };
+    assert_surface_shape_summary(&surface);
 }
 
 #[test]
 fn bee_ime_roots_are_auditable() {
-    audit::<SetMarkedTextArgs>("setMarkedText", "args");
-    audit::<bool>("setMarkedText", "response");
-
-    audit::<SetPhaseArgs>("setPhase", "args");
-    audit::<bool>("setPhase", "response");
-
-    audit::<CommitTextArgs>("commitText", "args");
-    audit::<bool>("commitText", "response");
-
-    audit::<AdvanceTranscriptArgs>("advanceTranscript", "args");
-    audit::<bool>("advanceTranscript", "response");
-
-    audit::<EmptyArgs>("stopDictating", "args");
-    audit::<bool>("stopDictating", "response");
-
-    audit::<EmptyArgs>("imeHello", "args");
-    audit::<String>("imeHello", "response");
-
-    audit::<EmptyArgs>("imeAttach", "args");
-    audit::<bool>("imeAttach", "response");
-
-    audit::<EmptyArgs>("imeActivationRevoked", "args");
-    audit::<bool>("imeActivationRevoked", "response");
-
-    audit::<ImeContextLostArgs>("imeContextLost", "args");
-    audit::<bool>("imeContextLost", "response");
-
-    audit::<ImeKeyEventArgs>("imeKeyEvent", "args");
-    audit::<bool>("imeKeyEvent", "response");
+    let surface = audit_roots! {
+        SetMarkedTextArgs, "setMarkedText", "args";
+        bool, "setMarkedText", "response";
+        SetPhaseArgs, "setPhase", "args";
+        bool, "setPhase", "response";
+        CommitTextArgs, "commitText", "args";
+        bool, "commitText", "response";
+        AdvanceTranscriptArgs, "advanceTranscript", "args";
+        bool, "advanceTranscript", "response";
+        EmptyArgs, "stopDictating", "args";
+        bool, "stopDictating", "response";
+        EmptyArgs, "imeHello", "args";
+        String, "imeHello", "response";
+        EmptyArgs, "imeAttach", "args";
+        bool, "imeAttach", "response";
+        EmptyArgs, "imeActivationRevoked", "args";
+        bool, "imeActivationRevoked", "response";
+        ImeContextLostArgs, "imeContextLost", "args";
+        bool, "imeContextLost", "response";
+        ImeKeyEventArgs, "imeKeyEvent", "args";
+        bool, "imeKeyEvent", "response";
+    };
+    assert_surface_shape_summary(&surface);
 }

--- a/vox/rust/vox-phon/src/lib.rs
+++ b/vox/rust/vox-phon/src/lib.rs
@@ -17,12 +17,15 @@ use std::{
 };
 
 use facet::{Facet, PtrConst, Shape};
-pub use phon::api::{JitFallbackRecord, JitFallbackReport, MethodJitFallbackReport};
+pub use phon::api::{
+    JitFallbackRecord, JitFallbackReport, JitShapeReport, MethodJitFallbackReport,
+    MethodJitShapeRecord, MethodJitShapeReport, MethodJitShapeSummary, NativeJitStats,
+};
 use phon::derive::{Derived, of_shape};
 use phon_engine::{Registry, typed};
-use phon_ir::Lowered;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use phon_ir::MemOp;
+use phon_ir::{Lowered, lowered_mem_program_stats};
 use vox_rt::sync::SyncMutex;
 
 pub mod schema;
@@ -190,6 +193,27 @@ impl TypedProgram {
             report
         }
     }
+
+    fn jit_shape_report(&self) -> JitShapeReport {
+        let lowered = lowered_mem_program_stats(&self.lowered);
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        {
+            JitShapeReport::new(
+                lowered,
+                self.native_decode
+                    .as_ref()
+                    .map(|native| native.0.stats().into()),
+                self.native_encode
+                    .as_ref()
+                    .map(|native| native.0.stats().into()),
+            )
+        }
+
+        #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+        {
+            JitShapeReport::new(lowered, None, None)
+        }
+    }
 }
 
 // The lowered program and native executors are immutable after construction, and
@@ -323,6 +347,15 @@ pub fn jit_fallback_report_for_shape(shape: &'static Shape) -> Result<JitFallbac
     Ok(typed_program_for_shape(shape)?.jit_fallback_report())
 }
 
+/// Report lowered shape and native-JIT code-layout counts for a shape-erased
+/// generated bridge root.
+///
+/// # Errors
+/// [`Error`] if `shape` cannot be lowered to a phon schema.
+pub fn jit_shape_report_for_shape(shape: &'static Shape) -> Result<JitShapeReport, Error> {
+    Ok(typed_program_for_shape(shape)?.jit_shape_report())
+}
+
 /// Report native-JIT fallback diagnostics scoped to a generated Vox method root.
 ///
 /// # Errors
@@ -333,6 +366,18 @@ pub fn method_jit_fallback_report_for_shape(
     phase: impl Into<String>,
 ) -> Result<MethodJitFallbackReport, Error> {
     Ok(jit_fallback_report_for_shape(shape)?.scoped(method, phase))
+}
+
+/// Report shape and native-JIT code-layout counts scoped to a generated Vox method root.
+///
+/// # Errors
+/// [`Error`] if `shape` cannot be lowered to a phon schema.
+pub fn method_jit_shape_report_for_shape(
+    shape: &'static Shape,
+    method: impl Into<String>,
+    phase: impl Into<String>,
+) -> Result<MethodJitShapeReport, Error> {
+    Ok(jit_shape_report_for_shape(shape)?.scoped(method, phase))
 }
 
 /// Decode `T` from phon-compact bytes, BORROWING from `bytes`: `&str`,
@@ -498,6 +543,51 @@ mod tests {
                     assert_eq!(record.path, "$");
                 }
             }
+        }
+    }
+
+    #[test]
+    fn vox_wire_shapes_expose_method_scoped_shape_reports() {
+        let mut surface = MethodJitShapeReport::default();
+        for (name, shape) in [
+            ("Message", Message::SHAPE),
+            ("MessagePayload", MessagePayload::SHAPE),
+            ("RequestCall", RequestCall::SHAPE),
+            ("RequestMessage", RequestMessage::SHAPE),
+            ("SchemaMessage", SchemaMessage::SHAPE),
+            ("Payload", Payload::SHAPE),
+            ("DodecaParseResult", DodecaParseResult::SHAPE),
+        ] {
+            let report =
+                method_jit_shape_report_for_shape(shape, name, "wire").unwrap_or_else(|err| {
+                    panic!("failed to build JIT shape report for {name}: {err}");
+                });
+            assert_eq!(report.records.len(), 1);
+            let record = &report.records[0];
+            assert_eq!(record.method, name);
+            assert_eq!(record.phase, "wire");
+            if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+                assert!(record.decode_native.is_some(), "{name} decode stats");
+                assert!(record.encode_native.is_some(), "{name} encode stats");
+            } else {
+                assert!(record.decode_native.is_none(), "{name} decode stats");
+                assert!(record.encode_native.is_none(), "{name} encode stats");
+            }
+            surface.extend(report);
+        }
+
+        let summary = surface.summary();
+        assert_eq!(summary.root_count, surface.records.len());
+        assert!(summary.lowered.total.op_count > 0);
+        assert!(summary.lowered.total.scalar_op_count > 0);
+        if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+            assert_eq!(summary.decode_native_count, summary.root_count);
+            assert_eq!(summary.encode_native_count, summary.root_count);
+            assert!(summary.decode_native.stencil_count >= summary.lowered.total.op_count);
+            assert!(summary.encode_native.stencil_count >= summary.lowered.total.op_count);
+        } else {
+            assert_eq!(summary.decode_native_count, 0);
+            assert_eq!(summary.encode_native_count, 0);
         }
     }
 

--- a/weavy/src/mem.rs
+++ b/weavy/src/mem.rs
@@ -971,7 +971,8 @@ pub struct MemProgramStats {
 }
 
 impl MemProgramStats {
-    fn add(&mut self, other: Self) {
+    /// Add another shape counter into this one.
+    pub fn accumulate(&mut self, other: Self) {
         self.op_count += other.op_count;
         self.scalar_op_count += other.scalar_op_count;
         self.scalar_run_count += other.scalar_run_count;
@@ -1005,6 +1006,16 @@ pub struct LoweredMemProgramStats {
     pub block_count: usize,
 }
 
+impl LoweredMemProgramStats {
+    /// Add another lowered-program shape counter into this one.
+    pub fn accumulate(&mut self, other: Self) {
+        self.root.accumulate(other.root);
+        self.blocks.accumulate(other.blocks);
+        self.total.accumulate(other.total);
+        self.block_count += other.block_count;
+    }
+}
+
 /// Count the typed memory IR shape for one program.
 #[must_use]
 pub fn mem_program_stats<BlockId>(program: &[MemOp<BlockId>]) -> MemProgramStats {
@@ -1021,10 +1032,10 @@ pub fn lowered_mem_program_stats<BlockId>(
     let root = mem_program_stats(&lowered.program);
     let mut blocks = MemProgramStats::default();
     for block in lowered.blocks.values() {
-        blocks.add(mem_program_stats(block));
+        blocks.accumulate(mem_program_stats(block));
     }
     let mut total = root;
-    total.add(blocks);
+    total.accumulate(blocks);
 
     LoweredMemProgramStats {
         root,

--- a/weavy/src/mem.rs
+++ b/weavy/src/mem.rs
@@ -940,6 +940,154 @@ pub fn element_min_wire<BlockId>(element: &[MemOp<BlockId>]) -> usize {
     usize::from(!zero_sized)
 }
 
+/// Shape-only counts for a typed memory program.
+///
+/// Nested inline programs are counted once, as shape, not multiplied by runtime
+/// sequence/map/set lengths. [`MemOp::CallBlock`] is counted as a call op; block
+/// bodies are counted by [`lowered_mem_program_stats`].
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MemProgramStats {
+    pub op_count: usize,
+    pub scalar_op_count: usize,
+    pub scalar_run_count: usize,
+    pub scalar_run_segment_count: usize,
+    pub native_int_count: usize,
+    pub sequence_count: usize,
+    pub set_count: usize,
+    pub bytes_count: usize,
+    pub borrow_count: usize,
+    pub option_count: usize,
+    pub enum_count: usize,
+    pub enum_variant_count: usize,
+    pub map_count: usize,
+    pub dynamic_count: usize,
+    pub result_count: usize,
+    pub pointer_count: usize,
+    pub skip_wire_count: usize,
+    pub default_count: usize,
+    pub opaque_count: usize,
+    pub call_block_count: usize,
+}
+
+impl MemProgramStats {
+    fn add(&mut self, other: Self) {
+        self.op_count += other.op_count;
+        self.scalar_op_count += other.scalar_op_count;
+        self.scalar_run_count += other.scalar_run_count;
+        self.scalar_run_segment_count += other.scalar_run_segment_count;
+        self.native_int_count += other.native_int_count;
+        self.sequence_count += other.sequence_count;
+        self.set_count += other.set_count;
+        self.bytes_count += other.bytes_count;
+        self.borrow_count += other.borrow_count;
+        self.option_count += other.option_count;
+        self.enum_count += other.enum_count;
+        self.enum_variant_count += other.enum_variant_count;
+        self.map_count += other.map_count;
+        self.dynamic_count += other.dynamic_count;
+        self.result_count += other.result_count;
+        self.pointer_count += other.pointer_count;
+        self.skip_wire_count += other.skip_wire_count;
+        self.default_count += other.default_count;
+        self.opaque_count += other.opaque_count;
+        self.call_block_count += other.call_block_count;
+    }
+}
+
+/// Shape-only counts for a lowered typed memory program with recursive blocks.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct LoweredMemProgramStats {
+    pub root: MemProgramStats,
+    pub blocks: MemProgramStats,
+    pub total: MemProgramStats,
+    pub block_count: usize,
+}
+
+/// Count the typed memory IR shape for one program.
+#[must_use]
+pub fn mem_program_stats<BlockId>(program: &[MemOp<BlockId>]) -> MemProgramStats {
+    let mut stats = MemProgramStats::default();
+    add_mem_program_stats(program, &mut stats);
+    stats
+}
+
+/// Count the typed memory IR shape for a lowered program and its block table.
+#[must_use]
+pub fn lowered_mem_program_stats<BlockId>(
+    lowered: &crate::Lowered<BlockId, MemOp<BlockId>>,
+) -> LoweredMemProgramStats {
+    let root = mem_program_stats(&lowered.program);
+    let mut blocks = MemProgramStats::default();
+    for block in lowered.blocks.values() {
+        blocks.add(mem_program_stats(block));
+    }
+    let mut total = root;
+    total.add(blocks);
+
+    LoweredMemProgramStats {
+        root,
+        blocks,
+        total,
+        block_count: lowered.blocks.len(),
+    }
+}
+
+fn add_mem_program_stats<BlockId>(program: &[MemOp<BlockId>], stats: &mut MemProgramStats) {
+    for op in program {
+        stats.op_count += 1;
+        match op {
+            MemOp::Scalar { .. } => stats.scalar_op_count += 1,
+            MemOp::ScalarRun(run) => {
+                stats.scalar_run_count += 1;
+                stats.scalar_run_segment_count += run.segments.len();
+            }
+            MemOp::NativeInt { .. } => stats.native_int_count += 1,
+            MemOp::Sequence(seq) => {
+                stats.sequence_count += 1;
+                add_mem_program_stats(&seq.element, stats);
+            }
+            MemOp::Set(set) => {
+                stats.set_count += 1;
+                add_mem_program_stats(&set.element, stats);
+            }
+            MemOp::Bytes(_) => stats.bytes_count += 1,
+            MemOp::Borrow(_) => stats.borrow_count += 1,
+            MemOp::Option(option) => {
+                stats.option_count += 1;
+                add_mem_program_stats(&option.some, stats);
+            }
+            MemOp::Enum(en) => {
+                stats.enum_count += 1;
+                stats.enum_variant_count += en.variants.len();
+                for variant in &en.variants {
+                    add_mem_program_stats(&variant.payload, stats);
+                }
+            }
+            MemOp::Map(map) => {
+                stats.map_count += 1;
+                add_mem_program_stats(&map.key, stats);
+                add_mem_program_stats(&map.value, stats);
+            }
+            MemOp::Dynamic { .. } => stats.dynamic_count += 1,
+            MemOp::Result(result) => {
+                stats.result_count += 1;
+                add_mem_program_stats(&result.ok, stats);
+                add_mem_program_stats(&result.err, stats);
+            }
+            MemOp::Pointer(pointer) => {
+                stats.pointer_count += 1;
+                add_mem_program_stats(&pointer.pointee, stats);
+            }
+            MemOp::SkipWire(_) => stats.skip_wire_count += 1,
+            MemOp::Default(_) => stats.default_count += 1,
+            MemOp::Opaque(_) => stats.opaque_count += 1,
+            MemOp::CallBlock { .. } => stats.call_block_count += 1,
+        }
+    }
+}
+
 /// Return the scalar alignment when an element program can be represented as one
 /// contiguous byte run inside a sequence or fixed array.
 #[must_use]
@@ -1298,6 +1446,88 @@ mod tests {
             }]),
             1
         );
+    }
+
+    #[test]
+    fn mem_program_stats_count_inline_shapes_and_lowered_blocks() {
+        let program = vec![
+            MemOp::<u8>::Scalar {
+                offset: 0,
+                size: 4,
+                align: 4,
+            },
+            MemOp::ScalarRun(Box::new(ScalarRunOp {
+                segments: vec![
+                    ScalarSegment {
+                        offset: 8,
+                        size: 2,
+                        align: 2,
+                    },
+                    ScalarSegment {
+                        offset: 12,
+                        size: 4,
+                        align: 4,
+                    },
+                ],
+            })),
+            MemOp::Enum(Box::new(EnumOp {
+                tag_offset: 16,
+                tag_width: 4,
+                variants: vec![
+                    EnumVariantOp {
+                        wire_index: 0,
+                        selector: 0,
+                        payload: vec![MemOp::Dynamic { field_offset: 24 }],
+                    },
+                    EnumVariantOp {
+                        wire_index: 1,
+                        selector: 1,
+                        payload: vec![MemOp::NativeInt {
+                            offset: 32,
+                            mem_size: 8,
+                            signed: false,
+                        }],
+                    },
+                ],
+                writer_only: vec![9],
+            })),
+            MemOp::CallBlock {
+                schema: 7,
+                offset: 40,
+            },
+        ];
+
+        let stats = mem_program_stats(&program);
+        assert_eq!(stats.op_count, 6);
+        assert_eq!(stats.scalar_op_count, 1);
+        assert_eq!(stats.scalar_run_count, 1);
+        assert_eq!(stats.scalar_run_segment_count, 2);
+        assert_eq!(stats.enum_count, 1);
+        assert_eq!(stats.enum_variant_count, 2);
+        assert_eq!(stats.dynamic_count, 1);
+        assert_eq!(stats.native_int_count, 1);
+        assert_eq!(stats.call_block_count, 1);
+
+        let mut lowered = crate::Lowered::new(program);
+        lowered.blocks.insert(
+            7,
+            vec![
+                MemOp::Scalar {
+                    offset: 0,
+                    size: 1,
+                    align: 1,
+                },
+                MemOp::SkipWire(Box::new(SkipOp::Scalar { size: 4, align: 4 })),
+            ],
+        );
+
+        let lowered_stats = lowered_mem_program_stats(&lowered);
+        assert_eq!(lowered_stats.block_count, 1);
+        assert_eq!(lowered_stats.root.op_count, 6);
+        assert_eq!(lowered_stats.blocks.op_count, 2);
+        assert_eq!(lowered_stats.blocks.skip_wire_count, 1);
+        assert_eq!(lowered_stats.total.op_count, 8);
+        assert_eq!(lowered_stats.total.scalar_op_count, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add reusable typed-memory shape stats in weavy and re-export them through phon-ir
- expose native copy-patch program stats for decode/encode JITs
- add phon::api::Codec::jit_shape_report() plus method-scoped shape reports and aggregate summaries
- expose the same shape reporting from vox-phon for shape-erased Vox bridge roots
- aggregate Bee and Vox surface roots in tests so the stats are exercised at service-surface scale

## Tests
- cargo check -p weavy -p phon-ir -p phon-jit -p phon -p vox-phon --features phon/jit
- cargo check -p weavy -p phon-ir -p phon -p vox-phon
- cargo nextest list -p phon --features phon/jit -E 'binary(bee_surface)'
- cargo nextest run -p phon --features phon/jit -E 'binary(bee_surface)'
- cargo nextest run -p weavy -p phon-jit -p phon -p vox-phon --features phon/jit
- cargo nextest run -p weavy -p phon -p vox-phon
- cargo clippy -p weavy -p phon-ir -p phon-jit -p phon -p vox-phon --features phon/jit -- -D warnings
- cargo clippy -p weavy -p phon-ir -p phon -p vox-phon -- -D warnings