### PR TITLE
Fast-path ordered Weavy scalar structs

### DIFF
--- a/facet-json/benches/typeplan_reuse.rs
+++ b/facet-json/benches/typeplan_reuse.rs
@@ -97,6 +97,35 @@ struct WideScalars {
     l: f64,
 }
 
+/// Scalar record with defaults, for missing-field synthesis.
+#[derive(Debug, Facet, serde::Deserialize)]
+struct DefaultScalars {
+    #[facet(default)]
+    #[serde(default)]
+    a: u8,
+    #[facet(default)]
+    #[serde(default)]
+    b: u16,
+    #[facet(default)]
+    #[serde(default)]
+    c: u32,
+    #[facet(default)]
+    #[serde(default)]
+    d: u64,
+    #[facet(default)]
+    #[serde(default)]
+    e: i8,
+    #[facet(default)]
+    #[serde(default)]
+    f: i16,
+    #[facet(default)]
+    #[serde(default)]
+    g: bool,
+    #[facet(default)]
+    #[serde(default)]
+    h: f64,
+}
+
 // =============================================================================
 // Test data
 // =============================================================================
@@ -149,6 +178,45 @@ const WIDE_SCALARS_JSON: &str = r#"{
     "j": -10,
     "k": true,
     "l": 11.5
+}"#;
+
+const WIDE_SCALARS_OUT_OF_ORDER_JSON: &str = r#"{
+    "l": 11.5,
+    "k": true,
+    "j": -10,
+    "i": 9,
+    "h": -8,
+    "g": -7,
+    "f": -6,
+    "e": -5,
+    "d": 4,
+    "c": 3,
+    "b": 2,
+    "a": 1
+}"#;
+
+const WIDE_SCALARS_SKIPPED_UNKNOWN_JSON: &str = r#"{
+    "a": 1,
+    "unknown_scalar": 12345,
+    "b": 2,
+    "unknown_array": [1, 2, 3, 4],
+    "c": 3,
+    "unknown_object": {"nested": true, "items": [1, 2, 3]},
+    "d": 4,
+    "e": -5,
+    "f": -6,
+    "g": -7,
+    "h": -8,
+    "i": 9,
+    "j": -10,
+    "k": true,
+    "l": 11.5
+}"#;
+
+const DEFAULT_SCALARS_MISSING_JSON: &str = r#"{
+    "a": 1,
+    "d": 4,
+    "h": 11.5
 }"#;
 
 fn bench_fresh_typeplan<T>(bencher: Bencher, json: &'static str)
@@ -471,6 +539,40 @@ fn wide_scalars_weavy_reused_plan(bencher: Bencher) {
 #[divan::bench]
 fn wide_scalars_serde_json(bencher: Bencher) {
     bench_serde_json::<WideScalars>(bencher, WIDE_SCALARS_JSON);
+}
+
+#[divan::bench]
+fn wide_scalars_out_of_order_weavy_reused_plan(bencher: Bencher) {
+    bench_weavy_reused_plan::<WideScalars>(bencher, WIDE_SCALARS_OUT_OF_ORDER_JSON);
+}
+
+#[divan::bench]
+fn wide_scalars_out_of_order_serde_json(bencher: Bencher) {
+    bench_serde_json::<WideScalars>(bencher, WIDE_SCALARS_OUT_OF_ORDER_JSON);
+}
+
+#[divan::bench]
+fn wide_scalars_skipped_unknown_weavy_reused_plan(bencher: Bencher) {
+    bench_weavy_reused_plan::<WideScalars>(bencher, WIDE_SCALARS_SKIPPED_UNKNOWN_JSON);
+}
+
+#[divan::bench]
+fn wide_scalars_skipped_unknown_serde_json(bencher: Bencher) {
+    bench_serde_json::<WideScalars>(bencher, WIDE_SCALARS_SKIPPED_UNKNOWN_JSON);
+}
+
+// =============================================================================
+// Benchmarks - Missing scalar fields with defaults
+// =============================================================================
+
+#[divan::bench]
+fn default_scalars_missing_weavy_reused_plan(bencher: Bencher) {
+    bench_weavy_reused_plan::<DefaultScalars>(bencher, DEFAULT_SCALARS_MISSING_JSON);
+}
+
+#[divan::bench]
+fn default_scalars_missing_serde_json(bencher: Bencher) {
+    bench_serde_json::<DefaultScalars>(bencher, DEFAULT_SCALARS_MISSING_JSON);
 }
 
 // =============================================================================

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -1112,7 +1112,14 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
                 JsonObjectKeyStep::End => return Ok(()),
                 JsonObjectKeyStep::Field { key, span } => {
                     let key_is_raw = matches!(key, JsonFieldKeyInput::Raw { .. });
-                    let matched = frame.match_field_input(&*self.parser, &key)?;
+                    if let Some((index, field)) =
+                        frame.match_next_field_input(&*self.parser, &key)?
+                    {
+                        self.read_scalar_struct_field(frame, index, field, key_is_raw, span)?;
+                        continue;
+                    }
+
+                    let matched = frame.match_unordered_field_input(&*self.parser, &key)?;
 
                     let Some(matched) = matched else {
                         let key = self.parser.materialize_field_key(key)?;
@@ -1134,7 +1141,7 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
                         field,
                         ordered,
                     } = matched;
-                    if !ordered && let Some(first_span) = frame.seen.get(index) {
+                    if let Some(first_span) = frame.seen.get(index) {
                         return Err(vm_error(
                             Some(span),
                             DeserializeErrorKind::DuplicateField {
@@ -1144,25 +1151,39 @@ impl<'parser, 'de, 'program, const TRUSTED_UTF8: bool>
                         ));
                     }
 
-                    let scalar = field
-                        .scalar
-                        .expect("scalar-only struct contains only scalar field plans");
-                    let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
-                    if key_is_raw {
-                        let value = self.parser.read_current_scalar_input()?;
-                        unsafe {
-                            scalar.write_input(&*self.parser, field.shape, field_ptr, value)?;
-                        }
-                    } else {
-                        let (value, value_span) = self.parser.read_scalar_token()?;
-                        unsafe {
-                            scalar.write(field.shape, field_ptr, value, value_span)?;
-                        }
-                    }
-                    frame.mark_seen(index, span);
+                    debug_assert!(!ordered);
+                    self.read_scalar_struct_field(frame, index, field, key_is_raw, span)?;
                 }
             }
         }
+    }
+
+    #[inline(always)]
+    fn read_scalar_struct_field<Seen: StructSeenStore>(
+        &mut self,
+        frame: &mut StructFrame<'program, Seen>,
+        index: usize,
+        field: &'program FieldPlan<ExecBlock>,
+        key_is_raw: bool,
+        span: Span,
+    ) -> Result<(), DeserializeError> {
+        let scalar = field
+            .scalar
+            .expect("scalar-only struct contains only scalar field plans");
+        let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
+        if key_is_raw {
+            let value = self.parser.read_current_scalar_input()?;
+            unsafe {
+                scalar.write_input(&*self.parser, field.shape, field_ptr, value)?;
+            }
+        } else {
+            let (value, value_span) = self.parser.read_scalar_token()?;
+            unsafe {
+                scalar.write(field.shape, field_ptr, value, value_span)?;
+            }
+        }
+        frame.mark_seen(index, span);
+        Ok(())
     }
 }
 
