### PR TITLE
Precompute facet-json native scalar readers

### DIFF
--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -349,9 +349,14 @@ struct JsonNativeScalarStructInfo {
     shape: &'static Shape,
     ordered_names: Box<[&'static str]>,
     fields: Box<[ScalarFieldPlan]>,
+    cursor_readers: Box<[NativeCursorScalarReader]>,
     dispatch: Option<RawFieldDispatch>,
     ordered_probe_skip: AtomicU8,
 }
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+type NativeCursorScalarReader =
+    fn(&mut NativeOrderedRootCursor<'_>, PtrUninit) -> Result<bool, DeserializeError>;
 
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
 struct JsonNativeScalarStructListInfo {
@@ -446,11 +451,17 @@ impl JsonNativePlan {
             .map(|field| field.name)
             .collect::<Vec<_>>()
             .into_boxed_slice();
+        let cursor_readers = fields
+            .iter()
+            .map(|field| native_cursor_scalar_reader(field.scalar.scalar))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
 
         Ok(JsonNativeScalarStructInfo {
             shape,
             ordered_names,
             fields,
+            cursor_readers,
             dispatch: dispatch.clone(),
             ordered_probe_skip: AtomicU8::new(0),
         })
@@ -958,7 +969,7 @@ impl JsonNativeState {
 
             let field = &info.fields[index];
             let field_ptr = unsafe { self.base.field_uninit(field.offset) };
-            if !Self::try_write_cursor_typed_scalar(cursor, field, field_ptr)? {
+            if !info.cursor_readers[index](cursor, field_ptr)? {
                 let token = cursor.consume_scalar_token("scalar")?;
                 parser.write_scalar_input_preselected(
                     field,
@@ -973,105 +984,6 @@ impl JsonNativeState {
             return Ok(false);
         }
         Ok(true)
-    }
-
-    #[inline]
-    fn try_write_cursor_typed_scalar(
-        cursor: &mut NativeOrderedRootCursor<'_>,
-        field: &ScalarFieldPlan,
-        dst: PtrUninit,
-    ) -> Result<bool, DeserializeError> {
-        match field.scalar.scalar {
-            ScalarType::Unit => {
-                if cursor.consume_null()? {
-                    unsafe {
-                        dst.put(());
-                    }
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-            ScalarType::Bool => {
-                if let Some(value) = cursor.consume_bool()? {
-                    unsafe {
-                        dst.put(value);
-                    }
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-            ScalarType::U8 => Self::try_write_cursor_unsigned::<u8>(cursor, dst),
-            ScalarType::U16 => Self::try_write_cursor_unsigned::<u16>(cursor, dst),
-            ScalarType::U32 => Self::try_write_cursor_unsigned::<u32>(cursor, dst),
-            ScalarType::U64 => Self::try_write_cursor_unsigned::<u64>(cursor, dst),
-            ScalarType::U128 => Self::try_write_cursor_unsigned::<u128>(cursor, dst),
-            ScalarType::USize => Self::try_write_cursor_unsigned::<usize>(cursor, dst),
-            ScalarType::I8 => Self::try_write_cursor_signed::<i8>(cursor, dst),
-            ScalarType::I16 => Self::try_write_cursor_signed::<i16>(cursor, dst),
-            ScalarType::I32 => Self::try_write_cursor_signed::<i32>(cursor, dst),
-            ScalarType::I64 => Self::try_write_cursor_signed::<i64>(cursor, dst),
-            ScalarType::I128 => Self::try_write_cursor_signed::<i128>(cursor, dst),
-            ScalarType::ISize => Self::try_write_cursor_signed::<isize>(cursor, dst),
-            ScalarType::F32 => {
-                if let Some(value) = cursor.consume_f64_number()? {
-                    unsafe {
-                        dst.put(value as f32);
-                    }
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-            ScalarType::F64 => {
-                if let Some(value) = cursor.consume_f64_number()? {
-                    unsafe {
-                        dst.put(value);
-                    }
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-            _ => Ok(false),
-        }
-    }
-
-    #[inline]
-    fn try_write_cursor_unsigned<T>(
-        cursor: &mut NativeOrderedRootCursor<'_>,
-        dst: PtrUninit,
-    ) -> Result<bool, DeserializeError>
-    where
-        T: TryFrom<u128>,
-    {
-        if let Some(value) = cursor.consume_unsigned_integer::<T>()? {
-            unsafe {
-                dst.put(value);
-            }
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    #[inline]
-    fn try_write_cursor_signed<T>(
-        cursor: &mut NativeOrderedRootCursor<'_>,
-        dst: PtrUninit,
-    ) -> Result<bool, DeserializeError>
-    where
-        T: TryFrom<i128>,
-    {
-        if let Some(value) = cursor.consume_signed_integer::<T>()? {
-            unsafe {
-                dst.put(value);
-            }
-            Ok(true)
-        } else {
-            Ok(false)
-        }
     }
 
     #[inline]
@@ -1168,6 +1080,133 @@ impl JsonNativeState {
         }
         interp.finish_success();
         Ok(())
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+fn native_cursor_scalar_reader(scalar: ScalarType) -> NativeCursorScalarReader {
+    match scalar {
+        ScalarType::Unit => read_native_cursor_unit,
+        ScalarType::Bool => read_native_cursor_bool,
+        ScalarType::U8 => read_native_cursor_unsigned::<u8>,
+        ScalarType::U16 => read_native_cursor_unsigned::<u16>,
+        ScalarType::U32 => read_native_cursor_unsigned::<u32>,
+        ScalarType::U64 => read_native_cursor_unsigned::<u64>,
+        ScalarType::U128 => read_native_cursor_unsigned::<u128>,
+        ScalarType::USize => read_native_cursor_unsigned::<usize>,
+        ScalarType::I8 => read_native_cursor_signed::<i8>,
+        ScalarType::I16 => read_native_cursor_signed::<i16>,
+        ScalarType::I32 => read_native_cursor_signed::<i32>,
+        ScalarType::I64 => read_native_cursor_signed::<i64>,
+        ScalarType::I128 => read_native_cursor_signed::<i128>,
+        ScalarType::ISize => read_native_cursor_signed::<isize>,
+        ScalarType::F32 => read_native_cursor_f32,
+        ScalarType::F64 => read_native_cursor_f64,
+        _ => read_native_cursor_raw,
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+fn read_native_cursor_raw(
+    _cursor: &mut NativeOrderedRootCursor<'_>,
+    _dst: PtrUninit,
+) -> Result<bool, DeserializeError> {
+    Ok(false)
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+fn read_native_cursor_unit(
+    cursor: &mut NativeOrderedRootCursor<'_>,
+    dst: PtrUninit,
+) -> Result<bool, DeserializeError> {
+    if cursor.consume_null()? {
+        unsafe {
+            dst.put(());
+        }
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+fn read_native_cursor_bool(
+    cursor: &mut NativeOrderedRootCursor<'_>,
+    dst: PtrUninit,
+) -> Result<bool, DeserializeError> {
+    if let Some(value) = cursor.consume_bool()? {
+        unsafe {
+            dst.put(value);
+        }
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+fn read_native_cursor_unsigned<T>(
+    cursor: &mut NativeOrderedRootCursor<'_>,
+    dst: PtrUninit,
+) -> Result<bool, DeserializeError>
+where
+    T: TryFrom<u128>,
+{
+    if let Some(value) = cursor.consume_unsigned_integer::<T>()? {
+        unsafe {
+            dst.put(value);
+        }
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+fn read_native_cursor_signed<T>(
+    cursor: &mut NativeOrderedRootCursor<'_>,
+    dst: PtrUninit,
+) -> Result<bool, DeserializeError>
+where
+    T: TryFrom<i128>,
+{
+    if let Some(value) = cursor.consume_signed_integer::<T>()? {
+        unsafe {
+            dst.put(value);
+        }
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+fn read_native_cursor_f32(
+    cursor: &mut NativeOrderedRootCursor<'_>,
+    dst: PtrUninit,
+) -> Result<bool, DeserializeError> {
+    if let Some(value) = cursor.consume_f64_number()? {
+        unsafe {
+            dst.put(value as f32);
+        }
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+fn read_native_cursor_f64(
+    cursor: &mut NativeOrderedRootCursor<'_>,
+    dst: PtrUninit,
+) -> Result<bool, DeserializeError> {
+    if let Some(value) = cursor.consume_f64_number()? {
+        unsafe {
+            dst.put(value);
+        }
+        Ok(true)
+    } else {
+        Ok(false)
     }
 }
 


### PR DESCRIPTION
## Summary

- precompute native cursor scalar reader functions while compiling ordered scalar struct plans
- replace the hot-loop `ScalarType` match with one indexed reader call per field
- keep unsupported scalar cases on the existing raw fallback reader

## Performance

Lower is better. Baseline is `origin/main` at `c6bea1b03`; PR is `b8940a4f8`.

The Ryzen 5 3600 Linux host does not exercise the macOS/aarch64 native cursor code path this PR targets, so it is included as a non-native guardrail.

### M4 Pro

| case | main | PR | PR vs main | PR Weavy/serde |
|---|---:|---:|---:|---:|
| wide_scalars | 173 ns | 158.7 ns | -8.3% | 0.72x |
| Vec<wide_scalars> | 463.9 ns | 432.3 ns | -6.8% | 0.71x |
| point | 29.88 ns | 30.72 ns | +2.8% | 1.10x |
| Vec<point> | 128.4 ns | 124.2 ns | -3.3% | 0.85x |
| float_point | 73.81 ns | 70 ns | -5.2% | 1.08x |
| Vec<float_point> | 316.8 ns | 313.7 ns | -1.0% | 1.12x |

### M2 Max

| case | main | PR | PR vs main | PR Weavy/serde |
|---|---:|---:|---:|---:|
| wide_scalars | 249.7 ns | 215.1 ns | -13.9% | 0.80x |
| Vec<wide_scalars> | 670.9 ns | 600.3 ns | -10.5% | 0.79x |
| point | 53.97 ns | 52.94 ns | -1.9% | 1.54x |
| Vec<point> | 176 ns | 165.9 ns | -5.7% | 0.88x |
| float_point | 176.2 ns | 153.5 ns | -12.9% | 1.95x |
| Vec<float_point> | 626.6 ns | 643.5 ns | +2.7% | 1.81x |

### Ryzen 5 3600

| case | main | PR | PR vs main | PR Weavy/serde |
|---|---:|---:|---:|---:|
| wide_scalars | 1.081 us | 1.071 us | -0.9% | 2.74x |
| Vec<wide_scalars> | 3.265 us | 3.276 us | +0.3% | 3.12x |
| point | 159.7 ns | 159.7 ns | 0.0% | 1.78x |
| Vec<point> | 731.7 ns | 730.7 ns | -0.1% | 2.60x |
| float_point | 379.7 ns | 380.7 ns | +0.3% | 2.71x |
| Vec<float_point> | 1.773 us | 1.802 us | +1.6% | 3.75x |

## Stax

M4 Pro baseline (`wide_scalars_weavy_jit_reused_plan`, run 15):

- `JsonNativeState::try_write_cursor_typed_scalar`: 191 samples

M4 Pro PR (`wide_scalars_weavy_jit_reused_plan`, run 16):

- `try_write_cursor_typed_scalar` is gone
- hottest project frames moved to scanner/key handling and the precomputed typed readers:
  - `Scanner::try_consume_one_byte_field_name_colon`: 108 samples
  - `Scanner::skip_whitespace`: 102 samples
  - `read_native_cursor_signed`: 64 samples
  - `read_native_cursor_unsigned`: 52 samples
  - `JsonNativeState::read_cursor_scalar_struct_object`: 73 samples

M2 Max PR (`wide_scalars_weavy_jit_reused_plan`, run 1):

- same native-reader shape:
  - `Scanner::try_consume_one_byte_field_name_colon`: 226 samples
  - `Scanner::skip_whitespace`: 174 samples
  - `Scanner::parse_number`: 144 samples
  - `read_native_cursor_signed`: 126 samples
  - `read_native_cursor_unsigned`: 88 samples
  - `JsonNativeState::read_cursor_scalar_struct_object`: 128 samples

Ryzen 5 3600 PR (`wide_scalars_weavy_jit_reused_plan`, run 1):

- confirms the x86_64/Linux path is still on the generic interpreter/parser surface:
  - `JsonParser::next_object_key_or_end`: 1141 samples
  - `JsonInterp::read_scalar_struct`: 1067 samples
  - `JsonParser::consume_scalar_input`: 981 samples
  - `Scanner::next_token`: 803 samples

## Verification

- `cargo fmt --all --check`
- `cargo check -p facet-json --all-features --all-targets --message-format=short`
- `cargo check -p facet-json --no-default-features --all-targets --message-format=short`
- `cargo clippy -p facet-json --all-features --all-targets --message-format=short -- -D warnings`
- `cargo nextest list -p facet-json --all-features -E 'test(weavy_jit) | test(weavy_rejects_duplicate_field_after_ordered_match) | test(weavy_drops_direct_list)'`
- `cargo nextest run -p facet-json --all-features -E 'test(weavy_jit) | test(weavy_rejects_duplicate_field_after_ordered_match) | test(weavy_drops_direct_list)'`
- `cargo nextest run -p facet-json --all-features --no-fail-fast`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p facet-json --all-features --no-deps --message-format=short`
