### PR TITLE
perf(facet-json): adopt Weavy list buffers directly

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -83,6 +83,14 @@ pub(crate) enum JsonObjectStep<'de> {
     End,
 }
 
+pub(crate) enum JsonSequenceScalarStep<'de> {
+    Value {
+        value: JsonScalarToken<'de>,
+        span: Span,
+    },
+    End,
+}
+
 pub(crate) enum JsonFieldKey<'de> {
     Borrowed(&'de str),
     Decoded(Cow<'de, str>),
@@ -1000,6 +1008,95 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
     }
 
+    pub(crate) fn next_sequence_scalar_or_end(
+        &mut self,
+    ) -> Result<JsonSequenceScalarStep<'de>, ParseError> {
+        if self.state.event_peek.is_some() {
+            if self.consume_sequence_end_if_next()? {
+                return Ok(JsonSequenceScalarStep::End);
+            }
+            let (value, span) = self.read_scalar_token()?;
+            return Ok(JsonSequenceScalarStep::Value { value, span });
+        }
+
+        match self.determine_action() {
+            NextAction::ArrayValue => {
+                let token = self.consume_spanned_token()?;
+                let span = token.span;
+                match token.token {
+                    ScanToken::ArrayEnd => {
+                        self.state.stack.pop();
+                        self.finish_value_in_parent();
+                        Ok(JsonSequenceScalarStep::End)
+                    }
+                    ScanToken::Eof => Err(ParseError::new(
+                        span,
+                        DeserializeErrorKind::UnexpectedEof {
+                            expected: "scalar or ']'",
+                        },
+                    )),
+                    _ => {
+                        let (value, span) = self.finish_scalar_token(token, "scalar or ']'")?;
+                        Ok(JsonSequenceScalarStep::Value { value, span })
+                    }
+                }
+            }
+            NextAction::ArrayComma => {
+                let token = self.consume_spanned_token()?;
+                let span = token.span;
+                match token.token {
+                    ScanToken::Comma => {
+                        if let Some(ContextState::Array(state)) = self.state.stack.last_mut() {
+                            *state = ArrayState::ValueOrEnd;
+                        }
+                        let token = self.consume_spanned_token()?;
+                        let span = token.span;
+                        match token.token {
+                            ScanToken::ArrayEnd => {
+                                self.state.stack.pop();
+                                self.finish_value_in_parent();
+                                Ok(JsonSequenceScalarStep::End)
+                            }
+                            ScanToken::Eof => Err(ParseError::new(
+                                span,
+                                DeserializeErrorKind::UnexpectedEof {
+                                    expected: "scalar or ']'",
+                                },
+                            )),
+                            _ => {
+                                let (value, span) =
+                                    self.finish_scalar_token(token, "scalar or ']'")?;
+                                Ok(JsonSequenceScalarStep::Value { value, span })
+                            }
+                        }
+                    }
+                    ScanToken::ArrayEnd => {
+                        self.state.stack.pop();
+                        self.finish_value_in_parent();
+                        Ok(JsonSequenceScalarStep::End)
+                    }
+                    ScanToken::Eof => Err(ParseError::new(
+                        span,
+                        DeserializeErrorKind::UnexpectedEof {
+                            expected: "',' or ']'",
+                        },
+                    )),
+                    _ => Err(self.unexpected_scan_token(&token, "',' or ']'")),
+                }
+            }
+            NextAction::RootFinished => Err(ParseError::new(
+                Span::new(self.current_offset(), 0),
+                DeserializeErrorKind::UnexpectedEof {
+                    expected: "scalar or ']'",
+                },
+            )),
+            _ => {
+                let token = self.consume_spanned_token()?;
+                Err(self.unexpected_scan_token(&token, "scalar or ']'"))
+            }
+        }
+    }
+
     fn next_significant_is(&self, expected: u8) -> Result<bool, ParseError> {
         Ok(matches!(
             self.peek_significant_byte()?,
@@ -1030,8 +1127,11 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         Err(self.unexpected(&token, "','"))
     }
 
-    fn consume_scalar_token(&mut self) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
-        let token = self.consume_spanned_token()?;
+    fn scalar_from_token(
+        &self,
+        token: scanner::SpannedToken,
+        expected: &'static str,
+    ) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
         let span = token.span;
         let value = match token.token {
             ScanToken::Null => JsonScalarToken::Null,
@@ -1054,14 +1154,33 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
             | ScanToken::ArrayStart
             | ScanToken::ArrayEnd
             | ScanToken::Colon
-            | ScanToken::Comma
-            | ScanToken::Eof => return Err(self.unexpected_scan_token(&token, "scalar")),
+            | ScanToken::Comma => return Err(self.unexpected_scan_token(&token, expected)),
+            ScanToken::Eof => {
+                return Err(ParseError::new(
+                    span,
+                    DeserializeErrorKind::UnexpectedEof { expected },
+                ));
+            }
             ScanToken::NeedMore { .. } => unreachable!("handled by consume_spanned_token"),
         };
+        Ok((value, span))
+    }
+
+    fn finish_scalar_token(
+        &mut self,
+        token: scanner::SpannedToken,
+        expected: &'static str,
+    ) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
+        let scalar = self.scalar_from_token(token, expected)?;
 
         self.state.root_started = true;
         self.finish_value_in_parent();
-        Ok((value, span))
+        Ok(scalar)
+    }
+
+    fn consume_scalar_token(&mut self) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
+        let token = self.consume_spanned_token()?;
+        self.finish_scalar_token(token, "scalar")
     }
 
     fn consume_null_token(&mut self) -> Result<bool, ParseError> {

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -22,7 +22,7 @@ use weavy::mem::runtime::{
 use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStats, Step};
 
 use crate::JsonParser;
-use crate::parser::{JsonFieldKey, JsonObjectStep, JsonScalarToken};
+use crate::parser::{JsonFieldKey, JsonObjectStep, JsonScalarToken, JsonSequenceScalarStep};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum JsonBlockId {
@@ -925,13 +925,13 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 element_layout,
                 loop_id,
             } => loop {
-                if self.parser.consume_sequence_end_if_next()? {
-                    return Ok(Control::Continue);
-                }
-
                 if let Some(scalar) = element_scalar {
+                    let (value, span) = match self.parser.next_sequence_scalar_or_end()? {
+                        JsonSequenceScalarStep::End => return Ok(Control::Continue),
+                        JsonSequenceScalarStep::Value { value, span } => (value, span),
+                    };
+
                     if let Some(slot) = self.direct_list_slot()? {
-                        let (value, span) = self.parser.read_scalar_token()?;
                         unsafe {
                             write_scalar(list.t(), *scalar, slot, value, span)?;
                             self.mark_direct_list_slot_initialized();
@@ -940,7 +940,6 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                     }
 
                     let scratch = self.scratch.reserve(*element_layout);
-                    let (value, span) = self.parser.read_scalar_token()?;
                     unsafe {
                         write_scalar(list.t(), *scalar, scratch_ptr_uninit(&scratch), value, span)?;
                     }
@@ -950,15 +949,19 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 }
 
                 if let Some(option_scalar) = element_option_scalar {
+                    let step = self.parser.next_sequence_scalar_or_end()?;
+                    let JsonSequenceScalarStep::Value { value, span } = step else {
+                        return Ok(Control::Continue);
+                    };
+
                     if let Some(slot) = self.direct_list_slot()? {
-                        if self.parser.consume_null_if_next()? {
+                        if matches!(&value, JsonScalarToken::Null) {
                             unsafe {
                                 (option_scalar.option.vtable.init_none)(slot);
                                 self.mark_direct_list_slot_initialized();
                             }
                         } else {
                             let inner = self.scratch.reserve(option_scalar.inner_layout);
-                            let (value, span) = self.parser.read_scalar_token()?;
                             unsafe {
                                 write_scalar(
                                     option_scalar.option.t(),
@@ -979,13 +982,12 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                     }
 
                     let scratch = self.scratch.reserve(*element_layout);
-                    if self.parser.consume_null_if_next()? {
+                    if matches!(&value, JsonScalarToken::Null) {
                         unsafe {
                             (option_scalar.option.vtable.init_none)(scratch_ptr_uninit(&scratch));
                         }
                     } else {
                         let inner = self.scratch.reserve(option_scalar.inner_layout);
-                        let (value, span) = self.parser.read_scalar_token()?;
                         unsafe {
                             write_scalar(
                                 option_scalar.option.t(),
@@ -1004,6 +1006,10 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                     self.push_list_element(*list, &scratch)?;
                     self.scratch.release(scratch);
                     continue;
+                }
+
+                if self.parser.consume_sequence_end_if_next()? {
+                    return Ok(Control::Continue);
                 }
 
                 if let Some(slot) = self.direct_list_slot()? {

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -739,9 +739,9 @@ impl<const TRUSTED_UTF8: bool> Drop for JsonInterp<'_, '_, '_, TRUSTED_UTF8> {
             return;
         }
 
-        while self.lists.pop().is_some() {}
-
         while self.structs.pop().is_some() {}
+
+        while self.lists.pop().is_some() {}
     }
 }
 

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -16,7 +16,9 @@ use facet_core::{
 };
 use facet_format::{DeserializeError, DeserializeErrorKind, FormatParser};
 use facet_reflect::Span;
-use weavy::mem::runtime::{HandleGuard, InitializedLedger, ScratchSession, ScratchSlot};
+use weavy::mem::runtime::{
+    HandleGuard, InitializedLedger, RawAllocError, RawArrayBuilder, ScratchSession, ScratchSlot,
+};
 use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStats, Step};
 
 use crate::JsonParser;
@@ -186,6 +188,7 @@ enum JsonOp<Block> {
     ReadList {
         list_shape: &'static Shape,
         list: ListDef,
+        element_layout: Layout,
         loop_id: Block,
     },
     ListNext {
@@ -304,8 +307,13 @@ impl Lowering {
                 }])
             }
             Def::List(list) => {
-                if list.init_in_place_with_capacity().is_none() || list.push().is_none() {
-                    return Err(unsupported(shape, "list initialization and push"));
+                if list.from_raw_parts().is_none()
+                    && (list.init_in_place_with_capacity().is_none() || list.push().is_none())
+                {
+                    return Err(unsupported(
+                        shape,
+                        "list from_raw_parts or initialization and push",
+                    ));
                 }
                 let element_layout = sized_layout(list.t())?;
                 let element_program = self.lower_shape(list.t())?;
@@ -324,6 +332,7 @@ impl Lowering {
                 Ok(vec![JsonOp::ReadList {
                     list_shape: shape,
                     list,
+                    element_layout,
                     loop_id,
                 }])
             }
@@ -441,10 +450,12 @@ fn resolve_json_op(
         JsonOp::ReadList {
             list_shape,
             list,
+            element_layout,
             loop_id,
         } => JsonOp::ReadList {
             list_shape,
             list,
+            element_layout,
             loop_id: resolve_block_ref(loop_id, refs)?,
         },
         JsonOp::ListNext {
@@ -557,11 +568,22 @@ fn unsupported(shape: &'static Shape, what: &'static str) -> DeserializeError {
     )
 }
 
+fn raw_alloc_error(error: RawAllocError) -> DeserializeError {
+    match error {
+        RawAllocError::InvalidLayout { .. } | RawAllocError::SizeOverflow { .. } => vm_error(
+            None,
+            DeserializeErrorKind::InvalidValue {
+                message: "raw list buffer layout overflow".into(),
+            },
+        ),
+    }
+}
+
 struct JsonInterp<'parser, 'de, 'program, const TRUSTED_UTF8: bool> {
     parser: &'parser mut JsonParser<'de, TRUSTED_UTF8>,
     base: PtrUninit,
     structs: InlineStack<StructFrame<'program>>,
-    lists: InlineStack<HandleGuard>,
+    lists: InlineStack<ListFrame>,
     scratch: ScratchSession,
     success: bool,
 }
@@ -589,11 +611,16 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
         list: ListDef,
         scratch: &ScratchSlot,
     ) -> Result<(), DeserializeError> {
-        let list_ptr = self
+        let list_ptr = match self
             .lists
             .last()
             .expect("list frame is present while pushing element")
-            .ptr();
+        {
+            ListFrame::Push { guard } => guard.ptr(),
+            ListFrame::Adopt { .. } => {
+                unreachable!("direct-adopt lists do not push through ListDef")
+            }
+        };
         let push = list
             .push()
             .ok_or_else(|| unsupported(list.t(), "list push"))?;
@@ -601,6 +628,31 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
             push(PtrMut::new(list_ptr), scratch_ptr_mut(scratch));
         }
         Ok(())
+    }
+
+    fn direct_list_slot(&mut self) -> Result<Option<PtrUninit>, DeserializeError> {
+        let frame = self
+            .lists
+            .last_mut()
+            .expect("list frame is present while decoding element");
+        let ListFrame::Adopt { builder, .. } = frame else {
+            return Ok(None);
+        };
+        let slot = builder.next_uninit_slot().map_err(raw_alloc_error)?;
+        Ok(Some(PtrUninit::new(slot)))
+    }
+
+    unsafe fn mark_direct_list_slot_initialized(&mut self) {
+        let frame = self
+            .lists
+            .last_mut()
+            .expect("list frame is present after direct element initialization");
+        let ListFrame::Adopt { builder, .. } = frame else {
+            unreachable!("only direct-adopt lists mark direct slots");
+        };
+        unsafe {
+            builder.mark_initialized();
+        }
     }
 }
 
@@ -635,6 +687,49 @@ impl<T> InlineStack<T> {
 
     fn last_mut(&mut self) -> Option<&mut T> {
         self.rest.last_mut().or(self.first.as_mut())
+    }
+}
+
+enum ListFrame {
+    Push {
+        guard: HandleGuard,
+    },
+    Adopt {
+        list_shape: &'static Shape,
+        list: ListDef,
+        list_ptr: PtrUninit,
+        builder: RawArrayBuilder,
+    },
+}
+
+impl ListFrame {
+    fn finish(self) -> Result<(), DeserializeError> {
+        match self {
+            Self::Push { mut guard } => {
+                guard.disarm();
+                Ok(())
+            }
+            Self::Adopt {
+                list_shape,
+                list,
+                list_ptr,
+                mut builder,
+            } => {
+                let from_raw_parts = list
+                    .from_raw_parts()
+                    .ok_or_else(|| unsupported(list_shape, "list from_raw_parts"))?;
+                unsafe {
+                    from_raw_parts(
+                        list_ptr,
+                        PtrMut::new(builder.ptr()),
+                        builder.len(),
+                        builder.cap(),
+                    );
+                }
+                builder.adopt();
+                Ok(())
+            }
+        }
     }
 }
 
@@ -791,18 +886,35 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
             JsonOp::ReadList {
                 list_shape,
                 list,
+                element_layout,
                 loop_id,
             } => {
                 self.parser.consume_array_start()?;
-                let init = list
-                    .init_in_place_with_capacity()
-                    .ok_or_else(|| unsupported(list_shape, "list initialization"))?;
-                let list_ptr = unsafe { init(self.base, 0) };
-                self.lists.push(HandleGuard::new(
-                    list_ptr.as_mut_byte_ptr(),
-                    *list_shape as *const Shape as *const (),
-                    drop_shape_value,
-                ));
+                if list.from_raw_parts().is_some() {
+                    let builder = RawArrayBuilder::new(
+                        *element_layout,
+                        list.t() as *const Shape as *const (),
+                        drop_shape_value,
+                    );
+                    self.lists.push(ListFrame::Adopt {
+                        list_shape,
+                        list: *list,
+                        list_ptr: self.base,
+                        builder,
+                    });
+                } else {
+                    let init = list
+                        .init_in_place_with_capacity()
+                        .ok_or_else(|| unsupported(list_shape, "list initialization"))?;
+                    let list_ptr = unsafe { init(self.base, 0) };
+                    self.lists.push(ListFrame::Push {
+                        guard: HandleGuard::new(
+                            list_ptr.as_mut_byte_ptr(),
+                            *list_shape as *const Shape as *const (),
+                            drop_shape_value,
+                        ),
+                    });
+                }
                 Ok(Control::CallBlockThen(*loop_id, Continuation::FinishList))
             }
             JsonOp::ListNext {
@@ -818,6 +930,15 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 }
 
                 if let Some(scalar) = element_scalar {
+                    if let Some(slot) = self.direct_list_slot()? {
+                        let (value, span) = self.parser.read_scalar_token()?;
+                        unsafe {
+                            write_scalar(list.t(), *scalar, slot, value, span)?;
+                            self.mark_direct_list_slot_initialized();
+                        }
+                        continue;
+                    }
+
                     let scratch = self.scratch.reserve(*element_layout);
                     let (value, span) = self.parser.read_scalar_token()?;
                     unsafe {
@@ -829,6 +950,34 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 }
 
                 if let Some(option_scalar) = element_option_scalar {
+                    if let Some(slot) = self.direct_list_slot()? {
+                        if self.parser.consume_null_if_next()? {
+                            unsafe {
+                                (option_scalar.option.vtable.init_none)(slot);
+                                self.mark_direct_list_slot_initialized();
+                            }
+                        } else {
+                            let inner = self.scratch.reserve(option_scalar.inner_layout);
+                            let (value, span) = self.parser.read_scalar_token()?;
+                            unsafe {
+                                write_scalar(
+                                    option_scalar.option.t(),
+                                    option_scalar.scalar,
+                                    scratch_ptr_uninit(&inner),
+                                    value,
+                                    span,
+                                )?;
+                                (option_scalar.option.vtable.init_some)(
+                                    slot,
+                                    scratch_ptr_mut(&inner),
+                                );
+                                self.mark_direct_list_slot_initialized();
+                            }
+                            self.scratch.release(inner);
+                        }
+                        continue;
+                    }
+
                     let scratch = self.scratch.reserve(*element_layout);
                     if self.parser.consume_null_if_next()? {
                         unsafe {
@@ -857,12 +1006,24 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                     continue;
                 }
 
+                if let Some(slot) = self.direct_list_slot()? {
+                    let old_base = self.base;
+                    self.base = slot;
+                    return Ok(call_program_or_block_then(
+                        element_program,
+                        Continuation::DirectListElement {
+                            old_base,
+                            loop_id: *loop_id,
+                        },
+                    ));
+                }
+
                 let scratch = self.scratch.reserve(*element_layout);
                 let old_base = self.base;
                 self.base = scratch_ptr_uninit(&scratch);
                 return Ok(call_program_or_block_then(
                     element_program,
-                    Continuation::ListElement {
+                    Continuation::PushedListElement {
                         list: *list,
                         old_base,
                         scratch,
@@ -937,14 +1098,14 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 Ok(Control::Continue)
             }
             Continuation::FinishList => {
-                let mut list = self
+                let list = self
                     .lists
                     .pop()
                     .expect("list frame is present after list program");
-                list.disarm();
+                list.finish()?;
                 Ok(Control::Continue)
             }
-            Continuation::ListElement {
+            Continuation::PushedListElement {
                 list,
                 old_base,
                 scratch,
@@ -952,6 +1113,13 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
             } => {
                 self.push_list_element(list, &scratch)?;
                 self.scratch.release(scratch);
+                self.base = old_base;
+                Ok(Control::CallBlock(loop_id))
+            }
+            Continuation::DirectListElement { old_base, loop_id } => {
+                unsafe {
+                    self.mark_direct_list_slot_initialized();
+                }
                 self.base = old_base;
                 Ok(Control::CallBlock(loop_id))
             }
@@ -1001,10 +1169,14 @@ enum Continuation {
         scratch: ScratchSlot,
     },
     FinishList,
-    ListElement {
+    PushedListElement {
         list: ListDef,
         old_base: PtrUninit,
         scratch: ScratchSlot,
+        loop_id: ExecBlock,
+    },
+    DirectListElement {
+        old_base: PtrUninit,
         loop_id: ExecBlock,
     },
     Pointer {

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -1,5 +1,8 @@
 use facet::Facet;
 use facet_format::DeserializeErrorKind;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DROPPED_LIST_ELEMENTS: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Facet, Debug, PartialEq)]
 struct Point {
@@ -23,6 +26,22 @@ struct MaybeScores {
 #[derive(Facet, Debug, PartialEq)]
 struct PointList {
     points: Vec<Point>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct Droppy {
+    value: u8,
+}
+
+impl Drop for Droppy {
+    fn drop(&mut self) {
+        DROPPED_LIST_ELEMENTS.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct DroppyList {
+    items: Vec<Droppy>,
 }
 
 #[derive(Facet, Debug, PartialEq)]
@@ -99,6 +118,15 @@ fn weavy_deserializes_structs_inside_lists() {
     let got: PointList =
         facet_json::from_str_weavy(r#"{"points":[{"x":1,"y":2},{"x":3,"y":4}]}"#).unwrap();
     assert_eq!(got.points, vec![Point { x: 1, y: 2 }, Point { x: 3, y: 4 }]);
+}
+
+#[test]
+fn weavy_drops_direct_list_elements_after_later_element_error() {
+    DROPPED_LIST_ELEMENTS.store(0, Ordering::SeqCst);
+
+    facet_json::from_str_weavy::<DroppyList>(r#"{"items":[{"value":1},{"value":"nope"}]}"#)
+        .unwrap_err();
+    assert_eq!(DROPPED_LIST_ELEMENTS.load(Ordering::SeqCst), 1);
 }
 
 #[test]

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -45,6 +45,17 @@ struct DroppyList {
 }
 
 #[derive(Facet, Debug, PartialEq)]
+struct DroppyPair {
+    item: Droppy,
+    tail: u8,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct DroppyPairList {
+    items: Vec<DroppyPair>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
 struct Node {
     id: u32,
     child: Option<Box<Node>>,
@@ -127,6 +138,18 @@ fn weavy_drops_direct_list_elements_after_later_element_error() {
     facet_json::from_str_weavy::<DroppyList>(r#"{"items":[{"value":1},{"value":"nope"}]}"#)
         .unwrap_err();
     assert_eq!(DROPPED_LIST_ELEMENTS.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn weavy_drops_partial_direct_list_struct_element_before_list_buffer() {
+    DROPPED_LIST_ELEMENTS.store(0, Ordering::SeqCst);
+
+    facet_json::from_str_weavy::<DroppyPairList>(
+        r#"{"items":[{"item":{"value":1},"tail":2},{"item":{"value":3},"tail":"nope"}]}"#,
+    )
+    .unwrap_err();
+
+    assert_eq!(DROPPED_LIST_ELEMENTS.load(Ordering::SeqCst), 2);
 }
 
 #[test]

--- a/weavy/src/mem/runtime.rs
+++ b/weavy/src/mem/runtime.rs
@@ -265,6 +265,149 @@ impl Drop for RawArrayBuffer {
 /// Caller-supplied drop hook for an initialized handle/value.
 pub type DropThunk = unsafe fn(ctx: *const (), ptr: *mut u8);
 
+/// Growable engine-owned raw storage for directly filling a sequence.
+///
+/// Callers reserve the next slot, initialize it, then mark it initialized. If
+/// decoding fails before adoption, dropping the builder calls the supplied drop
+/// thunk for initialized elements and frees the raw allocation. After a list
+/// handle adopts the buffer through a `from_raw_parts`-style thunk, call
+/// [`adopt`](Self::adopt) so the builder does not touch the values or buffer.
+#[derive(Debug)]
+pub struct RawArrayBuilder {
+    ptr: *mut u8,
+    len: usize,
+    cap: usize,
+    elem_layout: Layout,
+    allocation: Option<Layout>,
+    drop_ctx: *const (),
+    drop: DropThunk,
+}
+
+impl RawArrayBuilder {
+    /// Create an empty builder for elements with `elem_layout`.
+    #[must_use]
+    pub fn new(elem_layout: Layout, drop_ctx: *const (), drop: DropThunk) -> Self {
+        let empty = empty_array_layout(elem_layout.align());
+        Self {
+            ptr: allocate_or_dangling(empty),
+            len: 0,
+            cap: 0,
+            elem_layout,
+            allocation: None,
+            drop_ctx,
+            drop,
+        }
+    }
+
+    /// The start of the raw element storage.
+    #[must_use]
+    pub fn ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    /// Number of initialized elements.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Whether there are no initialized elements.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Number of element slots allocated.
+    #[must_use]
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+
+    /// Byte stride between elements.
+    #[must_use]
+    pub fn stride(&self) -> usize {
+        self.elem_layout.size()
+    }
+
+    /// Reserve and return the next uninitialized element slot.
+    pub fn next_uninit_slot(&mut self) -> Result<*mut u8, RawAllocError> {
+        let required = self.len.checked_add(1).ok_or(RawAllocError::SizeOverflow {
+            count: self.len,
+            stride: self.elem_layout.size(),
+        })?;
+        self.ensure_capacity(required)?;
+        Ok(unsafe { self.slot_unchecked(self.len) })
+    }
+
+    /// Mark the current next slot as initialized after the caller wrote it.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have just initialized the slot returned by
+    /// [`next_uninit_slot`](Self::next_uninit_slot), and must call this at most
+    /// once per reserved slot.
+    pub unsafe fn mark_initialized(&mut self) {
+        debug_assert!(self.len < self.cap, "marking beyond reserved capacity");
+        self.len += 1;
+    }
+
+    /// Mark the allocation and initialized values as adopted by the caller.
+    pub fn adopt(&mut self) {
+        self.len = 0;
+        self.cap = 0;
+        self.allocation = None;
+    }
+
+    unsafe fn slot_unchecked(&self, index: usize) -> *mut u8 {
+        unsafe { self.ptr.add(index * self.elem_layout.size()) }
+    }
+
+    fn ensure_capacity(&mut self, required: usize) -> Result<(), RawAllocError> {
+        if required <= self.cap {
+            return Ok(());
+        }
+
+        let doubled = self.cap.checked_mul(2).ok_or(RawAllocError::SizeOverflow {
+            count: self.cap,
+            stride: self.elem_layout.size(),
+        })?;
+        let next_cap = required.max(doubled).max(4);
+        let new_layout = array_layout(next_cap, self.elem_layout)?;
+
+        if self.elem_layout.size() == 0 {
+            self.cap = next_cap;
+            return Ok(());
+        }
+
+        let new_ptr = if let Some(old_layout) = self.allocation {
+            unsafe { alloc::realloc(self.ptr, old_layout, new_layout.size()) }
+        } else {
+            unsafe { alloc::alloc(new_layout) }
+        };
+        if new_ptr.is_null() {
+            alloc::handle_alloc_error(new_layout);
+        }
+
+        self.ptr = new_ptr;
+        self.cap = next_cap;
+        self.allocation = Some(new_layout);
+        Ok(())
+    }
+}
+
+impl Drop for RawArrayBuilder {
+    fn drop(&mut self) {
+        for index in (0..self.len).rev() {
+            let slot = unsafe { self.slot_unchecked(index) };
+            unsafe { (self.drop)(self.drop_ctx, slot) };
+        }
+
+        if let Some(layout) = self.allocation.take() {
+            unsafe { alloc::dealloc(self.ptr, layout) };
+        }
+    }
+}
+
 /// Guard for an initialized handle that must be dropped unless disarmed.
 #[derive(Debug)]
 pub struct HandleGuard {
@@ -508,6 +651,32 @@ fn allocate_or_dangling(layout: Layout) -> *mut u8 {
     }
 }
 
+fn empty_array_layout(align: usize) -> Layout {
+    Layout::from_size_align(0, align).expect("alignment came from a valid element layout")
+}
+
+fn array_layout(count: usize, element: Layout) -> Result<Layout, RawAllocError> {
+    if count == 0 || element.size() == 0 {
+        return Layout::from_size_align(0, element.align()).map_err(|_| {
+            RawAllocError::InvalidLayout {
+                size: 0,
+                align: element.align(),
+            }
+        });
+    }
+
+    let size = count
+        .checked_mul(element.size())
+        .ok_or(RawAllocError::SizeOverflow {
+            count,
+            stride: element.size(),
+        })?;
+    Layout::from_size_align(size, element.align()).map_err(|_| RawAllocError::InvalidLayout {
+        size,
+        align: element.align(),
+    })
+}
+
 fn layout_fits(buffer: Layout, requested: Layout) -> bool {
     buffer.size() >= requested.size() && buffer.align() >= requested.align()
 }
@@ -515,6 +684,7 @@ fn layout_fits(buffer: Layout, requested: Layout) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ptr;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     struct CountedDrop<'a>(&'a AtomicUsize);
@@ -528,6 +698,13 @@ mod tests {
     unsafe fn count_drop(ctx: *const (), _ptr: *mut u8) {
         let drops = unsafe { &*(ctx as *const AtomicUsize) };
         drops.fetch_add(1, Ordering::SeqCst);
+    }
+
+    unsafe fn counted_drop_in_place(ctx: *const (), ptr: *mut u8) {
+        let _drops = unsafe { &*(ctx as *const AtomicUsize) };
+        unsafe {
+            ptr::drop_in_place(ptr.cast::<CountedDrop<'_>>());
+        }
     }
 
     #[test]
@@ -568,6 +745,75 @@ mod tests {
         assert!(buffer.slot(3).is_none());
         let base = buffer.ptr() as usize;
         assert_eq!(buffer.slot(2).unwrap() as usize, base + 8);
+    }
+
+    #[test]
+    fn raw_array_builder_grows_and_drops_initialized_elements() {
+        let drops = AtomicUsize::new(0);
+        let ctx = &drops as *const AtomicUsize as *const ();
+        {
+            let mut builder =
+                RawArrayBuilder::new(Layout::new::<CountedDrop<'_>>(), ctx, counted_drop_in_place);
+            for _ in 0..5 {
+                let slot = builder.next_uninit_slot().unwrap();
+                unsafe {
+                    slot.cast::<CountedDrop<'_>>().write(CountedDrop(&drops));
+                    builder.mark_initialized();
+                }
+            }
+            assert_eq!(builder.len(), 5);
+            assert!(builder.cap() >= 5);
+        }
+        assert_eq!(drops.load(Ordering::SeqCst), 5);
+    }
+
+    #[test]
+    fn raw_array_builder_adopt_disarms_values_and_allocation() {
+        let drops = AtomicUsize::new(0);
+        let ctx = &drops as *const AtomicUsize as *const ();
+        let element = Layout::new::<u64>();
+        let mut builder = RawArrayBuilder::new(element, ctx, count_drop);
+        let slot = builder.next_uninit_slot().unwrap();
+        unsafe {
+            slot.cast::<u64>().write(42);
+            builder.mark_initialized();
+        }
+        assert_eq!(builder.len(), 1);
+        let ptr = builder.ptr();
+        let cap = builder.cap();
+
+        builder.adopt();
+        drop(builder);
+
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+        unsafe {
+            alloc::dealloc(ptr, array_layout(cap, element).unwrap());
+        }
+    }
+
+    #[test]
+    fn raw_array_builder_handles_zero_sized_elements() {
+        let drops = AtomicUsize::new(0);
+        let ctx = &drops as *const AtomicUsize as *const ();
+        {
+            let mut builder = RawArrayBuilder::new(Layout::new::<()>(), ctx, count_drop);
+
+            let first = builder.next_uninit_slot().unwrap();
+            unsafe {
+                first.cast::<()>().write(());
+                builder.mark_initialized();
+            }
+            let second = builder.next_uninit_slot().unwrap();
+            unsafe {
+                second.cast::<()>().write(());
+                builder.mark_initialized();
+            }
+
+            assert_eq!(builder.len(), 2);
+            assert_eq!(builder.stride(), 0);
+            assert_eq!(first, second);
+        }
+        assert_eq!(drops.load(Ordering::SeqCst), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This moves the opt-in facet-json Weavy list path from per-element `ListDef::push` to direct raw-buffer fill plus one `ListDef::from_raw_parts` adoption when that operation is available.

The default `facet_json::from_str` path is unchanged. The old initialize-and-push path remains as a fallback for list types that do not expose `from_raw_parts`.

## Changes

- Add `weavy::mem::runtime::RawArrayBuilder`, a growable raw element buffer with initialized-length tracking, error cleanup, ZST handling, and adoption disarming.
- Teach `facet-json` Weavy `ReadList` to choose a direct-adopt `ListFrame` when `ListDef::from_raw_parts` exists.
- Decode scalar, nullable-scalar, and child-program list elements directly into raw element slots on the direct path.
- Keep the existing scratch + `ListDef::push` path for fallback list types.
- Unwind in-flight struct frames before raw list buffers on errors, so partial `Vec<struct>` element cleanup cannot touch freed raw-buffer storage.
- Add public-path coverage for completed direct-list element cleanup and partially initialized direct-list struct element cleanup.
- Add a Weavy-only scalar-list parser step that consumes comma/end/value handling in one pass for `Vec<scalar>` and `Vec<Option<scalar>>`.

## Testing

- `cargo clippy -p weavy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo nextest run -p weavy`
- `cargo nextest run -p facet-json -E 'test(weavy_drops_direct_list) | test(weavy_drops_partial_direct_list_struct_element_before_list_buffer)'`
- `cargo nextest run -p facet-json -E 'test(weavy)'`
- `cargo nextest run -p facet-json`
- push hook: metadata, git, cargo-shear, clippy, docs, build tests, run tests

## Stax

Lower is better. `PR/serde` is this PR's Weavy median divided by this PR's `serde_json` median for the same benchmark.

### mur, x86_64 Linux

| Bench | PR Weavy | Main Weavy | Delta | PR/serde |
| --- | ---: | ---: | ---: | ---: |
| point | 413.3 ns | 469.1 ns | -11.9% | 6.42x |
| person | 1.464 us | 1.558 us | -6.0% | 3.88x |
| company | 4.230 us | 4.265 us | -0.8% | 3.58x |
| batch_1000 | 1.446 ms | 1.541 ms | -6.2% | 4.32x |

### souffle, Apple Silicon macOS

| Bench | PR Weavy | Main Weavy | Delta | PR/serde |
| --- | ---: | ---: | ---: | ---: |
| point | 257.0 ns | 246.9 ns | +4.1% | 7.25x |
| person | 721.7 ns | 746.5 ns | -3.3% | 3.67x |
| company | 2.142 us | 2.111 us | +1.5% | 3.26x |
| batch_1000 | 776.1 us | 796.8 us | -2.6% | 3.59x |
