### PR TITLE
perf(facet-json): fuse Weavy scalar child paths

### DIFF
--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -191,6 +191,7 @@ enum JsonOp<Block> {
     ListNext {
         list: ListDef,
         element_program: Program<JsonOp<Block>>,
+        element_scalar: Option<ScalarType>,
         element_layout: Layout,
         loop_id: Block,
     },
@@ -208,6 +209,7 @@ struct FieldPlan<Block> {
     offset: usize,
     shape: &'static Shape,
     program: Program<JsonOp<Block>>,
+    scalar: Option<ScalarType>,
     missing: MissingField,
 }
 
@@ -290,10 +292,12 @@ impl Lowering {
                 }
                 let element_layout = sized_layout(list.t())?;
                 let element_program = self.lower_shape(list.t())?;
+                let element_scalar = ScalarType::try_from_shape(list.t());
                 let loop_id = JsonBlockId::ListLoop(shape);
                 let loop_program = vec![JsonOp::ListNext {
                     list,
                     element_program: element_program.clone(),
+                    element_scalar,
                     element_layout,
                     loop_id,
                 }];
@@ -342,6 +346,7 @@ impl Lowering {
                             offset: field.offset,
                             shape: field_shape,
                             program,
+                            scalar: ScalarType::try_from_shape(field_shape),
                             missing: missing_field_action(field, container_has_default),
                         });
                     }
@@ -433,11 +438,13 @@ fn resolve_json_op(
         JsonOp::ListNext {
             list,
             element_program,
+            element_scalar,
             element_layout,
             loop_id,
         } => JsonOp::ListNext {
             list,
             element_program: resolve_json_program(element_program, refs)?,
+            element_scalar,
             element_layout,
             loop_id: resolve_block_ref(loop_id, refs)?,
         },
@@ -467,6 +474,7 @@ fn resolve_field_plans(
                 offset: field.offset,
                 shape: field.shape,
                 program: resolve_json_program(field.program, refs)?,
+                scalar: field.scalar,
                 missing: field.missing,
             })
         })
@@ -628,9 +636,23 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                         ));
                     }
 
+                    if let Some(scalar) = field.scalar {
+                        let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
+                        let (value, value_span) = self.parser.read_scalar_value()?;
+                        unsafe {
+                            write_scalar(field.shape, scalar, field_ptr, value, value_span)?;
+                        }
+                        let frame = self
+                            .structs
+                            .last_mut()
+                            .expect("struct frame is present while decoding scalar field");
+                        frame.seen.mark(index, span);
+                        return Ok(Control::CallBlock(*loop_id));
+                    }
+
                     let old_base = self.base;
                     self.base = unsafe { frame.base.field_uninit(field.offset) };
