### PR TITLE
perf(facet-json): read Weavy inputs directly from parser

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -78,6 +78,11 @@ impl JsonValueStart<'_> {
     }
 }
 
+pub(crate) enum JsonObjectStep<'de> {
+    Field { name: Cow<'de, str>, span: Span },
+    End,
+}
+
 /// Mutable parser state that can be saved and restored.
 #[derive(Clone)]
 struct ParserState<'de> {
@@ -678,6 +683,126 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         self.state.scanner_pos
     }
 
+    pub(crate) fn read_scalar_value(&mut self) -> Result<(ScalarValue<'de>, Span), ParseError> {
+        match self.consume_value_start("scalar")? {
+            JsonValueStart::Scalar(value, span) => Ok((value, span)),
+            value => Err(unexpected_value_start(value, "scalar")),
+        }
+    }
+
+    pub(crate) fn consume_object_start(&mut self) -> Result<Span, ParseError> {
+        match self.consume_value_start("object")? {
+            JsonValueStart::Object(span) => Ok(span),
+            value => Err(unexpected_value_start(value, "object")),
+        }
+    }
+
+    pub(crate) fn consume_array_start(&mut self) -> Result<Span, ParseError> {
+        match self.consume_value_start("array")? {
+            JsonValueStart::Array(span) => Ok(span),
+            value => Err(unexpected_value_start(value, "array")),
+        }
+    }
+
+    pub(crate) fn next_object_field_or_end(&mut self) -> Result<JsonObjectStep<'de>, ParseError> {
+        if let Some(event) = self.state.event_peek.take() {
+            self.state.peek_start_offset = None;
+            return match event.kind {
+                ParseEventKind::StructEnd => Ok(JsonObjectStep::End),
+                ParseEventKind::FieldKey(key) => {
+                    let Some(name) = key.name() else {
+                        return Err(ParseError::new(
+                            event.span,
+                            DeserializeErrorKind::InvalidValue {
+                                message: "JSON object field is missing a name".into(),
+                            },
+                        ));
+                    };
+                    Ok(JsonObjectStep::Field {
+                        name: name.clone(),
+                        span: event.span,
+                    })
+                }
+                other => Err(ParseError::new(
+                    event.span,
+                    DeserializeErrorKind::UnexpectedToken {
+                        got: other.kind_name().into(),
+                        expected: "field key or object end",
+                    },
+                )),
+            };
+        }
+
+        loop {
+            match self.determine_action() {
+                NextAction::ObjectKey => {
+                    let token = self.consume_token()?;
+                    let span = token.span;
+                    match token.kind {
+                        TokenKind::ObjectEnd => {
+                            self.state.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(JsonObjectStep::End);
+                        }
+                        TokenKind::String(name) => {
+                            self.expect_colon_token()?;
+                            if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                                *state = ObjectState::Value;
+                            }
+                            return Ok(JsonObjectStep::Field { name, span });
+                        }
+                        TokenKind::Eof => {
+                            return Err(ParseError::new(
+                                span,
+                                DeserializeErrorKind::UnexpectedEof {
+                                    expected: "field name or '}'",
+                                },
+                            ));
+                        }
+                        _ => return Err(self.unexpected(&token, "field name or '}'")),
+                    }
+                }
+                NextAction::ObjectComma => {
+                    let token = self.consume_token()?;
+                    let span = token.span;
+                    match token.kind {
+                        TokenKind::Comma => {
+                            if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                                *state = ObjectState::KeyOrEnd;
+                            }
+                        }
+                        TokenKind::ObjectEnd => {
+                            self.state.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(JsonObjectStep::End);
+                        }
+                        TokenKind::Eof => {
+                            return Err(ParseError::new(
+                                span,
+                                DeserializeErrorKind::UnexpectedEof {
+                                    expected: "',' or '}'",
+                                },
+                            ));
+                        }
+                        _ => return Err(self.unexpected(&token, "',' or '}'")),
+                    }
+                }
+                NextAction::RootFinished => {
+                    return Err(ParseError::new(
+                        Span::new(self.current_offset(), 0),
+                        DeserializeErrorKind::UnexpectedEof {
+                            expected: "field key or object end",
+                        },
+                    ));
+                }
+                _ => {
+                    let token = self.consume_token()?;
+                    return Err(self.unexpected(&token, "field key or object end"));
+                }
+            }
+        }
+    }
+
     pub(crate) fn consume_null_if_next(&mut self) -> Result<bool, ParseError> {
         if let Some(event) = self.state.event_peek.as_ref() {
             if matches!(event.kind, ParseEventKind::Scalar(ScalarValue::Null)) {
@@ -798,6 +923,67 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
             _ => Err(self.unexpected(&token, "']'")),
         }
     }
+
+    fn consume_value_start(
+        &mut self,
+        expected: &'static str,
+    ) -> Result<JsonValueStart<'de>, ParseError> {
+        if let Some(event) = self.state.event_peek.take() {
+            self.state.peek_start_offset = None;
+            return match event.kind {
+                ParseEventKind::StructStart(ContainerKind::Object) => {
+                    Ok(JsonValueStart::Object(event.span))
+                }
+                ParseEventKind::SequenceStart(ContainerKind::Array) => {
+                    Ok(JsonValueStart::Array(event.span))
+                }
+                ParseEventKind::Scalar(value) => Ok(JsonValueStart::Scalar(value, event.span)),
+                other => Err(ParseError::new(
+                    event.span,
+                    DeserializeErrorKind::UnexpectedToken {
+                        got: other.kind_name().into(),
+                        expected,
+                    },
+                )),
+            };
+        }
+
+        match self.determine_action() {
+            NextAction::ObjectValue | NextAction::ArrayValue | NextAction::RootValue => {
+                self.parse_direct_value_start_with_token(None)
+            }
+            NextAction::ArrayComma => {
+                self.consume_comma_token()?;
+                if let Some(ContextState::Array(state)) = self.state.stack.last_mut() {
+                    *state = ArrayState::ValueOrEnd;
+                }
+                self.parse_direct_value_start_with_token(None)
+            }
+            NextAction::RootFinished => Err(ParseError::new(
+                Span::new(self.current_offset(), 0),
+                DeserializeErrorKind::UnexpectedEof { expected },
+            )),
+            _ => {
+                let token = self.consume_token()?;
+                Err(self.unexpected(&token, expected))
+            }
+        }
+    }
+}
+
+fn unexpected_value_start(value: JsonValueStart<'_>, expected: &'static str) -> ParseError {
+    let (got, span) = match value {
+        JsonValueStart::Object(span) => ("object", span),
+        JsonValueStart::Array(span) => ("array", span),
+        JsonValueStart::Scalar(value, span) => (value.kind_name(), span),
+    };
+    ParseError::new(
+        span,
+        DeserializeErrorKind::UnexpectedToken {
+            got: got.into(),
+            expected,
+        },
+    )
 }
 
 impl<'de, const TRUSTED_UTF8: bool> FormatParser<'de> for JsonParser<'de, TRUSTED_UTF8> {

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -14,15 +14,13 @@ use facet_core::{
     Def, DefaultInPlaceFn, DefaultSource, Facet, Field, ListDef, OptionDef, PointerDef, PtrMut,
     PtrUninit, ScalarType, Shape, StructKind, Type, UserType,
 };
