### PR TITLE
Speed up Weavy scalar decode paths

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -84,11 +84,22 @@ pub(crate) enum JsonObjectStep<'de> {
 }
 
 pub(crate) enum JsonSequenceScalarStep<'de> {
-    Value {
-        value: JsonScalarToken<'de>,
-        span: Span,
-    },
+    Value { value: JsonScalarInput<'de> },
     End,
+}
+
+pub(crate) enum JsonScalarInput<'de> {
+    Raw(scanner::SpannedToken),
+    Materialized(JsonScalarToken<'de>, Span),
+}
+
+impl JsonScalarInput<'_> {
+    pub(crate) fn is_null(&self) -> bool {
+        match self {
+            Self::Raw(token) => matches!(token.token, ScanToken::Null),
+            Self::Materialized(value, _) => matches!(value, JsonScalarToken::Null),
+        }
+    }
 }
 
 pub(crate) enum JsonFieldKey<'de> {
@@ -324,7 +335,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         Ok(kind)
     }
 
-    fn parse_number(
+    pub(crate) fn parse_number(
         &self,
         start: usize,
         end: usize,
@@ -340,7 +351,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     }
 
     #[inline]
-    fn decode_string(
+    pub(crate) fn decode_string(
         &self,
         start: usize,
         end: usize,
@@ -784,13 +795,14 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         self.state.scanner_pos
     }
 
-    pub(crate) fn read_scalar_token(&mut self) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
+    pub(crate) fn read_scalar_input(&mut self) -> Result<JsonScalarInput<'de>, ParseError> {
         if let Some(event) = self.state.event_peek.take() {
             self.state.peek_start_offset = None;
             return match event.kind {
-                ParseEventKind::Scalar(value) => {
-                    Ok((JsonScalarToken::from_scalar_value(value), event.span))
-                }
+                ParseEventKind::Scalar(value) => Ok(JsonScalarInput::Materialized(
+                    JsonScalarToken::from_scalar_value(value),
+                    event.span,
+                )),
                 other => Err(ParseError::new(
                     event.span,
                     DeserializeErrorKind::UnexpectedToken {
@@ -803,14 +815,14 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
 
         match self.determine_action() {
             NextAction::ObjectValue | NextAction::ArrayValue | NextAction::RootValue => {
-                self.consume_scalar_token()
+                self.consume_scalar_input()
             }
             NextAction::ArrayComma => {
                 self.consume_comma_token()?;
                 if let Some(ContextState::Array(state)) = self.state.stack.last_mut() {
                     *state = ArrayState::ValueOrEnd;
                 }
-                self.consume_scalar_token()
+                self.consume_scalar_input()
             }
             NextAction::RootFinished => Err(ParseError::new(
                 Span::new(self.current_offset(), 0),
@@ -1015,8 +1027,8 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
             if self.consume_sequence_end_if_next()? {
                 return Ok(JsonSequenceScalarStep::End);
             }
-            let (value, span) = self.read_scalar_token()?;
-            return Ok(JsonSequenceScalarStep::Value { value, span });
+            let value = self.read_scalar_input()?;
+            return Ok(JsonSequenceScalarStep::Value { value });
         }
 
         match self.determine_action() {
@@ -1036,8 +1048,8 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                         },
                     )),
                     _ => {
-                        let (value, span) = self.finish_scalar_token(token, "scalar or ']'")?;
-                        Ok(JsonSequenceScalarStep::Value { value, span })
+                        let value = self.finish_scalar_input_token(token, "scalar or ']'")?;
+                        Ok(JsonSequenceScalarStep::Value { value })
                     }
                 }
             }
@@ -1064,9 +1076,9 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                                 },
                             )),
                             _ => {
-                                let (value, span) =
-                                    self.finish_scalar_token(token, "scalar or ']'")?;
-                                Ok(JsonSequenceScalarStep::Value { value, span })
+                                let value =
+                                    self.finish_scalar_input_token(token, "scalar or ']'")?;
+                                Ok(JsonSequenceScalarStep::Value { value })
                             }
                         }
                     }
@@ -1127,60 +1139,46 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         Err(self.unexpected(&token, "','"))
     }
 
-    fn scalar_from_token(
+    fn validate_scalar_token(
         &self,
-        token: scanner::SpannedToken,
+        token: &scanner::SpannedToken,
         expected: &'static str,
-    ) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
-        let span = token.span;
-        let value = match token.token {
-            ScanToken::Null => JsonScalarToken::Null,
-            ScanToken::True => JsonScalarToken::Bool(true),
-            ScanToken::False => JsonScalarToken::Bool(false),
-            ScanToken::String {
-                start,
-                end,
-                has_escapes,
-            } => JsonScalarToken::Str(self.decode_string(start, end, has_escapes, span)?),
-            ScanToken::Number { start, end, hint } => match self.parse_number(start, end, hint)? {
-                ParsedNumber::U64(value) => JsonScalarToken::U64(value),
-                ParsedNumber::I64(value) => JsonScalarToken::I64(value),
-                ParsedNumber::U128(value) => JsonScalarToken::U128(value),
-                ParsedNumber::I128(value) => JsonScalarToken::I128(value),
-                ParsedNumber::F64(value) => JsonScalarToken::F64(value),
-            },
+    ) -> Result<(), ParseError> {
+        match token.token {
+            ScanToken::Null
+            | ScanToken::True
+            | ScanToken::False
+            | ScanToken::String { .. }
+            | ScanToken::Number { .. } => Ok(()),
             ScanToken::ObjectStart
             | ScanToken::ObjectEnd
             | ScanToken::ArrayStart
             | ScanToken::ArrayEnd
             | ScanToken::Colon
-            | ScanToken::Comma => return Err(self.unexpected_scan_token(&token, expected)),
-            ScanToken::Eof => {
-                return Err(ParseError::new(
-                    span,
-                    DeserializeErrorKind::UnexpectedEof { expected },
-                ));
-            }
+            | ScanToken::Comma => Err(self.unexpected_scan_token(token, expected)),
+            ScanToken::Eof => Err(ParseError::new(
+                token.span,
+                DeserializeErrorKind::UnexpectedEof { expected },
+            )),
             ScanToken::NeedMore { .. } => unreachable!("handled by consume_spanned_token"),
-        };
-        Ok((value, span))
+        }
     }
 
