### PR TITLE
Run Weavy JSON plans with dense block refs

### DIFF
--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -20,7 +20,7 @@ use facet_format::{
 };
 use facet_reflect::Span;
 use weavy::mem::runtime::{HandleGuard, InitializedLedger, ScratchSession, ScratchSlot};
-use weavy::{Control, Lowered, Program, RunError, RunStats, Step};
+use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStats, Step};
 
 use crate::JsonParser;
 
@@ -32,6 +32,9 @@ enum JsonBlockId {
 }
 
 type BlockId = JsonBlockId;
+type ExecBlock = BlockRef;
+type SymbolicOp = JsonOp<BlockId>;
+type ExecOp = JsonOp<ExecBlock>;
 
 /// Deserialize a value from a JSON string through the opt-in Weavy runner.
 pub fn from_str_weavy<T>(input: &str) -> Result<T, DeserializeError>
@@ -75,7 +78,7 @@ where
 /// new VM backend and lets callers separate typed-shape lowering from repeated
 /// input decoding.
 pub struct JsonWeavyPlan<T> {
-    lowered: Lowered<BlockId, JsonOp>,
+    lowered: DenseLowered<ExecOp>,
     _marker: PhantomData<fn() -> T>,
 }
 
@@ -85,8 +88,9 @@ where
 {
     /// Lower `T::SHAPE` into the JSON-specific Weavy bytecode.
     pub fn build() -> Result<Self, DeserializeError> {
+        let symbolic = Lowering::new().lower(T::SHAPE)?;
         Ok(Self {
-            lowered: Lowering::new().lower(T::SHAPE)?,
+            lowered: resolve_json_lowered(symbolic)?,
             _marker: PhantomData,
         })
     }
@@ -122,7 +126,7 @@ where
         let mut slot = MaybeUninit::<T>::uninit();
         let root = PtrUninit::from_maybe_uninit(&mut slot);
         let mut interp = JsonInterp::new(parser, root);
-        let stats = match weavy::run_with_stats(&self.lowered, &mut interp) {
+        let stats = match weavy::run_dense_with_stats(&self.lowered, &mut interp) {
             Ok(stats) => stats,
             Err(err) => return Err(run_error(err)),
         };
@@ -138,7 +142,7 @@ where
         let mut slot = MaybeUninit::<T>::uninit();
         let root = PtrUninit::from_maybe_uninit(&mut slot);
         let mut interp = JsonInterp::new(parser, root);
-        if let Err(err) = weavy::run(&self.lowered, &mut interp) {
+        if let Err(err) = weavy::run_dense(&self.lowered, &mut interp) {
             return Err(run_error(err));
         }
         interp.finish_success();
@@ -147,7 +151,7 @@ where
     }
 }
 
-fn run_error(err: RunError<BlockId, DeserializeError>) -> DeserializeError {
+fn run_error(err: RunError<ExecBlock, DeserializeError>) -> DeserializeError {
     match err {
         RunError::Step(err) => err,
         RunError::MissingBlock(block) => vm_error(
@@ -160,52 +164,52 @@ fn run_error(err: RunError<BlockId, DeserializeError>) -> DeserializeError {
 }
 
 #[derive(Clone, Debug)]
-enum JsonOp {
-    CallBlock(BlockId),
+enum JsonOp<Block> {
+    CallBlock(Block),
     ReadScalar {
         shape: &'static Shape,
         scalar: ScalarType,
     },
     ReadStruct {
         shape: &'static Shape,
-        fields: Box<[FieldPlan]>,
-        loop_id: BlockId,
+        fields: Box<[FieldPlan<Block>]>,
+        loop_id: Block,
     },
     StructNext {
         shape: &'static Shape,
-        fields: Box<[FieldPlan]>,
-        loop_id: BlockId,
+        fields: Box<[FieldPlan<Block>]>,
+        loop_id: Block,
     },
     ReadOption {
         option: OptionDef,
-        some_program: Program<JsonOp>,
+        some_program: Program<JsonOp<Block>>,
         inner_layout: Layout,
     },
     ReadList {
         list_shape: &'static Shape,
         list: ListDef,
-        loop_id: BlockId,
+        loop_id: Block,
     },
     ListNext {
         list: ListDef,
-        element_program: Program<JsonOp>,
+        element_program: Program<JsonOp<Block>>,
         element_layout: Layout,
-        loop_id: BlockId,
+        loop_id: Block,
     },
     ReadPointer {
         pointer: PointerDef,
-        pointee_program: Program<JsonOp>,
+        pointee_program: Program<JsonOp<Block>>,
         pointee_layout: Layout,
     },
 }
 
 #[derive(Clone, Debug)]
-struct FieldPlan {
+struct FieldPlan<Block> {
     name: &'static str,
     alias: Option<&'static str>,
     offset: usize,
     shape: &'static Shape,
-    program: Program<JsonOp>,
+    program: Program<JsonOp<Block>>,
     missing: MissingField,
 }
 
@@ -218,7 +222,7 @@ enum MissingField {
 }
 
 struct Lowering {
-    lowered: Lowered<BlockId, JsonOp>,
+    lowered: Lowered<BlockId, SymbolicOp>,
     in_progress: Vec<&'static Shape>,
 }
 
@@ -233,13 +237,25 @@ impl Lowering {
         }
     }
 
-    fn lower(mut self, root: &'static Shape) -> Result<Lowered<BlockId, JsonOp>, DeserializeError> {
+    fn lower(
+        mut self,
+        root: &'static Shape,
+    ) -> Result<Lowered<BlockId, SymbolicOp>, DeserializeError> {
+        let root_id = JsonBlockId::Shape(root);
         self.lower_shape(root)?;
-        self.lowered.program = vec![JsonOp::CallBlock(JsonBlockId::Shape(root))];
+        self.lowered.program = self
+            .lowered
+            .blocks
+            .get(&root_id)
+            .expect("root shape was lowered into a block")
+            .clone();
         Ok(self.lowered)
     }
 
-    fn lower_shape(&mut self, shape: &'static Shape) -> Result<Program<JsonOp>, DeserializeError> {
+    fn lower_shape(
+        &mut self,
+        shape: &'static Shape,
+    ) -> Result<Program<SymbolicOp>, DeserializeError> {
         let block_id = JsonBlockId::Shape(shape);
         if self.lowered.blocks.contains_key(&block_id) || self.in_progress.contains(&shape) {
             return Ok(vec![JsonOp::CallBlock(block_id)]);
@@ -255,7 +271,7 @@ impl Lowering {
     fn lower_shape_body(
         &mut self,
         shape: &'static Shape,
-    ) -> Result<Program<JsonOp>, DeserializeError> {
+    ) -> Result<Program<SymbolicOp>, DeserializeError> {
         if let Some(scalar) = ScalarType::try_from_shape(shape) {
             return Ok(vec![JsonOp::ReadScalar { shape, scalar }]);
         }
@@ -351,6 +367,128 @@ impl Lowering {
     }
 }
 
+fn resolve_json_lowered(
+    symbolic: Lowered<BlockId, SymbolicOp>,
+) -> Result<DenseLowered<ExecOp>, DeserializeError> {
+    let refs = symbolic.block_refs();
+    let program = resolve_json_program(symbolic.program, &refs)?;
+    let mut blocks = Vec::with_capacity(symbolic.blocks.len());
+    for (_, block) in symbolic.blocks {
+        blocks.push(resolve_json_program(block, &refs)?);
+    }
+    Ok(DenseLowered::new(program, blocks))
+}
+
+fn resolve_json_program(
+    program: Program<SymbolicOp>,
+    refs: &BTreeMap<BlockId, ExecBlock>,
+) -> Result<Program<ExecOp>, DeserializeError> {
+    program
+        .into_iter()
+        .map(|op| resolve_json_op(op, refs))
+        .collect()
+}
+
+fn resolve_json_op(
+    op: SymbolicOp,
+    refs: &BTreeMap<BlockId, ExecBlock>,
+) -> Result<ExecOp, DeserializeError> {
+    Ok(match op {
+        JsonOp::CallBlock(block) => JsonOp::CallBlock(resolve_block_ref(block, refs)?),
+        JsonOp::ReadScalar { shape, scalar } => JsonOp::ReadScalar { shape, scalar },
+        JsonOp::ReadStruct {
+            shape,
+            fields,
+            loop_id,
+        } => JsonOp::ReadStruct {
+            shape,
+            fields: resolve_field_plans(fields, refs)?,
+            loop_id: resolve_block_ref(loop_id, refs)?,
+        },
+        JsonOp::StructNext {
+            shape,
+            fields,
+            loop_id,
+        } => JsonOp::StructNext {
+            shape,
+            fields: resolve_field_plans(fields, refs)?,
+            loop_id: resolve_block_ref(loop_id, refs)?,
+        },
+        JsonOp::ReadOption {
+            option,
+            some_program,
+            inner_layout,
+        } => JsonOp::ReadOption {
+            option,
+            some_program: resolve_json_program(some_program, refs)?,
+            inner_layout,
+        },
+        JsonOp::ReadList {
+            list_shape,
+            list,
+            loop_id,
+        } => JsonOp::ReadList {
+            list_shape,
+            list,
+            loop_id: resolve_block_ref(loop_id, refs)?,
+        },
+        JsonOp::ListNext {
+            list,
+            element_program,
+            element_layout,
+            loop_id,
+        } => JsonOp::ListNext {
+            list,
+            element_program: resolve_json_program(element_program, refs)?,
+            element_layout,
+            loop_id: resolve_block_ref(loop_id, refs)?,
+        },
+        JsonOp::ReadPointer {
+            pointer,
+            pointee_program,
+            pointee_layout,
+        } => JsonOp::ReadPointer {
+            pointer,
+            pointee_program: resolve_json_program(pointee_program, refs)?,
+            pointee_layout,
+        },
+    })
+}
+
+fn resolve_field_plans(
+    fields: Box<[FieldPlan<BlockId>]>,
+    refs: &BTreeMap<BlockId, ExecBlock>,
+) -> Result<Box<[FieldPlan<ExecBlock>]>, DeserializeError> {
+    fields
+        .into_vec()
+        .into_iter()
+        .map(|field| {
+            Ok(FieldPlan {
+                name: field.name,
+                alias: field.alias,
+                offset: field.offset,
+                shape: field.shape,
+                program: resolve_json_program(field.program, refs)?,
+                missing: field.missing,
+            })
+        })
+        .collect()
+}
+
+fn resolve_block_ref(
+    block: BlockId,
+    refs: &BTreeMap<BlockId, ExecBlock>,
+) -> Result<ExecBlock, DeserializeError> {
+    refs.get(&block).copied().ok_or_else(|| {
+        vm_error(
+            None,
+            DeserializeErrorKind::Unsupported {
+                message: format!("missing Weavy block {block:?}").into(),
+            },
+        )
+    })
+}
+
 fn missing_field_action(field: &Field, container_has_default: bool) -> MissingField {
     match field.default {
         Some(DefaultSource::Custom(default)) => MissingField::DefaultCustom(default),
@@ -435,7 +573,7 @@ impl<const TRUSTED_UTF8: bool> Drop for JsonInterp<'_, '_, '_, TRUSTED_UTF8> {
     }
 }
 
-impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, JsonOp>
+impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock, ExecOp>
     for JsonInterp<'parser, 'de, 'program, TRUSTED_UTF8>
 {
     type Error = DeserializeError;
@@ -443,8 +581,8 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
 
     fn step(
         &mut self,
-        op: &'program JsonOp,
-    ) -> Result<Control<'program, BlockId, JsonOp, Self::Continuation>, Self::Error> {
+        op: &'program ExecOp,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, Self::Continuation>, Self::Error> {
         match op {
             JsonOp::CallBlock(shape) => Ok(Control::CallBlock(*shape)),
             JsonOp::ReadScalar { shape, scalar } => {
@@ -667,7 +805,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, BlockId, J
     fn after_return(
         &mut self,
         continuation: Self::Continuation,
-    ) -> Result<Control<'program, BlockId, JsonOp, Self::Continuation>, Self::Error> {
+    ) -> Result<Control<'program, ExecBlock, ExecOp, Self::Continuation>, Self::Error> {
         match continuation {
             Continuation::FinishStruct => {
                 let frame = self
@@ -762,7 +900,7 @@ enum Continuation {
         index: usize,
         span: Span,
         old_base: PtrUninit,
-        loop_id: BlockId,
+        loop_id: ExecBlock,
     },
     OptionSome {
         option: OptionDef,
@@ -775,7 +913,7 @@ enum Continuation {
         list: ListDef,
         old_base: PtrUninit,
         scratch: ScratchSlot,
-        loop_id: BlockId,
+        loop_id: ExecBlock,
     },
     Pointer {
         pointer: PointerDef,
@@ -788,12 +926,16 @@ enum Continuation {
 struct StructFrame<'program> {
     shape: &'static Shape,
     base: PtrUninit,
-    fields: &'program [FieldPlan],
+    fields: &'program [FieldPlan<ExecBlock>],
     seen: InitializedLedger<Span>,
 }
 
 impl<'program> StructFrame<'program> {
-    fn new(shape: &'static Shape, base: PtrUninit, fields: &'program [FieldPlan]) -> Self {
+    fn new(
+        shape: &'static Shape,
+        base: PtrUninit,
+        fields: &'program [FieldPlan<ExecBlock>],
+    ) -> Self {
         Self {
             shape,
             base,

--- a/weavy/src/lib.rs
+++ b/weavy/src/lib.rs
@@ -13,6 +13,28 @@ use std::collections::BTreeMap;
 /// A flat lowered program for an op vocabulary supplied by the caller.
 pub type Program<Op> = Vec<Op>;
 
+/// Dense index for a callable lowered block.
+///
+/// This is the executable counterpart to caller-defined symbolic block ids. A
+/// plan can keep symbolic ids while lowering and diagnostics are useful, then
+/// resolve them once into dense block refs before running hot interpreter paths.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BlockRef(usize);
+
+impl BlockRef {
+    /// Build a dense block ref from a block-table index.
+    #[must_use]
+    pub fn new(index: usize) -> Self {
+        Self(index)
+    }
+
+    /// Return this ref's block-table index.
+    #[must_use]
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
 /// A root program plus named block programs.
 ///
 /// Recursive shapes are represented by block calls instead of by infinitely
@@ -34,6 +56,46 @@ impl<BlockId, Op> Lowered<BlockId, Op> {
             program,
             blocks: BTreeMap::new(),
         }
+    }
+}
+
+impl<BlockId, Op> Lowered<BlockId, Op>
+where
+    BlockId: Clone + Ord,
+{
+    /// Return the dense executable block refs for this lowered block table.
+    ///
+    /// The returned map follows the same sorted order as [`BTreeMap`], so callers
+    /// can consume `self.blocks` in key order and rewrite symbolic block ids to
+    /// matching [`BlockRef`] values.
+    #[must_use]
+    pub fn block_refs(&self) -> BTreeMap<BlockId, BlockRef> {
+        self.blocks
+            .keys()
+            .cloned()
+            .enumerate()
+            .map(|(index, block)| (block, BlockRef::new(index)))
+            .collect()
+    }
+}
+
+/// A root program plus dense block programs.
+///
+/// Unlike [`Lowered`], this form has no runtime symbolic lookup table. Block
+/// calls use [`BlockRef`] and dispatch by indexing into `blocks`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DenseLowered<Op> {
+    /// Entry program.
+    pub program: Program<Op>,
+    /// Callable block programs, addressed by [`BlockRef`].
+    pub blocks: Vec<Program<Op>>,
+}
+
+impl<Op> DenseLowered<Op> {
+    /// Build a dense lowered program.
+    #[must_use]
+    pub fn new(program: Program<Op>, blocks: Vec<Program<Op>>) -> Self {
+        Self { program, blocks }
     }
 }
 
@@ -203,6 +265,25 @@ impl Accounting for RunStats {
     }
 }
 
+trait BlockTable<'program, BlockId, Op> {
+    fn get_block(&'program self, block: &BlockId) -> Option<&'program [Op]>;
+}
+
+impl<'program, BlockId, Op> BlockTable<'program, BlockId, Op> for BTreeMap<BlockId, Program<Op>>
+where
+    BlockId: Ord,
+{
+    fn get_block(&'program self, block: &BlockId) -> Option<&'program [Op]> {
+        self.get(block).map(Vec::as_slice)
+    }
+}
+
+impl<'program, Op> BlockTable<'program, BlockRef, Op> for [Program<Op>] {
+    fn get_block(&'program self, block: &BlockRef) -> Option<&'program [Op]> {
+        self.get(block.index()).map(Vec::as_slice)
+    }
+}
+
 /// Run a lowered program through caller-supplied op semantics.
 ///
 /// The runner maintains its own program stack. Calling a block or inline program
@@ -235,6 +316,28 @@ where
     run_program_with_stats(&lowered.program, &lowered.blocks, stepper)
 }
 
+/// Run a dense lowered program through caller-supplied op semantics.
+pub fn run_dense<'program, Op, S>(
+    lowered: &'program DenseLowered<Op>,
+    stepper: &mut S,
+) -> Result<(), RunError<BlockRef, S::Error>>
+where
+    S: Step<'program, BlockRef, Op>,
+{
+    run_dense_program(&lowered.program, &lowered.blocks, stepper)
+}
+
+/// Run a dense lowered program and return opt-in execution counters.
+pub fn run_dense_with_stats<'program, Op, S>(
+    lowered: &'program DenseLowered<Op>,
+    stepper: &mut S,
+) -> Result<RunStats, RunError<BlockRef, S::Error>>
+where
+    S: Step<'program, BlockRef, Op>,
+{
+    run_dense_program_with_stats(&lowered.program, &lowered.blocks, stepper)
+}
+
 /// Run a program with an explicit block table.
 pub fn run_program<'program, BlockId, Op, S>(
     program: &'program [Op],
@@ -264,9 +367,36 @@ where
     Ok(stats)
 }
 
-fn run_program_accounted<'program, BlockId, Op, S, A>(
+/// Run a dense program with an explicit dense block table.
+pub fn run_dense_program<'program, Op, S>(
     program: &'program [Op],
-    blocks: &'program BTreeMap<BlockId, Program<Op>>,
+    blocks: &'program [Program<Op>],
+    stepper: &mut S,
+) -> Result<(), RunError<BlockRef, S::Error>>
+where
+    S: Step<'program, BlockRef, Op>,
+{
+    let mut accounting = NoAccounting;
+    run_program_accounted(program, blocks, stepper, &mut accounting)
+}
+
+/// Run a dense program with an explicit dense block table and return counters.
+pub fn run_dense_program_with_stats<'program, Op, S>(
+    program: &'program [Op],
+    blocks: &'program [Program<Op>],
+    stepper: &mut S,
+) -> Result<RunStats, RunError<BlockRef, S::Error>>
+where
+    S: Step<'program, BlockRef, Op>,
+{
+    let mut stats = RunStats::default();
+    run_program_accounted(program, blocks, stepper, &mut stats)?;
+    Ok(stats)
+}
+
+fn run_program_accounted<'program, BlockId, Op, S, A, Blocks>(
+    program: &'program [Op],
+    blocks: &'program Blocks,
     stepper: &mut S,
     accounting: &mut A,
 ) -> Result<(), RunError<BlockId, S::Error>>
@@ -274,6 +404,7 @@ where
     BlockId: Clone + Ord,
     S: Step<'program, BlockId, Op>,
     A: Accounting,
+    Blocks: BlockTable<'program, BlockId, Op> + ?Sized,
 {
     let mut frames = Vec::with_capacity(16);
     frames.push(Frame {
@@ -297,9 +428,9 @@ where
     Ok(())
 }
 
-fn finish_frame<'program, BlockId, Op, S, A>(
+fn finish_frame<'program, BlockId, Op, S, A, Blocks>(
     frames: &mut Vec<Frame<'program, Op, S::Continuation>>,
-    blocks: &'program BTreeMap<BlockId, Program<Op>>,
+    blocks: &'program Blocks,
     stepper: &mut S,
     accounting: &mut A,
 ) -> Result<(), RunError<BlockId, S::Error>>
@@ -307,6 +438,7 @@ where
     BlockId: Clone + Ord,
     S: Step<'program, BlockId, Op>,
     A: Accounting,
+    Blocks: BlockTable<'program, BlockId, Op> + ?Sized,
 {
     let continuation = frames.pop().and_then(|frame| frame.continuation);
     accounting.returned();
@@ -318,10 +450,10 @@ where
     Ok(())
 }
 
-fn apply_control<'program, BlockId, Op, S, A>(
+fn apply_control<'program, BlockId, Op, S, A, Blocks>(
     control: Control<'program, BlockId, Op, S::Continuation>,
     frames: &mut Vec<Frame<'program, Op, S::Continuation>>,
-    blocks: &'program BTreeMap<BlockId, Program<Op>>,
+    blocks: &'program Blocks,
     stepper: &mut S,
     accounting: &mut A,
 ) -> Result<(), RunError<BlockId, S::Error>>
@@ -329,6 +461,7 @@ where
     BlockId: Clone + Ord,
     S: Step<'program, BlockId, Op>,
     A: Accounting,
+    Blocks: BlockTable<'program, BlockId, Op> + ?Sized,
 {
     let mut control = control;
     loop {
@@ -354,7 +487,7 @@ where
             }
             Control::CallBlock(block) => {
                 let program = blocks
-                    .get(&block)
+                    .get_block(&block)
                     .ok_or_else(|| RunError::MissingBlock(block.clone()))?;
                 accounting.block_call();
                 frames.push(Frame {
@@ -366,7 +499,7 @@ where
             }
             Control::CallBlockThen(block, continuation) => {
                 let program = blocks
-                    .get(&block)
+                    .get_block(&block)
                     .ok_or_else(|| RunError::MissingBlock(block.clone()))?;
                 accounting.block_call();
                 frames.push(Frame {
@@ -408,6 +541,10 @@ mod tests {
         seen: Vec<u32>,
     }
 
+    struct DenseEval {
+        seen: Vec<u32>,
+    }
+
     impl<'program> Step<'program, u32, Op> for Eval {
         type Error = ();
         type Continuation = u32;
@@ -433,6 +570,38 @@ mod tests {
             &mut self,
             tag: Self::Continuation,
         ) -> Result<Control<'program, u32, Op, Self::Continuation>, Self::Error> {
+            self.seen.push(tag);
+            Ok(Control::Continue)
+        }
+    }
+
+    impl<'program> Step<'program, BlockRef, Op> for DenseEval {
+        type Error = ();
+        type Continuation = u32;
+
+        fn step(
+            &mut self,
+            op: &'program Op,
+        ) -> Result<Control<'program, BlockRef, Op, Self::Continuation>, Self::Error> {
+            Ok(match op {
+                Op::Push(n) => {
+                    self.seen.push(*n);
+                    Control::Continue
+                }
+                Op::Call(block) => Control::CallBlock(BlockRef::new(*block as usize)),
+                Op::CallThen(block, tag) => {
+                    Control::CallBlockThen(BlockRef::new(*block as usize), *tag)
+                }
+                Op::Nested(program) => Control::CallProgram(program),
+                Op::NestedThen(program, tag) => Control::CallProgramThen(program, *tag),
+                Op::Stop => Control::Return,
+            })
+        }
+
+        fn after_return(
+            &mut self,
+            tag: Self::Continuation,
+        ) -> Result<Control<'program, BlockRef, Op, Self::Continuation>, Self::Error> {
             self.seen.push(tag);
             Ok(Control::Continue)
         }
@@ -483,6 +652,42 @@ mod tests {
                 max_frame_depth: 2,
             }
         );
+    }
+
+    #[test]
+    fn block_refs_match_lowered_block_order() {
+        let lowered = Lowered {
+            program: vec![Op::Call(10)],
+            blocks: BTreeMap::from([(10, vec![Op::Push(1)]), (20, vec![Op::Push(2)])]),
+        };
+
+        let refs = lowered.block_refs();
+
+        assert_eq!(refs[&10], BlockRef::new(0));
+        assert_eq!(refs[&20], BlockRef::new(1));
+    }
+
+    #[test]
+    fn run_dense_dispatches_block_refs_by_index() {
+        let lowered = DenseLowered::new(
+            vec![Op::Push(1), Op::Call(1), Op::Push(4)],
+            vec![vec![Op::Push(99)], vec![Op::Push(2), Op::Push(3)]],
+        );
+        let mut eval = DenseEval { seen: Vec::new() };
+
+        run_dense(&lowered, &mut eval).unwrap();
+
+        assert_eq!(eval.seen, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn run_dense_reports_missing_block_ref() {
+        let lowered = DenseLowered::new(vec![Op::Call(2)], vec![vec![Op::Push(1)]]);
+        let mut eval = DenseEval { seen: Vec::new() };
+
+        let err = run_dense(&lowered, &mut eval).unwrap_err();
+
+        assert_eq!(err, RunError::MissingBlock(BlockRef::new(2)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `weavy::BlockRef`, `DenseLowered`, and `run_dense*` entrypoints for executable lowered programs with dense block dispatch
- keep the existing symbolic `Lowered<BlockId, Op>` and `run*` APIs intact for current PHON callers
- resolve the opt-in JSON Weavy plan from symbolic `JsonBlockId`s to dense `BlockRef`s at plan-build time
- inline the root shape block into the dense JSON root program while keeping the block table for recursive calls

## Performance

Measured with:

```console
stax record -- cargo bench -p facet-json --bench typeplan_reuse -- --skip serde_json_from_slice --color never --sample-count 40 --sample-size 1 --max-time 2
```

Baseline is the merged #2282 table.

| Case | Weavy Before | Weavy After | Delta | Weavy vs serde_json |
| --- | ---: | ---: | ---: | ---: |
| point | 457.7 ns | 416.2 ns | 9.1% faster | 10.0x slower |
| person | 1.812 us | 1.582 us | 12.7% faster | 9.5x slower |
| company | 3.916 us | 3.457 us | 11.7% faster | 6.4x slower |
| batch 1000 | 1.745 ms | 1.684 ms | 3.5% faster | 8.0x slower |

Fresh isolated `stax` profile:

```console
stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench batch_1000_weavy_reused_plan --color never --sample-count 200 --sample-size 20 --max-time 20
```

That was run 29: median `1.723 ms` for 1000 Weavy decodes, `5844 kperf / 4613 intervals`.

Profile changes:

- `Shape::cmp` no longer appears in the sampled top frames.
- `apply_control` is still visible, but lower than before.
- next clear target is parser/event churn: `peek_event`, `produce_event`, token consumption, and `ParseEvent` cloning.

## Checks

- `cargo check -p weavy -p facet-json`
- `cargo nextest run -p weavy`
- `cargo nextest run -p facet-json`
- `cargo clippy -p weavy -p facet-json --all-targets --all-features -- -D warnings`
- push hook: passed
