### PR TITLE
Speed up facet-json VM struct hot path

### DIFF
--- a/facet-json/benches/typeplan_reuse.rs
+++ b/facet-json/benches/typeplan_reuse.rs
@@ -144,6 +144,20 @@ fn point_reused_vm_plan(bencher: Bencher) {
     });
 }
 
+/// VM path with explicit plan reuse and runtime stats collection
+#[divan::bench]
+fn point_reused_vm_plan_with_stats(bencher: Bencher) {
+    let json = POINT_JSON;
+    let plan = facet_json::JsonVmPlan::<Point>::build().unwrap();
+
+    bencher.bench(|| {
+        let (result, stats): (Point, _) =
+            black_box(plan.from_str_with_stats(black_box(json)).unwrap());
+        black_box(stats);
+        black_box(result)
+    });
+}
+
 /// serde_json path
 #[divan::bench]
 fn point_serde_json(bencher: Bencher) {
@@ -210,6 +224,20 @@ fn person_reused_vm_plan(bencher: Bencher) {
     });
 }
 
+/// VM path with explicit plan reuse and runtime stats collection
+#[divan::bench]
+fn person_reused_vm_plan_with_stats(bencher: Bencher) {
+    let json = PERSON_JSON;
+    let plan = facet_json::JsonVmPlan::<Person>::build().unwrap();
+
+    bencher.bench(|| {
+        let (result, stats): (Person, _) =
+            black_box(plan.from_str_with_stats(black_box(json)).unwrap());
+        black_box(stats);
+        black_box(result)
+    });
+}
+
 /// serde_json path
 #[divan::bench]
 fn person_serde_json(bencher: Bencher) {
@@ -272,6 +300,20 @@ fn company_reused_vm_plan(bencher: Bencher) {
 
     bencher.bench(|| {
         let result: Company = black_box(plan.from_str(black_box(json)).unwrap());
+        black_box(result)
+    });
+}
+
+/// VM path with explicit plan reuse and runtime stats collection
+#[divan::bench]
+fn company_reused_vm_plan_with_stats(bencher: Bencher) {
+    let json = COMPANY_JSON;
+    let plan = facet_json::JsonVmPlan::<Company>::build().unwrap();
+
+    bencher.bench(|| {
+        let (result, stats): (Company, _) =
+            black_box(plan.from_str_with_stats(black_box(json)).unwrap());
+        black_box(stats);
         black_box(result)
     });
 }
@@ -345,6 +387,21 @@ fn batch_1000_reused_vm_plan(bencher: Bencher) {
     bencher.bench(|| {
         for _ in 0..1000 {
             let result: Person = plan.from_str(black_box(json)).unwrap();
+            black_box(result);
+        }
+    });
+}
+
+/// 1000 deserializations reusing the same VM plan with runtime stats collection
+#[divan::bench]
+fn batch_1000_reused_vm_plan_with_stats(bencher: Bencher) {
+    let json = PERSON_JSON;
+    let plan = facet_json::JsonVmPlan::<Person>::build().unwrap();
+
+    bencher.bench(|| {
+        for _ in 0..1000 {
+            let (result, stats): (Person, _) = plan.from_str_with_stats(black_box(json)).unwrap();
+            black_box(stats);
             black_box(result);
         }
     });

--- a/facet-json/src/bytecode.rs
+++ b/facet-json/src/bytecode.rs
@@ -146,8 +146,46 @@ pub enum JsonBytes {
 pub struct JsonStruct {
     /// Expected fields in lowered planning order.
     pub fields: Vec<JsonField>,
+    /// Lookup table from accepted JSON field names to field indexes.
+    pub lookup: JsonFieldLookup,
     /// Unknown-field behavior for this object.
     pub unknown_fields: UnknownFields,
+}
+
+/// Fast lookup from a JSON object key to a field index.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum JsonFieldLookup {
+    /// For small structs, linear scan over name/index pairs is cache-friendly.
+    Small(Vec<JsonFieldLookupEntry>),
+    /// For larger structs, dispatch through sorted first-byte-prefix buckets.
+    PrefixBuckets {
+        /// Number of leading bytes used to compute each prefix.
+        prefix_len: usize,
+        /// Lookup entries grouped by bucket.
+        entries: Vec<JsonFieldLookupEntry>,
+        /// Sorted bucket metadata.
+        buckets: Vec<JsonFieldBucket>,
+    },
+}
+
+/// One accepted field name in a JSON field lookup table.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct JsonFieldLookupEntry {
+    /// Primary field name or alias.
+    pub name: &'static str,
+    /// Lowered field index.
+    pub index: usize,
+}
+
+/// One prefix bucket in a JSON field lookup table.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct JsonFieldBucket {
+    /// Little-endian prefix of the leading `prefix_len` bytes.
+    pub prefix: u64,
+    /// First entry for this bucket in `JsonFieldLookup::PrefixBuckets::entries`.
+    pub start: usize,
+    /// Number of entries in this bucket.
+    pub len: usize,
 }
 
 /// One named JSON field.
