### PR TITLE
Fast-path tiny Weavy scalar structs

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -87,6 +87,18 @@ pub(crate) enum JsonObjectKeyStep<'de> {
     End,
 }
 
+pub(crate) enum JsonObjectOrderedScalarStep<'de> {
+    Matched {
+        span: Span,
+        value: JsonScalarInput<'de>,
+    },
+    Field {
+        key: JsonFieldKeyInput<'de>,
+        span: Span,
+    },
+    End,
+}
+
 pub(crate) enum JsonSequenceScalarStep<'de> {
     Value { value: JsonScalarInput<'de> },
     End,
@@ -1096,6 +1108,118 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
     }
 
+    pub(crate) fn next_ordered_object_scalar_or_key(
+        &mut self,
+        expected: &str,
+    ) -> Result<JsonObjectOrderedScalarStep<'de>, ParseError> {
+        if self.state.event_peek.is_some() {
+            return self.next_object_key_or_end().map(|step| match step {
+                JsonObjectKeyStep::Field { key, span } => {
+                    JsonObjectOrderedScalarStep::Field { key, span }
+                }
+                JsonObjectKeyStep::End => JsonObjectOrderedScalarStep::End,
+            });
+        }
+
+        loop {
+            match self.determine_action() {
+                NextAction::ObjectKey => {
+                    let token = self.consume_spanned_token()?;
+                    let span = token.span;
+                    match token.token {
+                        ScanToken::ObjectEnd => {
+                            self.state.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(JsonObjectOrderedScalarStep::End);
+                        }
+                        ScanToken::String {
+                            start,
+                            end,
+                            has_escapes,
+                        } => {
+                            self.expect_colon_token()?;
+                            if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                                *state = ObjectState::Value;
+                            }
+                            if !has_escapes && &self.input[start..end] == expected.as_bytes() {
+                                let value = self.consume_scalar_input()?;
+                                return Ok(JsonObjectOrderedScalarStep::Matched { span, value });
+                            }
+                            return Ok(JsonObjectOrderedScalarStep::Field {
+                                key: JsonFieldKeyInput::Raw {
+                                    start,
+                                    end,
+                                    has_escapes,
+                                    span,
+                                },
+                                span,
+                            });
+                        }
+                        ScanToken::Eof => {
+                            return Err(ParseError::new(
+                                span,
+                                DeserializeErrorKind::UnexpectedEof {
+                                    expected: "field name or '}'",
+                                },
+                            ));
+                        }
+                        _ => return Err(self.unexpected_scan_token(&token, "field name or '}'")),
+                    }
+                }
+                NextAction::ObjectComma => {
+                    if self.consume_punctuation_token(b',')?.is_some() {
+                        if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                            *state = ObjectState::KeyOrEnd;
+                        }
+                        continue;
+                    }
+
+                    if self.consume_punctuation_token(b'}')?.is_some() {
+                        self.state.stack.pop();
+                        self.finish_value_in_parent();
+                        return Ok(JsonObjectOrderedScalarStep::End);
+                    }
+
+                    let token = self.consume_spanned_token()?;
+                    let span = token.span;
+                    match token.token {
+                        ScanToken::Comma => {
+                            if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                                *state = ObjectState::KeyOrEnd;
+                            }
+                        }
+                        ScanToken::ObjectEnd => {
+                            self.state.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(JsonObjectOrderedScalarStep::End);
+                        }
+                        ScanToken::Eof => {
+                            return Err(ParseError::new(
+                                span,
+                                DeserializeErrorKind::UnexpectedEof {
+                                    expected: "',' or '}'",
+                                },
+                            ));
+                        }
+                        _ => return Err(self.unexpected_scan_token(&token, "',' or '}'")),
+                    }
+                }
+                NextAction::RootFinished => {
+                    return Err(ParseError::new(
+                        Span::new(self.current_offset(), 0),
+                        DeserializeErrorKind::UnexpectedEof {
+                            expected: "field key or object end",
+                        },
+                    ));
+                }
+                _ => {
+                    let token = self.consume_spanned_token()?;
+                    return Err(self.unexpected_scan_token(&token, "field key or object end"));
+                }
+            }
+        }
+    }
+
     pub(crate) fn consume_null_if_next(&mut self) -> Result<bool, ParseError> {
         if let Some(event) = self.state.event_peek.as_ref() {
             if matches!(event.kind, ParseEventKind::Scalar(ScalarValue::Null)) {
@@ -1159,6 +1283,32 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                 }
                 _ => Ok(false),
             },
+            _ => Ok(false),
+        }
+    }
+
+    pub(crate) fn consume_object_end_if_next(&mut self) -> Result<bool, ParseError> {
+        if let Some(event) = self.state.event_peek.as_ref() {
+            if matches!(event.kind, ParseEventKind::StructEnd) {
+                self.state.event_peek = None;
+                self.state.peek_start_offset = None;
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+
+        match self.determine_action() {
+            NextAction::ObjectKey | NextAction::ObjectComma => {
+                if !self.next_significant_is(b'}')? {
+                    return Ok(false);
+                }
+                let Some(_) = self.consume_punctuation_token(b'}')? else {
+                    return Ok(false);
+                };
+                self.state.stack.pop();
+                self.finish_value_in_parent();
+                Ok(true)
+            }
             _ => Ok(false),
         }
     }

--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -99,6 +99,34 @@ pub(crate) enum JsonObjectOrderedScalarStep<'de> {
     End,
 }
 
+pub(crate) enum JsonObjectOrderedI32Step<'de> {
+    Matched {
+        span: Span,
+        value: i32,
+    },
+    MatchedInput {
+        span: Span,
+        value: JsonScalarInput<'de>,
+    },
+    Field {
+        key: JsonFieldKeyInput<'de>,
+        span: Span,
+    },
+    End,
+}
+
+impl<'de> From<JsonObjectOrderedScalarStep<'de>> for JsonObjectOrderedI32Step<'de> {
+    fn from(step: JsonObjectOrderedScalarStep<'de>) -> Self {
+        match step {
+            JsonObjectOrderedScalarStep::Matched { span, value } => {
+                Self::MatchedInput { span, value }
+            }
+            JsonObjectOrderedScalarStep::Field { key, span } => Self::Field { key, span },
+            JsonObjectOrderedScalarStep::End => Self::End,
+        }
+    }
+}
+
 pub(crate) enum JsonSequenceScalarStep<'de> {
     Value { value: JsonScalarInput<'de> },
     End,
@@ -330,6 +358,41 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
 
         Ok(span)
+    }
+
+    #[inline]
+    fn try_consume_exact_string_token(
+        &mut self,
+        expected: &str,
+    ) -> Result<Option<Span>, ParseError> {
+        let span = self
+            .scanner
+            .try_consume_exact_string(self.input, expected.as_bytes())
+            .map_err(scan_error_to_parse_error)?;
+
+        if let Some(span) = span {
+            self.state.last_token_start = span.offset as usize;
+            self.state.scanner_pos = self.scanner.pos();
+        }
+
+        Ok(span)
+    }
+
+    #[inline]
+    fn try_consume_i32_number(&mut self) -> Result<Option<(Span, i32)>, ParseError> {
+        let value = self
+            .scanner
+            .try_consume_i32_number(self.input)
+            .map_err(scan_error_to_parse_error)?;
+
+        if let Some((span, _)) = value {
+            self.state.last_token_start = span.offset as usize;
+            self.state.scanner_pos = self.scanner.pos();
+            self.state.root_started = true;
+            self.finish_value_in_parent();
+        }
+
+        Ok(value)
     }
 
     fn materialize_token_kind(
@@ -1080,6 +1143,90 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                             self.state.stack.pop();
                             self.finish_value_in_parent();
                             return Ok(JsonObjectKeyStep::End);
+                        }
+                        ScanToken::Eof => {
+                            return Err(ParseError::new(
+                                span,
+                                DeserializeErrorKind::UnexpectedEof {
+                                    expected: "',' or '}'",
+                                },
+                            ));
+                        }
+                        _ => return Err(self.unexpected_scan_token(&token, "',' or '}'")),
+                    }
+                }
+                NextAction::RootFinished => {
+                    return Err(ParseError::new(
+                        Span::new(self.current_offset(), 0),
+                        DeserializeErrorKind::UnexpectedEof {
+                            expected: "field key or object end",
+                        },
+                    ));
+                }
+                _ => {
+                    let token = self.consume_spanned_token()?;
+                    return Err(self.unexpected_scan_token(&token, "field key or object end"));
+                }
+            }
+        }
+    }
+
+    pub(crate) fn next_ordered_object_i32_or_key(
+        &mut self,
+        expected: &str,
+    ) -> Result<JsonObjectOrderedI32Step<'de>, ParseError> {
+        if self.state.event_peek.is_some() {
+            return self
+                .next_ordered_object_scalar_or_key(expected)
+                .map(Into::into);
+        }
+
+        loop {
+            match self.determine_action() {
+                NextAction::ObjectKey => {
+                    if let Some(span) = self.try_consume_exact_string_token(expected)? {
+                        self.expect_colon_token()?;
+                        if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                            *state = ObjectState::Value;
+                        }
+                        if let Some((_, value)) = self.try_consume_i32_number()? {
+                            return Ok(JsonObjectOrderedI32Step::Matched { span, value });
+                        }
+
+                        let value = self.consume_scalar_input()?;
+                        return Ok(JsonObjectOrderedI32Step::MatchedInput { span, value });
+                    }
+
+                    return self
+                        .next_ordered_object_scalar_or_key(expected)
+                        .map(Into::into);
+                }
+                NextAction::ObjectComma => {
+                    if self.consume_punctuation_token(b',')?.is_some() {
+                        if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                            *state = ObjectState::KeyOrEnd;
+                        }
+                        continue;
+                    }
+
+                    if self.consume_punctuation_token(b'}')?.is_some() {
+                        self.state.stack.pop();
+                        self.finish_value_in_parent();
+                        return Ok(JsonObjectOrderedI32Step::End);
+                    }
+
+                    let token = self.consume_spanned_token()?;
+                    let span = token.span;
+                    match token.token {
+                        ScanToken::Comma => {
+                            if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                                *state = ObjectState::KeyOrEnd;
+                            }
+                        }
+                        ScanToken::ObjectEnd => {
+                            self.state.stack.pop();
+                            self.finish_value_in_parent();
+                            return Ok(JsonObjectOrderedI32Step::End);
                         }
                         ScanToken::Eof => {
                             return Err(ParseError::new(

--- a/facet-json/src/scanner.rs
+++ b/facet-json/src/scanner.rs
@@ -186,6 +186,96 @@ impl Scanner {
         }
     }
 
+    pub fn try_consume_exact_string(
+        &mut self,
+        buf: &[u8],
+        expected: &[u8],
+    ) -> Result<Option<Span>, ScanError> {
+        if expected.iter().any(|byte| matches!(*byte, b'"' | b'\\')) {
+            return Ok(None);
+        }
+
+        let original = self.pos;
+        self.skip_whitespace(buf)?;
+
+        let start = self.pos;
+        if buf.get(self.pos) != Some(&b'"') {
+            self.pos = original;
+            return Ok(None);
+        }
+        self.pos += 1;
+
+        let expected_end = self.pos + expected.len();
+        if buf.get(self.pos..expected_end) != Some(expected) {
+            self.pos = original;
+            return Ok(None);
+        }
+        self.pos = expected_end;
+
+        if buf.get(self.pos) != Some(&b'"') {
+            self.pos = original;
+            return Ok(None);
+        }
+        self.pos += 1;
+
+        Ok(Some(Span::new(start, self.pos - start)))
+    }
+
+    pub fn try_consume_i32_number(&mut self, buf: &[u8]) -> Result<Option<(Span, i32)>, ScanError> {
+        let original = self.pos;
+        self.skip_whitespace(buf)?;
+
+        let start = self.pos;
+        let Some(&first) = buf.get(self.pos) else {
+            self.pos = original;
+            return Ok(None);
+        };
+        let negative = first == b'-';
+        if negative {
+            self.pos += 1;
+        } else if !first.is_ascii_digit() {
+            self.pos = original;
+            return Ok(None);
+        }
+
+        let digits_start = self.pos;
+        let mut value = 0i64;
+        while let Some(&byte) = buf.get(self.pos) {
+            if !byte.is_ascii_digit() {
+                break;
+            }
+            value = match value
+                .checked_mul(10)
+                .and_then(|value| value.checked_add((byte - b'0') as i64))
+            {
+                Some(value) => value,
+                None => {
+                    self.pos = original;
+                    return Ok(None);
+                }
+            };
+            self.pos += 1;
+        }
+
+        if self.pos == digits_start {
+            self.pos = original;
+            return Ok(None);
+        }
+
+        if matches!(buf.get(self.pos), Some(b'.' | b'e' | b'E')) {
+            self.pos = original;
+            return Ok(None);
+        }
+
+        let value = if negative { -value } else { value };
+        let Ok(value) = i32::try_from(value) else {
+            self.pos = original;
+            return Ok(None);
+        };
+
+        Ok(Some((Span::new(start, self.pos - start), value)))
+    }
+
     /// Scan the next token from the buffer.
     pub fn next_token(&mut self, buf: &[u8]) -> ScanResult {
         self.skip_whitespace(buf)?;

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -24,8 +24,8 @@ use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStat
 
 use crate::JsonParser;
 use crate::parser::{
-    JsonFieldKeyInput, JsonObjectKeyStep, JsonObjectOrderedScalarStep, JsonScalarInput,
-    JsonScalarToken, JsonSequenceScalarStep,
+    JsonFieldKeyInput, JsonObjectKeyStep, JsonObjectOrderedI32Step, JsonObjectOrderedScalarStep,
+    JsonScalarInput, JsonScalarToken, JsonSequenceScalarStep,
 };
 use crate::scanner::{NumberHint, ParsedNumber, SpannedToken, Token as ScanToken};
 
@@ -1274,7 +1274,7 @@ where
         let mut frame = TinyScalarStructFrame::new(shape, base, fields);
 
         loop {
-            let Some(expected) = frame.fields.get(frame.next_field).map(|field| field.name) else {
+            let Some(field) = frame.fields.get(frame.next_field).copied() else {
                 if self.parser.consume_object_end_if_next()? {
                     break;
                 }
@@ -1286,12 +1286,31 @@ where
                 }
                 continue;
             };
+            let expected = field.name;
+
+            if field.scalar.scalar == ScalarType::I32 {
+                match self.parser.next_ordered_object_i32_or_key(expected)? {
+                    JsonObjectOrderedI32Step::End => break,
+                    JsonObjectOrderedI32Step::Matched { span, value } => {
+                        let index = frame.next_field;
+                        self.write_tiny_i32_struct_field(&mut frame, index, field, span, value);
+                    }
+                    JsonObjectOrderedI32Step::MatchedInput { span, value } => {
+                        let index = frame.next_field;
+                        let field = frame.fields[index];
+                        self.write_tiny_scalar_struct_field(&mut frame, index, field, span, value)?;
+                    }
+                    JsonObjectOrderedI32Step::Field { key, span } => {
+                        self.read_tiny_scalar_struct_pending_field(&mut frame, key, span)?;
+                    }
+                }
+                continue;
+            }
 
             match self.parser.next_ordered_object_scalar_or_key(expected)? {
                 JsonObjectOrderedScalarStep::End => break,
                 JsonObjectOrderedScalarStep::Matched { span, value } => {
                     let index = frame.next_field;
-                    let field = frame.fields[index];
                     self.write_tiny_scalar_struct_field(&mut frame, index, field, span, value)?;
                 }
                 JsonObjectOrderedScalarStep::Field { key, span } => {
@@ -1374,6 +1393,21 @@ where
         }
         frame.mark_seen(index, span);
         Ok(())
+    }
+
+    fn write_tiny_i32_struct_field(
+        &mut self,
+        frame: &mut TinyScalarStructFrame<'program>,
+        index: usize,
+        field: ScalarFieldPlan,
+        span: Span,
+        value: i32,
+    ) {
+        let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
+        unsafe {
+            field_ptr.put(value);
+        }
+        frame.mark_seen(index, span);
     }
 
     fn read_scalar_struct_fields<Seen: StructSeenStore>(

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -24,7 +24,8 @@ use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStat
 
 use crate::JsonParser;
 use crate::parser::{
-    JsonFieldKeyInput, JsonObjectKeyStep, JsonScalarInput, JsonScalarToken, JsonSequenceScalarStep,
+    JsonFieldKeyInput, JsonObjectKeyStep, JsonObjectOrderedScalarStep, JsonScalarInput,
+    JsonScalarToken, JsonSequenceScalarStep,
 };
 use crate::scanner::{NumberHint, ParsedNumber, SpannedToken, Token as ScanToken};
 
@@ -1230,6 +1231,10 @@ where
     ) -> Result<(), DeserializeError> {
         self.parser.consume_object_start()?;
         let base = self.base;
+        if fields.len() <= TINY_SCALAR_STRUCT_MAX_FIELDS {
+            return self.read_tiny_scalar_struct_fields(shape, base, fields);
+        }
+
         match StructTracking::for_len(fields.len()) {
             StructTracking::Inline => {
                 let mut frame = StructFrame::<ScalarFieldPlan, InitializedLedger<Span>>::new(
@@ -1257,6 +1262,117 @@ where
                 }
             }
         }
+        Ok(())
+    }
+
+    fn read_tiny_scalar_struct_fields(
+        &mut self,
+        shape: &'static Shape,
+        base: PtrUninit,
+        fields: &'program [ScalarFieldPlan],
+    ) -> Result<(), DeserializeError> {
+        let mut frame = TinyScalarStructFrame::new(shape, base, fields);
+
+        loop {
+            let Some(expected) = frame.fields.get(frame.next_field).map(|field| field.name) else {
+                if self.parser.consume_object_end_if_next()? {
+                    break;
+                }
+                match self.parser.next_object_key_or_end()? {
+                    JsonObjectKeyStep::End => break,
+                    JsonObjectKeyStep::Field { key, span } => {
+                        self.read_tiny_scalar_struct_pending_field(&mut frame, key, span)?;
+                    }
+                }
+                continue;
+            };
+
+            match self.parser.next_ordered_object_scalar_or_key(expected)? {
+                JsonObjectOrderedScalarStep::End => break,
+                JsonObjectOrderedScalarStep::Matched { span, value } => {
+                    let index = frame.next_field;
+                    let field = frame.fields[index];
+                    self.write_tiny_scalar_struct_field(&mut frame, index, field, span, value)?;
+                }
+                JsonObjectOrderedScalarStep::Field { key, span } => {
+                    self.read_tiny_scalar_struct_pending_field(&mut frame, key, span)?;
+                }
+            }
+        }
+
+        if frame.all_initialized() {
+            core::mem::forget(frame);
+        } else {
+            unsafe {
+                frame.fill_missing_fields()?;
+            }
+        }
+        Ok(())
+    }
+
+    fn read_tiny_scalar_struct_pending_field(
+        &mut self,
+        frame: &mut TinyScalarStructFrame<'program>,
+        key: JsonFieldKeyInput<'_>,
+        span: Span,
+    ) -> Result<(), DeserializeError> {
+        let key_is_raw = matches!(key, JsonFieldKeyInput::Raw { .. });
+        let matched =
+            if let Some((index, field)) = frame.match_next_field_input(&*self.parser, &key)? {
+                Some((index, field))
+            } else {
+                frame.match_unordered_field_input(&*self.parser, &key)?
+            };
+
+        let Some((index, field)) = matched else {
+            let key = self.parser.materialize_field_key(key)?;
+            if frame.shape.has_deny_unknown_fields_attr() {
+                return Err(vm_error(
+                    Some(span),
+                    DeserializeErrorKind::UnknownField {
+                        field: key.as_str().to_owned().into(),
+                        suggestion: None,
+                    },
+                ));
+            }
+            self.parser.skip_value()?;
+            return Ok(());
+        };
+
+        if let Some(first_span) = frame.seen_span(index) {
+            return Err(vm_error(
+                Some(span),
+                DeserializeErrorKind::DuplicateField {
+                    field: field.name.into(),
+                    first_span: Some(first_span),
+                },
+            ));
+        }
+
+        let value = if key_is_raw {
+            self.parser.read_current_scalar_input()?
+        } else {
+            let (value, value_span) = self.parser.read_scalar_token()?;
+            JsonScalarInput::Materialized(value, value_span)
+        };
+        self.write_tiny_scalar_struct_field(frame, index, field, span, value)
+    }
+
+    fn write_tiny_scalar_struct_field(
+        &mut self,
+        frame: &mut TinyScalarStructFrame<'program>,
+        index: usize,
+        field: ScalarFieldPlan,
+        span: Span,
+        value: JsonScalarInput<'_>,
+    ) -> Result<(), DeserializeError> {
+        let field_ptr = unsafe { frame.base.field_uninit(field.offset) };
+        unsafe {
+            field
+                .scalar
+                .write_input(&*self.parser, field.shape, field_ptr, value)?;
+        }
+        frame.mark_seen(index, span);
         Ok(())
     }
 
@@ -1863,6 +1979,17 @@ struct MatchedField<'program, Field> {
     ordered: bool,
 }
 
+const TINY_SCALAR_STRUCT_MAX_FIELDS: usize = 3;
+
+struct TinyScalarStructFrame<'program> {
+    shape: &'static Shape,
+    base: PtrUninit,
+    fields: &'program [ScalarFieldPlan],
+    initialized: u8,
+    spans: [Span; TINY_SCALAR_STRUCT_MAX_FIELDS],
+    next_field: usize,
+}
+
 struct StructFrame<'program, Field: StructFieldPlan, Seen: StructSeenStore> {
     shape: &'static Shape,
     base: PtrUninit,
@@ -2067,6 +2194,201 @@ impl<'program> LargeStructFrameSlot<'program> {
 
 fn struct_seen_bit(index: usize) -> u64 {
     1u64 << index
+}
+
+impl<'program> TinyScalarStructFrame<'program> {
+    fn new(shape: &'static Shape, base: PtrUninit, fields: &'program [ScalarFieldPlan]) -> Self {
+        debug_assert!(fields.len() <= TINY_SCALAR_STRUCT_MAX_FIELDS);
+        Self {
+            shape,
+            base,
+            fields,
+            initialized: 0,
+            spans: [Span { offset: 0, len: 0 }; TINY_SCALAR_STRUCT_MAX_FIELDS],
+            next_field: 0,
+        }
+    }
+
+    #[inline(always)]
+    fn is_initialized(&self, index: usize) -> bool {
+        debug_assert!(index < TINY_SCALAR_STRUCT_MAX_FIELDS);
+        (self.initialized & tiny_struct_seen_bit(index)) != 0
+    }
+
+    #[inline(always)]
+    fn seen_span(&self, index: usize) -> Option<Span> {
+        self.is_initialized(index).then_some(self.spans[index])
+    }
+
+    #[inline(always)]
+    fn all_initialized(&self) -> bool {
+        self.initialized == self.complete_mask()
+    }
+
+    #[inline(always)]
+    fn complete_mask(&self) -> u8 {
+        (1u8 << self.fields.len()) - 1
+    }
+
+    #[inline(always)]
+    fn mark_seen(&mut self, index: usize, span: Span) {
+        debug_assert!(index < self.fields.len());
+        self.spans[index] = span;
+        self.initialized |= tiny_struct_seen_bit(index);
+        if index == self.next_field {
+            self.advance_next_field();
+        }
+    }
+
+    #[inline(always)]
+    fn advance_next_field(&mut self) {
+        while self
+            .fields
+            .get(self.next_field)
+            .is_some_and(|_| self.is_initialized(self.next_field))
+        {
+            self.next_field += 1;
+        }
+    }
+
+    #[inline(always)]
+    fn match_next_field_input<'de, const TRUSTED_UTF8: bool>(
+        &self,
+        parser: &JsonParser<'de, TRUSTED_UTF8>,
+        key: &JsonFieldKeyInput<'de>,
+    ) -> Result<Option<(usize, ScalarFieldPlan)>, ParseError> {
+        let Some(field) = self.fields.get(self.next_field).copied() else {
+            return Ok(None);
+        };
+        if let Some(key) = parser.field_key_unescaped_bytes(key) {
+            return Ok(field
+                .matches_key_bytes(key)
+                .then_some((self.next_field, field)));
+        }
+        if field.matches_key_input(parser, key)? {
+            Ok(Some((self.next_field, field)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[inline]
+    fn match_unordered_field_input<'de, const TRUSTED_UTF8: bool>(
+        &self,
+        parser: &JsonParser<'de, TRUSTED_UTF8>,
+        key: &JsonFieldKeyInput<'de>,
+    ) -> Result<Option<(usize, ScalarFieldPlan)>, ParseError> {
+        if let Some(key) = parser.field_key_unescaped_bytes(key) {
+            return Ok(self.match_unordered_field_bytes(key));
+        }
+
+        self.fields
+            .iter()
+            .copied()
+            .enumerate()
+            .filter(|(index, _)| *index != self.next_field)
+            .find_map(
+                |(index, field)| match field.matches_key_input(parser, key) {
+                    Ok(true) => Some(Ok((index, field))),
+                    Ok(false) => None,
+                    Err(err) => Some(Err(err)),
+                },
+            )
+            .transpose()
+    }
+
+    #[inline]
+    fn match_unordered_field_bytes(&self, key: &[u8]) -> Option<(usize, ScalarFieldPlan)> {
+        self.fields
+            .iter()
+            .copied()
+            .enumerate()
+            .filter(|(index, _)| *index != self.next_field)
+            .find(|(_, field)| field.matches_key_bytes(key))
+    }
+
+    unsafe fn fill_missing_fields(mut self) -> Result<(), DeserializeError> {
+        for (index, field) in self.fields.iter().copied().enumerate() {
+            if self.is_initialized(index) {
+                continue;
+            }
+
+            let field_ptr = unsafe { self.base.field_uninit(field.offset) };
+            match field.missing {
+                MissingField::Required => {
+                    return Err(vm_error(
+                        None,
+                        DeserializeErrorKind::MissingField {
+                            field: field.name,
+                            container_shape: self.shape,
+                        },
+                    ));
+                }
+                MissingField::DefaultCustom(default) => {
+                    unsafe {
+                        default(field_ptr);
+                    }
+                    self.mark_seen(index, Span { offset: 0, len: 0 });
+                }
+                MissingField::DefaultTrait { explicit } => {
+                    if unsafe { field.shape.call_default_in_place(field_ptr) }.is_some() {
+                        self.mark_seen(index, Span { offset: 0, len: 0 });
+                    } else if explicit {
+                        return Err(vm_error(
+                            None,
+                            DeserializeErrorKind::Unsupported {
+                                message: format!(
+                                    "field `{}` on {} has #[facet(default)] but no default_in_place",
+                                    field.name, self.shape
+                                )
+                                .into(),
+                            },
+                        ));
+                    } else {
+                        return Err(vm_error(
+                            None,
+                            DeserializeErrorKind::MissingField {
+                                field: field.name,
+                                container_shape: self.shape,
+                            },
+                        ));
+                    }
+                }
+                MissingField::OptionNone(option) => {
+                    unsafe {
+                        (option.vtable.init_none)(field_ptr);
+                    }
+                    self.mark_seen(index, Span { offset: 0, len: 0 });
+                }
+            }
+        }
+        core::mem::forget(self);
+        Ok(())
+    }
+
+    unsafe fn drop_initialized_fields(&self) {
+        for index in (0..self.fields.len()).rev() {
+            if self.is_initialized(index) {
+                let field = self.fields[index];
+                let ptr = unsafe { self.base.field_init(field.offset) };
+                unsafe {
+                    let _ = field.shape.call_drop_in_place(ptr);
+                }
+            }
+        }
+    }
+}
+
+impl Drop for TinyScalarStructFrame<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            self.drop_initialized_fields();
+        }
+    }
+}
+
+fn tiny_struct_seen_bit(index: usize) -> u8 {
+    1u8 << index
 }
 
 impl<'program, Field, Seen> StructFrame<'program, Field, Seen>
@@ -2563,10 +2885,27 @@ write_unsigned_input!(write_usize_input, usize, "usize");
 
 write_signed_input!(write_i8_input, i8, "i8");
 write_signed_input!(write_i16_input, i16, "i16");
-write_signed_input!(write_i32_input, i32, "i32");
 write_signed_input!(write_i64_input, i64, "i64");
 write_signed_input!(write_i128_input, i128, "i128");
 write_signed_input!(write_isize_input, isize, "isize");
+
+fn write_i32_input<'de, const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'de, TRUSTED_UTF8>,
+    dst: PtrUninit,
+    value: JsonScalarInput<'de>,
+) -> Result<(), DeserializeError> {
+    let value = match value {
+        JsonScalarInput::Raw(token) => {
+            let span = token.span;
+            raw_into_i32::<TRUSTED_UTF8>(parser, token, span)?
+        }
+        JsonScalarInput::Materialized(value, span) => into_signed::<i32>(value, span, "i32")?,
+    };
+    unsafe {
+        dst.put(value);
+    }
+    Ok(())
+}
 
 fn write_borrowed_str_input_shaped<'de, const TRUSTED_UTF8: bool>(
     parser: &JsonParser<'de, TRUSTED_UTF8>,
@@ -3302,6 +3641,69 @@ where
         }
     };
     T::try_from(value).map_err(|_| number_out_of_range(span, value.to_string(), target))
