### PR TITLE
Specialize scalar struct lists in facet-json JIT

### DIFF
--- a/facet-json/benches/typeplan_reuse.rs
+++ b/facet-json/benches/typeplan_reuse.rs
@@ -131,6 +131,8 @@ struct DefaultScalars {
 // =============================================================================
 
 const POINT_JSON: &str = r#"{"x": 10, "y": 20}"#;
+const POINT_LIST_JSON: &str =
+    r#"[{"x":10,"y":20},{"x":30,"y":40},{"x":50,"y":60},{"x":70,"y":80}]"#;
 
 const PERSON_JSON: &str = r#"{
     "name": "Alice",
@@ -155,6 +157,12 @@ const COMPANY_JSON: &str = r#"{
 }"#;
 
 const FLOAT_POINT_JSON: &str = r#"{"x": 12.5, "y": -0.03125, "z": 9000.125}"#;
+const FLOAT_POINT_LIST_JSON: &str = r#"[
+    {"x": 12.5, "y": -0.03125, "z": 9000.125},
+    {"x": -4.25, "y": 2.5, "z": 0.125},
+    {"x": 100.0, "y": -200.5, "z": 300.75},
+    {"x": 0.0, "y": 1.0, "z": -1.0}
+]"#;
 
 const SENSOR_FRAME_JSON: &str = r#"{
     "id": 9001,
@@ -180,6 +188,12 @@ const WIDE_SCALARS_JSON: &str = r#"{
     "l": 11.5
 }"#;
 
+const WIDE_SCALARS_LIST_JSON: &str = r#"[
+    {"a":1,"b":2,"c":3,"d":4,"e":-5,"f":-6,"g":-7,"h":-8,"i":9,"j":-10,"k":true,"l":11.5},
+    {"a":12,"b":13,"c":14,"d":15,"e":-16,"f":-17,"g":-18,"h":-19,"i":20,"j":-21,"k":false,"l":22.5},
+    {"a":23,"b":24,"c":25,"d":26,"e":-27,"f":-28,"g":-29,"h":-30,"i":31,"j":-32,"k":true,"l":33.5}
+]"#;
+
 const WIDE_SCALARS_OUT_OF_ORDER_JSON: &str = r#"{
     "l": 11.5,
     "k": true,
@@ -194,6 +208,12 @@ const WIDE_SCALARS_OUT_OF_ORDER_JSON: &str = r#"{
     "b": 2,
     "a": 1
 }"#;
+
+const WIDE_SCALARS_LIST_OUT_OF_ORDER_JSON: &str = r#"[
+    {"a":1,"b":2,"c":3,"d":4,"e":-5,"f":-6,"g":-7,"h":-8,"i":9,"j":-10,"k":true,"l":11.5},
+    {"l":22.5,"k":false,"j":-21,"i":20,"h":-19,"g":-18,"f":-17,"e":-16,"d":15,"c":14,"b":13,"a":12},
+    {"a":23,"b":24,"c":25,"d":26,"e":-27,"f":-28,"g":-29,"h":-30,"i":31,"j":-32,"k":true,"l":33.5}
+]"#;
 
 const WIDE_SCALARS_SKIPPED_UNKNOWN_JSON: &str = r#"{
     "a": 1,
@@ -212,6 +232,12 @@ const WIDE_SCALARS_SKIPPED_UNKNOWN_JSON: &str = r#"{
     "k": true,
     "l": 11.5
 }"#;
+
+const WIDE_SCALARS_LIST_SKIPPED_UNKNOWN_JSON: &str = r#"[
+    {"a":1,"b":2,"c":3,"d":4,"e":-5,"f":-6,"g":-7,"h":-8,"i":9,"j":-10,"k":true,"l":11.5},
+    {"a":12,"unknown_scalar":12345,"b":13,"unknown_array":[1,2,3,4],"c":14,"unknown_object":{"nested":true,"items":[1,2,3]},"d":15,"e":-16,"f":-17,"g":-18,"h":-19,"i":20,"j":-21,"k":false,"l":22.5},
+    {"a":23,"b":24,"c":25,"d":26,"e":-27,"f":-28,"g":-29,"h":-30,"i":31,"j":-32,"k":true,"l":33.5}
+]"#;
 
 const DEFAULT_SCALARS_MISSING_JSON: &str = r#"{
     "a": 1,
