### PR TITLE
Add Linux x86_64 Weavy native JIT support

### DIFF
--- a/copypatch/Cargo.toml
+++ b/copypatch/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Reusable copy-and-patch JIT substrate: executable memory (W^X), AArch64 relocation patching, and build-time stencil extraction. Backend-agnostic — no IR, no schema."
+description = "Reusable copy-and-patch JIT substrate: executable memory (W^X), relocation patching, and build-time stencil extraction. Backend-agnostic — no IR, no schema."
 
 [package.metadata]
 
@@ -16,7 +16,7 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 # Only used by the build-time `extract` module (parsing the stencil object file).
 object = { workspace = true, optional = true }
 
-[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
+[target.'cfg(any(all(target_os = "macos", target_arch = "aarch64"), all(target_os = "linux", target_arch = "x86_64")))'.dependencies]
 libc = "0.2"
 
 [features]

--- a/copypatch/src/exec.rs
+++ b/copypatch/src/exec.rs
@@ -1,4 +1,4 @@
-//! Executable memory for copied machine code, on Apple Silicon.
+//! Executable memory for copied machine code.
 //!
 //! macOS on Apple Silicon enforces write-xor-execute on JIT pages: a `MAP_JIT`
 //! region is either writable or executable per thread, toggled with
@@ -7,11 +7,13 @@
 //! takes a finished code buffer (already relocation-patched by the caller), copies
 //! it into a fresh `MAP_JIT` page, makes it executable, and frees it on drop.
 //!
-//! A second backend (x86-64, or Linux `mmap`+`mprotect`) would add its own
-//! `ExecBuf` behind the same `new`/`as_ptr`/`Drop` surface.
+//! Linux on x86-64 uses a normal anonymous writable mapping, copies the patched
+//! code into it, then flips the region to read-execute with `mprotect`.
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use core::ffi::c_void;
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 unsafe extern "C" {
     /// Toggle the calling thread's JIT pages between writable (`0`) and
     /// executable (`1`).
@@ -38,6 +40,23 @@ impl ExecBuf {
     #[must_use]
     pub fn new(code: &[u8]) -> ExecBuf {
         assert!(!code.is_empty(), "cannot execute empty code");
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        {
+            return Self::new_apple_silicon(code);
+        }
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        {
+            return Self::new_linux_x86_64(code);
+        }
+        #[allow(unreachable_code)]
+        {
+            let _ = code;
+            panic!("ExecBuf is not available for this target");
+        }
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    fn new_apple_silicon(code: &[u8]) -> ExecBuf {
         let len = code.len();
         unsafe {
             let ptr = libc::mmap(
@@ -61,6 +80,29 @@ impl ExecBuf {
         }
     }
 
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    fn new_linux_x86_64(code: &[u8]) -> ExecBuf {
+        let len = code.len();
+        unsafe {
+            let ptr = libc::mmap(
+                core::ptr::null_mut(),
+                len,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            );
+            assert!(ptr != libc::MAP_FAILED, "mmap failed");
+            let ptr = ptr.cast::<u8>();
+
+            core::ptr::copy_nonoverlapping(code.as_ptr(), ptr, len);
+            let rc = libc::mprotect(ptr.cast(), len, libc::PROT_READ | libc::PROT_EXEC);
+            assert_eq!(rc, 0, "mprotect(PROT_READ | PROT_EXEC) failed");
+
+            ExecBuf { ptr, len }
+        }
+    }
+
     /// The entry pointer to the copied code.
     #[must_use]
     pub fn as_ptr(&self) -> *const u8 {
@@ -71,7 +113,7 @@ impl ExecBuf {
 impl Drop for ExecBuf {
     fn drop(&mut self) {
         unsafe {
-            libc::munmap(self.ptr.cast::<c_void>(), self.len);
+            libc::munmap(self.ptr.cast(), self.len);
         }
     }
 }

--- a/copypatch/src/extract.rs
+++ b/copypatch/src/extract.rs
@@ -14,15 +14,12 @@
 use std::path::Path;
 use std::process::Command;
 
-/// One extracted stencil: its machine code, and the offsets (relative to the
-/// stencil's start) of the `BRANCH26` continuation relocations to patch.
+/// One extracted stencil: its machine code, and the offsets of continuation
+/// relocations to patch, relative to the stencil's start.
 pub struct Stencil {
-    /// The stencil's machine-code bytes (a slice of `__text`).
+    /// The stencil's machine-code bytes.
     pub bytes: Vec<u8>,
-    /// Offsets within `bytes` of `BRANCH26` relocations targeting the
-    /// continuation symbol; the holes the JIT patches with [`patch_branch26`].
-    ///
-    /// [`patch_branch26`]: crate::patch_branch26
+    /// Offsets within `bytes` of relocations targeting the continuation symbol.
     pub cont_relocs: Vec<usize>,
 }
 
@@ -32,12 +29,10 @@ pub struct Stencil {
 /// (The conditional test itself stays internal to the stencil — a local branch,
 /// no relocation — so only the unconditional continuations need patching.)
 pub struct StencilN {
-    /// The stencil's machine-code bytes (a slice of `__text`).
+    /// The stencil's machine-code bytes.
     pub bytes: Vec<u8>,
-    /// `cont_relocs[i]` are the offsets within `bytes` of the `BRANCH26`
-    /// relocations targeting `cont_symbols[i]` (the holes the JIT patches with
-    /// [`patch_branch26`](crate::patch_branch26)), aligned to the `cont_symbols`
-    /// argument order.
+    /// `cont_relocs[i]` are the offsets within `bytes` of the relocations
+    /// targeting `cont_symbols[i]`, aligned to the `cont_symbols` argument order.
     pub cont_relocs: Vec<Vec<usize>>,
 }
 
@@ -78,6 +73,8 @@ pub fn compile_object(
         "-O",
         "-C",
         "panic=abort",
+        "-C",
+        "relocation-model=static",
         "--target",
         target,
     ]);
@@ -97,20 +94,20 @@ pub fn compile_object(
     }
 }
 
-/// Extract one stencil's bytes and continuation relocations from `obj`'s `__text`
+/// Extract one stencil's bytes and continuation relocations from `obj`'s text
 /// section by symbol name.
 ///
 /// `all_symbols` is every stencil symbol in the object (used to find where this
 /// stencil's code ends — the next symbol's address, or the section end).
 /// `cont_symbol` is the external continuation the stencil branches to; only its
-/// `BRANCH26` relocations are reported (the holes the JIT patches). Symbol names
-/// match with or without a leading underscore (Mach-O's C symbol mangling).
+/// relocations are reported. Symbol names match with or without a leading
+/// underscore (Mach-O's C symbol mangling).
 ///
 /// For a stencil with more than one successor (a conditional branch), use
 /// [`extract_stencil_n`].
 ///
 /// # Panics
-/// If the object can't be parsed, has no `__text`, or `symbol` is absent.
+/// If the object can't be parsed or `symbol` is absent.
 #[must_use]
 pub fn extract_stencil(
     obj: &[u8],
@@ -127,12 +124,12 @@ pub fn extract_stencil(
 
 /// Extract one stencil's bytes and its continuation relocations grouped by
 /// **several** continuation symbols (e.g. a conditional branch's `then`/`else`).
-/// `cont_relocs[i]` are the `BRANCH26` holes targeting `cont_symbols[i]`, aligned
-/// to argument order; a symbol with no relocations in the stencil yields an empty
+/// `cont_relocs[i]` are the holes targeting `cont_symbols[i]`, aligned to
+/// argument order; a symbol with no relocations in the stencil yields an empty
 /// inner vec. See [`extract_stencil`] for `all_symbols`/`symbol` semantics.
 ///
 /// # Panics
-/// If the object can't be parsed, has no `__text`, or `symbol` is absent.
+/// If the object can't be parsed or `symbol` is absent.
 #[must_use]
 pub fn extract_stencil_n(
     obj: &[u8],
@@ -143,38 +140,56 @@ pub fn extract_stencil_n(
     use object::{Object, ObjectSection, ObjectSymbol, RelocationTarget};
 
     let file = object::File::parse(obj).expect("parse object file");
-    let text = file
-        .sections()
-        .find(|s| s.name() == Ok("__text"))
-        .expect("no __text section");
-    let data = text.data().expect("read __text data");
-    let text_index = text.index();
-
-    let addr_of = |name: &str| -> u64 {
-        file.symbols()
-            .find(|s| {
-                s.section_index() == Some(text_index)
-                    && s.name().is_ok_and(|n| n == name || n == format!("_{name}"))
-            })
-            .unwrap_or_else(|| panic!("symbol {name} not found"))
-            .address()
+    let wanted = |symbol_name: &str, wanted: &str| {
+        symbol_name == wanted || symbol_name == format!("_{wanted}")
     };
 
-    let mut boundaries: Vec<u64> = all_symbols.iter().map(|s| addr_of(s)).collect();
-    boundaries.push(data.len() as u64);
+    let stencil_symbol = file
+        .symbols()
+        .find(|s| s.name().is_ok_and(|n| wanted(n, symbol)))
+        .unwrap_or_else(|| panic!("symbol {symbol} not found"));
+    let section_index = stencil_symbol
+        .section_index()
+        .unwrap_or_else(|| panic!("symbol {symbol} is not in a section"));
+    let text = file
+        .section_by_index(section_index)
+        .expect("read symbol section");
+    let data = text.data().expect("read text data");
+    let section_addr = text.address();
+
+    let addr_of_in_section = |name: &str| -> Option<u64> {
+        file.symbols()
+            .find(|s| {
+                s.section_index() == Some(section_index) && s.name().is_ok_and(|n| wanted(n, name))
+            })
+            .map(|s| s.address())
+    };
+
+    let mut boundaries: Vec<u64> = all_symbols
+        .iter()
+        .filter_map(|s| addr_of_in_section(s))
+        .collect();
+    boundaries.push(section_addr + data.len() as u64);
     boundaries.sort_unstable();
 
-    let start = addr_of(symbol);
+    let start = stencil_symbol.address();
     let end = *boundaries
         .iter()
         .find(|&&b| b > start)
         .expect("a boundary past the stencil");
 
-    let bytes = data[start as usize..end as usize].to_vec();
+    let start_offset = start
+        .checked_sub(section_addr)
+        .expect("symbol starts before its section");
+    let end_offset = end
+        .checked_sub(section_addr)
+        .expect("symbol ends before its section");
+
+    let bytes = data[start_offset as usize..end_offset as usize].to_vec();
 
     let mut cont_relocs: Vec<Vec<usize>> = vec![Vec::new(); cont_symbols.len()];
     for (offset, reloc) in text.relocations() {
-        if offset < start || offset >= end {
+        if offset < start_offset || offset >= end_offset {
             continue;
         }
         if let RelocationTarget::Symbol(idx) = reloc.target()
@@ -183,7 +198,7 @@ pub fn extract_stencil_n(
         {
             for (i, cont) in cont_symbols.iter().enumerate() {
                 if name == *cont || name == format!("_{cont}") {
-                    cont_relocs[i].push((offset - start) as usize);
+                    cont_relocs[i].push((offset - start_offset) as usize);
                 }
             }
         }

--- a/copypatch/src/lib.rs
+++ b/copypatch/src/lib.rs
@@ -7,8 +7,10 @@
 //!
 //! - `ExecBuf` — allocate executable memory, copy machine code in, satisfy the
 //!   platform's write-xor-execute and instruction-cache rules, and free it on
-//!   drop. (Apple Silicon / `MAP_JIT` today; other backends slot in here.)
+//!   drop.
 //! - [`patch_branch26`] — patch an AArch64 `B`/`BL` (`BRANCH26`) immediate so a
+//!   copied stencil's continuation branch targets the next stencil.
+//! - [`patch_x86_rel32`] — patch an x86/x86_64 `rel32` branch immediate so a
 //!   copied stencil's continuation branch targets the next stencil.
 //! - the `extract` module (the `build` feature) — at *build* time, compile a stencil
 //!   source file with rustc (`--emit=obj`) and pull each stencil's bytes and its
@@ -20,13 +22,19 @@
 //! runs and patches bytes — it never encodes an instruction or interprets a
 //! schema.
 
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    all(target_os = "linux", target_arch = "x86_64")
+))]
 mod exec;
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    all(target_os = "linux", target_arch = "x86_64")
+))]
 pub use exec::ExecBuf;
 
 mod patch;
-pub use patch::patch_branch26;
+pub use patch::{patch_branch26, patch_x86_rel32};
 
 #[cfg(feature = "build")]
 pub mod extract;

--- a/copypatch/src/patch.rs
+++ b/copypatch/src/patch.rs
@@ -1,11 +1,12 @@
 //! AArch64 relocation patching.
 //!
 //! A copy-and-patch stencil leaves its continuation as a relocation: a `B`/`BL`
-//! whose 26-bit immediate is a hole. After copying stencils into one buffer, the
-//! caller patches each hole so the branch targets the next stencil. Both `site`
-//! and `target` are byte offsets within that buffer; since the branch is
-//! PC-relative the in-buffer delta equals the in-memory delta, so patching before
-//! copying into executable memory is sound.
+//! whose 26-bit immediate is a hole, or an x86/x86-64 branch whose `rel32`
+//! immediate is a hole. After copying stencils into one buffer, the caller
+//! patches each hole so the branch targets the next stencil. Both `site` and
+//! `target` are byte offsets within that buffer; since the branch is PC-relative
+//! the in-buffer delta equals the in-memory delta, so patching before copying
+//! into executable memory is sound.
 
 /// Patch an AArch64 `B`/`BL` (`BRANCH26`) at `site` in `code` so it targets byte
 /// offset `target` within the same buffer.
@@ -20,4 +21,28 @@ pub fn patch_branch26(code: &mut [u8], site: usize, target: usize) {
     let imm26 = (delta as u32) & 0x03FF_FFFF;
     let patched = (instr & 0xFC00_0000) | imm26;
     code[site..site + 4].copy_from_slice(&patched.to_le_bytes());
+}
+
+/// Patch an x86/x86-64 `rel32` immediate at `site` in `code` so it targets byte
+/// offset `target` within the same buffer.
+///
+/// The relocation site is the first byte of the 4-byte immediate, not the branch
+/// opcode. `target - (site + 4)` must fit in `i32`; stencils copied into a single
+/// buffer keep that range small.
+pub fn patch_x86_rel32(code: &mut [u8], site: usize, target: usize) {
+    let delta = target as isize - (site as isize + 4);
+    let delta = i32::try_from(delta).expect("x86 rel32 continuation out of range");
+    code[site..site + 4].copy_from_slice(&delta.to_le_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn x86_rel32_patches_relative_to_next_instruction() {
+        let mut code = [0_u8; 16];
+        patch_x86_rel32(&mut code, 5, 13);
+        assert_eq!(i32::from_le_bytes(code[5..9].try_into().unwrap()), 4);
+    }
 }

--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -264,7 +264,13 @@ pub(crate) struct OrderedObjectProbeSave {
     scanner_pos: usize,
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 pub(crate) struct NativeOrderedRootCursor<'de> {
     input: &'de [u8],
     scanner: Scanner,
@@ -1123,7 +1129,13 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
     }
 
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     pub(crate) fn consume_array_object_start_fast(&mut self) -> Result<Span, ParseError> {
         if self.state.event_peek.is_some() {
             return self.consume_object_start();
@@ -1163,7 +1175,13 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         }
     }
 
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     fn consume_direct_array_object_start(
         &mut self,
         require_comma: bool,
@@ -1561,7 +1579,13 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     }
 
     #[inline]
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     pub(crate) fn try_consume_ordered_i32_object_with<E, W>(
         &mut self,
         expected: &[&str],
@@ -1585,7 +1609,13 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     }
 
     #[inline]
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     pub(crate) fn try_consume_ordered_scalar_object_with<E, W>(
         &mut self,
         expected: &[&str],
@@ -1613,17 +1643,35 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         Ok(matched)
     }
 
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     pub(crate) fn save_native_probe(&self) -> OrderedObjectProbeSave {
         self.save_ordered_object_probe()
     }
 
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     pub(crate) fn restore_native_probe(&mut self, save: OrderedObjectProbeSave) {
         self.restore_ordered_object_probe(save);
     }
 
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     pub(crate) fn native_ordered_root_cursor(&self) -> Option<NativeOrderedRootCursor<'de>> {
         if self.state.event_peek.is_some()
             || !self.state.stack.is_empty()
@@ -1640,7 +1688,13 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
         })
     }
 
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     pub(crate) fn commit_native_ordered_root(&mut self, cursor: NativeOrderedRootCursor<'de>) {
         self.scanner = cursor.scanner;
         self.state.stack.clear();
@@ -1734,7 +1788,13 @@ impl<'de, const TRUSTED_UTF8: bool> JsonParser<'de, TRUSTED_UTF8> {
     }
 
     #[inline]
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     fn try_consume_ordered_scalar_object_inner<E, W>(
         &mut self,
         expected: &[&str],
@@ -2411,7 +2471,13 @@ impl<'de, const TRUSTED_UTF8: bool> FormatParser<'de> for JsonParser<'de, TRUSTE
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 impl<'de> NativeOrderedRootCursor<'de> {
     #[inline]
     pub(crate) fn consume_root_object_start(&mut self) -> Result<bool, ParseError> {

--- a/facet-json/src/scanner.rs
+++ b/facet-json/src/scanner.rs
@@ -322,7 +322,13 @@ impl Scanner {
         Ok(Some(span))
     }
 
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     #[inline]
     pub fn try_consume_array_object_start(
         &mut self,
@@ -407,7 +413,13 @@ impl Scanner {
         Ok(Some((Span::new(start, self.pos - start), value)))
     }
 
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     #[inline]
     pub fn try_consume_bool(&mut self, buf: &[u8]) -> Result<Option<(Span, bool)>, ScanError> {
         let original = self.pos;
@@ -427,7 +439,13 @@ impl Scanner {
         Ok(None)
     }
 
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     #[inline]
     pub fn try_consume_null(&mut self, buf: &[u8]) -> Result<Option<Span>, ScanError> {
         let original = self.pos;
@@ -443,7 +461,13 @@ impl Scanner {
         Ok(None)
     }
 
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     #[inline]
     pub fn try_consume_unsigned_integer<T>(
         &mut self,
@@ -496,7 +520,13 @@ impl Scanner {
         Ok(Some((Span::new(start, self.pos - start), value)))
     }
 
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     #[inline]
     pub fn try_consume_signed_integer<T>(
         &mut self,
@@ -566,7 +596,13 @@ impl Scanner {
         Ok(Some((Span::new(start, self.pos - start), value)))
     }
 
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     #[inline]
     pub fn try_consume_f64_number(&mut self, buf: &[u8]) -> Result<Option<(Span, f64)>, ScanError> {
         let original = self.pos;

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -10,7 +10,13 @@ use core::alloc::Layout;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::str::FromStr;
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 use core::sync::atomic::{AtomicU8, Ordering};
 
 use facet_core::{
@@ -25,7 +31,13 @@ use weavy::mem::runtime::{
 use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStats, Step};
 
 use crate::JsonParser;
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 use crate::parser::NativeOrderedRootCursor;
 use crate::parser::{
     JsonFieldKeyInput, JsonObjectKeyStep, JsonObjectOrderedI32Step, JsonObjectOrderedScalarStep,
@@ -152,7 +164,13 @@ impl JsonWeavyJitFallbackReport {
 pub struct JsonWeavyPlan<T> {
     lowered: DenseLowered<ExecOp>,
     execution: JsonWeavyExecutionMode,
-    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     native: Option<JsonNativePlan>,
     jit_fallback_reason: Option<&'static str>,
     _marker: PhantomData<fn() -> T>,
@@ -182,7 +200,13 @@ where
         let lowered = resolve_json_lowered(symbolic)?;
         let mut jit_fallback_reason = None;
 
-        #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+        #[cfg(all(
+            feature = "jit",
+            any(
+                all(target_os = "macos", target_arch = "aarch64"),
+                all(target_os = "linux", target_arch = "x86_64")
+            )
+        ))]
         let native = if execution == JsonWeavyExecutionMode::Jit {
             match JsonNativePlan::compile(&lowered) {
                 Ok(native) => Some(native),
@@ -195,7 +219,13 @@ where
             None
         };
 
-        #[cfg(not(all(feature = "jit", target_os = "macos", target_arch = "aarch64")))]
+        #[cfg(not(all(
+            feature = "jit",
+            any(
+                all(target_os = "macos", target_arch = "aarch64"),
+                all(target_os = "linux", target_arch = "x86_64")
+            )
+        )))]
         if execution == JsonWeavyExecutionMode::Jit {
             jit_fallback_reason = Some(json_weavy_jit_fallback_reason());
         }
@@ -203,7 +233,13 @@ where
         Ok(Self {
             lowered,
             execution,
-            #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+            #[cfg(all(
+                feature = "jit",
+                any(
+                    all(target_os = "macos", target_arch = "aarch64"),
+                    all(target_os = "linux", target_arch = "x86_64")
+                )
+            ))]
             native,
             jit_fallback_reason,
             _marker: PhantomData,
@@ -219,7 +255,13 @@ where
     /// Backend currently selected for this plan.
     #[must_use]
     pub fn active_backend(&self) -> JsonWeavyActiveBackend {
-        #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+        #[cfg(all(
+            feature = "jit",
+            any(
+                all(target_os = "macos", target_arch = "aarch64"),
+                all(target_os = "linux", target_arch = "x86_64")
+            )
+        ))]
         if self.native.is_some() {
             return JsonWeavyActiveBackend::NativeJit;
         }
@@ -304,7 +346,13 @@ where
         let mut slot = MaybeUninit::<T>::uninit();
         let root = PtrUninit::from_maybe_uninit(&mut slot);
 
-        #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+        #[cfg(all(
+            feature = "jit",
+            any(
+                all(target_os = "macos", target_arch = "aarch64"),
+                all(target_os = "linux", target_arch = "x86_64")
+            )
+        ))]
         if let Some(native) = &self.native
             && native.should_enter()
         {
@@ -322,29 +370,59 @@ where
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 struct JsonNativePlan {
     native: weavy::jit::NativeProgram,
     calls: Box<[weavy::jit::HostCallInfo]>,
     root: Box<JsonNativeRootInfo>,
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 // Safety: native plans are immutable after construction; raw pointers in their
 // program stream point into `calls`/`scalar_structs`, both owned by the plan.
 unsafe impl Send for JsonNativePlan {}
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 // Safety: see the `Send` impl; running a plan only mutates per-call state.
 unsafe impl Sync for JsonNativePlan {}
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 enum JsonNativeRootInfo {
     ScalarStruct(JsonNativeScalarStructInfo),
     ScalarStructList(JsonNativeScalarStructListInfo),
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 struct JsonNativeScalarStructInfo {
     shape: &'static Shape,
     ordered_names: Box<[&'static str]>,
@@ -354,11 +432,23 @@ struct JsonNativeScalarStructInfo {
     ordered_probe_skip: AtomicU8,
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 type NativeCursorScalarReader =
     fn(&mut NativeOrderedRootCursor<'_>, PtrUninit) -> Result<bool, DeserializeError>;
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 struct JsonNativeScalarStructListInfo {
     list_shape: &'static Shape,
     list: ListDef,
@@ -366,10 +456,22 @@ struct JsonNativeScalarStructListInfo {
     element: JsonNativeScalarStructInfo,
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 const ORDERED_PROBE_BACKOFF: u8 = u8::MAX;
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 struct JsonNativeState {
     parser: *mut (),
     lowered: *const DenseLowered<ExecOp>,
@@ -378,7 +480,13 @@ struct JsonNativeState {
     error: Option<DeserializeError>,
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 impl JsonNativePlan {
     fn compile(lowered: &DenseLowered<ExecOp>) -> Result<Self, &'static str> {
         let root = match lowered.program.as_slice() {
@@ -573,7 +681,13 @@ impl JsonNativePlan {
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 unsafe extern "C" fn json_native_read_root(state: *mut (), info: *const ()) -> bool {
     let state = unsafe { &mut *state.cast::<JsonNativeState>() };
     let info = unsafe { &*info.cast::<JsonNativeRootInfo>() };
@@ -592,7 +706,13 @@ unsafe extern "C" fn json_native_read_root(state: *mut (), info: *const ()) -> b
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 impl JsonNativeState {
     unsafe fn read_root<const TRUSTED_UTF8: bool>(
         &mut self,
@@ -1083,7 +1203,13 @@ impl JsonNativeState {
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 fn native_cursor_scalar_reader(scalar: ScalarType) -> NativeCursorScalarReader {
     match scalar {
         ScalarType::Unit => read_native_cursor_unit,
@@ -1106,7 +1232,13 @@ fn native_cursor_scalar_reader(scalar: ScalarType) -> NativeCursorScalarReader {
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 fn read_native_cursor_raw(
     _cursor: &mut NativeOrderedRootCursor<'_>,
     _dst: PtrUninit,
@@ -1114,7 +1246,13 @@ fn read_native_cursor_raw(
     Ok(false)
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 fn read_native_cursor_unit(
     cursor: &mut NativeOrderedRootCursor<'_>,
     dst: PtrUninit,
@@ -1129,7 +1267,13 @@ fn read_native_cursor_unit(
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 fn read_native_cursor_bool(
     cursor: &mut NativeOrderedRootCursor<'_>,
     dst: PtrUninit,
@@ -1144,7 +1288,13 @@ fn read_native_cursor_bool(
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 fn read_native_cursor_unsigned<T>(
     cursor: &mut NativeOrderedRootCursor<'_>,
     dst: PtrUninit,
@@ -1162,7 +1312,13 @@ where
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 fn read_native_cursor_signed<T>(
     cursor: &mut NativeOrderedRootCursor<'_>,
     dst: PtrUninit,
@@ -1180,7 +1336,13 @@ where
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 fn read_native_cursor_f32(
     cursor: &mut NativeOrderedRootCursor<'_>,
     dst: PtrUninit,
@@ -1195,7 +1357,13 @@ fn read_native_cursor_f32(
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 fn read_native_cursor_f64(
     cursor: &mut NativeOrderedRootCursor<'_>,
     dst: PtrUninit,
@@ -1210,7 +1378,13 @@ fn read_native_cursor_f64(
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 impl JsonNativeRootInfo {
     fn should_enter_native(&self) -> bool {
         match self {
@@ -1220,7 +1394,13 @@ impl JsonNativeRootInfo {
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 impl JsonNativeScalarStructInfo {
     fn should_enter_native(&self) -> bool {
         let skip = self.ordered_probe_skip.load(Ordering::Relaxed);
@@ -1241,7 +1421,13 @@ impl JsonNativeScalarStructInfo {
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 impl JsonNativeScalarStructListInfo {
     fn should_enter_native(&self) -> bool {
         self.element.should_enter_native()
@@ -1252,14 +1438,26 @@ impl JsonNativeScalarStructListInfo {
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 struct NativeScalarStructGuard<'program> {
     base: PtrUninit,
     fields: &'program [ScalarFieldPlan],
     initialized: u64,
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 impl<'program> NativeScalarStructGuard<'program> {
     fn new(base: PtrUninit, fields: &'program [ScalarFieldPlan]) -> Self {
         debug_assert!(fields.len() <= u64::BITS as usize);
@@ -1279,7 +1477,13 @@ impl<'program> NativeScalarStructGuard<'program> {
     }
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 impl Drop for NativeScalarStructGuard<'_> {
     fn drop(&mut self) {
         for index in (0..self.fields.len()).rev() {
@@ -1313,7 +1517,10 @@ fn json_weavy_jit_fallback_reason() -> &'static str {
 
 #[cfg(all(
     feature = "jit",
-    not(all(target_os = "macos", target_arch = "aarch64"))
+    not(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    ))
 ))]
 fn json_weavy_jit_fallback_reason() -> &'static str {
     let _ = json_weavy_native_jit_available();

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -190,14 +190,20 @@ fn weavy_plan_can_be_reused() {
     assert_eq!(second, Point { x: 3, y: 4 });
 }
 
+fn native_jit_expected() -> bool {
+    cfg!(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))
+}
+
 #[test]
 fn weavy_jit_plan_uses_native_for_root_scalar_struct_when_available() {
     let plan = facet_json::JsonWeavyPlan::<Point>::build_jit().unwrap();
-    let native_available = cfg!(all(
-        feature = "jit",
-        target_os = "macos",
-        target_arch = "aarch64"
-    ));
+    let native_available = native_jit_expected();
 
     assert_eq!(
         plan.execution_mode(),
@@ -248,7 +254,7 @@ fn weavy_jit_plan_reports_fallback_for_unsupported_root_shape() {
     assert_eq!(report.records[0].path, "$");
     let expected_reason = if !cfg!(feature = "jit") {
         "facet-json was built without its jit feature"
-    } else if !cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+    } else if !native_jit_expected() {
         "native JIT is not enabled for this build target"
     } else {
         "JSON native JIT currently supports root scalar structs or scalar struct lists only"
@@ -270,7 +276,7 @@ fn weavy_jit_plan_reports_fallback_for_defaulted_scalar_struct() {
     assert_eq!(report.records[0].path, "$");
     let expected_reason = if !cfg!(feature = "jit") {
         "facet-json was built without its jit feature"
-    } else if !cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+    } else if !native_jit_expected() {
         "native JIT is not enabled for this build target"
     } else {
         "JSON native JIT currently supports required scalar struct fields only"
@@ -297,11 +303,7 @@ fn weavy_jit_ordered_scalar_struct_replays_after_i32_cursor_mismatch() {
 fn weavy_jit_plan_uses_native_for_root_scalar_struct_list_when_available() {
     let plan = facet_json::JsonWeavyPlan::<Vec<Point>>::build_jit().unwrap();
     let report = plan.jit_fallback_report();
-    let native_available = cfg!(all(
-        feature = "jit",
-        target_os = "macos",
-        target_arch = "aarch64"
-    ));
+    let native_available = native_jit_expected();
 
     assert_eq!(
         plan.active_backend(),

--- a/weavy/build.rs
+++ b/weavy/build.rs
@@ -17,8 +17,8 @@ fn main() {
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
 
-        if target_os == "macos" && target_arch == "aarch64" {
-            emit_arm64_macos(&out, &generated);
+        if native_copy_patch_target(&target_os, &target_arch) {
+            emit_native(&out, &generated);
         } else {
             emit_empty(&generated);
         }
@@ -37,7 +37,15 @@ fn emit_empty(generated: &Path) {
 }
 
 #[cfg(feature = "jit")]
-fn emit_arm64_macos(out: &Path, generated: &Path) {
+fn native_copy_patch_target(target_os: &str, target_arch: &str) -> bool {
+    matches!(
+        (target_os, target_arch),
+        ("macos", "aarch64") | ("linux", "x86_64")
+    )
+}
+
+#[cfg(feature = "jit")]
+fn emit_native(out: &Path, generated: &Path) {
     println!("cargo:rerun-if-changed=stencils/hostcall.rs");
     println!("cargo:rerun-if-changed=build.rs");
 
@@ -79,7 +87,7 @@ fn emit(out: &mut String, name: &str, doc: &str, stencil: &Stencil) {
 #[cfg(feature = "jit")]
 fn emit_cont(out: &mut String, name: &str, of: &str, stencil: &Stencil) {
     out.push_str(&format!(
-        "/// Byte offsets within `{of}` of the continuation `BRANCH26` relocations to patch.\n\
+        "/// Byte offsets within `{of}` of the continuation relocations to patch.\n\
          pub const {name}: &[usize] = &{:?};\n",
         stencil.cont_relocs
     ));

--- a/weavy/src/jit.rs
+++ b/weavy/src/jit.rs
@@ -4,9 +4,12 @@
 //! functions, state ABI, host calls, and lowering policy; Weavy only exposes the
 //! neutral mechanics that multiple backends need.
 
-pub use copypatch::patch_branch26;
+pub use copypatch::{patch_branch26, patch_x86_rel32};
 
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    all(target_os = "linux", target_arch = "x86_64")
+))]
 pub use copypatch::ExecBuf;
 
 /// Shared copy-and-patch stencil bytes extracted by Weavy's build script.
@@ -19,8 +22,10 @@ pub mod stencils {
 }
 
 /// Whether this build can allocate and run native copy-and-patch code.
-pub const NATIVE_COPY_PATCH_AVAILABLE: bool =
-    cfg!(all(target_os = "macos", target_arch = "aarch64"));
+pub const NATIVE_COPY_PATCH_AVAILABLE: bool = cfg!(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    all(target_os = "linux", target_arch = "x86_64")
+));
 
 /// One consumer-supplied intrinsic in a shared Weavy host-call chain.
 #[repr(C)]
@@ -112,6 +117,28 @@ impl StencilLayout {
         patch_branch26(&mut self.code, site, target);
     }
 
+    /// Patch an x86/x86-64 `rel32` continuation relocation to another offset.
+    pub fn patch_x86_rel32(&mut self, site: usize, target: usize) {
+        patch_x86_rel32(&mut self.code, site, target);
+    }
+
+    /// Patch one continuation relocation to another offset in this layout.
+    pub fn patch_continuation(&mut self, site: usize, target: usize) {
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        {
+            return self.patch_branch26(site, target);
+        }
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        {
+            return self.patch_x86_rel32(site, target);
+        }
+        #[allow(unreachable_code)]
+        {
+            let _ = (site, target);
+            panic!("native copy-and-patch is not available for this target");
+        }
+    }
+
     /// Append one word to a chain's program stream.
     pub fn push_prog_word(&mut self, prog_index: usize, value: u64) {
         self.progs[prog_index].push(value);
@@ -152,7 +179,7 @@ impl StencilLayout {
     /// Patch one shared host-call stencil's continuation to `target`.
     pub fn patch_hostcall_continuation(&mut self, hostcall_start: usize, target: usize) {
         for &rel in stencils::HOSTCALL_CONT {
-            self.patch_branch26(hostcall_start + rel, target);
+            self.patch_continuation(hostcall_start + rel, target);
         }
     }
 
@@ -186,7 +213,10 @@ impl StencilLayout {
 /// The ABI is still owned by the caller: this only binds a finalized
 /// [`StencilLayout`] into native memory and keeps each chain's program stream in
 /// stable heap storage for stencils to read.
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    all(target_os = "linux", target_arch = "x86_64")
+))]
 pub struct NativeProgram {
     buf: ExecBuf,
     progs: Vec<Vec<u64>>,
@@ -194,7 +224,10 @@ pub struct NativeProgram {
     stencil_count: usize,
 }
 
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    all(target_os = "linux", target_arch = "x86_64")
+))]
 impl NativeProgram {
     /// Make a finalized stencil layout executable.
     #[must_use]
@@ -322,14 +355,32 @@ mod tests {
         assert_eq!(layout.stencil_count(), 2);
     }
 
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    ))]
+    fn ret_stencil() -> &'static [u8] {
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        {
+            &[0xc0, 0x03, 0x5f, 0xd6]
+        }
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        {
+            &[0xc3]
+        }
+    }
+
+    #[cfg(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    ))]
     #[test]
     fn native_program_owns_executable_code_and_program_slots() {
         use super::NativeProgram;
 
         let mut layout = StencilLayout::new();
         let root = layout.start_chain();
-        layout.emit_stencil(&[0xc0, 0x03, 0x5f, 0xd6]);
+        layout.emit_stencil(ret_stencil());
         layout.push_prog_word(root.prog_index, 7);
         let slot = layout.reserve_prog_slot(root.prog_index);
 
@@ -346,7 +397,10 @@ mod tests {
         unsafe { entry(&mut ctx) };
     }
 
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[cfg(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    ))]
     #[test]
     fn shared_hostcall_stencil_runs_consumer_intrinsic() {
         use super::{HostCallCtx, HostCallInfo, NativeProgram};


### PR DESCRIPTION
## Summary

- Add Linux x86_64 executable copy-patch support to `copypatch` using `mmap` + `mprotect`, with `munmap` cleanup.
- Add x86_64 `rel32` continuation patching and make stencil extraction section-aware for ELF `.text.<symbol>` output.
- Enable Weavy `NativeProgram` and the facet-json Weavy native JIT lane on Linux x86_64.

The important extraction detail is that shared stencils now compile with `-C relocation-model=static`; on Linux x86_64 that turns the continuation from an indirect GOT jump into a direct patchable `R_X86_64_PLT32` / `rel32` jump.

## Performance

Baseline: `origin/main` at `4cb2195e7`.
PR: `05190e41d`.
Lower is better.

### Ryzen 5 3600

| case | main JIT | PR JIT | PR vs main | PR Weavy / serde_json |
|---|---:|---:|---:|---:|
| `wide_scalars` | 1.081 us | 400.7 ns | -62.9% | 1.03x |
| `Vec<wide_scalars>` | 3.275 us | 1.061 us | -67.6% | 1.00x |
| `point` | 159.7 ns | 99.74 ns | -37.5% | 1.24x |
| `Vec<point>` | 720.7 ns | 320.7 ns | -55.5% | 1.07x |
| `float_point` | 370.7 ns | 209.7 ns | -43.4% | 1.40x |
| `Vec<float_point>` | 1.722 us | 700.7 ns | -59.3% | 1.40x |

### M4 Pro Guardrail

macOS/aarch64 already had native copy-patch before this PR; this is a no-regression check for the existing lane.

| case | main JIT | PR JIT | PR vs main | PR Weavy / serde_json |
|---|---:|---:|---:|---:|
| `wide_scalars` | 165.7 ns | 166.7 ns | +0.6% | 0.77x |
| `Vec<wide_scalars>` | 416.7 ns | 416.7 ns | 0.0% | 0.72x |
| `point` | 41.73 ns | 28.81 ns | -31.0% | 1.06x |
| `Vec<point>` | 120.8 ns | 120.7 ns | -0.1% | 0.73x |
| `float_point` | 66.8 ns | 66.09 ns | -1.1% | 1.04x |
| `Vec<float_point>` | 291.7 ns | 291.6 ns | 0.0% | 1.00x |

The tiny M4 `point` row is noisy, so the main claim is the Ryzen 5 3600 enablement table. The M4 native path stays effectively flat.

## Stax

Ryzen 5 3600, PR build, `wide_scalars_weavy_jit_reused_plan`:

- stax run: `2`
- divan median under stax: `410.7 ns`
- top project frames:
  - `facet_json::weavy_deser::JsonNativeState::read_cursor_scalar_struct_object`
  - `facet_json::scanner::Scanner::try_consume_one_byte_field_name_colon`
  - `facet_json::weavy_deser::read_native_cursor_signed`
  - `facet_json::scanner::Scanner::skip_whitespace`
  - `facet_json::weavy_deser::read_native_cursor_unsigned`

The old interpreted scalar-struct frame is not in the hot set on Linux x86_64.

## Verification

M4 Pro:

- `cargo fmt --all --check`
- `cargo check -p copypatch --all-features --all-targets --message-format=short`
- `cargo check -p weavy --features jit --all-targets --message-format=short`
- `cargo check -p facet-json --all-features --all-targets --message-format=short`
- `cargo nextest run -p weavy --features jit -E 'test(native_program_owns_executable_code_and_program_slots) | test(shared_hostcall_stencil_runs_consumer_intrinsic)'`
- `cargo nextest run -p copypatch --all-features -E 'test(x86_rel32_patches_relative_to_next_instruction)'`
- `cargo nextest run -p facet-json --all-features -E 'test(weavy_jit)'`
- pre-push hook passed workspace metadata, shear, affected, clippy, docs, build tests, and run tests

Ryzen 5 3600:

- `cargo check -p weavy --features jit --all-targets --message-format=short`
- `cargo check -p facet-json --all-features --all-targets --message-format=short`
- `cargo nextest run -p weavy --features jit -E 'test(native_program_owns_executable_code_and_program_slots) | test(shared_hostcall_stencil_runs_consumer_intrinsic)'`
- `cargo nextest run -p copypatch --all-features -E 'test(x86_rel32_patches_relative_to_next_instruction)'`
- `cargo nextest run -p facet-json --all-features -E 'test(weavy_jit)'` (`12/12` passed)
