### PR TITLE
Use raw field dispatch for all Weavy structs

### DIFF
--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -475,12 +475,11 @@ impl Lowering {
                     }
                     let fields = fields.into_boxed_slice();
                     let loop_id = JsonBlockId::StructLoop(shape);
-                    let raw_field_dispatch = should_use_raw_field_dispatch(shape, &fields);
                     let tracking = StructTracking::for_len(fields.len());
                     let loop_program = vec![JsonOp::StructNext {
                         shape,
                         loop_id,
-                        raw_field_dispatch,
+                        raw_field_dispatch: true,
                         tracking,
                     }];
                     self.lowered.blocks.insert(loop_id, loop_program);
@@ -627,19 +626,6 @@ fn resolve_block_ref(
             },
         )
     })
-}
-
-fn should_use_raw_field_dispatch<Block>(
-    shape: &'static Shape,
-    fields: &[FieldPlan<Block>],
-) -> bool {
-    let all_scalar = fields.iter().all(|field| field.scalar.is_some());
-    let size = shape
-        .layout
-        .sized_layout()
-        .map(|layout| layout.size())
-        .unwrap_or(usize::MAX);
-    !all_scalar || fields.len() > 2 || size > 16
 }
 
 fn missing_field_action(field: &Field, container_has_default: bool) -> MissingField {


### PR DESCRIPTION
## Summary
Always use raw field dispatch for Weavy JSON struct loops.

The previous heuristic kept tiny all-scalar records on the materialized field/scalar path when the struct had at most two fields and a layout size of at most 16 bytes. The stax point profile showed exactly that case still paying the materialized scalar path. This removes the exception so tiny structs use the same raw field-key/raw scalar path as larger structs.

## Notes
I also tested a parser container-start and inline parser-stack change from the same profile, but dropped it from this PR because broader `typeplan_reuse` rows regressed. This PR keeps only the raw-dispatch change that moved the point profile onto `consume_scalar_input`, `write_i32_input`, `raw_into_signed`, and `ScalarPlan::write_input`.

## Testing
- `cargo fmt --check`
- `cargo check -p facet-json`
- `cargo nextest list -p facet-json -E "test(weavy)"`
- `cargo nextest run -p facet-json -E "test(weavy)"`
- `cargo clippy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo bench -p facet-json --bench typeplan_reuse --no-run`
- `cargo nextest list -p facet-json`
- `cargo nextest run -p facet-json`
- `git diff --check`
- `stax` on `souffle` for `point_weavy_reused_plan`

## Performance
Median Divan times on `souffle`, lower is better. `PR Weavy/serde` uses the PR serde_json median from the same full-table run.

| Bench | Main Weavy | PR Weavy | PR vs main | PR Weavy/serde |
|---|---:|---:|---:|---:|
| point | 178.9 ns | 173.7 ns | -2.9% | 5.36x |
| person | 650.2 ns | 645.0 ns | -0.8% | 3.29x |
| company | 1.832 us | 1.832 us | 0.0% | 2.94x |
| batch_1000 | 663.8 us | 660.2 us | -0.5% | 3.06x |
| float_point | 257.0 ns | 257.0 ns | 0.0% | 3.41x |
| wide_scalars | 775.3 ns | 759.5 ns | -2.0% | 2.93x |

`sensor_frame` was noisy: the full-table run showed `1.457 us -> 1.499 us`, while selected reruns returned `1.458 us`. It was already on raw dispatch before this PR, so I am treating that as noise rather than a changed hot path.

## Stax
Final profile on `souffle`: run 271, archive `/tmp/facet-point-weavy-run271-souffle.stax`.

The point profile moved from the materialized scalar path to the raw scalar path:

- `consume_scalar_input`
- `write_i32_input`
- `raw_into_signed`
- `ScalarPlan::write_input`
