### PR TITLE
Specialize ordered scalar roots in facet-json JIT

### DIFF
--- a/facet-json/benches/typeplan_reuse.rs
+++ b/facet-json/benches/typeplan_reuse.rs
@@ -513,6 +513,11 @@ fn float_point_weavy_reused_plan(bencher: Bencher) {
 }
 
 #[divan::bench]
+fn float_point_weavy_jit_reused_plan(bencher: Bencher) {
+    bench_weavy_jit_reused_plan::<FloatPoint>(bencher, FLOAT_POINT_JSON);
+}
+
+#[divan::bench]
 fn float_point_serde_json(bencher: Bencher) {
     bench_serde_json::<FloatPoint>(bencher, FLOAT_POINT_JSON);
 }
@@ -607,6 +612,11 @@ fn wide_scalars_skipped_unknown_serde_json(bencher: Bencher) {
 #[divan::bench]
 fn default_scalars_missing_weavy_reused_plan(bencher: Bencher) {
     bench_weavy_reused_plan::<DefaultScalars>(bencher, DEFAULT_SCALARS_MISSING_JSON);
+}
+
+#[divan::bench]
+fn default_scalars_missing_weavy_jit_reused_plan(bencher: Bencher) {
+    bench_weavy_jit_reused_plan::<DefaultScalars>(bencher, DEFAULT_SCALARS_MISSING_JSON);
 }
 
 #[divan::bench]

--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -254,7 +254,7 @@ enum ContextState {
     Array(ArrayState),
 }
 
-struct OrderedI32ObjectProbeSave {
+struct OrderedObjectProbeSave {
     scanner: Scanner,
     stack_len: usize,
     stack_top: Option<ContextState>,
@@ -1470,8 +1470,63 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     }
 
     #[inline(never)]
-    fn save_ordered_i32_object_probe(&self) -> OrderedI32ObjectProbeSave {
-        OrderedI32ObjectProbeSave {
+    pub(crate) fn try_consume_ordered_i32_object(
+        &mut self,
+        expected: &[&str],
+        spans: &mut [Span],
+        values: &mut [i32],
+    ) -> Result<bool, ParseError> {
+        debug_assert_eq!(expected.len(), spans.len());
+        debug_assert_eq!(expected.len(), values.len());
+
+        if expected.is_empty() || self.state.event_peek.is_some() {
+            return Ok(false);
+        }
+
+        let save = self.save_ordered_object_probe();
+        self.consume_object_start_fast()?;
+        let matched = self.try_consume_ordered_i32_object_fields_inner(expected, spans, values)?;
+        if !matched {
+            self.restore_ordered_object_probe(save);
+        }
+        Ok(matched)
+    }
+
+    pub(crate) fn try_consume_ordered_scalar_object_with<E, W>(
+        &mut self,
+        expected: &[&str],
+        mut consume: W,
+    ) -> Result<bool, E>
+    where
+        E: From<ParseError>,
+        W: FnMut(
+            &JsonParser<'de, TRUSTED_UTF8>,
+            usize,
+            Span,
+            scanner::SpannedToken,
+        ) -> Result<(), E>,
+    {
+        if expected.is_empty() || self.state.event_peek.is_some() {
+            return Ok(false);
+        }
+
+        let save = self.save_ordered_object_probe();
+        self.consume_object_start_fast().map_err(E::from)?;
+        let matched = self.try_consume_ordered_scalar_object_inner(expected, &mut consume)?;
+        if !matched {
+            self.restore_ordered_object_probe(save);
+        }
+        Ok(matched)
+    }
+
+    #[inline(never)]
+    fn save_ordered_i32_object_probe(&self) -> OrderedObjectProbeSave {
+        self.save_ordered_object_probe()
+    }
+
+    #[inline(never)]
+    fn save_ordered_object_probe(&self) -> OrderedObjectProbeSave {
+        OrderedObjectProbeSave {
             scanner: self.scanner.clone(),
             stack_len: self.state.stack.len(),
             stack_top: self.state.stack.last().cloned(),
@@ -1483,7 +1538,12 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     }
 
     #[cold]
-    fn restore_ordered_i32_object_probe(&mut self, save: OrderedI32ObjectProbeSave) {
+    fn restore_ordered_i32_object_probe(&mut self, save: OrderedObjectProbeSave) {
+        self.restore_ordered_object_probe(save);
+    }
+
+    #[cold]
+    fn restore_ordered_object_probe(&mut self, save: OrderedObjectProbeSave) {
         self.scanner = save.scanner;
         self.state.stack.truncate(save.stack_len);
         if let Some(top) = save.stack_top {
@@ -1546,6 +1606,80 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
             return Ok(false);
         }
         if self.consume_punctuation_token(b'}')?.is_none() {
+            return Ok(false);
+        }
+        self.state.stack.pop();
+        self.finish_value_in_parent();
+        Ok(true)
+    }
+
+    #[inline(never)]
+    fn try_consume_ordered_scalar_object_inner<E, W>(
+        &mut self,
+        expected: &[&str],
+        consume: &mut W,
+    ) -> Result<bool, E>
+    where
+        E: From<ParseError>,
+        W: FnMut(
+            &JsonParser<'de, TRUSTED_UTF8>,
+            usize,
+            Span,
+            scanner::SpannedToken,
+        ) -> Result<(), E>,
+    {
+        for (index, expected) in expected.iter().copied().enumerate() {
+            if index > 0 {
+                if self.determine_action() != NextAction::ObjectComma {
+                    return Ok(false);
+                }
+                if self
+                    .consume_punctuation_token(b',')
+                    .map_err(E::from)?
+                    .is_none()
+                {
+                    return Ok(false);
+                }
+                if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                    *state = ObjectState::KeyOrEnd;
+                } else {
+                    return Ok(false);
+                }
+            }
+
+            if self.determine_action() != NextAction::ObjectKey {
+                return Ok(false);
+            }
+
+            let Some(span) = self
+                .try_consume_exact_string_token(expected)
+                .map_err(E::from)?
+            else {
+                return Ok(false);
+            };
+            self.expect_colon_token().map_err(E::from)?;
+            if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                *state = ObjectState::Value;
+            } else {
+                return Ok(false);
+            }
+
+            let token = self.consume_spanned_token().map_err(E::from)?;
+            self.validate_scalar_token(&token, "scalar")
+                .map_err(E::from)?;
+            self.state.root_started = true;
+            self.finish_value_in_parent();
+            consume(self, index, span, token)?;
+        }
+
+        if self.determine_action() != NextAction::ObjectComma {
+            return Ok(false);
+        }
+        if self
+            .consume_punctuation_token(b'}')
+            .map_err(E::from)?
+            .is_none()
+        {
             return Ok(false);
         }
         self.state.stack.pop();

--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -1470,6 +1470,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     }
 
     #[inline(never)]
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
     pub(crate) fn try_consume_ordered_i32_object(
         &mut self,
         expected: &[&str],
@@ -1492,6 +1493,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         Ok(matched)
     }
 
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
     pub(crate) fn try_consume_ordered_scalar_object_with<E, W>(
         &mut self,
         expected: &[&str],
@@ -1614,6 +1616,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     }
 
     #[inline(never)]
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
     fn try_consume_ordered_scalar_object_inner<E, W>(
         &mut self,
         expected: &[&str],

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -10,6 +10,8 @@ use core::alloc::Layout;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::str::FromStr;
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+use core::sync::atomic::{AtomicU8, Ordering};
 
 use facet_core::{
     Def, DefaultInPlaceFn, DefaultSource, Facet, Field, ListDef, OptionDef, PointerDef, PtrMut,
@@ -297,16 +299,17 @@ where
     where
         for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
     {
+        let mut slot = MaybeUninit::<T>::uninit();
+        let root = PtrUninit::from_maybe_uninit(&mut slot);
+
         #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
-        if let Some(native) = &self.native {
-            let mut slot = MaybeUninit::<T>::uninit();
-            let root = PtrUninit::from_maybe_uninit(&mut slot);
+        if let Some(native) = &self.native
+            && native.should_enter()
+        {
             native.run(parser, root)?;
             return Ok(unsafe { slot.assume_init() });
         }
 
-        let mut slot = MaybeUninit::<T>::uninit();
-        let root = PtrUninit::from_maybe_uninit(&mut slot);
         let mut interp = JsonInterp::new(parser, root);
         if let Err(err) = weavy::run_dense(&self.lowered, &mut interp) {
             return Err(run_error(err));
@@ -336,9 +339,14 @@ unsafe impl Sync for JsonNativePlan {}
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
 struct JsonNativeScalarStructInfo {
     shape: &'static Shape,
+    ordered_names: Box<[&'static str]>,
     fields: Box<[ScalarFieldPlan]>,
     dispatch: Option<RawFieldDispatch>,
+    ordered_probe_skip: AtomicU8,
 }
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+const ORDERED_PROBE_BACKOFF: u8 = u8::MAX;
 
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
 struct JsonNativeState {
@@ -362,10 +370,25 @@ impl JsonNativePlan {
             return Err("JSON native JIT currently supports root scalar structs only");
         };
 
+        let fields = fields.clone();
+        if fields
+            .iter()
+            .any(|field| !matches!(field.missing, MissingField::Required))
+        {
+            return Err("JSON native JIT currently supports required scalar struct fields only");
+        }
+
+        let ordered_names = fields
+            .iter()
+            .map(|field| field.name)
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
         let scalar_structs = vec![JsonNativeScalarStructInfo {
             shape,
-            fields: fields.clone(),
+            ordered_names,
+            fields,
             dispatch: dispatch.clone(),
+            ordered_probe_skip: AtomicU8::new(0),
         }]
         .into_boxed_slice();
         let calls = vec![weavy::jit::HostCallInfo {
@@ -386,6 +409,12 @@ impl JsonNativePlan {
             calls,
             scalar_structs,
         })
+    }
+
+    fn should_enter(&self) -> bool {
+        self.scalar_structs
+            .first()
+            .is_none_or(JsonNativeScalarStructInfo::should_enter_native)
     }
 
     fn run<const TRUSTED_UTF8: bool>(
@@ -448,10 +477,168 @@ impl JsonNativeState {
         for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
     {
         let parser = unsafe { &mut *self.parser.cast::<JsonParser<'_, TRUSTED_UTF8>>() };
+        let can_probe_ordered = tiny_i32_struct_fields_are_fusible(&info.fields)
+            || info.fields.len() <= u64::BITS as usize;
+        if can_probe_ordered {
+            if self.try_read_ordered_i32_scalar_struct(parser, info)? {
+                info.record_ordered_probe(true);
+                return Ok(());
+            }
+
+            if self.try_read_ordered_scalar_struct(parser, info)? {
+                info.record_ordered_probe(true);
+                return Ok(());
+            }
+
+            info.record_ordered_probe(false);
+        }
+
+        self.read_scalar_struct_interpreted(parser, info)
+    }
+
+    fn try_read_ordered_i32_scalar_struct<const TRUSTED_UTF8: bool>(
+        &mut self,
+        parser: &mut JsonParser<'_, TRUSTED_UTF8>,
+        info: &JsonNativeScalarStructInfo,
+    ) -> Result<bool, DeserializeError> {
+        if !tiny_i32_struct_fields_are_fusible(&info.fields) {
+            return Ok(false);
+        }
+
+        let mut spans = [Span { offset: 0, len: 0 }; TINY_SCALAR_STRUCT_MAX_FIELDS];
+        let mut values = [0i32; TINY_SCALAR_STRUCT_MAX_FIELDS];
+        let len = info.fields.len();
+        if !parser.try_consume_ordered_i32_object(
+            &info.ordered_names,
+            &mut spans[..len],
+            &mut values[..len],
+        )? {
+            return Ok(false);
+        }
+
+        let mut guard = NativeScalarStructGuard::new(self.base, &info.fields);
+        for (index, field) in info.fields.iter().copied().enumerate() {
+            let field_ptr = unsafe { self.base.field_uninit(field.offset) };
+            unsafe {
+                field_ptr.put(values[index]);
+            }
+            guard.mark(index);
+        }
+        guard.finish();
+        Ok(true)
+    }
+
+    fn try_read_ordered_scalar_struct<const TRUSTED_UTF8: bool>(
+        &mut self,
+        parser: &mut JsonParser<'_, TRUSTED_UTF8>,
+        info: &JsonNativeScalarStructInfo,
+    ) -> Result<bool, DeserializeError>
+    where
+        for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
+    {
+        if info.fields.len() > u64::BITS as usize {
+            return Ok(false);
+        }
+
+        let mut guard = NativeScalarStructGuard::new(self.base, &info.fields);
+        let matched = parser.try_consume_ordered_scalar_object_with(
+            &info.ordered_names,
+            |parser, index, _, token| {
+                let field = &info.fields[index];
+                let field_ptr = unsafe { self.base.field_uninit(field.offset) };
+                parser.write_scalar_input_preselected(
+                    field,
+                    field_ptr,
+                    JsonScalarInput::Raw(token),
+                )?;
+                guard.mark(index);
+                Ok::<(), DeserializeError>(())
+            },
+        )?;
+        if !matched {
+            return Ok(false);
+        }
+        guard.finish();
+        Ok(true)
+    }
+
+    fn read_scalar_struct_interpreted<const TRUSTED_UTF8: bool>(
+        &mut self,
+        parser: &mut JsonParser<'_, TRUSTED_UTF8>,
+        info: &JsonNativeScalarStructInfo,
+    ) -> Result<(), DeserializeError>
+    where
+        for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
+    {
         let mut interp = JsonInterp::new(parser, self.base);
         interp.read_scalar_struct(info.shape, &info.fields, info.dispatch.as_ref())?;
         interp.finish_success();
         Ok(())
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+impl JsonNativeScalarStructInfo {
+    fn should_enter_native(&self) -> bool {
+        let skip = self.ordered_probe_skip.load(Ordering::Relaxed);
+        if skip == 0 {
+            return true;
+        }
+
+        self.ordered_probe_skip
+            .store(skip.saturating_sub(1), Ordering::Relaxed);
+        false
+    }
+
+    fn record_ordered_probe(&self, matched: bool) {
+        self.ordered_probe_skip.store(
+            if matched { 0 } else { ORDERED_PROBE_BACKOFF },
+            Ordering::Relaxed,
+        );
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+struct NativeScalarStructGuard<'program> {
+    base: PtrUninit,
+    fields: &'program [ScalarFieldPlan],
+    initialized: u64,
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+impl<'program> NativeScalarStructGuard<'program> {
+    fn new(base: PtrUninit, fields: &'program [ScalarFieldPlan]) -> Self {
+        debug_assert!(fields.len() <= u64::BITS as usize);
+        Self {
+            base,
+            fields,
+            initialized: 0,
+        }
+    }
+
+    fn mark(&mut self, index: usize) {
+        self.initialized |= struct_seen_bit(index);
+    }
+
+    fn finish(self) {
+        core::mem::forget(self);
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+impl Drop for NativeScalarStructGuard<'_> {
+    fn drop(&mut self) {
+        for index in (0..self.fields.len()).rev() {
+            if (self.initialized & struct_seen_bit(index)) == 0 {
+                continue;
+            }
+
+            let field = self.fields[index];
+            let ptr = unsafe { self.base.field_init(field.offset) };
+            unsafe {
+                let _ = field.shape.call_drop_in_place(ptr);
+            }
+        }
     }
 }
 

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -257,12 +257,128 @@ fn weavy_jit_plan_reports_fallback_for_unsupported_root_shape() {
 }
 
 #[test]
+fn weavy_jit_plan_reports_fallback_for_defaulted_scalar_struct() {
+    let plan = facet_json::JsonWeavyPlan::<WideDefaultStruct>::build_jit().unwrap();
+
+    assert_eq!(
+        plan.active_backend(),
+        facet_json::JsonWeavyActiveBackend::Interpreter
+    );
+
+    let report = plan.jit_fallback_report();
+    assert!(!report.is_empty(), "{report:?}");
+    assert_eq!(report.records[0].path, "$");
+    let expected_reason = if !cfg!(feature = "jit") {
+        "facet-json was built without its jit feature"
+    } else if !cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        "native JIT is not enabled for this build target"
+    } else {
+        "JSON native JIT currently supports required scalar struct fields only"
+    };
+    assert_eq!(report.records[0].reason, expected_reason);
+}
+
+#[test]
 fn weavy_jit_helpers_deserialize_through_jit_requested_plan_slot() {
     let from_str: Point = facet_json::from_str_weavy_jit(r#"{"x":1,"y":2}"#).unwrap();
     let from_slice: Point = facet_json::from_slice_weavy_jit(br#"{"x":3,"y":4}"#).unwrap();
 
     assert_eq!(from_str, Point { x: 1, y: 2 });
     assert_eq!(from_slice, Point { x: 3, y: 4 });
+}
+
+#[test]
+fn weavy_jit_scalar_struct_handles_ordered_wide_scalars() {
+    let plan = facet_json::JsonWeavyPlan::<WideScalarStruct>::build_jit().unwrap();
+    let got = plan
+        .from_str(
+            r#"{"a":1,"b":2,"c":3,"d":4,"e":-5,"f":-6,"g":-7,"h":-8,"i":9,"j":-10,"k":true,"l":11.5}"#,
+        )
+        .unwrap();
+
+    assert_eq!(
+        got,
+        WideScalarStruct {
+            a: 1,
+            b: 2,
+            c: 3,
+            d: 4,
+            e: -5,
+            f: -6,
+            g: -7,
+            h: -8,
+            i: 9,
+            j: -10,
+            k: true,
+            l: 11.5,
+        }
+    );
+}
+
+#[test]
+fn weavy_jit_scalar_struct_falls_back_for_non_ordered_objects() {
+    let plan = facet_json::JsonWeavyPlan::<WideScalarStruct>::build_jit().unwrap();
+    let out_of_order = plan
+        .from_str(
+            r#"{"l":11.5,"k":true,"j":-10,"i":9,"h":-8,"g":-7,"f":-6,"e":-5,"d":4,"c":3,"b":2,"a":1}"#,
+        )
+        .unwrap();
+    let skipped_unknown = plan
+        .from_str(
+            r#"{"a":1,"unknown_scalar":12345,"b":2,"unknown_array":[1,2,3],"c":3,"unknown_object":{"nested":true},"d":4,"e":-5,"f":-6,"g":-7,"h":-8,"i":9,"j":-10,"k":true,"l":11.5}"#,
+        )
+        .unwrap();
+
+    let expected = WideScalarStruct {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+        e: -5,
+        f: -6,
+        g: -7,
+        h: -8,
+        i: 9,
+        j: -10,
+        k: true,
+        l: 11.5,
+    };
+    assert_eq!(out_of_order, expected);
+    assert_eq!(skipped_unknown, expected);
+}
+
+#[test]
+fn weavy_jit_scalar_struct_falls_back_for_missing_defaults_and_duplicates() {
+    let defaults = facet_json::JsonWeavyPlan::<WideDefaultStruct>::build_jit()
+        .unwrap()
+        .from_str(r#"{"a":1,"d":4,"l":11.5}"#)
+        .unwrap();
+    assert_eq!(
+        defaults,
+        WideDefaultStruct {
+            a: 1,
+            b: 0,
+            c: 0,
+            d: 4,
+            e: 0,
+            f: 0,
+            g: 0,
+            h: 0,
+            i: 0,
+            j: 0,
+            k: false,
+            l: 11.5,
+        }
+    );
+
+    let err = facet_json::JsonWeavyPlan::<Point>::build_jit()
+        .unwrap()
+        .from_str(r#"{"x":1,"y":2,"x":3}"#)
+        .unwrap_err();
+    assert!(matches!(
+        err.kind,
+        DeserializeErrorKind::DuplicateField { ref field, .. } if field == "x"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add transactional ordered-object parser probes for native scalar-struct roots
- make the facet-json native path write ordered scalar roots directly with init-guard cleanup
- add adaptive native bypass after ordered misses so out-of-order and skipped-field data falls back to the interpreter path without repeated probe tax
- keep defaulted scalar roots on interpreter fallback and report that explicitly
- add JIT parity tests and benchmark rows for float/default scalar shapes

## Benchmarks
`target/release/deps/typeplan_reuse-20d2ec0a5121a148 --bench --min-time 2 --threads 1 ...`

Local Apple Silicon, `facet-json --all-features`, Divan means shown. Point medians are near timer precision, so ratios use means.

| case | serde | interp | JIT | JIT/serde | JIT vs interp |
|---|---:|---:|---:|---:|---:|
| point ordered | 41.85 ns | 70.2 ns | 61.95 ns | 1.48x | -11.8% |
| float ordered | 63.68 ns | 163.6 ns | 109.0 ns | 1.71x | -33.4% |
| wide ordered | 222.7 ns | 412.0 ns | 274.1 ns | 1.23x | -33.5% |
| wide out-of-order | 215.2 ns | 493.8 ns | 497.4 ns | 2.31x | +0.7% |
| wide skipped unknown | 342.1 ns | 653.9 ns | 658.6 ns | 1.93x | +0.7% |
| default missing, native off | 64.62 ns | 171.3 ns | 174.3 ns | 2.70x | +1.8% |

## Stax
- ordered wide JIT top frames are `JsonParser::try_consume_ordered_scalar_object_inner`, scanner token/key handling, punctuation, and scalar writes
- out-of-order JIT profiles return to `JsonInterp::read_scalar_struct`, confirming the adaptive bypass behavior

## Verification
- `cargo fmt --check`
- `cargo clippy -p facet-json --all-features --all-targets --message-format=short -- -D warnings`
- `cargo nextest run -p facet-json --all-features --no-fail-fast` - 414 passed
- `RUSTDOCFLAGS="-D warnings" cargo doc -p facet-json --no-deps --all-features`
- `cargo bench -p facet-json --all-features --bench typeplan_reuse --no-run`
- `stax record` for wide ordered, point/float, and wide out-of-order JIT rows