### PR TITLE
Support maps in facet-json Weavy deserializer

### DIFF
--- a/facet-json/benches/canada.rs
+++ b/facet-json/benches/canada.rs
@@ -84,3 +84,14 @@ fn weavy_reused_plan(bencher: Bencher) {
         black_box(result)
     });
 }
+
+#[divan::bench]
+fn weavy_jit_reused_plan(bencher: Bencher) {
+    let data = json_str();
+    let plan = facet_json::JsonWeavyPlan::<FeatureCollection>::build_jit().unwrap();
+
+    bencher.bench(|| {
+        let result: FeatureCollection = black_box(plan.from_str(black_box(data)).unwrap());
+        black_box(result)
+    });
+}

--- a/facet-json/benches/citm.rs
+++ b/facet-json/benches/citm.rs
@@ -113,3 +113,25 @@ fn facet_json(bencher: Bencher) {
         black_box(result)
     });
 }
+
+#[divan::bench]
+fn weavy_reused_plan(bencher: Bencher) {
+    let data = json_str();
+    let plan = facet_json::JsonWeavyPlan::<CitmCatalog>::build().unwrap();
+
+    bencher.bench(|| {
+        let result: CitmCatalog = black_box(plan.from_str(black_box(data)).unwrap());
+        black_box(result)
+    });
+}
+
+#[divan::bench]
+fn weavy_jit_reused_plan(bencher: Bencher) {
+    let data = json_str();
+    let plan = facet_json::JsonWeavyPlan::<CitmCatalog>::build_jit().unwrap();
+
+    bencher.bench(|| {
+        let result: CitmCatalog = black_box(plan.from_str(black_box(data)).unwrap());
+        black_box(result)
+    });
+}

--- a/facet-json/benches/twitter.rs
+++ b/facet-json/benches/twitter.rs
@@ -472,3 +472,14 @@ fn weavy_reused_plan(bencher: Bencher) {
         black_box(result)
     });
 }
+
+#[divan::bench]
+fn weavy_jit_reused_plan(bencher: Bencher) {
+    let data = json_str();
+    let plan = facet_json::JsonWeavyPlan::<TwitterOwned>::build_jit().unwrap();
+
+    bencher.bench(|| {
+        let result: TwitterOwned = black_box(plan.from_str(black_box(data)).unwrap());
+        black_box(result)
+    });
+}

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -20,8 +20,8 @@ use core::str::FromStr;
 use core::sync::atomic::{AtomicU8, Ordering};
 
 use facet_core::{
-    Def, DefaultInPlaceFn, DefaultSource, Facet, Field, ListDef, OptionDef, PointerDef, PtrMut,
-    PtrUninit, ScalarType, Shape, StructKind, Type, UserType,
+    Def, DefaultInPlaceFn, DefaultSource, Facet, Field, ListDef, MapDef, OptionDef, PointerDef,
+    PtrMut, PtrUninit, ScalarType, Shape, StructKind, Type, UserType,
 };
 use facet_format::{DeserializeError, DeserializeErrorKind, FormatParser, ParseError};
 use facet_reflect::Span;