-use facet_format::{
-    ContainerKind, DeserializeError, DeserializeErrorKind, FieldKey, FormatParser, ParseEvent,
-    ParseEventKind, ScalarValue,
-};
+use facet_format::{DeserializeError, DeserializeErrorKind, FormatParser, ScalarValue};
 use facet_reflect::Span;
 use weavy::mem::runtime::{HandleGuard, InitializedLedger, ScratchSession, ScratchSlot};
 use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStats, Step};
 
 use crate::JsonParser;
+use crate::parser::JsonObjectStep;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum JsonBlockId {
@@ -549,12 +547,6 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
     fn finish_success(&mut self) {
         self.success = true;
     }
-
-    fn next_event(&mut self, expected: &'static str) -> Result<ParseEvent<'de>, DeserializeError> {
-        self.parser
-            .next_event()?
-            .ok_or_else(|| vm_error(None, DeserializeErrorKind::UnexpectedEof { expected }))
-    }
 }
 
 impl<const TRUSTED_UTF8: bool> Drop for JsonInterp<'_, '_, '_, TRUSTED_UTF8> {
@@ -582,20 +574,9 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
         match op {
             JsonOp::CallBlock(shape) => Ok(Control::CallBlock(*shape)),
             JsonOp::ReadScalar { shape, scalar } => {
-                let event = self.next_event("scalar")?;
-                match event.kind {
-                    ParseEventKind::Scalar(value) => unsafe {
-                        write_scalar(shape, *scalar, self.base, value, event.span)?;
-                    },
-                    other => {
-                        return Err(vm_error(
-                            Some(event.span),
-                            DeserializeErrorKind::UnexpectedToken {
-                                got: other.kind_name().into(),
-                                expected: "scalar",
-                            },
-                        ));
-                    }
+                let (value, span) = self.parser.read_scalar_value()?;
+                unsafe {
+                    write_scalar(shape, *scalar, self.base, value, span)?;
                 }
                 Ok(Control::Continue)
             }
@@ -604,20 +585,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 fields,
                 loop_id,
             } => {
-                let event = self.next_event("object")?;
-                if !matches!(
-                    event.kind,
-                    ParseEventKind::StructStart(ContainerKind::Object)
-                ) {
-                    return Err(vm_error(
-                        Some(event.span),
-                        DeserializeErrorKind::UnexpectedToken {
-                            got: event.kind.kind_name().into(),
-                            expected: "object",
-                        },
-                    ));
-                }
-
+                self.parser.consume_object_start()?;
                 self.structs
                     .push(StructFrame::new(shape, self.base, fields));
                 Ok(Control::CallBlockThen(*loop_id, Continuation::FinishStruct))
@@ -626,67 +594,53 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 shape,
                 fields,
                 loop_id,
-            } => {
-                let event = self.next_event("field key or object end")?;
-                match event.kind {
-                    ParseEventKind::StructEnd => Ok(Control::Continue),
-                    ParseEventKind::FieldKey(key) => {
-                        let Some(field_name) = field_key_name(&key) else {
-                            self.parser.skip_value()?;
-                            return Ok(Control::CallBlock(*loop_id));
-                        };
-
-                        let Some((index, field)) = fields.iter().enumerate().find(|(_, field)| {
-                            field.name == field_name || field.alias == Some(field_name)
-                        }) else {
-                            if shape.has_deny_unknown_fields_attr() {
-                                return Err(vm_error(
-                                    Some(event.span),
-                                    DeserializeErrorKind::UnknownField {
-                                        field: field_name.to_owned().into(),
-                                        suggestion: None,
-                                    },
-                                ));
-                            }
-                            self.parser.skip_value()?;
-                            return Ok(Control::CallBlock(*loop_id));
-                        };
-
-                        let frame = self
-                            .structs
-                            .last()
-                            .expect("struct frame is present while decoding fields");
-                        if let Some(first_span) = frame.seen.get(index).copied() {
+            } => match self.parser.next_object_field_or_end()? {
+                JsonObjectStep::End => Ok(Control::Continue),
+                JsonObjectStep::Field { name, span } => {
+                    let field_name = name.as_ref();
+                    let Some((index, field)) = fields.iter().enumerate().find(|(_, field)| {
+                        field.name == field_name || field.alias == Some(field_name)
+                    }) else {
+                        if shape.has_deny_unknown_fields_attr() {
                             return Err(vm_error(
-                                Some(event.span),
-                                DeserializeErrorKind::DuplicateField {
-                                    field: field.name.into(),
-                                    first_span: Some(first_span),
+                                Some(span),
+                                DeserializeErrorKind::UnknownField {
+                                    field: field_name.to_owned().into(),
+                                    suggestion: None,
                                 },
                             ));
                         }
+                        self.parser.skip_value()?;
+                        return Ok(Control::CallBlock(*loop_id));
+                    };
 
-                        let old_base = self.base;
-                        self.base = unsafe { frame.base.field_uninit(field.offset) };
-                        Ok(Control::CallProgramThen(
-                            &field.program,
-                            Continuation::FieldDone {
-                                index,
-                                span: event.span,
-                                old_base,
-                                loop_id: *loop_id,
+                    let frame = self
+                        .structs
+                        .last()
+                        .expect("struct frame is present while decoding fields");
+                    if let Some(first_span) = frame.seen.get(index).copied() {
+                        return Err(vm_error(
+                            Some(span),
+                            DeserializeErrorKind::DuplicateField {
+                                field: field.name.into(),
+                                first_span: Some(first_span),
                             },
-                        ))
+                        ));
                     }
-                    other => Err(vm_error(
-                        Some(event.span),
-                        DeserializeErrorKind::UnexpectedToken {
-                            got: other.kind_name().into(),
-                            expected: "field key or object end",
+
+                    let old_base = self.base;
+                    self.base = unsafe { frame.base.field_uninit(field.offset) };
+                    Ok(Control::CallProgramThen(
+                        &field.program,
+                        Continuation::FieldDone {
+                            index,
+                            span,
+                            old_base,
+                            loop_id: *loop_id,
                         },
-                    )),
+                    ))
                 }
-            }
+            },
             JsonOp::ReadOption {
                 option,
                 some_program,
@@ -717,19 +671,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 list,
                 loop_id,
             } => {
-                let event = self.next_event("array")?;
-                if !matches!(
-                    event.kind,
-                    ParseEventKind::SequenceStart(ContainerKind::Array)
-                ) {
-                    return Err(vm_error(
-                        Some(event.span),
-                        DeserializeErrorKind::UnexpectedToken {
-                            got: event.kind.kind_name().into(),
-                            expected: "array",
-                        },
-                    ));
-                }
+                self.parser.consume_array_start()?;
                 let init = list
                     .init_in_place_with_capacity()
                     .ok_or_else(|| unsupported(list_shape, "list initialization"))?;
@@ -1221,10 +1163,6 @@ where
         other => return Err(type_mismatch_name(span, target, other.kind_name())),
     };
     T::try_from(value).map_err(|_| number_out_of_range(span, value.to_string(), target))
-}
-
-fn field_key_name<'a>(key: &'a FieldKey<'_>) -> Option<&'a str> {
-    key.name().map(|name| name.as_ref())
 }
 
 fn vm_error(span: Option<Span>, kind: DeserializeErrorKind) -> DeserializeError {

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -20,6 +20,11 @@ struct MaybeScores {
 }
 
 #[derive(Facet, Debug, PartialEq)]
+struct PointList {
+    points: Vec<Point>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
 struct Node {
     id: u32,
     child: Option<Box<Node>>,
@@ -60,6 +65,13 @@ fn weavy_deserializes_options_and_lists() {
 fn weavy_deserializes_null_options_inside_lists() {
     let got: MaybeScores = facet_json::from_str_weavy(r#"{"scores":[1,null,2,null]}"#).unwrap();
     assert_eq!(got.scores, vec![Some(1), None, Some(2), None]);
+}
+
+#[test]
+fn weavy_deserializes_structs_inside_lists() {
+    let got: PointList =
+        facet_json::from_str_weavy(r#"{"points":[{"x":1,"y":2},{"x":3,"y":4}]}"#).unwrap();
+    assert_eq!(got.points, vec![Point { x: 1, y: 2 }, Point { x: 3, y: 4 }]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This removes the remaining generic `ParseEvent` path from the opt-in facet-json Weavy deserializer. Weavy now reads scalar values, object starts, field keys/object ends, and array starts through direct `JsonParser` methods instead of routing through `FormatParser::next_event()`.

The generic event API is still intact for the default facet-json path. The new direct methods live on `JsonParser`, so Weavy stays a typed-memory/control runner and does not gain JSON-specific parsing logic.

## Changes

- Add direct parser methods for Weavy:
  - `read_scalar_value`
  - `consume_object_start`
  - `consume_array_start`
  - `next_object_field_or_end`
- Remove `ParseEvent` / `ParseEventKind` use from `facet-json`'s Weavy interpreter.
- Add Weavy coverage for structs inside lists, exercising object starts behind array commas.

## Performance

Stax, post-rebuild bench binary, medians:

| case | default | reused typeplan | weavy | serde_json | weavy/serde | vs #2285 weavy |
|---|---:|---:|---:|---:|---:|---:|
| point | 723.1 ns | 677.9 ns | 344.5 ns | 28.32 ns | 12.2x | 8.1% faster |
| person | 3.729 us | 3.713 us | 1.245 us | 173.8 ns | 7.2x | 7.3% faster |
| company | 5.559 us | 5.343 us | 2.947 us | 528.9 ns | 5.6x | 9.7% faster |
| batch 1000 | 4.056 ms | 3.908 ms | 1.321 ms | 193.3 us | 6.8x | 11.9% faster |

Profile note: isolated Weavy batch profile stax run 47 no longer has `produce_event`, `peek_event`, `ParseEvent`, or `ParseEvent::clone` in the hot list. The visible hot path is now Weavy control/dispatch plus direct parser/scanner work.

## Commands

```console
cargo check -p facet-json
cargo nextest list -p facet-json -E 'test(weavy)'
cargo nextest run -p facet-json -E 'test(weavy)'
cargo nextest run -p facet-json
cargo clippy -p facet-json --all-targets --all-features -- -D warnings
cargo bench -p facet-json --bench typeplan_reuse --no-run
stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench point --skip serde_json_from_slice --color never --sample-count 200 --sample-size 100 --max-time 5
stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench person --skip serde_json_from_slice --color never --sample-count 200 --sample-size 50 --max-time 5
stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench company --skip serde_json_from_slice --color never --sample-count 200 --sample-size 20 --max-time 5
stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench batch_1000 --skip serde_json_from_slice --color never --sample-count 200 --sample-size 20 --max-time 10
stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench batch_1000_weavy_reused_plan --color never --sample-count 200 --sample-size 20 --max-time 20
stax top --run 47 --limit 35 --sort self
```
