### PR TITLE
Speed up facet-json VM parsing

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -54,6 +54,33 @@ pub enum TokenKind<'de> {
     Eof,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum JsonValueStart<'de> {
+    Object(Span),
+    Array(Span),
+    Scalar(ScalarValue<'de>, Span),
+}
+
+impl JsonValueStart<'_> {
+    pub(crate) fn span(&self) -> Span {
+        match self {
+            Self::Object(span) | Self::Array(span) | Self::Scalar(_, span) => *span,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum JsonObjectStep<'de> {
+    End(Span),
+    Key { name: Cow<'de, str>, span: Span },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum JsonArrayStep<'de> {
+    End(Span),
+    Value(JsonValueStart<'de>),
+}
+
 /// Mutable parser state that can be saved and restored.
 #[derive(Clone)]
 struct ParserState<'de> {
@@ -275,6 +302,20 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         &mut self,
         first: Option<MaterializedToken<'de>>,
     ) -> Result<ParseEvent<'de>, ParseError> {
+        let value = self.parse_direct_value_start_with_token(first)?;
+        let span = value.span();
+        let kind = match value {
+            JsonValueStart::Object(_) => ParseEventKind::StructStart(ContainerKind::Object),
+            JsonValueStart::Array(_) => ParseEventKind::SequenceStart(ContainerKind::Array),
+            JsonValueStart::Scalar(scalar, _) => ParseEventKind::Scalar(scalar),
+        };
+        Ok(ParseEvent::new(kind, span))
+    }
+
+    fn parse_direct_value_start_with_token(
+        &mut self,
+        first: Option<MaterializedToken<'de>>,
+    ) -> Result<JsonValueStart<'de>, ParseError> {
         let token = match first {
             Some(tok) => tok,
             None => self.consume_token()?,
@@ -288,80 +329,55 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                 self.state
                     .stack
                     .push(ContextState::Object(ObjectState::KeyOrEnd));
-                Ok(ParseEvent::new(
-                    ParseEventKind::StructStart(ContainerKind::Object),
-                    span,
-                ))
+                Ok(JsonValueStart::Object(span))
             }
             TokenKind::ArrayStart => {
                 self.state
                     .stack
                     .push(ContextState::Array(ArrayState::ValueOrEnd));
-                Ok(ParseEvent::new(
-                    ParseEventKind::SequenceStart(ContainerKind::Array),
-                    span,
-                ))
+                Ok(JsonValueStart::Array(span))
             }
             TokenKind::String(s) => {
-                let event = ParseEvent::new(ParseEventKind::Scalar(ScalarValue::Str(s)), span);
                 self.finish_value_in_parent();
-                Ok(event)
+                Ok(JsonValueStart::Scalar(ScalarValue::Str(s), span))
             }
             TokenKind::True => {
                 self.finish_value_in_parent();
-                Ok(ParseEvent::new(
-                    ParseEventKind::Scalar(ScalarValue::Bool(true)),
-                    span,
-                ))
+                Ok(JsonValueStart::Scalar(ScalarValue::Bool(true), span))
             }
             TokenKind::False => {
                 self.finish_value_in_parent();
-                Ok(ParseEvent::new(
-                    ParseEventKind::Scalar(ScalarValue::Bool(false)),
-                    span,
-                ))
+                Ok(JsonValueStart::Scalar(ScalarValue::Bool(false), span))
             }
             TokenKind::Null => {
                 self.finish_value_in_parent();
-                Ok(ParseEvent::new(
-                    ParseEventKind::Scalar(ScalarValue::Null),
-                    span,
-                ))
+                Ok(JsonValueStart::Scalar(ScalarValue::Null, span))
             }
             TokenKind::U64(n) => {
                 self.finish_value_in_parent();
-                Ok(ParseEvent::new(
-                    ParseEventKind::Scalar(ScalarValue::U64(n)),
-                    span,
-                ))
+                Ok(JsonValueStart::Scalar(ScalarValue::U64(n), span))
             }
             TokenKind::I64(n) => {
                 self.finish_value_in_parent();
-                Ok(ParseEvent::new(
-                    ParseEventKind::Scalar(ScalarValue::I64(n)),
-                    span,
-                ))
+                Ok(JsonValueStart::Scalar(ScalarValue::I64(n), span))
             }
             TokenKind::U128(n) => {
                 self.finish_value_in_parent();
-                Ok(ParseEvent::new(
-                    ParseEventKind::Scalar(ScalarValue::Str(Cow::Owned(n.to_string()))),
+                Ok(JsonValueStart::Scalar(
+                    ScalarValue::Str(Cow::Owned(n.to_string())),
                     span,
                 ))
             }
             TokenKind::I128(n) => {
                 self.finish_value_in_parent();
-                Ok(ParseEvent::new(
-                    ParseEventKind::Scalar(ScalarValue::Str(Cow::Owned(n.to_string()))),
+                Ok(JsonValueStart::Scalar(
+                    ScalarValue::Str(Cow::Owned(n.to_string())),
                     span,
                 ))
             }
             TokenKind::F64(n) => {
                 self.finish_value_in_parent();
-                Ok(ParseEvent::new(
-                    ParseEventKind::Scalar(ScalarValue::F64(n)),
-                    span,
-                ))
+                Ok(JsonValueStart::Scalar(ScalarValue::F64(n), span))
             }
             TokenKind::ObjectEnd | TokenKind::ArrayEnd => Err(self.unexpected(&token, "value")),
             TokenKind::Comma | TokenKind::Colon => Err(self.unexpected(&token, "value")),
@@ -644,6 +660,213 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     /// Get current position in input.
     fn current_offset(&self) -> usize {
         self.state.scanner_pos
+    }
+
+    pub(crate) fn next_value_start(&mut self) -> Result<Option<JsonValueStart<'de>>, ParseError> {
+        if let Some(event) = self.state.event_peek.take() {
+            self.state.peek_start_offset = None;
+            return match event.kind {
+                ParseEventKind::StructStart(_) => Ok(Some(JsonValueStart::Object(event.span))),
+                ParseEventKind::SequenceStart(_) => Ok(Some(JsonValueStart::Array(event.span))),
+                ParseEventKind::Scalar(scalar) => {
+                    Ok(Some(JsonValueStart::Scalar(scalar, event.span)))
+                }
+                _ => Err(ParseError::new(
+                    event.span,
+                    DeserializeErrorKind::UnexpectedToken {
+                        got: event.kind.kind_name().into(),
+                        expected: "value",
+                    },
+                )),
+            };
+        }
+
+        match self.determine_action() {
+            NextAction::ObjectValue | NextAction::RootValue => {
+                self.parse_direct_value_start_with_token(None).map(Some)
+            }
+            NextAction::RootFinished => Ok(None),
+            _ => self
+                .produce_event()?
+                .map_or(Ok(None), |event| match event.kind {
+                    ParseEventKind::StructStart(_) => Ok(Some(JsonValueStart::Object(event.span))),
+                    ParseEventKind::SequenceStart(_) => Ok(Some(JsonValueStart::Array(event.span))),
+                    ParseEventKind::Scalar(scalar) => {
+                        Ok(Some(JsonValueStart::Scalar(scalar, event.span)))
+                    }
+                    _ => Err(ParseError::new(
+                        event.span,
+                        DeserializeErrorKind::UnexpectedToken {
+                            got: event.kind.kind_name().into(),
+                            expected: "value",
+                        },
+                    )),
+                }),
+        }
+    }
+
+    pub(crate) fn next_object_key_or_end(&mut self) -> Result<JsonObjectStep<'de>, ParseError> {
+        loop {
+            match self.determine_action() {
+                NextAction::ObjectKey => {
+                    let token = self.consume_token()?;
+                    let span = token.span;
+                    match token.kind {
+                        TokenKind::ObjectEnd => {
+                            self.state.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(JsonObjectStep::End(span));
+                        }
+                        TokenKind::String(name) => {
+                            self.expect_colon()?;
+                            if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                                *state = ObjectState::Value;
+                            }
+                            return Ok(JsonObjectStep::Key { name, span });
+                        }
+                        TokenKind::Eof => {
+                            return Err(ParseError::new(
+                                span,
+                                DeserializeErrorKind::UnexpectedEof {
+                                    expected: "field name or '}'",
+                                },
+                            ));
+                        }
+                        _ => return Err(self.unexpected(&token, "field name or '}'")),
+                    }
+                }
+                NextAction::ObjectComma => {
+                    let token = self.consume_token()?;
+                    let span = token.span;
+                    match token.kind {
+                        TokenKind::Comma => {
+                            if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                                *state = ObjectState::KeyOrEnd;
+                            }
+                        }
+                        TokenKind::ObjectEnd => {
+                            self.state.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(JsonObjectStep::End(span));
+                        }
+                        TokenKind::Eof => {
+                            return Err(ParseError::new(
+                                span,
+                                DeserializeErrorKind::UnexpectedEof {
+                                    expected: "',' or '}'",
+                                },
+                            ));
+                        }
+                        _ => return Err(self.unexpected(&token, "',' or '}'")),
+                    }
+                }
+                _ => {
+                    return self.produce_event()?.map_or_else(
+                        || {
+                            Err(ParseError::new(
+                                Span::new(self.current_offset(), 0),
+                                DeserializeErrorKind::UnexpectedEof {
+                                    expected: "field key or object end",
+                                },
+                            ))
+                        },
+                        |event| match event.kind {
+                            ParseEventKind::StructEnd => Ok(JsonObjectStep::End(event.span)),
+                            ParseEventKind::FieldKey(key) => {
+                                let Some(name) = key.name() else {
+                                    return Err(ParseError::new(
+                                        event.span,
+                                        DeserializeErrorKind::UnexpectedToken {
+                                            got: "ordered field".into(),
+                                            expected: "named field key",
+                                        },
+                                    ));
+                                };
+                                Ok(JsonObjectStep::Key {
+                                    name: name.clone(),
+                                    span: event.span,
+                                })
+                            }
+                            _ => Err(ParseError::new(
+                                event.span,
+                                DeserializeErrorKind::UnexpectedToken {
+                                    got: event.kind.kind_name().into(),
+                                    expected: "field key or object end",
+                                },
+                            )),
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    pub(crate) fn next_array_value_or_end(&mut self) -> Result<JsonArrayStep<'de>, ParseError> {
+        loop {
+            match self.determine_action() {
+                NextAction::ArrayValue => {
+                    let token = self.consume_token()?;
+                    let span = token.span;
+                    match token.kind {
+                        TokenKind::ArrayEnd => {
+                            self.state.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(JsonArrayStep::End(span));
+                        }
+                        TokenKind::Eof => {
+                            return Err(ParseError::new(
+                                span,
+                                DeserializeErrorKind::UnexpectedEof {
+                                    expected: "value or ']'",
+                                },
+                            ));
+                        }
+                        TokenKind::Comma | TokenKind::Colon => {
+                            return Err(self.unexpected(&token, "value or ']'"));
+                        }
+                        _ => {
+                            return self
+                                .parse_direct_value_start_with_token(Some(token))
+                                .map(JsonArrayStep::Value);
+                        }
+                    }
+                }
+                NextAction::ArrayComma => {
+                    let token = self.consume_token()?;
+                    let span = token.span;
+                    match token.kind {
+                        TokenKind::Comma => {
+                            if let Some(ContextState::Array(state)) = self.state.stack.last_mut() {
+                                *state = ArrayState::ValueOrEnd;
+                            }
+                        }
+                        TokenKind::ArrayEnd => {
+                            self.state.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(JsonArrayStep::End(span));
+                        }
+                        TokenKind::Eof => {
+                            return Err(ParseError::new(
+                                span,
+                                DeserializeErrorKind::UnexpectedEof {
+                                    expected: "',' or ']'",
+                                },
+                            ));
+                        }
+                        _ => return Err(self.unexpected(&token, "',' or ']'")),
+                    }
+                }
+                _ => {
+                    return Err(ParseError::new(
+                        Span::new(self.current_offset(), 0),
+                        DeserializeErrorKind::UnexpectedToken {
+                            got: "non-array parser state".into(),
+                            expected: "array element or array end",
+                        },
+                    ));
+                }
+            }
+        }
     }
 }
 

--- a/facet-json/src/vm.rs
+++ b/facet-json/src/vm.rs
@@ -8,10 +8,7 @@ use std::{
 };
 
 use facet_core::{Facet, ScalarType, Shape};
-use facet_format::{
-    ContainerKind, DeserializeError, DeserializeErrorKind, FormatParser, ParseEvent,
-    ParseEventKind, ScalarValue, SpanGuard,
-};
+use facet_format::{DeserializeError, DeserializeErrorKind, FormatParser, ScalarValue, SpanGuard};
 use facet_reflect::{
     HeapValue, Partial, ReflectError, ReflectErrorKind, Span, TypePlan, TypePlanCore,
 };
@@ -23,6 +20,7 @@ use crate::{
         JsonScalar, JsonString, JsonStringRole, JsonStruct, LowerError, UnknownFields,
         lower_type_plan,
     },
+    parser::{JsonArrayStep, JsonObjectStep, JsonValueStart},
 };
 
 /// Runtime counters from the experimental JSON VM path.
@@ -242,6 +240,7 @@ where
 struct JsonVm<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: bool> {
     parser: &'parser mut JsonParser<'input, TRUSTED_UTF8>,
     lowered: &'program JsonLowered,
+    pending_value: Option<JsonValueStart<'input>>,
     last_span: Span,
     stats: JsonVmStats,
 }
@@ -256,6 +255,7 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
         Self {
             parser,
             lowered,
+            pending_value: None,
             last_span: Span::new(0, 0),
             stats: JsonVmStats::default(),
         }
@@ -334,17 +334,14 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
                 self.check_enter_shape(&partial, shape)?;
             }
             JsonOp::Null => {
-                let event = self.next_event("null")?;
-                let ParseEventKind::Scalar(ScalarValue::Null) = event.kind else {
-                    return Err(self.unexpected_event(&event, "null"));
+                let value = self.next_value_start("null")?;
+                let JsonValueStart::Scalar(ScalarValue::Null, _) = value else {
+                    return Err(self.unexpected_value(&value, "null"));
                 };
                 partial = self.set_default(partial)?;
             }
             JsonOp::Scalar(policy) => {
-                let event = self.next_event("scalar")?;
-                let ParseEventKind::Scalar(scalar) = event.kind else {
-                    return Err(self.unexpected_event(&event, "scalar"));
-                };
+                let scalar = self.next_scalar("scalar")?;
                 partial = self.set_scalar(partial, scalar, *policy)?;
             }
             JsonOp::String(policy) => {
@@ -358,18 +355,13 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
             }
             JsonOp::RawJson => return Err(self.unsupported("VM raw JSON capture")),
             JsonOp::Struct(plan) => {
-                let event = self.next_event("object")?;
-                match event.kind {
-                    ParseEventKind::StructStart(ContainerKind::Object) => {
-                        push_continuation(frames, continuation);
-                        frames.push(VmFrame::Struct {
-                            plan,
-                            seen: SeenFields::new(plan.fields.len()),
-                        });
-                        return Ok((partial, ProgramControl::Suspend));
-                    }
-                    _ => return Err(self.unexpected_event(&event, "object")),
-                }
+                self.expect_object_start("object")?;
+                push_continuation(frames, continuation);
+                frames.push(VmFrame::Struct {
+                    plan,
+                    seen: SeenFields::new(plan.fields.len()),
+                });
+                return Ok((partial, ProgramControl::Suspend));
             }
             JsonOp::Tuple { .. } => return Err(self.unsupported("VM tuple deserialization")),
             JsonOp::List {
@@ -379,28 +371,23 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
                 if *byte_optimized {
                     return Err(self.unsupported("VM byte-optimized list deserialization"));
                 }
-                let event = self.next_event("array")?;
-                match event.kind {
-                    ParseEventKind::SequenceStart(ContainerKind::Array) => {
-                        partial = self.init_list(partial)?;
-                        push_continuation(frames, continuation);
-                        frames.push(VmFrame::List { element });
-                        return Ok((partial, ProgramControl::Suspend));
-                    }
-                    _ => return Err(self.unexpected_event(&event, "array")),
-                }
+                self.expect_array_start("array")?;
+                partial = self.init_list(partial)?;
+                push_continuation(frames, continuation);
+                frames.push(VmFrame::List { element });
+                return Ok((partial, ProgramControl::Suspend));
             }
             JsonOp::Array { .. } => return Err(self.unsupported("VM array deserialization")),
             JsonOp::Map { .. } => return Err(self.unsupported("VM map deserialization")),
             JsonOp::Set { .. } => return Err(self.unsupported("VM set deserialization")),
             JsonOp::Option { some } => {
-                let event = self.peek_event("option value")?;
-                match event.kind {
-                    ParseEventKind::Scalar(ScalarValue::Null) => {
-                        let _ = self.next_event("null")?;
+                let value = self.next_value_start("option value")?;
+                match value {
+                    JsonValueStart::Scalar(ScalarValue::Null, _) => {
                         partial = self.set_default(partial)?;
                     }
-                    _ => {
+                    value => {
+                        self.pending_value = Some(value);
                         partial = self.begin_some(partial)?;
                         push_continuation(frames, continuation);
                         frames.push(VmFrame::EndCurrent);
@@ -458,13 +445,13 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
         plan: &'program JsonStruct,
         mut seen: SeenFields,
     ) -> Result<Partial<'input, false>, DeserializeError> {
-        let event = self.next_event("field key or object end")?;
-        match event.kind {
-            ParseEventKind::StructEnd => Ok(partial),
-            ParseEventKind::FieldKey(ref key) => {
-                let Some(name) = key.name() else {
-                    return Err(self.unexpected_event(&event, "named field key"));
-                };
+        let step = self.parser.next_object_key_or_end()?;
+        self.last_span = match &step {
+            JsonObjectStep::End(span) | JsonObjectStep::Key { span, .. } => *span,
+        };
+        match step {
+            JsonObjectStep::End(_) => Ok(partial),
+            JsonObjectStep::Key { name, .. } => {
                 let Some((idx, field)) = find_field(plan, name.as_ref()) else {
                     return self.handle_unknown_field(partial, frames, plan, seen, name.as_ref());
                 };
@@ -481,9 +468,16 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
                         field: Cow::Owned(name.to_string()),
                         first_span: None,
                     }
-                    .with_span(event.span));
+                    .with_span(self.last_span));
                 }
                 partial = self.begin_nth_field(partial, idx)?;
+                if can_inline_field_program(&field.value) {
+                    partial = self.run_program(partial, frames, &field.value, 0)?;
+                    self.record_step(frames.len() + 1, partial.frame_count());
+                    partial = self.end(partial)?;
+                    frames.push(VmFrame::Struct { plan, seen });
+                    return Ok(partial);
+                }
                 frames.push(VmFrame::Struct { plan, seen });
                 frames.push(VmFrame::EndCurrent);
                 frames.push(VmFrame::Program {
@@ -492,7 +486,6 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
                 });
                 Ok(partial)
             }
-            _ => Err(self.unexpected_event(&event, "field key or object end")),
         }
     }
 
@@ -525,13 +518,15 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
         frames: &mut Vec<VmFrame<'program>>,
         element: &'program JsonProgram,
     ) -> Result<Partial<'input, false>, DeserializeError> {
-        let event = self.peek_event("array element or array end")?;
-        match event.kind {
-            ParseEventKind::SequenceEnd => {
-                let _ = self.next_event("array end")?;
+        let step = self.parser.next_array_value_or_end()?;
+        match step {
+            JsonArrayStep::End(span) => {
+                self.last_span = span;
                 Ok(partial)
             }
-            _ => {
+            JsonArrayStep::Value(value) => {
+                self.last_span = value.span();
+                self.pending_value = Some(value);
                 partial = self.begin_list_item(partial)?;
                 frames.push(VmFrame::List { element });
                 frames.push(VmFrame::EndCurrent);
@@ -584,9 +579,9 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
         if policy.role != JsonStringRole::Value {
             return Err(self.unsupported("VM non-value string deserialization"));
         }
-        let event = self.next_event("string")?;
-        let ParseEventKind::Scalar(ScalarValue::Str(s)) = event.kind else {
-            return Err(self.unexpected_event(&event, "string"));
+        let value = self.next_value_start("string")?;
+        let JsonValueStart::Scalar(ScalarValue::Str(s), _) = value else {
+            return Err(self.unexpected_value(&value, "string"));
         };
         self.set_string(partial, s)
     }
@@ -687,29 +682,45 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
         Ok(())
     }
 
-    fn next_event(
+    fn next_value_start(
         &mut self,
         expected: &'static str,
-    ) -> Result<ParseEvent<'input>, DeserializeError> {
-        match self.parser.next_event()? {
-            Some(event) => {
-                self.last_span = event.span;
-                Ok(event)
+    ) -> Result<JsonValueStart<'input>, DeserializeError> {
+        if let Some(value) = self.pending_value.take() {
+            self.last_span = value.span();
+            return Ok(value);
+        }
+
+        match self.parser.next_value_start()? {
+            Some(value) => {
+                self.last_span = value.span();
+                Ok(value)
             }
             None => Err(DeserializeErrorKind::UnexpectedEof { expected }.with_span(self.last_span)),
         }
     }
 
-    fn peek_event(
+    fn next_scalar(
         &mut self,
         expected: &'static str,
-    ) -> Result<ParseEvent<'input>, DeserializeError> {
-        match self.parser.peek_event()? {
-            Some(event) => {
-                self.last_span = event.span;
-                Ok(event)
-            }
-            None => Err(DeserializeErrorKind::UnexpectedEof { expected }.with_span(self.last_span)),
+    ) -> Result<ScalarValue<'input>, DeserializeError> {
+        match self.next_value_start(expected)? {
+            JsonValueStart::Scalar(scalar, _) => Ok(scalar),
+            value => Err(self.unexpected_value(&value, expected)),
+        }
+    }
+
+    fn expect_object_start(&mut self, expected: &'static str) -> Result<(), DeserializeError> {
+        match self.next_value_start(expected)? {
+            JsonValueStart::Object(_) => Ok(()),
+            value => Err(self.unexpected_value(&value, expected)),
+        }
+    }
+
+    fn expect_array_start(&mut self, expected: &'static str) -> Result<(), DeserializeError> {
+        match self.next_value_start(expected)? {
+            JsonValueStart::Array(_) => Ok(()),
+            value => Err(self.unexpected_value(&value, expected)),
         }
     }
 
@@ -837,12 +848,21 @@ impl<'parser, 'input, 'program, const TRUSTED_UTF8: bool, const COLLECT_STATS: b
         }
     }
 
-    fn unexpected_event(&self, event: &ParseEvent<'_>, expected: &'static str) -> DeserializeError {
+    fn unexpected_value(
+        &self,
+        value: &JsonValueStart<'_>,
+        expected: &'static str,
+    ) -> DeserializeError {
+        let got = match value {
+            JsonValueStart::Object(_) => "object",
+            JsonValueStart::Array(_) => "array",
+            JsonValueStart::Scalar(scalar, _) => scalar.kind_name(),
+        };
         DeserializeErrorKind::UnexpectedToken {
-            got: Cow::Borrowed(event.kind.kind_name()),
+            got: Cow::Borrowed(got),
             expected,
         }
-        .with_span(event.span)
+        .with_span(value.span())
     }
 
     fn unsupported(&self, message: &'static str) -> DeserializeError {
@@ -899,6 +919,15 @@ fn push_continuation<'program>(
     if let Some((program, pc)) = continuation {
         frames.push(VmFrame::Program { program, pc });
     }
+}
+
+fn can_inline_field_program(program: &JsonProgram) -> bool {
+    program.iter().all(|op| {
+        matches!(
+            op,
+            JsonOp::EnterShape { .. } | JsonOp::Null | JsonOp::Scalar(_) | JsonOp::String(_)
+        )
+    })
 }
 
 fn find_field<'program>(


### PR DESCRIPTION
## Summary
- Adds crate-local direct JSON parser stepping APIs for the VM so object starts, field keys, array values, and scalar value starts avoid the generic `ParseEvent`/`FieldKey` path.
- Carries one pre-consumed JSON value through the VM for array elements and non-null options.
- Inlines simple scalar/string/null struct field bodies so ordinary fields avoid a child program frame plus `EndCurrent` frame.

## Performance
Fresh baseline: `origin/main` at `6ae5313f6` in `/tmp/facet-vm-baseline-JMpGAK`.
Current branch: `4cf689fad`.
Command: `cargo bench -p facet-json --bench typeplan_reuse`.

| Benchmark | main VM | PR VM | Delta | main reused VM plan | PR reused VM plan | Delta | serde_json | PR reused / serde |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `point` | 499.7 ns | 489.3 ns | 2.1% faster | 473.7 ns | 429.4 ns | 9.4% faster | 27.41 ns | 15.7x slower |
| `person` | 3.332 us | 3.207 us | 3.8% faster | 3.312 us | 3.124 us | 5.7% faster | 176.8 ns | 17.7x slower |
| `company` | 4.749 us | 4.291 us | 9.6% faster | 4.708 us | 4.437 us | 5.8% faster | 583.7 ns | 7.6x slower |
| `batch_1000` | 3.360 ms | 3.197 ms | 4.9% faster | 3.353 ms | 3.165 ms | 5.6% faster | 187.1 us | 16.9x slower |

## Testing
- `cargo check -p facet-json`
- `cargo nextest list -p facet-json -E "test(vm) | test(prefix_field_lookup)"`
- `cargo nextest run -p facet-json -E "test(vm) | test(prefix_field_lookup)"`
- `cargo nextest run -p facet-json`
- `cargo clippy -p facet-json --all-features --all-targets --message-format=short -- -D warnings`
- `cargo nextest run -p facet-json --features stacker -E "test(vm)"`
- `cargo bench -p facet-json --bench typeplan_reuse` on main and branch