-    fn finish_scalar_token(
+    fn finish_scalar_input_token(
         &mut self,
         token: scanner::SpannedToken,
         expected: &'static str,
-    ) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
-        let scalar = self.scalar_from_token(token, expected)?;
+    ) -> Result<JsonScalarInput<'de>, ParseError> {
+        self.validate_scalar_token(&token, expected)?;
 
         self.state.root_started = true;
         self.finish_value_in_parent();
-        Ok(scalar)
+        Ok(JsonScalarInput::Raw(token))
     }
 
-    fn consume_scalar_token(&mut self) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
+    fn consume_scalar_input(&mut self) -> Result<JsonScalarInput<'de>, ParseError> {
         let token = self.consume_spanned_token()?;
-        self.finish_scalar_token(token, "scalar")
+        self.finish_scalar_input_token(token, "scalar")
     }
 
     fn consume_null_token(&mut self) -> Result<bool, ParseError> {

--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -795,6 +795,45 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         self.state.scanner_pos
     }
 
+    pub(crate) fn read_scalar_token(&mut self) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
+        if let Some(event) = self.state.event_peek.take() {
+            self.state.peek_start_offset = None;
+            return match event.kind {
+                ParseEventKind::Scalar(value) => {
+                    Ok((JsonScalarToken::from_scalar_value(value), event.span))
+                }
+                other => Err(ParseError::new(
+                    event.span,
+                    DeserializeErrorKind::UnexpectedToken {
+                        got: other.kind_name().into(),
+                        expected: "scalar",
+                    },
+                )),
+            };
+        }
+
+        match self.determine_action() {
+            NextAction::ObjectValue | NextAction::ArrayValue | NextAction::RootValue => {
+                self.consume_scalar_token()
+            }
+            NextAction::ArrayComma => {
+                self.consume_comma_token()?;
+                if let Some(ContextState::Array(state)) = self.state.stack.last_mut() {
+                    *state = ArrayState::ValueOrEnd;
+                }
+                self.consume_scalar_token()
+            }
+            NextAction::RootFinished => Err(ParseError::new(
+                Span::new(self.current_offset(), 0),
+                DeserializeErrorKind::UnexpectedEof { expected: "scalar" },
+            )),
+            _ => {
+                let token = self.consume_spanned_token()?;
+                Err(self.unexpected_scan_token(&token, "scalar"))
+            }
+        }
+    }
+
     pub(crate) fn read_scalar_input(&mut self) -> Result<JsonScalarInput<'de>, ParseError> {
         if let Some(event) = self.state.event_peek.take() {
             self.state.peek_start_offset = None;
@@ -1164,6 +1203,57 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
     }
 