-                    Ok(Control::CallProgramThen(
+                    Ok(call_program_or_block_then(
                         &field.program,
                         Continuation::FieldDone {
                             index,
@@ -656,7 +678,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 let scratch = self.scratch.reserve(*inner_layout);
                 let old_base = self.base;
                 self.base = scratch_ptr_uninit(&scratch);
-                Ok(Control::CallProgramThen(
+                Ok(call_program_or_block_then(
                     some_program,
                     Continuation::OptionSome {
                         option: *option,
@@ -686,6 +708,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
             JsonOp::ListNext {
                 list,
                 element_program,
+                element_scalar,
                 element_layout,
                 loop_id,
             } => {
@@ -693,10 +716,31 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                     return Ok(Control::Continue);
                 }
 
+                if let Some(scalar) = element_scalar {
+                    let scratch = self.scratch.reserve(*element_layout);
+                    let (value, span) = self.parser.read_scalar_value()?;
+                    unsafe {
+                        write_scalar(list.t(), *scalar, scratch_ptr_uninit(&scratch), value, span)?;
+                    }
+                    let list_ptr = self
+                        .lists
+                        .last()
+                        .expect("list frame is present while decoding scalar element")
+                        .ptr();
+                    let push = list
+                        .push()
+                        .ok_or_else(|| unsupported(list.t(), "list push"))?;
+                    unsafe {
+                        push(PtrMut::new(list_ptr), scratch_ptr_mut(&scratch));
+                    }
+                    self.scratch.release(scratch);
+                    return Ok(Control::CallBlock(*loop_id));
+                }
+
                 let scratch = self.scratch.reserve(*element_layout);
                 let old_base = self.base;
                 self.base = scratch_ptr_uninit(&scratch);
-                Ok(Control::CallProgramThen(
+                Ok(call_program_or_block_then(
                     element_program,
                     Continuation::ListElement {
                         list: *list,
@@ -717,7 +761,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 let scratch = self.scratch.reserve(*pointee_layout);
                 let old_base = self.base;
                 self.base = scratch_ptr_uninit(&scratch);
-                Ok(Control::CallProgramThen(
+                Ok(call_program_or_block_then(
                     pointee_program,
                     Continuation::Pointer {
                         pointer: *pointer,
@@ -819,6 +863,16 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 Ok(Control::Continue)
             }
         }
+    }
+}
+
+fn call_program_or_block_then<'program>(
+    program: &'program [ExecOp],
+    continuation: Continuation,
+) -> Control<'program, ExecBlock, ExecOp, Continuation> {
+    match program {
+        [JsonOp::CallBlock(block)] => Control::CallBlockThen(*block, continuation),
+        _ => Control::CallProgramThen(program, continuation),
     }
 }
 

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -111,3 +111,16 @@ fn weavy_stats_report_block_calls_for_recursive_shape() {
     assert!(stats.block_call_count >= 3, "{stats:?}");
     assert!(stats.max_frame_depth >= 2, "{stats:?}");
 }
+
+#[test]
+fn weavy_stats_keep_scalar_fields_and_lists_in_loop() {
+    let (_, point_stats): (Point, _) =
+        facet_json::from_str_weavy_with_stats(r#"{"x":10,"y":20}"#).unwrap();
+    assert_eq!(point_stats.inline_call_count, 0, "{point_stats:?}");
+
+    let (_, stats): (Person, _) = facet_json::from_str_weavy_with_stats(
+        r#"{"name":"Ada","age":37,"favorite":null,"scores":[1,2,3]}"#,
+    )
+    .unwrap();
+    assert_eq!(stats.inline_call_count, 0, "{stats:?}");
+}


### PR DESCRIPTION
## Summary

- Fuse scalar struct fields into the `StructNext` loop so scalar field payloads no longer enter a child program frame.
- Fuse scalar list elements into the `ListNext` loop while preserving the existing scratch + `ListDef::push` ownership path.
- Collapse one-op child programs of the form `[CallBlock(block)]` into direct `CallBlockThen` for fields, options, list elements, and pointers.
- Add a public-path stats assertion that scalar-heavy Weavy deserialization uses zero inline child calls.

## Performance

Measured with `stax record` on `facet-json/benches/typeplan_reuse.rs`.
`vs prev` compares against the last merged direct-parser PR medians.

| Bench | Weavy | serde_json | Weavy/serde | vs prev |
|---|---:|---:|---:|---:|
| point | 249 ns | 27.77 ns | 9.0x | 27.7% faster |
| person | 882.2 ns | 170.5 ns | 5.2x | 29.1% faster |
| company | 2.383 us | 608.2 ns | 3.9x | 19.1% faster |
| batch 1000 | 1.040 ms | 203.9 us | 5.1x | 21.3% faster |

Isolated Weavy batch profile:

- `stax record` run 57: `batch_1000_weavy_reused_plan` median 981 us.
- Top remaining self-time is still interpreter control and parser/scanner work: `weavy::apply_control`, `JsonInterp::step`, `weavy::run_program_accounted`, `consume_spanned_token`, `Scanner::next_token`, and `write_scalar`.

## Testing

- `cargo check -p facet-json`
- `cargo nextest run -p facet-json -E 'test(weavy)'`
- `cargo nextest run -p facet-json`
- `cargo clippy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo bench -p facet-json --bench typeplan_reuse --no-run`
- `stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench point --skip serde_json_from_slice --color never --sample-count 200 --sample-size 100 --max-time 5`
- `stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench person --skip serde_json_from_slice --color never --sample-count 200 --sample-size 100 --max-time 5`
- `stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench company --skip serde_json_from_slice --color never --sample-count 200 --sample-size 100 --max-time 5`
- `stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench batch --skip serde_json_from_slice --color never --sample-count 200 --sample-size 100 --max-time 5`
- `stax record -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench batch_1000_weavy_reused_plan --color never --sample-count 200 --sample-size 100 --max-time 5`
- `stax top --run 57 --limit 20 --sort self`
