### PR TITLE
Speed up native Weavy scalar struct lists

### DIFF
--- a/facet-json/src/parser.rs
+++ b/facet-json/src/parser.rs
@@ -277,6 +277,19 @@ pub(crate) struct NativeOrderedRootCursor<'de> {
     last_token_start: usize,
 }
 
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NativeArrayStep {
+    Element,
+    End,
+}
+
 #[derive(Debug, Clone, Copy)]
 enum ObjectState {
     KeyOrEnd,
@@ -2669,24 +2682,27 @@ impl<'de> NativeOrderedRootCursor<'de> {
     }
 
     #[inline]
-    pub(crate) fn consume_array_end_if_next(
+    pub(crate) fn consume_array_step(
         &mut self,
         after_element: bool,
-    ) -> Result<bool, ParseError> {
-        let original = self.scanner.clone();
+    ) -> Result<Option<NativeArrayStep>, ParseError> {
         if self.consume_punctuation(b']')? {
-            return Ok(true);
-        }
-        self.scanner = original.clone();
-
-        if after_element {
-            if self.consume_punctuation(b',')? && self.consume_punctuation(b']')? {
-                return Ok(true);
-            }
-            self.scanner = original;
+            return Ok(Some(NativeArrayStep::End));
         }
 
-        Ok(false)
+        if !after_element {
+            return Ok(Some(NativeArrayStep::Element));
+        }
+
+        if !self.consume_punctuation(b',')? {
+            return Ok(None);
+        }
+
+        if self.consume_punctuation(b']')? {
+            return Ok(Some(NativeArrayStep::End));
+        }
+
+        Ok(Some(NativeArrayStep::Element))
     }
 
     #[inline]

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -31,6 +31,10 @@ use weavy::mem::runtime::{
 use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStats, Step};
 
 use crate::JsonParser;
+use crate::parser::{
+    JsonFieldKeyInput, JsonObjectKeyStep, JsonObjectOrderedI32Step, JsonObjectOrderedScalarStep,
+    JsonScalarInput, JsonScalarToken, JsonSequenceScalarStep,
+};
 #[cfg(all(
     feature = "jit",
     any(
@@ -38,11 +42,7 @@ use crate::JsonParser;
         all(target_os = "linux", target_arch = "x86_64")
     )
 ))]
-use crate::parser::NativeOrderedRootCursor;
-use crate::parser::{
-    JsonFieldKeyInput, JsonObjectKeyStep, JsonObjectOrderedI32Step, JsonObjectOrderedScalarStep,
-    JsonScalarInput, JsonScalarToken, JsonSequenceScalarStep,
-};
+use crate::parser::{NativeArrayStep, NativeOrderedRootCursor};
 use crate::scanner::{NumberHint, ParsedNumber, SpannedToken, Token as ScanToken};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -781,6 +781,11 @@ impl JsonNativeState {
             return Ok(());
         }
 
