### PR TITLE
perf(facet-json): drain scalar list elements in Weavy

### DIFF
--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -192,6 +192,7 @@ enum JsonOp<Block> {
         list: ListDef,
         element_program: Program<JsonOp<Block>>,
         element_scalar: Option<ScalarType>,
+        element_option_scalar: Option<ListOptionScalar>,
         element_layout: Layout,
         loop_id: Block,
     },
@@ -211,6 +212,13 @@ struct FieldPlan<Block> {
     program: Program<JsonOp<Block>>,
     scalar: Option<ScalarType>,
     missing: MissingField,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ListOptionScalar {
+    option: OptionDef,
+    scalar: ScalarType,
+    inner_layout: Layout,
 }
 
 impl<Block> FieldPlan<Block> {
@@ -302,11 +310,13 @@ impl Lowering {
                 let element_layout = sized_layout(list.t())?;
                 let element_program = self.lower_shape(list.t())?;
                 let element_scalar = ScalarType::try_from_shape(list.t());
+                let element_option_scalar = list_option_scalar(list.t())?;
                 let loop_id = JsonBlockId::ListLoop(shape);
                 let loop_program = vec![JsonOp::ListNext {
                     list,
                     element_program: element_program.clone(),
                     element_scalar,
+                    element_option_scalar,
                     element_layout,
                     loop_id,
                 }];
@@ -441,12 +451,14 @@ fn resolve_json_op(
             list,
             element_program,
             element_scalar,
+            element_option_scalar,
             element_layout,
             loop_id,
         } => JsonOp::ListNext {
             list,
             element_program: resolve_json_program(element_program, refs)?,
             element_scalar,
+            element_option_scalar,
             element_layout,
             loop_id: resolve_block_ref(loop_id, refs)?,
         },
@@ -514,6 +526,20 @@ fn missing_field_action(field: &Field, container_has_default: bool) -> MissingFi
     }
 }
 
+fn list_option_scalar(shape: &'static Shape) -> Result<Option<ListOptionScalar>, DeserializeError> {
+    let Def::Option(option) = shape.def else {
+        return Ok(None);
+    };
+    let Some(scalar) = ScalarType::try_from_shape(option.t()) else {
+        return Ok(None);
+    };
+    Ok(Some(ListOptionScalar {
+        option,
+        scalar,
+        inner_layout: sized_layout(option.t())?,
+    }))
+}
+
 fn sized_layout(shape: &'static Shape) -> Result<Layout, DeserializeError> {
     shape
         .layout
@@ -556,6 +582,25 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
 
     fn finish_success(&mut self) {
         self.success = true;
+    }
+
+    fn push_list_element(
+        &mut self,
+        list: ListDef,
+        scratch: &ScratchSlot,
+    ) -> Result<(), DeserializeError> {
+        let list_ptr = self
+            .lists
+            .last()
+            .expect("list frame is present while pushing element")
+            .ptr();
+        let push = list
+            .push()
+            .ok_or_else(|| unsupported(list.t(), "list push"))?;
+        unsafe {
+            push(PtrMut::new(list_ptr), scratch_ptr_mut(scratch));
+        }
+        Ok(())
     }
 }
 
@@ -764,9 +809,10 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 list,
                 element_program,
                 element_scalar,
+                element_option_scalar,
                 element_layout,
                 loop_id,
-            } => {
+            } => loop {
                 if self.parser.consume_sequence_end_if_next()? {
                     return Ok(Control::Continue);
                 }
@@ -777,25 +823,44 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                     unsafe {
                         write_scalar(list.t(), *scalar, scratch_ptr_uninit(&scratch), value, span)?;
                     }
-                    let list_ptr = self
-                        .lists
-                        .last()
-                        .expect("list frame is present while decoding scalar element")
-                        .ptr();
-                    let push = list
-                        .push()
-                        .ok_or_else(|| unsupported(list.t(), "list push"))?;
-                    unsafe {
-                        push(PtrMut::new(list_ptr), scratch_ptr_mut(&scratch));
-                    }
+                    self.push_list_element(*list, &scratch)?;
                     self.scratch.release(scratch);
-                    return Ok(Control::CallBlock(*loop_id));
+                    continue;
+                }
+
+                if let Some(option_scalar) = element_option_scalar {
+                    let scratch = self.scratch.reserve(*element_layout);
+                    if self.parser.consume_null_if_next()? {
+                        unsafe {
+                            (option_scalar.option.vtable.init_none)(scratch_ptr_uninit(&scratch));
+                        }
+                    } else {
+                        let inner = self.scratch.reserve(option_scalar.inner_layout);
+                        let (value, span) = self.parser.read_scalar_token()?;
+                        unsafe {
+                            write_scalar(
+                                option_scalar.option.t(),
+                                option_scalar.scalar,
+                                scratch_ptr_uninit(&inner),
+                                value,
+                                span,
+                            )?;
+                            (option_scalar.option.vtable.init_some)(
+                                scratch_ptr_uninit(&scratch),
+                                scratch_ptr_mut(&inner),
+                            );
+                        }
+                        self.scratch.release(inner);
+                    }
+                    self.push_list_element(*list, &scratch)?;
+                    self.scratch.release(scratch);
+                    continue;
                 }
 
                 let scratch = self.scratch.reserve(*element_layout);
                 let old_base = self.base;
                 self.base = scratch_ptr_uninit(&scratch);
