### PR TITLE
Share typed-memory runtime guards in Weavy

### DIFF
--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -19,6 +19,7 @@ use facet_format::{
     ParseEventKind, ScalarValue,
 };
 use facet_reflect::Span;
+use weavy::mem::runtime::{HandleGuard, InitializedLedger, RawScratch};
 use weavy::{Control, Lowered, Program, RunError, RunStats, Step};
 
 use crate::JsonParser;
@@ -375,7 +376,7 @@ struct JsonInterp<'parser, 'de, 'program, const TRUSTED_UTF8: bool> {
     parser: &'parser mut JsonParser<'de, TRUSTED_UTF8>,
     base: PtrUninit,
     structs: Vec<StructFrame<'program>>,
-    lists: Vec<ListFrame>,
+    lists: Vec<HandleGuard>,
     success: bool,
 }
 
@@ -413,11 +414,7 @@ impl<const TRUSTED_UTF8: bool> Drop for JsonInterp<'_, '_, '_, TRUSTED_UTF8> {
             return;
         }
 
-        while let Some(list) = self.lists.pop() {
-            unsafe {
-                let _ = list.shape.call_drop_in_place(list.ptr);
-            }
-        }
+        while self.lists.pop().is_some() {}
 
         while self.structs.pop().is_some() {}
     }
@@ -510,7 +507,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                             .structs
                             .last()
                             .expect("struct frame is present while decoding fields");
