### PR TITLE
Speed up facet-json ordered native JIT probes

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -389,6 +389,42 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     }
 
     #[inline]
+    fn try_consume_ordered_field_prefix(
+        &mut self,
+        expected: &str,
+        require_comma: bool,
+    ) -> Result<Option<Span>, ParseError> {
+        match (require_comma, self.state.stack.last()) {
+            (false, Some(ContextState::Object(ObjectState::KeyOrEnd)))
+            | (true, Some(ContextState::Object(ObjectState::CommaOrEnd))) => {}
+            _ => return Ok(None),
+        }
+
+        let expected_bytes = expected.as_bytes();
+        let span = if let [expected] = expected_bytes {
+            self.scanner
+                .try_consume_one_byte_field_name_colon(self.input, *expected, require_comma)
+        } else {
+            self.scanner.try_consume_exact_field_name_colon(
+                self.input,
+                expected_bytes,
+                require_comma,
+            )
+        }
+        .map_err(scan_error_to_parse_error)?;
+
+        if let Some(span) = span {
+            self.state.last_token_start = span.offset as usize;
+            self.state.scanner_pos = self.scanner.pos();
+            if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
+                *state = ObjectState::Value;
+            }
+        }
+
+        Ok(span)
+    }
+
+    #[inline]
     fn try_consume_i32_number(&mut self) -> Result<Option<(Span, i32)>, ParseError> {
         let value = self
             .scanner
@@ -1080,6 +1116,23 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
     }
 
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    pub(crate) fn consume_array_object_start_fast(&mut self) -> Result<Span, ParseError> {
+        if self.state.event_peek.is_some() {
+            return self.consume_object_start();
+        }
+
+        match self.state.stack.last() {
+            Some(ContextState::Array(ArrayState::ValueOrEnd)) => {
+                self.consume_direct_array_object_start(false)
+            }
+            Some(ContextState::Array(ArrayState::CommaOrEnd)) => {
+                self.consume_direct_array_object_start(true)
+            }
+            _ => self.consume_object_start_fast(),
+        }
+    }
+
     pub(crate) fn consume_array_start_fast(&mut self) -> Result<Span, ParseError> {
         if self.state.event_peek.is_some() {
             return self.consume_array_start();
@@ -1100,6 +1153,31 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
                 }
             }
             _ => self.consume_array_start(),
+        }
+    }
+
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    fn consume_direct_array_object_start(
+        &mut self,
+        require_comma: bool,
+    ) -> Result<Span, ParseError> {
+        if let Some(span) = self
+            .scanner
+            .try_consume_array_object_start(self.input, require_comma)
+            .map_err(scan_error_to_parse_error)?
+        {
+            if let Some(ContextState::Array(state)) = self.state.stack.last_mut() {
+                *state = ArrayState::ValueOrEnd;
+            }
+            self.state.last_token_start = span.offset as usize;
+            self.state.scanner_pos = self.scanner.pos();
+            self.state.root_started = true;
+            self.state
+                .stack
+                .push(ContextState::Object(ObjectState::KeyOrEnd));
+            Ok(span)
+        } else {
+            self.consume_object_start_fast()
         }
     }
 
@@ -1447,7 +1525,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
     }
 
-    #[inline(never)]
+    #[inline]
     pub(crate) fn try_consume_ordered_i32_object_fields(
         &mut self,
         expected: &[&str],
@@ -1462,37 +1540,44 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
 
         let save = self.save_ordered_i32_object_probe();
-        let matched = self.try_consume_ordered_i32_object_fields_inner(expected, spans, values)?;
+        let mut consume =
+            |_: &JsonParser<'de, TRUSTED_UTF8>, index: usize, span: Span, value: i32| {
+                spans[index] = span;
+                values[index] = value;
+                Ok::<(), ParseError>(())
+            };
+        let matched = self.try_consume_ordered_i32_object_fields_inner(expected, &mut consume)?;
         if !matched {
             self.restore_ordered_i32_object_probe(save);
         }
         Ok(matched)
     }
 
-    #[inline(never)]
+    #[inline]
     #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
