### PR TITLE
Speed up facet-json ordered native roots

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -264,6 +264,13 @@ pub(crate) struct OrderedObjectProbeSave {
     scanner_pos: usize,
 }
 
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+pub(crate) struct NativeOrderedRootCursor<'de> {
+    input: &'de [u8],
+    scanner: Scanner,
+    last_token_start: usize,
+}
+
 #[derive(Debug, Clone, Copy)]
 enum ObjectState {
     KeyOrEnd,
@@ -1616,6 +1623,33 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         self.restore_ordered_object_probe(save);
     }
 
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    pub(crate) fn native_ordered_root_cursor(&self) -> Option<NativeOrderedRootCursor<'de>> {
+        if self.state.event_peek.is_some()
+            || !self.state.stack.is_empty()
+            || self.state.root_started
+            || self.state.root_complete
+        {
+            return None;
+        }
+
+        Some(NativeOrderedRootCursor {
+            input: self.input,
+            scanner: self.scanner.clone(),
+            last_token_start: self.state.last_token_start,
+        })
+    }
+
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    pub(crate) fn commit_native_ordered_root(&mut self, cursor: NativeOrderedRootCursor<'de>) {
+        self.scanner = cursor.scanner;
+        self.state.stack.clear();
+        self.state.root_started = true;
+        self.state.root_complete = true;
+        self.state.last_token_start = cursor.last_token_start;
+        self.state.scanner_pos = self.scanner.pos();
+    }
+
     #[inline]
     fn save_ordered_i32_object_probe(&self) -> OrderedObjectProbeSave {
         self.save_ordered_object_probe()
@@ -2374,5 +2408,139 @@ impl<'de, const TRUSTED_UTF8: bool> FormatParser<'de> for JsonParser<'de, TRUSTE
         let offset = self.state.last_token_start;
         let len = self.current_offset().saturating_sub(offset);
         Some(Span::new(offset, len))
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+impl<'de> NativeOrderedRootCursor<'de> {
+    #[inline]
+    pub(crate) fn consume_root_object_start(&mut self) -> Result<bool, ParseError> {
+        self.consume_punctuation(b'{')
+    }
+
+    #[inline]
+    pub(crate) fn consume_root_array_start(&mut self) -> Result<bool, ParseError> {
+        self.consume_punctuation(b'[')
+    }
+
+    #[inline]
+    pub(crate) fn consume_array_object_start(
+        &mut self,
+        require_comma: bool,
+    ) -> Result<bool, ParseError> {
+        let span = self
+            .scanner
+            .try_consume_array_object_start(self.input, require_comma)
+            .map_err(scan_error_to_parse_error)?;
+        if let Some(span) = span {
+            self.last_token_start = span.offset as usize;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    #[inline]
+    pub(crate) fn consume_ordered_field_prefix(
+        &mut self,
+        expected: &str,
+        require_comma: bool,
+    ) -> Result<Option<Span>, ParseError> {
+        let expected = expected.as_bytes();
+        let span = if let [expected] = expected {
+            self.scanner
+                .try_consume_one_byte_field_name_colon(self.input, *expected, require_comma)
+        } else {
+            self.scanner
+                .try_consume_exact_field_name_colon(self.input, expected, require_comma)
+        }
+        .map_err(scan_error_to_parse_error)?;
+
+        if let Some(span) = span {
+            self.last_token_start = span.offset as usize;
+        }
+        Ok(span)
+    }
+
+    #[inline]
+    pub(crate) fn consume_i32(&mut self) -> Result<Option<(Span, i32)>, ParseError> {
+        let value = self
+            .scanner
+            .try_consume_i32_number(self.input)
+            .map_err(scan_error_to_parse_error)?;
+        if let Some((span, _)) = value {
+            self.last_token_start = span.offset as usize;
+        }
+        Ok(value)
+    }
+
+    #[inline]
+    pub(crate) fn consume_scalar_token(
+        &mut self,
+        expected: &'static str,
+    ) -> Result<scanner::SpannedToken, ParseError> {
+        let token = self
+            .scanner
+            .next_token(self.input)
+            .map_err(scan_error_to_parse_error)?;
+        match token.token {
+            ScanToken::Null
+            | ScanToken::True
+            | ScanToken::False
+            | ScanToken::String { .. }
+            | ScanToken::Number { .. } => {
+                self.last_token_start = token.span.offset as usize;
+                Ok(token)
+            }
+            ScanToken::Eof => Err(ParseError::new(
+                token.span,
+                DeserializeErrorKind::UnexpectedEof { expected },
+            )),
+            _ => Err(ParseError::new(
+                token.span,
+                DeserializeErrorKind::UnexpectedToken {
+                    got: format!("{:?}", token.token).into(),
+                    expected,
+                },
+            )),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn consume_object_end(&mut self) -> Result<bool, ParseError> {
+        self.consume_punctuation(b'}')
+    }
+
+    #[inline]
+    pub(crate) fn consume_array_end_if_next(
+        &mut self,
+        after_element: bool,
+    ) -> Result<bool, ParseError> {
+        let original = self.scanner.clone();
+        if self.consume_punctuation(b']')? {
+            return Ok(true);
+        }
+        self.scanner = original.clone();
+
+        if after_element {
+            if self.consume_punctuation(b',')? && self.consume_punctuation(b']')? {
+                return Ok(true);
+            }
+            self.scanner = original;
+        }
+
+        Ok(false)
+    }
+
+    #[inline]
+    fn consume_punctuation(&mut self, byte: u8) -> Result<bool, ParseError> {
+        let span = self
+            .scanner
+            .consume_punctuation(self.input, byte)
+            .map_err(scan_error_to_parse_error)?;
+        if let Some(span) = span {
+            self.last_token_start = span.offset as usize;
+            return Ok(true);
+        }
+        Ok(false)
     }
 }

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -25,6 +25,8 @@ use weavy::mem::runtime::{
 use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStats, Step};
 
 use crate::JsonParser;
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+use crate::parser::NativeOrderedRootCursor;
 use crate::parser::{
     JsonFieldKeyInput, JsonObjectKeyStep, JsonObjectOrderedI32Step, JsonObjectOrderedScalarStep,
     JsonScalarInput, JsonScalarToken, JsonSequenceScalarStep,
@@ -609,6 +611,16 @@ impl JsonNativeState {
         let can_probe_ordered = tiny_i32_struct_fields_are_fusible(&info.fields)
             || info.fields.len() <= u64::BITS as usize;
         if can_probe_ordered {
+            if self.try_read_cursor_i32_scalar_struct(parser, info)? {
+                info.record_ordered_probe(true);
+                return Ok(());
+            }
+
+            if self.try_read_cursor_scalar_struct(parser, info)? {
+                info.record_ordered_probe(true);
+                return Ok(());
+            }
+
             if self.try_read_ordered_i32_scalar_struct(parser, info)? {
                 info.record_ordered_probe(true);
                 return Ok(());
@@ -633,6 +645,16 @@ impl JsonNativeState {
         for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
     {
         let parser = unsafe { &mut *self.parser.cast::<JsonParser<'_, TRUSTED_UTF8>>() };
+        if self.try_read_cursor_i32_scalar_struct_list(parser, info)? {
+            info.record_ordered_probe(true);
+            return Ok(());
+        }
+
+        if self.try_read_cursor_scalar_struct_list(parser, info)? {
+            info.record_ordered_probe(true);
+            return Ok(());
+        }
+
         let save = parser.save_native_probe();
         parser.consume_array_start_fast()?;
 
@@ -696,6 +718,255 @@ impl JsonNativeState {
         }
         builder.adopt();
         Ok(())
+    }
+
+    #[inline]
+    fn try_read_cursor_i32_scalar_struct<const TRUSTED_UTF8: bool>(
+        &mut self,
+        parser: &mut JsonParser<'_, TRUSTED_UTF8>,
+        info: &JsonNativeScalarStructInfo,
+    ) -> Result<bool, DeserializeError> {
+        if !tiny_i32_struct_fields_are_fusible(&info.fields) {
+            return Ok(false);
+        }
+
+        let Some(mut cursor) = parser.native_ordered_root_cursor() else {
+            return Ok(false);
+        };
+        if !cursor.consume_root_object_start()? {
+            return Ok(false);
+        }
+
+        let mut guard = NativeScalarStructGuard::new(self.base, &info.fields);
+        let matched =
+            self.read_cursor_i32_scalar_struct_object(&mut cursor, info, &mut guard, None)?;
+        if !matched {
+            return Ok(false);
+        }
+
+        guard.finish();
+        parser.commit_native_ordered_root(cursor);
+        Ok(true)
+    }
+
+    #[inline]
+    fn try_read_cursor_i32_scalar_struct_list<const TRUSTED_UTF8: bool>(
+        &mut self,
+        parser: &mut JsonParser<'_, TRUSTED_UTF8>,
+        info: &JsonNativeScalarStructListInfo,
+    ) -> Result<bool, DeserializeError> {
+        if !tiny_i32_struct_fields_are_fusible(&info.element.fields) {
+            return Ok(false);
+        }
+
+        let Some(mut cursor) = parser.native_ordered_root_cursor() else {
+            return Ok(false);
+        };
+        if !cursor.consume_root_array_start()? {
+            return Ok(false);
+        }
+
+        let mut builder = RawArrayBuilder::new(
+            info.element_layout,
+            info.list.t() as *const Shape as *const (),
+            drop_shape_value,
+        );
+        let mut after_element = false;
+        loop {
+            if cursor.consume_array_end_if_next(after_element)? {
+                self.adopt_native_list(info, &mut builder)?;
+                parser.commit_native_ordered_root(cursor);
+                return Ok(true);
+            }
+
+            let slot = builder.next_uninit_slot().map_err(raw_alloc_error)?;
+            let old_base = self.base;
+            self.base = PtrUninit::new(slot);
+
+            let mut guard = NativeScalarStructGuard::new(self.base, &info.element.fields);
+            let matched = self.read_cursor_i32_scalar_struct_object(
+                &mut cursor,
+                &info.element,
+                &mut guard,
+                Some(after_element),
+            );
+            self.base = old_base;
+
+            let matched = matched?;
+            if !matched {
+                return Ok(false);
+            }
+
+            guard.finish();
+            unsafe {
+                builder.mark_initialized();
+            }
+            after_element = true;
+        }
+    }
+
+    #[inline]
+    fn try_read_cursor_scalar_struct<const TRUSTED_UTF8: bool>(
+        &mut self,
+        parser: &mut JsonParser<'_, TRUSTED_UTF8>,
+        info: &JsonNativeScalarStructInfo,
+    ) -> Result<bool, DeserializeError>
+    where
+        for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
+    {
+        if info.fields.len() > u64::BITS as usize {
+            return Ok(false);
+        }
+
+        let Some(mut cursor) = parser.native_ordered_root_cursor() else {
+            return Ok(false);
+        };
+        if !cursor.consume_root_object_start()? {
+            return Ok(false);
+        }
+
+        let mut guard = NativeScalarStructGuard::new(self.base, &info.fields);
+        let matched =
+            self.read_cursor_scalar_struct_object(parser, &mut cursor, info, &mut guard, None)?;
+        if !matched {
+            return Ok(false);
+        }
+
+        guard.finish();
+        parser.commit_native_ordered_root(cursor);
+        Ok(true)
+    }
+
+    #[inline]
+    fn try_read_cursor_scalar_struct_list<const TRUSTED_UTF8: bool>(
+        &mut self,
+        parser: &mut JsonParser<'_, TRUSTED_UTF8>,
+        info: &JsonNativeScalarStructListInfo,
+    ) -> Result<bool, DeserializeError>
+    where
+        for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
+    {
+        if info.element.fields.len() > u64::BITS as usize {
+            return Ok(false);
+        }
+
+        let Some(mut cursor) = parser.native_ordered_root_cursor() else {
+            return Ok(false);
+        };
+        if !cursor.consume_root_array_start()? {
+            return Ok(false);
+        }
+
+        let mut builder = RawArrayBuilder::new(
+            info.element_layout,
+            info.list.t() as *const Shape as *const (),
+            drop_shape_value,
+        );
+        let mut after_element = false;
+        loop {
+            if cursor.consume_array_end_if_next(after_element)? {
+                self.adopt_native_list(info, &mut builder)?;
+                parser.commit_native_ordered_root(cursor);
+                return Ok(true);
+            }
+
+            let slot = builder.next_uninit_slot().map_err(raw_alloc_error)?;
+            let old_base = self.base;
+            self.base = PtrUninit::new(slot);
+
+            let mut guard = NativeScalarStructGuard::new(self.base, &info.element.fields);
+            let matched = self.read_cursor_scalar_struct_object(
+                parser,
+                &mut cursor,
+                &info.element,
+                &mut guard,
+                Some(after_element),
+            );
+            self.base = old_base;
+
+            let matched = matched?;
+            if !matched {
+                return Ok(false);
+            }
+
+            guard.finish();
+            unsafe {
+                builder.mark_initialized();
+            }
+            after_element = true;
+        }
+    }
+
+    #[inline]
+    fn read_cursor_i32_scalar_struct_object(
+        &mut self,
+        cursor: &mut NativeOrderedRootCursor<'_>,
+        info: &JsonNativeScalarStructInfo,
+        guard: &mut NativeScalarStructGuard<'_>,
+        array_element_object: Option<bool>,
+    ) -> Result<bool, DeserializeError> {
+        if let Some(require_comma) = array_element_object
+            && !cursor.consume_array_object_start(require_comma)?
+        {
+            return Ok(false);
+        }
+
+        for (index, expected) in info.ordered_names.iter().copied().enumerate() {
+            let Some(_span) = cursor.consume_ordered_field_prefix(expected, index > 0)? else {
+                return Ok(false);
+            };
+            let Some((_, value)) = cursor.consume_i32()? else {
+                return Ok(false);
+            };
+
+            let field = info.fields[index];
+            let field_ptr = unsafe { self.base.field_uninit(field.offset) };
+            unsafe {
+                field_ptr.put(value);
+            }
+            guard.mark(index);
+        }
+
+        if !cursor.consume_object_end()? {
+            return Ok(false);
+        }
+        Ok(true)
+    }
+
+    #[inline]
+    fn read_cursor_scalar_struct_object<const TRUSTED_UTF8: bool>(
+        &mut self,
+        parser: &JsonParser<'_, TRUSTED_UTF8>,
+        cursor: &mut NativeOrderedRootCursor<'_>,
+        info: &JsonNativeScalarStructInfo,
+        guard: &mut NativeScalarStructGuard<'_>,
+        array_element_object: Option<bool>,
+    ) -> Result<bool, DeserializeError>
+    where
+        for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
+    {
+        if let Some(require_comma) = array_element_object
+            && !cursor.consume_array_object_start(require_comma)?
+        {
+            return Ok(false);
+        }
+
+        for (index, expected) in info.ordered_names.iter().copied().enumerate() {
+            let Some(_span) = cursor.consume_ordered_field_prefix(expected, index > 0)? else {
+                return Ok(false);
+            };
+            let token = cursor.consume_scalar_token("scalar")?;
+
+            let field = &info.fields[index];
+            let field_ptr = unsafe { self.base.field_uninit(field.offset) };
+            parser.write_scalar_input_preselected(field, field_ptr, JsonScalarInput::Raw(token))?;
+            guard.mark(index);
+        }
+
+        if !cursor.consume_object_end()? {
+            return Ok(false);
+        }
+        Ok(true)
     }
 
     #[inline]

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -288,6 +288,12 @@ fn weavy_jit_helpers_deserialize_through_jit_requested_plan_slot() {
 }
 
 #[test]
+fn weavy_jit_ordered_scalar_struct_replays_after_i32_cursor_mismatch() {
+    let got: Point = facet_json::from_str_weavy_jit(r#"{"x":1,"y":"2"}"#).unwrap();
+    assert_eq!(got, Point { x: 1, y: 2 });
+}
+
+#[test]
 fn weavy_jit_plan_uses_native_for_root_scalar_struct_list_when_available() {
     let plan = facet_json::JsonWeavyPlan::<Vec<Point>>::build_jit().unwrap();
     let report = plan.jit_fallback_report();


### PR DESCRIPTION
## Summary

Moves the ordered `facet-json` native JIT probes onto a root-local cursor that scans with a cloned scanner and commits parser state only after the whole root value succeeds.

The native path now tries:

- direct i32 cursor scan for fusible ordered scalar structs/lists
- raw scalar cursor scan for ordered scalar structs/lists
- the existing parser-mutating ordered helpers as fallback
- the interpreted Weavy path for out-of-order, missing/defaulted, unknown, or unsupported shapes

This is a step toward making JSON parsing VM/JIT-visible: the hot ordered root path is no longer forced to mutate `JsonParser` token-by-token.

## Performance

Divan, macOS aarch64, `facet-json` all features. Baseline is `origin/main` at `c71fac4a9`; PR is `f6c14af55`.

| Shape | main JIT | PR JIT | PR JIT / serde_json | JIT change |
|---|---:|---:|---:|---:|
| `Point` | 46.92 ns | 42.08 ns | 1.50x | -10.3% |
| `Vec<Point>` | 154.6 ns | 123.6 ns | 0.85x | -20.1% |
| `FloatPoint` | 105.4 ns | 76.22 ns | 1.15x | -27.7% |
| `Vec<FloatPoint>` | 387.1 ns | 362.7 ns | 1.26x | -6.3% |
| `WideScalars` | 243.5 ns | 215.4 ns | 0.97x | -11.5% |
| `Vec<WideScalars>` | 634.9 ns | 570.1 ns | 0.95x | -10.2% |

Fallback-oriented rows are still fallback-oriented:

| Shape | PR JIT | PR JIT / serde_json |
|---|---:|---:|
| `WideScalars` out-of-order | 496.2 ns | 2.32x |
| `WideScalars` skipped unknown | 648.6 ns | 2.02x |
| `Vec<WideScalars>` out-of-order | 1.411 us | 2.39x |
| `Vec<WideScalars>` skipped unknown | 1.568 us | 2.24x |

Stax profile:

- `stax record -F 1900 -l 15 -- target/release/deps/typeplan_reuse-20d2ec0a5121a148 --bench --min-time 5 --threads 1 wide_scalars_weavy_jit_reused_plan`
- `stax top --run 12 --limit 30`
- Remaining hot frames: `Scanner::next_token`, `Scanner::try_consume_one_byte_field_name_colon`, `Scanner::skip_whitespace`, `raw_into_unsigned`, `raw_into_signed`.

## Verification

- `cargo fmt --check`
- `cargo check -p facet-json --all-features --all-targets --message-format=short`
- `cargo check -p facet-json --no-default-features --all-targets --message-format=short`
- `cargo clippy -p facet-json --all-features --all-targets --message-format=short -- -D warnings`
- `cargo nextest list -p facet-json --all-features -E 'test(weavy_jit) | test(weavy_rejects_duplicate_field_after_ordered_match) | test(weavy_drops_direct_list)'`
- `cargo nextest run -p facet-json --all-features -E 'test(weavy_jit) | test(weavy_rejects_duplicate_field_after_ordered_match) | test(weavy_drops_direct_list)'`
- `cargo nextest run -p facet-json --all-features --no-fail-fast`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p facet-json --all-features --no-deps --message-format=short`
- push hook also passed clippy/docs/build-tests/run-tests
