### PR TITLE
perf(facet-json): read Weavy field keys directly

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -79,8 +79,22 @@ impl JsonValueStart<'_> {
 }
 
 pub(crate) enum JsonObjectStep<'de> {
-    Field { name: Cow<'de, str>, span: Span },
+    Field { key: JsonFieldKey<'de>, span: Span },
     End,
+}
+
+pub(crate) enum JsonFieldKey<'de> {
+    Borrowed(&'de str),
+    Decoded(Cow<'de, str>),
+}
+
+impl JsonFieldKey<'_> {
+    pub(crate) fn as_str(&self) -> &str {
+        match self {
+            Self::Borrowed(value) => value,
+            Self::Decoded(value) => value.as_ref(),
+        }
+    }
 }
 
 pub(crate) enum JsonScalarToken<'de> {
@@ -326,16 +340,8 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         span: Span,
     ) -> Result<Cow<'de, str>, ParseError> {
         if !has_escapes {
-            if TRUSTED_UTF8 {
-                // SAFETY: Caller guarantees input is valid UTF-8
-                unsafe { scanner::decode_string_borrowed_unchecked(self.input, start, end) }
-                    .map(Cow::Borrowed)
-                    .ok_or_else(|| invalid_utf8_parse_error(span))
-            } else {
-                scanner::decode_string_borrowed(self.input, start, end)
-                    .map(Cow::Borrowed)
-                    .ok_or_else(|| invalid_utf8_parse_error(span))
-            }
+            self.borrow_string_no_escapes(start, end, span)
+                .map(Cow::Borrowed)
         } else if TRUSTED_UTF8 {
             // SAFETY: Caller guarantees input is valid UTF-8
             Ok(Cow::Owned(
@@ -347,6 +353,40 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                 scanner::decode_string_owned(self.input, start, end)
                     .map_err(scan_error_to_parse_error)?,
             ))
+        }
+    }
+
+    #[inline]
+    fn borrow_string_no_escapes(
+        &self,
+        start: usize,
+        end: usize,
+        span: Span,
+    ) -> Result<&'de str, ParseError> {
+        let slice = &self.input[start..end];
+        if TRUSTED_UTF8 {
+            // SAFETY: The input came from &str, and the scanner already reported
+            // this token as a string without escapes.
+            Ok(unsafe { core::str::from_utf8_unchecked(slice) })
+        } else {
+            core::str::from_utf8(slice).map_err(|_| invalid_utf8_parse_error(span))
+        }
+    }
+
+    #[inline]
+    fn decode_field_key(
+        &self,
+        start: usize,
+        end: usize,
+        has_escapes: bool,
+        span: Span,
+    ) -> Result<JsonFieldKey<'de>, ParseError> {
+        if !has_escapes {
+            self.borrow_string_no_escapes(start, end, span)
+                .map(JsonFieldKey::Borrowed)
+        } else {
+            self.decode_string(start, end, has_escapes, span)
+                .map(JsonFieldKey::Decoded)
         }
     }
 
@@ -804,7 +844,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                         ));
                     };
                     Ok(JsonObjectStep::Field {
-                        name: name.clone(),
+                        key: JsonFieldKey::Decoded(name.clone()),
                         span: event.span,
                     })
                 }