@@ -359,6 +385,25 @@ fn point_serde_json_from_slice(bencher: Bencher) {
         let result: Point = black_box(serde_json::from_slice(black_box(json)).unwrap());
         black_box(result)
     });
+}
+
+// =============================================================================
+// Benchmarks - Vec<Point> (ordered scalar struct list)
+// =============================================================================
+
+#[divan::bench]
+fn point_list_weavy_reused_plan(bencher: Bencher) {
+    bench_weavy_reused_plan::<Vec<Point>>(bencher, POINT_LIST_JSON);
+}
+
+#[divan::bench]
+fn point_list_weavy_jit_reused_plan(bencher: Bencher) {
+    bench_weavy_jit_reused_plan::<Vec<Point>>(bencher, POINT_LIST_JSON);
+}
+
+#[divan::bench]
+fn point_list_serde_json(bencher: Bencher) {
+    bench_serde_json::<Vec<Point>>(bencher, POINT_LIST_JSON);
 }
 
 // =============================================================================
@@ -523,6 +568,25 @@ fn float_point_serde_json(bencher: Bencher) {
 }
 
 // =============================================================================
+// Benchmarks - Vec<FloatPoint> (float-heavy scalar struct list)
+// =============================================================================
+
+#[divan::bench]
+fn float_point_list_weavy_reused_plan(bencher: Bencher) {
+    bench_weavy_reused_plan::<Vec<FloatPoint>>(bencher, FLOAT_POINT_LIST_JSON);
+}
+
+#[divan::bench]
+fn float_point_list_weavy_jit_reused_plan(bencher: Bencher) {
+    bench_weavy_jit_reused_plan::<Vec<FloatPoint>>(bencher, FLOAT_POINT_LIST_JSON);
+}
+
+#[divan::bench]
+fn float_point_list_serde_json(bencher: Bencher) {
+    bench_serde_json::<Vec<FloatPoint>>(bencher, FLOAT_POINT_LIST_JSON);
+}
+
+// =============================================================================
 // Benchmarks - SensorFrame (numeric arrays)
 // =============================================================================
 
