### PR TITLE
Speed up Weavy JSON field dispatch

### DIFF
--- a/facet-json/src/error.rs
+++ b/facet-json/src/error.rs
@@ -127,7 +127,7 @@ pub enum JsonErrorKind {
     InvalidUtf8,
     /// Solver error (for flattened types)
     Solver(String),
-    /// I/O error (for streaming deserialization)
+    /// I/O error
     Io(String),
 }
 

--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -293,18 +293,10 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
 
     #[inline]
     fn consume_spanned_token(&mut self) -> Result<scanner::SpannedToken, ParseError> {
-        let mut spanned = self
+        let spanned = self
             .scanner
             .next_token(self.input)
             .map_err(scan_error_to_parse_error)?;
-
-        // Handle NeedMore by finalizing - we have full input so this is true EOF
-        if matches!(spanned.token, ScanToken::NeedMore { .. }) {
-            spanned = self
-                .scanner
-                .finalize_at_eof(self.input)
-                .map_err(scan_error_to_parse_error)?;
-        }
 
         self.state.last_token_start = spanned.span.offset as usize;
         self.state.scanner_pos = self.scanner.pos();
@@ -343,7 +335,6 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                 }
             }
             ScanToken::Eof => TokenKind::Eof,
-            ScanToken::NeedMore { .. } => unreachable!("handled above"),
         };
         Ok(kind)
     }
@@ -643,14 +634,6 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                     DeserializeErrorKind::UnexpectedEof { expected: "value" },
                 ));
             }
-            ScanToken::NeedMore { .. } => {
-                return Err(ParseError::new(
-                    first.span,
-                    DeserializeErrorKind::UnexpectedEof {
-                        expected: "more data",
-                    },
-                ));
-            }
         }
 
         let end = self.scanner.pos();
@@ -697,14 +680,6 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                     return Err(ParseError::new(
                         spanned.span,
                         DeserializeErrorKind::UnexpectedEof { expected: "value" },
-                    ));
-                }
-                ScanToken::NeedMore { .. } => {
-                    return Err(ParseError::new(
-                        spanned.span,
-                        DeserializeErrorKind::UnexpectedEof {
-                            expected: "more data",
-                        },
                     ));
                 }
                 _ => {}
@@ -1279,7 +1254,6 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                 token.span,
                 DeserializeErrorKind::UnexpectedEof { expected },
             )),
-            ScanToken::NeedMore { .. } => unreachable!("handled by consume_spanned_token"),
         }
     }
 
@@ -1317,7 +1291,6 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                     DeserializeErrorKind::UnexpectedEof { expected },
                 ));
             }
-            ScanToken::NeedMore { .. } => unreachable!("handled by consume_spanned_token"),
         };
         Ok((value, span))
     }
@@ -1635,14 +1608,6 @@ impl<'de, const TRUSTED_UTF8: bool> FormatParser<'de> for JsonParser<'de, TRUSTE
                     return Err(ParseError::new(
                         first.span,
                         DeserializeErrorKind::UnexpectedEof { expected: "value" },
-                    ));
-                }
-                ScanToken::NeedMore { .. } => {
-                    return Err(ParseError::new(
-                        first.span,
-                        DeserializeErrorKind::UnexpectedEof {
-                            expected: "more data",
-                        },
                     ));
                 }
                 _ => {

--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -78,8 +78,11 @@ impl JsonValueStart<'_> {
     }
 }
 
-pub(crate) enum JsonObjectStep<'de> {
-    Field { key: JsonFieldKey<'de>, span: Span },
+pub(crate) enum JsonObjectKeyStep<'de> {
+    Field {
+        key: JsonFieldKeyInput<'de>,
+        span: Span,
+    },
     End,
 }
 
@@ -114,6 +117,16 @@ impl JsonFieldKey<'_> {
             Self::Decoded(value) => value.as_ref(),
         }
     }
+}
+
+pub(crate) enum JsonFieldKeyInput<'de> {
+    Raw {
+        start: usize,
+        end: usize,
+        has_escapes: bool,
+        span: Span,
+    },
+    Materialized(JsonFieldKey<'de>),
 }
 
 pub(crate) enum JsonScalarToken<'de> {
