### PR TITLE
Reuse Weavy scratch slots in facet-json

### DIFF
--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -19,7 +19,7 @@ use facet_format::{
     ParseEventKind, ScalarValue,
 };
 use facet_reflect::Span;
-use weavy::mem::runtime::{HandleGuard, InitializedLedger, RawScratch};
+use weavy::mem::runtime::{HandleGuard, InitializedLedger, ScratchSession, ScratchSlot};
 use weavy::{Control, Lowered, Program, RunError, RunStats, Step};
 
 use crate::JsonParser;
@@ -38,8 +38,7 @@ pub fn from_str_weavy<T>(input: &str) -> Result<T, DeserializeError>
 where
     T: Facet<'static>,
 {
-    let (value, _) = from_str_weavy_with_stats(input)?;
-    Ok(value)
+    JsonWeavyPlan::<T>::build()?.from_str(input)
 }
 
 /// Deserialize a value from JSON bytes through the opt-in Weavy runner.
@@ -47,8 +46,7 @@ pub fn from_slice_weavy<T>(input: &[u8]) -> Result<T, DeserializeError>
 where
     T: Facet<'static>,
 {
-    let (value, _) = from_slice_weavy_with_stats(input)?;
-    Ok(value)
+    JsonWeavyPlan::<T>::build()?.from_slice(input)
 }
 
 /// Deserialize a value from a JSON string through the opt-in Weavy runner and
@@ -95,14 +93,14 @@ where
 
     /// Deserialize from a JSON string using this pre-lowered plan.
     pub fn from_str(&self, input: &str) -> Result<T, DeserializeError> {
-        let (value, _) = self.from_str_with_stats(input)?;
-        Ok(value)
+        let mut parser = JsonParser::<true>::new(input.as_bytes());
+        self.deserialize::<true>(&mut parser)
     }
 
     /// Deserialize from JSON bytes using this pre-lowered plan.
     pub fn from_slice(&self, input: &[u8]) -> Result<T, DeserializeError> {
-        let (value, _) = self.from_slice_with_stats(input)?;
-        Ok(value)
+        let mut parser = JsonParser::<false>::new(input);
+        self.deserialize::<false>(&mut parser)
     }
 
     /// Deserialize from a JSON string and return Weavy runner counters.
@@ -131,6 +129,21 @@ where
         interp.finish_success();
 
         Ok((unsafe { slot.assume_init() }, stats))
+    }
+
+    fn deserialize<const TRUSTED_UTF8: bool>(
+        &self,
+        parser: &mut JsonParser<'_, TRUSTED_UTF8>,
+    ) -> Result<T, DeserializeError> {
+        let mut slot = MaybeUninit::<T>::uninit();
+        let root = PtrUninit::from_maybe_uninit(&mut slot);
+        let mut interp = JsonInterp::new(parser, root);
+        if let Err(err) = weavy::run(&self.lowered, &mut interp) {
+            return Err(run_error(err));
+        }
+        interp.finish_success();
+
+        Ok(unsafe { slot.assume_init() })
     }
 }
 
@@ -377,6 +390,7 @@ struct JsonInterp<'parser, 'de, 'program, const TRUSTED_UTF8: bool> {
     base: PtrUninit,
     structs: Vec<StructFrame<'program>>,
     lists: Vec<HandleGuard>,
+    scratch: ScratchSession,
     success: bool,
 }
 
@@ -389,6 +403,7 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
             base,
             structs: Vec::new(),
             lists: Vec::new(),
+            scratch: ScratchSession::new(),
             success: false,
         }
     }
@@ -556,9 +571,9 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                     _ => {}
                 }
 
-                let scratch = Scratch::alloc(option.t(), *inner_layout);
+                let scratch = self.scratch.reserve(*inner_layout);
                 let old_base = self.base;
