### PR TITLE
Optimize Weavy tiny i32 and raw scalar field matching

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -254,6 +254,16 @@ enum ContextState {
     Array(ArrayState),
 }
 
+struct OrderedI32ObjectProbeSave {
+    scanner: Scanner,
+    stack_len: usize,
+    stack_top: Option<ContextState>,
+    root_started: bool,
+    root_complete: bool,
+    last_token_start: usize,
+    scanner_pos: usize,
+}
+
 #[derive(Debug, Clone, Copy)]
 enum ObjectState {
     KeyOrEnd,
@@ -1435,6 +1445,112 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                 }
             }
         }
+    }
+
+    #[inline(never)]
+    pub(crate) fn try_consume_ordered_i32_object_fields(
+        &mut self,
+        expected: &[&str],
+        spans: &mut [Span],
+        values: &mut [i32],
+    ) -> Result<bool, ParseError> {
+        debug_assert_eq!(expected.len(), spans.len());
+        debug_assert_eq!(expected.len(), values.len());
+
+        if self.state.event_peek.is_some() {
+            return Ok(false);
+        }
+
+        let save = self.save_ordered_i32_object_probe();
+        let matched = self.try_consume_ordered_i32_object_fields_inner(expected, spans, values)?;
+        if !matched {
+            self.restore_ordered_i32_object_probe(save);
+        }
+        Ok(matched)
+    }
+
+    #[inline(never)]
+    fn save_ordered_i32_object_probe(&self) -> OrderedI32ObjectProbeSave {
+        OrderedI32ObjectProbeSave {
+            scanner: self.scanner.clone(),
+            stack_len: self.state.stack.len(),
+            stack_top: self.state.stack.last().cloned(),
+            root_started: self.state.root_started,
+            root_complete: self.state.root_complete,
+            last_token_start: self.state.last_token_start,
+            scanner_pos: self.state.scanner_pos,
+        }
+    }
+
+    #[cold]
+    fn restore_ordered_i32_object_probe(&mut self, save: OrderedI32ObjectProbeSave) {
+        self.scanner = save.scanner;
+        self.state.stack.truncate(save.stack_len);
+        if let Some(top) = save.stack_top {
+            if let Some(slot) = self.state.stack.last_mut() {
+                *slot = top;
+            } else {
+                self.state.stack.push(top);
+            }
+        }
+        self.state.root_started = save.root_started;
+        self.state.root_complete = save.root_complete;
+        self.state.last_token_start = save.last_token_start;
+        self.state.scanner_pos = save.scanner_pos;
+    }
+
+    #[inline(never)]
+    fn try_consume_ordered_i32_object_fields_inner(
+        &mut self,
+        expected: &[&str],
+        spans: &mut [Span],
+        values: &mut [i32],
+    ) -> Result<bool, ParseError> {
+        for (index, expected) in expected.iter().copied().enumerate() {
+            if index > 0 {
+                if self.determine_action() != NextAction::ObjectComma {
+                    return Ok(false);
+                }
+                if self.consume_punctuation_token(b',')?.is_none() {
+                    return Ok(false);
+                }
+                if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                    *state = ObjectState::KeyOrEnd;
+                } else {
+                    return Ok(false);
+                }
+            }
+
+            if self.determine_action() != NextAction::ObjectKey {
+                return Ok(false);
+            }
+
+            let Some(span) = self.try_consume_exact_string_token(expected)? else {
+                return Ok(false);
+            };
+            self.expect_colon_token()?;
+            if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                *state = ObjectState::Value;
+            } else {
+                return Ok(false);
+            }
+
+            let Some((_, value)) = self.try_consume_i32_number()? else {
+                return Ok(false);
+            };
+            spans[index] = span;
+            values[index] = value;
+        }
+
+        if self.determine_action() != NextAction::ObjectComma {
+            return Ok(false);
+        }
+        if self.consume_punctuation_token(b'}')?.is_none() {
+            return Ok(false);
+        }
+        self.state.stack.pop();
+        self.finish_value_in_parent();
+        Ok(true)
     }
 
     pub(crate) fn consume_null_if_next(&mut self) -> Result<bool, ParseError> {

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -1272,6 +1272,10 @@ where
         fields: &'program [ScalarFieldPlan],
     ) -> Result<(), DeserializeError> {
         let mut frame = TinyScalarStructFrame::new(shape, base, fields);
+        if self.try_read_fused_tiny_i32_struct_fields(&mut frame)? {
+            core::mem::forget(frame);
+            return Ok(());
+        }
 
         loop {
             let Some(field) = frame.fields.get(frame.next_field).copied() else {
@@ -1327,6 +1331,36 @@ where
             }
         }
         Ok(())
+    }
+
+    fn try_read_fused_tiny_i32_struct_fields(
+        &mut self,
+        frame: &mut TinyScalarStructFrame<'program>,
+    ) -> Result<bool, DeserializeError> {
+        if !tiny_i32_struct_fields_are_fusible(frame.fields) {
+            return Ok(false);
+        }
+
+        let mut names = [""; TINY_SCALAR_STRUCT_MAX_FIELDS];
+        let mut spans = [Span { offset: 0, len: 0 }; TINY_SCALAR_STRUCT_MAX_FIELDS];
+        let mut values = [0i32; TINY_SCALAR_STRUCT_MAX_FIELDS];
+        for (index, field) in frame.fields.iter().enumerate() {
+            names[index] = field.name;
+        }
+
+        if !self.parser.try_consume_ordered_i32_object_fields(
+            &names[..frame.fields.len()],
+            &mut spans[..frame.fields.len()],
+            &mut values[..frame.fields.len()],
+        )? {
+            return Ok(false);
+        }
+
+        for index in 0..frame.fields.len() {
+            let field = frame.fields[index];
+            self.write_tiny_i32_struct_field(frame, index, field, spans[index], values[index]);
+        }
+        Ok(true)
     }
 
     fn read_tiny_scalar_struct_pending_field(
@@ -1427,7 +1461,11 @@ where
                         continue;
                     }
 
