### PR TITLE
perf(facet-json): let Weavy read scalar tokens directly

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -83,6 +83,50 @@ pub(crate) enum JsonObjectStep<'de> {
     End,
 }
 
+pub(crate) enum JsonScalarToken<'de> {
+    Null,
+    Bool(bool),
+    Str(Cow<'de, str>),
+    U64(u64),
+    I64(i64),
+    U128(u128),
+    I128(i128),
+    F64(f64),
+    Other,
+}
+
+impl<'de> JsonScalarToken<'de> {
+    pub(crate) fn kind_name(&self) -> &'static str {
+        match self {
+            Self::Null => "null",
+            Self::Bool(_) => "bool",
+            Self::Str(_) => "string",
+            Self::U64(_) => "u64",
+            Self::I64(_) => "i64",
+            Self::U128(_) => "u128",
+            Self::I128(_) => "i128",
+            Self::F64(_) => "f64",
+            Self::Other => "scalar",
+        }
+    }
+
+    fn from_scalar_value(value: ScalarValue<'de>) -> Self {
+        match value {
+            ScalarValue::Unit | ScalarValue::Null => Self::Null,
+            ScalarValue::Bool(value) => Self::Bool(value),
+            ScalarValue::Char(value) => Self::Str(Cow::Owned(value.into())),
+            ScalarValue::I64(value) => Self::I64(value),
+            ScalarValue::U64(value) => Self::U64(value),
+            ScalarValue::I128(value) => Self::I128(value),
+            ScalarValue::U128(value) => Self::U128(value),
+            ScalarValue::F64(value) => Self::F64(value),
+            ScalarValue::Str(value) => Self::Str(value),
+            ScalarValue::Bytes(_) => Self::Other,
+            _ => Self::Other,
+        }
+    }
+}
+
 /// Mutable parser state that can be saved and restored.
 #[derive(Clone)]
 struct ParserState<'de> {
@@ -243,13 +287,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                 has_escapes,
             } => TokenKind::String(self.decode_string(start, end, has_escapes, span)?),
             ScanToken::Number { start, end, hint } => {
-                let parsed = if TRUSTED_UTF8 {
-                    // SAFETY: Input came from &str, so it's valid UTF-8
-                    unsafe { scanner::parse_number_unchecked(self.input, start, end, hint) }
-                } else {
-                    scanner::parse_number(self.input, start, end, hint)
-                }
-                .map_err(scan_error_to_parse_error)?;
+                let parsed = self.parse_number(start, end, hint)?;
                 match parsed {
                     ParsedNumber::U64(n) => TokenKind::U64(n),
                     ParsedNumber::I64(n) => TokenKind::I64(n),
@@ -262,6 +300,21 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
             ScanToken::NeedMore { .. } => unreachable!("handled above"),
         };
         Ok(kind)
+    }
+
+    fn parse_number(
+        &self,
+        start: usize,
+        end: usize,
+        hint: scanner::NumberHint,
+    ) -> Result<ParsedNumber, ParseError> {
+        if TRUSTED_UTF8 {
+            // SAFETY: Input came from &str, so it's valid UTF-8
+            unsafe { scanner::parse_number_unchecked(self.input, start, end, hint) }
+        } else {
+            scanner::parse_number(self.input, start, end, hint)
+        }
+        .map_err(scan_error_to_parse_error)
     }
 
     #[inline]
@@ -683,10 +736,42 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         self.state.scanner_pos
     }
 