@@ -50,6 +50,7 @@ enum JsonBlockId {
     Shape(&'static Shape),
     StructLoop(&'static Shape),
     ListLoop(&'static Shape),
+    MapLoop(&'static Shape),
 }
 
 type BlockId = JsonBlockId;
@@ -1698,6 +1699,20 @@ enum JsonOp<Block> {
         element_layout: Layout,
         loop_id: Block,
     },
+    ReadMap {
+        map_shape: &'static Shape,
+        map: MapDef,
+        loop_id: Block,
+    },
+    MapNext {
+        map: MapDef,
+        key_scalar: ScalarType,
+        key_layout: Layout,
+        value_program: Program<JsonOp<Block>>,
+        value_scalar: Option<ScalarPlan>,
+        value_layout: Layout,
+        loop_id: Block,
+    },
     ReadPointer {
         pointer: PointerDef,
         pointee_program: Program<JsonOp<Block>>,
@@ -2094,6 +2109,35 @@ impl Lowering {
                     loop_id,
                 }])
             }
+            Def::Map(map) => {
+                let Some(key_scalar) = ScalarType::try_from_shape(map.k()) else {
+                    return Err(unsupported(shape, "scalar map key"));
+                };
+                if !matches!(key_scalar, ScalarType::String | ScalarType::CowStr) {
+                    return Err(unsupported(shape, "string map key"));
+                }
+
+                let key_layout = sized_layout(map.k())?;
+                let value_layout = sized_layout(map.v())?;
+                let value_program = self.lower_shape(map.v())?;
+                let value_scalar = ScalarType::try_from_shape(map.v()).map(ScalarPlan::new);
+                let loop_id = JsonBlockId::MapLoop(shape);
+                let loop_program = vec![JsonOp::MapNext {
+                    map,
+                    key_scalar,
+                    key_layout,
+                    value_program: value_program.clone(),
+                    value_scalar,
+                    value_layout,
+                    loop_id,
+                }];
+                self.lowered.blocks.insert(loop_id, loop_program);
+                Ok(vec![JsonOp::ReadMap {
+                    map_shape: shape,
+                    map,
+                    loop_id,
+                }])
+            }
             Def::Pointer(pointer) => {
                 let pointee = pointer
                     .pointee()
@@ -2290,6 +2334,32 @@ fn resolve_json_op(
             element_layout,
             loop_id: resolve_block_ref(loop_id, refs)?,
         },
+        JsonOp::ReadMap {
+            map_shape,
+            map,
+            loop_id,
+        } => JsonOp::ReadMap {
+            map_shape,
+            map,
+            loop_id: resolve_block_ref(loop_id, refs)?,
+        },
+        JsonOp::MapNext {
+            map,
+            key_scalar,
+            key_layout,
+            value_program,
+            value_scalar,
+            value_layout,
+            loop_id,
+        } => JsonOp::MapNext {
+            map,
+            key_scalar,
+            key_layout,
+            value_program: resolve_json_program(value_program, refs)?,
+            value_scalar,
+            value_layout,
+            loop_id: resolve_block_ref(loop_id, refs)?,
+        },
         JsonOp::ReadPointer {
             pointer,
             pointee_program,
@@ -2403,6 +2473,7 @@ struct JsonInterp<'parser, 'de, 'program, const TRUSTED_UTF8: bool> {
         InlineStack<StructFrame<'program, FieldPlan<ExecBlock>, InitializedLedger<Span>>>,
     large_structs: Option<Box<LargeStructStack<'program>>>,
     lists: InlineStack<ListFrame>,
+    maps: InlineStack<MapFrame>,
     scratch: ScratchSession,
     success: bool,
 }
@@ -2419,6 +2490,7 @@ where
             inline_structs: InlineStack::new(),
             large_structs: None,
             lists: InlineStack::new(),
+            maps: InlineStack::new(),
             scratch: ScratchSession::new(),
             success: false,
         }
@@ -2681,6 +2753,84 @@ where
         unsafe {
             builder.mark_initialized();
         }
+    }
+
+    fn insert_map_entry(
+        &mut self,
+        map: MapDef,
+        key_scalar: ScalarType,
+        key_layout: Layout,
+        key: String,
+        value_scratch: ScratchSlot,
+    ) -> Result<(), DeserializeError> {
+        let key_scratch = self.scratch.reserve(key_layout);
+        unsafe {
+            write_map_key(map.k(), key_scalar, scratch_ptr_uninit(&key_scratch), key)?;
+        }
+
+        let map_ptr = self
+            .maps
+            .last()
+            .expect("map frame is present while inserting entry")
+            .ptr();
+        unsafe {
+            (map.vtable.insert)(
+                PtrMut::new(map_ptr),
+                scratch_ptr_mut(&key_scratch),
+                scratch_ptr_mut(&value_scratch),
+            );
+        }
+        self.scratch.release(value_scratch);
+        self.scratch.release(key_scratch);
+        Ok(())
+    }
+
+    fn step_map_next(
+        &mut self,
+        plan: MapStepPlan<'program>,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, Continuation>, DeserializeError> {
+        let key = match self.parser.next_object_key_or_end()? {
+            JsonObjectKeyStep::End => return Ok(Control::Continue),
+            JsonObjectKeyStep::Field { key, span: _ } => {
+                self.parser.materialize_field_key(key)?.as_str().to_owned()
+            }
+        };
+
+        let value_scratch = self.scratch.reserve(plan.value_layout);
+        if let Some(scalar) = plan.value_scalar {
+            let value = self.parser.read_current_scalar_input()?;
+            unsafe {
+                scalar.write_input(
+                    &*self.parser,
+                    plan.map.v(),
+                    scratch_ptr_uninit(&value_scratch),
+                    value,
+                )?;
+            }
+            self.insert_map_entry(
+                plan.map,
+                plan.key_scalar,
+                plan.key_layout,
+                key,
+                value_scratch,
+            )?;
+            return Ok(Control::CallBlock(plan.loop_id));
+        }
+
+        let old_base = self.base;
+        self.base = scratch_ptr_uninit(&value_scratch);
+        Ok(call_program_or_block_then(
+            plan.value_program,
+            Continuation::MapValueDone {
+                map: plan.map,
+                key_scalar: plan.key_scalar,
+                key_layout: plan.key_layout,
+                key,
+                value_scratch,
+                old_base,
+                loop_id: plan.loop_id,
+            },
+        ))
     }
 
     fn list_next_scalar(
@@ -3164,6 +3314,31 @@ impl ListFrame {
     }
 }
 
+#[derive(Clone, Copy)]
+struct MapStepPlan<'program> {
+    map: MapDef,
+    key_scalar: ScalarType,
+    key_layout: Layout,
+    value_program: &'program [ExecOp],
+    value_scalar: Option<ScalarPlan>,
+    value_layout: Layout,
+    loop_id: ExecBlock,
+}
+
+struct MapFrame {
+    guard: HandleGuard,
+}
+
+impl MapFrame {
+    fn ptr(&self) -> *mut u8 {
+        self.guard.ptr()
+    }
+
+    fn finish(mut self) {
+        self.guard.disarm();
+    }
+}
+
 impl<const TRUSTED_UTF8: bool> Drop for JsonInterp<'_, '_, '_, TRUSTED_UTF8> {
     fn drop(&mut self) {
         if self.success {
@@ -3175,6 +3350,7 @@ impl<const TRUSTED_UTF8: bool> Drop for JsonInterp<'_, '_, '_, TRUSTED_UTF8> {
             while large_structs.pop().is_some() {}
         }
 
+        while self.maps.pop().is_some() {}
         while self.lists.pop().is_some() {}
     }
 }