-                    let matched = frame.match_unordered_field_input(&*self.parser, &key)?;
+                    let matched = if let Some(key) = self.parser.field_key_unescaped_bytes(&key) {
+                        frame.match_unordered_scalar_field_bytes(key)
+                    } else {
+                        frame.match_unordered_field_input(&*self.parser, &key)?
+                    };
 
                     let Some(matched) = matched else {
                         let key = self.parser.materialize_field_key(key)?;
@@ -2014,6 +2052,16 @@ struct MatchedField<'program, Field> {
 }
 
 const TINY_SCALAR_STRUCT_MAX_FIELDS: usize = 3;
+
+fn tiny_i32_struct_fields_are_fusible(fields: &[ScalarFieldPlan]) -> bool {
+    !fields.is_empty()
+        && fields.len() <= TINY_SCALAR_STRUCT_MAX_FIELDS
+        && fields.iter().all(|field| {
+            field.alias.is_none()
+                && field.scalar.scalar == ScalarType::I32
+                && matches!(field.missing, MissingField::Required)
+        })
+}
 
 struct TinyScalarStructFrame<'program> {
     shape: &'static Shape,
@@ -2656,6 +2704,43 @@ where
             }
         }
     }
+}
+
+impl<'program, Seen> StructFrame<'program, ScalarFieldPlan, Seen>
+where
+    Seen: StructSeenStore,
+{
+    #[inline]
+    fn match_unordered_scalar_field_bytes(
+        &self,
+        key: &[u8],
+    ) -> Option<MatchedField<'program, ScalarFieldPlan>> {
+        if key.len() != 1 {
+            return self.match_unordered_field_bytes(key);
+        }
+
+        let key = key[0];
+        self.fields
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| *index != self.next_field)
+            .find(|(_, field)| scalar_field_matches_single_byte_key(field, key))
+            .map(|(index, field)| MatchedField {
+                index,
+                field,
+                ordered: false,
+            })
+    }
+}
+
+#[inline(always)]
+fn scalar_field_matches_single_byte_key(field: &ScalarFieldPlan, key: u8) -> bool {
+    let name = field.name.as_bytes();
+    (name.len() == 1 && name[0] == key)
+        || field.alias.is_some_and(|alias| {
+            let alias = alias.as_bytes();
+            alias.len() == 1 && alias[0] == key
+        })
 }
 
 impl<Field, Seen> Drop for StructFrame<'_, Field, Seen>


### PR DESCRIPTION
## Summary

- add a rollback-safe parser primitive for tiny ordered `i32` JSON objects
- use it for fusible tiny scalar structs in the Weavy deserializer
- add a scalar-struct raw-key fast path for single-byte unordered keys, improving reverse-order scalar records

## Benchmarks

`souffle`, Divan exact filters, `--min-time 3 --threads 1`, medians.

| Bench | Main | Branch | Delta | Weavy/serde |
|---|---:|---:|---:|---:|
| point | 91.67 ns | 86.01 ns | -6.2% | 2.53x |
| float point | 207.2 ns | 207.4 ns | +0.1% | 2.77x |
| person | 624.2 ns | 624.4 ns | +0.0% | 3.01x |
| company | 1.374 us | 1.374 us | +0.0% | 2.20x |
| sensor frame | 1.333 us | 1.333 us | +0.0% | 2.91x |
| wide ordered | 499.2 ns | 499.4 ns | +0.0% | 1.94x |
| wide out-of-order | 749.2 ns | 541.4 ns | -27.7% | 2.15x |
| wide skipped unknown | 791.2 ns | 791.4 ns | +0.0% | 2.08x |
| default missing | 249.2 ns | 207.4 ns | -16.8% | 2.84x |
| batch 1000 | 608.4 us | 607.7 us | -0.1% | 2.83x |

## Verification

- `cargo check -p facet-json`
- `cargo fmt --check`
- `cargo nextest run -p facet-json`
- `cargo clippy -p facet-json --all-targets --all-features -- -D warnings`
- `cargo bench -p facet-json --bench typeplan_reuse --no-run`
- `target/release/deps/typeplan_reuse-e8dbbec308fa3681 --bench --exact --min-time 3 --threads 1 ...` on `souffle`
