### PR TITLE
Specialize facet-json native cursor scalars

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -2474,6 +2474,77 @@ impl<'de> NativeOrderedRootCursor<'de> {
     }
 
     #[inline]
+    pub(crate) fn consume_bool(&mut self) -> Result<Option<bool>, ParseError> {
+        let value = self
+            .scanner
+            .try_consume_bool(self.input)
+            .map_err(scan_error_to_parse_error)?;
+        if let Some((span, value)) = value {
+            self.last_token_start = span.offset as usize;
+            return Ok(Some(value));
+        }
+        Ok(None)
+    }
+
+    #[inline]
+    pub(crate) fn consume_null(&mut self) -> Result<bool, ParseError> {
+        let span = self
+            .scanner
+            .try_consume_null(self.input)
+            .map_err(scan_error_to_parse_error)?;
+        if let Some(span) = span {
+            self.last_token_start = span.offset as usize;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    #[inline]
+    pub(crate) fn consume_unsigned_integer<T>(&mut self) -> Result<Option<T>, ParseError>
+    where
+        T: TryFrom<u128>,
+    {
+        let value = self
+            .scanner
+            .try_consume_unsigned_integer(self.input)
+            .map_err(scan_error_to_parse_error)?;
+        if let Some((span, value)) = value {
+            self.last_token_start = span.offset as usize;
+            return Ok(Some(value));
+        }
+        Ok(None)
+    }
+
+    #[inline]
+    pub(crate) fn consume_signed_integer<T>(&mut self) -> Result<Option<T>, ParseError>
+    where
+        T: TryFrom<i128>,
+    {
+        let value = self
+            .scanner
+            .try_consume_signed_integer(self.input)
+            .map_err(scan_error_to_parse_error)?;
+        if let Some((span, value)) = value {
+            self.last_token_start = span.offset as usize;
+            return Ok(Some(value));
+        }
+        Ok(None)
+    }
+
+    #[inline]
+    pub(crate) fn consume_f64_number(&mut self) -> Result<Option<f64>, ParseError> {
+        let value = self
+            .scanner
+            .try_consume_f64_number(self.input)
+            .map_err(scan_error_to_parse_error)?;
+        if let Some((span, value)) = value {
+            self.last_token_start = span.offset as usize;
+            return Ok(Some(value));
+        }
+        Ok(None)
+    }
+
+    #[inline]
     pub(crate) fn consume_scalar_token(
         &mut self,
         expected: &'static str,

--- a/facet-json/src/scanner.rs
+++ b/facet-json/src/scanner.rs
@@ -407,6 +407,202 @@ impl Scanner {
         Ok(Some((Span::new(start, self.pos - start), value)))
     }
 
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[inline]
+    pub fn try_consume_bool(&mut self, buf: &[u8]) -> Result<Option<(Span, bool)>, ScanError> {
+        let original = self.pos;
+        self.skip_whitespace_if_needed(buf)?;
+
+        let start = self.pos;
+        if bytes_match_at(buf, self.pos, b"true") {
+            self.pos += 4;
+            return Ok(Some((Span::new(start, 4), true)));
+        }
+        if bytes_match_at(buf, self.pos, b"false") {
+            self.pos += 5;
+            return Ok(Some((Span::new(start, 5), false)));
+        }
+
+        self.pos = original;
+        Ok(None)
+    }
+
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[inline]
+    pub fn try_consume_null(&mut self, buf: &[u8]) -> Result<Option<Span>, ScanError> {
+        let original = self.pos;
+        self.skip_whitespace_if_needed(buf)?;
+
+        let start = self.pos;
+        if bytes_match_at(buf, self.pos, b"null") {
+            self.pos += 4;
+            return Ok(Some(Span::new(start, 4)));
+        }
+
+        self.pos = original;
+        Ok(None)
+    }
+
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[inline]
+    pub fn try_consume_unsigned_integer<T>(
+        &mut self,
+        buf: &[u8],
+    ) -> Result<Option<(Span, T)>, ScanError>
+    where
+        T: TryFrom<u128>,
+    {
+        let original = self.pos;
+        self.skip_whitespace_if_needed(buf)?;
+
+        let start = self.pos;
+        let Some(&first) = buf.get(self.pos) else {
+            self.pos = original;
+            return Ok(None);
+        };
+        if !first.is_ascii_digit() {
+            self.pos = original;
+            return Ok(None);
+        }
+
+        let mut value = 0u128;
+        while let Some(&byte) = buf.get(self.pos) {
+            if !byte.is_ascii_digit() {
+                break;
+            }
+            value = match value
+                .checked_mul(10)
+                .and_then(|value| value.checked_add((byte - b'0') as u128))
+            {
+                Some(value) => value,
+                None => {
+                    self.pos = original;
+                    return Ok(None);
+                }
+            };
+            self.pos += 1;
+        }
+
+        if matches!(buf.get(self.pos), Some(b'.' | b'e' | b'E')) {
+            self.pos = original;
+            return Ok(None);
+        }
+
+        let Ok(value) = T::try_from(value) else {
+            self.pos = original;
+            return Ok(None);
+        };
+
+        Ok(Some((Span::new(start, self.pos - start), value)))
+    }
+
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[inline]
+    pub fn try_consume_signed_integer<T>(
+        &mut self,
+        buf: &[u8],
+    ) -> Result<Option<(Span, T)>, ScanError>
+    where
+        T: TryFrom<i128>,
+    {
+        let original = self.pos;
+        self.skip_whitespace_if_needed(buf)?;
+
+        let start = self.pos;
+        let Some(&first) = buf.get(self.pos) else {
+            self.pos = original;
+            return Ok(None);
+        };
+        let negative = first == b'-';
+        if negative {
+            self.pos += 1;
+        } else if !first.is_ascii_digit() {
+            self.pos = original;
+            return Ok(None);
+        }
+
+        let digits_start = self.pos;
+        let mut value = 0i128;
+        while let Some(&byte) = buf.get(self.pos) {
+            if !byte.is_ascii_digit() {
+                break;
+            }
+            value = if negative {
+                match value
+                    .checked_mul(10)
+                    .and_then(|value| value.checked_sub((byte - b'0') as i128))
+                {
+                    Some(value) => value,
+                    None => {
+                        self.pos = original;
+                        return Ok(None);
+                    }
+                }
+            } else {
+                match value
+                    .checked_mul(10)
+                    .and_then(|value| value.checked_add((byte - b'0') as i128))
+                {
+                    Some(value) => value,
+                    None => {
+                        self.pos = original;
+                        return Ok(None);
+                    }
+                }
+            };
+            self.pos += 1;
+        }
+
+        if self.pos == digits_start || matches!(buf.get(self.pos), Some(b'.' | b'e' | b'E')) {
+            self.pos = original;
+            return Ok(None);
+        }
+
+        let Ok(value) = T::try_from(value) else {
+            self.pos = original;
+            return Ok(None);
+        };
+
+        Ok(Some((Span::new(start, self.pos - start), value)))
+    }
+
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[inline]
+    pub fn try_consume_f64_number(&mut self, buf: &[u8]) -> Result<Option<(Span, f64)>, ScanError> {
+        let original = self.pos;
+        self.skip_whitespace_if_needed(buf)?;
+
+        let start = self.pos;
+        if !matches!(buf.get(self.pos), Some(b'-' | b'0'..=b'9')) {
+            self.pos = original;
+            return Ok(None);
+        }
+
+        let token = match self.scan_number(buf, start) {
+            Ok(token) => token,
+            Err(_) => {
+                self.pos = original;
+                return Ok(None);
+            }
+        };
+        let Token::Number { start, end, hint } = token.token else {
+            unreachable!("scan_number returns a number token");
+        };
+        let value = match parse_number(buf, start, end, hint) {
+            Ok(ParsedNumber::F64(value)) => value,
+            Ok(ParsedNumber::I64(value)) => value as f64,
+            Ok(ParsedNumber::U64(value)) => value as f64,
+            Ok(ParsedNumber::I128(value)) => value as f64,
+            Ok(ParsedNumber::U128(value)) => value as f64,
+            Err(_) => {
+                self.pos = original;
+                return Ok(None);
+            }
+        };
+
+        Ok(Some((token.span, value)))
+    }
+
     /// Scan the next token from the buffer.
     pub fn next_token(&mut self, buf: &[u8]) -> ScanResult {
         self.skip_whitespace_if_needed(buf)?;

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -955,11 +955,17 @@ impl JsonNativeState {
             let Some(_span) = cursor.consume_ordered_field_prefix(expected, index > 0)? else {
                 return Ok(false);
             };
-            let token = cursor.consume_scalar_token("scalar")?;
 
             let field = &info.fields[index];
             let field_ptr = unsafe { self.base.field_uninit(field.offset) };
-            parser.write_scalar_input_preselected(field, field_ptr, JsonScalarInput::Raw(token))?;
+            if !Self::try_write_cursor_typed_scalar(cursor, field, field_ptr)? {
+                let token = cursor.consume_scalar_token("scalar")?;
+                parser.write_scalar_input_preselected(
+                    field,
+                    field_ptr,
+                    JsonScalarInput::Raw(token),
+                )?;
+            }
             guard.mark(index);
         }
 
@@ -967,6 +973,105 @@ impl JsonNativeState {
             return Ok(false);
         }
         Ok(true)
+    }
+
+    #[inline]
+    fn try_write_cursor_typed_scalar(
+        cursor: &mut NativeOrderedRootCursor<'_>,
+        field: &ScalarFieldPlan,
+        dst: PtrUninit,
+    ) -> Result<bool, DeserializeError> {
+        match field.scalar.scalar {
+            ScalarType::Unit => {
+                if cursor.consume_null()? {
+                    unsafe {
+                        dst.put(());
+                    }
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            ScalarType::Bool => {
+                if let Some(value) = cursor.consume_bool()? {
+                    unsafe {
+                        dst.put(value);
+                    }
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            ScalarType::U8 => Self::try_write_cursor_unsigned::<u8>(cursor, dst),
+            ScalarType::U16 => Self::try_write_cursor_unsigned::<u16>(cursor, dst),
+            ScalarType::U32 => Self::try_write_cursor_unsigned::<u32>(cursor, dst),
+            ScalarType::U64 => Self::try_write_cursor_unsigned::<u64>(cursor, dst),
+            ScalarType::U128 => Self::try_write_cursor_unsigned::<u128>(cursor, dst),
+            ScalarType::USize => Self::try_write_cursor_unsigned::<usize>(cursor, dst),
+            ScalarType::I8 => Self::try_write_cursor_signed::<i8>(cursor, dst),
+            ScalarType::I16 => Self::try_write_cursor_signed::<i16>(cursor, dst),
+            ScalarType::I32 => Self::try_write_cursor_signed::<i32>(cursor, dst),
+            ScalarType::I64 => Self::try_write_cursor_signed::<i64>(cursor, dst),
+            ScalarType::I128 => Self::try_write_cursor_signed::<i128>(cursor, dst),
+            ScalarType::ISize => Self::try_write_cursor_signed::<isize>(cursor, dst),
+            ScalarType::F32 => {
+                if let Some(value) = cursor.consume_f64_number()? {
+                    unsafe {
+                        dst.put(value as f32);
+                    }
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            ScalarType::F64 => {
+                if let Some(value) = cursor.consume_f64_number()? {
+                    unsafe {
+                        dst.put(value);
+                    }
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+    #[inline]
+    fn try_write_cursor_unsigned<T>(
+        cursor: &mut NativeOrderedRootCursor<'_>,
+        dst: PtrUninit,
+    ) -> Result<bool, DeserializeError>
+    where
+        T: TryFrom<u128>,
+    {
+        if let Some(value) = cursor.consume_unsigned_integer::<T>()? {
+            unsafe {
+                dst.put(value);
+            }
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    #[inline]
+    fn try_write_cursor_signed<T>(
+        cursor: &mut NativeOrderedRootCursor<'_>,
+        dst: PtrUninit,
+    ) -> Result<bool, DeserializeError>
+    where
+        T: TryFrom<i128>,
+    {
+        if let Some(value) = cursor.consume_signed_integer::<T>()? {
+            unsafe {
+                dst.put(value);
+            }
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     #[inline]

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -361,6 +361,34 @@ fn weavy_jit_scalar_struct_handles_ordered_wide_scalars() {
 }
 
 #[test]
+fn weavy_jit_ordered_wide_scalars_accept_numeric_strings() {
+    let plan = facet_json::JsonWeavyPlan::<WideScalarStruct>::build_jit().unwrap();
+    let got = plan
+        .from_str(
+            r#"{"a":"1","b":2,"c":"3","d":4,"e":"-5","f":-6,"g":"-7","h":-8,"i":"9","j":-10,"k":true,"l":"11.5"}"#,
+        )
+        .unwrap();
+
+    assert_eq!(
+        got,
+        WideScalarStruct {
+            a: 1,
+            b: 2,
+            c: 3,
+            d: 4,
+            e: -5,
+            f: -6,
+            g: -7,
+            h: -8,
+            i: 9,
+            j: -10,
+            k: true,
+            l: 11.5,
+        }
+    );
+}
+
+#[test]
 fn weavy_jit_scalar_struct_list_handles_ordered_wide_scalars() {
     let plan = facet_json::JsonWeavyPlan::<Vec<WideScalarStruct>>::build_jit().unwrap();
     let got = plan


### PR DESCRIPTION
## Summary

Specializes the facet-json native ordered cursor path so scalar struct fields can be read directly by their target scalar type instead of always materializing a scanner token and then routing through the generic raw scalar conversion path.

The fast path now handles bool, null/unit, signed and unsigned integer widths, and f32/f64. Unsupported or policy-sensitive inputs still fall back to the existing raw scalar writer, including numeric strings.

## Performance

Lower is better. Baseline is `origin/main` at `418d9cf16`; this PR is `a33723f16`. Both were run locally with:

```sh
target/release/deps/typeplan_reuse-20d2ec0a5121a148 --bench --min-time 1 --threads 1 <filter>
```

| bench | main Weavy JIT | PR Weavy JIT | Weavy delta | PR Weavy/serde |
|---|---:|---:|---:|---:|
| `wide_scalars` | 211.5 ns | 172.3 ns | 1.23x faster | 0.81x |
| `Vec<wide_scalars>` | 559.0 ns | 454.9 ns | 1.23x faster | 0.78x |
| `point` | 41.65 ns | 29.30 ns | 1.42x faster | 1.06x |
| `Vec<point>` | 120.3 ns | 121.6 ns | same-ish | 0.86x |
| `float_point` | 74.06 ns | 68.87 ns | 1.08x faster | 1.07x |
| `Vec<float_point>` | 328.7 ns | 315.4 ns | 1.04x faster | 1.15x |

Fallback/control rows stayed in the same range: `wide_scalars_out_of_order` is 2.45x serde on this PR, and `wide_scalars_skipped_unknown` is 2.06x serde.

## Stax

Profiled the exact hot row on baseline and this PR:

```sh
stax record -F 1900 -l 15 -- target/release/deps/typeplan_reuse-20d2ec0a5121a148 --bench --min-time 5 --threads 1 wide_scalars_weavy_jit_reused_plan
```

Baseline stax run 14 had the old path in the top frames:

- `Scanner::next_token`: 247 samples
- `raw_into_signed`: 54 samples
- `raw_into_unsigned`: 52 samples

This PR stax run 13 removed those from the top 40. The hot project frames are now the typed scalar cursor/write path, one-byte field-name scan, whitespace, and the remaining f64 number parse.

## Testing

```sh
cargo fmt --all --check
cargo check -p facet-json --all-features --all-targets --message-format=short
cargo check -p facet-json --no-default-features --all-targets --message-format=short
cargo clippy -p facet-json --all-features --all-targets --message-format=short -- -D warnings
cargo nextest list -p facet-json --all-features -E 'test(weavy_jit) | test(weavy_rejects_duplicate_field_after_ordered_match) | test(weavy_drops_direct_list)'
cargo nextest run -p facet-json --all-features -E 'test(weavy_jit) | test(weavy_rejects_duplicate_field_after_ordered_match) | test(weavy_drops_direct_list)'
cargo nextest run -p facet-json --all-features --no-fail-fast
RUSTDOCFLAGS=-Dwarnings cargo doc -p facet-json --all-features --no-deps --message-format=short
```
