### PR TITLE
Fuse Weavy scalar-only struct decoding

### DIFF
--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -173,6 +173,10 @@ enum JsonOp<Block> {
         shape: &'static Shape,
         scalar: ScalarPlan,
     },
+    ReadScalarStruct {
+        shape: &'static Shape,
+        fields: Box<[FieldPlan<Block>]>,
+    },
     ReadStruct {
         shape: &'static Shape,
         fields: Box<[FieldPlan<Block>]>,
@@ -474,6 +478,10 @@ impl Lowering {
                         });
                     }
                     let fields = fields.into_boxed_slice();
+                    if fields.iter().all(|field| field.scalar.is_some()) {
+                        return Ok(vec![JsonOp::ReadScalarStruct { shape, fields }]);
+                    }
+
                     let loop_id = JsonBlockId::StructLoop(shape);
                     let tracking = StructTracking::for_len(fields.len());
                     let loop_program = vec![JsonOp::StructNext {
@@ -524,6 +532,10 @@ fn resolve_json_op(
     Ok(match op {
         JsonOp::CallBlock(block) => JsonOp::CallBlock(resolve_block_ref(block, refs)?),
         JsonOp::ReadScalar { shape, scalar } => JsonOp::ReadScalar { shape, scalar },
+        JsonOp::ReadScalarStruct { shape, fields } => JsonOp::ReadScalarStruct {
+            shape,
+            fields: resolve_field_plans(fields, refs)?,
+        },
         JsonOp::ReadStruct {
             shape,
             fields,
@@ -1056,6 +1068,102 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
             self.scratch.release(scratch);
         }
     }
+
+    fn read_scalar_struct(
+        &mut self,
+        shape: &'static Shape,
+        fields: &'program [FieldPlan<ExecBlock>],
+    ) -> Result<(), DeserializeError> {
+        self.parser.consume_object_start()?;
+        let base = self.base;
+        match StructTracking::for_len(fields.len()) {
+            StructTracking::Inline => {
+                let mut frame = StructFrame::<InitializedLedger<Span>>::new(shape, base, fields);
+                self.read_scalar_struct_fields(shape, &mut frame)?;
+                unsafe {
+                    frame.fill_missing_fields()?;
+                }
+            }
+            StructTracking::Bitset => {
+                let mut frame = StructFrame::<BitsetStructSeen>::new(shape, base, fields);
+                self.read_scalar_struct_fields(shape, &mut frame)?;
+                unsafe {
+                    frame.fill_missing_fields()?;
+                }
+            }
+            StructTracking::Heap => {
+                let mut frame = StructFrame::<HeapStructSeen>::new(shape, base, fields);
+                self.read_scalar_struct_fields(shape, &mut frame)?;
+                unsafe {
+                    frame.fill_missing_fields()?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn read_scalar_struct_fields<Seen: StructSeenStore>(
+        &mut self,
+        shape: &'static Shape,
+        frame: &mut StructFrame<'program, Seen>,
+    ) -> Result<(), DeserializeError> {
+        loop {
+            match self.parser.next_object_key_or_end()? {
+                JsonObjectKeyStep::End => return Ok(()),
+                JsonObjectKeyStep::Field { key, span } => {
+                    let key_is_raw = matches!(key, JsonFieldKeyInput::Raw { .. });
+                    let matched = frame.match_field_input(&*self.parser, &key)?;
+
+                    let Some(matched) = matched else {
+                        let key = self.parser.materialize_field_key(key)?;
+                        if shape.has_deny_unknown_fields_attr() {
+                            return Err(vm_error(
+                                Some(span),
+                                DeserializeErrorKind::UnknownField {
+                                    field: key.as_str().to_owned().into(),
+                                    suggestion: None,
+                                },
+                            ));
+                        }
+                        self.parser.skip_value()?;
+                        continue;
+                    };
+
+                    let MatchedField {
+                        index,
+                        field,
+                        ordered,
+                    } = matched;
+                    if !ordered && let Some(first_span) = frame.seen.get(index) {
+                        return Err(vm_error(
+                            Some(span),
+                            DeserializeErrorKind::DuplicateField {
+                                field: field.name.into(),
+                                first_span: Some(first_span),
+                            },
+                        ));
+                    }
+
+                    let scalar = field
+                        .scalar
+                        .expect("scalar-only struct contains only scalar field plans");
+                    let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
+                    if key_is_raw {
+                        let value = self.parser.read_current_scalar_input()?;
+                        unsafe {
+                            scalar.write_input(&*self.parser, field.shape, field_ptr, value)?;
+                        }
+                    } else {
+                        let (value, value_span) = self.parser.read_scalar_token()?;
+                        unsafe {
+                            scalar.write(field.shape, field_ptr, value, value_span)?;
+                        }
+                    }
+                    frame.mark_seen(index, span);
+                }
+            }
+        }
+    }
 }
 
 struct InlineStack<T> {
@@ -1167,6 +1275,10 @@ impl<'program, 'parser, 'de, const TRUSTED_UTF8: bool> Step<'program, ExecBlock,
                 unsafe {
                     scalar.write(shape, self.base, value, span)?;
                 }
+                Ok(Control::Continue)
+            }
+            JsonOp::ReadScalarStruct { shape, fields } => {
+                self.read_scalar_struct(shape, fields)?;
                 Ok(Control::Continue)
             }
             JsonOp::ReadStruct {

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -84,6 +84,22 @@ struct LoosePoint {
     x: u8,
 }
 
+#[derive(Facet, Debug, PartialEq)]
+struct WideScalarStruct {
+    a: u8,
+    b: u16,
+    c: u32,
+    d: u64,
+    e: i8,
+    f: i16,
+    g: i32,
+    h: i64,
+    i: usize,
+    j: isize,
+    k: bool,
+    l: f64,
+}
+
 #[test]
 fn weavy_deserializes_named_struct_scalars() {
     let point: Point = facet_json::from_str_weavy(r#"{"y":20,"x":10}"#).unwrap();
@@ -146,6 +162,32 @@ fn weavy_rejects_duplicate_field_after_ordered_match() {
         err.kind,
         DeserializeErrorKind::DuplicateField { ref field, .. } if field == "x"
     ));
+}
+
+#[test]
+fn weavy_deserializes_wide_scalar_struct() {
+    let got: WideScalarStruct = facet_json::from_str_weavy(
+        r#"{"a":1,"b":2,"c":3,"d":4,"e":-5,"f":-6,"g":-7,"h":-8,"i":9,"j":-10,"k":true,"l":11.5}"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        got,
+        WideScalarStruct {
+            a: 1,
+            b: 2,
+            c: 3,
+            d: 4,
+            e: -5,
+            f: -6,
+            g: -7,
+            h: -8,
+            i: 9,
+            j: -10,
+            k: true,
+            l: 11.5,
+        }
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Add a scalar-only struct op to the opt-in Weavy JSON deserializer.

For named structs where every field is scalar, lowering now emits `ReadScalarStruct` instead of `ReadStruct` plus a `StructNext` loop block. The new op decodes the whole object in one VM step while still reusing the existing `FieldPlan`, `StructFrame`, duplicate-field checks, missing/default handling, and initialized-field cleanup.

This hits records like `Point`, `FloatPoint`, `WideScalars`, and nested scalar-only structs such as `Employee`/`Address`, while mixed structs with options/lists/pointers stay on the existing path.

## Testing
- `cargo fmt --check`
- `cargo check -p facet-json`
- `cargo nextest list -p facet-json -E "test(weavy)"`
- `cargo nextest run -p facet-json -E "test(weavy)"`
- `cargo clippy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo bench -p facet-json --bench typeplan_reuse --no-run`
- `cargo nextest list -p facet-json`
- `cargo nextest run -p facet-json` (401/401)
- `git diff --check`

## Performance
Median Divan times on `souffle`, lower is better. `PR Weavy/serde` uses the PR serde_json median from the same full-table run; `batch_1000` uses the corrected selected rerun after rebuilding both commits.

| Bench | Main Weavy | PR Weavy | PR vs main | PR Weavy/serde |
|---|---:|---:|---:|---:|
| point | 171.5 ns | 143.9 ns | -16.1% | 4.37x |
| float_point | 252.3 ns | 218.1 ns | -13.6% | 2.91x |
| wide_scalars | 790.7 ns | 676.4 ns | -14.5% | 2.63x |
| company | 1.791 us | 1.666 us | -7.0% | 2.74x |
| person | 642.9 ns | 640.0 ns | -0.5% | 3.29x |
| sensor_frame | 1.457 us | 1.447 us | -0.7% | 3.18x |
| batch_1000 | 663.5 us | 656.7 us | -1.0% | 3.04x |

Raw logs on `souffle`:
- `/tmp/facet-typeplan-main-scalar-struct-souffle.log`
- `/tmp/facet-typeplan-branch-scalar-struct-souffle.log`
- `/tmp/facet-typeplan-main-scalar-struct-selected-souffle.log`
- `/tmp/facet-typeplan-branch-scalar-struct-selected-souffle.log`

## Stax
Recorded on `souffle`:
- `point_weavy_reused_plan`: stax run 272
- `wide_scalars_weavy_reused_plan`: stax run 274

The post-change profiles show the remaining hot path inside parser/token scanning, raw scalar conversion, field matching, and `ScalarPlan::write_input`; the scalar-only struct now runs through one `Step` instead of the old `ReadStruct -> StructNext block -> FinishStruct` control path.