@@ -187,6 +225,103 @@ pub enum MissingField {
     Default,
     /// Leave unset because the reflected type can complete it.
     Omit,
+}
+
+const FIELD_LOOKUP_THRESHOLD: usize = 8;
+
+impl JsonFieldLookup {
+    /// Build a JSON field lookup from lowered field metadata.
+    #[must_use]
+    pub fn from_fields(fields: &[JsonField]) -> Self {
+        let mut entries = Vec::with_capacity(fields.len().saturating_mul(2));
+        for (index, field) in fields.iter().enumerate() {
+            entries.push(JsonFieldLookupEntry {
+                name: field.name,
+                index,
+            });
+            if let Some(alias) = field.alias {
+                entries.push(JsonFieldLookupEntry { name: alias, index });
+            }
+        }
+
+        if entries.len() <= FIELD_LOOKUP_THRESHOLD {
+            return Self::Small(entries);
+        }
+
+        let prefix_len = choose_field_prefix_len(&entries);
+        entries.sort_by_key(|entry| compute_field_prefix(entry.name, prefix_len));
+
+        let mut buckets = Vec::new();
+        let mut start = 0;
+        while start < entries.len() {
+            let prefix = compute_field_prefix(entries[start].name, prefix_len);
+            let mut end = start + 1;
+            while end < entries.len()
+                && compute_field_prefix(entries[end].name, prefix_len) == prefix
+            {
+                end += 1;
+            }
+            buckets.push(JsonFieldBucket {
+                prefix,
+                start,
+                len: end - start,
+            });
+            start = end;
+        }
+
+        Self::PrefixBuckets {
+            prefix_len,
+            entries,
+            buckets,
+        }
+    }
+
+    /// Find a lowered field index by JSON object key.
+    #[inline]
+    #[must_use]
+    pub fn find(&self, name: &str) -> Option<usize> {
+        match self {
+            Self::Small(entries) => entries
+                .iter()
+                .find(|entry| entry.name == name)
+                .map(|entry| entry.index),
+            Self::PrefixBuckets {
+                prefix_len,
+                entries,
+                buckets,
+            } => {
+                let prefix = compute_field_prefix(name, *prefix_len);
+                let bucket_idx = buckets
+                    .binary_search_by_key(&prefix, |bucket| bucket.prefix)
+                    .ok()?;
+                let bucket = buckets[bucket_idx];
+                entries[bucket.start..bucket.start + bucket.len]
+                    .iter()
+                    .find(|entry| entry.name == name)
+                    .map(|entry| entry.index)
+            }
+        }
+    }
+}
+
+fn choose_field_prefix_len(entries: &[JsonFieldLookupEntry]) -> usize {
+    let long_key_count = entries.iter().filter(|entry| entry.name.len() >= 8).count();
+    if long_key_count > entries.len() / 2 {
+        8
+    } else {
+        4
+    }
+}
+
+#[inline]
+fn compute_field_prefix(name: &str, prefix_len: usize) -> u64 {
+    name.as_bytes()
+        .iter()
+        .take(prefix_len)
+        .enumerate()
+        .fold(0, |prefix, (index, byte)| {
+            prefix | ((*byte as u64) << (index * 8))
+        })
 }
 
 /// Enum representation used by JSON deserialization.
@@ -494,11 +629,13 @@ impl Lowerer<'_> {
         } else {
             UnknownFields::Ignore
         };
+        let fields = fields
+            .iter()
+            .map(|field| self.lower_field(field))
+            .collect::<LowerResult<Vec<_>>>()?;
         Ok(JsonStruct {
-            fields: fields
-                .iter()
-                .map(|field| self.lower_field(field))
-                .collect::<LowerResult<_>>()?,
+            lookup: JsonFieldLookup::from_fields(&fields),
+            fields,
             unknown_fields,
         })
     }