@@ -406,6 +419,62 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         } else {
             self.decode_string(start, end, has_escapes, span)
                 .map(JsonFieldKey::Decoded)
+        }
+    }
+
+    #[inline]
+    pub(crate) fn field_key_unescaped_bytes(&self, key: &JsonFieldKeyInput<'de>) -> Option<&[u8]> {
+        match key {
+            JsonFieldKeyInput::Raw {
+                start,
+                end,
+                has_escapes: false,
+                ..
+            } => Some(&self.input[*start..*end]),
+            JsonFieldKeyInput::Raw {
+                has_escapes: true, ..
+            }
+            | JsonFieldKeyInput::Materialized(_) => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn field_key_matches(
+        &self,
+        key: &JsonFieldKeyInput<'de>,
+        expected: &str,
+    ) -> Result<bool, ParseError> {
+        match key {
+            JsonFieldKeyInput::Raw {
+                start,
+                end,
+                has_escapes,
+                span,
+            } => {
+                if !has_escapes {
+                    Ok(&self.input[*start..*end] == expected.as_bytes())
+                } else {
+                    self.decode_string(*start, *end, *has_escapes, *span)
+                        .map(|decoded| decoded.as_ref() == expected)
+                }
+            }
+            JsonFieldKeyInput::Materialized(key) => Ok(key.as_str() == expected),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn materialize_field_key(
+        &self,
+        key: JsonFieldKeyInput<'de>,
+    ) -> Result<JsonFieldKey<'de>, ParseError> {
+        match key {
+            JsonFieldKeyInput::Raw {
+                start,
+                end,
+                has_escapes,
+                span,
+            } => self.decode_field_key(start, end, has_escapes, span),
+            JsonFieldKeyInput::Materialized(key) => Ok(key),
         }
     }
 
@@ -874,6 +943,10 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
     }
 
+    pub(crate) fn read_current_scalar_input(&mut self) -> Result<JsonScalarInput<'de>, ParseError> {
+        self.consume_scalar_input()
+    }
+
     pub(crate) fn consume_object_start(&mut self) -> Result<Span, ParseError> {
         match self.consume_value_start("object")? {
             JsonValueStart::Object(span) => Ok(span),
@@ -888,11 +961,11 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
     }
 
-    pub(crate) fn next_object_field_or_end(&mut self) -> Result<JsonObjectStep<'de>, ParseError> {
+    pub(crate) fn next_object_key_or_end(&mut self) -> Result<JsonObjectKeyStep<'de>, ParseError> {
         if let Some(event) = self.state.event_peek.take() {
             self.state.peek_start_offset = None;
             return match event.kind {
-                ParseEventKind::StructEnd => Ok(JsonObjectStep::End),
+                ParseEventKind::StructEnd => Ok(JsonObjectKeyStep::End),
                 ParseEventKind::FieldKey(key) => {
                     let Some(name) = key.name() else {
                         return Err(ParseError::new(
@@ -902,8 +975,8 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                             },
                         ));
                     };
-                    Ok(JsonObjectStep::Field {
-                        key: JsonFieldKey::Decoded(name.clone()),
+                    Ok(JsonObjectKeyStep::Field {
+                        key: JsonFieldKeyInput::Materialized(JsonFieldKey::Decoded(name.clone())),
                         span: event.span,
                     })
                 }
@@ -926,19 +999,26 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                         ScanToken::ObjectEnd => {
                             self.state.stack.pop();
                             self.finish_value_in_parent();
-                            return Ok(JsonObjectStep::End);
+                            return Ok(JsonObjectKeyStep::End);
                         }
                         ScanToken::String {
                             start,
                             end,
                             has_escapes,
                         } => {
-                            let key = self.decode_field_key(start, end, has_escapes, span)?;
                             self.expect_colon_token()?;
                             if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
                                 *state = ObjectState::Value;
                             }
-                            return Ok(JsonObjectStep::Field { key, span });
+                            return Ok(JsonObjectKeyStep::Field {
+                                key: JsonFieldKeyInput::Raw {
+                                    start,
+                                    end,
+                                    has_escapes,
+                                    span,
+                                },
+                                span,
+                            });
                         }
                         ScanToken::Eof => {
                             return Err(ParseError::new(
@@ -963,7 +1043,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                         ScanToken::ObjectEnd => {
                             self.state.stack.pop();
                             self.finish_value_in_parent();
-                            return Ok(JsonObjectStep::End);
+                            return Ok(JsonObjectKeyStep::End);
                         }
                         ScanToken::Eof => {
                             return Err(ParseError::new(

--- a/facet-json/src/scanner.rs
+++ b/facet-json/src/scanner.rs
@@ -6,7 +6,6 @@
 //!
 //! This design enables:
 //! - Zero-copy borrowed strings (when no escapes)
-//! - Streaming from `std::io::Read` with buffer refills
 //! - Skipping values without allocation (RawJson, unknown fields)
 
 use core::str;
@@ -54,11 +53,6 @@ pub enum Token {
     },
     /// End of input reached
     Eof,
-    /// Buffer exhausted mid-token - need refill for streaming
-    NeedMore {
-        /// How many bytes were consumed before hitting the boundary
-        consumed: usize,
-    },
 }
 
 /// Hint about number format to guide parsing
@@ -107,37 +101,13 @@ pub type ScanResult = Result<SpannedToken, ScanError>;
 
 /// JSON scanner state machine.
 ///
-/// The scanner operates on a byte buffer and tracks position. For streaming,
-/// the buffer can be refilled when `Token::NeedMore` is returned.
+/// The scanner operates on a complete byte buffer and tracks position.
 #[derive(Clone)]
 pub struct Scanner {
     /// Current position in the buffer
     pos: usize,
-    /// State for resuming after NeedMore (for streaming)
-    state: ScanState,
     /// Whether to allow JSONC-style comments (`//` and `/* */`)
     allow_comments: bool,
-}
-
-/// Internal state for resuming mid-token after buffer refill
-#[derive(Debug, Clone, Default)]
-enum ScanState {
-    #[default]
-    Ready,
-    /// In the middle of scanning a string
-    InString {
-        start: usize,
-        has_escapes: bool,
-        escape_next: bool,
-    },
-    /// In the middle of scanning a number
-    InNumber { start: usize, hint: NumberHint },
-    /// In the middle of scanning a literal (true/false/null)
-    InLiteral {
-        start: usize,
-        expected: &'static [u8],
-        matched: usize,
-    },
 }
 
 impl Scanner {
@@ -145,7 +115,6 @@ impl Scanner {
     pub const fn new() -> Self {
         Self {
             pos: 0,
-            state: ScanState::Ready,
             allow_comments: false,
         }
     }
@@ -154,7 +123,6 @@ impl Scanner {
     pub const fn new_with_comments() -> Self {
         Self {
             pos: 0,
-            state: ScanState::Ready,
             allow_comments: true,
         }
     }
@@ -164,7 +132,6 @@ impl Scanner {
     pub const fn at_position(pos: usize) -> Self {
         Self {
             pos,
-            state: ScanState::Ready,
             allow_comments: false,
         }
     }
@@ -195,7 +162,6 @@ impl Scanner {
     ) -> Result<Option<(usize, u8)>, ScanError> {
         let mut scanner = self.clone();
         scanner.pos = pos;
-        scanner.state = ScanState::Ready;
         scanner.skip_whitespace(buf)?;
         Ok(buf
             .get(scanner.pos)
@@ -203,98 +169,8 @@ impl Scanner {
             .map(|byte| (scanner.pos, byte)))
     }
 
-    /// Finalize any pending token at true EOF.
-    ///
-    /// Call this when the scanner returned `NeedMore` but no more data is available.
-    /// Returns the completed token if one is pending (e.g., a number at EOF),
-    /// or an error if the token is incomplete (e.g., unterminated string).
-    pub fn finalize_at_eof(&mut self, buf: &[u8]) -> ScanResult {
-        match core::mem::take(&mut self.state) {
-            ScanState::Ready => {
-                // Nothing pending
-                Ok(SpannedToken {
-                    token: Token::Eof,
-                    span: Span::new(self.pos, 0),
-                })
-            }
-            ScanState::InNumber { start, hint } => {
-                // Number is complete at EOF (numbers don't need closing delimiter)
-                let end = self.pos;
-                if end == start || (end == start + 1 && buf.get(start) == Some(&b'-')) {
-                    return Err(ScanError {
-                        kind: ScanErrorKind::UnexpectedEof("in number"),
-                        span: Span::new(start, end - start),
-                    });
-                }
-                Ok(SpannedToken {
-                    token: Token::Number { start, end, hint },
-                    span: Span::new(start, end - start),
-                })
-            }
-            ScanState::InString { start, .. } => {
-                // Unterminated string
-                Err(ScanError {
-                    kind: ScanErrorKind::UnexpectedEof("in string"),
-                    span: Span::new(start, self.pos - start),
-                })
-            }
-            ScanState::InLiteral {
-                start,
-                expected,
-                matched,
-            } => {
-                // Check if the literal is complete
-                if matched == expected.len() {
-                    let token = match expected {
-                        b"true" => Token::True,
-                        b"false" => Token::False,
-                        b"null" => Token::Null,
-                        _ => unreachable!(),
-                    };
-                    Ok(SpannedToken {
-                        token,
-                        span: Span::new(start, expected.len()),
-                    })
-                } else {
-                    Err(ScanError {
-                        kind: ScanErrorKind::UnexpectedEof("in literal"),
-                        span: Span::new(start, self.pos - start),
-                    })
-                }
-            }
-        }
-    }
-
     /// Scan the next token from the buffer.
-    ///
-    /// Returns `Token::NeedMore` if the buffer is exhausted mid-token,
-    /// allowing the caller to refill and retry.
     pub fn next_token(&mut self, buf: &[u8]) -> ScanResult {
-        // Fast path: if state is Ready, skip the mem::take overhead
-        if !matches!(self.state, ScanState::Ready) {
-            // If we have pending state from a previous NeedMore, resume
-            match core::mem::take(&mut self.state) {
-                ScanState::Ready => unreachable!(),
-                ScanState::InString {
-                    start,
-                    has_escapes,
-                    escape_next,
-                } => {
-                    return self.resume_string(buf, start, has_escapes, escape_next);
-                }
-                ScanState::InNumber { start, hint } => {
-                    return self.resume_number(buf, start, hint);
-                }
-                ScanState::InLiteral {
-                    start,
-                    expected,
-                    matched,
-                } => {
-                    return self.resume_literal(buf, start, expected, matched);
-                }
-            }
-        }
-
         self.skip_whitespace(buf)?;
 
         let start = self.pos;
@@ -426,17 +302,6 @@ impl Scanner {
         self.scan_string_content(buf, start, content_start, false, false)
     }
 
-    fn resume_string(
-        &mut self,
-        buf: &[u8],
-        start: usize,
-        has_escapes: bool,
-        escape_next: bool,
-    ) -> ScanResult {
-        let content_start = start + 1; // After opening quote
-        self.scan_string_content(buf, start, content_start, has_escapes, escape_next)
-    }
-
     fn scan_string_content(
         &mut self,
         buf: &[u8],
@@ -484,14 +349,8 @@ impl Scanner {
                 if byte == b'u' {
                     // Check if we have 4 more bytes
                     if self.pos + 4 > buf.len() {
-                        // Need more data
-                        self.state = ScanState::InString {
-                            start,
-                            has_escapes: true,
-                            escape_next: false,
-                        };
-                        return Ok(SpannedToken {
-                            token: Token::NeedMore { consumed: start },
+                        return Err(ScanError {
+                            kind: ScanErrorKind::UnexpectedEof("in unicode escape"),
                             span: Span::new(start, self.pos - start),
                         });
                     }
@@ -503,14 +362,8 @@ impl Scanner {
                         && buf.get(self.pos + 1) == Some(&b'u')
                     {
                         if self.pos + 6 > buf.len() {
-                            // Need more data for second surrogate
-                            self.state = ScanState::InString {
-                                start,
-                                has_escapes: true,
-                                escape_next: false,
-                            };
-                            return Ok(SpannedToken {
-                                token: Token::NeedMore { consumed: start },
+                            return Err(ScanError {
+                                kind: ScanErrorKind::UnexpectedEof("in unicode escape"),
                                 span: Span::new(start, self.pos - start),
                             });
                         }
@@ -548,23 +401,10 @@ impl Scanner {
         }
 
         // Reached end of buffer without closing quote
-        if escape_next || self.pos > start {
-            // Mid-string, need more data
-            self.state = ScanState::InString {
-                start,
-                has_escapes,
-                escape_next,
-            };
-            Ok(SpannedToken {
-                token: Token::NeedMore { consumed: start },
-                span: Span::new(start, self.pos - start),
-            })
-        } else {
-            Err(ScanError {
-                kind: ScanErrorKind::UnexpectedEof("in string"),
-                span: Span::new(start, self.pos - start),
-            })
-        }
+        Err(ScanError {
+            kind: ScanErrorKind::UnexpectedEof("in string"),
+            span: Span::new(start, self.pos - start),
+        })
     }
 
     /// Scan a number, finding its boundaries and determining its type hint.
@@ -576,18 +416,6 @@ impl Scanner {
             self.pos += 1;
         }
 
-        self.scan_number_content(buf, start, hint)
-    }
-
-    fn resume_number(&mut self, buf: &[u8], start: usize, hint: NumberHint) -> ScanResult {
-        // Reset position to start of number and re-scan with the larger buffer.
-        // Needed since we might have stopped in an exponent. We also need to handle
-        // negative numbers by ignoring the leading - (can use the hint since it may have
-        // changed from the exponent)
-        self.pos = start;
-        if buf.get(self.pos) == Some(&b'-') {
-            self.pos += 1;
-        }
         self.scan_number_content(buf, start, hint)
     }
 
@@ -645,17 +473,6 @@ impl Scanner {
 
         self.pos = pos;
 
-        // Check if we're at end of buffer - might need more data
-        // Numbers end at whitespace, punctuation, or true EOF
-        if pos == buf.len() {
-            // At end of buffer - need more data to see terminator
-            self.state = ScanState::InNumber { start, hint };
-            return Ok(SpannedToken {
-                token: Token::NeedMore { consumed: start },
-                span: Span::new(start, pos - start),
-            });
-        }
-
         let end = pos;
 
         // Validate we actually parsed something
@@ -685,22 +502,6 @@ impl Scanner {
         self.scan_literal_content(buf, start, expected, 0, token)
     }
 
-    fn resume_literal(
-        &mut self,
-        buf: &[u8],
-        start: usize,
-        expected: &'static [u8],
-        matched: usize,
-    ) -> ScanResult {
-        let token = match expected {
-            b"true" => Token::True,
-            b"false" => Token::False,
-            b"null" => Token::Null,
-            _ => unreachable!(),
-        };
-        self.scan_literal_content(buf, start, expected, matched, token)
-    }
-
     fn scan_literal_content(
         &mut self,
         buf: &[u8],
@@ -722,14 +523,8 @@ impl Scanner {
                     });
                 }
                 None => {
-                    // Need more data
-                    self.state = ScanState::InLiteral {
-                        start,
-                        expected,
-                        matched,
-                    };
-                    return Ok(SpannedToken {
-                        token: Token::NeedMore { consumed: start },
+                    return Err(ScanError {
+                        kind: ScanErrorKind::UnexpectedEof("in literal"),
                         span: Span::new(start, self.pos - start),
                     });
                 }
@@ -1436,10 +1231,16 @@ mod tests {
             }
         ));
 
-        // Number at end of buffer returns NeedMore (streaming behavior)
+        // Number at end of buffer is complete in the complete-buffer parser.
         scanner.set_pos(0);
         let result = scanner.next_token(b"42").unwrap();
-        assert!(matches!(result.token, Token::NeedMore { .. }));
+        assert!(matches!(
+            result.token,
+            Token::Number {
+                hint: NumberHint::Unsigned,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -14,7 +14,7 @@ use facet_core::{
     Def, DefaultInPlaceFn, DefaultSource, Facet, Field, ListDef, OptionDef, PointerDef, PtrMut,
     PtrUninit, ScalarType, Shape, StructKind, Type, UserType,
 };
-use facet_format::{DeserializeError, DeserializeErrorKind, FormatParser};
+use facet_format::{DeserializeError, DeserializeErrorKind, FormatParser, ParseError};
 use facet_reflect::Span;
 use weavy::mem::runtime::{
     HandleGuard, InitializedLedger, RawAllocError, RawArrayBuilder, ScratchSession, ScratchSlot,
@@ -23,7 +23,7 @@ use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStat
 
 use crate::JsonParser;
 use crate::parser::{
-    JsonFieldKey, JsonObjectStep, JsonScalarInput, JsonScalarToken, JsonSequenceScalarStep,
+    JsonFieldKeyInput, JsonObjectKeyStep, JsonScalarInput, JsonScalarToken, JsonSequenceScalarStep,
 };
 use crate::scanner::{ParsedNumber, SpannedToken, Token as ScanToken};
 
@@ -181,6 +181,7 @@ enum JsonOp<Block> {
     StructNext {
         shape: &'static Shape,
         loop_id: Block,
+        raw_field_dispatch: bool,
     },
     ReadOption {
         option: OptionDef,
@@ -257,6 +258,38 @@ impl ScalarPlan {
 
         unsafe { write_scalar(shape, self.scalar, dst, value, span) }
     }
+
+    unsafe fn write_input<const TRUSTED_UTF8: bool>(
+        self,
+        parser: &JsonParser<'_, TRUSTED_UTF8>,
+        shape: &'static Shape,
+        dst: PtrUninit,
+        value: JsonScalarInput<'_>,
+    ) -> Result<(), DeserializeError> {
+        match self.scalar {
+            ScalarType::Unit => write_unit_input(parser, shape, dst, value),
+            ScalarType::Bool => write_bool_input(parser, shape, dst, value),
+            ScalarType::Char => write_char_input(parser, shape, dst, value),
+            ScalarType::String => write_string_input(parser, shape, dst, value),
+            ScalarType::CowStr => write_cow_str_input(parser, shape, dst, value),
+            ScalarType::Str => write_borrowed_str_input(parser, dst, value),
+            ScalarType::F32 => write_f32_input(parser, shape, dst, value),
+            ScalarType::F64 => write_f64_input(parser, shape, dst, value),
+            ScalarType::U8 => write_u8_input(parser, dst, value),
+            ScalarType::U16 => write_u16_input(parser, dst, value),
+            ScalarType::U32 => write_u32_input(parser, dst, value),
+            ScalarType::U64 => write_u64_input(parser, dst, value),
+            ScalarType::U128 => write_u128_input(parser, dst, value),
+            ScalarType::USize => write_usize_input(parser, dst, value),
+            ScalarType::I8 => write_i8_input(parser, dst, value),
+            ScalarType::I16 => write_i16_input(parser, dst, value),
+            ScalarType::I32 => write_i32_input(parser, dst, value),
+            ScalarType::I64 => write_i64_input(parser, dst, value),
+            ScalarType::I128 => write_i128_input(parser, dst, value),
+            ScalarType::ISize => write_isize_input(parser, dst, value),
+            _ => unsafe { write_scalar_input(parser, shape, self.scalar, dst, value) },
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -267,9 +300,25 @@ struct ListOptionScalar {
 }
 
 impl<Block> FieldPlan<Block> {
-    fn matches_key(&self, key: &JsonFieldKey<'_>) -> bool {
-        let key = key.as_str();
-        self.name == key || self.alias == Some(key)
+    #[inline]
+    fn matches_key_bytes(&self, key: &[u8]) -> bool {
+        self.name.as_bytes() == key || self.alias.is_some_and(|alias| alias.as_bytes() == key)
+    }
+
+    #[inline]
+    fn matches_key_input<'de, const TRUSTED_UTF8: bool>(
+        &self,
+        parser: &JsonParser<'de, TRUSTED_UTF8>,
+        key: &JsonFieldKeyInput<'de>,
+    ) -> Result<bool, ParseError> {
+        if parser.field_key_matches(key, self.name)? {
+            return Ok(true);
+        }
+
+        match self.alias {
+            Some(alias) => parser.field_key_matches(key, alias),
+            None => Ok(false),
+        }
     }
 }
 
@@ -425,7 +474,12 @@ impl Lowering {
                     }
                     let fields = fields.into_boxed_slice();
                     let loop_id = JsonBlockId::StructLoop(shape);
-                    let loop_program = vec![JsonOp::StructNext { shape, loop_id }];
+                    let raw_field_dispatch = should_use_raw_field_dispatch(shape, &fields);
+                    let loop_program = vec![JsonOp::StructNext {
+                        shape,
+                        loop_id,
+                        raw_field_dispatch,
+                    }];
                     self.lowered.blocks.insert(loop_id, loop_program);
                     Ok(vec![JsonOp::ReadStruct {
                         shape,
@@ -477,9 +531,14 @@ fn resolve_json_op(
             fields: resolve_field_plans(fields, refs)?,
             loop_id: resolve_block_ref(loop_id, refs)?,
         },
-        JsonOp::StructNext { shape, loop_id } => JsonOp::StructNext {
+        JsonOp::StructNext {
+            shape,
+            loop_id,
+            raw_field_dispatch,
+        } => JsonOp::StructNext {
             shape,
             loop_id: resolve_block_ref(loop_id, refs)?,
+            raw_field_dispatch,
         },
         JsonOp::ReadOption {
             option,
@@ -563,6 +622,19 @@ fn resolve_block_ref(
             },
         )
     })
+}
+
+fn should_use_raw_field_dispatch<Block>(
+    shape: &'static Shape,
+    fields: &[FieldPlan<Block>],
+) -> bool {
+    let all_scalar = fields.iter().all(|field| field.scalar.is_some());
+    let size = shape
+        .layout
+        .sized_layout()
+        .map(|layout| layout.size())
+        .unwrap_or(usize::MAX);
+    !all_scalar || fields.len() > 2 || size > 16
 }
 
 fn missing_field_action(field: &Field, container_has_default: bool) -> MissingField {
@@ -905,17 +977,31 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                     .push(StructFrame::new(shape, self.base, fields));
                 Ok(Control::CallBlockThen(*loop_id, Continuation::FinishStruct))
             }
-            JsonOp::StructNext { shape, loop_id } => loop {
-                match self.parser.next_object_field_or_end()? {
-                    JsonObjectStep::End => return Ok(Control::Continue),
-                    JsonObjectStep::Field { key, span } => {
-                        let frame = self
-                            .structs
-                            .last()
-                            .expect("struct frame is present while matching fields");
-                        let matched = frame.match_field(&key);
+            JsonOp::StructNext {
+                shape,
+                loop_id,
+                raw_field_dispatch,
+            } => loop {
+                match self.parser.next_object_key_or_end()? {
+                    JsonObjectKeyStep::End => return Ok(Control::Continue),
+                    JsonObjectKeyStep::Field { mut key, span } => {
+                        let key_is_raw =
+                            *raw_field_dispatch && matches!(key, JsonFieldKeyInput::Raw { .. });
+                        if !*raw_field_dispatch {
+                            key = JsonFieldKeyInput::Materialized(
+                                self.parser.materialize_field_key(key)?,
+                            );
+                        }
+                        let matched = {
+                            let frame = self
+                                .structs
+                                .last()
+                                .expect("struct frame is present while matching fields");
+                            frame.match_field_input(&*self.parser, &key)?
+                        };
 
                         let Some(matched) = matched else {
+                            let key = self.parser.materialize_field_key(key)?;
                             if shape.has_deny_unknown_fields_attr() {
                                 return Err(vm_error(
                                     Some(span),
@@ -933,6 +1019,10 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                             field,
                             ordered,
                         } = matched;
+                        let frame = self
+                            .structs
+                            .last()
+                            .expect("struct frame is present while decoding fields");
 
                         if !ordered && let Some(first_span) = frame.seen.get(index).copied() {
                             return Err(vm_error(
@@ -946,9 +1036,21 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
 
                         if let Some(scalar) = field.scalar {
                             let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
-                            let (value, value_span) = self.parser.read_scalar_token()?;
-                            unsafe {
-                                scalar.write(field.shape, field_ptr, value, value_span)?;
+                            if key_is_raw {
+                                let value = self.parser.read_current_scalar_input()?;
+                                unsafe {
+                                    scalar.write_input(
+                                        &*self.parser,
+                                        field.shape,
+                                        field_ptr,
+                                        value,
+                                    )?;
+                                }
+                            } else {
+                                let (value, value_span) = self.parser.read_scalar_token()?;
+                                unsafe {
+                                    scalar.write(field.shape, field_ptr, value, value_span)?;
+                                }
                             }
                             let frame = self
                                 .structs
@@ -1328,9 +1430,48 @@ impl<'program> StructFrame<'program> {
         }
     }
 
-    fn match_field(&self, key: &JsonFieldKey<'_>) -> Option<MatchedField<'program>> {
+    fn match_field_input<'de, const TRUSTED_UTF8: bool>(
+        &self,
+        parser: &JsonParser<'de, TRUSTED_UTF8>,
+        key: &JsonFieldKeyInput<'de>,
+    ) -> Result<Option<MatchedField<'program>>, ParseError> {
+        if let Some(key) = parser.field_key_unescaped_bytes(key) {
+            return Ok(self.match_field_bytes(key));
+        }
+
         if let Some(field) = self.fields.get(self.next_field)
-            && field.matches_key(key)
+            && field.matches_key_input(parser, key)?
+        {
+            return Ok(Some(MatchedField {
+                index: self.next_field,
+                field,
+                ordered: true,
+            }));
+        }
+
+        let matched = self
+            .fields
+            .iter()
+            .enumerate()
+            .find_map(
+                |(index, field)| match field.matches_key_input(parser, key) {
+                    Ok(true) => Some(Ok(MatchedField {
+                        index,
+                        field,
+                        ordered: false,
+                    })),
+                    Ok(false) => None,
+                    Err(err) => Some(Err(err)),
+                },
+            )
+            .transpose()?;
+
+        Ok(matched)
+    }
+
+    fn match_field_bytes(&self, key: &[u8]) -> Option<MatchedField<'program>> {
+        if let Some(field) = self.fields.get(self.next_field)
+            && field.matches_key_bytes(key)
         {
             return Some(MatchedField {
                 index: self.next_field,
@@ -1342,7 +1483,7 @@ impl<'program> StructFrame<'program> {
         self.fields
             .iter()
             .enumerate()
-            .find(|(_, field)| field.matches_key(key))
+            .find(|(_, field)| field.matches_key_bytes(key))
             .map(|(index, field)| MatchedField {
                 index,
                 field,
@@ -1458,6 +1599,183 @@ fn scratch_ptr_uninit(scratch: &ScratchSlot) -> PtrUninit {
 
 unsafe fn scratch_ptr_mut(scratch: &ScratchSlot) -> PtrMut {
     unsafe { scratch_ptr_uninit(scratch).assume_init() }
+}
+
+fn write_unit_input<const TRUSTED_UTF8: bool>(
+    _parser: &JsonParser<'_, TRUSTED_UTF8>,
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarInput<'_>,
+) -> Result<(), DeserializeError> {
+    match value {
+        JsonScalarInput::Raw(token) => match token.token {
+            ScanToken::Null => unsafe {
+                dst.put(());
+                Ok(())
+            },
+            other => Err(type_mismatch(
+                token.span,
+                shape,
+                raw_token_kind_name(&other),
+            )),
+        },
+        JsonScalarInput::Materialized(value, span) => unsafe {
+            write_unit_token(shape, dst, value, span)
+        },
+    }
+}
+
+fn write_bool_input<const TRUSTED_UTF8: bool>(
+    _parser: &JsonParser<'_, TRUSTED_UTF8>,
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarInput<'_>,
+) -> Result<(), DeserializeError> {
+    match value {
+        JsonScalarInput::Raw(token) => match token.token {
+            ScanToken::True => unsafe {
+                dst.put(true);
+                Ok(())
+            },
+            ScanToken::False => unsafe {
+                dst.put(false);
+                Ok(())
+            },
+            other => Err(type_mismatch(
+                token.span,
+                shape,
+                raw_token_kind_name(&other),
+            )),
+        },
+        JsonScalarInput::Materialized(value, span) => unsafe {
+            write_bool_token(shape, dst, value, span)
+        },
+    }
+}
+
+fn write_char_input<const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarInput<'_>,
+) -> Result<(), DeserializeError> {
+    match value {
+        JsonScalarInput::Raw(token) => {
+            let span = token.span;
+            let value = raw_string(parser, token, shape)?;
+            let mut chars = value.chars();
+            let Some(ch) = chars.next() else {
+                return Err(invalid_value(span, "empty string is not a char"));
+            };
+            if chars.next().is_some() {
+                return Err(invalid_value(span, "string has more than one char"));
+            }
+            unsafe {
+                dst.put(ch);
+            }
+            Ok(())
+        }
+        JsonScalarInput::Materialized(value, span) => unsafe {
+            write_char_token(shape, dst, value, span)
+        },
+    }
+}
+
+fn write_string_input<const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarInput<'_>,
+) -> Result<(), DeserializeError> {
+    match value {
+        JsonScalarInput::Raw(token) => {
+            let value = raw_string(parser, token, shape)?;
+            unsafe {
+                dst.put(value.into_owned());
+            }
+            Ok(())
+        }
+        JsonScalarInput::Materialized(value, span) => unsafe {
+            write_string_token(shape, dst, value, span)
+        },
+    }
+}
+
+fn write_cow_str_input<const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarInput<'_>,
+) -> Result<(), DeserializeError> {
+    match value {
+        JsonScalarInput::Raw(token) => {
+            let value = raw_string(parser, token, shape)?;
+            unsafe {
+                dst.put::<Cow<'static, str>>(Cow::Owned(value.into_owned()));
+            }
+            Ok(())
+        }
+        JsonScalarInput::Materialized(value, span) => unsafe {
+            write_cow_str_token(shape, dst, value, span)
+        },
+    }
+}
+
+fn write_borrowed_str_input<const TRUSTED_UTF8: bool>(
+    _parser: &JsonParser<'_, TRUSTED_UTF8>,
+    _dst: PtrUninit,
+    value: JsonScalarInput<'_>,
+) -> Result<(), DeserializeError> {
+    let span = match value {
+        JsonScalarInput::Raw(token) => token.span,
+        JsonScalarInput::Materialized(_, span) => span,
+    };
+    Err(vm_error(
+        Some(span),
+        DeserializeErrorKind::CannotBorrow {
+            reason: "Weavy JSON owned deserializer does not support borrowed str yet".into(),
+        },
+    ))
+}
+
+fn write_f32_input<const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarInput<'_>,
+) -> Result<(), DeserializeError> {
+    match value {
+        JsonScalarInput::Raw(token) => {
+            let span = token.span;
+            unsafe {
+                dst.put(raw_to_f64(parser, token, span, shape)? as f32);
+            }
+            Ok(())
+        }
+        JsonScalarInput::Materialized(value, span) => unsafe {
+            write_f32_token(shape, dst, value, span)
+        },
+    }
+}
+
+fn write_f64_input<const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    shape: &'static Shape,
+    dst: PtrUninit,
+    value: JsonScalarInput<'_>,
+) -> Result<(), DeserializeError> {
+    match value {
+        JsonScalarInput::Raw(token) => {
+            let span = token.span;
+            unsafe {
+                dst.put(raw_to_f64(parser, token, span, shape)?);
+            }
+            Ok(())
+        }
+        JsonScalarInput::Materialized(value, span) => unsafe {
+            write_f64_token(shape, dst, value, span)
+        },
+    }
 }
 
 macro_rules! write_unsigned_input {

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -2366,7 +2366,6 @@ fn raw_token_kind_name(token: &ScanToken) -> &'static str {
         ScanToken::Colon => "colon",
         ScanToken::Comma => "comma",
         ScanToken::Eof => "eof",
-        ScanToken::NeedMore { .. } => "incomplete token",
     }
 }
 

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -66,6 +66,24 @@ struct EscapedFieldName {
     quoted_key: u8,
 }
 
+#[derive(Facet, Debug, PartialEq)]
+struct AliasedName {
+    #[facet(alias = "old_name")]
+    new_name: String,
+    count: u8,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+#[facet(deny_unknown_fields)]
+struct StrictPoint {
+    x: u8,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct LoosePoint {
+    x: u8,
+}
+
 #[test]
 fn weavy_deserializes_named_struct_scalars() {
     let point: Point = facet_json::from_str_weavy(r#"{"y":20,"x":10}"#).unwrap();
@@ -82,6 +100,34 @@ fn weavy_deserializes_escaped_field_names() {
 
     assert_eq!(from_str, expected);
     assert_eq!(from_slice, expected);
+}
+
+#[test]
+fn weavy_matches_alias_on_raw_field_key() {
+    let got: AliasedName = facet_json::from_str_weavy(r#"{"old_name":"value","count":5}"#).unwrap();
+
+    assert_eq!(
+        got,
+        AliasedName {
+            new_name: "value".to_owned(),
+            count: 5,
+        }
+    );
+}
+
+#[test]
+fn weavy_reports_unknown_field_after_raw_key_matching() {
+    let err = facet_json::from_str_weavy::<StrictPoint>(r#"{"x":1,"extra":2}"#).unwrap_err();
+    assert!(matches!(
+        err.kind,
+        DeserializeErrorKind::UnknownField { ref field, .. } if field == "extra"
+    ));
+}
+
+#[test]
+fn weavy_validates_skipped_unknown_raw_field_key_utf8() {
+    let err = facet_json::from_slice_weavy::<LoosePoint>(b"{\"x\":1,\"\xff\":2}").unwrap_err();
+    assert!(matches!(err.kind, DeserializeErrorKind::InvalidUtf8 { .. }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Speeds up the opt-in Weavy JSON deserializer field loop by matching scanner-originated object keys without materializing field names first. It also keeps scalar struct fields on the raw scanner-token path when the key came from the scanner, with direct writers for the common scalar kinds.

This PR also removes the fake streaming state from the low-level JSON scanner. The public facet-json deserialization path already takes a complete `&[u8]` / `&str`; `NeedMore` was immediately finalized as EOF by `JsonParser`, so keeping resumable scanner state only added hot-path baggage without providing an incremental parser API.

## Changes

- Add parser APIs for raw object-key matching/materialization and raw current-scalar consumption.
- Route Weavy struct dispatch through raw key matching for larger/mixed structs, preserving materialized fallback for tiny all-scalar structs and peeked events.
- Add direct raw scalar-input writers for unit, bool, char, string, Cow<str>, floats, and integer widths.
- Remove `ScanToken::NeedMore`, resumable `ScanState`, and EOF finalization plumbing from the JSON scanner/parser path.
- Preserve invalid UTF-8 validation when unknown raw keys are skipped.
- Add integration coverage for raw alias matching, unknown-field reporting, and skipped unknown raw-key UTF-8 validation.

## Testing

- `cargo check -p facet-json`
- `cargo clippy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo nextest list -p facet-json -E 'test(scanner)'`
- `cargo nextest run -p facet-json -E 'test(scanner)'`
- `cargo nextest list -p facet-json -E 'test(weavy)'`
- `cargo nextest run -p facet-json -E 'test(weavy)'`
- `cargo nextest run -p facet-json`
- `git diff --check`

## Performance

Measured with `stax record` on `mur` and `souffle`, comparing medians against `origin/main`. Positive delta is slower. `Weavy/serde` compares the PR's Weavy median to `serde_json` from the same PR run.

| Host | Bench | Weavy PR | vs main | Weavy/serde |
|---|---:|---:|---:|---:|
| mur | point | 380.7 ns | -13.6% | 4.24x |
| mur | person | 1.232 us | -10.2% | 3.43x |
| mur | company | 3.545 us | -9.9% | 3.48x |
| mur | batch_1000 | 1.255 ms | -14.7% | 3.87x |
| souffle | point | 249.5 ns | -14.1% | 6.05x |
| souffle | person | 832.5 ns | -13.0% | 3.46x |
| souffle | company | 2.207 us | -10.2% | 2.95x |
| souffle | batch_1000 | 824.9 us | -15.1% | 3.08x |

The attempted raw-writer function-table variant was measured separately and dropped because the indirect calls regressed the table. The current shape-specialized field dispatch plus complete-buffer scanner cleanup removes the tiny-struct positives from the previous PR table.