-    pub(crate) fn try_consume_ordered_i32_object(
+    pub(crate) fn try_consume_ordered_i32_object_with<E, W>(
         &mut self,
         expected: &[&str],
-        spans: &mut [Span],
-        values: &mut [i32],
-    ) -> Result<bool, ParseError> {
-        debug_assert_eq!(expected.len(), spans.len());
-        debug_assert_eq!(expected.len(), values.len());
-
+        mut consume: W,
+    ) -> Result<bool, E>
+    where
+        E: From<ParseError>,
+        W: FnMut(&JsonParser<'de, TRUSTED_UTF8>, usize, Span, i32) -> Result<(), E>,
+    {
         if expected.is_empty() || self.state.event_peek.is_some() {
             return Ok(false);
         }
 
         let save = self.save_ordered_object_probe();
-        self.consume_object_start_fast()?;
-        let matched = self.try_consume_ordered_i32_object_fields_inner(expected, spans, values)?;
+        self.consume_array_object_start_fast().map_err(E::from)?;
+        let matched = self.try_consume_ordered_i32_object_fields_inner(expected, &mut consume)?;
         if !matched {
             self.restore_ordered_object_probe(save);
         }
         Ok(matched)
     }
 
+    #[inline]
     #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
     pub(crate) fn try_consume_ordered_scalar_object_with<E, W>(
         &mut self,
@@ -1513,7 +1598,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
 
         let save = self.save_ordered_object_probe();
-        self.consume_object_start_fast().map_err(E::from)?;
+        self.consume_array_object_start_fast().map_err(E::from)?;
         let matched = self.try_consume_ordered_scalar_object_inner(expected, &mut consume)?;
         if !matched {
             self.restore_ordered_object_probe(save);
@@ -1531,12 +1616,12 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         self.restore_ordered_object_probe(save);
     }
 
-    #[inline(never)]
+    #[inline]
     fn save_ordered_i32_object_probe(&self) -> OrderedObjectProbeSave {
         self.save_ordered_object_probe()
     }
 
-    #[inline(never)]
+    #[inline]
     fn save_ordered_object_probe(&self) -> OrderedObjectProbeSave {
         OrderedObjectProbeSave {
             scanner: self.scanner.clone(),
@@ -1571,50 +1656,12 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         self.state.scanner_pos = save.scanner_pos;
     }
 
-    #[inline(never)]
-    fn try_consume_ordered_i32_object_fields_inner(
-        &mut self,
-        expected: &[&str],
-        spans: &mut [Span],
-        values: &mut [i32],
-    ) -> Result<bool, ParseError> {
-        for (index, expected) in expected.iter().copied().enumerate() {
-            if index > 0 {
-                if self.determine_action() != NextAction::ObjectComma {
-                    return Ok(false);
-                }
-                if self.consume_punctuation_token(b',')?.is_none() {
-                    return Ok(false);
-                }
-                if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
-                    *state = ObjectState::KeyOrEnd;
-                } else {
-                    return Ok(false);
-                }
-            }
-
-            if self.determine_action() != NextAction::ObjectKey {
-                return Ok(false);
-            }
-
-            let Some(span) = self.try_consume_exact_string_token(expected)? else {
-                return Ok(false);
-            };
-            self.expect_colon_token()?;
-            if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
-                *state = ObjectState::Value;
-            } else {
-                return Ok(false);
-            }
-
-            let Some((_, value)) = self.try_consume_i32_number()? else {
-                return Ok(false);
-            };
-            spans[index] = span;
-            values[index] = value;
-        }
-
-        if self.determine_action() != NextAction::ObjectComma {
+    #[inline]
+    fn consume_ordered_object_end(&mut self) -> Result<bool, ParseError> {
+        if !matches!(
+            self.state.stack.last(),
+            Some(ContextState::Object(ObjectState::CommaOrEnd))
+        ) {
             return Ok(false);
         }
         if self.consume_punctuation_token(b'}')?.is_none() {
@@ -1625,7 +1672,34 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         Ok(true)
     }
 
-    #[inline(never)]
+    #[inline]
+    fn try_consume_ordered_i32_object_fields_inner<E, W>(
+        &mut self,
+        expected: &[&str],
+        consume: &mut W,
+    ) -> Result<bool, E>
+    where
+        E: From<ParseError>,
+        W: FnMut(&JsonParser<'de, TRUSTED_UTF8>, usize, Span, i32) -> Result<(), E>,
+    {
+        for (index, expected) in expected.iter().copied().enumerate() {
+            let Some(span) = self
+                .try_consume_ordered_field_prefix(expected, index > 0)
+                .map_err(E::from)?
+            else {
+                return Ok(false);
+            };
+
+            let Some((_, value)) = self.try_consume_i32_number().map_err(E::from)? else {
+                return Ok(false);
+            };
+            consume(self, index, span, value)?;
+        }
+
+        self.consume_ordered_object_end().map_err(E::from)
+    }
+
+    #[inline]
     #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
     fn try_consume_ordered_scalar_object_inner<E, W>(
         &mut self,
@@ -1642,40 +1716,12 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         ) -> Result<(), E>,
     {
         for (index, expected) in expected.iter().copied().enumerate() {
-            if index > 0 {
-                if self.determine_action() != NextAction::ObjectComma {
-                    return Ok(false);
-                }
-                if self
-                    .consume_punctuation_token(b',')
-                    .map_err(E::from)?
-                    .is_none()
-                {
-                    return Ok(false);
-                }
-                if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
-                    *state = ObjectState::KeyOrEnd;
-                } else {
-                    return Ok(false);
-                }
-            }
-
-            if self.determine_action() != NextAction::ObjectKey {
-                return Ok(false);
-            }
-
             let Some(span) = self
-                .try_consume_exact_string_token(expected)
+                .try_consume_ordered_field_prefix(expected, index > 0)
                 .map_err(E::from)?
             else {
                 return Ok(false);
             };
-            self.expect_colon_token().map_err(E::from)?;
-            if let Some(ContextState::Object(state)) = self.state.stack.last_mut() {
-                *state = ObjectState::Value;
-            } else {
-                return Ok(false);
-            }
 
             let token = self.consume_spanned_token().map_err(E::from)?;
             self.validate_scalar_token(&token, "scalar")
@@ -1685,19 +1731,7 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
             consume(self, index, span, token)?;
         }
 
-        if self.determine_action() != NextAction::ObjectComma {
-            return Ok(false);
-        }
-        if self
-            .consume_punctuation_token(b'}')
-            .map_err(E::from)?
-            .is_none()
-        {
-            return Ok(false);
-        }
-        self.state.stack.pop();
-        self.finish_value_in_parent();
-        Ok(true)
+        self.consume_ordered_object_end().map_err(E::from)
     }
 
     pub(crate) fn consume_null_if_next(&mut self) -> Result<bool, ParseError> {
@@ -1754,7 +1788,22 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
             }
             NextAction::ArrayComma => match self.peek_significant_byte()? {
                 Some((_, b']')) => self.consume_array_end_token(),
-                Some((comma_pos, b',')) if self.significant_after_is(comma_pos + 1, b']')? => {
+                Some((comma_pos, b',')) => {
+                    match self.input.get(comma_pos + 1) {
+                        Some(b']') => {}
+                        Some(b' ' | b'\t' | b'\n' | b'\r') => {
+                            if !self.significant_after_is(comma_pos + 1, b']')? {
+                                return Ok(false);
+                            }
+                        }
+                        Some(b'/') if self.scanner.allows_comments() => {
+                            if !self.significant_after_is(comma_pos + 1, b']')? {
+                                return Ok(false);
+                            }
+                        }
+                        _ => return Ok(false),
+                    }
+
                     self.consume_comma_token()?;
                     if let Some(ContextState::Array(state)) = self.state.stack.last_mut() {
                         *state = ArrayState::ValueOrEnd;

--- a/facet-json/src/scanner.rs
+++ b/facet-json/src/scanner.rs
@@ -141,6 +141,11 @@ impl Scanner {
         self.pos
     }
 
+    /// Whether JSONC-style comments are accepted.
+    pub const fn allows_comments(&self) -> bool {
+        self.allow_comments
+    }
+
     /// Set position (used after buffer operations)
     #[allow(dead_code)]
     pub const fn set_pos(&mut self, pos: usize) {
@@ -162,7 +167,7 @@ impl Scanner {
     ) -> Result<Option<(usize, u8)>, ScanError> {
         let mut scanner = self.clone();
         scanner.pos = pos;
-        scanner.skip_whitespace(buf)?;
+        scanner.skip_whitespace_if_needed(buf)?;
         Ok(buf
             .get(scanner.pos)
             .copied()
@@ -175,7 +180,7 @@ impl Scanner {
         buf: &[u8],
         expected: u8,
     ) -> Result<Option<Span>, ScanError> {
-        self.skip_whitespace(buf)?;
+        self.skip_whitespace_if_needed(buf)?;
 
         let start = self.pos;
         if buf.get(self.pos) == Some(&expected) {
@@ -191,12 +196,12 @@ impl Scanner {
         buf: &[u8],
         expected: &[u8],
     ) -> Result<Option<Span>, ScanError> {
-        if expected.iter().any(|byte| matches!(*byte, b'"' | b'\\')) {
+        if !can_match_unescaped_string(expected) {
             return Ok(None);
         }
 
         let original = self.pos;
-        self.skip_whitespace(buf)?;
+        self.skip_whitespace_if_needed(buf)?;
 
         let start = self.pos;
         if buf.get(self.pos) != Some(&b'"') {
@@ -205,12 +210,11 @@ impl Scanner {
         }
         self.pos += 1;
 
-        let expected_end = self.pos + expected.len();
-        if buf.get(self.pos..expected_end) != Some(expected) {
+        if !bytes_match_at(buf, self.pos, expected) {
             self.pos = original;
             return Ok(None);
         }
-        self.pos = expected_end;
+        self.pos += expected.len();
 
         if buf.get(self.pos) != Some(&b'"') {
             self.pos = original;
@@ -221,9 +225,136 @@ impl Scanner {
         Ok(Some(Span::new(start, self.pos - start)))
     }
 
+    #[inline]
+    pub fn try_consume_exact_field_name_colon(
+        &mut self,
+        buf: &[u8],
+        expected: &[u8],
+        require_comma: bool,
+    ) -> Result<Option<Span>, ScanError> {
+        if !can_match_unescaped_string(expected) {
+            return Ok(None);
+        }
+
+        let original = self.pos;
+        self.skip_whitespace_if_needed(buf)?;
+
+        if require_comma {
+            if buf.get(self.pos) != Some(&b',') {
+                self.pos = original;
+                return Ok(None);
+            }
+            self.pos += 1;
+            self.skip_whitespace_if_needed(buf)?;
+        }
+
+        let start = self.pos;
+        if buf.get(self.pos) != Some(&b'"') {
+            self.pos = original;
+            return Ok(None);
+        }
+        self.pos += 1;
+
+        if !bytes_match_at(buf, self.pos, expected) {
+            self.pos = original;
+            return Ok(None);
+        }
+        self.pos += expected.len();
+
+        if buf.get(self.pos) != Some(&b'"') {
+            self.pos = original;
+            return Ok(None);
+        }
+        self.pos += 1;
+        let span = Span::new(start, self.pos - start);
+
+        self.skip_whitespace_if_needed(buf)?;
+        if buf.get(self.pos) != Some(&b':') {
+            self.pos = original;
+            return Ok(None);
+        }
+        self.pos += 1;
+
+        Ok(Some(span))
+    }
+
+    #[inline]
+    pub fn try_consume_one_byte_field_name_colon(
+        &mut self,
+        buf: &[u8],
+        expected: u8,
+        require_comma: bool,
+    ) -> Result<Option<Span>, ScanError> {
+        if matches!(expected, b'"' | b'\\' | 0x00..=0x1f) {
+            return Ok(None);
+        }
+
+        let original = self.pos;
+        self.skip_whitespace_if_needed(buf)?;
+
+        if require_comma {
+            if buf.get(self.pos) != Some(&b',') {
+                self.pos = original;
+                return Ok(None);
+            }
+            self.pos += 1;
+            self.skip_whitespace_if_needed(buf)?;
+        }
+
+        let start = self.pos;
+        if !matches!(
+            (buf.get(self.pos), buf.get(self.pos + 1), buf.get(self.pos + 2)),
+            (Some(b'"'), Some(byte), Some(b'"')) if *byte == expected
+        ) {
+            self.pos = original;
+            return Ok(None);
+        }
+        self.pos += 3;
+        let span = Span::new(start, 3);
+
+        self.skip_whitespace_if_needed(buf)?;
+        if buf.get(self.pos) != Some(&b':') {
+            self.pos = original;
+            return Ok(None);
+        }
+        self.pos += 1;
+
+        Ok(Some(span))
+    }
+
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[inline]
+    pub fn try_consume_array_object_start(
+        &mut self,
+        buf: &[u8],
+        require_comma: bool,
+    ) -> Result<Option<Span>, ScanError> {
+        let original = self.pos;
+        self.skip_whitespace_if_needed(buf)?;
+
+        if require_comma {
+            if buf.get(self.pos) != Some(&b',') {
+                self.pos = original;
+                return Ok(None);
+            }
+            self.pos += 1;
+            self.skip_whitespace_if_needed(buf)?;
+        }
+
+        let start = self.pos;
+        if buf.get(self.pos) != Some(&b'{') {
+            self.pos = original;
+            return Ok(None);
+        }
+        self.pos += 1;
+
+        Ok(Some(Span::new(start, 1)))
+    }
+
+    #[inline]
     pub fn try_consume_i32_number(&mut self, buf: &[u8]) -> Result<Option<(Span, i32)>, ScanError> {
         let original = self.pos;
-        self.skip_whitespace(buf)?;
+        self.skip_whitespace_if_needed(buf)?;
 
         let start = self.pos;
         let Some(&first) = buf.get(self.pos) else {
@@ -278,7 +409,7 @@ impl Scanner {
 
     /// Scan the next token from the buffer.
     pub fn next_token(&mut self, buf: &[u8]) -> ScanResult {
-        self.skip_whitespace(buf)?;
+        self.skip_whitespace_if_needed(buf)?;
 
         let start = self.pos;
         let Some(&byte) = buf.get(self.pos) else {
@@ -398,6 +529,15 @@ impl Scanner {
         }
         self.pos = pos;
         Ok(())
+    }
+
+    #[inline]
+    fn skip_whitespace_if_needed(&mut self, buf: &[u8]) -> Result<(), ScanError> {
+        match buf.get(self.pos) {
+            Some(b' ' | b'\t' | b'\n' | b'\r') => self.skip_whitespace(buf),
+            Some(b'/') if self.allow_comments => self.skip_whitespace(buf),
+            _ => Ok(()),
+        }
     }
 
     /// Scan a string, finding its boundaries and noting if it has escapes.
@@ -642,6 +782,35 @@ impl Scanner {
             token,
             span: Span::new(start, expected.len()),
         })
+    }
+}
+
+fn can_match_unescaped_string(expected: &[u8]) -> bool {
+    !expected
+        .iter()
+        .any(|byte| matches!(*byte, b'"' | b'\\' | 0x00..=0x1f))
+}
+
+#[inline]
+fn bytes_match_at(buf: &[u8], pos: usize, expected: &[u8]) -> bool {
+    match expected {
+        [] => true,
+        [a] => buf.get(pos) == Some(a),
+        [a, b] => {
+            matches!((buf.get(pos), buf.get(pos + 1)), (Some(x), Some(y)) if x == a && y == b)
+        }
+        [a, b, c] => {
+            matches!((buf.get(pos), buf.get(pos + 1), buf.get(pos + 2)), (Some(x), Some(y), Some(z)) if x == a && y == b && z == c)
+        }
+        [a, b, c, d] => {
+            matches!((buf.get(pos), buf.get(pos + 1), buf.get(pos + 2), buf.get(pos + 3)), (Some(w), Some(x), Some(y), Some(z)) if w == a && x == b && y == c && z == d)
+        }
+        _ => {
+            let Some(end) = pos.checked_add(expected.len()) else {
+                return false;
+            };
+            buf.get(pos..end) == Some(expected)
+        }
     }
 }
 

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -698,6 +698,7 @@ impl JsonNativeState {
         Ok(())
     }
 
+    #[inline]
     fn try_read_ordered_i32_scalar_struct<const TRUSTED_UTF8: bool>(
         &mut self,
         parser: &mut JsonParser<'_, TRUSTED_UTF8>,
@@ -707,29 +708,28 @@ impl JsonNativeState {
             return Ok(false);
         }
 
-        let mut spans = [Span { offset: 0, len: 0 }; TINY_SCALAR_STRUCT_MAX_FIELDS];
-        let mut values = [0i32; TINY_SCALAR_STRUCT_MAX_FIELDS];
-        let len = info.fields.len();
-        if !parser.try_consume_ordered_i32_object(
+        let mut guard = NativeScalarStructGuard::new(self.base, &info.fields);
+        let matched = parser.try_consume_ordered_i32_object_with(
             &info.ordered_names,
-            &mut spans[..len],
-            &mut values[..len],
-        )? {
+            |_, index, _, value| {
+                let field = info.fields[index];
+                let field_ptr = unsafe { self.base.field_uninit(field.offset) };
+                unsafe {
+                    field_ptr.put(value);
+                }
+                guard.mark(index);
+                Ok::<(), DeserializeError>(())
+            },
+        )?;
+        if !matched {
             return Ok(false);
         }
 
-        let mut guard = NativeScalarStructGuard::new(self.base, &info.fields);
-        for (index, field) in info.fields.iter().copied().enumerate() {
-            let field_ptr = unsafe { self.base.field_uninit(field.offset) };
-            unsafe {
-                field_ptr.put(values[index]);
-            }
-            guard.mark(index);
-        }
         guard.finish();
         Ok(true)
     }
 
+    #[inline]
     fn try_read_ordered_scalar_struct<const TRUSTED_UTF8: bool>(
         &mut self,
         parser: &mut JsonParser<'_, TRUSTED_UTF8>,


### PR DESCRIPTION
## Summary

Speeds up facet-json's native Weavy JIT ordered-struct path by reducing parser/scanner overhead on the shapes we keep benchmarking against serde_json. The main win is that ordered object fields now consume optional comma + key + colon as one scanner transaction, with a one-byte key fast path for compact scalar structs like `Point` and `WideScalars`.

## Changes

- Fuse ordered field-prefix consumption for native ordered scalar structs.
- Fuse array-element object start for native `Vec<scalar-struct>` roots.
- Avoid entering whitespace/comment scanning when the next byte cannot be whitespace.
- Avoid the expensive trailing-comma lookahead for compact `,{` list continuations.
- Write tiny i32 native fields directly under the existing init guard instead of parsing into temporary arrays first.
- Let the hot ordered native loops inline so closure/direct-write paths optimize properly.

## Performance

Command: `target/release/deps/typeplan_reuse-20d2ec0a5121a148 --bench --min-time 2 --threads 1 ...`

| Shape | serde_json mean | Weavy JIT mean | JIT / serde | JIT vs interp |
|---|---:|---:|---:|---:|
| `Vec<Point>` ordered | 155.0 ns | 152.8 ns | 0.99x | -62.4% |
| `Vec<FloatPoint>` ordered | 277.6 ns | 383.2 ns | 1.38x | -52.8% |
| `WideScalars` ordered | 223.7 ns | 234.6 ns | 1.05x | -45.6% |
| `Vec<WideScalars>` ordered | 590.4 ns | 620.6 ns | 1.05x | -52.3% |
| `WideScalars` out-of-order | 205.2 ns | 513.6 ns | 2.50x | +0.4% |
| `WideScalars` skipped unknowns | 316.9 ns | 645.4 ns | 2.04x | +0.0% |

The out-of-order/skipped rows intentionally still fall back to the interpreted Weavy path; they are included to show the native probe does not materially add overhead there.

stax was used to guide the changes. The profiles pointed at field-prefix matching, short-key memcmp, whitespace checks, list-end lookahead, and forced out-of-line ordered parser frames before the final inlining/list-probe pass.

## Verification

- `cargo fmt --check`
- `cargo check -p facet-json --all-features --all-targets --message-format=short`
- `cargo clippy -p facet-json --all-features --all-targets --message-format=short -- -D warnings`
- `cargo check -p facet-json --no-default-features --all-targets --message-format=short`
- `cargo nextest run -p facet-json --all-features -E 'test(weavy_jit) | test(weavy_rejects_duplicate_field_after_ordered_match) | test(weavy_drops_direct_list)'`
- `cargo nextest run -p facet-json --all-features --no-fail-fast` (`417 passed`)
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p facet-json --all-features --no-deps --message-format=short`