@@ -3417,6 +3593,39 @@ where
                     },
                 ));
             },
+            JsonOp::ReadMap {
+                map_shape,
+                map,
+                loop_id,
+            } => {
+                self.parser.consume_object_start_fast()?;
+                let map_ptr = unsafe { (map.vtable.init_in_place_with_capacity)(self.base, 0) };
+                self.maps.push(MapFrame {
+                    guard: HandleGuard::new(
+                        map_ptr.as_mut_byte_ptr(),
+                        *map_shape as *const Shape as *const (),
+                        drop_shape_value,
+                    ),
+                });
+                Ok(Control::CallBlockThen(*loop_id, Continuation::FinishMap))
+            }
+            JsonOp::MapNext {
+                map,
+                key_scalar,
+                key_layout,
+                value_program,
+                value_scalar,
+                value_layout,
+                loop_id,
+            } => self.step_map_next(MapStepPlan {
+                map: *map,
+                key_scalar: *key_scalar,
+                key_layout: *key_layout,
+                value_program,
+                value_scalar: *value_scalar,
+                value_layout: *value_layout,
+                loop_id: *loop_id,
+            }),
             JsonOp::ReadPointer {
                 pointer,
                 pointee_program,
@@ -3516,6 +3725,27 @@ where
                 list.finish()?;
                 Ok(Control::Continue)
             }