-                self.base = scratch.ptr_uninit();
+                self.base = scratch_ptr_uninit(&scratch);
                 Ok(Control::CallProgramThen(
                     some_program,
                     Continuation::OptionSome {
@@ -612,9 +627,9 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                     _ => {}
                 }
 
-                let scratch = Scratch::alloc(list.t(), *element_layout);
+                let scratch = self.scratch.reserve(*element_layout);
                 let old_base = self.base;
-                self.base = scratch.ptr_uninit();
+                self.base = scratch_ptr_uninit(&scratch);
                 Ok(Control::CallProgramThen(
                     element_program,
                     Continuation::ListElement {
@@ -630,12 +645,12 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                 pointee_program,
                 pointee_layout,
             } => {
-                let pointee = pointer
+                pointer
                     .pointee()
                     .ok_or_else(|| unsupported_shape_message("opaque pointer"))?;
-                let scratch = Scratch::alloc(pointee, *pointee_layout);
+                let scratch = self.scratch.reserve(*pointee_layout);
                 let old_base = self.base;
-                self.base = scratch.ptr_uninit();
+                self.base = scratch_ptr_uninit(&scratch);
                 Ok(Control::CallProgramThen(
                     pointee_program,
                     Continuation::Pointer {
@@ -682,12 +697,12 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                 option,
                 option_ptr,
                 old_base,
-                mut scratch,
+                scratch,
             } => {
                 unsafe {
-                    (option.vtable.init_some)(option_ptr, scratch.ptr_mut());
+                    (option.vtable.init_some)(option_ptr, scratch_ptr_mut(&scratch));
                 }
-                scratch.dealloc_uninit();
+                self.scratch.release(scratch);
                 self.base = old_base;
                 Ok(Control::Continue)
             }
@@ -702,7 +717,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
             Continuation::ListElement {
                 list,
                 old_base,
-                mut scratch,
+                scratch,
                 loop_id,
             } => {
                 let list_ptr = self
@@ -714,9 +729,9 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                     .push()
                     .ok_or_else(|| unsupported(list.t(), "list push"))?;
                 unsafe {
-                    push(PtrMut::new(list_ptr), scratch.ptr_mut());
+                    push(PtrMut::new(list_ptr), scratch_ptr_mut(&scratch));
                 }
-                scratch.dealloc_uninit();
+                self.scratch.release(scratch);
                 self.base = old_base;
                 Ok(Control::CallBlock(loop_id))
             }
@@ -724,16 +739,16 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
                 pointer,
                 pointer_ptr,
                 old_base,
-                mut scratch,
+                scratch,
             } => {
                 let new_into = pointer
                     .vtable
                     .new_into_fn
                     .ok_or_else(|| unsupported_shape_message("pointer without new_into"))?;
                 unsafe {
-                    new_into(pointer_ptr, scratch.ptr_mut());
+                    new_into(pointer_ptr, scratch_ptr_mut(&scratch));
                 }
-                scratch.dealloc_uninit();
+                self.scratch.release(scratch);
                 self.base = old_base;
                 Ok(Control::Continue)
             }
@@ -753,20 +768,20 @@ enum Continuation {
         option: OptionDef,
         option_ptr: PtrUninit,
         old_base: PtrUninit,
-        scratch: Scratch,
+        scratch: ScratchSlot,
     },
     FinishList,
     ListElement {
         list: ListDef,
         old_base: PtrUninit,
-        scratch: Scratch,
+        scratch: ScratchSlot,
         loop_id: BlockId,
     },
     Pointer {
         pointer: PointerDef,
         pointer_ptr: PtrUninit,
         old_base: PtrUninit,
-        scratch: Scratch,
+        scratch: ScratchSlot,
     },
 }
 
@@ -872,28 +887,12 @@ unsafe fn drop_shape_value(ctx: *const (), ptr: *mut u8) {
     }
 }
 
-struct Scratch {
-    raw: RawScratch,
+fn scratch_ptr_uninit(scratch: &ScratchSlot) -> PtrUninit {
+    PtrUninit::new(scratch.ptr())
 }
 
-impl Scratch {
-    fn alloc(_shape: &'static Shape, layout: Layout) -> Self {
-        Self {
-            raw: RawScratch::from_layout(layout),
-        }
-    }
-
-    fn ptr_uninit(&self) -> PtrUninit {
-        PtrUninit::new(self.raw.ptr())
-    }
-
-    unsafe fn ptr_mut(&self) -> PtrMut {
-        unsafe { self.ptr_uninit().assume_init() }
-    }
-
-    fn dealloc_uninit(&mut self) {
-        self.raw.dealloc_uninit();
-    }
+unsafe fn scratch_ptr_mut(scratch: &ScratchSlot) -> PtrMut {
+    unsafe { scratch_ptr_uninit(scratch).assume_init() }
 }
 
 unsafe fn write_scalar(

--- a/weavy/src/lib.rs
+++ b/weavy/src/lib.rs
@@ -275,11 +275,12 @@ where
     S: Step<'program, BlockId, Op>,
     A: Accounting,
 {
-    let mut frames = vec![Frame {
+    let mut frames = Vec::with_capacity(16);
+    frames.push(Frame {
         program,
         ip: 0,
         continuation: None,
-    }];
+    });
     accounting.frame_pushed(frames.len());
 
     while let Some(frame) = frames.last_mut() {

--- a/weavy/src/mem/runtime.rs
+++ b/weavy/src/mem/runtime.rs
@@ -83,6 +83,90 @@ impl Drop for RawScratch {
     }
 }
 
+/// Reusable scratch storage for one interpreter run.
+///
+/// A session keeps raw buffers around after a moved-out child value is released,
+/// so repeated list elements or option/pointer payloads can reuse memory instead
+/// of allocating for every child decode. Dropping the session frees all buffers
+/// without dropping values.
+#[derive(Debug, Default)]
+pub struct ScratchSession {
+    buffers: Vec<ScratchBuffer>,
+}
+
+#[derive(Debug)]
+struct ScratchBuffer {
+    ptr: *mut u8,
+    layout: Layout,
+    active: bool,
+}
+
+/// A checked-out scratch slot from [`ScratchSession`].
+#[derive(Debug)]
+pub struct ScratchSlot {
+    index: usize,
+    ptr: *mut u8,
+}
+
+impl ScratchSession {
+    /// Create an empty scratch session.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reserve scratch storage for `layout`.
+    pub fn reserve(&mut self, layout: Layout) -> ScratchSlot {
+        if let Some((index, buffer)) = self
+            .buffers
+            .iter_mut()
+            .enumerate()
+            .find(|(_, buffer)| !buffer.active && layout_fits(buffer.layout, layout))
+        {
+            buffer.active = true;
+            return ScratchSlot {
+                index,
+                ptr: buffer.ptr,
+            };
+        }
+
+        let ptr = allocate_or_dangling(layout);
+        let index = self.buffers.len();
+        self.buffers.push(ScratchBuffer {
+            ptr,
+            layout,
+            active: true,
+        });
+        ScratchSlot { index, ptr }
+    }
+
+    /// Release a moved-out scratch slot for reuse.
+    pub fn release(&mut self, slot: ScratchSlot) {
+        let buffer = &mut self.buffers[slot.index];
+        debug_assert!(buffer.active, "scratch slot released twice");
+        debug_assert_eq!(buffer.ptr, slot.ptr, "scratch slot pointer mismatch");
+        buffer.active = false;
+    }
+}
+
+impl ScratchSlot {
+    /// The raw storage pointer for this slot.
+    #[must_use]
+    pub fn ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+}
+
+impl Drop for ScratchSession {
+    fn drop(&mut self) {
+        for buffer in self.buffers.drain(..) {
+            if buffer.layout.size() != 0 {
+                unsafe { alloc::dealloc(buffer.ptr, buffer.layout) };
+            }
+        }
+    }
+}
+
 /// Engine-owned raw contiguous storage for a sequence of elements.
 ///
 /// Dropping frees only the raw allocation. Call [`adopt`](Self::adopt) after a
@@ -297,6 +381,10 @@ fn allocate_or_dangling(layout: Layout) -> *mut u8 {
     }
 }
 
+fn layout_fits(buffer: Layout, requested: Layout) -> bool {
+    buffer.size() >= requested.size() && buffer.align() >= requested.align()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -313,6 +401,28 @@ mod tests {
         assert_eq!(scratch.ptr() as usize, 8);
         scratch.dealloc_uninit();
         scratch.dealloc_uninit();
+    }
+
+    #[test]
+    fn scratch_session_reuses_released_slots() {
+        let mut session = ScratchSession::new();
+        let first = session.reserve(Layout::from_size_align(16, 8).unwrap());
+        let first_ptr = first.ptr();
+        session.release(first);
+
+        let second = session.reserve(Layout::from_size_align(8, 4).unwrap());
+        assert_eq!(second.ptr(), first_ptr);
+        session.release(second);
+    }
+
+    #[test]
+    fn scratch_session_keeps_active_slots_distinct() {
+        let mut session = ScratchSession::new();
+        let first = session.reserve(Layout::from_size_align(16, 8).unwrap());
+        let second = session.reserve(Layout::from_size_align(16, 8).unwrap());
+        assert_ne!(second.ptr(), first.ptr());
+        session.release(second);
+        session.release(first);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `weavy::mem::runtime::ScratchSession` so format runners can reuse moved-out child scratch storage during one interpreter run
- switch the JSON Weavy option/list/pointer child decode path from per-child `RawScratch` allocation to session slots
- route non-stats JSON Weavy entrypoints through `weavy::run` instead of paying `RunStats` bookkeeping, while keeping the `*_with_stats` APIs unchanged
- start the generic Weavy frame stack with enough capacity for the common nested path to avoid repeated frame-stack growth

## Performance

Measured with:

```console
stax record -- cargo bench -p facet-json --bench typeplan_reuse -- --skip serde_json_from_slice --color never --sample-count 12 --sample-size 1 --max-time 1
```

Baseline is the previous pre-PR run; after is this branch.

| Case | Weavy Before | Weavy After | Delta | Weavy vs serde_json |
| --- | ---: | ---: | ---: | ---: |
| point | 583.2 ns | 457.7 ns | 21.5% faster | 11.0x slower |
| person | 1.874 us | 1.812 us | 3.3% faster | 8.7x slower |
| company | 4.166 us | 3.916 us | 6.0% faster | 5.7x slower |
| batch 1000 | 1.870 ms | 1.745 ms | 6.7% faster | 8.5x slower |

## Checks

- `cargo check -p weavy -p facet-json`
- `cargo nextest run -p weavy`
- `cargo nextest run -p facet-json`
- `cargo clippy -p weavy -p facet-json --all-targets --all-features -- -D warnings`
- push hook: passed