@@ -598,6 +735,19 @@ mod tests {
         next: Option<Box<Node>>,
     }
 
+    #[derive(facet::Facet)]
+    struct Wide {
+        account_id: u32,
+        billing_id: u32,
+        customer_id: u32,
+        delivery_id: u32,
+        employee_id: u32,
+        fixture_id: u32,
+        gateway_id: u32,
+        hardware_id: u32,
+        invoice_id: u32,
+    }
+
     #[test]
     fn lowers_struct_fields_from_type_plan() {
         let core = facet_reflect::TypePlan::<Person>::build().unwrap().core();
@@ -613,6 +763,22 @@ mod tests {
         assert_eq!(plan.fields[0].missing, MissingField::Required);
         assert_eq!(plan.fields[1].name, "age");
         assert!(lowered.blocks.is_empty());
+    }
+
+    #[test]
+    fn lowers_large_struct_with_prefix_field_lookup() {
+        let core = facet_reflect::TypePlan::<Wide>::build().unwrap().core();
+        let lowered = lower_type_plan(&core).unwrap();
+
+        let [JsonOp::EnterShape { .. }, JsonOp::Struct(plan)] = lowered.program.as_slice() else {
+            panic!("expected enter-shape plus struct op");
+        };
+
+        assert!(matches!(plan.lookup, JsonFieldLookup::PrefixBuckets { .. }));
+        for (idx, field) in plan.fields.iter().enumerate() {
+            assert_eq!(plan.lookup.find(field.name), Some(idx));
+        }
+        assert_eq!(plan.lookup.find("missing_id"), None);
     }
 
     #[test]

--- a/facet-json/src/vm.rs
+++ b/facet-json/src/vm.rs
@@ -265,33 +265,27 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
         &mut self,
         mut partial: Partial<'input, false>,
     ) -> Result<Partial<'input, false>, DeserializeError> {
-        let mut frames = vec![VmFrame::Program {
+        let mut frames = Vec::with_capacity(16);
+        frames.push(VmFrame::Program {
             program: &self.lowered.program,
             pc: 0,
-        }];
+        });
 
         while let Some(frame) = frames.pop() {
-            if COLLECT_STATS {
-                self.stats.record(frames.len() + 1, partial.frame_count());
-            }
             match frame {
                 VmFrame::Program { program, pc } => {
-                    if pc >= program.len() {
-                        continue;
-                    }
-                    frames.push(VmFrame::Program {
-                        program,
-                        pc: pc + 1,
-                    });
-                    partial = self.execute_op(partial, &mut frames, &program[pc])?;
+                    partial = self.run_program(partial, &mut frames, program, pc)?;
                 }
                 VmFrame::EndCurrent => {
+                    self.record_step(frames.len() + 1, partial.frame_count());
                     partial = self.end(partial)?;
                 }
                 VmFrame::Struct { plan, seen } => {
+                    self.record_step(frames.len() + 1, partial.frame_count());
                     partial = self.step_struct(partial, &mut frames, plan, seen)?;
                 }
                 VmFrame::List { element } => {
+                    self.record_step(frames.len() + 1, partial.frame_count());
                     partial = self.step_list(partial, &mut frames, element)?;
                 }
             }
@@ -300,21 +294,44 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
         Ok(partial)
     }
 