-                Ok(call_program_or_block_then(
+                return Ok(call_program_or_block_then(
                     element_program,
                     Continuation::ListElement {
                         list: *list,
@@ -803,8 +868,8 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                         scratch,
                         loop_id: *loop_id,
                     },
-                ))
-            }
+                ));
+            },
             JsonOp::ReadPointer {
                 pointer,
                 pointee_program,
@@ -885,17 +950,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 scratch,
                 loop_id,
             } => {
-                let list_ptr = self
-                    .lists
-                    .last()
-                    .expect("list frame is present after element program")
-                    .ptr();
-                let push = list
-                    .push()
-                    .ok_or_else(|| unsupported(list.t(), "list push"))?;
-                unsafe {
-                    push(PtrMut::new(list_ptr), scratch_ptr_mut(&scratch));
-                }
+                self.push_list_element(list, &scratch)?;
                 self.scratch.release(scratch);
                 self.base = old_base;
                 Ok(Control::CallBlock(loop_id))

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -150,4 +150,34 @@ fn weavy_stats_keep_scalar_fields_and_lists_in_loop() {
     )
     .unwrap();
     assert_eq!(stats.inline_call_count, 0, "{stats:?}");
+
+    let (_, short_list): (Person, _) = facet_json::from_str_weavy_with_stats(
+        r#"{"name":"Ada","age":37,"favorite":null,"scores":[1]}"#,
+    )
+    .unwrap();
+    let (_, long_list): (Person, _) = facet_json::from_str_weavy_with_stats(
+        r#"{"name":"Ada","age":37,"favorite":null,"scores":[1,2,3,4,5]}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        short_list.block_call_count, long_list.block_call_count,
+        "{short_list:?} {long_list:?}"
+    );
+    assert_eq!(
+        short_list.step_count, long_list.step_count,
+        "{short_list:?} {long_list:?}"
+    );
+
+    let (_, short_option_list): (MaybeScores, _) =
+        facet_json::from_str_weavy_with_stats(r#"{"scores":[1]}"#).unwrap();
+    let (_, long_option_list): (MaybeScores, _) =
+        facet_json::from_str_weavy_with_stats(r#"{"scores":[1,null,2,null,3]}"#).unwrap();
+    assert_eq!(
+        short_option_list.block_call_count, long_option_list.block_call_count,
+        "{short_option_list:?} {long_option_list:?}"
+    );
+    assert_eq!(
+        short_option_list.step_count, long_option_list.step_count,
+        "{short_option_list:?} {long_option_list:?}"
+    );
 }


### PR DESCRIPTION
## Summary

This moves Weavy JSON list decoding for scalar elements onto the same drain-loop shape as ordered scalar struct fields. `Vec<T>` for scalar `T` and `Vec<Option<T>>` for scalar `T` now consume all contiguous JSON array elements inside one `ListNext` op instead of bouncing through a Weavy block call per element.

The default `facet_json::from_str` path is unchanged; this only affects the opt-in Weavy JSON deserializer.

## Changes

- Add a lowered descriptor for `Option<scalar>` list elements.
- Reuse one helper for moving an initialized scratch element into the active list handle.
- Keep non-scalar list elements on the existing child-program path.
- Add stats assertions that scalar and nullable-scalar list runner work is invariant with list length.

## Stax Results

Medians from `stax record -F 4000` around `facet-json/benches/typeplan_reuse`.

### mur, x86_64 Linux

| Bench | PR Weavy | Main Weavy | Delta | PR Weavy/serde |
|---|---:|---:|---:|---:|
| point | 402.4 ns | 466.1 ns | -13.7% | 6.78x |
| person | 1.553 us | 1.632 us | -4.8% | 4.16x |
| company | 4.260 us | 4.299 us | -0.9% | 3.56x |
| batch_1000 | 1.536 ms | 1.612 ms | -4.7% | 4.24x |

### souffle, Apple Silicon macOS

| Bench | PR Weavy | Main Weavy | Delta | PR Weavy/serde |
|---|---:|---:|---:|---:|
| point | 203.8 ns | 240.2 ns | -15.2% | 5.52x |
| person | 749.8 ns | 796.2 ns | -5.8% | 3.86x |
| company | 2.111 us | 2.274 us | -7.2% | 3.44x |
| batch_1000 | 802.2 us | 824.4 us | -2.7% | 3.67x |

## Testing

- `cargo clippy -p weavy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo nextest run -p facet-json -E 'test(weavy)'`
- `cargo nextest run -p facet-json`
