### PR TITLE
perf(facet-json): make Weavy object decoding do more per step

### DIFF
--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -175,7 +175,6 @@ enum JsonOp<Block> {
     },
     StructNext {
         shape: &'static Shape,
-        fields: Box<[FieldPlan<Block>]>,
         loop_id: Block,
     },
     ReadOption {
@@ -359,11 +358,7 @@ impl Lowering {
                     }
                     let fields = fields.into_boxed_slice();
                     let loop_id = JsonBlockId::StructLoop(shape);
-                    let loop_program = vec![JsonOp::StructNext {
-                        shape,
-                        fields: fields.clone(),
-                        loop_id,
-                    }];
+                    let loop_program = vec![JsonOp::StructNext { shape, loop_id }];
                     self.lowered.blocks.insert(loop_id, loop_program);
                     Ok(vec![JsonOp::ReadStruct {
                         shape,
@@ -415,13 +410,8 @@ fn resolve_json_op(
             fields: resolve_field_plans(fields, refs)?,
             loop_id: resolve_block_ref(loop_id, refs)?,
         },
-        JsonOp::StructNext {
+        JsonOp::StructNext { shape, loop_id } => JsonOp::StructNext {
             shape,
-            fields,
-            loop_id,
-        } => JsonOp::StructNext {
-            shape,
-            fields: resolve_field_plans(fields, refs)?,
             loop_id: resolve_block_ref(loop_id, refs)?,
         },
         JsonOp::ReadOption {
@@ -639,76 +629,68 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                     .push(StructFrame::new(shape, self.base, fields));
                 Ok(Control::CallBlockThen(*loop_id, Continuation::FinishStruct))
             }
-            JsonOp::StructNext {
-                shape,
-                fields,
-                loop_id,
-            } => match self.parser.next_object_field_or_end()? {
-                JsonObjectStep::End => Ok(Control::Continue),
-                JsonObjectStep::Field { key, span } => {
-                    let mut matched = None;
-                    for (index, field) in fields.iter().enumerate() {
-                        if field.matches_key(&key) {
-                            matched = Some((index, field));
-                            break;
-                        }
-                    }
+            JsonOp::StructNext { shape, loop_id } => {
+                match self.parser.next_object_field_or_end()? {
+                    JsonObjectStep::End => Ok(Control::Continue),
+                    JsonObjectStep::Field { key, span } => {
+                        let frame = self
+                            .structs
+                            .last()
+                            .expect("struct frame is present while matching fields");
+                        let matched = frame.match_field(&key);
 
-                    let Some((index, field)) = matched else {
-                        if shape.has_deny_unknown_fields_attr() {
+                        let Some((index, field)) = matched else {
+                            if shape.has_deny_unknown_fields_attr() {
+                                return Err(vm_error(
+                                    Some(span),
+                                    DeserializeErrorKind::UnknownField {
+                                        field: key.as_str().to_owned().into(),
+                                        suggestion: None,
+                                    },
+                                ));
+                            }
+                            self.parser.skip_value()?;
+                            return Ok(Control::CallBlock(*loop_id));
+                        };
+
+                        if let Some(first_span) = frame.seen.get(index).copied() {
                             return Err(vm_error(
                                 Some(span),
-                                DeserializeErrorKind::UnknownField {
-                                    field: key.as_str().to_owned().into(),
-                                    suggestion: None,
+                                DeserializeErrorKind::DuplicateField {
+                                    field: field.name.into(),
+                                    first_span: Some(first_span),
                                 },
                             ));
                         }
-                        self.parser.skip_value()?;
-                        return Ok(Control::CallBlock(*loop_id));
-                    };
 
-                    let frame = self
-                        .structs
-                        .last()
-                        .expect("struct frame is present while decoding fields");
-                    if let Some(first_span) = frame.seen.get(index).copied() {
-                        return Err(vm_error(
-                            Some(span),
-                            DeserializeErrorKind::DuplicateField {
-                                field: field.name.into(),
-                                first_span: Some(first_span),
-                            },
-                        ));
-                    }
-
-                    if let Some(scalar) = field.scalar {
-                        let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
-                        let (value, value_span) = self.parser.read_scalar_token()?;
-                        unsafe {
-                            write_scalar(field.shape, scalar, field_ptr, value, value_span)?;
+                        if let Some(scalar) = field.scalar {
+                            let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
+                            let (value, value_span) = self.parser.read_scalar_token()?;
+                            unsafe {
+                                write_scalar(field.shape, scalar, field_ptr, value, value_span)?;
+                            }
+                            let frame = self
+                                .structs
+                                .last_mut()
+                                .expect("struct frame is present while decoding scalar field");
+                            frame.mark_seen(index, span);
+                            return Ok(Control::CallBlock(*loop_id));
                         }
-                        let frame = self
-                            .structs
-                            .last_mut()
-                            .expect("struct frame is present while decoding scalar field");
-                        frame.seen.mark(index, span);
-                        return Ok(Control::CallBlock(*loop_id));
-                    }
 
-                    let old_base = self.base;
-                    self.base = unsafe { frame.base.field_uninit(field.offset) };
-                    Ok(call_program_or_block_then(
-                        &field.program,
-                        Continuation::FieldDone {
-                            index,
-                            span,
-                            old_base,
-                            loop_id: *loop_id,
-                        },
-                    ))
+                        let old_base = self.base;
+                        self.base = unsafe { frame.base.field_uninit(field.offset) };
+                        Ok(call_program_or_block_then(
+                            &field.program,
+                            Continuation::FieldDone {
+                                index,
+                                span,
+                                old_base,
+                                loop_id: *loop_id,
+                            },
+                        ))
+                    }
                 }
-            },
+            }
             JsonOp::ReadOption {
                 option,
                 some_program,
@@ -845,7 +827,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                     .structs
                     .last_mut()
                     .expect("struct frame is present after field program");
-                frame.seen.mark(index, span);
+                frame.mark_seen(index, span);
                 self.base = old_base;
                 Ok(Control::CallBlock(loop_id))
             }
@@ -956,6 +938,7 @@ struct StructFrame<'program> {
     base: PtrUninit,
     fields: &'program [FieldPlan<ExecBlock>],
     seen: InitializedLedger<Span>,
+    next_field: usize,
 }
 
 impl<'program> StructFrame<'program> {
@@ -969,6 +952,40 @@ impl<'program> StructFrame<'program> {
             base,
             fields,
             seen: InitializedLedger::new(fields.len()),
+            next_field: 0,
+        }
+    }
+
+    fn match_field(
+        &self,
+        key: &JsonFieldKey<'_>,
+    ) -> Option<(usize, &'program FieldPlan<ExecBlock>)> {
+        if let Some(field) = self.fields.get(self.next_field)
+            && field.matches_key(key)
+        {
+            return Some((self.next_field, field));
+        }
+
+        self.fields
+            .iter()
+            .enumerate()
+            .find(|(_, field)| field.matches_key(key))
+    }
+
+    fn mark_seen(&mut self, index: usize, span: Span) {
+        self.seen.mark(index, span);
+        if index == self.next_field {
+            self.advance_next_field();
+        }
+    }
+
+    fn advance_next_field(&mut self) {
+        while self
+            .fields
+            .get(self.next_field)
+            .is_some_and(|_| self.seen.is_initialized(self.next_field))
+        {
+            self.next_field += 1;
         }
     }
 

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -639,7 +639,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                             .expect("struct frame is present while matching fields");
                         let matched = frame.match_field(&key);
 
-                        let Some((index, field)) = matched else {
+                        let Some(matched) = matched else {
                             if shape.has_deny_unknown_fields_attr() {
                                 return Err(vm_error(
                                     Some(span),
@@ -652,8 +652,13 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                             self.parser.skip_value()?;
                             continue;
                         };
+                        let MatchedField {
+                            index,
+                            field,
+                            ordered,
+                        } = matched;
 
-                        if let Some(first_span) = frame.seen.get(index).copied() {
+                        if !ordered && let Some(first_span) = frame.seen.get(index).copied() {
                             return Err(vm_error(
                                 Some(span),
                                 DeserializeErrorKind::DuplicateField {
@@ -933,6 +938,12 @@ enum Continuation {
     },
 }
 
+struct MatchedField<'program> {
+    index: usize,
+    field: &'program FieldPlan<ExecBlock>,
+    ordered: bool,
+}
+
 struct StructFrame<'program> {
     shape: &'static Shape,
     base: PtrUninit,
@@ -956,20 +967,26 @@ impl<'program> StructFrame<'program> {
         }
     }
 
-    fn match_field(
-        &self,
-        key: &JsonFieldKey<'_>,
-    ) -> Option<(usize, &'program FieldPlan<ExecBlock>)> {
+    fn match_field(&self, key: &JsonFieldKey<'_>) -> Option<MatchedField<'program>> {
         if let Some(field) = self.fields.get(self.next_field)
             && field.matches_key(key)
         {
-            return Some((self.next_field, field));
+            return Some(MatchedField {
+                index: self.next_field,
+                field,
+                ordered: true,
+            });
         }
 
         self.fields
             .iter()
             .enumerate()
             .find(|(_, field)| field.matches_key(key))
+            .map(|(index, field)| MatchedField {
+                index,
+                field,
+                ordered: false,
+            })
     }
 
     fn mark_seen(&mut self, index: usize, span: Span) {

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -629,9 +629,9 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                     .push(StructFrame::new(shape, self.base, fields));
                 Ok(Control::CallBlockThen(*loop_id, Continuation::FinishStruct))
             }
-            JsonOp::StructNext { shape, loop_id } => {
+            JsonOp::StructNext { shape, loop_id } => loop {
                 match self.parser.next_object_field_or_end()? {
-                    JsonObjectStep::End => Ok(Control::Continue),
+                    JsonObjectStep::End => return Ok(Control::Continue),
                     JsonObjectStep::Field { key, span } => {
                         let frame = self
                             .structs
@@ -650,7 +650,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                                 ));
                             }
                             self.parser.skip_value()?;
-                            return Ok(Control::CallBlock(*loop_id));
+                            continue;
                         };
 
                         if let Some(first_span) = frame.seen.get(index).copied() {
@@ -674,12 +674,12 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                                 .last_mut()
                                 .expect("struct frame is present while decoding scalar field");
                             frame.mark_seen(index, span);
-                            return Ok(Control::CallBlock(*loop_id));
+                            continue;
                         }
 
                         let old_base = self.base;
                         self.base = unsafe { frame.base.field_uninit(field.offset) };
-                        Ok(call_program_or_block_then(
+                        return Ok(call_program_or_block_then(
                             &field.program,
                             Continuation::FieldDone {
                                 index,
@@ -687,10 +687,10 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                                 old_base,
                                 loop_id: *loop_id,
                             },
-                        ))
+                        ));
                     }
                 }
-            }
+            },
             JsonOp::ReadOption {
                 option,
                 some_program,

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -180,6 +180,7 @@ enum JsonOp<Block> {
     ReadOption {
         option: OptionDef,
         some_program: Program<JsonOp<Block>>,
+        some_scalar: Option<ScalarType>,
         inner_layout: Layout,
     },
     ReadList {
@@ -286,9 +287,11 @@ impl Lowering {
             Def::Option(option) => {
                 let inner_layout = sized_layout(option.t())?;
                 let some_program = self.lower_shape(option.t())?;
+                let some_scalar = ScalarType::try_from_shape(option.t());
                 Ok(vec![JsonOp::ReadOption {
                     option,
                     some_program,
+                    some_scalar,
                     inner_layout,
                 }])
             }
@@ -417,10 +420,12 @@ fn resolve_json_op(
         JsonOp::ReadOption {
             option,
             some_program,
+            some_scalar,
             inner_layout,
         } => JsonOp::ReadOption {
             option,
             some_program: resolve_json_program(some_program, refs)?,
+            some_scalar,
             inner_layout,
         },
         JsonOp::ReadList {
@@ -699,6 +704,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
             JsonOp::ReadOption {
                 option,
                 some_program,
+                some_scalar,
                 inner_layout,
             } => {
                 if self.parser.consume_null_if_next()? {
@@ -709,6 +715,22 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 }
 
                 let scratch = self.scratch.reserve(*inner_layout);
+                if let Some(scalar) = some_scalar {
+                    let (value, span) = self.parser.read_scalar_token()?;
+                    unsafe {
+                        write_scalar(
+                            option.t(),
+                            *scalar,
+                            scratch_ptr_uninit(&scratch),
+                            value,
+                            span,
+                        )?;
+                        (option.vtable.init_some)(self.base, scratch_ptr_mut(&scratch));
+                    }
+                    self.scratch.release(scratch);
+                    return Ok(Control::Continue);
+                }
+
                 let old_base = self.base;
                 self.base = scratch_ptr_uninit(&scratch);
                 Ok(call_program_or_block_then(

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -1,4 +1,5 @@
 use facet::Facet;
+use facet_format::DeserializeErrorKind;
 
 #[derive(Facet, Debug, PartialEq)]
 struct Point {
@@ -60,6 +61,15 @@ fn weavy_plan_can_be_reused() {
     let second = plan.from_str(r#"{"x":3,"y":4}"#).unwrap();
     assert_eq!(first, Point { x: 1, y: 2 });
     assert_eq!(second, Point { x: 3, y: 4 });
+}
+
+#[test]
+fn weavy_rejects_duplicate_field_after_ordered_match() {
+    let err = facet_json::from_str_weavy::<Point>(r#"{"x":1,"y":2,"x":3}"#).unwrap_err();
+    assert!(matches!(
+        err.kind,
+        DeserializeErrorKind::DuplicateField { ref field, .. } if field == "x"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This makes the facet-json Weavy object path do more useful work per VM step:

- moves field dispatch state into the active `StructFrame`, with an ordered-field fast path and exact fallback for out-of-order / duplicate keys
- removes the duplicate `fields` payload from `StructNext` bytecode
- drains scalar and unknown object fields inside the `StructNext` op instead of returning to the Weavy runner after each scalar field
- decodes `Option<T>` inline when `T` is scalar, avoiding the child-program + continuation round trip for e.g. `Option<String>`
- adds public-path duplicate-field coverage for the ordered fast path

## Stax

Median times from `facet-json`'s `typeplan_reuse` bench. `Weavy/serde` compares this PR's Weavy reused-plan path against `serde_json` on the same host/run.

### mur, x86_64 Linux

This host stayed noisy/mixed in repeated runs. The final exact-ref pass is mostly flat, with `point` worse in that sample.

| bench | main Weavy | PR Weavy | delta | PR serde_json | Weavy/serde |
|---|---:|---:|---:|---:|---:|
| point | 404.7 ns | 470.8 ns | +16.3% | 64.47 ns | 7.30x |
| person | 1.629 us | 1.632 us | +0.2% | 367.8 ns | 4.44x |
| company | 4.314 us | 4.291 us | -0.5% | 1.131 us | 3.79x |
| batch_1000 | 1.622 ms | 1.621 ms | -0.1% | 331.1 us | 4.90x |

### souffle, Apple Silicon macOS

| bench | main Weavy | PR Weavy | delta | PR serde_json | Weavy/serde |
|---|---:|---:|---:|---:|---:|
| point | 243.7 ns | 244.0 ns | +0.1% | 37.33 ns | 6.54x |
| person | 842.0 ns | 793.6 ns | -5.7% | 197.1 ns | 4.03x |
| company | 2.247 us | 2.115 us | -5.9% | 614.9 ns | 3.44x |
| batch_1000 | 1.018 ms | 935.0 us | -8.2% | 216.4 us | 4.32x |

## Testing

- `cargo nextest run -p facet-json -E 'test(weavy)'`
- `cargo clippy -p weavy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo nextest run -p facet-json`
- push hook: clippy, build tests, docs, run tests