+    fn run_program(
+        &mut self,
+        mut partial: Partial<'input, false>,
+        frames: &mut Vec<VmFrame<'program>>,
+        program: &'program JsonProgram,
+        mut pc: usize,
+    ) -> Result<Partial<'input, false>, DeserializeError> {
+        while let Some(op) = program.get(pc) {
+            self.record_step(frames.len() + 1, partial.frame_count());
+            pc += 1;
+            let continuation = (pc < program.len()).then_some((program, pc));
+            let (next_partial, control) = self.execute_op(partial, frames, op, continuation)?;
+            partial = next_partial;
+            match control {
+                ProgramControl::Continue => {}
+                ProgramControl::Suspend | ProgramControl::Stop => return Ok(partial),
+            }
+        }
+
+        Ok(partial)
+    }
+
+    fn record_step(&mut self, vm_frames: usize, partial_frames: usize) {
+        if COLLECT_STATS {
+            self.stats.record(vm_frames, partial_frames);
+        }
+    }
+
     fn execute_op(
         &mut self,
         mut partial: Partial<'input, false>,
         frames: &mut Vec<VmFrame<'program>>,
         op: &'program JsonOp,
-    ) -> Result<Partial<'input, false>, DeserializeError> {
+        continuation: ProgramContinuation<'program>,
+    ) -> Result<(Partial<'input, false>, ProgramControl), DeserializeError> {
         match op {
             JsonOp::EnterShape { shape } => {
-                if partial.shape() != *shape {
-                    return Err(DeserializeErrorKind::TypeMismatch {
-                        expected: shape,
-                        got: Cow::Owned(format!("VM partial shape {}", partial.shape())),
-                    }
-                    .with_span(self.last_span));
-                }
+                self.check_enter_shape(&partial, shape)?;
             }
             JsonOp::Null => {
                 let event = self.next_event("null")?;
@@ -344,10 +361,12 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
                 let event = self.next_event("object")?;
                 match event.kind {
                     ParseEventKind::StructStart(ContainerKind::Object) => {
+                        push_continuation(frames, continuation);
                         frames.push(VmFrame::Struct {
                             plan,
                             seen: SeenFields::new(plan.fields.len()),
                         });
+                        return Ok((partial, ProgramControl::Suspend));
                     }
                     _ => return Err(self.unexpected_event(&event, "object")),
                 }
@@ -364,7 +383,9 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
                 match event.kind {
                     ParseEventKind::SequenceStart(ContainerKind::Array) => {
                         partial = self.init_list(partial)?;
+                        push_continuation(frames, continuation);
                         frames.push(VmFrame::List { element });
+                        return Ok((partial, ProgramControl::Suspend));
                     }
                     _ => return Err(self.unexpected_event(&event, "array")),
                 }
@@ -381,26 +402,31 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
                     }
                     _ => {
                         partial = self.begin_some(partial)?;
+                        push_continuation(frames, continuation);
                         frames.push(VmFrame::EndCurrent);
                         frames.push(VmFrame::Program {
                             program: some,
                             pc: 0,
                         });
+                        return Ok((partial, ProgramControl::Suspend));
                     }
                 }
             }
             JsonOp::Result { .. } => return Err(self.unsupported("VM result deserialization")),
             JsonOp::Enum(en) => return Err(self.unsupported_enum(en)),
             JsonOp::Pointer { pointee } => {
-                partial = self.begin_pointer(partial, frames, pointee)?;
+                partial = self.begin_pointer(partial, frames, pointee, continuation)?;
+                return Ok((partial, ProgramControl::Suspend));
             }
             JsonOp::Transparent { inner } => {
                 partial = self.begin_inner(partial)?;
+                push_continuation(frames, continuation);
                 frames.push(VmFrame::EndCurrent);
                 frames.push(VmFrame::Program {
                     program: inner,
                     pc: 0,
                 });
+                return Ok((partial, ProgramControl::Suspend));
             }
             JsonOp::Proxy { .. } => return Err(self.unsupported("VM proxy deserialization")),
             JsonOp::OpaquePointer => return Err(self.unsupported("VM opaque pointer")),
@@ -415,12 +441,14 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
                         self.unsupported_owned(format!("VM missing recursive block {block_id:?}"))
                     );
                 };
+                push_continuation(frames, continuation);
                 frames.push(VmFrame::Program { program, pc: 0 });
+                return Ok((partial, ProgramControl::Suspend));
             }
-            JsonOp::Return => {}
+            JsonOp::Return => return Ok((partial, ProgramControl::Stop)),
         }
 
-        Ok(partial)
+        Ok((partial, ProgramControl::Continue))
     }
 
     fn step_struct(
@@ -521,6 +549,7 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
         partial: Partial<'input, false>,
         frames: &mut Vec<VmFrame<'program>>,
         pointee: &'program JsonProgram,
+        continuation: ProgramContinuation<'program>,
     ) -> Result<Partial<'input, false>, DeserializeError> {
         let (partial, action) =
             facet_dessert::begin_pointer(partial).map_err(|e| self.dessert_error(e))?;
