### PR TITLE
Speed up Weavy scalar token handling

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -1,6 +1,7 @@
 extern crate alloc;
 
 use alloc::{borrow::Cow, collections::VecDeque, format, vec::Vec};
+use core::str;
 
 use facet_core::Facet as _;
 use facet_format::{
@@ -304,6 +305,21 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         Ok(spanned)
     }
 
+    #[inline]
+    fn consume_punctuation_token(&mut self, byte: u8) -> Result<Option<Span>, ParseError> {
+        let span = self
+            .scanner
+            .consume_punctuation(self.input, byte)
+            .map_err(scan_error_to_parse_error)?;
+
+        if let Some(span) = span {
+            self.state.last_token_start = span.offset as usize;
+            self.state.scanner_pos = self.scanner.pos();
+        }
+
+        Ok(span)
+    }
+
     fn materialize_token_kind(
         &self,
         token: ScanToken,
@@ -352,6 +368,22 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
             scanner::parse_number(self.input, start, end, hint)
         }
         .map_err(scan_error_to_parse_error)
+    }
+
+    #[inline]
+    pub(crate) fn number_text(
+        &self,
+        start: usize,
+        end: usize,
+        span: Span,
+    ) -> Result<&'de str, ParseError> {
+        let slice = &self.input[start..end];
+        if TRUSTED_UTF8 {
+            // SAFETY: Input came from &str, so it is valid UTF-8.
+            Ok(unsafe { str::from_utf8_unchecked(slice) })
+        } else {
+            str::from_utf8(slice).map_err(|_| invalid_utf8_parse_error(span))
+        }
     }
 
     #[inline]
@@ -484,6 +516,10 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     }
 
     fn expect_colon_token(&mut self) -> Result<(), ParseError> {
+        if self.consume_punctuation_token(b':')?.is_some() {
+            return Ok(());
+        }
+
         let token = self.consume_spanned_token()?;
         if !matches!(token.token, ScanToken::Colon) {
             return Err(self.unexpected_scan_token(&token, "':'"));
@@ -1007,6 +1043,19 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                     }
                 }
                 NextAction::ObjectComma => {
+                    if self.consume_punctuation_token(b',')?.is_some() {
+                        if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                            *state = ObjectState::KeyOrEnd;
+                        }
+                        continue;
+                    }
+
+                    if self.consume_punctuation_token(b'}')?.is_some() {
+                        self.state.stack.pop();
+                        self.finish_value_in_parent();
+                        return Ok(JsonObjectKeyStep::End);
+                    }
+
                     let token = self.consume_spanned_token()?;
                     let span = token.span;
                     match token.token {

--- a/facet-json/src/scanner.rs
+++ b/facet-json/src/scanner.rs
@@ -169,6 +169,23 @@ impl Scanner {
             .map(|byte| (scanner.pos, byte)))
     }
 
