### PR TITLE
Fast-path Weavy container starts

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -1047,6 +1047,76 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
     }
 
+    pub(crate) fn consume_object_start_fast(&mut self) -> Result<Span, ParseError> {
+        if self.state.event_peek.is_some() {
+            return self.consume_object_start();
+        }
+
+        match self.determine_action() {
+            NextAction::ObjectValue | NextAction::ArrayValue | NextAction::RootValue => {
+                self.consume_direct_object_start()
+            }
+            NextAction::ArrayComma => {
+                if self.consume_punctuation_token(b',')?.is_some() {
+                    if let Some(ContextState::Array(state)) = self.state.stack.last_mut() {
+                        *state = ArrayState::ValueOrEnd;
+                    }
+                    self.consume_direct_object_start()
+                } else {
+                    self.consume_object_start()
+                }
+            }
+            _ => self.consume_object_start(),
+        }
+    }
+
+    pub(crate) fn consume_array_start_fast(&mut self) -> Result<Span, ParseError> {
+        if self.state.event_peek.is_some() {
+            return self.consume_array_start();
+        }
+
+        match self.determine_action() {
+            NextAction::ObjectValue | NextAction::ArrayValue | NextAction::RootValue => {
+                self.consume_direct_array_start()
+            }
+            NextAction::ArrayComma => {
+                if self.consume_punctuation_token(b',')?.is_some() {
+                    if let Some(ContextState::Array(state)) = self.state.stack.last_mut() {
+                        *state = ArrayState::ValueOrEnd;
+                    }
+                    self.consume_direct_array_start()
+                } else {
+                    self.consume_array_start()
+                }
+            }
+            _ => self.consume_array_start(),
+        }
+    }
+
+    fn consume_direct_object_start(&mut self) -> Result<Span, ParseError> {
+        if let Some(span) = self.consume_punctuation_token(b'{')? {
+            self.state.root_started = true;
+            self.state
+                .stack
+                .push(ContextState::Object(ObjectState::KeyOrEnd));
+            Ok(span)
+        } else {
+            self.consume_object_start()
+        }
+    }
+
+    fn consume_direct_array_start(&mut self) -> Result<Span, ParseError> {
+        if let Some(span) = self.consume_punctuation_token(b'[')? {
+            self.state.root_started = true;
+            self.state
+                .stack
+                .push(ContextState::Array(ArrayState::ValueOrEnd));
+            Ok(span)
+        } else {
+            self.consume_array_start()
+        }
+    }
+
     pub(crate) fn next_object_key_or_end(&mut self) -> Result<JsonObjectKeyStep<'de>, ParseError> {
         if let Some(event) = self.state.event_peek.take() {
             self.state.peek_start_offset = None;

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -1229,7 +1229,7 @@ where
         shape: &'static Shape,
         fields: &'program [ScalarFieldPlan],
     ) -> Result<(), DeserializeError> {
-        self.parser.consume_object_start()?;
+        self.parser.consume_object_start_fast()?;
         let base = self.base;
         if fields.len() <= TINY_SCALAR_STRUCT_MAX_FIELDS {
             return self.read_tiny_scalar_struct_fields(shape, base, fields);
@@ -1623,7 +1623,7 @@ where
                 fields,
                 loop_id,
             } => {
-                self.parser.consume_object_start()?;
+                self.parser.consume_object_start_fast()?;
                 let tracking = StructTracking::for_len(fields.len());
                 let base = self.base;
                 match tracking {
@@ -1694,7 +1694,7 @@ where
                 element_layout,
                 loop_id,
             } => {
-                self.parser.consume_array_start()?;
+                self.parser.consume_array_start_fast()?;
                 if list.from_raw_parts().is_some() {
                     let builder = RawArrayBuilder::new(
                         *element_layout,


### PR DESCRIPTION
## Summary

This removes the generic value-start parser path from Weavy container entry. `ReadScalarStruct`, `ReadStruct`, and `ReadList` now use parser helpers that consume `{` / `[` directly and push the matching parser context.

The fast helpers stay conservative: event-peeked input and non-matching/malformed input delegate back to the existing `consume_object_start` / `consume_array_start` paths, so error construction and the general facet-format parser behavior remain owned by the current code.

## Performance

Measured on `souffle` with `typeplan_reuse`, direct bench binary, `--bench --min-time 5 --threads 1`. Medians shown. Weavy/serde uses the branch run serde_json median.

| case | main -> PR | delta | Weavy/serde |
|---|---:|---:|---:|
| point | 124.5 ns -> 92.06 ns | -26.1% | 2.75x |
| float point | 208.5 ns -> 207.6 ns | -0.4% | 2.76x |
| person | 624.5 ns -> 624.6 ns | +0.0% | 3.18x |
| company | 1.416 us -> 1.374 us | -3.0% | 2.20x |
| sensor frame | 1.374 us -> 1.333 us | -3.0% | 2.91x |
| wide ordered | 541.5 ns -> 494.4 ns | -8.7% | 1.92x |
| wide out-of-order | 790.5 ns -> 790.6 ns | +0.0% | 3.17x |
| wide skipped unknown | 832.5 ns -> 791.6 ns | -4.9% | 2.08x |
| default missing | 249.5 ns -> 249.6 ns | +0.0% | 3.41x |
| batch 1000 | 621.4 us -> 604.7 us | -2.7% | 2.81x |

The big point win is because the root object no longer goes through `consume_value_start` / `parse_direct_value_start_with_token`; wide ordered and skipped-unknown also benefit because they enter the object fast path and then continue with existing ordered/skip logic. Out-of-order wide stays flat, as expected, because unordered field matching dominates there.

Stax run `281` on the branch was used for attribution only. The old `parse_direct_value_start_with_token` frame is gone from the point hot list; the remaining entry samples are in `consume_direct_object_start` / `Scanner::consume_punctuation`, plus the existing ordered i32 key/value path.

## Testing

- `cargo check -p facet-json`
- `cargo fmt --check`
- `cargo clippy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo nextest list -p facet-json -E "test(weavy) | test(raw_json) | test(skip_unknown) | test(list_deferred_processing)"`
- `cargo nextest run -p facet-json -E "test(weavy) | test(raw_json) | test(skip_unknown) | test(list_deferred_processing)"`
- `cargo nextest list -p facet-json`
- `cargo nextest run -p facet-json`