+        if self.try_read_cursor_f64_scalar_struct_list(parser, info)? {
+            info.record_ordered_probe(true);
+            return Ok(());
+        }
+
         if self.try_read_cursor_scalar_struct_list(parser, info)? {
             info.record_ordered_probe(true);
             return Ok(());
@@ -904,10 +909,14 @@ impl JsonNativeState {
         );
         let mut after_element = false;
         loop {
-            if cursor.consume_array_end_if_next(after_element)? {
-                self.adopt_native_list(info, &mut builder)?;
-                parser.commit_native_ordered_root(cursor);
-                return Ok(true);
+            match cursor.consume_array_step(after_element)? {
+                Some(NativeArrayStep::End) => {
+                    self.adopt_native_list(info, &mut builder)?;
+                    parser.commit_native_ordered_root(cursor);
+                    return Ok(true);
+                }
+                Some(NativeArrayStep::Element) => {}
+                None => return Ok(false),
             }
 
             let slot = builder.next_uninit_slot().map_err(raw_alloc_error)?;
@@ -919,7 +928,67 @@ impl JsonNativeState {
                 &mut cursor,
                 &info.element,
                 &mut guard,
-                Some(after_element),
+                Some(false),
+            );
+            self.base = old_base;
+
+            let matched = matched?;
+            if !matched {
+                return Ok(false);
+            }
+
+            guard.finish();
+            unsafe {
+                builder.mark_initialized();
+            }
+            after_element = true;
+        }
+    }
+
+    #[inline]
+    fn try_read_cursor_f64_scalar_struct_list<const TRUSTED_UTF8: bool>(
+        &mut self,
+        parser: &mut JsonParser<'_, TRUSTED_UTF8>,
+        info: &JsonNativeScalarStructListInfo,
+    ) -> Result<bool, DeserializeError> {
+        if !tiny_f64_struct_fields_are_fusible(&info.element.fields) {
+            return Ok(false);
+        }
+
+        let Some(mut cursor) = parser.native_ordered_root_cursor() else {
+            return Ok(false);
+        };
+        if !cursor.consume_root_array_start()? {
+            return Ok(false);
+        }
+
+        let mut builder = RawArrayBuilder::new(
+            info.element_layout,
+            info.list.t() as *const Shape as *const (),
+            drop_shape_value,
+        );
+        let mut after_element = false;
+        loop {
+            match cursor.consume_array_step(after_element)? {
+                Some(NativeArrayStep::End) => {
+                    self.adopt_native_list(info, &mut builder)?;
+                    parser.commit_native_ordered_root(cursor);
+                    return Ok(true);
+                }
+                Some(NativeArrayStep::Element) => {}
+                None => return Ok(false),
+            }
+
+            let slot = builder.next_uninit_slot().map_err(raw_alloc_error)?;
+            let old_base = self.base;
+            self.base = PtrUninit::new(slot);
+
+            let mut guard = NativeScalarStructGuard::new(self.base, &info.element.fields);
+            let matched = self.read_cursor_f64_scalar_struct_object(
+                &mut cursor,
+                &info.element,
+                &mut guard,
+                Some(false),
             );
             self.base = old_base;
 
@@ -995,10 +1064,14 @@ impl JsonNativeState {
         );
         let mut after_element = false;
         loop {
-            if cursor.consume_array_end_if_next(after_element)? {
-                self.adopt_native_list(info, &mut builder)?;
-                parser.commit_native_ordered_root(cursor);
-                return Ok(true);
+            match cursor.consume_array_step(after_element)? {
+                Some(NativeArrayStep::End) => {
+                    self.adopt_native_list(info, &mut builder)?;
+                    parser.commit_native_ordered_root(cursor);
+                    return Ok(true);
+                }
+                Some(NativeArrayStep::Element) => {}
+                None => return Ok(false),
             }
 
             let slot = builder.next_uninit_slot().map_err(raw_alloc_error)?;
@@ -1011,7 +1084,7 @@ impl JsonNativeState {
                 &mut cursor,
                 &info.element,
                 &mut guard,
-                Some(after_element),
+                Some(false),
             );
             self.base = old_base;
 

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -415,6 +415,54 @@ fn weavy_jit_ordered_float_scalars_replay_after_string_mismatch() {
 }
 
 #[test]
+fn weavy_jit_scalar_struct_list_handles_ordered_float_scalars() {
+    let plan = facet_json::JsonWeavyPlan::<Vec<FloatPoint>>::build_jit().unwrap();
+    let got = plan
+        .from_str(r#"[{"x":12.5,"y":-0.03125,"z":9000.125},{"x":-4.25,"y":2.5,"z":0.125}]"#)
+        .unwrap();
+
+    assert_eq!(
+        got,
+        vec![
+            FloatPoint {
+                x: 12.5,
+                y: -0.03125,
+                z: 9000.125,
+            },
+            FloatPoint {
+                x: -4.25,
+                y: 2.5,
+                z: 0.125,
+            },
+        ]
+    );
+}
+
+#[test]
+fn weavy_jit_scalar_struct_list_replays_after_float_string_mismatch() {
+    let plan = facet_json::JsonWeavyPlan::<Vec<FloatPoint>>::build_jit().unwrap();
+    let got = plan
+        .from_str(r#"[{"x":12.5,"y":-0.03125,"z":9000.125},{"x":-4.25,"y":"2.5","z":0.125}]"#)
+        .unwrap();
+
+    assert_eq!(
+        got,
+        vec![
+            FloatPoint {
+                x: 12.5,
+                y: -0.03125,
+                z: 9000.125,
+            },
+            FloatPoint {
+                x: -4.25,
+                y: 2.5,
+                z: 0.125,
+            },
+        ]
+    );
+}
+
+#[test]
 fn weavy_jit_scalar_struct_list_handles_ordered_wide_scalars() {
     let plan = facet_json::JsonWeavyPlan::<Vec<WideScalarStruct>>::build_jit().unwrap();
     let got = plan


### PR DESCRIPTION
## Summary

This PR tightens the native Weavy scalar-struct list loop in `facet-json`.

- replaces the speculative `consume_array_end_if_next` scanner clone/restore with a cursor `NativeArrayStep`
- adds a direct f64 scalar-struct list lane so `Vec<FloatPoint>` does not re-enter the generic scalar-struct object dispatcher for each element
- routes the i32/generic native list lanes through the same array-step primitive, consuming list commas once before object parsing
- adds list tests for ordered f64 scalar structs and replay after a f64 numeric-string mismatch

## Benchmarks

Median wall time, Divan, `--threads 1`.

### `Vec<FloatPoint>`

| Machine | main Weavy JIT | PR Weavy JIT | Delta | PR serde_json | PR Weavy / serde_json |
|---|---:|---:|---:|---:|---:|
| M4 Pro | 249.7 ns | 207.6 ns | -16.9% | 290.6 ns | 0.71x |
| M2 Max | 499.5 ns | 458.5 ns | -8.2% | 332.5 ns | 1.38x |
| Ryzen 5 3600 | 590.7 ns | 530.6 ns | -10.2% | 500.6 ns | 1.06x |

### Guardrail: Ordered `Vec<WideScalarStruct>`

| Machine | main Weavy JIT | PR Weavy JIT | Delta |
|---|---:|---:|---:|
| M4 Pro | 416.7 ns | 416.6 ns | ~flat |
| M2 Max | 582.7 ns | 541.7 ns | -7.0% |
| Ryzen 5 3600 | 1.091 us | 1.071 us | -1.8% |

### Stax

`stax record -F 1900 -l 15 -- ... float_point_list_weavy_jit_reused_plan` on M4 Pro captured 9,752 samples.

Top self frames:

| Samples | Function |
|---:|---|
| 821 | `JsonNativeState::read_cursor_f64_scalar_struct_object` |
| 414 | `facet_json::scanner::parse_f64` |
| 190 | `Scanner::consume_punctuation` |
| 52 | `NativeOrderedRootCursor::consume_array_step` |
| 39 | `RawArrayBuilder::next_uninit_slot` |

## Testing

- `cargo check -p facet-json --all-features --all-targets --message-format=short`
- `cargo nextest run -p facet-json --all-features`
- `cargo fmt --all --check`
- push hook: clippy, docs, build tests, run tests
