### PR TITLE
Speed up Weavy f64 cursor parsing

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -2528,6 +2528,27 @@ impl<'de> NativeOrderedRootCursor<'de> {
     }
 
     #[inline]
+    pub(crate) fn consume_ordered_f64_field(
+        &mut self,
+        expected: &str,
+        require_comma: bool,
+    ) -> Result<Option<f64>, ParseError> {
+        let [expected] = expected.as_bytes() else {
+            return Ok(None);
+        };
+        let value = self
+            .scanner
+            .try_consume_one_byte_field_name_colon_f64(self.input, *expected, require_comma)
+            .map_err(scan_error_to_parse_error)?;
+
+        if let Some((span, value)) = value {
+            self.last_token_start = span.offset as usize;
+            return Ok(Some(value));
+        }
+        Ok(None)
+    }
+
+    #[inline]
     pub(crate) fn consume_i32(&mut self) -> Result<Option<(Span, i32)>, ParseError> {
         let value = self
             .scanner

--- a/facet-json/src/scanner.rs
+++ b/facet-json/src/scanner.rs
@@ -330,6 +330,55 @@ impl Scanner {
         )
     ))]
     #[inline]
+    pub fn try_consume_one_byte_field_name_colon_f64(
+        &mut self,
+        buf: &[u8],
+        expected: u8,
+        require_comma: bool,
+    ) -> Result<Option<(Span, f64)>, ScanError> {
+        if matches!(expected, b'"' | b'\\' | 0x00..=0x1f) {
+            return Ok(None);
+        }
+
+        let original = self.pos;
+        self.skip_whitespace_if_needed(buf)?;
+
+        if require_comma {
+            if buf.get(self.pos) != Some(&b',') {
+                self.pos = original;
+                return Ok(None);
+            }
+            self.pos += 1;
+            self.skip_whitespace_if_needed(buf)?;
+        }
+
+        if !matches!(
+            (buf.get(self.pos), buf.get(self.pos + 1), buf.get(self.pos + 2)),
+            (Some(b'"'), Some(byte), Some(b'"')) if *byte == expected
+        ) {
+            self.pos = original;
+            return Ok(None);
+        }
+        self.pos += 3;
+
+        self.skip_whitespace_if_needed(buf)?;
+        if buf.get(self.pos) != Some(&b':') {
+            self.pos = original;
+            return Ok(None);
+        }
+        self.pos += 1;
+
+        self.try_consume_f64_number_with_rollback(buf, original)
+    }
+
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
+    #[inline]
     pub fn try_consume_array_object_start(
         &mut self,
         buf: &[u8],
@@ -606,6 +655,22 @@ impl Scanner {
     #[inline]
     pub fn try_consume_f64_number(&mut self, buf: &[u8]) -> Result<Option<(Span, f64)>, ScanError> {
         let original = self.pos;
+        self.try_consume_f64_number_with_rollback(buf, original)
+    }
+
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
+    #[inline(always)]
+    fn try_consume_f64_number_with_rollback(
+        &mut self,
+        buf: &[u8],
+        original: usize,
+    ) -> Result<Option<(Span, f64)>, ScanError> {
         self.skip_whitespace_if_needed(buf)?;
 
         let start = self.pos;
@@ -614,29 +679,37 @@ impl Scanner {
             return Ok(None);
         }
 
-        let token = match self.scan_number(buf, start) {
-            Ok(token) => token,
-            Err(_) => {
-                self.pos = original;
-                return Ok(None);
-            }
-        };
-        let Token::Number { start, end, hint } = token.token else {
-            unreachable!("scan_number returns a number token");
-        };
-        let value = match parse_number(buf, start, end, hint) {
-            Ok(ParsedNumber::F64(value)) => value,
-            Ok(ParsedNumber::I64(value)) => value as f64,
-            Ok(ParsedNumber::U64(value)) => value as f64,
-            Ok(ParsedNumber::I128(value)) => value as f64,
-            Ok(ParsedNumber::U128(value)) => value as f64,
+        let (end, hint) = match self.scan_number_bounds(buf, start) {
+            Ok(bounds) => bounds,
             Err(_) => {
                 self.pos = original;
                 return Ok(None);
             }
         };
 
-        Ok(Some((token.span, value)))
+        let value = if hint == NumberHint::Float {
+            match parse_f64(buf, start, end) {
+                Ok(value) => value,
+                Err(_) => {
+                    self.pos = original;
+                    return Ok(None);
+                }
+            }
+        } else {
+            match parse_number(buf, start, end, hint) {
+                Ok(ParsedNumber::F64(value)) => value,
+                Ok(ParsedNumber::I64(value)) => value as f64,
+                Ok(ParsedNumber::U64(value)) => value as f64,
+                Ok(ParsedNumber::I128(value)) => value as f64,
+                Ok(ParsedNumber::U128(value)) => value as f64,
+                Err(_) => {
+                    self.pos = original;
+                    return Ok(None);
+                }
+            }
+        };
+
+        Ok(Some((Span::new(start, end - start), value)))
     }
 
     /// Scan the next token from the buffer.
@@ -888,6 +961,20 @@ impl Scanner {
 
     /// Scan a number, finding its boundaries and determining its type hint.
     fn scan_number(&mut self, buf: &[u8], start: usize) -> ScanResult {
+        let (end, hint) = self.scan_number_bounds(buf, start)?;
+
+        Ok(SpannedToken {
+            token: Token::Number { start, end, hint },
+            span: Span::new(start, end - start),
+        })
+    }
+
+    #[inline]
+    fn scan_number_bounds(
+        &mut self,
+        buf: &[u8],
+        start: usize,
+    ) -> Result<(usize, NumberHint), ScanError> {
         let mut hint = NumberHint::Unsigned;
 
         if buf.get(self.pos) == Some(&b'-') {
@@ -895,15 +982,16 @@ impl Scanner {
             self.pos += 1;
         }
 
-        self.scan_number_content(buf, start, hint)
+        self.scan_number_content_bounds(buf, start, hint)
     }
 
-    fn scan_number_content(
+    #[inline]
+    fn scan_number_content_bounds(
         &mut self,
         buf: &[u8],
         start: usize,
         mut hint: NumberHint,
-    ) -> ScanResult {
+    ) -> Result<(usize, NumberHint), ScanError> {
         let mut pos = self.pos;
 
         // Integer part
@@ -964,10 +1052,7 @@ impl Scanner {
             });
         }
 
-        Ok(SpannedToken {
-            token: Token::Number { start, end, hint },
-            span: Span::new(start, end - start),
-        })
+        Ok((end, hint))
     }
 
     /// Scan a literal keyword (true, false, null)
@@ -1487,18 +1572,12 @@ pub fn parse_number(
     end: usize,
     hint: NumberHint,
 ) -> Result<ParsedNumber, ScanError> {
-    use lexical_parse_float::FromLexical as _;
     use lexical_parse_integer::FromLexical as _;
 
     let slice = &buf[start..end];
 
     match hint {
-        NumberHint::Float => f64::from_lexical(slice)
-            .map(ParsedNumber::F64)
-            .map_err(|_| ScanError {
-                kind: ScanErrorKind::UnexpectedChar('?'),
-                span: Span::new(start, end - start),
-            }),
+        NumberHint::Float => parse_f64(buf, start, end).map(ParsedNumber::F64),
         NumberHint::Signed => {
             if let Ok(n) = i64::from_lexical(slice) {
                 Ok(ParsedNumber::I64(n))
@@ -1524,6 +1603,17 @@ pub fn parse_number(
             }
         }
     }
+}
+
+#[cfg(feature = "lexical-parse")]
+#[inline]
+fn parse_f64(buf: &[u8], start: usize, end: usize) -> Result<f64, ScanError> {
+    use lexical_parse_float::FromLexical as _;
+
+    f64::from_lexical(&buf[start..end]).map_err(|_| ScanError {
+        kind: ScanErrorKind::UnexpectedChar('?'),
+        span: Span::new(start, end - start),
+    })
 }
 
 /// Parse a number from the buffer slice, skipping UTF-8 validation.
@@ -1586,13 +1676,7 @@ fn parse_number_inner(
     hint: NumberHint,
 ) -> Result<ParsedNumber, ScanError> {
     match hint {
-        NumberHint::Float => s
-            .parse::<f64>()
-            .map(ParsedNumber::F64)
-            .map_err(|_| ScanError {
-                kind: ScanErrorKind::UnexpectedChar('?'),
-                span: Span::new(start, end - start),
-            }),
+        NumberHint::Float => parse_f64_inner(s, start, end).map(ParsedNumber::F64),
         NumberHint::Signed => {
             if let Ok(n) = s.parse::<i64>() {
                 Ok(ParsedNumber::I64(n))
@@ -1618,6 +1702,27 @@ fn parse_number_inner(
             }
         }
     }
+}
+
+#[cfg(not(feature = "lexical-parse"))]
+#[inline]
+fn parse_f64(buf: &[u8], start: usize, end: usize) -> Result<f64, ScanError> {
+    let slice = &buf[start..end];
+    let s = str::from_utf8(slice).map_err(|_| ScanError {
+        kind: ScanErrorKind::InvalidUtf8,
+        span: Span::new(start, end - start),
+    })?;
+
+    parse_f64_inner(s, start, end)
+}
+
+#[cfg(not(feature = "lexical-parse"))]
+#[inline]
+fn parse_f64_inner(s: &str, start: usize, end: usize) -> Result<f64, ScanError> {
+    s.parse::<f64>().map_err(|_| ScanError {
+        kind: ScanErrorKind::UnexpectedChar('?'),
+        span: Span::new(start, end - start),
+    })
 }
 
 #[cfg(test)]
@@ -1862,5 +1967,69 @@ mod tests {
                 ParsedNumber::F64(3.14)
             );
         }
+    }
+
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
+    #[test]
+    fn try_consume_f64_number_direct_path() {
+        let mut scanner = Scanner::new();
+        let (span, value) = scanner
+            .try_consume_f64_number(b"  -0.03125,")
+            .unwrap()
+            .unwrap();
+        assert_eq!(span, Span::new(2, 8));
+        assert_eq!(value, -0.03125);
+
+        let mut scanner = Scanner::new();
+        let (span, value) = scanner.try_consume_f64_number(b"9000}").unwrap().unwrap();
+        assert_eq!(span, Span::new(0, 4));
+        assert_eq!(value, 9000.0);
+    }
+
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
+    #[test]
+    fn try_consume_f64_number_rolls_back_on_invalid_float() {
+        let mut scanner = Scanner::new();
+        assert!(scanner.try_consume_f64_number(b"1e,").unwrap().is_none());
+        assert_eq!(scanner.pos(), 0);
+    }
+
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
+    #[test]
+    fn try_consume_one_byte_field_name_colon_f64_rolls_back_together() {
+        let mut scanner = Scanner::new();
+        let (span, value) = scanner
+            .try_consume_one_byte_field_name_colon_f64(br#" "x": -1.25,"#, b'x', false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(span, Span::new(6, 5));
+        assert_eq!(value, -1.25);
+
+        let mut scanner = Scanner::new();
+        assert!(
+            scanner
+                .try_consume_one_byte_field_name_colon_f64(br#" "x": "1.25""#, b'x', false)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(scanner.pos(), 0);
     }
 }

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -1076,6 +1076,15 @@ impl JsonNativeState {
     where
         for<'de> JsonParser<'de, TRUSTED_UTF8>: ScalarInputPreselected<'de, TRUSTED_UTF8>,
     {
+        if tiny_f64_struct_fields_are_fusible(&info.fields) {
+            return self.read_cursor_f64_scalar_struct_object(
+                cursor,
+                info,
+                guard,
+                array_element_object,
+            );
+        }
+
         if let Some(require_comma) = array_element_object
             && !cursor.consume_array_object_start(require_comma)?
         {
@@ -1096,6 +1105,39 @@ impl JsonNativeState {
                     field_ptr,
                     JsonScalarInput::Raw(token),
                 )?;
+            }
+            guard.mark(index);
+        }
+
+        if !cursor.consume_object_end()? {
+            return Ok(false);
+        }
+        Ok(true)
+    }
+
+    #[inline]
+    fn read_cursor_f64_scalar_struct_object(
+        &mut self,
+        cursor: &mut NativeOrderedRootCursor<'_>,
+        info: &JsonNativeScalarStructInfo,
+        guard: &mut NativeScalarStructGuard<'_>,
+        array_element_object: Option<bool>,
+    ) -> Result<bool, DeserializeError> {
+        if let Some(require_comma) = array_element_object
+            && !cursor.consume_array_object_start(require_comma)?
+        {
+            return Ok(false);
+        }
+
+        for (index, expected) in info.ordered_names.iter().copied().enumerate() {
+            let Some(value) = cursor.consume_ordered_f64_field(expected, index > 0)? else {
+                return Ok(false);
+            };
+
+            let field = info.fields[index];
+            let field_ptr = unsafe { self.base.field_uninit(field.offset) };
+            unsafe {
+                field_ptr.put(value);
             }
             guard.mark(index);
         }
@@ -3500,6 +3542,24 @@ fn tiny_i32_struct_fields_are_fusible(fields: &[ScalarFieldPlan]) -> bool {
         && fields.iter().all(|field| {
             field.alias.is_none()
                 && field.scalar.scalar == ScalarType::I32
+                && matches!(field.missing, MissingField::Required)
+        })
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+fn tiny_f64_struct_fields_are_fusible(fields: &[ScalarFieldPlan]) -> bool {
+    !fields.is_empty()
+        && fields.len() <= TINY_SCALAR_STRUCT_MAX_FIELDS
+        && fields.iter().all(|field| {
+            field.alias.is_none()
+                && field.scalar.scalar == ScalarType::F64
+                && matches!(field.name.as_bytes(), [_])
                 && matches!(field.missing, MissingField::Required)
         })
 }

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -11,6 +11,13 @@ struct Point {
 }
 
 #[derive(Facet, Debug, PartialEq)]
+struct FloatPoint {
+    x: f64,
+    y: f64,
+    z: f64,
+}
+
+#[derive(Facet, Debug, PartialEq)]
 struct Person {
     name: String,
     age: u32,
@@ -386,6 +393,23 @@ fn weavy_jit_ordered_wide_scalars_accept_numeric_strings() {
             j: -10,
             k: true,
             l: 11.5,
+        }
+    );
+}
+
+#[test]
+fn weavy_jit_ordered_float_scalars_replay_after_string_mismatch() {
+    let plan = facet_json::JsonWeavyPlan::<FloatPoint>::build_jit().unwrap();
+    let got = plan
+        .from_str(r#"{"x":12.5,"y":"-0.03125","z":9000.125}"#)
+        .unwrap();
+
+    assert_eq!(
+        got,
+        FloatPoint {
+            x: 12.5,
+            y: -0.03125,
+            z: 9000.125,
         }
     );
 }


### PR DESCRIPTION
## Summary

- Split the scanner's number-boundary walk from `SpannedToken` construction so native cursor reads can use the bounds directly.
- Add a direct `f64` parse helper for known-float cursor fields, avoiding `Token::Number` and `ParsedNumber` on that path.
- Add a fused one-byte-field-name + colon + `f64` cursor probe for tiny all-`f64` scalar structs.
- Keep integer-to-`f64` on the previous `ParsedNumber` route so the fast path does not broaden accepted integer literals.
- Add scanner and integration tests for direct float reads, fused field reads, rollback, and replay through the richer path when an all-`f64` struct sees a numeric string.

## Performance

Baseline: `origin/main` at `08612af22`.
PR: `420cc4d47`.
Lower is better.

### Ryzen 5 3600

| case | main JIT | PR JIT | PR vs main | PR Weavy / serde_json |
|---|---:|---:|---:|---:|
| `float_point` | 200.7 ns | 169.7 ns | -15.4% | 1.00x |
| `Vec<float_point>` | 700.7 ns | 580.7 ns | -17.1% | 1.12x |

### M4 Pro

| case | main JIT | PR JIT | PR vs main | PR Weavy / serde_json |
|---|---:|---:|---:|---:|
| `float_point` | 68.75 ns | 50.86 ns | -26.0% | 0.80x |
| `Vec<float_point>` | 291.7 ns | 208.7 ns | -28.5% | 0.72x |

## Stax

Ryzen 5 3600, final PR build, `float_point_weavy_jit_reused_plan`:

- stax run: `7`
- divan median under stax: `169.7 ns`
- the old `facet_json::scanner::parse_number` frame remains gone
- separate field-key and cursor-f64 frames collapsed into `JsonNativeState::read_cursor_f64_scalar_struct_object`
- top project frames now include:
  - `facet_json::scanner::parse_f64`
  - `facet_json::weavy_deser::JsonNativeState::read_cursor_f64_scalar_struct_object`
  - `facet_json::weavy_deser::JsonNativeState::read_root`
  - `facet_json::scanner::Scanner::consume_punctuation`

## Verification

- `cargo fmt --all --check`
- `cargo check -p facet-json --all-features --all-targets --message-format=short`
- `cargo nextest run -p facet-json --all-features -E 'test(try_consume_f64_number) | test(try_consume_one_byte_field_name_colon_f64) | test(weavy_jit_ordered_float_scalars_replay_after_string_mismatch) | test(weavy_jit)'`
- push hook passed metadata, cargo-shear, affected, clippy, docs, build tests, and run tests