@@ -532,6 +561,7 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
                 Err(self.unsupported("VM smart-pointer slice deserialization"))
             }
             facet_dessert::PointerAction::SizedPointee => {
+                push_continuation(frames, continuation);
                 frames.push(VmFrame::EndCurrent);
                 frames.push(VmFrame::Program {
                     program: pointee,
@@ -565,9 +595,9 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
         &mut self,
         mut partial: Partial<'input, false>,
         scalar: ScalarValue<'input>,
-        _policy: JsonScalar,
+        policy: JsonScalar,
     ) -> Result<Partial<'input, false>, DeserializeError> {
-        let scalar_type = partial.shape().scalar_type();
+        let scalar_type = policy.ty;
         match scalar {
             ScalarValue::Unit | ScalarValue::Null => self.set_default(partial),
             ScalarValue::Bool(value) => self.set(partial, value),
@@ -621,7 +651,7 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
             ScalarValue::F64(value) => match scalar_type {
                 Some(ScalarType::F32) => self.set(partial, value as f32),
                 Some(ScalarType::F64) => self.set(partial, value),
-                _ if partial.shape().vtable.has_parse() => {
+                _ if policy.from_str => {
                     partial = self.parse_from_str(partial, &value.to_string())?;
                     Ok(partial)
                 }
@@ -631,6 +661,30 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
             ScalarValue::Bytes(value) => self.set_bytes(partial, value),
             _ => Err(self.unsupported("VM unknown scalar value")),
         }
+    }
+
+    #[inline]
+    fn check_enter_shape(
+        &self,
+        partial: &Partial<'input, false>,
+        expected: &'static Shape,
+    ) -> Result<(), DeserializeError> {
+        #[cfg(debug_assertions)]
+        {
+            if partial.shape() != expected {
+                return Err(DeserializeErrorKind::TypeMismatch {
+                    expected,
+                    got: Cow::Owned(format!("VM partial shape {}", partial.shape())),
+                }
+                .with_span(self.last_span));
+            }
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            let _ = partial;
+            let _ = expected;
+        }
+        Ok(())
     }
 
     fn next_event(
@@ -827,6 +881,24 @@ enum VmFrame<'program> {
     List {
         element: &'program JsonProgram,
     },
+}
+
+type ProgramContinuation<'program> = Option<(&'program JsonProgram, usize)>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProgramControl {
+    Continue,
+    Suspend,
+    Stop,
+}
+
+fn push_continuation<'program>(
+    frames: &mut Vec<VmFrame<'program>>,
+    continuation: ProgramContinuation<'program>,
+) {
+    if let Some((program, pc)) = continuation {
+        frames.push(VmFrame::Program { program, pc });
+    }
 }
 
 fn find_field<'program>(

--- a/facet-json/src/vm.rs
+++ b/facet-json/src/vm.rs
@@ -141,20 +141,24 @@ where
     /// Deserialize a JSON string through this plan.
     #[doc(hidden)]
     pub fn from_str(&self, input: &str) -> Result<T, DeserializeError> {
-        self.from_str_with_stats(input).map(|(value, _)| value)
+        let mut parser = JsonParser::<true>::new(input.as_bytes());
+        deserialize_owned_with_vm::<T, true, false>(&mut parser, &self.inner)
+            .map(|(value, _)| value)
     }
 
     /// Deserialize JSON bytes through this plan.
     #[doc(hidden)]
     pub fn from_slice(&self, input: &[u8]) -> Result<T, DeserializeError> {
-        self.from_slice_with_stats(input).map(|(value, _)| value)
+        let mut parser = JsonParser::<false>::new(input);
+        deserialize_owned_with_vm::<T, false, false>(&mut parser, &self.inner)
+            .map(|(value, _)| value)
     }
 
     /// Deserialize a JSON string through this plan and return VM stats.
     #[doc(hidden)]
     pub fn from_str_with_stats(&self, input: &str) -> Result<(T, JsonVmStats), DeserializeError> {
         let mut parser = JsonParser::<true>::new(input.as_bytes());
-        deserialize_owned_with_vm::<T, true>(&mut parser, &self.inner)
+        deserialize_owned_with_vm::<T, true, true>(&mut parser, &self.inner)
     }
 
     /// Deserialize JSON bytes through this plan and return VM stats.
@@ -164,11 +168,11 @@ where
         input: &[u8],
     ) -> Result<(T, JsonVmStats), DeserializeError> {
         let mut parser = JsonParser::<false>::new(input);
-        deserialize_owned_with_vm::<T, false>(&mut parser, &self.inner)
+        deserialize_owned_with_vm::<T, false, true>(&mut parser, &self.inner)
     }
 }
 