-    pub(crate) fn read_scalar_value(&mut self) -> Result<(ScalarValue<'de>, Span), ParseError> {
-        match self.consume_value_start("scalar")? {
-            JsonValueStart::Scalar(value, span) => Ok((value, span)),
-            value => Err(unexpected_value_start(value, "scalar")),
+    pub(crate) fn read_scalar_token(&mut self) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
+        if let Some(event) = self.state.event_peek.take() {
+            self.state.peek_start_offset = None;
+            return match event.kind {
+                ParseEventKind::Scalar(value) => {
+                    Ok((JsonScalarToken::from_scalar_value(value), event.span))
+                }
+                other => Err(ParseError::new(
+                    event.span,
+                    DeserializeErrorKind::UnexpectedToken {
+                        got: other.kind_name().into(),
+                        expected: "scalar",
+                    },
+                )),
+            };
+        }
+
+        match self.determine_action() {
+            NextAction::ObjectValue | NextAction::ArrayValue | NextAction::RootValue => {
+                self.consume_scalar_token()
+            }
+            NextAction::ArrayComma => {
+                self.consume_comma_token()?;
+                if let Some(ContextState::Array(state)) = self.state.stack.last_mut() {
+                    *state = ArrayState::ValueOrEnd;
+                }
+                self.consume_scalar_token()
+            }
+            NextAction::RootFinished => Err(ParseError::new(
+                Span::new(self.current_offset(), 0),
+                DeserializeErrorKind::UnexpectedEof { expected: "scalar" },
+            )),
+            _ => {
+                let token = self.consume_spanned_token()?;
+                Err(self.unexpected_scan_token(&token, "scalar"))
+            }
         }
     }
 
@@ -898,6 +983,40 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
             return Ok(());
         }
         Err(self.unexpected(&token, "','"))
+    }
+
+    fn consume_scalar_token(&mut self) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
+        let token = self.consume_spanned_token()?;
+        let span = token.span;
+        let value = match token.token {
+            ScanToken::Null => JsonScalarToken::Null,
+            ScanToken::True => JsonScalarToken::Bool(true),
+            ScanToken::False => JsonScalarToken::Bool(false),
+            ScanToken::String {
+                start,
+                end,
+                has_escapes,
+            } => JsonScalarToken::Str(self.decode_string(start, end, has_escapes, span)?),
+            ScanToken::Number { start, end, hint } => match self.parse_number(start, end, hint)? {
+                ParsedNumber::U64(value) => JsonScalarToken::U64(value),
+                ParsedNumber::I64(value) => JsonScalarToken::I64(value),
+                ParsedNumber::U128(value) => JsonScalarToken::U128(value),
+                ParsedNumber::I128(value) => JsonScalarToken::I128(value),
+                ParsedNumber::F64(value) => JsonScalarToken::F64(value),
+            },
+            ScanToken::ObjectStart
+            | ScanToken::ObjectEnd
+            | ScanToken::ArrayStart
+            | ScanToken::ArrayEnd
+            | ScanToken::Colon
+            | ScanToken::Comma
+            | ScanToken::Eof => return Err(self.unexpected_scan_token(&token, "scalar")),
+            ScanToken::NeedMore { .. } => unreachable!("handled by consume_spanned_token"),
+        };
+
+        self.state.root_started = true;
+        self.finish_value_in_parent();
+        Ok((value, span))
     }
 
     fn consume_null_token(&mut self) -> Result<bool, ParseError> {

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -14,13 +14,13 @@ use facet_core::{
     Def, DefaultInPlaceFn, DefaultSource, Facet, Field, ListDef, OptionDef, PointerDef, PtrMut,
     PtrUninit, ScalarType, Shape, StructKind, Type, UserType,
 };
-use facet_format::{DeserializeError, DeserializeErrorKind, FormatParser, ScalarValue};
+use facet_format::{DeserializeError, DeserializeErrorKind, FormatParser};
 use facet_reflect::Span;
 use weavy::mem::runtime::{HandleGuard, InitializedLedger, ScratchSession, ScratchSlot};
 use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStats, Step};
 
 use crate::JsonParser;