+}
+
+fn raw_into_i32<const TRUSTED_UTF8: bool>(
+    parser: &JsonParser<'_, TRUSTED_UTF8>,
+    token: SpannedToken,
+    span: Span,
+) -> Result<i32, DeserializeError> {
+    match token.token {
+        ScanToken::Number { start, end, hint } => match hint {
+            NumberHint::Signed | NumberHint::Unsigned => {
+                let text = parser.number_text(start, end, span)?;
+                if let Some(value) = parse_i32_bytes(text.as_bytes()) {
+                    return Ok(value);
+                }
+                let value = parsed_signed_number(parser, start, end, hint, span, "i32")?;
+                i32::try_from(value)
+                    .map_err(|_| number_out_of_range(span, value.to_string(), "i32"))
+            }
+            NumberHint::Float => {
+                let value = parsed_signed_number(parser, start, end, hint, span, "i32")?;
+                i32::try_from(value)
+                    .map_err(|_| number_out_of_range(span, value.to_string(), "i32"))
+            }
+        },
+        ScanToken::String {
+            start,
+            end,
+            has_escapes,
+        } => {
+            let value = parser.decode_string(start, end, has_escapes, span)?;
+            value
+                .parse::<i32>()
+                .map_err(|_| number_out_of_range(span, value.into_owned(), "i32"))
+        }
+        other => Err(type_mismatch_name(span, "i32", raw_token_kind_name(&other))),
+    }
+}
+
+fn parse_i32_bytes(bytes: &[u8]) -> Option<i32> {
+    let (&first, rest) = bytes.split_first()?;
+    let (negative, digits) = if first == b'-' {
+        (true, rest)
+    } else {
+        (false, bytes)
+    };
+    if digits.is_empty() {
+        return None;
+    }
+
+    let mut value = 0i64;
+    for &byte in digits {
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        value = value.checked_mul(10)?.checked_add((byte - b'0') as i64)?;
+    }
+
+    if negative {
+        let value = -value;
+        i32::try_from(value).ok()
+    } else {
+        i32::try_from(value).ok()
+    }
 }
 
 fn parsed_unsigned_number<const TRUSTED_UTF8: bool>(

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -147,6 +147,13 @@ fn weavy_validates_skipped_unknown_raw_field_key_utf8() {
 }
 
 #[test]
+fn weavy_tiny_scalar_struct_skips_unknown_container_value() {
+    let got: LoosePoint =
+        facet_json::from_str_weavy(r#"{"x":1,"extra":{"nested":[true,false]}}"#).unwrap();
+    assert_eq!(got, LoosePoint { x: 1 });
+}
+
+#[test]
 fn weavy_plan_can_be_reused() {
     let plan = facet_json::JsonWeavyPlan::<Point>::build().unwrap();
     let first = plan.from_str(r#"{"x":1,"y":2}"#).unwrap();


### PR DESCRIPTION
## Summary

This keeps the existing tiny scalar struct path and adds a narrower ordered `i32` fast path for records like `Point { x: i32, y: i32 }`.

The parser now has conservative scanner-backed primitives for an exact raw field key and a direct i32 number. The Weavy tiny scalar runner uses them only when the next ordered tiny field is actually `i32`; escaped keys, aliases, unknown fields, out-of-order fields, non-number values, overflow, and event-peeked input all fall back to the existing scalar-input path.

## Performance

Measured on `souffle` with `typeplan_reuse`, direct bench binary, `--bench --min-time 5 --threads 1`. Medians shown. Weavy/serde uses the same branch run serde_json median.

| case | main -> PR | delta | Weavy/serde |
|---|---:|---:|---:|
| point | 165.5 ns -> 124.6 ns | -24.7% | 3.76x |
| float point | 208.5 ns -> 208.6 ns | +0.0% | 2.75x |
| person | 624.5 ns -> 624.6 ns | +0.0% | 3.18x |
| company | 1.416 us -> 1.416 us | +0.0% | 2.27x |
| sensor frame | 1.374 us -> 1.374 us | +0.0% | 3.00x |
| wide ordered | 541.5 ns -> 541.6 ns | +0.0% | 2.17x |
| wide out-of-order | 791.5 ns -> 790.6 ns | -0.1% | 3.13x |
| wide skipped unknown | 832.5 ns -> 832.6 ns | +0.0% | 2.19x |
| default missing | 249.5 ns -> 249.6 ns | +0.0% | 3.41x |
| batch 1000 | 622.9 us -> 619.2 us | -0.6% | 2.89x |

Focused point smoke on `souffle` measured `point_weavy_reused_plan` at 124.6 ns vs `point_serde_json` at 41.6 ns, roughly 3.0x serde in that point-only run.

Stax run `280` on the updated point path shows the old generic i32 parse/write frames are gone from the hot list. The remaining samples are mostly `JsonWeavyPlan::from_str`, `next_ordered_object_i32_or_key`, `Scanner::try_consume_i32_number`, exact-key matching, punctuation, and Divan timing overhead.

## Testing

- `cargo check -p facet-json`
- `cargo fmt --check`
- `cargo clippy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo nextest list -p facet-json -E "test(weavy) | test(scalar) | test(integer) | test(numeric) | test(skip_unknown)"`
- `cargo nextest run -p facet-json -E "test(weavy) | test(scalar) | test(integer) | test(numeric) | test(skip_unknown)"`
- `cargo nextest list -p facet-json`
- `cargo nextest run -p facet-json`