+    fn scalar_from_token(
+        &self,
+        token: scanner::SpannedToken,
+        expected: &'static str,
+    ) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
+        let span = token.span;
+        let value = match token.token {
+            ScanToken::Null => JsonScalarToken::Null,
+            ScanToken::True => JsonScalarToken::Bool(true),
+            ScanToken::False => JsonScalarToken::Bool(false),
+            ScanToken::String {
+                start,
+                end,
+                has_escapes,
+            } => JsonScalarToken::Str(self.decode_string(start, end, has_escapes, span)?),
+            ScanToken::Number { start, end, hint } => match self.parse_number(start, end, hint)? {
+                ParsedNumber::U64(value) => JsonScalarToken::U64(value),
+                ParsedNumber::I64(value) => JsonScalarToken::I64(value),
+                ParsedNumber::U128(value) => JsonScalarToken::U128(value),
+                ParsedNumber::I128(value) => JsonScalarToken::I128(value),
+                ParsedNumber::F64(value) => JsonScalarToken::F64(value),
+            },
+            ScanToken::ObjectStart
+            | ScanToken::ObjectEnd
+            | ScanToken::ArrayStart
+            | ScanToken::ArrayEnd
+            | ScanToken::Colon
+            | ScanToken::Comma => return Err(self.unexpected_scan_token(&token, expected)),
+            ScanToken::Eof => {
+                return Err(ParseError::new(
+                    span,
+                    DeserializeErrorKind::UnexpectedEof { expected },
+                ));
+            }
+            ScanToken::NeedMore { .. } => unreachable!("handled by consume_spanned_token"),
+        };
+        Ok((value, span))
+    }
+
+    fn finish_scalar_token(
+        &mut self,
+        token: scanner::SpannedToken,
+        expected: &'static str,
+    ) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
+        let scalar = self.scalar_from_token(token, expected)?;
+
+        self.state.root_started = true;
+        self.finish_value_in_parent();
+        Ok(scalar)
+    }
+
     fn finish_scalar_input_token(
         &mut self,
         token: scanner::SpannedToken,
@@ -1179,6 +1269,11 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     fn consume_scalar_input(&mut self) -> Result<JsonScalarInput<'de>, ParseError> {
         let token = self.consume_spanned_token()?;
         self.finish_scalar_input_token(token, "scalar")
+    }
+
+    fn consume_scalar_token(&mut self) -> Result<(JsonScalarToken<'de>, Span), ParseError> {
+        let token = self.consume_spanned_token()?;
+        self.finish_scalar_token(token, "scalar")
     }
 
     fn consume_null_token(&mut self) -> Result<bool, ParseError> {

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -171,7 +171,7 @@ enum JsonOp<Block> {
     CallBlock(Block),
     ReadScalar {
         shape: &'static Shape,
-        scalar: ScalarType,
+        scalar: ScalarPlan,
     },
     ReadStruct {
         shape: &'static Shape,
@@ -185,7 +185,7 @@ enum JsonOp<Block> {
     ReadOption {
         option: OptionDef,
         some_program: Program<JsonOp<Block>>,
-        some_scalar: Option<ScalarType>,
+        some_scalar: Option<ScalarPlan>,
         inner_layout: Layout,
     },
     ReadList {
@@ -216,8 +216,47 @@ struct FieldPlan<Block> {
     offset: usize,
     shape: &'static Shape,
     program: Program<JsonOp<Block>>,
-    scalar: Option<ScalarType>,
+    scalar: Option<ScalarPlan>,
     missing: MissingField,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ScalarPlan {
+    scalar: ScalarType,
+    write: Option<MaterializedScalarWriter>,
+}
+
+type MaterializedScalarWriter = for<'de> unsafe fn(
+    &'static Shape,
+    PtrUninit,
+    JsonScalarToken<'de>,
+    Span,
+) -> Result<(), DeserializeError>;
+
+impl ScalarPlan {
+    fn new(scalar: ScalarType) -> Self {
+        Self {
+            scalar,
+            write: materialized_scalar_writer(scalar),
+        }
+    }
+
+    unsafe fn write(
+        self,
+        shape: &'static Shape,
+        dst: PtrUninit,
+        value: JsonScalarToken<'_>,
+        span: Span,
+    ) -> Result<(), DeserializeError> {
+        if let Some(write) = self.write {
+            unsafe {
+                write(shape, dst, value, span)?;
+            }
+            return Ok(());
+        }
+
+        unsafe { write_scalar(shape, self.scalar, dst, value, span) }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -294,14 +333,17 @@ impl Lowering {
         shape: &'static Shape,
     ) -> Result<Program<SymbolicOp>, DeserializeError> {
         if let Some(scalar) = ScalarType::try_from_shape(shape) {
-            return Ok(vec![JsonOp::ReadScalar { shape, scalar }]);
+            return Ok(vec![JsonOp::ReadScalar {
+                shape,
+                scalar: ScalarPlan::new(scalar),
+            }]);
         }
 
         match shape.def {
             Def::Option(option) => {
                 let inner_layout = sized_layout(option.t())?;
                 let some_program = self.lower_shape(option.t())?;
-                let some_scalar = ScalarType::try_from_shape(option.t());
+                let some_scalar = ScalarType::try_from_shape(option.t()).map(ScalarPlan::new);
                 Ok(vec![JsonOp::ReadOption {
                     option,
                     some_program,
@@ -377,7 +419,7 @@ impl Lowering {
                             offset: field.offset,
                             shape: field_shape,
                             program,
-                            scalar: ScalarType::try_from_shape(field_shape),
+                            scalar: ScalarType::try_from_shape(field_shape).map(ScalarPlan::new),
                             missing: missing_field_action(field, container_has_default),
                         });
                     }
@@ -849,7 +891,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
             JsonOp::ReadScalar { shape, scalar } => {
                 let (value, span) = self.parser.read_scalar_token()?;
                 unsafe {
-                    write_scalar(shape, *scalar, self.base, value, span)?;
+                    scalar.write(shape, self.base, value, span)?;
                 }
                 Ok(Control::Continue)
             }
@@ -906,7 +948,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                             let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
                             let (value, value_span) = self.parser.read_scalar_token()?;
                             unsafe {
-                                write_scalar(field.shape, scalar, field_ptr, value, value_span)?;
+                                scalar.write(field.shape, field_ptr, value, value_span)?;
                             }
                             let frame = self
                                 .structs
@@ -947,13 +989,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 if let Some(scalar) = some_scalar {
                     let (value, span) = self.parser.read_scalar_token()?;
                     unsafe {
-                        write_scalar(
-                            option.t(),
-                            *scalar,
-                            scratch_ptr_uninit(&scratch),
-                            value,
-                            span,
-                        )?;
+                        scalar.write(option.t(), scratch_ptr_uninit(&scratch), value, span)?;
                         (option.vtable.init_some)(self.base, scratch_ptr_mut(&scratch));
                     }
                     self.scratch.release(scratch);
@@ -1485,6 +1521,202 @@ write_signed_input!(write_i32_input, i32, "i32");
 write_signed_input!(write_i64_input, i64, "i64");
 write_signed_input!(write_i128_input, i128, "i128");
 write_signed_input!(write_isize_input, isize, "isize");
+
+fn materialized_scalar_writer(scalar: ScalarType) -> Option<MaterializedScalarWriter> {
+    match scalar {
+        ScalarType::Unit => Some(write_unit_token),
+        ScalarType::Bool => Some(write_bool_token),
+        ScalarType::Char => Some(write_char_token),
+        ScalarType::String => Some(write_string_token),
+        ScalarType::CowStr => Some(write_cow_str_token),
+        ScalarType::Str => Some(write_borrowed_str_token),
+        ScalarType::F32 => Some(write_f32_token),
+        ScalarType::F64 => Some(write_f64_token),
+        ScalarType::U8 => Some(write_u8_token),
+        ScalarType::U16 => Some(write_u16_token),
+        ScalarType::U32 => Some(write_u32_token),
+        ScalarType::U64 => Some(write_u64_token),
+        ScalarType::U128 => Some(write_u128_token),
+        ScalarType::USize => Some(write_usize_token),
+        ScalarType::I8 => Some(write_i8_token),
+        ScalarType::I16 => Some(write_i16_token),
+        ScalarType::I32 => Some(write_i32_token),
+        ScalarType::I64 => Some(write_i64_token),
+        ScalarType::I128 => Some(write_i128_token),
+        ScalarType::ISize => Some(write_isize_token),
+        _ => None,
+    }
+}
+
+unsafe fn write_unit_token(
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarToken<'_>,
+    span: Span,
+) -> Result<(), DeserializeError> {
+    match value {
+        JsonScalarToken::Null => unsafe {
+            dst.put(());
+            Ok(())
+        },
+        other => Err(type_mismatch(span, shape, other.kind_name())),
+    }
+}
+
+unsafe fn write_bool_token(
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarToken<'_>,
+    span: Span,
+) -> Result<(), DeserializeError> {
+    match value {
+        JsonScalarToken::Bool(value) => unsafe {
+            dst.put(value);
+            Ok(())
+        },
+        other => Err(type_mismatch(span, shape, other.kind_name())),
+    }
+}
+
+unsafe fn write_char_token(
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarToken<'_>,
+    span: Span,
+) -> Result<(), DeserializeError> {
+    let JsonScalarToken::Str(value) = value else {
+        return Err(type_mismatch(span, shape, value.kind_name()));
+    };
+    let mut chars = value.chars();
+    let Some(ch) = chars.next() else {
+        return Err(invalid_value(span, "empty string is not a char"));
+    };
+    if chars.next().is_some() {
+        return Err(invalid_value(span, "string has more than one char"));
+    }
+    unsafe {
+        dst.put(ch);
+    }
+    Ok(())
+}
+
+unsafe fn write_string_token(
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarToken<'_>,
+    span: Span,
+) -> Result<(), DeserializeError> {
+    let JsonScalarToken::Str(value) = value else {
+        return Err(type_mismatch(span, shape, value.kind_name()));
+    };
+    unsafe {
+        dst.put(value.into_owned());
+    }
+    Ok(())
+}
+
+unsafe fn write_cow_str_token(
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarToken<'_>,
+    span: Span,
+) -> Result<(), DeserializeError> {
+    let JsonScalarToken::Str(value) = value else {
+        return Err(type_mismatch(span, shape, value.kind_name()));
+    };
+    unsafe {
+        dst.put::<Cow<'static, str>>(Cow::Owned(value.into_owned()));
+    }
+    Ok(())
+}
+
+unsafe fn write_borrowed_str_token(
+    _shape: &'static Shape,
+    _dst: PtrUninit,
+    _value: JsonScalarToken<'_>,
+    span: Span,
+) -> Result<(), DeserializeError> {
+    Err(vm_error(
+        Some(span),
+        DeserializeErrorKind::CannotBorrow {
+            reason: "Weavy JSON owned deserializer does not support borrowed str yet".into(),
+        },
+    ))
+}
+
+unsafe fn write_f32_token(
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarToken<'_>,
+    span: Span,
+) -> Result<(), DeserializeError> {
+    let value = scalar_to_f64(value, span, shape)?;
+    unsafe {
+        dst.put(value as f32);
+    }
+    Ok(())
+}
+
+unsafe fn write_f64_token(
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarToken<'_>,
+    span: Span,
+) -> Result<(), DeserializeError> {
+    let value = scalar_to_f64(value, span, shape)?;
+    unsafe {
+        dst.put(value);
+    }
+    Ok(())
+}
+
+macro_rules! write_unsigned_token {
+    ($name:ident, $ty:ty, $target:literal) => {
+        unsafe fn $name(
+            _shape: &'static Shape,
+            dst: PtrUninit,
+            value: JsonScalarToken<'_>,
+            span: Span,
+        ) -> Result<(), DeserializeError> {
+            let value = into_unsigned::<$ty>(value, span, $target)?;
+            unsafe {
+                dst.put(value);
+            }
+            Ok(())
+        }
+    };
+}
+
+macro_rules! write_signed_token {
+    ($name:ident, $ty:ty, $target:literal) => {
+        unsafe fn $name(
+            _shape: &'static Shape,
+            dst: PtrUninit,
+            value: JsonScalarToken<'_>,
+            span: Span,
+        ) -> Result<(), DeserializeError> {
+            let value = into_signed::<$ty>(value, span, $target)?;
+            unsafe {
+                dst.put(value);
+            }
+            Ok(())
+        }
+    };
+}
+
+write_unsigned_token!(write_u8_token, u8, "u8");
+write_unsigned_token!(write_u16_token, u16, "u16");
+write_unsigned_token!(write_u32_token, u32, "u32");
+write_unsigned_token!(write_u64_token, u64, "u64");
+write_unsigned_token!(write_u128_token, u128, "u128");
+write_unsigned_token!(write_usize_token, usize, "usize");
+
+write_signed_token!(write_i8_token, i8, "i8");
+write_signed_token!(write_i16_token, i16, "i16");
+write_signed_token!(write_i32_token, i32, "i32");
+write_signed_token!(write_i64_token, i64, "i64");
+write_signed_token!(write_i128_token, i128, "i128");
+write_signed_token!(write_isize_token, isize, "isize");
 
 unsafe fn write_scalar_input<const TRUSTED_UTF8: bool>(
     parser: &JsonParser<'_, TRUSTED_UTF8>,

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -657,6 +657,92 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
             builder.mark_initialized();
         }
     }
+
+    fn list_next_scalar(
+        &mut self,
+        list: ListDef,
+        scalar: ScalarType,
+        element_layout: Layout,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, Continuation>, DeserializeError> {
+        match scalar {
+            ScalarType::U8 => {
+                self.list_next_scalar_with(list, element_layout, write_u8_input::<TRUSTED_UTF8>)
+            }
+            ScalarType::U16 => {
+                self.list_next_scalar_with(list, element_layout, write_u16_input::<TRUSTED_UTF8>)
+            }
+            ScalarType::U32 => {
+                self.list_next_scalar_with(list, element_layout, write_u32_input::<TRUSTED_UTF8>)
+            }
+            ScalarType::U64 => {
+                self.list_next_scalar_with(list, element_layout, write_u64_input::<TRUSTED_UTF8>)
+            }
+            ScalarType::U128 => {
+                self.list_next_scalar_with(list, element_layout, write_u128_input::<TRUSTED_UTF8>)
+            }
+            ScalarType::USize => {
+                self.list_next_scalar_with(list, element_layout, write_usize_input::<TRUSTED_UTF8>)
+            }
+            ScalarType::I8 => {
+                self.list_next_scalar_with(list, element_layout, write_i8_input::<TRUSTED_UTF8>)
+            }
+            ScalarType::I16 => {
+                self.list_next_scalar_with(list, element_layout, write_i16_input::<TRUSTED_UTF8>)
+            }
+            ScalarType::I32 => {
+                self.list_next_scalar_with(list, element_layout, write_i32_input::<TRUSTED_UTF8>)
+            }
+            ScalarType::I64 => {
+                self.list_next_scalar_with(list, element_layout, write_i64_input::<TRUSTED_UTF8>)
+            }
+            ScalarType::I128 => {
+                self.list_next_scalar_with(list, element_layout, write_i128_input::<TRUSTED_UTF8>)
+            }
+            ScalarType::ISize => {
+                self.list_next_scalar_with(list, element_layout, write_isize_input::<TRUSTED_UTF8>)
+            }
+            _ => {
+                let shape = list.t();
+                self.list_next_scalar_with(list, element_layout, |parser, dst, value| unsafe {
+                    write_scalar_input(parser, shape, scalar, dst, value)
+                })
+            }
+        }
+    }
+
+    fn list_next_scalar_with<W>(
+        &mut self,
+        list: ListDef,
+        element_layout: Layout,
+        mut write: W,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, Continuation>, DeserializeError>
+    where
+        W: FnMut(
+            &JsonParser<'de, TRUSTED_UTF8>,
+            PtrUninit,
+            JsonScalarInput<'de>,
+        ) -> Result<(), DeserializeError>,
+    {
+        loop {
+            let value = match self.parser.next_sequence_scalar_or_end()? {
+                JsonSequenceScalarStep::End => return Ok(Control::Continue),
+                JsonSequenceScalarStep::Value { value } => value,
+            };
+
+            if let Some(slot) = self.direct_list_slot()? {
+                write(self.parser, slot, value)?;
+                unsafe {
+                    self.mark_direct_list_slot_initialized();
+                }
+                continue;
+            }
+
+            let scratch = self.scratch.reserve(element_layout);
+            write(self.parser, scratch_ptr_uninit(&scratch), value)?;
+            self.push_list_element(list, &scratch)?;
+            self.scratch.release(scratch);
+        }
+    }
 }
 
 struct InlineStack<T> {
@@ -761,9 +847,9 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
         match op {
             JsonOp::CallBlock(shape) => Ok(Control::CallBlock(*shape)),
             JsonOp::ReadScalar { shape, scalar } => {
-                let value = self.parser.read_scalar_input()?;
+                let (value, span) = self.parser.read_scalar_token()?;
                 unsafe {
-                    write_scalar_input(self.parser, shape, *scalar, self.base, value)?;
+                    write_scalar(shape, *scalar, self.base, value, span)?;
                 }
                 Ok(Control::Continue)
             }
@@ -818,15 +904,9 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
 
                         if let Some(scalar) = field.scalar {
                             let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
-                            let value = self.parser.read_scalar_input()?;
+                            let (value, value_span) = self.parser.read_scalar_token()?;
                             unsafe {
-                                write_scalar_input(
-                                    self.parser,
-                                    field.shape,
-                                    scalar,
-                                    field_ptr,
-                                    value,
-                                )?;
+                                write_scalar(field.shape, scalar, field_ptr, value, value_span)?;
                             }
                             let frame = self
                                 .structs
@@ -865,14 +945,14 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
 
                 let scratch = self.scratch.reserve(*inner_layout);
                 if let Some(scalar) = some_scalar {
-                    let value = self.parser.read_scalar_input()?;
+                    let (value, span) = self.parser.read_scalar_token()?;
                     unsafe {
-                        write_scalar_input(
-                            self.parser,
+                        write_scalar(
                             option.t(),
                             *scalar,
                             scratch_ptr_uninit(&scratch),
                             value,
+                            span,
                         )?;
                         (option.vtable.init_some)(self.base, scratch_ptr_mut(&scratch));
                     }
@@ -935,32 +1015,7 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 loop_id,
             } => loop {
                 if let Some(scalar) = element_scalar {
-                    let value = match self.parser.next_sequence_scalar_or_end()? {
-                        JsonSequenceScalarStep::End => return Ok(Control::Continue),
-                        JsonSequenceScalarStep::Value { value } => value,
-                    };
-
-                    if let Some(slot) = self.direct_list_slot()? {
-                        unsafe {
-                            write_scalar_input(self.parser, list.t(), *scalar, slot, value)?;
-                            self.mark_direct_list_slot_initialized();
-                        }
-                        continue;
-                    }
-
-                    let scratch = self.scratch.reserve(*element_layout);
-                    unsafe {
-                        write_scalar_input(
-                            self.parser,
-                            list.t(),
-                            *scalar,
-                            scratch_ptr_uninit(&scratch),
-                            value,
-                        )?;
-                    }
-                    self.push_list_element(*list, &scratch)?;
-                    self.scratch.release(scratch);
-                    continue;
+                    return self.list_next_scalar(*list, *scalar, *element_layout);
                 }
 
                 if let Some(option_scalar) = element_option_scalar {
@@ -1368,6 +1423,68 @@ fn scratch_ptr_uninit(scratch: &ScratchSlot) -> PtrUninit {
 unsafe fn scratch_ptr_mut(scratch: &ScratchSlot) -> PtrMut {
     unsafe { scratch_ptr_uninit(scratch).assume_init() }
 }
+
+macro_rules! write_unsigned_input {
+    ($name:ident, $ty:ty, $target:literal) => {
+        fn $name<'de, const TRUSTED_UTF8: bool>(
+            parser: &JsonParser<'de, TRUSTED_UTF8>,
+            dst: PtrUninit,
+            value: JsonScalarInput<'de>,
+        ) -> Result<(), DeserializeError> {
+            let value = match value {
+                JsonScalarInput::Raw(token) => {
+                    let span = token.span;
+                    raw_into_unsigned::<$ty, TRUSTED_UTF8>(parser, token, span, $target)?
+                }
+                JsonScalarInput::Materialized(value, span) => {
+                    into_unsigned::<$ty>(value, span, $target)?
+                }
+            };
+            unsafe {
+                dst.put(value);
+            }
+            Ok(())
+        }
+    };
+}
+
+macro_rules! write_signed_input {
+    ($name:ident, $ty:ty, $target:literal) => {
+        fn $name<'de, const TRUSTED_UTF8: bool>(
+            parser: &JsonParser<'de, TRUSTED_UTF8>,
+            dst: PtrUninit,
+            value: JsonScalarInput<'de>,
+        ) -> Result<(), DeserializeError> {
+            let value = match value {
+                JsonScalarInput::Raw(token) => {
+                    let span = token.span;
+                    raw_into_signed::<$ty, TRUSTED_UTF8>(parser, token, span, $target)?
+                }
+                JsonScalarInput::Materialized(value, span) => {
+                    into_signed::<$ty>(value, span, $target)?
+                }
+            };
+            unsafe {
+                dst.put(value);
+            }
+            Ok(())
+        }
+    };
+}
+
+write_unsigned_input!(write_u8_input, u8, "u8");
+write_unsigned_input!(write_u16_input, u16, "u16");
+write_unsigned_input!(write_u32_input, u32, "u32");
+write_unsigned_input!(write_u64_input, u64, "u64");
+write_unsigned_input!(write_u128_input, u128, "u128");
+write_unsigned_input!(write_usize_input, usize, "usize");
+
+write_signed_input!(write_i8_input, i8, "i8");
+write_signed_input!(write_i16_input, i16, "i16");
+write_signed_input!(write_i32_input, i32, "i32");
+write_signed_input!(write_i64_input, i64, "i64");
+write_signed_input!(write_i128_input, i128, "i128");
+write_signed_input!(write_isize_input, isize, "isize");
 
 unsafe fn write_scalar_input<const TRUSTED_UTF8: bool>(
     parser: &JsonParser<'_, TRUSTED_UTF8>,

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -22,7 +22,10 @@ use weavy::mem::runtime::{
 use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStats, Step};
 
 use crate::JsonParser;
-use crate::parser::{JsonFieldKey, JsonObjectStep, JsonScalarToken, JsonSequenceScalarStep};
+use crate::parser::{
+    JsonFieldKey, JsonObjectStep, JsonScalarInput, JsonScalarToken, JsonSequenceScalarStep,
+};
+use crate::scanner::{ParsedNumber, SpannedToken, Token as ScanToken};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum JsonBlockId {
@@ -758,9 +761,9 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
         match op {
             JsonOp::CallBlock(shape) => Ok(Control::CallBlock(*shape)),
             JsonOp::ReadScalar { shape, scalar } => {
-                let (value, span) = self.parser.read_scalar_token()?;
+                let value = self.parser.read_scalar_input()?;
                 unsafe {
-                    write_scalar(shape, *scalar, self.base, value, span)?;
+                    write_scalar_input(self.parser, shape, *scalar, self.base, value)?;
                 }
                 Ok(Control::Continue)
             }
@@ -815,9 +818,15 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
 
                         if let Some(scalar) = field.scalar {
                             let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
-                            let (value, value_span) = self.parser.read_scalar_token()?;
+                            let value = self.parser.read_scalar_input()?;
                             unsafe {
-                                write_scalar(field.shape, scalar, field_ptr, value, value_span)?;
+                                write_scalar_input(
+                                    self.parser,
+                                    field.shape,
+                                    scalar,
+                                    field_ptr,
+                                    value,
+                                )?;
                             }
                             let frame = self
                                 .structs
@@ -856,14 +865,14 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
 
                 let scratch = self.scratch.reserve(*inner_layout);
                 if let Some(scalar) = some_scalar {
-                    let (value, span) = self.parser.read_scalar_token()?;
+                    let value = self.parser.read_scalar_input()?;
                     unsafe {
-                        write_scalar(
+                        write_scalar_input(
+                            self.parser,
                             option.t(),
                             *scalar,
                             scratch_ptr_uninit(&scratch),
                             value,
-                            span,
                         )?;
                         (option.vtable.init_some)(self.base, scratch_ptr_mut(&scratch));
                     }
@@ -926,14 +935,14 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 loop_id,
             } => loop {
                 if let Some(scalar) = element_scalar {
-                    let (value, span) = match self.parser.next_sequence_scalar_or_end()? {
+                    let value = match self.parser.next_sequence_scalar_or_end()? {
                         JsonSequenceScalarStep::End => return Ok(Control::Continue),
-                        JsonSequenceScalarStep::Value { value, span } => (value, span),
+                        JsonSequenceScalarStep::Value { value } => value,
                     };
 
                     if let Some(slot) = self.direct_list_slot()? {
                         unsafe {
-                            write_scalar(list.t(), *scalar, slot, value, span)?;
+                            write_scalar_input(self.parser, list.t(), *scalar, slot, value)?;
                             self.mark_direct_list_slot_initialized();
                         }
                         continue;
@@ -941,7 +950,13 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
 
                     let scratch = self.scratch.reserve(*element_layout);
                     unsafe {
-                        write_scalar(list.t(), *scalar, scratch_ptr_uninit(&scratch), value, span)?;
+                        write_scalar_input(
+                            self.parser,
+                            list.t(),
+                            *scalar,
+                            scratch_ptr_uninit(&scratch),
+                            value,
+                        )?;
                     }
                     self.push_list_element(*list, &scratch)?;
                     self.scratch.release(scratch);
@@ -950,12 +965,12 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
 
                 if let Some(option_scalar) = element_option_scalar {
                     let step = self.parser.next_sequence_scalar_or_end()?;
-                    let JsonSequenceScalarStep::Value { value, span } = step else {
+                    let JsonSequenceScalarStep::Value { value } = step else {
                         return Ok(Control::Continue);
                     };
 
                     if let Some(slot) = self.direct_list_slot()? {
-                        if matches!(&value, JsonScalarToken::Null) {
+                        if value.is_null() {
                             unsafe {
                                 (option_scalar.option.vtable.init_none)(slot);
                                 self.mark_direct_list_slot_initialized();
@@ -963,12 +978,12 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                         } else {
                             let inner = self.scratch.reserve(option_scalar.inner_layout);
                             unsafe {
-                                write_scalar(
+                                write_scalar_input(
+                                    self.parser,
                                     option_scalar.option.t(),
                                     option_scalar.scalar,
                                     scratch_ptr_uninit(&inner),
                                     value,
-                                    span,
                                 )?;
                                 (option_scalar.option.vtable.init_some)(
                                     slot,
@@ -982,19 +997,19 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                     }
 
                     let scratch = self.scratch.reserve(*element_layout);
-                    if matches!(&value, JsonScalarToken::Null) {
+                    if value.is_null() {
                         unsafe {
                             (option_scalar.option.vtable.init_none)(scratch_ptr_uninit(&scratch));
                         }
                     } else {
                         let inner = self.scratch.reserve(option_scalar.inner_layout);
                         unsafe {
-                            write_scalar(
+                            write_scalar_input(
+                                self.parser,
                                 option_scalar.option.t(),
                                 option_scalar.scalar,
                                 scratch_ptr_uninit(&inner),
                                 value,
-                                span,
                             )?;
                             (option_scalar.option.vtable.init_some)(
                                 scratch_ptr_uninit(&scratch),
@@ -1354,6 +1369,182 @@ unsafe fn scratch_ptr_mut(scratch: &ScratchSlot) -> PtrMut {
     unsafe { scratch_ptr_uninit(scratch).assume_init() }
 }
 
+unsafe fn write_scalar_input<const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    shape: &'static Shape,
+    scalar: ScalarType,
+    dst: PtrUninit,
+    value: JsonScalarInput<'_>,
+) -> Result<(), DeserializeError> {
+    match value {
+        JsonScalarInput::Raw(token) => unsafe {
+            write_scalar_raw(parser, shape, scalar, dst, token)
+        },
+        JsonScalarInput::Materialized(value, span) => unsafe {
+            write_scalar(shape, scalar, dst, value, span)
+        },
+    }
+}
+
+unsafe fn write_scalar_raw<const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    shape: &'static Shape,
+    scalar: ScalarType,
+    dst: PtrUninit,
+    token: SpannedToken,
+) -> Result<(), DeserializeError> {
+    let span = token.span;
+    match scalar {
+        ScalarType::Unit => match token.token {
+            ScanToken::Null => unsafe {
+                dst.put(());
+            },
+            other => return Err(type_mismatch(span, shape, raw_token_kind_name(&other))),
+        },
+        ScalarType::Bool => match token.token {
+            ScanToken::True => unsafe {
+                dst.put(true);
+            },
+            ScanToken::False => unsafe {
+                dst.put(false);
+            },
+            other => return Err(type_mismatch(span, shape, raw_token_kind_name(&other))),
+        },
+        ScalarType::Char => {
+            let value = raw_string(parser, token, shape)?;
+            let mut chars = value.chars();
+            let Some(ch) = chars.next() else {
+                return Err(invalid_value(span, "empty string is not a char"));
+            };
+            if chars.next().is_some() {
+                return Err(invalid_value(span, "string has more than one char"));
+            }
+            unsafe {
+                dst.put(ch);
+            }
+        }
+        ScalarType::String => {
+            let value = raw_string(parser, token, shape)?;
+            unsafe {
+                dst.put(value.into_owned());
+            }
+        }
+        ScalarType::CowStr => {
+            let value = raw_string(parser, token, shape)?;
+            unsafe {
+                dst.put::<Cow<'static, str>>(Cow::Owned(value.into_owned()));
+            }
+        }
+        ScalarType::Str => {
+            return Err(vm_error(
+                Some(span),
+                DeserializeErrorKind::CannotBorrow {
+                    reason: "Weavy JSON owned deserializer does not support borrowed str yet"
+                        .into(),
+                },
+            ));
+        }
+        ScalarType::F32 => unsafe {
+            dst.put(raw_to_f64(parser, token, span, shape)? as f32);
+        },
+        ScalarType::F64 => unsafe {
+            dst.put(raw_to_f64(parser, token, span, shape)?);
+        },
+        ScalarType::U8 => unsafe {
+            dst.put(raw_into_unsigned::<u8, TRUSTED_UTF8>(
+                parser, token, span, "u8",
+            )?);
+        },
+        ScalarType::U16 => unsafe {
+            dst.put(raw_into_unsigned::<u16, TRUSTED_UTF8>(
+                parser, token, span, "u16",
+            )?);
+        },
+        ScalarType::U32 => unsafe {
+            dst.put(raw_into_unsigned::<u32, TRUSTED_UTF8>(
+                parser, token, span, "u32",
+            )?);
+        },
+        ScalarType::U64 => unsafe {
+            dst.put(raw_into_unsigned::<u64, TRUSTED_UTF8>(
+                parser, token, span, "u64",
+            )?);
+        },
+        ScalarType::U128 => unsafe {
+            dst.put(raw_into_unsigned::<u128, TRUSTED_UTF8>(
+                parser, token, span, "u128",
+            )?);
+        },
+        ScalarType::USize => unsafe {
+            dst.put(raw_into_unsigned::<usize, TRUSTED_UTF8>(
+                parser, token, span, "usize",
+            )?);
+        },
+        ScalarType::I8 => unsafe {
+            dst.put(raw_into_signed::<i8, TRUSTED_UTF8>(
+                parser, token, span, "i8",
+            )?);
+        },
+        ScalarType::I16 => unsafe {
+            dst.put(raw_into_signed::<i16, TRUSTED_UTF8>(
+                parser, token, span, "i16",
+            )?);
+        },
+        ScalarType::I32 => unsafe {
+            dst.put(raw_into_signed::<i32, TRUSTED_UTF8>(
+                parser, token, span, "i32",
+            )?);
+        },
+        ScalarType::I64 => unsafe {
+            dst.put(raw_into_signed::<i64, TRUSTED_UTF8>(
+                parser, token, span, "i64",
+            )?);
+        },
+        ScalarType::I128 => unsafe {
+            dst.put(raw_into_signed::<i128, TRUSTED_UTF8>(
+                parser, token, span, "i128",
+            )?);
+        },
+        ScalarType::ISize => unsafe {
+            dst.put(raw_into_signed::<isize, TRUSTED_UTF8>(
+                parser, token, span, "isize",
+            )?);
+        },
+        ScalarType::ConstTypeId => {
+            return Err(vm_error(
+                Some(span),
+                DeserializeErrorKind::Unsupported {
+                    message: "Weavy JSON deserializer does not support ConstTypeId yet".into(),
+                },
+            ));
+        }
+        #[cfg(feature = "net")]
+        ScalarType::SocketAddr
+        | ScalarType::IpAddr
+        | ScalarType::Ipv4Addr
+        | ScalarType::Ipv6Addr => {
+            let value = raw_string(parser, token, shape)?;
+            match unsafe { shape.call_parse(value.as_ref(), dst) } {
+                Some(Ok(())) => {}
+                Some(Err(err)) => return Err(invalid_value(span, format!("{err}"))),
+                None => return Err(unsupported(shape, "parsed scalar")),
+            }
+        }
+        _ => {
+            return Err(vm_error(
+                Some(span),
+                DeserializeErrorKind::Unsupported {
+                    message: format!(
+                        "Weavy JSON deserializer does not yet support scalar {scalar:?}"
+                    )
+                    .into(),
+                },
+            ));
+        }
+    }
+    Ok(())
+}
+
 unsafe fn write_scalar(
     shape: &'static Shape,
     scalar: ScalarType,
@@ -1489,6 +1680,178 @@ unsafe fn write_scalar(
         }
     }
     Ok(())
+}
+
+fn raw_token_kind_name(token: &ScanToken) -> &'static str {
+    match token {
+        ScanToken::Null => "null",
+        ScanToken::True | ScanToken::False => "bool",
+        ScanToken::String { .. } => "string",
+        ScanToken::Number { hint, .. } => match hint {
+            crate::scanner::NumberHint::Unsigned => "u64",
+            crate::scanner::NumberHint::Signed => "i64",
+            crate::scanner::NumberHint::Float => "f64",
+        },
+        ScanToken::ObjectStart => "object start",
+        ScanToken::ObjectEnd => "object end",
+        ScanToken::ArrayStart => "array start",
+        ScanToken::ArrayEnd => "array end",
+        ScanToken::Colon => "colon",
+        ScanToken::Comma => "comma",
+        ScanToken::Eof => "eof",
+        ScanToken::NeedMore { .. } => "incomplete token",
+    }
+}
+
+fn parsed_number_kind_name(value: &ParsedNumber) -> &'static str {
+    match value {
+        ParsedNumber::U64(_) => "u64",
+        ParsedNumber::I64(_) => "i64",
+        ParsedNumber::U128(_) => "u128",
+        ParsedNumber::I128(_) => "i128",
+        ParsedNumber::F64(_) => "f64",
+    }
+}
+
+fn raw_string<'de, const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'de, TRUSTED_UTF8>,
+    token: SpannedToken,
+    shape: &'static Shape,
+) -> Result<Cow<'de, str>, DeserializeError> {
+    let span = token.span;
+    match token.token {
+        ScanToken::String {
+            start,
+            end,
+            has_escapes,
+        } => Ok(parser.decode_string(start, end, has_escapes, span)?),
+        other => Err(type_mismatch(span, shape, raw_token_kind_name(&other))),
+    }
+}
+
+fn raw_to_f64<const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    token: SpannedToken,
+    span: Span,
+    shape: &'static Shape,
+) -> Result<f64, DeserializeError> {
+    match token.token {
+        ScanToken::Number { start, end, hint } => {
+            let number = parser.parse_number(start, end, hint)?;
+            match number {
+                ParsedNumber::F64(value) => Ok(value),
+                ParsedNumber::I64(value) => Ok(value as f64),
+                ParsedNumber::U64(value) => Ok(value as f64),
+                ParsedNumber::I128(value) => Ok(value as f64),
+                ParsedNumber::U128(value) => Ok(value as f64),
+            }
+        }
+        ScanToken::String {
+            start,
+            end,
+            has_escapes,
+        } => {
+            let value = parser.decode_string(start, end, has_escapes, span)?;
+            value
+                .parse::<f64>()
+                .map_err(|_| type_mismatch(span, shape, "string"))
+        }
+        other => Err(type_mismatch(span, shape, raw_token_kind_name(&other))),
+    }
+}
+
+fn raw_into_unsigned<T, const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    token: SpannedToken,
+    span: Span,
+    target: &'static str,
+) -> Result<T, DeserializeError>
+where
+    T: TryFrom<u128>,
+{
+    let value = match token.token {
+        ScanToken::Number { start, end, hint } => {
+            let number = parser.parse_number(start, end, hint)?;
+            match number {
+                ParsedNumber::U64(value) => value as u128,
+                ParsedNumber::U128(value) => value,
+                ParsedNumber::I64(value) if value >= 0 => value as u128,
+                ParsedNumber::I128(value) if value >= 0 => value as u128,
+                other => {
+                    return Err(type_mismatch_name(
+                        span,
+                        target,
+                        parsed_number_kind_name(&other),
+                    ));
+                }
+            }
+        }
+        ScanToken::String {
+            start,
+            end,
+            has_escapes,
+        } => {
+            let value = parser.decode_string(start, end, has_escapes, span)?;
+            value
+                .parse::<u128>()
+                .map_err(|_| number_out_of_range(span, value.into_owned(), target))?
+        }
+        other => {
+            return Err(type_mismatch_name(
+                span,
+                target,
+                raw_token_kind_name(&other),
+            ));
+        }
+    };
+    T::try_from(value).map_err(|_| number_out_of_range(span, value.to_string(), target))
+}
+
+fn raw_into_signed<T, const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    token: SpannedToken,
+    span: Span,
+    target: &'static str,
+) -> Result<T, DeserializeError>
+where
+    T: TryFrom<i128>,
+{
+    let value = match token.token {
+        ScanToken::Number { start, end, hint } => {
+            let number = parser.parse_number(start, end, hint)?;
+            match number {
+                ParsedNumber::I64(value) => value as i128,
+                ParsedNumber::I128(value) => value,
+                ParsedNumber::U64(value) => value as i128,
+                ParsedNumber::U128(value) if value <= i128::MAX as u128 => value as i128,
+                other => {
+                    return Err(type_mismatch_name(
+                        span,
+                        target,
+                        parsed_number_kind_name(&other),
+                    ));
+                }
+            }
+        }
+        ScanToken::String {
+            start,
+            end,
+            has_escapes,
+        } => {
+            let value = parser.decode_string(start, end, has_escapes, span)?;
+            value
+                .parse::<i128>()
+                .map_err(|_| number_out_of_range(span, value.into_owned(), target))?
+        }
+        other => {
+            return Err(type_mismatch_name(
+                span,
+                target,
+                raw_token_kind_name(&other),
+            ));
+        }
+    };
+    T::try_from(value).map_err(|_| number_out_of_range(span, value.to_string(), target))
 }
 
 fn scalar_to_f64(

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -119,6 +119,17 @@ fn weavy_deserializes_options_and_lists() {
 }
 
 #[test]
+fn weavy_deserializes_numeric_strings_on_raw_scalar_path() {
+    let person: Person = facet_json::from_str_weavy(
+        r#"{"name":"Ada","age":"37","favorite":null,"scores":["1","2","3"]}"#,
+    )
+    .unwrap();
+
+    assert_eq!(person.age, 37);
+    assert_eq!(person.scores, vec![1, 2, 3]);
+}
+
+#[test]
 fn weavy_deserializes_null_options_inside_lists() {
     let got: MaybeScores = facet_json::from_str_weavy(r#"{"scores":[1,null,2,null]}"#).unwrap();
     assert_eq!(got.scores, vec![Some(1), None, Some(2), None]);


### PR DESCRIPTION
## Summary

This PR tightens the opt-in facet-json Weavy deserializer scalar paths:

- keeps raw scanner-token scalar input for sequence loops, where it can avoid materializing per element
- restores ordinary scalar fields/options/root values to the materialized scalar reader after the broad raw-token path measured as a regression
- hoists integer scalar list dispatch out of the per-element loop
- lowers root/field/option scalar writes into a `ScalarPlan`, so supported scalar fields call preselected materialized writers

The default facet-json deserializer path is unchanged.

## Performance

Measured with `stax record` around the compiled `typeplan_reuse` benchmark binary on both hosts, comparing this branch to `origin/main`. Numbers below use Divan's fastest column.

### mur

| Bench | PR Weavy | Main Weavy | Delta | PR/serde |
|---|---:|---:|---:|---:|
| point | 429.7 ns | 430.6 ns | -0.2% | 5.76x |
| person | 1.351 us | 1.401 us | -3.6% | 4.15x |
| company | 3.756 us | 4.046 us | -7.2% | 3.95x |
| batch_1000 | 1.372 ms | 1.415 ms | -3.0% | 4.21x |

### souffle

| Bench | PR Weavy | Main Weavy | Delta | PR/serde |
|---|---:|---:|---:|---:|
| point | 215.6 ns | 216.6 ns | -0.5% | 6.59x |
| person | 739.0 ns | 717.9 ns | +2.9% | 3.85x |
| company | 2.040 us | 2.165 us | -5.8% | 3.50x |
| batch_1000 | 890.6 us | 819.7 us | +8.6% | 3.86x |

The `souffle` full-matrix batch row was noisy; a longer isolated stax run of only `batch_1000_weavy_reused_plan` was essentially tied:

| Host | PR Weavy | Main Weavy | Delta |
|---|---:|---:|---:|
| souffle isolated batch | 747.4 us | 748.5 us | -0.1% |

## Testing

- `cargo check -p facet-json -p weavy`
- `cargo nextest run -p facet-json -E 'test(weavy)'`
- `cargo clippy -p weavy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo nextest run -p facet-json`
- `git diff --check`
- push hooks passed