-                        if let Some(first_span) = frame.seen[index] {
+                        if let Some(first_span) = frame.seen.get(index).copied() {
                             return Err(vm_error(
                                 Some(event.span),
                                 DeserializeErrorKind::DuplicateField {
@@ -559,9 +556,9 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                     _ => {}
                 }
 
-                let scratch = Scratch::alloc(option.t(), *inner_layout)?;
+                let scratch = Scratch::alloc(option.t(), *inner_layout);
                 let old_base = self.base;
-                self.base = scratch.ptr;
+                self.base = scratch.ptr_uninit();
                 Ok(Control::CallProgramThen(
                     some_program,
                     Continuation::OptionSome {
@@ -594,10 +591,11 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                     .init_in_place_with_capacity()
                     .ok_or_else(|| unsupported(list_shape, "list initialization"))?;
                 let list_ptr = unsafe { init(self.base, 0) };
-                self.lists.push(ListFrame {
-                    shape: list_shape,
-                    ptr: list_ptr,
-                });
+                self.lists.push(HandleGuard::new(
+                    list_ptr.as_mut_byte_ptr(),
+                    *list_shape as *const Shape as *const (),
+                    drop_shape_value,
+                ));
                 Ok(Control::CallBlockThen(*loop_id, Continuation::FinishList))
             }
             JsonOp::ListNext {
@@ -614,9 +612,9 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                     _ => {}
                 }
 
-                let scratch = Scratch::alloc(list.t(), *element_layout)?;
+                let scratch = Scratch::alloc(list.t(), *element_layout);
                 let old_base = self.base;
-                self.base = scratch.ptr;
+                self.base = scratch.ptr_uninit();
                 Ok(Control::CallProgramThen(
                     element_program,
                     Continuation::ListElement {
@@ -635,9 +633,9 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                 let pointee = pointer
                     .pointee()
                     .ok_or_else(|| unsupported_shape_message("opaque pointer"))?;
-                let scratch = Scratch::alloc(pointee, *pointee_layout)?;
+                let scratch = Scratch::alloc(pointee, *pointee_layout);
                 let old_base = self.base;
-                self.base = scratch.ptr;
+                self.base = scratch.ptr_uninit();
                 Ok(Control::CallProgramThen(
                     pointee_program,
                     Continuation::Pointer {
@@ -676,7 +674,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                     .structs
                     .last_mut()
                     .expect("struct frame is present after field program");
-                frame.seen[index] = Some(span);
+                frame.seen.mark(index, span);
                 self.base = old_base;
                 Ok(Control::CallBlock(loop_id))
             }
@@ -694,7 +692,11 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                 Ok(Control::Continue)
             }
             Continuation::FinishList => {
-                self.lists.pop();
+                let mut list = self
+                    .lists
+                    .pop()
+                    .expect("list frame is present after list program");
+                list.disarm();
                 Ok(Control::Continue)
             }
             Continuation::ListElement {
@@ -707,12 +709,12 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                     .lists
                     .last()
                     .expect("list frame is present after element program")
-                    .ptr;
+                    .ptr();
                 let push = list
                     .push()
                     .ok_or_else(|| unsupported(list.t(), "list push"))?;
                 unsafe {
-                    push(list_ptr, scratch.ptr_mut());
+                    push(PtrMut::new(list_ptr), scratch.ptr_mut());
                 }
                 scratch.dealloc_uninit();
                 self.base = old_base;
@@ -772,7 +774,7 @@ struct StructFrame<'program> {
     shape: &'static Shape,
     base: PtrUninit,
     fields: &'program [FieldPlan],
-    seen: Vec<Option<Span>>,
+    seen: InitializedLedger<Span>,
 }
 
 impl<'program> StructFrame<'program> {
@@ -781,13 +783,13 @@ impl<'program> StructFrame<'program> {
             shape,
             base,
             fields,
-            seen: vec![None; fields.len()],
+            seen: InitializedLedger::new(fields.len()),
         }
     }
 
     unsafe fn fill_missing_fields(mut self) -> Result<(), DeserializeError> {
         for (index, field) in self.fields.iter().enumerate() {
-            if self.seen[index].is_some() {
+            if self.seen.is_initialized(index) {
                 continue;
             }
 
@@ -806,11 +808,11 @@ impl<'program> StructFrame<'program> {
                     unsafe {
                         default(field_ptr);
                     }
-                    self.seen[index] = Some(Span { offset: 0, len: 0 });
+                    self.seen.mark(index, Span { offset: 0, len: 0 });
                 }
                 MissingField::DefaultTrait { explicit } => {
                     if unsafe { field.shape.call_default_in_place(field_ptr) }.is_some() {
-                        self.seen[index] = Some(Span { offset: 0, len: 0 });
+                        self.seen.mark(index, Span { offset: 0, len: 0 });
                     } else if explicit {
                         return Err(vm_error(
                             None,
@@ -836,7 +838,7 @@ impl<'program> StructFrame<'program> {
                     unsafe {
                         (option.vtable.init_none)(field_ptr);
                     }
-                    self.seen[index] = Some(Span { offset: 0, len: 0 });
+                    self.seen.mark(index, Span { offset: 0, len: 0 });
                 }
             }
         }
@@ -845,10 +847,8 @@ impl<'program> StructFrame<'program> {
     }
 
     unsafe fn drop_initialized_fields(&self) {
-        for (index, field) in self.fields.iter().enumerate().rev() {
-            if self.seen[index].is_none() {
-                continue;
-            }
+        for (index, _) in self.seen.iter_initialized_rev() {
+            let field = &self.fields[index];
             let ptr = unsafe { self.base.field_init(field.offset) };
             unsafe {
                 let _ = field.shape.call_drop_in_place(ptr);
@@ -865,58 +865,34 @@ impl Drop for StructFrame<'_> {
     }
 }
 
-#[derive(Clone, Copy)]
-struct ListFrame {
-    shape: &'static Shape,
-    ptr: PtrMut,
+unsafe fn drop_shape_value(ctx: *const (), ptr: *mut u8) {
+    let shape = unsafe { &*(ctx as *const Shape) };
+    unsafe {
+        let _ = shape.call_drop_in_place(PtrMut::new(ptr));
+    }
 }
 
 struct Scratch {
-    shape: &'static Shape,
-    ptr: PtrUninit,
-    active: bool,
+    raw: RawScratch,
 }
 
 impl Scratch {
-    fn alloc(shape: &'static Shape, layout: Layout) -> Result<Self, DeserializeError> {
-        let ptr = if layout.size() == 0 {
-            core::ptr::null_mut::<u8>().wrapping_add(layout.align())
-        } else {
-            let ptr = unsafe { alloc::alloc::alloc(layout) };
-            if ptr.is_null() {
-                alloc::alloc::handle_alloc_error(layout);
-            }
-            ptr
-        };
-        Ok(Self {
-            shape,
-            ptr: PtrUninit::new(ptr),
-            active: true,
-        })
+    fn alloc(_shape: &'static Shape, layout: Layout) -> Self {
+        Self {
+            raw: RawScratch::from_layout(layout),
+        }
+    }
+
+    fn ptr_uninit(&self) -> PtrUninit {
+        PtrUninit::new(self.raw.ptr())
     }
 
     unsafe fn ptr_mut(&self) -> PtrMut {
-        unsafe { self.ptr.assume_init() }
+        unsafe { self.ptr_uninit().assume_init() }
     }
 
     fn dealloc_uninit(&mut self) {
-        if !self.active {
-            return;
-        }
-        unsafe {
-            let _ = self.shape.deallocate_uninit(self.ptr);
-        }
-        self.active = false;
-    }
-}
-
-impl Drop for Scratch {
-    fn drop(&mut self) {
-        if self.active {
-            unsafe {
-                let _ = self.shape.deallocate_uninit(self.ptr);
-            }
-        }
+        self.raw.dealloc_uninit();
     }
 }
 

--- a/phon/rust/phon-engine/src/typed.rs
+++ b/phon/rust/phon-engine/src/typed.rs
@@ -41,6 +41,7 @@ use phon_schema::{
     DecodeError, Field, Primitive, SchemaId, SchemaKind, SchemaRef, Value, Variant, VariantPayload,
     read_value, write_value,
 };
+use weavy::mem::runtime::{InitTarget, RawAllocError, RawArrayBuffer, RawScratch};
 use weavy::{Control, RunError, RunStats, Step};
 
 use crate::compact::{self, CompactError, Registry, Resolved, alignment, pad_to, skip_pad};
@@ -1880,74 +1881,6 @@ struct DecodeInterp<'bytes> {
     base: *mut u8,
 }
 
-struct Scratch {
-    ptr: *mut u8,
-    layout: Option<alloc::Layout>,
-}
-
-impl Scratch {
-    fn new(size: usize, align: usize) -> Result<Self> {
-        let (ptr, layout) = alloc_scratch(size, align)?;
-        Ok(Self { ptr, layout })
-    }
-}
-
-impl Drop for Scratch {
-    fn drop(&mut self) {
-        free_scratch(self.ptr, self.layout);
-        self.layout = None;
-    }
-}
-
-struct SequenceBuffer {
-    ptr: *mut u8,
-    cap: usize,
-    stride: usize,
-    layout: Option<alloc::Layout>,
-}
-
-impl SequenceBuffer {
-    fn new(count: usize, stride: usize, elem_align: usize) -> Result<Self> {
-        if count == 0 || stride == 0 {
-            Ok(Self {
-                ptr: elem_align as *mut u8,
-                cap: count,
-                stride,
-                layout: None,
-            })
-        } else {
-            let layout =
-                alloc::Layout::from_size_align(count * stride, elem_align).map_err(|_| {
-                    CompactError::Decode(DecodeError::Malformed("sequence layout overflow"))
-                })?;
-            // Safety: layout has non-zero size (count > 0 and stride > 0).
-            let ptr = unsafe { alloc::alloc(layout) };
-            if ptr.is_null() {
-                alloc::handle_alloc_error(layout);
-            }
-            Ok(Self {
-                ptr,
-                cap: count,
-                stride,
-                layout: Some(layout),
-            })
-        }
-    }
-
-    fn adopt(&mut self) {
-        self.layout = None;
-    }
-}
-
-impl Drop for SequenceBuffer {
-    fn drop(&mut self) {
-        if let Some(layout) = self.layout.take() {
-            // Safety: `ptr` was allocated with this layout and has not been adopted.
-            unsafe { alloc::dealloc(self.ptr, layout) };
-        }
-    }
-}
-
 enum DecodeContinuation<'program> {
     RestoreBase {
         previous_base: *mut u8,
@@ -1955,7 +1888,7 @@ enum DecodeContinuation<'program> {
     Sequence {
         previous_base: *mut u8,
         element: &'program MemProgram,
-        buffer: SequenceBuffer,
+        buffer: RawArrayBuffer,
         next_index: usize,
         count: usize,
         list: *mut u8,
@@ -1966,7 +1899,7 @@ enum DecodeContinuation<'program> {
         set: &'program SetOp,
         set_ptr: *mut u8,
         remaining_after_current: usize,
-        scratch: Scratch,
+        scratch: RawScratch,
     },
     MapKey {
         previous_base: *mut u8,
@@ -1974,8 +1907,8 @@ enum DecodeContinuation<'program> {
         map_ptr: *mut u8,
         total: usize,
         remaining: usize,
-        key_scratch: Scratch,
-        value_scratch: Scratch,
+        key_scratch: RawScratch,
+        value_scratch: RawScratch,
     },
     MapValue {
         previous_base: *mut u8,
@@ -1983,13 +1916,13 @@ enum DecodeContinuation<'program> {
         map_ptr: *mut u8,
         total: usize,
         remaining: usize,
-        key_scratch: Scratch,
-        value_scratch: Scratch,
+        key_scratch: RawScratch,
+        value_scratch: RawScratch,
     },
     Init {
         previous_base: *mut u8,
         target: InitTarget,
-        scratch: Scratch,
+        scratch: RawScratch,
     },
 }
 
@@ -2070,18 +2003,24 @@ impl<'program> Step<'program, SchemaId, MemOp> for DecodeInterp<'_> {
             }
             MemOp::Sequence(s) => {
                 let count = self.reader.read_len(s.min_wire)?;
-                let mut buffer = SequenceBuffer::new(count, s.stride, s.elem_align)?;
+                let mut buffer = alloc_sequence_buffer(count, s.stride, s.elem_align)?;
                 // Safety: the handle lives at `field_offset`.
                 let list = unsafe { self.base.add(s.field_offset) };
                 if count == 0 {
                     unsafe {
-                        (s.thunks.from_raw_parts)(s.thunks.ctx, list, buffer.ptr, count, buffer.cap)
+                        (s.thunks.from_raw_parts)(
+                            s.thunks.ctx,
+                            list,
+                            buffer.ptr(),
+                            count,
+                            buffer.cap(),
+                        )
                     };
                     buffer.adopt();
                     Control::Continue
                 } else {
                     let previous_base = self.base;
-                    self.base = buffer.ptr;
+                    self.base = buffer.ptr();
                     Control::CallProgramThen(
                         &s.element,
                         DecodeContinuation::Sequence {
@@ -2335,13 +2274,13 @@ impl<'program> Step<'program, SchemaId, MemOp> for DecodeInterp<'_> {
             } => {
                 if next_index == count {
                     unsafe {
-                        (thunks.from_raw_parts)(thunks.ctx, list, buffer.ptr, count, buffer.cap)
+                        (thunks.from_raw_parts)(thunks.ctx, list, buffer.ptr(), count, buffer.cap())
                     };
                     buffer.adopt();
                     self.base = previous_base;
                     Ok(Control::Continue)
                 } else {
-                    self.base = unsafe { buffer.ptr.add(next_index * buffer.stride) };
+                    self.base = unsafe { buffer.slot_unchecked(next_index) };
                     Ok(Control::CallProgramThen(
                         element,
                         DecodeContinuation::Sequence {
@@ -2365,7 +2304,8 @@ impl<'program> Step<'program, SchemaId, MemOp> for DecodeInterp<'_> {
             } => {
                 // Safety: scratch holds an initialized element; `insert` moves it
                 // into the set and tells us whether it was unique.
-                let inserted = unsafe { (set.thunks.insert)(set.thunks.ctx, set_ptr, scratch.ptr) };
+                let inserted =
+                    unsafe { (set.thunks.insert)(set.thunks.ctx, set_ptr, scratch.ptr()) };
                 drop(scratch);
                 if !inserted {
                     return Err(CompactError::Decode(DecodeError::DuplicateElement));
@@ -2381,7 +2321,7 @@ impl<'program> Step<'program, SchemaId, MemOp> for DecodeInterp<'_> {
                 key_scratch,
                 value_scratch,
             } => {
-                self.base = value_scratch.ptr;
+                self.base = value_scratch.ptr();
                 Ok(Control::CallProgramThen(
                     &map.value,
                     DecodeContinuation::MapValue {
@@ -2408,8 +2348,8 @@ impl<'program> Step<'program, SchemaId, MemOp> for DecodeInterp<'_> {
                     (map.thunks.insert)(
                         map.thunks.ctx,
                         map_ptr,
-                        key_scratch.ptr,
-                        value_scratch.ptr,
+                        key_scratch.ptr(),
+                        value_scratch.ptr(),
                     );
                 }
                 drop(key_scratch);
@@ -2430,7 +2370,7 @@ impl<'program> Step<'program, SchemaId, MemOp> for DecodeInterp<'_> {
                 target,
                 scratch,
             } => {
-                unsafe { (target.init)(target.ctx, target.handle, scratch.ptr) };
+                unsafe { target.initialize(scratch.ptr()) };
                 drop(scratch);
                 self.base = previous_base;
                 Ok(Control::Continue)
@@ -2452,8 +2392,8 @@ impl DecodeInterp<'_> {
             return Ok(Control::Continue);
         }
 
-        let scratch = Scratch::new(set.elem_size, set.elem_align)?;
-        self.base = scratch.ptr;
+        let scratch = alloc_scratch(set.elem_size, set.elem_align)?;
+        self.base = scratch.ptr();
         Ok(Control::CallProgramThen(
             &set.element,
             DecodeContinuation::SetElement {
@@ -2479,9 +2419,9 @@ impl DecodeInterp<'_> {
             return Ok(Control::Continue);
         }
 
-        let key_scratch = Scratch::new(map.key_size, map.key_align)?;
-        let value_scratch = Scratch::new(map.value_size, map.value_align)?;
-        self.base = key_scratch.ptr;
+        let key_scratch = alloc_scratch(map.key_size, map.key_align)?;
+        let value_scratch = alloc_scratch(map.value_size, map.value_align)?;
+        self.base = key_scratch.ptr();
         Ok(Control::CallProgramThen(
             &map.key,
             DecodeContinuation::MapKey {
@@ -2503,9 +2443,9 @@ impl DecodeInterp<'_> {
         align: usize,
         target: InitTarget,
     ) -> Result<Control<'program, SchemaId, MemOp, DecodeContinuation<'program>>> {
-        let scratch = Scratch::new(size, align)?;
+        let scratch = alloc_scratch(size, align)?;
         let previous_base = self.base;
-        self.base = scratch.ptr;
+        self.base = scratch.ptr();
         Ok(Control::CallProgramThen(
             program,
             DecodeContinuation::Init {
@@ -2517,40 +2457,28 @@ impl DecodeInterp<'_> {
     }
 }
 
-/// Allocate an engine-owned scratch buffer of `size`/`align` for a decoded
-/// key/value before it is moved into a map. A zero-size element needs no
-/// allocation: a dangling-but-aligned pointer suffices (and `free_scratch` then
-/// does nothing for it).
-fn alloc_scratch(size: usize, align: usize) -> Result<(*mut u8, Option<alloc::Layout>)> {
-    if size == 0 {
-        Ok((align as *mut u8, None))
-    } else {
-        let layout = alloc::Layout::from_size_align(size, align).map_err(|_| {
-            CompactError::Decode(DecodeError::Malformed("map scratch layout overflow"))
-        })?;
-        // Safety: size > 0.
-        let buf = unsafe { alloc::alloc(layout) };
-        if buf.is_null() {
-            alloc::handle_alloc_error(layout);
+fn alloc_scratch(size: usize, align: usize) -> Result<RawScratch> {
+    RawScratch::new(size, align).map_err(scratch_alloc_error)
+}
+
+fn alloc_sequence_buffer(count: usize, stride: usize, elem_align: usize) -> Result<RawArrayBuffer> {
+    RawArrayBuffer::new(count, stride, elem_align).map_err(sequence_alloc_error)
+}
+
+fn scratch_alloc_error(error: RawAllocError) -> CompactError {
+    match error {
+        RawAllocError::InvalidLayout { .. } | RawAllocError::SizeOverflow { .. } => {
+            CompactError::Decode(DecodeError::Malformed("scratch layout overflow"))
         }
-        Ok((buf, Some(layout)))
     }
 }
 
-/// Free a scratch buffer from [`alloc_scratch`] WITHOUT dropping its contents
-/// (ownership was moved into the map by `insert`). A `None` layout is a zero-size
-/// dangling pointer that was never allocated.
-fn free_scratch(buf: *mut u8, layout: Option<alloc::Layout>) {
-    if let Some(layout) = layout {
-        // Safety: `buf` was allocated by `alloc_scratch` with this exact layout.
-        unsafe { alloc::dealloc(buf, layout) };
+fn sequence_alloc_error(error: RawAllocError) -> CompactError {
+    match error {
+        RawAllocError::InvalidLayout { .. } | RawAllocError::SizeOverflow { .. } => {
+            CompactError::Decode(DecodeError::Malformed("sequence layout overflow"))
+        }
     }
-}
-
-struct InitTarget {
-    ctx: *const (),
-    handle: *mut u8,
-    init: unsafe extern "C" fn(ctx: *const (), handle: *mut u8, value: *mut u8),
 }
 
 /// Lower `descriptor` and decode `bytes` into the value at `base` in one step.

--- a/weavy/src/mem.rs
+++ b/weavy/src/mem.rs
@@ -5,6 +5,8 @@
 //! constructing `Vec`/map/set handles, reading `Option`/`Result` presence,
 //! validating string bytes, and delegating opaque payloads.
 
+pub mod runtime;
+
 /// A type-erased "write this field's default in place" operation, supplied by
 /// the front door for a reader-only field that can be filled locally.
 ///

--- a/weavy/src/mem/runtime.rs
+++ b/weavy/src/mem/runtime.rs
@@ -1,0 +1,361 @@
+//! Runtime ownership helpers for typed-memory interpreters.
+//!
+//! This module stays deliberately below any format, schema, or reflection
+//! model. It owns raw temporary storage and adoption state; callers decide what
+//! values live there and which thunks move those values into final handles.
+
+use std::alloc::{self, Layout};
+use std::error::Error;
+use std::fmt;
+
+/// Allocation/layout failures for raw typed-memory runtime buffers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RawAllocError {
+    /// `size` and `align` do not form a valid Rust allocation layout.
+    InvalidLayout { size: usize, align: usize },
+    /// `count * stride` overflowed while sizing an array buffer.
+    SizeOverflow { count: usize, stride: usize },
+}
+
+impl fmt::Display for RawAllocError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::InvalidLayout { size, align } => {
+                write!(f, "invalid raw memory layout: size={size}, align={align}")
+            }
+            Self::SizeOverflow { count, stride } => {
+                write!(
+                    f,
+                    "raw array buffer size overflow: count={count}, stride={stride}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for RawAllocError {}
+
+/// Engine-owned raw scratch storage for one value.
+///
+/// Dropping a `RawScratch` frees the allocation without dropping the value. This
+/// is the correct behavior after an interpreter moves the initialized value into
+/// a caller handle through an init/push/insert thunk.
+#[derive(Debug)]
+pub struct RawScratch {
+    ptr: *mut u8,
+    layout: Option<Layout>,
+}
+
+impl RawScratch {
+    /// Allocate scratch storage for a value with `size` and `align`.
+    pub fn new(size: usize, align: usize) -> Result<Self, RawAllocError> {
+        let layout = Layout::from_size_align(size, align)
+            .map_err(|_| RawAllocError::InvalidLayout { size, align })?;
+        Ok(Self::from_layout(layout))
+    }
+
+    /// Allocate scratch storage for a value with an already-validated layout.
+    #[must_use]
+    pub fn from_layout(layout: Layout) -> Self {
+        let ptr = allocate_or_dangling(layout);
+        let layout = (layout.size() != 0).then_some(layout);
+        Self { ptr, layout }
+    }
+
+    /// The raw storage pointer.
+    #[must_use]
+    pub fn ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    /// Free the scratch storage without dropping any value that may have lived
+    /// in it.
+    pub fn dealloc_uninit(&mut self) {
+        if let Some(layout) = self.layout.take() {
+            unsafe { alloc::dealloc(self.ptr, layout) };
+        }
+    }
+}
+
+impl Drop for RawScratch {
+    fn drop(&mut self) {
+        self.dealloc_uninit();
+    }
+}
+
+/// Engine-owned raw contiguous storage for a sequence of elements.
+///
+/// Dropping frees only the raw allocation. Call [`adopt`](Self::adopt) after a
+/// sequence handle takes ownership of the buffer.
+#[derive(Debug)]
+pub struct RawArrayBuffer {
+    ptr: *mut u8,
+    cap: usize,
+    stride: usize,
+    layout: Option<Layout>,
+}
+
+impl RawArrayBuffer {
+    /// Allocate storage for `count` elements with `stride` bytes and
+    /// `elem_align` alignment.
+    pub fn new(count: usize, stride: usize, elem_align: usize) -> Result<Self, RawAllocError> {
+        let layout = if count == 0 || stride == 0 {
+            Layout::from_size_align(0, elem_align).map_err(|_| RawAllocError::InvalidLayout {
+                size: 0,
+                align: elem_align,
+            })?
+        } else {
+            let size = count
+                .checked_mul(stride)
+                .ok_or(RawAllocError::SizeOverflow { count, stride })?;
+            Layout::from_size_align(size, elem_align).map_err(|_| RawAllocError::InvalidLayout {
+                size,
+                align: elem_align,
+            })?
+        };
+
+        let ptr = allocate_or_dangling(layout);
+        let layout = (layout.size() != 0).then_some(layout);
+        Ok(Self {
+            ptr,
+            cap: count,
+            stride,
+            layout,
+        })
+    }
+
+    /// The start of the raw element storage.
+    #[must_use]
+    pub fn ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    /// The number of elements this buffer can hold.
+    #[must_use]
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+
+    /// The byte stride between elements.
+    #[must_use]
+    pub fn stride(&self) -> usize {
+        self.stride
+    }
+
+    /// Return the element slot for `index` when it is within capacity.
+    #[must_use]
+    pub fn slot(&self, index: usize) -> Option<*mut u8> {
+        if index >= self.cap {
+            return None;
+        }
+        Some(unsafe { self.slot_unchecked(index) })
+    }
+
+    /// Return the element slot for `index` without bounds checks.
+    ///
+    /// # Safety
+    ///
+    /// `index` must be less than [`cap`](Self::cap). If `stride` is non-zero,
+    /// the allocation created by [`new`](Self::new) guarantees the offset cannot
+    /// overflow for in-bounds indices.
+    pub unsafe fn slot_unchecked(&self, index: usize) -> *mut u8 {
+        unsafe { self.ptr.add(index * self.stride) }
+    }
+
+    /// Mark the allocation as adopted by the caller.
+    pub fn adopt(&mut self) {
+        self.layout = None;
+    }
+}
+
+impl Drop for RawArrayBuffer {
+    fn drop(&mut self) {
+        if let Some(layout) = self.layout.take() {
+            unsafe { alloc::dealloc(self.ptr, layout) };
+        }
+    }
+}
+
+/// Caller-supplied drop hook for an initialized handle/value.
+pub type DropThunk = unsafe fn(ctx: *const (), ptr: *mut u8);
+
+/// Guard for an initialized handle that must be dropped unless disarmed.
+#[derive(Debug)]
+pub struct HandleGuard {
+    ptr: *mut u8,
+    ctx: *const (),
+    drop: DropThunk,
+    active: bool,
+}
+
+impl HandleGuard {
+    /// Track `ptr` as initialized and owned by this guard.
+    #[must_use]
+    pub fn new(ptr: *mut u8, ctx: *const (), drop: DropThunk) -> Self {
+        Self {
+            ptr,
+            ctx,
+            drop,
+            active: true,
+        }
+    }
+
+    /// The initialized handle/value pointer.
+    #[must_use]
+    pub fn ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    /// Prevent this guard from dropping the handle/value.
+    pub fn disarm(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for HandleGuard {
+    fn drop(&mut self) {
+        if self.active {
+            unsafe { (self.drop)(self.ctx, self.ptr) };
+        }
+    }
+}
+
+/// Bookkeeping for initialized child slots.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InitializedLedger<Mark> {
+    marks: Vec<Option<Mark>>,
+}
+
+impl<Mark> InitializedLedger<Mark> {
+    /// Create a ledger with `len` uninitialized slots.
+    #[must_use]
+    pub fn new(len: usize) -> Self {
+        Self {
+            marks: (0..len).map(|_| None).collect(),
+        }
+    }
+
+    /// Return whether `index` is initialized.
+    #[must_use]
+    pub fn is_initialized(&self, index: usize) -> bool {
+        self.marks[index].is_some()
+    }
+
+    /// Return the mark for `index` when initialized.
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<&Mark> {
+        self.marks[index].as_ref()
+    }
+
+    /// Mark `index` initialized.
+    pub fn mark(&mut self, index: usize, mark: Mark) {
+        self.marks[index] = Some(mark);
+    }
+
+    /// Initialized slots in reverse index order.
+    pub fn iter_initialized_rev(&self) -> impl Iterator<Item = (usize, &Mark)> {
+        self.marks
+            .iter()
+            .enumerate()
+            .rev()
+            .filter_map(|(index, mark)| mark.as_ref().map(|mark| (index, mark)))
+    }
+}
+
+/// Neutral "initialize handle from scratch value" target.
+#[derive(Clone, Copy, Debug)]
+pub struct InitTarget {
+    /// Opaque per-type context.
+    pub ctx: *const (),
+    /// Destination handle to initialize.
+    pub handle: *mut u8,
+    /// Move `*value` into `handle`.
+    pub init: unsafe extern "C" fn(ctx: *const (), handle: *mut u8, value: *mut u8),
+}
+
+impl InitTarget {
+    /// Initialize the destination handle by moving from `value`.
+    ///
+    /// # Safety
+    ///
+    /// `value` must point to an initialized value of the type expected by this
+    /// target, and `handle` must point to uninitialized storage for the handle.
+    pub unsafe fn initialize(self, value: *mut u8) {
+        unsafe { (self.init)(self.ctx, self.handle, value) };
+    }
+}
+
+fn allocate_or_dangling(layout: Layout) -> *mut u8 {
+    if layout.size() == 0 {
+        layout.align() as *mut u8
+    } else {
+        let ptr = unsafe { alloc::alloc(layout) };
+        if ptr.is_null() {
+            alloc::handle_alloc_error(layout);
+        }
+        ptr
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    unsafe fn count_drop(ctx: *const (), _ptr: *mut u8) {
+        let drops = unsafe { &*(ctx as *const AtomicUsize) };
+        drops.fetch_add(1, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn raw_scratch_handles_zero_sized_storage() {
+        let mut scratch = RawScratch::new(0, 8).unwrap();
+        assert_eq!(scratch.ptr() as usize, 8);
+        scratch.dealloc_uninit();
+        scratch.dealloc_uninit();
+    }
+
+    #[test]
+    fn raw_array_buffer_checks_slots() {
+        let buffer = RawArrayBuffer::new(3, 4, 4).unwrap();
+        assert_eq!(buffer.cap(), 3);
+        assert_eq!(buffer.stride(), 4);
+        assert!(buffer.slot(3).is_none());
+        let base = buffer.ptr() as usize;
+        assert_eq!(buffer.slot(2).unwrap() as usize, base + 8);
+    }
+
+    #[test]
+    fn handle_guard_drops_unless_disarmed() {
+        let drops = AtomicUsize::new(0);
+        let ctx = &drops as *const AtomicUsize as *const ();
+
+        {
+            let value = 0u8;
+            let _guard = HandleGuard::new(&value as *const u8 as *mut u8, ctx, count_drop);
+        }
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+        {
+            let value = 0u8;
+            let mut guard = HandleGuard::new(&value as *const u8 as *mut u8, ctx, count_drop);
+            guard.disarm();
+        }
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn initialized_ledger_reports_reverse_order() {
+        let mut ledger = InitializedLedger::new(4);
+        assert!(!ledger.is_initialized(2));
+        ledger.mark(1, "one");
+        ledger.mark(3, "three");
+
+        assert_eq!(ledger.get(1), Some(&"one"));
+        let initialized = ledger
+            .iter_initialized_rev()
+            .map(|(index, mark)| (index, *mark))
+            .collect::<Vec<_>>();
+        assert_eq!(initialized, vec![(3, "three"), (1, "one")]);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `weavy::mem::runtime`, a neutral typed-memory runtime layer:
  - `RawScratch` for move-then-free scratch storage.
  - `RawArrayBuffer` for adoptable contiguous sequence buffers.
  - `InitTarget` for handle init thunks.
  - `HandleGuard` for caller-supplied drop-on-error guards.
  - `InitializedLedger` for initialized child-slot bookkeeping.
- Migrates PHON typed decode off its local `Scratch`, `SequenceBuffer`, `InitTarget`, and raw free helpers.
- Migrates the opt-in facet-json Weavy backend off its local scratch allocator, list guard, and initialized-field ledger.

This keeps `weavy` format/reflection neutral: callers still provide parser semantics, shape/schema identities, drop callbacks, and local error mapping.

## Notes

This does not claim full PHON partial-decode cleanup. PHON still needs explicit drop/destruction metadata in the descriptor/thunk layer before set/map/sequence partial initialization can be cleaned up as completely as JSON's current path.

## Performance

Measured with stax run 18:

```text
stax record -- cargo bench -p facet-json --bench typeplan_reuse -- --skip serde_json_from_slice --color never --sample-count 12 --sample-size 1 --max-time 1
```

Median results:

| Case | Reused Partial | Weavy plan | Impact | serde_json |
| --- | ---: | ---: | ---: | ---: |
| point | 750.2 ns | 583.2 ns | 1.29x faster | 41.74 ns |
| person | 3.812 us | 1.874 us | 2.03x faster | 187.2 ns |
| company | 5.729 us | 4.166 us | 1.38x faster | 562.2 ns |
| batch 1000 | 3.734 ms | 1.870 ms | 2.00x faster | 205.6 us |

## Verification

- `cargo check -p weavy -p phon-engine -p facet-json`
- `cargo nextest list -p weavy`
- `cargo nextest list -p phon-engine`
- `cargo nextest list -p facet-json -E 'test(weavy)'`
- `cargo nextest run -p weavy -p phon-engine`
- `cargo nextest run -p facet-json -E 'test(weavy)'`
- `cargo clippy -p weavy -p phon-engine -p facet-json --all-targets --all-features -- -D warnings`
- `cargo nextest run -p facet-json`
- `cargo bench -p facet-json --bench typeplan_reuse --no-run`
- `stax record -- cargo bench -p facet-json --bench typeplan_reuse -- --skip serde_json_from_slice --color never --sample-count 12 --sample-size 1 --max-time 1`
- pre-push hook: clippy, docs, build tests, run tests all passed