+            Continuation::FinishMap => {
+                let map = self
+                    .maps
+                    .pop()
+                    .expect("map frame is present after map program");
+                map.finish();
+                Ok(Control::Continue)
+            }
+            Continuation::MapValueDone {
+                map,
+                key_scalar,
+                key_layout,
+                key,
+                value_scratch,
+                old_base,
+                loop_id,
+            } => {
+                self.insert_map_entry(map, key_scalar, key_layout, key, value_scratch)?;
+                self.base = old_base;
+                Ok(Control::CallBlock(loop_id))
+            }
             Continuation::PushedListElement {
                 list,
                 old_base,
@@ -3583,6 +3813,16 @@ enum Continuation {
         scratch: ScratchSlot,
     },
     FinishList,
+    FinishMap,
+    MapValueDone {
+        map: MapDef,
+        key_scalar: ScalarType,
+        key_layout: Layout,
+        key: String,
+        value_scratch: ScratchSlot,
+        old_base: PtrUninit,
+        loop_id: ExecBlock,
+    },
     PushedListElement {
         list: ListDef,
         old_base: PtrUninit,
@@ -4366,6 +4606,29 @@ fn scratch_ptr_uninit(scratch: &ScratchSlot) -> PtrUninit {
 
 unsafe fn scratch_ptr_mut(scratch: &ScratchSlot) -> PtrMut {
     unsafe { scratch_ptr_uninit(scratch).assume_init() }
+}
+
+unsafe fn write_map_key(
+    shape: &'static Shape,
+    scalar: ScalarType,
+    dst: PtrUninit,
+    key: String,
+) -> Result<(), DeserializeError> {
+    match scalar {
+        ScalarType::String => {
+            unsafe {
+                dst.put(key);
+            }
+            Ok(())
+        }
+        ScalarType::CowStr => {
+            unsafe {
+                dst.put::<Cow<'static, str>>(Cow::Owned(key));
+            }
+            Ok(())
+        }
+        _ => Err(unsupported(shape, "string map key")),
+    }
 }
 
 fn write_unit_input<'de, const TRUSTED_UTF8: bool>(

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -1,5 +1,6 @@
 use facet::Facet;
 use facet_format::DeserializeErrorKind;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static DROPPED_LIST_ELEMENTS: AtomicUsize = AtomicUsize::new(0);
@@ -33,6 +34,13 @@ struct MaybeScores {
 #[derive(Facet, Debug, PartialEq)]
 struct PointList {
     points: Vec<Point>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct MapHolder {
+    names: HashMap<String, String>,
+    buckets: HashMap<String, Vec<u64>>,
+    points: HashMap<String, Point>,
 }
 
 #[derive(Facet, Debug, PartialEq)]
@@ -195,6 +203,26 @@ fn weavy_plan_can_be_reused() {
     let second = plan.from_str(r#"{"x":3,"y":4}"#).unwrap();
     assert_eq!(first, Point { x: 1, y: 2 });
     assert_eq!(second, Point { x: 3, y: 4 });
+}
+
+#[test]
+fn weavy_deserializes_hash_maps() {
+    let got: MapHolder = facet_json::from_str_weavy(
+        r#"{
+            "names":{"100":"main","200":"balcony","escaped\u005fkey":"decoded"},
+            "buckets":{"topic":[10,20,30],"empty":[]},
+            "points":{"origin":{"x":0,"y":0},"target":{"y":7,"x":5}}
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(got.names["100"], "main");
+    assert_eq!(got.names["200"], "balcony");
+    assert_eq!(got.names["escaped_key"], "decoded");
+    assert_eq!(got.buckets["topic"], vec![10, 20, 30]);
+    assert_eq!(got.buckets["empty"], Vec::<u64>::new());
+    assert_eq!(got.points["origin"], Point { x: 0, y: 0 });
+    assert_eq!(got.points["target"], Point { x: 5, y: 7 });
 }
 
 fn native_jit_expected() -> bool {


### PR DESCRIPTION
## Summary

Adds JSON object map support to the opt-in facet-json Weavy deserializer. This unblocks shapes like `HashMap<String, String>`, `HashMap<String, Vec<u64>>`, and `HashMap<String, Struct>` so `citm_catalog` can run through the Weavy path instead of failing during plan construction.

## Changes

- Lower `Def::Map` into `ReadMap` / `MapNext` Weavy JSON ops.
- Initialize map handles through `MapDef`, guard them for error cleanup, and insert owned string keys plus scalar or nested Weavy-decoded values.
- Cover map support with a public-path integration test, including escaped JSON object keys.
- Add Weavy interpreter and JIT-requested rows to the CITM classic bench, and add missing JIT-requested rows for Twitter and Canada.

## Benchmarks

Apple M4 Pro, direct Divan binaries:

`--bench --min-time 1 --sample-count 20 --threads 1`

JIT-requested rows currently use the interpreter backend for these classic root shapes; they are included so we can track the lane consistently.

| Benchmark | serde_json median | Weavy median | Weavy / serde | Weavy JIT median | JIT / serde |
|---|---:|---:|---:|---:|---:|
| citm | 1.040 ms | 3.184 ms | 3.06x | 3.193 ms | 3.07x |
| twitter | 415.3 us | 1.030 ms | 2.48x | 1.030 ms | 2.48x |
| canada | 2.699 ms | 9.593 ms | 3.55x | 9.591 ms | 3.55x |

stax profile:

- `stax record -F 1900 -l 15 -- target/release/deps/citm-23207028cf9281cf --bench --min-time 10 --threads 1 weavy_reused_plan`
- Recorded run 18 with nonzero samples.
- Top costs are still interpreter dispatch/scanner/object iteration/list finishing; map insertion does not stand out as a dominant separate leaf in this profile.

## Testing

- `cargo check -p facet-json --all-features --all-targets --message-format=short`
- `cargo nextest run -p facet-json --all-features -E 'test(weavy_deserializes_hash_maps)'`
- `cargo nextest run -p facet-json --all-features`
- `cargo clippy --workspace --all-targets --all-features --message-format=short -- -D warnings`
- push hook: clippy/docs/build tests/run tests all passed
