### PR TITLE
perf(facet-json): avoid event peeks in Weavy loops

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -677,6 +677,127 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     fn current_offset(&self) -> usize {
         self.state.scanner_pos
     }
+
+    pub(crate) fn consume_null_if_next(&mut self) -> Result<bool, ParseError> {
+        if let Some(event) = self.state.event_peek.as_ref() {
+            if matches!(event.kind, ParseEventKind::Scalar(ScalarValue::Null)) {
+                self.state.event_peek = None;
+                self.state.peek_start_offset = None;
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+
+        match self.determine_action() {
+            NextAction::ObjectValue | NextAction::ArrayValue | NextAction::RootValue => {
+                if !self.next_significant_is(b'n')? {
+                    return Ok(false);
+                }
+                self.consume_null_token()
+            }
+            NextAction::ArrayComma => {
+                let Some((comma_pos, b',')) = self.peek_significant_byte()? else {
+                    return Ok(false);
+                };
+                if !self.significant_after_is(comma_pos + 1, b'n')? {
+                    return Ok(false);
+                }
+
+                self.consume_comma_token()?;
+                if let Some(ContextState::Array(state)) = self.state.stack.last_mut() {
+                    *state = ArrayState::ValueOrEnd;
+                }
+                self.consume_null_token()
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub(crate) fn consume_sequence_end_if_next(&mut self) -> Result<bool, ParseError> {
+        if let Some(event) = self.state.event_peek.as_ref() {
+            if matches!(event.kind, ParseEventKind::SequenceEnd) {
+                self.state.event_peek = None;
+                self.state.peek_start_offset = None;
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+
+        match self.determine_action() {
+            NextAction::ArrayValue => {
+                if !self.next_significant_is(b']')? {
+                    return Ok(false);
+                }
+                self.consume_array_end_token()
+            }
+            NextAction::ArrayComma => match self.peek_significant_byte()? {
+                Some((_, b']')) => self.consume_array_end_token(),
+                Some((comma_pos, b',')) if self.significant_after_is(comma_pos + 1, b']')? => {
+                    self.consume_comma_token()?;
+                    if let Some(ContextState::Array(state)) = self.state.stack.last_mut() {
+                        *state = ArrayState::ValueOrEnd;
+                    }
+                    self.consume_array_end_token()
+                }
+                _ => Ok(false),
+            },
+            _ => Ok(false),
+        }
+    }
+
+    fn next_significant_is(&self, expected: u8) -> Result<bool, ParseError> {
+        Ok(matches!(
+            self.peek_significant_byte()?,
+            Some((_, byte)) if byte == expected
+        ))
+    }
+
+    fn significant_after_is(&self, pos: usize, expected: u8) -> Result<bool, ParseError> {
+        Ok(matches!(
+            self.scanner
+                .peek_significant_byte_from(self.input, pos)
+                .map_err(scan_error_to_parse_error)?,
+            Some((_, byte)) if byte == expected
+        ))
+    }
+
+    fn peek_significant_byte(&self) -> Result<Option<(usize, u8)>, ParseError> {
+        self.scanner
+            .peek_significant_byte(self.input)
+            .map_err(scan_error_to_parse_error)
+    }
+
+    fn consume_comma_token(&mut self) -> Result<(), ParseError> {
+        let token = self.consume_token()?;
+        if matches!(token.kind, TokenKind::Comma) {
+            return Ok(());
+        }
+        Err(self.unexpected(&token, "','"))
+    }
+
+    fn consume_null_token(&mut self) -> Result<bool, ParseError> {
+        let token = self.consume_token()?;
+        match token.kind {
+            TokenKind::Null => {
+                self.state.root_started = true;
+                self.finish_value_in_parent();
+                Ok(true)
+            }
+            _ => Err(self.unexpected(&token, "null")),
+        }
+    }
+
+    fn consume_array_end_token(&mut self) -> Result<bool, ParseError> {
+        let token = self.consume_token()?;
+        match token.kind {
+            TokenKind::ArrayEnd => {
+                self.state.stack.pop();
+                self.finish_value_in_parent();
+                Ok(true)
+            }
+            _ => Err(self.unexpected(&token, "']'")),
+        }
+    }
 }
 
 impl<'de, const TRUSTED_UTF8: bool> FormatParser<'de> for JsonParser<'de, TRUSTED_UTF8> {

--- a/facet-json/src/scanner.rs
+++ b/facet-json/src/scanner.rs
@@ -109,6 +109,7 @@ pub type ScanResult = Result<SpannedToken, ScanError>;
 ///
 /// The scanner operates on a byte buffer and tracks position. For streaming,
 /// the buffer can be refilled when `Token::NeedMore` is returned.
+#[derive(Clone)]
 pub struct Scanner {
     /// Current position in the buffer
     pos: usize,
@@ -177,6 +178,29 @@ impl Scanner {
     #[allow(dead_code)]
     pub const fn set_pos(&mut self, pos: usize) {
         self.pos = pos;
+    }
+
+    /// Return the next non-whitespace/comment byte without changing scanner
+    /// state.
+    pub fn peek_significant_byte(&self, buf: &[u8]) -> Result<Option<(usize, u8)>, ScanError> {
+        self.peek_significant_byte_from(buf, self.pos)
+    }
+
+    /// Return the next non-whitespace/comment byte at or after `pos` without
+    /// changing scanner state.
+    pub fn peek_significant_byte_from(
+        &self,
+        buf: &[u8],
+        pos: usize,
+    ) -> Result<Option<(usize, u8)>, ScanError> {
+        let mut scanner = self.clone();
+        scanner.pos = pos;
+        scanner.state = ScanState::Ready;
+        scanner.skip_whitespace(buf)?;
+        Ok(buf
+            .get(scanner.pos)
+            .copied()
+            .map(|byte| (scanner.pos, byte)))
     }
 
     /// Finalize any pending token at true EOF.

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -555,10 +555,6 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
             .next_event()?
             .ok_or_else(|| vm_error(None, DeserializeErrorKind::UnexpectedEof { expected }))
     }
-
-    fn peek_event(&mut self) -> Result<Option<ParseEvent<'de>>, DeserializeError> {
-        Ok(self.parser.peek_event()?)
-    }
 }
 
 impl<const TRUSTED_UTF8: bool> Drop for JsonInterp<'_, '_, '_, TRUSTED_UTF8> {
@@ -696,17 +692,11 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 some_program,
                 inner_layout,
             } => {
-                match self.peek_event()? {
-                    Some(event)
-                        if matches!(event.kind, ParseEventKind::Scalar(ScalarValue::Null)) =>
-                    {
-                        let _ = self.next_event("null")?;
-                        unsafe {
-                            (option.vtable.init_none)(self.base);
-                        }
-                        return Ok(Control::Continue);
+                if self.parser.consume_null_if_next()? {
+                    unsafe {
+                        (option.vtable.init_none)(self.base);
                     }
-                    _ => {}
+                    return Ok(Control::Continue);
                 }
 
                 let scratch = self.scratch.reserve(*inner_layout);
@@ -757,12 +747,8 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 element_layout,
                 loop_id,
             } => {
-                match self.peek_event()? {
-                    Some(event) if matches!(event.kind, ParseEventKind::SequenceEnd) => {
-                        let _ = self.next_event("array end")?;
-                        return Ok(Control::Continue);
-                    }
-                    _ => {}
+                if self.parser.consume_sequence_end_if_next()? {
+                    return Ok(Control::Continue);
                 }
 
                 let scratch = self.scratch.reserve(*element_layout);

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -15,6 +15,11 @@ struct Person {
 }
 
 #[derive(Facet, Debug, PartialEq)]
+struct MaybeScores {
+    scores: Vec<Option<u16>>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
 struct Node {
     id: u32,
     child: Option<Box<Node>>,
@@ -49,6 +54,18 @@ fn weavy_deserializes_options_and_lists() {
             scores: vec![1, 2, 3],
         }
     );
+}
+
+#[test]
+fn weavy_deserializes_null_options_inside_lists() {
+    let got: MaybeScores = facet_json::from_str_weavy(r#"{"scores":[1,null,2,null]}"#).unwrap();
+    assert_eq!(got.scores, vec![Some(1), None, Some(2), None]);
+}
+
+#[test]
+fn weavy_deserializes_top_level_null_option() {
+    let got: Option<u16> = facet_json::from_str_weavy("null").unwrap();
+    assert_eq!(got, None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This removes two event-materializing branches from the opt-in facet-json Weavy deserializer. Option null checks and list-end checks now use parser intrinsics that consume `null` / `]` directly from the scanner when possible, instead of calling `peek_event()` and cloning a `ParseEvent`.

The parser keeps the old peeked-event fallback, so existing `FormatParser` behavior stays intact. The Weavy integration tests now cover null options inside lists and a top-level null option.

## Performance

Stax, post-rebuild bench binary, medians:

| case | default | reused typeplan | weavy | serde_json | weavy/serde | vs #2284 weavy |
|---|---:|---:|---:|---:|---:|---:|
| point | 692.6 ns | 659.9 ns | 374.7 ns | 28.09 ns | 13.3x | 10.0% faster |
| person | 3.630 us | 3.608 us | 1.343 us | 173.9 ns | 7.7x | 15.1% faster |
| company | 5.446 us | 5.421 us | 3.264 us | 526.8 ns | 6.2x | 5.6% faster |
| batch 1000 | 4.065 ms | 4.034 ms | 1.500 ms | 210.4 us | 7.1x | 10.9% faster |

Profile note: the merged baseline isolated batch profile had `FormatParser::peek_event` and `ParseEvent::clone` in the top self-time list. The new isolated batch profile (stax run 42) has neither in the top 30; the remaining hot work is direct parser/scanner time plus `weavy::apply_control`.

## Commands

```console
cargo check -p facet-json
cargo nextest run -p facet-json -E 'test(weavy)'
cargo nextest run -p facet-json
cargo clippy -p facet-json --all-targets --all-features -- -D warnings
cargo bench -p facet-json --bench typeplan_reuse --no-run
stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench point --skip serde_json_from_slice --color never --sample-count 200 --sample-size 100 --max-time 5
stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench person --skip serde_json_from_slice --color never --sample-count 200 --sample-size 50 --max-time 5
stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench company --skip serde_json_from_slice --color never --sample-count 200 --sample-size 20 --max-time 5
stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench batch_1000 --skip serde_json_from_slice --color never --sample-count 200 --sample-size 20 --max-time 10
stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench batch_1000_weavy_reused_plan --color never --sample-count 200 --sample-size 20 --max-time 20
```