-fn deserialize_owned_with_vm<T, const TRUSTED_UTF8: bool>(
+fn deserialize_owned_with_vm<T, const TRUSTED_UTF8: bool, const COLLECT_STATS: bool>(
     parser: &mut JsonParser<'_, TRUSTED_UTF8>,
     plan: &JsonVmPlanInner,
 ) -> Result<(T, JsonVmStats), DeserializeError>
@@ -177,7 +181,7 @@ where
 {
     let partial = Partial::alloc_owned_with_plan(Arc::clone(&plan.type_plan))?;
 
-    let mut vm = JsonVm::new(parser, plan.lowered.as_ref());
+    let mut vm = JsonVm::<TRUSTED_UTF8, COLLECT_STATS>::new(parser, plan.lowered.as_ref());
 
     // SAFETY: owned deserialization does not borrow from the JSON input.
     #[allow(unsafe_code)]
@@ -235,15 +239,15 @@ where
     })
 }
 
-struct JsonVm<'parser, 'input, 'program, const TRUSTED_UTF8: bool> {
+struct JsonVm<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: bool> {
     parser: &'parser mut JsonParser<'input, TRUSTED_UTF8>,
     lowered: &'program JsonLowered,
     last_span: Span,
     stats: JsonVmStats,
 }
 
-impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool>
-    JsonVm<'parser, 'input, 'program, TRUSTED_UTF8>
+impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: bool>
+    JsonVm<'parser, 'input, 'program, TRUSTED_UTF8, COLLECT_STATS>
 {
     fn new(
         parser: &'parser mut JsonParser<'input, TRUSTED_UTF8>,
@@ -267,7 +271,9 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool>
         }];
 
         while let Some(frame) = frames.pop() {
-            self.stats.record(frames.len() + 1, partial.frame_count());
+            if COLLECT_STATS {
+                self.stats.record(frames.len() + 1, partial.frame_count());
+            }
             match frame {
                 VmFrame::Program { program, pc } => {
                     if pc >= program.len() {
@@ -340,7 +346,7 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool>
                     ParseEventKind::StructStart(ContainerKind::Object) => {
                         frames.push(VmFrame::Struct {
                             plan,
-                            seen: vec![false; plan.fields.len()],
+                            seen: SeenFields::new(plan.fields.len()),
                         });
                     }
                     _ => return Err(self.unexpected_event(&event, "object")),
@@ -422,7 +428,7 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool>
         mut partial: Partial<'input, false>,
         frames: &mut Vec<VmFrame<'program>>,
         plan: &'program JsonStruct,
-        mut seen: Vec<bool>,
+        mut seen: SeenFields,
     ) -> Result<Partial<'input, false>, DeserializeError> {
         let event = self.next_event("field key or object end")?;
         match event.kind {
@@ -442,14 +448,13 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool>
                 if field.flattened {
                     return Err(self.unsupported("VM flattened struct field"));
                 }
-                if seen[idx] {
+                if seen.mark(idx) {
                     return Err(DeserializeErrorKind::DuplicateField {
                         field: Cow::Owned(name.to_string()),
                         first_span: None,
                     }
                     .with_span(event.span));
                 }
-                seen[idx] = true;
                 partial = self.begin_nth_field(partial, idx)?;
                 frames.push(VmFrame::Struct { plan, seen });
                 frames.push(VmFrame::EndCurrent);
@@ -468,7 +473,7 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool>
         partial: Partial<'input, false>,
         frames: &mut Vec<VmFrame<'program>>,
         plan: &'program JsonStruct,
-        seen: Vec<bool>,
+        seen: SeenFields,
         name: &str,
     ) -> Result<Partial<'input, false>, DeserializeError> {
         match plan.unknown_fields {
@@ -817,7 +822,7 @@ enum VmFrame<'program> {
     EndCurrent,
     Struct {
         plan: &'program JsonStruct,
-        seen: Vec<bool>,
+        seen: SeenFields,
     },
     List {
         element: &'program JsonProgram,
@@ -828,10 +833,41 @@ fn find_field<'program>(
     plan: &'program JsonStruct,
     name: &str,
 ) -> Option<(usize, &'program JsonField)> {
-    plan.fields
-        .iter()
-        .enumerate()
-        .find(|(_, field)| field.name == name || field.alias == Some(name))
+    let idx = plan.lookup.find(name)?;
+    let field = &plan.fields[idx];
+    Some((idx, field))
+}
+
+#[derive(Debug)]
+enum SeenFields {
+    Bits(u64),
+    Many(Vec<bool>),
+}
+
+impl SeenFields {
+    fn new(field_count: usize) -> Self {
+        if field_count <= u64::BITS as usize {
+            Self::Bits(0)
+        } else {
+            Self::Many(vec![false; field_count])
+        }
+    }
+
+    fn mark(&mut self, idx: usize) -> bool {
+        match self {
+            Self::Bits(bits) => {
+                let bit = 1_u64 << idx;
+                let was_seen = *bits & bit != 0;
+                *bits |= bit;
+                was_seen
+            }
+            Self::Many(seen) => {
+                let was_seen = seen[idx];
+                seen[idx] = true;
+                was_seen
+            }
+        }
+    }
 }
 
 fn lower_error(error: LowerError) -> DeserializeError {

--- a/facet-json/tests/integration/vm_deser.rs
+++ b/facet-json/tests/integration/vm_deser.rs
@@ -1,4 +1,5 @@
 use facet::Facet;
+use facet_format::DeserializeErrorKind;
 
 #[derive(Debug, Facet, PartialEq, Eq)]
 struct Person {
@@ -122,4 +123,16 @@ fn vm_skips_unknown_fields_when_the_type_allows_it() {
             age: 37
         }
     );
+}
+
+#[test]
+fn vm_rejects_duplicate_struct_fields() {
+    let json = r#"{"name":"Ada","name":"Lovelace","age":37}"#;
+
+    let err = facet_json::from_str_vm::<Person>(json).unwrap_err();
+
+    assert!(matches!(
+        err.kind,
+        DeserializeErrorKind::DuplicateField { ref field, .. } if field.as_ref() == "name"
+    ));
 }


### PR DESCRIPTION
## Summary
- Make normal `JsonVmPlan::{from_str, from_slice}` use a stats-free const-generic VM path while keeping `*_with_stats` instrumented.
- Lower accepted field-name metadata into `JsonStruct`, using linear lookup for small structs and sorted prefix buckets for larger structs.
- Track seen struct fields inline with a `u64` for up to 64 fields, allocating only for wider structs.
- Run bytecode programs linearly inside one VM frame and only suspend when entering child/container work.
- Use lowered `JsonScalar` policy at runtime instead of rediscovering scalar type/parse support from `Partial`.
- Keep `EnterShape` as debug validation metadata, but erase the shape check from release VM execution.

## Performance
Measured with `cargo bench -p facet-json --bench typeplan_reuse` on `origin/main` (`b3ba466ef`) and this PR (`f4d186338`). Default features only; values are medians from adjacent local runs.

| Benchmark | origin/main | PR | Impact | serde_json on PR | PR / serde_json |
| --- | ---: | ---: | ---: | ---: | ---: |
| `point_vm` | 536.1 ns | 505.0 ns | 5.8% faster | 29.72 ns | 17.0x slower |
| `point_reused_vm_plan` | 515.3 ns | 473.7 ns | 8.1% faster | 29.72 ns | 15.9x slower |
| `person_vm` | 3.540 us | 3.333 us | 5.8% faster | 171.6 ns | 19.4x slower |
| `person_reused_vm_plan` | 3.540 us | 3.332 us | 5.9% faster | 171.6 ns | 19.4x slower |
| `company_vm` | 4.999 us | 4.915 us | 1.7% faster | 541.7 ns | 9.1x slower |
| `company_reused_vm_plan` | 4.916 us | 4.874 us | 0.9% faster | 541.7 ns | 9.0x slower |
| `batch_1000_vm` | 3.587 ms | 3.398 ms | 5.3% faster | 191.0 us | 17.8x slower |
| `batch_1000_reused_vm_plan` | 3.656 ms | 3.345 ms | 8.5% faster | 191.0 us | 17.5x slower |

Read: this moves the VM interpreter overhead in the right direction, but serde_json still shows the real target: the remaining gap is mostly parser/event/reflect setter overhead, not plan construction. `stacker` is only used for stack assertions, not throughput comparison.

## Testing
- `cargo check -p facet-json`
- `cargo nextest run -p facet-json` (391 passed)
- `cargo clippy -p facet-json --all-features --all-targets --message-format=short -- -D warnings`
- `cargo nextest run -p facet-json --features stacker -E 'test(vm)'` (6 passed; stack measurement assertions only)\n- `cargo bench -p facet-json --bench typeplan_reuse` on `origin/main` and this PR\n