+    /// Consume one expected punctuation byte after whitespace/comments.
+    pub fn consume_punctuation(
+        &mut self,
+        buf: &[u8],
+        expected: u8,
+    ) -> Result<Option<Span>, ScanError> {
+        self.skip_whitespace(buf)?;
+
+        let start = self.pos;
+        if buf.get(self.pos) == Some(&expected) {
+            self.pos += 1;
+            Ok(Some(Span::new(start, 1)))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Scan the next token from the buffer.
     pub fn next_token(&mut self, buf: &[u8]) -> ScanResult {
         self.skip_whitespace(buf)?;

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -9,6 +9,7 @@ use alloc::{
 use core::alloc::Layout;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
+use core::str::FromStr;
 
 use facet_core::{
     Def, DefaultInPlaceFn, DefaultSource, Facet, Field, ListDef, OptionDef, PointerDef, PtrMut,
@@ -25,7 +26,7 @@ use crate::JsonParser;
 use crate::parser::{
     JsonFieldKeyInput, JsonObjectKeyStep, JsonScalarInput, JsonScalarToken, JsonSequenceScalarStep,
 };
-use crate::scanner::{ParsedNumber, SpannedToken, Token as ScanToken};
+use crate::scanner::{NumberHint, ParsedNumber, SpannedToken, Token as ScanToken};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum JsonBlockId {
@@ -2991,25 +2992,22 @@ fn raw_into_unsigned<T, const TRUSTED_UTF8: bool>(
     target: &'static str,
 ) -> Result<T, DeserializeError>
 where
+    T: FromStr,
     T: TryFrom<u128>,
 {
     let value = match token.token {
-        ScanToken::Number { start, end, hint } => {
-            let number = parser.parse_number(start, end, hint)?;
-            match number {
-                ParsedNumber::U64(value) => value as u128,
-                ParsedNumber::U128(value) => value,
-                ParsedNumber::I64(value) if value >= 0 => value as u128,
-                ParsedNumber::I128(value) if value >= 0 => value as u128,
-                other => {
-                    return Err(type_mismatch_name(
-                        span,
-                        target,
-                        parsed_number_kind_name(&other),
-                    ));
+        ScanToken::Number { start, end, hint } => match hint {
+            NumberHint::Unsigned => {
+                let text = parser.number_text(start, end, span)?;
+                if let Ok(value) = text.parse::<T>() {
+                    return Ok(value);
                 }
+                parsed_unsigned_number(parser, start, end, hint, span, target)?
             }
-        }
+            NumberHint::Signed | NumberHint::Float => {
+                parsed_unsigned_number(parser, start, end, hint, span, target)?
+            }
+        },
         ScanToken::String {
             start,
             end,
@@ -3038,25 +3036,20 @@ fn raw_into_signed<T, const TRUSTED_UTF8: bool>(
     target: &'static str,
 ) -> Result<T, DeserializeError>
 where
+    T: FromStr,
     T: TryFrom<i128>,
 {
     let value = match token.token {
-        ScanToken::Number { start, end, hint } => {
-            let number = parser.parse_number(start, end, hint)?;
-            match number {
-                ParsedNumber::I64(value) => value as i128,
-                ParsedNumber::I128(value) => value,
-                ParsedNumber::U64(value) => value as i128,
-                ParsedNumber::U128(value) if value <= i128::MAX as u128 => value as i128,
-                other => {
-                    return Err(type_mismatch_name(
-                        span,
-                        target,
-                        parsed_number_kind_name(&other),
-                    ));
+        ScanToken::Number { start, end, hint } => match hint {
+            NumberHint::Signed | NumberHint::Unsigned => {
+                let text = parser.number_text(start, end, span)?;
+                if let Ok(value) = text.parse::<T>() {
+                    return Ok(value);
                 }
+                parsed_signed_number(parser, start, end, hint, span, target)?
             }
-        }
+            NumberHint::Float => parsed_signed_number(parser, start, end, hint, span, target)?,
+        },
         ScanToken::String {
             start,
             end,
@@ -3076,6 +3069,50 @@ where
         }
     };
     T::try_from(value).map_err(|_| number_out_of_range(span, value.to_string(), target))
+}
+
+fn parsed_unsigned_number<const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    start: usize,
+    end: usize,
+    hint: NumberHint,
+    span: Span,
+    target: &'static str,
+) -> Result<u128, DeserializeError> {
+    let number = parser.parse_number(start, end, hint)?;
+    match number {
+        ParsedNumber::U64(value) => Ok(value as u128),
+        ParsedNumber::U128(value) => Ok(value),
+        ParsedNumber::I64(value) if value >= 0 => Ok(value as u128),
+        ParsedNumber::I128(value) if value >= 0 => Ok(value as u128),
+        other => Err(type_mismatch_name(
+            span,
+            target,
+            parsed_number_kind_name(&other),
+        )),
+    }
+}
+
+fn parsed_signed_number<const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    start: usize,
+    end: usize,
+    hint: NumberHint,
+    span: Span,
+    target: &'static str,
+) -> Result<i128, DeserializeError> {
+    let number = parser.parse_number(start, end, hint)?;
+    match number {
+        ParsedNumber::I64(value) => Ok(value as i128),
+        ParsedNumber::I128(value) => Ok(value),
+        ParsedNumber::U64(value) => Ok(value as i128),
+        ParsedNumber::U128(value) if value <= i128::MAX as u128 => Ok(value as i128),
+        other => Err(type_mismatch_name(
+            span,
+            target,
+            parsed_number_kind_name(&other),
+        )),
+    }
 }
 
 fn scalar_to_f64(


### PR DESCRIPTION
## Summary

This PR bundles two profiler-backed scalar-path improvements for `facet-json` / Weavy deserialization:

- Parse raw integer JSON tokens directly into the target integer type before falling back to the old broad `ParsedNumber` path for edge-case classification.
- Add a scanner/parser fast path for expected punctuation (`:`, object `,`, object `}`), so scalar-heavy object decoding avoids tokenizing punctuation through the full `next_token` path when the expected byte is present.

The fallback paths still use the existing token machinery when punctuation is wrong or when numeric direct parsing misses, so public error behavior stays anchored to the old parser.

## Performance

Measured on `souffle`, direct Divan bench binary, `--threads 1`, selected rows, `--max-time 10`. Ratio is PR Weavy / PR serde_json.

| Case | main Weavy | PR Weavy | delta | PR serde | Weavy/serde |
|---|---:|---:|---:|---:|---:|
| point | 145.2 ns | 135.9 ns | -6.4% | 32.42 ns | 4.19x |
| float point | 215.5 ns | 206.2 ns | -4.3% | 74.73 ns | 2.76x |
| wide scalars ordered | 634.8 ns | 561.7 ns | -11.5% | 257.0 ns | 2.19x |
| wide scalars out of order | 939.4 ns | 811.7 ns | -13.6% | 250.5 ns | 3.24x |
| wide scalars skipped unknown | 931.8 ns | 832.5 ns | -10.7% | 379.4 ns | 2.19x |
| default scalars missing | 265.0 ns | 238.7 ns | -9.9% | 72.13 ns | 3.31x |
| person | 634.8 ns | 598.2 ns | -5.8% | 195.8 ns | 3.06x |
| sensor frame | 1.431 us | 1.395 us | -2.5% | 452.3 ns | 3.08x |
| company | 1.583 us | 1.499 us | -5.3% | 624.2 ns | 2.40x |
| batch 1000 | 659.1 us | 628.5 us | -4.6% | 215.4 us | 2.92x |

## Stax

Fresh final profile: `stax` run 277 on `wide_scalars_weavy_reused_plan`.

Top self-time after this PR:

| Function | self |
|---|---:|
| `Scanner::next_token` | 609.110 ms |
| `ScalarPlan::write_input` | 254.485 ms |
| `JsonInterp::read_scalar_struct` | 246.564 ms |
| `JsonParser::next_object_key_or_end` | 242.866 ms |
| `Scanner::consume_punctuation` | 163.384 ms |
| `JsonParser::consume_scalar_input` | 101.221 ms |
| `raw_into_unsigned` | 68.568 ms |
| `raw_into_signed` | 55.832 ms |
| `JsonParser::expect_colon_token` | 41.598 ms |

For context, the previous profile on this same wide scalar row had `Scanner::next_token` around 908 ms and `expect_colon_token` around 170 ms. The new punctuation path moves expected punctuation out of full token scanning; direct integer parsing also keeps `parse_number_inner` out of the hot top rows except for fallback/float work.

## Testing

- `cargo check -p facet-json`
- `cargo fmt --check`
- `cargo clippy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo nextest list -p facet-json -E 'test(weavy) | test(scalar) | test(integer) | test(numeric) | test(skip_unknown)'`
- `cargo nextest run -p facet-json -E 'test(weavy) | test(scalar) | test(integer) | test(numeric) | test(skip_unknown)'` (47 passed)
- `cargo nextest list -p facet-json`
- `cargo nextest run -p facet-json` (401 passed)
- `cargo bench -p facet-json --bench typeplan_reuse --no-run`
- direct Divan selected rows on `souffle`
- `stax record -F 1900 -l 15 -- target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench --min-time 10 --threads 1 wide_scalars_weavy_reused_plan`