@@ -1936,6 +1957,58 @@ impl<'program, Seen: StructSeenStore> StructFrame<'program, Seen> {
         Ok(matched)
     }
 
+    #[inline(always)]
+    fn match_next_field_input<'de, const TRUSTED_UTF8: bool>(
+        &self,
+        parser: &JsonParser<'de, TRUSTED_UTF8>,
+        key: &JsonFieldKeyInput<'de>,
+    ) -> Result<Option<(usize, &'program FieldPlan<ExecBlock>)>, ParseError> {
+        let Some(field) = self.fields.get(self.next_field) else {
+            return Ok(None);
+        };
+        if let Some(key) = parser.field_key_unescaped_bytes(key) {
+            return Ok(field
+                .matches_key_bytes(key)
+                .then_some((self.next_field, field)));
+        }
+        if field.matches_key_input(parser, key)? {
+            Ok(Some((self.next_field, field)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[inline]
+    fn match_unordered_field_input<'de, const TRUSTED_UTF8: bool>(
+        &self,
+        parser: &JsonParser<'de, TRUSTED_UTF8>,
+        key: &JsonFieldKeyInput<'de>,
+    ) -> Result<Option<MatchedField<'program>>, ParseError> {
+        if let Some(key) = parser.field_key_unescaped_bytes(key) {
+            return Ok(self.match_unordered_field_bytes(key));
+        }
+
+        let matched = self
+            .fields
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| *index != self.next_field)
+            .find_map(
+                |(index, field)| match field.matches_key_input(parser, key) {
+                    Ok(true) => Some(Ok(MatchedField {
+                        index,
+                        field,
+                        ordered: false,
+                    })),
+                    Ok(false) => None,
+                    Err(err) => Some(Err(err)),
+                },
+            )
+            .transpose()?;
+
+        Ok(matched)
+    }
+
     fn match_field_bytes(&self, key: &[u8]) -> Option<MatchedField<'program>> {
         if let Some(field) = self.fields.get(self.next_field)
             && field.matches_key_bytes(key)
@@ -1950,6 +2023,20 @@ impl<'program, Seen: StructSeenStore> StructFrame<'program, Seen> {
         self.fields
             .iter()
             .enumerate()
+            .find(|(_, field)| field.matches_key_bytes(key))
+            .map(|(index, field)| MatchedField {
+                index,
+                field,
+                ordered: false,
+            })
+    }
+
+    #[inline]
+    fn match_unordered_field_bytes(&self, key: &[u8]) -> Option<MatchedField<'program>> {
+        self.fields
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| *index != self.next_field)
             .find(|(_, field)| field.matches_key_bytes(key))
             .map(|(index, field)| MatchedField {
                 index,


### PR DESCRIPTION
## Summary

This PR adds benchmark coverage for the shape Amos asked for: ordered scalar structs, out-of-order scalar fields, skipped unknown fields, and default-backed missing fields, always paired with serde_json rows.

On the implementation side, the Weavy scalar-only struct loop now tries the expected next field first while preserving the raw field-key byte shortcut. If the input is not in plan order, it falls back to the unordered matcher, which now skips the already-tested next-field slot.

## Performance

Measured on `souffle`, direct Divan bench binary, `--threads 1`. Existing rows compare `origin/main` to this branch using selected 10s reruns. Serde rows are from the branch broad table.

| Case | main Weavy | PR Weavy | delta | PR serde | Weavy/serde |
|---|---:|---:|---:|---:|---:|
| point | 145.2 ns | 143.9 ns | -0.9% | 33.11 ns | 4.35x |
| float point | 218.1 ns | 214.2 ns | -1.8% | 75.1 ns | 2.85x |
| wide scalars ordered | 676.5 ns | 629.6 ns | -6.9% | 257.4 ns | 2.45x |
| company | 1.644 us | 1.624 us | -1.2% | 624.5 ns | 2.60x |
| person | 645.2 ns | 640.0 ns | -0.8% | 196.1 ns | 3.26x |
| sensor frame | 1.447 us | 1.447 us | 0.0% | 447.5 ns | 3.23x |
| batch 1000 | 656.8 us | 660.9 us | +0.6% | 214.9 us | 3.08x |

New branch-only coverage:

| Case | PR Weavy | PR serde | Weavy/serde |
|---|---:|---:|---:|
| wide scalars out of order | 900.5 ns | 252.1 ns | 3.57x |
| wide scalars skipped unknown | 931.8 ns | 379.8 ns | 2.45x |
| default scalars missing fields | 262.5 ns | 72.5 ns | 3.62x |

## Stax

Fresh `souffle` profile: `stax` run 275 on `wide_scalars_weavy_reused_plan`.

Top self-time after this change:

| Function | self |
|---|---:|
| `Scanner::next_token` | 908.342 ms |
| `JsonParser::next_object_key_or_end` | 284.645 ms |
| `ScalarPlan::write_input` | 269.948 ms |
| `JsonInterp::read_scalar_struct` | 261.710 ms |
| `JsonParser::expect_colon_token` | 170.039 ms |
| `parse_number_inner` | 92.742 ms |
| `_platform_memcmp` | 68.570 ms |

The old field matcher is no longer visible as its own top self-time hotspot in the ordered wide scalar profile; the remaining visible weight is scanner/parser/scalar write plus the fused scalar-struct loop.

## Testing

- `cargo fmt --check`
- `cargo clippy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo nextest list -p facet-json`
- `cargo nextest run -p facet-json` (401 passed)
- `cargo bench -p facet-json --bench typeplan_reuse --no-run`
- `target/release/deps/typeplan_reuse-e8dbbec308fa3681 --list`
- `target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench --min-time 1 --threads 1 wide_scalars_weavy_reused_plan`
- `stax record -F 1900 -l 15 -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench --min-time 10 --threads 1 wide_scalars_weavy_reused_plan`