@@ -603,6 +667,58 @@ fn wide_scalars_skipped_unknown_weavy_jit_reused_plan(bencher: Bencher) {
 #[divan::bench]
 fn wide_scalars_skipped_unknown_serde_json(bencher: Bencher) {
     bench_serde_json::<WideScalars>(bencher, WIDE_SCALARS_SKIPPED_UNKNOWN_JSON);
+}
+
+// =============================================================================
+// Benchmarks - Vec<WideScalars> (wide scalar struct list)
+// =============================================================================
+
+#[divan::bench]
+fn wide_scalars_list_weavy_reused_plan(bencher: Bencher) {
+    bench_weavy_reused_plan::<Vec<WideScalars>>(bencher, WIDE_SCALARS_LIST_JSON);
+}
+
+#[divan::bench]
+fn wide_scalars_list_weavy_jit_reused_plan(bencher: Bencher) {
+    bench_weavy_jit_reused_plan::<Vec<WideScalars>>(bencher, WIDE_SCALARS_LIST_JSON);
+}
+
+#[divan::bench]
+fn wide_scalars_list_serde_json(bencher: Bencher) {
+    bench_serde_json::<Vec<WideScalars>>(bencher, WIDE_SCALARS_LIST_JSON);
+}
+
+#[divan::bench]
+fn wide_scalars_list_out_of_order_weavy_reused_plan(bencher: Bencher) {
+    bench_weavy_reused_plan::<Vec<WideScalars>>(bencher, WIDE_SCALARS_LIST_OUT_OF_ORDER_JSON);
+}
+
+#[divan::bench]
+fn wide_scalars_list_out_of_order_weavy_jit_reused_plan(bencher: Bencher) {
+    bench_weavy_jit_reused_plan::<Vec<WideScalars>>(bencher, WIDE_SCALARS_LIST_OUT_OF_ORDER_JSON);
+}
+
+#[divan::bench]
+fn wide_scalars_list_out_of_order_serde_json(bencher: Bencher) {
+    bench_serde_json::<Vec<WideScalars>>(bencher, WIDE_SCALARS_LIST_OUT_OF_ORDER_JSON);
+}
+
+#[divan::bench]
+fn wide_scalars_list_skipped_unknown_weavy_reused_plan(bencher: Bencher) {
+    bench_weavy_reused_plan::<Vec<WideScalars>>(bencher, WIDE_SCALARS_LIST_SKIPPED_UNKNOWN_JSON);
+}
+
+#[divan::bench]
+fn wide_scalars_list_skipped_unknown_weavy_jit_reused_plan(bencher: Bencher) {
+    bench_weavy_jit_reused_plan::<Vec<WideScalars>>(
+        bencher,
+        WIDE_SCALARS_LIST_SKIPPED_UNKNOWN_JSON,
+    );
+}
+
+#[divan::bench]
+fn wide_scalars_list_skipped_unknown_serde_json(bencher: Bencher) {
+    bench_serde_json::<Vec<WideScalars>>(bencher, WIDE_SCALARS_LIST_SKIPPED_UNKNOWN_JSON);
 }
 
 // =============================================================================

--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -254,7 +254,7 @@ enum ContextState {
     Array(ArrayState),
 }
 
-struct OrderedObjectProbeSave {
+pub(crate) struct OrderedObjectProbeSave {
     scanner: Scanner,
     stack_len: usize,
     stack_top: Option<ContextState>,
@@ -1519,6 +1519,16 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
             self.restore_ordered_object_probe(save);
         }
         Ok(matched)
+    }
+
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    pub(crate) fn save_native_probe(&self) -> OrderedObjectProbeSave {
+        self.save_ordered_object_probe()
+    }
+
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    pub(crate) fn restore_native_probe(&mut self, save: OrderedObjectProbeSave) {
+        self.restore_ordered_object_probe(save);
     }
 
     #[inline(never)]

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -306,7 +306,7 @@ where
         if let Some(native) = &self.native
             && native.should_enter()
         {
-            native.run(parser, root)?;
+            native.run(parser, root, &self.lowered)?;
             return Ok(unsafe { slot.assume_init() });
         }
 
@@ -324,7 +324,7 @@ where
 struct JsonNativePlan {
     native: weavy::jit::NativeProgram,
     calls: Box<[weavy::jit::HostCallInfo]>,
-    scalar_structs: Box<[JsonNativeScalarStructInfo]>,
+    root: Box<JsonNativeRootInfo>,
 }
 
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
@@ -337,6 +337,12 @@ unsafe impl Send for JsonNativePlan {}
 unsafe impl Sync for JsonNativePlan {}
 
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+enum JsonNativeRootInfo {
+    ScalarStruct(JsonNativeScalarStructInfo),
+    ScalarStructList(JsonNativeScalarStructListInfo),
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
 struct JsonNativeScalarStructInfo {
     shape: &'static Shape,
     ordered_names: Box<[&'static str]>,
@@ -346,11 +352,20 @@ struct JsonNativeScalarStructInfo {
 }
 
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+struct JsonNativeScalarStructListInfo {
+    list_shape: &'static Shape,
+    list: ListDef,
+    element_layout: Layout,
+    element: JsonNativeScalarStructInfo,
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
 const ORDERED_PROBE_BACKOFF: u8 = u8::MAX;
 
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
 struct JsonNativeState {
     parser: *mut (),
+    lowered: *const DenseLowered<ExecOp>,
     trusted_utf8: bool,
     base: PtrUninit,
     error: Option<DeserializeError>,
@@ -359,18 +374,64 @@ struct JsonNativeState {
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
 impl JsonNativePlan {
     fn compile(lowered: &DenseLowered<ExecOp>) -> Result<Self, &'static str> {
-        let [
-            JsonOp::ReadScalarStruct {
-                shape,
-                fields,
-                dispatch,
-            },
-        ] = lowered.program.as_slice()
-        else {
-            return Err("JSON native JIT currently supports root scalar structs only");
+        let root = match lowered.program.as_slice() {
+            [
+                JsonOp::ReadScalarStruct {
+                    shape,
+                    fields,
+                    dispatch,
+                },
+            ] => JsonNativeRootInfo::ScalarStruct(Self::compile_scalar_struct_info(
+                shape, fields, dispatch,
+            )?),
+            [
+                JsonOp::ReadList {
+                    list_shape,
+                    list,
+                    element_layout,
+                    loop_id,
+                },
+            ] => JsonNativeRootInfo::ScalarStructList(Self::compile_scalar_struct_list_info(
+                lowered,
+                list_shape,
+                *list,
+                *element_layout,
+                *loop_id,
+            )?),
+            _ => {
+                return Err(
+                    "JSON native JIT currently supports root scalar structs or scalar struct lists only",
+                );
+            }
         };
+        let root = Box::new(root);
 
-        let fields = fields.clone();
+        let calls = vec![weavy::jit::HostCallInfo {
+            info: core::ptr::from_ref(&*root).cast(),
+            call: json_native_read_root,
+        }]
+        .into_boxed_slice();
+
+        let mut layout = weavy::jit::StencilLayout::new();
+        let root_chain = layout.start_chain();
+        let hostcall = layout.emit_hostcall(root_chain, core::ptr::from_ref(&calls[0]));
+        let done = layout.emit_done();
+        layout.patch_hostcall_continuation(hostcall, done);
+        let native = weavy::jit::NativeProgram::new(layout, root_chain);
+
+        Ok(Self {
+            native,
+            calls,
+            root,
+        })
+    }
+
+    fn compile_scalar_struct_info(
+        shape: &'static Shape,
+        fields: &[ScalarFieldPlan],
+        dispatch: &Option<RawFieldDispatch>,
+    ) -> Result<JsonNativeScalarStructInfo, &'static str> {
+        let fields = fields.to_vec().into_boxed_slice();
         if fields
             .iter()
             .any(|field| !matches!(field.missing, MissingField::Required))
@@ -383,50 +444,101 @@ impl JsonNativePlan {
             .map(|field| field.name)
             .collect::<Vec<_>>()
             .into_boxed_slice();
-        let scalar_structs = vec![JsonNativeScalarStructInfo {
+
+        Ok(JsonNativeScalarStructInfo {
             shape,
             ordered_names,
             fields,
             dispatch: dispatch.clone(),
             ordered_probe_skip: AtomicU8::new(0),
-        }]
-        .into_boxed_slice();
-        let calls = vec![weavy::jit::HostCallInfo {
-            info: core::ptr::from_ref(&scalar_structs[0]).cast(),
-            call: json_native_read_scalar_struct,
-        }]
-        .into_boxed_slice();
-
-        let mut layout = weavy::jit::StencilLayout::new();
-        let root = layout.start_chain();
-        let hostcall = layout.emit_hostcall(root, core::ptr::from_ref(&calls[0]));
-        let done = layout.emit_done();
-        layout.patch_hostcall_continuation(hostcall, done);
-        let native = weavy::jit::NativeProgram::new(layout, root);
-
-        Ok(Self {
-            native,
-            calls,
-            scalar_structs,
         })
     }
 
+    fn compile_scalar_struct_list_info(
+        lowered: &DenseLowered<ExecOp>,
+        list_shape: &'static Shape,
+        list: ListDef,
+        element_layout: Layout,
+        loop_id: ExecBlock,
+    ) -> Result<JsonNativeScalarStructListInfo, &'static str> {
+        if list.from_raw_parts().is_none() {
+            return Err(
+                "JSON native JIT currently supports raw-adoptable scalar struct lists only",
+            );
+        }
+
+        let loop_program = lowered
+            .blocks
+            .get(loop_id.index())
+            .ok_or("JSON native JIT root list loop block is missing")?;
+        let [
+            JsonOp::ListNext {
+                element_program,
+                element_scalar,
+                element_option_scalar,
+                ..
+            },
+        ] = loop_program.as_slice()
+        else {
+            return Err("JSON native JIT currently supports scalar struct list loops only");
+        };
+        if element_scalar.is_some() || element_option_scalar.is_some() {
+            return Err("JSON native JIT currently supports scalar struct list elements only");
+        }
+
+        let element = Self::compile_scalar_struct_program(lowered, element_program)?;
+
+        Ok(JsonNativeScalarStructListInfo {
+            list_shape,
+            list,
+            element_layout,
+            element,
+        })
+    }
+
+    fn compile_scalar_struct_program(
+        lowered: &DenseLowered<ExecOp>,
+        program: &[ExecOp],
+    ) -> Result<JsonNativeScalarStructInfo, &'static str> {
+        let program = match program {
+            [JsonOp::CallBlock(block)] => lowered
+                .blocks
+                .get(block.index())
+                .ok_or("JSON native JIT scalar struct element block is missing")?
+                .as_slice(),
+            program => program,
+        };
+
+        let [
+            JsonOp::ReadScalarStruct {
+                shape,
+                fields,
+                dispatch,
+            },
+        ] = program
+        else {
+            return Err("JSON native JIT currently supports scalar struct list elements only");
+        };
+
+        Self::compile_scalar_struct_info(shape, fields, dispatch)
+    }
+
     fn should_enter(&self) -> bool {
-        self.scalar_structs
-            .first()
-            .is_none_or(JsonNativeScalarStructInfo::should_enter_native)
+        self.root.should_enter_native()
     }
 
     fn run<const TRUSTED_UTF8: bool>(
         &self,
         parser: &mut JsonParser<'_, TRUSTED_UTF8>,
         base: PtrUninit,
+        lowered: &DenseLowered<ExecOp>,
     ) -> Result<(), DeserializeError>
     where
         for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
     {
         let mut state = JsonNativeState {
             parser: (parser as *mut JsonParser<'_, TRUSTED_UTF8>).cast(),
+            lowered: lowered as *const DenseLowered<ExecOp>,
             trusted_utf8: TRUSTED_UTF8,
             base,
             error: None,
@@ -440,7 +552,7 @@ impl JsonNativePlan {
             entry(&mut cx);
         }
 
-        let _ = (&self.calls, &self.scalar_structs);
+        let _ = (&self.calls, &self.root);
         match state.error {
             Some(error) => Err(error),
             None => Ok(()),
@@ -449,13 +561,13 @@ impl JsonNativePlan {
 }
 
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
-unsafe extern "C" fn json_native_read_scalar_struct(state: *mut (), info: *const ()) -> bool {
+unsafe extern "C" fn json_native_read_root(state: *mut (), info: *const ()) -> bool {
     let state = unsafe { &mut *state.cast::<JsonNativeState>() };
-    let info = unsafe { &*info.cast::<JsonNativeScalarStructInfo>() };
+    let info = unsafe { &*info.cast::<JsonNativeRootInfo>() };
     let result = if state.trusted_utf8 {
-        unsafe { state.read_scalar_struct::<true>(info) }
+        unsafe { state.read_root::<true>(info) }
     } else {
-        unsafe { state.read_scalar_struct::<false>(info) }
+        unsafe { state.read_root::<false>(info) }
     };
 
     match result {
@@ -469,6 +581,23 @@ unsafe extern "C" fn json_native_read_scalar_struct(state: *mut (), info: *const
 
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
 impl JsonNativeState {
+    unsafe fn read_root<const TRUSTED_UTF8: bool>(
+        &mut self,
+        info: &JsonNativeRootInfo,
+    ) -> Result<(), DeserializeError>
+    where
+        for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
+    {
+        match info {
+            JsonNativeRootInfo::ScalarStruct(info) => unsafe {
+                self.read_scalar_struct::<TRUSTED_UTF8>(info)
+            },
+            JsonNativeRootInfo::ScalarStructList(info) => unsafe {
+                self.read_scalar_struct_list::<TRUSTED_UTF8>(info)
+            },
+        }
+    }
+
     unsafe fn read_scalar_struct<const TRUSTED_UTF8: bool>(
         &mut self,
         info: &JsonNativeScalarStructInfo,
@@ -494,6 +623,79 @@ impl JsonNativeState {
         }
 
         self.read_scalar_struct_interpreted(parser, info)
+    }
+
+    unsafe fn read_scalar_struct_list<const TRUSTED_UTF8: bool>(
+        &mut self,
+        info: &JsonNativeScalarStructListInfo,
+    ) -> Result<(), DeserializeError>
+    where
+        for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
+    {
+        let parser = unsafe { &mut *self.parser.cast::<JsonParser<'_, TRUSTED_UTF8>>() };
+        let save = parser.save_native_probe();
+        parser.consume_array_start_fast()?;
+
+        let mut builder = RawArrayBuilder::new(
+            info.element_layout,
+            info.list.t() as *const Shape as *const (),
+            drop_shape_value,
+        );
+        loop {
+            if parser.consume_sequence_end_if_next()? {
+                self.adopt_native_list(info, &mut builder)?;
+                info.record_ordered_probe(true);
+                return Ok(());
+            }
+
+            let slot = builder.next_uninit_slot().map_err(raw_alloc_error)?;
+            let old_base = self.base;
+            self.base = PtrUninit::new(slot);
+            let matched = self
+                .try_read_ordered_i32_scalar_struct(parser, &info.element)
+                .and_then(|matched| {
+                    if matched {
+                        Ok(true)
+                    } else {
+                        self.try_read_ordered_scalar_struct(parser, &info.element)
+                    }
+                });
+            self.base = old_base;
+            let matched = matched?;
+
+            if matched {
+                unsafe {
+                    builder.mark_initialized();
+                }
+                continue;
+            }
+
+            info.record_ordered_probe(false);
+            drop(builder);
+            parser.restore_native_probe(save);
+            return self.read_interpreted(parser);
+        }
+    }
+
+    fn adopt_native_list(
+        &mut self,
+        info: &JsonNativeScalarStructListInfo,
+        builder: &mut RawArrayBuilder,
+    ) -> Result<(), DeserializeError> {
+        let from_raw_parts = info
+            .list
+            .from_raw_parts()
+            .ok_or_else(|| unsupported(info.list_shape, "list from_raw_parts"))?;
+        unsafe {
+            from_raw_parts(
+                self.base,
+                PtrMut::new(builder.ptr()),
+                builder.len(),
+                builder.cap(),
+            );
+        }
+        builder.adopt();
+        Ok(())
     }
 
     fn try_read_ordered_i32_scalar_struct<const TRUSTED_UTF8: bool>(
@@ -575,6 +777,32 @@ impl JsonNativeState {
         interp.finish_success();
         Ok(())
     }
+
+    fn read_interpreted<const TRUSTED_UTF8: bool>(
+        &mut self,
+        parser: &mut JsonParser<'_, TRUSTED_UTF8>,
+    ) -> Result<(), DeserializeError>
+    where
+        for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
+    {
+        let lowered = unsafe { &*self.lowered };
+        let mut interp = JsonInterp::new(parser, self.base);
+        if let Err(err) = weavy::run_dense(lowered, &mut interp) {
+            return Err(run_error(err));
+        }
+        interp.finish_success();
+        Ok(())
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+impl JsonNativeRootInfo {
+    fn should_enter_native(&self) -> bool {
+        match self {
+            Self::ScalarStruct(info) => info.should_enter_native(),
+            Self::ScalarStructList(info) => info.should_enter_native(),
+        }
+    }
 }
 
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
@@ -595,6 +823,17 @@ impl JsonNativeScalarStructInfo {
             if matched { 0 } else { ORDERED_PROBE_BACKOFF },
             Ordering::Relaxed,
         );
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+impl JsonNativeScalarStructListInfo {
+    fn should_enter_native(&self) -> bool {
+        self.element.should_enter_native()
+    }
+
+    fn record_ordered_probe(&self, matched: bool) {
+        self.element.record_ordered_probe(matched);
     }
 }
 

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -251,7 +251,7 @@ fn weavy_jit_plan_reports_fallback_for_unsupported_root_shape() {
     } else if !cfg!(all(target_os = "macos", target_arch = "aarch64")) {
         "native JIT is not enabled for this build target"
     } else {
-        "JSON native JIT currently supports root scalar structs only"
+        "JSON native JIT currently supports root scalar structs or scalar struct lists only"
     };
     assert_eq!(report.records[0].reason, expected_reason);
 }
@@ -288,6 +288,45 @@ fn weavy_jit_helpers_deserialize_through_jit_requested_plan_slot() {
 }
 
 #[test]
+fn weavy_jit_plan_uses_native_for_root_scalar_struct_list_when_available() {
+    let plan = facet_json::JsonWeavyPlan::<Vec<Point>>::build_jit().unwrap();
+    let report = plan.jit_fallback_report();
+    let native_available = cfg!(all(
+        feature = "jit",
+        target_os = "macos",
+        target_arch = "aarch64"
+    ));
+
+    assert_eq!(
+        plan.active_backend(),
+        if native_available {
+            facet_json::JsonWeavyActiveBackend::NativeJit
+        } else {
+            facet_json::JsonWeavyActiveBackend::Interpreter
+        },
+        "{report:?}"
+    );
+
+    let got = plan
+        .from_str(r#"[{"x":1,"y":2},{"x":3,"y":4},{"x":5,"y":6}]"#)
+        .unwrap();
+    assert_eq!(
+        got,
+        vec![
+            Point { x: 1, y: 2 },
+            Point { x: 3, y: 4 },
+            Point { x: 5, y: 6 },
+        ]
+    );
+
+    if native_available {
+        assert!(report.is_empty(), "{report:?}");
+    } else {
+        assert!(!report.is_empty(), "{report:?}");
+    }
+}
+
+#[test]
 fn weavy_jit_scalar_struct_handles_ordered_wide_scalars() {
     let plan = facet_json::JsonWeavyPlan::<WideScalarStruct>::build_jit().unwrap();
     let got = plan
@@ -312,6 +351,50 @@ fn weavy_jit_scalar_struct_handles_ordered_wide_scalars() {
             k: true,
             l: 11.5,
         }
+    );
+}
+
+#[test]
+fn weavy_jit_scalar_struct_list_handles_ordered_wide_scalars() {
+    let plan = facet_json::JsonWeavyPlan::<Vec<WideScalarStruct>>::build_jit().unwrap();
+    let got = plan
+        .from_str(
+            r#"[{"a":1,"b":2,"c":3,"d":4,"e":-5,"f":-6,"g":-7,"h":-8,"i":9,"j":-10,"k":true,"l":11.5},{"a":12,"b":13,"c":14,"d":15,"e":-16,"f":-17,"g":-18,"h":-19,"i":20,"j":-21,"k":false,"l":22.5}]"#,
+        )
+        .unwrap();
+
+    assert_eq!(
+        got,
+        vec![
+            WideScalarStruct {
+                a: 1,
+                b: 2,
+                c: 3,
+                d: 4,
+                e: -5,
+                f: -6,
+                g: -7,
+                h: -8,
+                i: 9,
+                j: -10,
+                k: true,
+                l: 11.5,
+            },
+            WideScalarStruct {
+                a: 12,
+                b: 13,
+                c: 14,
+                d: 15,
+                e: -16,
+                f: -17,
+                g: -18,
+                h: -19,
+                i: 20,
+                j: -21,
+                k: false,
+                l: 22.5,
+            },
+        ]
     );
 }
 
@@ -348,6 +431,54 @@ fn weavy_jit_scalar_struct_falls_back_for_non_ordered_objects() {
 }
 
 #[test]
+fn weavy_jit_scalar_struct_list_falls_back_for_non_ordered_objects() {
+    let plan = facet_json::JsonWeavyPlan::<Vec<WideScalarStruct>>::build_jit().unwrap();
+    let out_of_order = plan
+        .from_str(
+            r#"[{"a":1,"b":2,"c":3,"d":4,"e":-5,"f":-6,"g":-7,"h":-8,"i":9,"j":-10,"k":true,"l":11.5},{"l":22.5,"k":false,"j":-21,"i":20,"h":-19,"g":-18,"f":-17,"e":-16,"d":15,"c":14,"b":13,"a":12}]"#,
+        )
+        .unwrap();
+    let skipped_unknown = plan
+        .from_str(
+            r#"[{"a":1,"b":2,"c":3,"d":4,"e":-5,"f":-6,"g":-7,"h":-8,"i":9,"j":-10,"k":true,"l":11.5},{"a":12,"unknown_scalar":12345,"b":13,"unknown_array":[1,2,3],"c":14,"unknown_object":{"nested":true},"d":15,"e":-16,"f":-17,"g":-18,"h":-19,"i":20,"j":-21,"k":false,"l":22.5}]"#,
+        )
+        .unwrap();
+
+    let expected = vec![
+        WideScalarStruct {
+            a: 1,
+            b: 2,
+            c: 3,
+            d: 4,
+            e: -5,
+            f: -6,
+            g: -7,
+            h: -8,
+            i: 9,
+            j: -10,
+            k: true,
+            l: 11.5,
+        },
+        WideScalarStruct {
+            a: 12,
+            b: 13,
+            c: 14,
+            d: 15,
+            e: -16,
+            f: -17,
+            g: -18,
+            h: -19,
+            i: 20,
+            j: -21,
+            k: false,
+            l: 22.5,
+        },
+    ];
+    assert_eq!(out_of_order, expected);
+    assert_eq!(skipped_unknown, expected);
+}
+
+#[test]
 fn weavy_jit_scalar_struct_falls_back_for_missing_defaults_and_duplicates() {
     let defaults = facet_json::JsonWeavyPlan::<WideDefaultStruct>::build_jit()
         .unwrap()
@@ -374,6 +505,15 @@ fn weavy_jit_scalar_struct_falls_back_for_missing_defaults_and_duplicates() {
     let err = facet_json::JsonWeavyPlan::<Point>::build_jit()
         .unwrap()
         .from_str(r#"{"x":1,"y":2,"x":3}"#)
+        .unwrap_err();
+    assert!(matches!(
+        err.kind,
+        DeserializeErrorKind::DuplicateField { ref field, .. } if field == "x"
+    ));
+
+    let err = facet_json::JsonWeavyPlan::<Vec<Point>>::build_jit()
+        .unwrap()
+        .from_str(r#"[{"x":1,"y":2},{"x":3,"y":4,"x":5}]"#)
         .unwrap_err();
     assert!(matches!(
         err.kind,


### PR DESCRIPTION
## Summary
- extend the facet-json native JIT root recognizer from scalar structs to root lists of required-field scalar structs
- reuse the existing `RawArrayBuilder`/`from_raw_parts` list adoption path for direct slot initialization
- add a scanner-aware native probe save/restore so non-ordered list elements can restore and fall back to the interpreter
- preserve adaptive bypass after ordered misses, now for list roots too
- add integration coverage and Divan rows for ordered and non-ordered scalar-struct lists

## Benchmarks
`target/release/deps/typeplan_reuse-20d2ec0a5121a148 --bench --min-time 2 --threads 1 ...`

Local Apple Silicon, `facet-json --all-features`, Divan means shown.

| case | serde | interp | JIT | JIT/serde | JIT vs interp |
|---|---:|---:|---:|---:|---:|
| Vec<Point> ordered | 146.7 ns | 471.3 ns | 206.3 ns | 1.41x | -56.2% |
| Vec<FloatPoint> ordered | 278.0 ns | 822.6 ns | 426.9 ns | 1.54x | -48.1% |
| Vec<WideScalars> ordered | 593.5 ns | 1.312 us | 746.2 ns | 1.26x | -43.1% |
| Vec<WideScalars> out-of-order | 584.7 ns | 1.387 us | 1.403 us | 2.40x | +1.2% |
| Vec<WideScalars> skipped unknown | 748.6 ns | 1.549 us | 1.538 us | 2.05x | -0.7% |

## Stax
- ordered wide-list JIT: top frames are `JsonParser::try_consume_ordered_scalar_object_inner`, scanner token/key handling, punctuation, and scalar writes; native list plumbing is not a major frame
- out-of-order wide-list JIT: profile returns to `JsonInterp::read_scalar_struct`, confirming the transactional fallback path

## Verification
- `cargo fmt --check`
- `cargo check -p facet-json --all-features --all-targets --message-format=short`
- `cargo clippy -p facet-json --all-features --all-targets --message-format=short -- -D warnings`
- `cargo nextest list -p facet-json --all-features -E ...`
- `cargo nextest run -p facet-json --all-features -E ...` - focused list-JIT tests passed
- `cargo nextest run -p facet-json --all-features --no-fail-fast` - 417 passed
- `cargo check -p facet-json --no-default-features --all-targets --message-format=short`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p facet-json --no-deps --all-features`
- `cargo bench -p facet-json --all-features --bench typeplan_reuse --no-run`
- `stax record` for ordered wide-list JIT and out-of-order wide-list JIT rows