-use crate::parser::JsonObjectStep;
+use crate::parser::{JsonObjectStep, JsonScalarToken};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum JsonBlockId {
@@ -622,7 +622,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
         match op {
             JsonOp::CallBlock(shape) => Ok(Control::CallBlock(*shape)),
             JsonOp::ReadScalar { shape, scalar } => {
-                let (value, span) = self.parser.read_scalar_value()?;
+                let (value, span) = self.parser.read_scalar_token()?;
                 unsafe {
                     write_scalar(shape, *scalar, self.base, value, span)?;
                 }
@@ -680,7 +680,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
 
                     if let Some(scalar) = field.scalar {
                         let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
-                        let (value, value_span) = self.parser.read_scalar_value()?;
+                        let (value, value_span) = self.parser.read_scalar_token()?;
                         unsafe {
                             write_scalar(field.shape, scalar, field_ptr, value, value_span)?;
                         }
@@ -760,7 +760,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
 
                 if let Some(scalar) = element_scalar {
                     let scratch = self.scratch.reserve(*element_layout);
-                    let (value, span) = self.parser.read_scalar_value()?;
+                    let (value, span) = self.parser.read_scalar_token()?;
                     unsafe {
                         write_scalar(list.t(), *scalar, scratch_ptr_uninit(&scratch), value, span)?;
                     }
@@ -1065,27 +1065,24 @@ unsafe fn write_scalar(
     shape: &'static Shape,
     scalar: ScalarType,
     dst: PtrUninit,
-    value: ScalarValue<'_>,
+    value: JsonScalarToken<'_>,
     span: Span,
 ) -> Result<(), DeserializeError> {
     match scalar {
         ScalarType::Unit => match value {
-            ScalarValue::Null | ScalarValue::Unit => {
+            JsonScalarToken::Null => {
                 unsafe { dst.put(()) };
             }
             other => return Err(type_mismatch(span, shape, other.kind_name())),
         },
         ScalarType::Bool => match value {
-            ScalarValue::Bool(value) => {
+            JsonScalarToken::Bool(value) => {
                 unsafe { dst.put(value) };
             }
             other => return Err(type_mismatch(span, shape, other.kind_name())),
         },
         ScalarType::Char => match value {
-            ScalarValue::Char(value) => {
-                unsafe { dst.put(value) };
-            }
-            ScalarValue::Str(value) => {
+            JsonScalarToken::Str(value) => {
                 let mut chars = value.chars();
                 let Some(ch) = chars.next() else {
                     return Err(invalid_value(span, "empty string is not a char"));
@@ -1099,14 +1096,14 @@ unsafe fn write_scalar(
         },
         ScalarType::String => {
             let string = match value {
-                ScalarValue::Str(value) => value.into_owned(),
+                JsonScalarToken::Str(value) => value.into_owned(),
                 other => return Err(type_mismatch(span, shape, other.kind_name())),
             };
             unsafe { dst.put(string) };
         }
         ScalarType::CowStr => {
             let string = match value {
-                ScalarValue::Str(value) => value.into_owned(),
+                JsonScalarToken::Str(value) => value.into_owned(),
                 other => return Err(type_mismatch(span, shape, other.kind_name())),
             };
             unsafe { dst.put::<Cow<'static, str>>(Cow::Owned(string)) };
@@ -1177,7 +1174,7 @@ unsafe fn write_scalar(
         | ScalarType::IpAddr
         | ScalarType::Ipv4Addr
         | ScalarType::Ipv6Addr => {
-            let ScalarValue::Str(value) = value else {
+            let JsonScalarToken::Str(value) = value else {
                 return Err(type_mismatch(span, shape, value.kind_name()));
             };
             match unsafe { shape.call_parse(value.as_ref(), dst) } {
@@ -1202,17 +1199,17 @@ unsafe fn write_scalar(
 }
 
 fn scalar_to_f64(
-    value: ScalarValue<'_>,
+    value: JsonScalarToken<'_>,
     span: Span,
     shape: &'static Shape,
 ) -> Result<f64, DeserializeError> {
     match value {
-        ScalarValue::F64(value) => Ok(value),
-        ScalarValue::I64(value) => Ok(value as f64),
-        ScalarValue::U64(value) => Ok(value as f64),
-        ScalarValue::I128(value) => Ok(value as f64),
-        ScalarValue::U128(value) => Ok(value as f64),
-        ScalarValue::Str(value) => value
+        JsonScalarToken::F64(value) => Ok(value),
+        JsonScalarToken::I64(value) => Ok(value as f64),
+        JsonScalarToken::U64(value) => Ok(value as f64),
+        JsonScalarToken::I128(value) => Ok(value as f64),
+        JsonScalarToken::U128(value) => Ok(value as f64),
+        JsonScalarToken::Str(value) => value
             .parse::<f64>()
             .map_err(|_| type_mismatch(span, shape, "string")),
         other => Err(type_mismatch(span, shape, other.kind_name())),
@@ -1220,7 +1217,7 @@ fn scalar_to_f64(
 }
 
 fn into_unsigned<T>(
-    value: ScalarValue<'_>,
+    value: JsonScalarToken<'_>,
     span: Span,
     target: &'static str,
 ) -> Result<T, DeserializeError>
@@ -1228,11 +1225,11 @@ where
     T: TryFrom<u128>,
 {
     let value = match value {
-        ScalarValue::U64(value) => value as u128,
-        ScalarValue::U128(value) => value,
-        ScalarValue::I64(value) if value >= 0 => value as u128,
-        ScalarValue::I128(value) if value >= 0 => value as u128,
-        ScalarValue::Str(value) => value
+        JsonScalarToken::U64(value) => value as u128,
+        JsonScalarToken::U128(value) => value,
+        JsonScalarToken::I64(value) if value >= 0 => value as u128,
+        JsonScalarToken::I128(value) if value >= 0 => value as u128,
+        JsonScalarToken::Str(value) => value
             .parse::<u128>()
             .map_err(|_| number_out_of_range(span, value.into_owned(), target))?,
         other => return Err(type_mismatch_name(span, target, other.kind_name())),
@@ -1241,7 +1238,7 @@ where
 }
 
 fn into_signed<T>(
-    value: ScalarValue<'_>,
+    value: JsonScalarToken<'_>,
     span: Span,
     target: &'static str,
 ) -> Result<T, DeserializeError>
@@ -1249,11 +1246,11 @@ where
     T: TryFrom<i128>,
 {
     let value = match value {
-        ScalarValue::I64(value) => value as i128,
-        ScalarValue::I128(value) => value,
-        ScalarValue::U64(value) => value as i128,
-        ScalarValue::U128(value) if value <= i128::MAX as u128 => value as i128,
-        ScalarValue::Str(value) => value
+        JsonScalarToken::I64(value) => value as i128,
+        JsonScalarToken::I128(value) => value,
+        JsonScalarToken::U64(value) => value as i128,
+        JsonScalarToken::U128(value) if value <= i128::MAX as u128 => value as i128,
+        JsonScalarToken::Str(value) => value
             .parse::<i128>()
             .map_err(|_| number_out_of_range(span, value.into_owned(), target))?,
         other => return Err(type_mismatch_name(span, target, other.kind_name())),


### PR DESCRIPTION

## Summary
- Add a crate-local `JsonScalarToken` path in `JsonParser` so the Weavy backend can consume scalar tokens without first materializing `facet_format::ScalarValue`.
- Keep the existing `FormatParser` event path unchanged; this is only used by the opt-in Weavy JSON deserializer.
- Preserve existing string-number compatibility and scalar mismatch behavior in the Weavy writer.

## Validation
- `cargo nextest run -p facet-json -E 'test(weavy)'`
- `cargo clippy -p facet-json --all-targets --all-features -- -D warnings`
- Push preflight passed on `fbb8e6edd`.
- Remote `stax` measurements on `mur` and `souffle`, using checkout-installed `stax` via `cargo xtask install`.

## Stax Medians

`mur` point was rerun after an outlier in the first branch pass; the row below uses the stable rerun median.

| Host | Case | main Weavy | PR Weavy | PR delta | PR Weavy / serde_json |
|---|---:|---:|---:|---:|---:|
| mur | point | 540.2 ns | 542.5 ns | +0.4% | 8.6x |
| mur | person | 1.883 us | 1.807 us | -4.0% | 4.7x |
| mur | company | 4.984 us | 4.870 us | -2.3% | 4.3x |
| mur | batch_1000 | 1.763 ms | 1.711 ms | -3.0% | 5.2x |
| souffle | point | 317.8 ns | 249.5 ns | -21.5% | 7.0x |
| souffle | person | 1.010 us | 904.7 ns | -10.4% | 4.7x |
| souffle | company | 3.085 us | 2.764 us | -10.4% | 4.4x |
| souffle | batch_1000 | 1.263 ms | 1.145 ms | -9.3% | 4.3x |