@@ -821,22 +861,27 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         loop {
             match self.determine_action() {
                 NextAction::ObjectKey => {
-                    let token = self.consume_token()?;
+                    let token = self.consume_spanned_token()?;
                     let span = token.span;
-                    match token.kind {
-                        TokenKind::ObjectEnd => {
+                    match token.token {
+                        ScanToken::ObjectEnd => {
                             self.state.stack.pop();
                             self.finish_value_in_parent();
                             return Ok(JsonObjectStep::End);
                         }
-                        TokenKind::String(name) => {
+                        ScanToken::String {
+                            start,
+                            end,
+                            has_escapes,
+                        } => {
+                            let key = self.decode_field_key(start, end, has_escapes, span)?;
                             self.expect_colon_token()?;
                             if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
                                 *state = ObjectState::Value;
                             }
-                            return Ok(JsonObjectStep::Field { name, span });
+                            return Ok(JsonObjectStep::Field { key, span });
                         }
-                        TokenKind::Eof => {
+                        ScanToken::Eof => {
                             return Err(ParseError::new(
                                 span,
                                 DeserializeErrorKind::UnexpectedEof {
@@ -844,24 +889,24 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                                 },
                             ));
                         }
-                        _ => return Err(self.unexpected(&token, "field name or '}'")),
+                        _ => return Err(self.unexpected_scan_token(&token, "field name or '}'")),
                     }
                 }
                 NextAction::ObjectComma => {
-                    let token = self.consume_token()?;
+                    let token = self.consume_spanned_token()?;
                     let span = token.span;
-                    match token.kind {
-                        TokenKind::Comma => {
+                    match token.token {
+                        ScanToken::Comma => {
                             if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
                                 *state = ObjectState::KeyOrEnd;
                             }
                         }
-                        TokenKind::ObjectEnd => {
+                        ScanToken::ObjectEnd => {
                             self.state.stack.pop();
                             self.finish_value_in_parent();
                             return Ok(JsonObjectStep::End);
                         }
-                        TokenKind::Eof => {
+                        ScanToken::Eof => {
                             return Err(ParseError::new(
                                 span,
                                 DeserializeErrorKind::UnexpectedEof {
@@ -869,7 +914,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                                 },
                             ));
                         }
-                        _ => return Err(self.unexpected(&token, "',' or '}'")),
+                        _ => return Err(self.unexpected_scan_token(&token, "',' or '}'")),
                     }
                 }
                 NextAction::RootFinished => {
@@ -881,8 +926,8 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                     ));
                 }
                 _ => {
-                    let token = self.consume_token()?;
-                    return Err(self.unexpected(&token, "field key or object end"));
+                    let token = self.consume_spanned_token()?;
+                    return Err(self.unexpected_scan_token(&token, "field key or object end"));
                 }
             }
         }

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -20,7 +20,7 @@ use weavy::mem::runtime::{HandleGuard, InitializedLedger, ScratchSession, Scratc
 use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStats, Step};
 
 use crate::JsonParser;
-use crate::parser::{JsonObjectStep, JsonScalarToken};
+use crate::parser::{JsonFieldKey, JsonObjectStep, JsonScalarToken};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum JsonBlockId {
@@ -214,8 +214,9 @@ struct FieldPlan<Block> {
 }
 
 impl<Block> FieldPlan<Block> {
-    fn matches_name(&self, name: &str) -> bool {
-        self.name == name || self.alias == Some(name)
+    fn matches_key(&self, key: &JsonFieldKey<'_>) -> bool {
+        let key = key.as_str();
+        self.name == key || self.alias == Some(key)
     }
 }
 
@@ -644,18 +645,21 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 loop_id,
             } => match self.parser.next_object_field_or_end()? {
                 JsonObjectStep::End => Ok(Control::Continue),
-                JsonObjectStep::Field { name, span } => {
-                    let field_name = name.as_ref();
-                    let Some((index, field)) = fields
-                        .iter()
-                        .enumerate()
-                        .find(|(_, field)| field.matches_name(field_name))
-                    else {
+                JsonObjectStep::Field { key, span } => {
+                    let mut matched = None;
+                    for (index, field) in fields.iter().enumerate() {
+                        if field.matches_key(&key) {
+                            matched = Some((index, field));
+                            break;
+                        }
+                    }
+
+                    let Some((index, field)) = matched else {
                         if shape.has_deny_unknown_fields_attr() {
                             return Err(vm_error(
                                 Some(span),
                                 DeserializeErrorKind::UnknownField {
-                                    field: field_name.to_owned().into(),
+                                    field: key.as_str().to_owned().into(),
                                     suggestion: None,
                                 },
                             ));

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -30,10 +30,27 @@ struct Node {
     child: Option<Box<Node>>,
 }
 
+#[derive(Facet, Debug, PartialEq)]
+struct EscapedFieldName {
+    quoted_key: u8,
+}
+
 #[test]
 fn weavy_deserializes_named_struct_scalars() {
     let point: Point = facet_json::from_str_weavy(r#"{"y":20,"x":10}"#).unwrap();
     assert_eq!(point, Point { x: 10, y: 20 });
+}
+
+#[test]
+fn weavy_deserializes_escaped_field_names() {
+    let expected = EscapedFieldName { quoted_key: 7 };
+    let json = r#"{"quoted\u005fkey":7}"#;
+
+    let from_str: EscapedFieldName = facet_json::from_str_weavy(json).unwrap();
+    let from_slice: EscapedFieldName = facet_json::from_slice_weavy(json.as_bytes()).unwrap();
+
+    assert_eq!(from_str, expected);
+    assert_eq!(from_slice, expected);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR trims the Weavy JSON deserializer's field/string hot path:

- reads object field keys directly from scanner tokens instead of materializing the generic token/Cow path first
- carries field keys as a small `JsonFieldKey` into the Weavy backend for direct field matching
- borrows no-escape strings directly from scanner-provided spans, avoiding the redundant `\\` rescan after `has_escapes = false`
- adds a Weavy integration test for escaped JSON field names on both `from_str_weavy` and `from_slice_weavy`

The default `facet_json::from_str` path is unchanged.

## Validation

- `cargo nextest list -p facet-json -E 'test(weavy)'`
- `cargo nextest run -p facet-json -E 'test(weavy)'`
- `cargo nextest run -p facet-json`
- `cargo clippy -p facet-json --all-targets --all-features -- -D warnings`

## Performance

All numbers are stax-wrapped single-filter benchmark medians from `facet-json/benches/typeplan_reuse.rs`.

### mur, x86_64 Linux

| bench | main Weavy | PR Weavy | PR delta | PR Weavy/serde |
|---|---:|---:|---:|---:|
| point | 572.8 ns | 545.9 ns | -4.7% | 7.4x |
| person | 2.086 us | 1.574 us | -24.5% | 4.6x |
| company | 4.841 us | 4.123 us | -14.8% | 3.1x |
| batch 1000 | 1.843 ms | 1.649 ms | -10.5% | 4.3x |

### souffle, Apple Silicon macOS

| bench | main Weavy | PR Weavy | PR delta | PR Weavy/serde |
|---|---:|---:|---:|---:|
| point | 301.9 ns | 254.6 ns | -15.7% | 6.8x |
| person | 878.3 ns | 867.7 ns | -1.2% | 4.4x |
| company | 2.334 us | 2.316 us | -0.8% | 3.8x |
| batch 1000 | 1.123 ms | 1.097 ms | -2.3% | 5.1x |

