### PR TITLE
perf(weavy): tighten JSON runner bookkeeping

### DIFF
--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -213,6 +213,12 @@ struct FieldPlan<Block> {
     missing: MissingField,
 }
 
+impl<Block> FieldPlan<Block> {
+    fn matches_name(&self, name: &str) -> bool {
+        self.name == name || self.alias == Some(name)
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 enum MissingField {
     Required,
@@ -532,8 +538,8 @@ fn unsupported(shape: &'static Shape, what: &'static str) -> DeserializeError {
 struct JsonInterp<'parser, 'de, 'program, const TRUSTED_UTF8: bool> {
     parser: &'parser mut JsonParser<'de, TRUSTED_UTF8>,
     base: PtrUninit,
-    structs: Vec<StructFrame<'program>>,
-    lists: Vec<HandleGuard>,
+    structs: InlineStack<StructFrame<'program>>,
+    lists: InlineStack<HandleGuard>,
     scratch: ScratchSession,
     success: bool,
 }
@@ -545,8 +551,8 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
         Self {
             parser,
             base,
-            structs: Vec::new(),
-            lists: Vec::new(),
+            structs: InlineStack::new(),
+            lists: InlineStack::new(),
             scratch: ScratchSession::new(),
             success: false,
         }
@@ -554,6 +560,40 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
 
     fn finish_success(&mut self) {
         self.success = true;
+    }
+}
+
+struct InlineStack<T> {
+    first: Option<T>,
+    rest: Vec<T>,
+}
+
+impl<T> InlineStack<T> {
+    fn new() -> Self {
+        Self {
+            first: None,
+            rest: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, value: T) {
+        if self.first.is_none() {
+            self.first = Some(value);
+        } else {
+            self.rest.push(value);
+        }
+    }
+
+    fn pop(&mut self) -> Option<T> {
+        self.rest.pop().or_else(|| self.first.take())
+    }
+
+    fn last(&self) -> Option<&T> {
+        self.rest.last().or(self.first.as_ref())
+    }
+
+    fn last_mut(&mut self) -> Option<&mut T> {
+        self.rest.last_mut().or(self.first.as_mut())
     }
 }
 
@@ -606,9 +646,11 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 JsonObjectStep::End => Ok(Control::Continue),
                 JsonObjectStep::Field { name, span } => {
                     let field_name = name.as_ref();
-                    let Some((index, field)) = fields.iter().enumerate().find(|(_, field)| {
-                        field.name == field_name || field.alias == Some(field_name)
-                    }) else {
+                    let Some((index, field)) = fields
+                        .iter()
+                        .enumerate()
+                        .find(|(_, field)| field.matches_name(field_name))
+                    else {
                         if shape.has_deny_unknown_fields_attr() {
                             return Err(vm_error(
                                 Some(span),

--- a/weavy/src/mem/runtime.rs
+++ b/weavy/src/mem/runtime.rs
@@ -5,8 +5,10 @@
 //! values live there and which thunks move those values into final handles.
 
 use std::alloc::{self, Layout};
+use std::array;
 use std::error::Error;
 use std::fmt;
+use std::mem::MaybeUninit;
 
 /// Allocation/layout failures for raw typed-memory runtime buffers.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -305,45 +307,170 @@ impl Drop for HandleGuard {
 }
 
 /// Bookkeeping for initialized child slots.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct InitializedLedger<Mark> {
-    marks: Vec<Option<Mark>>,
+pub struct InitializedLedger<Mark, const INLINE: usize = 8> {
+    storage: LedgerStorage<Mark, INLINE>,
 }
 
-impl<Mark> InitializedLedger<Mark> {
+enum LedgerStorage<Mark, const INLINE: usize> {
+    Inline {
+        len: usize,
+        initialized: u64,
+        marks: [MaybeUninit<Mark>; INLINE],
+    },
+    Heap(Vec<Option<Mark>>),
+}
+
+impl<Mark, const INLINE: usize> InitializedLedger<Mark, INLINE> {
     /// Create a ledger with `len` uninitialized slots.
     #[must_use]
     pub fn new(len: usize) -> Self {
-        Self {
-            marks: (0..len).map(|_| None).collect(),
+        let storage = if len <= INLINE && len <= u64::BITS as usize {
+            LedgerStorage::Inline {
+                len,
+                initialized: 0,
+                marks: array::from_fn(|_| MaybeUninit::uninit()),
+            }
+        } else {
+            LedgerStorage::Heap((0..len).map(|_| None).collect())
+        };
+        Self { storage }
+    }
+
+    fn len(&self) -> usize {
+        match &self.storage {
+            LedgerStorage::Inline { len, .. } => *len,
+            LedgerStorage::Heap(marks) => marks.len(),
         }
     }
 
     /// Return whether `index` is initialized.
     #[must_use]
     pub fn is_initialized(&self, index: usize) -> bool {
-        self.marks[index].is_some()
+        match &self.storage {
+            LedgerStorage::Inline {
+                len, initialized, ..
+            } => {
+                assert!(index < *len, "ledger index out of bounds");
+                (*initialized & initialized_bit(index)) != 0
+            }
+            LedgerStorage::Heap(marks) => marks[index].is_some(),
+        }
     }
 
     /// Return the mark for `index` when initialized.
     #[must_use]
     pub fn get(&self, index: usize) -> Option<&Mark> {
-        self.marks[index].as_ref()
+        match &self.storage {
+            LedgerStorage::Inline {
+                len,
+                initialized,
+                marks,
+            } => {
+                assert!(index < *len, "ledger index out of bounds");
+                ((*initialized & initialized_bit(index)) != 0)
+                    .then(|| unsafe { marks[index].assume_init_ref() })
+            }
+            LedgerStorage::Heap(marks) => marks[index].as_ref(),
+        }
     }
 
     /// Mark `index` initialized.
     pub fn mark(&mut self, index: usize, mark: Mark) {
-        self.marks[index] = Some(mark);
+        match &mut self.storage {
+            LedgerStorage::Inline {
+                len,
+                initialized,
+                marks,
+            } => {
+                assert!(index < *len, "ledger index out of bounds");
+                let bit = initialized_bit(index);
+                if (*initialized & bit) != 0 {
+                    unsafe {
+                        marks[index].assume_init_drop();
+                    }
+                }
+                marks[index].write(mark);
+                *initialized |= bit;
+            }
+            LedgerStorage::Heap(marks) => {
+                marks[index] = Some(mark);
+            }
+        }
     }
 
     /// Initialized slots in reverse index order.
     pub fn iter_initialized_rev(&self) -> impl Iterator<Item = (usize, &Mark)> {
-        self.marks
-            .iter()
-            .enumerate()
+        (0..self.len())
             .rev()
-            .filter_map(|(index, mark)| mark.as_ref().map(|mark| (index, mark)))
+            .filter_map(|index| self.get(index).map(|mark| (index, mark)))
     }
+}
+
+impl<Mark: Clone, const INLINE: usize> Clone for InitializedLedger<Mark, INLINE> {
+    fn clone(&self) -> Self {
+        Self {
+            storage: self.storage.clone(),
+        }
+    }
+}
+
+impl<Mark: fmt::Debug, const INLINE: usize> fmt::Debug for InitializedLedger<Mark, INLINE> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map().entries(self.iter_initialized_rev()).finish()
+    }
+}
+
+impl<Mark: PartialEq, const INLINE: usize> PartialEq for InitializedLedger<Mark, INLINE> {
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len()
+            && (0..self.len()).all(|index| self.get(index) == other.get(index))
+    }
+}
+
+impl<Mark: Eq, const INLINE: usize> Eq for InitializedLedger<Mark, INLINE> {}
+
+impl<Mark: Clone, const INLINE: usize> Clone for LedgerStorage<Mark, INLINE> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Inline {
+                len,
+                initialized,
+                marks,
+            } => {
+                let mut cloned = InitializedLedger::<Mark, INLINE>::new(*len);
+                for (index, mark) in marks.iter().enumerate().take(*len) {
+                    if (*initialized & initialized_bit(index)) != 0 {
+                        cloned.mark(index, unsafe { mark.assume_init_ref() }.clone());
+                    }
+                }
+                cloned.storage
+            }
+            Self::Heap(marks) => Self::Heap(marks.clone()),
+        }
+    }
+}
+
+impl<Mark, const INLINE: usize> Drop for LedgerStorage<Mark, INLINE> {
+    fn drop(&mut self) {
+        if let Self::Inline {
+            len,
+            initialized,
+            marks,
+        } = self
+        {
+            for (index, mark) in marks.iter_mut().enumerate().take(*len) {
+                if (*initialized & initialized_bit(index)) != 0 {
+                    unsafe {
+                        mark.assume_init_drop();
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn initialized_bit(index: usize) -> u64 {
+    1u64 << index
 }
 
 /// Neutral "initialize handle from scratch value" target.
@@ -389,6 +516,14 @@ fn layout_fits(buffer: Layout, requested: Layout) -> bool {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountedDrop<'a>(&'a AtomicUsize);
+
+    impl Drop for CountedDrop<'_> {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
 
     unsafe fn count_drop(ctx: *const (), _ptr: *mut u8) {
         let drops = unsafe { &*(ctx as *const AtomicUsize) };
@@ -456,7 +591,7 @@ mod tests {
 
     #[test]
     fn initialized_ledger_reports_reverse_order() {
-        let mut ledger = InitializedLedger::new(4);
+        let mut ledger: InitializedLedger<&str> = InitializedLedger::new(4);
         assert!(!ledger.is_initialized(2));
         ledger.mark(1, "one");
         ledger.mark(3, "three");
@@ -467,5 +602,33 @@ mod tests {
             .map(|(index, mark)| (index, *mark))
             .collect::<Vec<_>>();
         assert_eq!(initialized, vec![(3, "three"), (1, "one")]);
+    }
+
+    #[test]
+    fn initialized_ledger_drops_replaced_and_live_inline_marks() {
+        let drops = AtomicUsize::new(0);
+        {
+            let mut ledger: InitializedLedger<CountedDrop<'_>> = InitializedLedger::new(1);
+            ledger.mark(0, CountedDrop(&drops));
+            assert_eq!(drops.load(Ordering::SeqCst), 0);
+
+            ledger.mark(0, CountedDrop(&drops));
+            assert_eq!(drops.load(Ordering::SeqCst), 1);
+        }
+        assert_eq!(drops.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn initialized_ledger_reports_reverse_order_from_heap_storage() {
+        let mut ledger: InitializedLedger<&str, 2> = InitializedLedger::new(4);
+        ledger.mark(0, "zero");
+        ledger.mark(2, "two");
+
+        assert_eq!(ledger.get(2), Some(&"two"));
+        let initialized = ledger
+            .iter_initialized_rev()
+            .map(|(index, mark)| (index, *mark))
+            .collect::<Vec<_>>();
+        assert_eq!(initialized, vec![(2, "two"), (0, "zero")]);
     }
 }


### PR DESCRIPTION

## Summary
- Keep small `InitializedLedger` instances inline instead of allocating a heap `Vec` for the common small-field case.
- Store inline ledger marks behind an initialized bitmask plus `MaybeUninit`, preserving heap fallback for wider ledgers.
- Use an inline first slot for the JSON Weavy struct/list guard stacks, avoiding a `Vec` allocation for the common single-frame case.

## Validation
- `cargo nextest run -p weavy`
- `cargo nextest run -p facet-json -E 'test(weavy)'`
- `cargo clippy -p weavy --all-targets --all-features -- -D warnings`
- `cargo clippy -p facet-json --all-targets --all-features -- -D warnings`
- Push preflight passed on `a6780e58b`.
- Remote `stax` measurements on `mur` and `souffle`, using checkout-installed `stax` via `cargo xtask install`.

## Stax Medians

| Host | Case | main Weavy | PR Weavy | PR delta | PR Weavy / serde_json |
|---|---:|---:|---:|---:|---:|
| mur | point | 525.6 ns | 504.6 ns | -4.0% | 7.8x |
| mur | person | 1.902 us | 1.881 us | -1.1% | 4.9x |
| mur | company | 5.086 us | 4.954 us | -2.6% | 4.1x |
| mur | batch_1000 | 1.893 ms | 1.841 ms | -2.7% | 5.6x |
| souffle | point | 319.5 ns | 285.2 ns | -10.7% | 8.1x |
| souffle | person | 1.075 us | 1.101 us | +2.4% | 4.9x |
| souffle | company | 3.034 us | 3.139 us | +3.5% | 5.1x |
| souffle | batch_1000 | 1.236 ms | 1.261 ms | +2.0% | 4.7x |
