### PR TITLE
Inline acyclic facet-hash plans

### DIFF
--- a/facet-hash/src/lib.rs
+++ b/facet-hash/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
-use alloc::collections::BTreeMap;
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::alloc::Layout;
@@ -333,6 +333,7 @@ struct FieldPlan<Block> {
 struct Lowering {
     lowered: Lowered<BlockId, SymbolicOp>,
     in_progress: Vec<&'static Shape>,
+    needed_blocks: BTreeSet<BlockId>,
     mode: HashMode,
 }
 
@@ -344,25 +345,22 @@ impl Lowering {
                 blocks: BTreeMap::new(),
             },
             in_progress: Vec::new(),
+            needed_blocks: BTreeSet::new(),
             mode,
         }
     }
 
     fn lower(mut self, root: &'static Shape) -> Result<Lowered<BlockId, SymbolicOp>, HashError> {
-        let root_id = HashBlockId::Shape(root);
-        self.lower_shape(root)?;
-        self.lowered.program = self
-            .lowered
-            .blocks
-            .get(&root_id)
-            .expect("root shape was lowered into a block")
-            .clone();
+        self.lowered.program = self.lower_shape(root)?;
         Ok(self.lowered)
     }
 
     fn lower_shape(&mut self, shape: &'static Shape) -> Result<Program<SymbolicOp>, HashError> {
         let block_id = HashBlockId::Shape(shape);
         if self.lowered.blocks.contains_key(&block_id) || self.in_progress.contains(&shape) {
+            if self.in_progress.contains(&shape) {
+                self.needed_blocks.insert(block_id);
+            }
             return Ok(vec![WeavyOp::Control(ControlOp::CallBlock {
                 block: block_id,
                 base_offset: 0,
@@ -372,11 +370,10 @@ impl Lowering {
         self.in_progress.push(shape);
         let program = self.lower_shape_body(shape)?;
         self.in_progress.pop();
-        self.lowered.blocks.insert(block_id, program);
-        Ok(vec![WeavyOp::Control(ControlOp::CallBlock {
-            block: block_id,
-            base_offset: 0,
-        })])
+        if self.needed_blocks.remove(&block_id) {
+            self.lowered.blocks.insert(block_id, program.clone());
+        }
+        Ok(program)
     }
 
     fn lower_shape_body(

--- a/facet-hash/tests/basic.rs
+++ b/facet-hash/tests/basic.rs
@@ -31,6 +31,12 @@ struct Nested {
     maybe: Result<Option<u16>, String>,
 }
 
+#[derive(Clone, Debug, Facet)]
+struct Node {
+    value: u32,
+    next: Option<Box<Node>>,
+}
+
 #[derive(Default)]
 struct RecordingHasher {
     bytes: Vec<u8>,
@@ -194,12 +200,31 @@ fn plan_reports_canonical_effect_stats() {
 
     let stats = plan.effect_stats();
 
-    assert!(stats.block_count > 0);
+    assert_eq!(stats.block_count, 0);
     assert!(stats.total.intrinsic_op_count > 0);
     assert!(stats.total.sink_write_count > 0);
     assert!(stats.total.typed_memory_read_count > 0);
     assert!(stats.total.barrier_count > 0);
     assert_eq!(stats.total.opaque_count, 0);
+}
+
+#[test]
+fn recursive_shapes_still_lower_blocks() {
+    let plan = HashPlan::<Node>::build().unwrap();
+    let short = Node {
+        value: 1,
+        next: None,
+    };
+    let long = Node {
+        value: 1,
+        next: Some(Box::new(Node {
+            value: 2,
+            next: None,
+        })),
+    };
+
+    assert!(plan.effect_stats().block_count > 0);
+    assert_ne!(plan.hash64(&short).unwrap(), plan.hash64(&long).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- inline acyclic facet-hash shape programs instead of routing every shape through a canonical block call
- keep canonical blocks for recursive backedges, with a recursive `Node` coverage case
- remove ordinary `CallBlock` / `after_return` interpreter overhead from reused hash plans

## Stax benchmarks
Stax run: `18`, bench binary: `facet-hash/benches/reuse.rs`, single thread, `--min-time 0.5`.

Prior-to-new Weavy medians:

| case | prior | new | change |
|---|---:|---:|---:|
| point value | 63.54 ns | 53.98 ns | 15% faster |
| person value | 366.9 ns | 312.1 ns | 15% faster |
| hash company value | 515.3 ns | 424.1 ns | 18% faster |
| company structural | 749.7 ns | 624.6 ns | 17% faster |

Current baseline-relative medians:

| case | baseline | Weavy | relative |
|---|---:|---:|---:|
| point native Hash | 6.204 ns | 53.98 ns | 8.7x slower |
| person native Hash | 30.05 ns | 312.1 ns | 10.4x slower |
| hash-company native Hash | 54.3 ns | 424.1 ns | 7.8x slower |
| company Peek structural | 249.6 ns | 624.6 ns | 2.5x slower |

`stax top --run 18 --limit 20` shows the expected shift: interpreter frame traffic dropped, and the profile is increasingly dominated by SipHash writes plus `HashPlan::hash64`.

## Verification
- `cargo check -p facet-hash --all-targets --message-format=short`
- `cargo nextest run -p facet-hash`
- `cargo clippy -p facet-hash --all-targets --message-format=short -- -D warnings`
- `cargo fmt --all --check`
- `cargo doc -p facet-hash --no-deps --message-format=short`
- `git diff --check`
- pre-push hook: passed
