### PR TITLE
Expand facet-json Weavy parity

### DIFF
--- a/facet-json/WEAVY_PARITY.md
+++ b/facet-json/WEAVY_PARITY.md
@@ -48,8 +48,8 @@ We should not switch `from_str` / `from_slice` to Weavy by default until:
 | `Option<T>` | Covered | Top-level null option, absent option field, `Option<String>`, and `Vec<Option<u16>>` are covered. | Add `Option<struct>` and `Option<map>` oracle shapes. |
 | Lists / `Vec<T>` | Covered | Scalar lists, struct lists, nullable scalar lists, direct-list adoption, and drop-on-error tests are covered. | Add nested list-of-list and list-of-map oracle shapes. |
 | String-key maps | Covered | `HashMap<String, String>`, map values as vectors/structs, duplicate keys, replacement drops, and value-error drops are covered. | Add `BTreeMap` / `IndexMap` parity rows if those vtables differ materially. |
-| Non-string scalar map keys | Gap | The lowerer rejects map keys unless they are `String` or `Cow<str>`; default path has integer map-key tests. | Implement key parsing through the typed scalar writers, then add integer-key map parity tests. |
-| Sets | Gap | The Weavy lowerer has list and map branches, but no set branch. | Add set descriptors/adoption or choose an adapter boundary. |
+| Non-string scalar map keys | Partial | Weavy supports exact-width signed/unsigned integer keys with direct default-path parity tests. Float-like keys and enum unit-variant keys are still default-only. | Add float-like and enum map-key parity or split those into dedicated rows. |
+| Sets | Covered | Weavy lowers set shapes through `SetDef` init/insert vtables; direct tests and oracle-bank shapes cover `BTreeSet`, `HashSet`, nullable scalar elements, nested struct elements, duplicates, and drop-on-error. | Consider a bulk `from_slice` optimization once raw-builder ownership is explicit. |
 | Smart pointers | Partial | Pointer lowering is generic when `new_into` exists; recursive `Box<Node>` is covered. | Add `Box<T>`, `Rc<T>`, `Arc<T>`, `Box<str>`, `Rc<str>`, `Arc<str>`, and `Arc<[T]>` parity tests. |
 | Recursive shapes | Covered | `Node { child: Option<Box<Node>> }` and stats tests cover recursive block calls. | Add recursive list/map payloads when those shapes enter the oracle bank. |
 | Tuple structs, tuple values, newtypes | Gap | The lowerer rejects non-named structs. | Decide JSON shape for tuple/newtype lowering and add format-suite parity cases. |
@@ -98,9 +98,8 @@ still run through the interpreter, and that fallback must remain visible.
 1. Add explicit Weavy tests for root scalars, `rename` / `rename_all`, custom
    defaults, and representative parsed scalar-like types. These are likely
    already close to supported and reduce uncertainty cheaply.
-2. Implement non-string map keys. This is isolated, clearly tested by the
-   current default path, and pressures map-key scalar parsing without touching
-   enum dispatch yet.
+2. Extend non-string map keys beyond integers. This keeps map-key scalar
+   parsing moving before enum dispatch lands.
 3. Start enum lowering with externally tagged variants. This is the first major
    JSON-specific surface needed before `facet-json` can move away from
    `facet-format` for real.

--- a/facet-json/WEAVY_PARITY.md
+++ b/facet-json/WEAVY_PARITY.md
@@ -1,0 +1,106 @@
+# facet-json Weavy parity grid
+
+This file tracks the work needed before the Weavy deserializer can become the
+main `facet-json` deserialization backend.
+
+Scope: deserialization only. Serialization has its own path today.
+
+## Legend
+
+- **Covered**: Weavy lowers and runs this surface, with direct tests or fuzz
+  oracle coverage.
+- **Partial**: part of the surface works, but coverage or semantics are not yet
+  enough for a default switch.
+- **Gap**: the current Weavy lowerer rejects this shape or there is no Weavy
+  entrypoint yet.
+
+## Promotion gates
+
+We should not switch `from_str` / `from_slice` to Weavy by default until:
+
+1. Every **Gap** row in the deserialization grid is either implemented or
+   deliberately kept on an explicit compatibility adapter.
+2. Every **Partial** row has a direct Weavy test and an oracle/fuzz story when
+   the surface is broad enough.
+3. Unsupported shapes fail predictably at plan build time, not halfway through
+   partially initialized output.
+4. Native JIT fallback is observable through `jit_fallback_report()` whenever
+   `build_jit()` cannot stay native.
+5. Error parity requirements are written down per surface. Success/failure
+   parity is required broadly; exact diagnostic parity can stay narrower.
+
+## Deserialization grid
+
+| Surface | Status | Current evidence | Next action |
+|---|---|---|---|
+| Owned `from_str` / `from_slice` replacement | Partial | Public default APIs still use `facet-format`; opt-in APIs are `from_str_weavy`, `from_slice_weavy`, and reusable `JsonWeavyPlan`. | Switch defaults only after this grid is green or explicitly adapter-backed. |
+| Borrowed output APIs | Gap | Weavy APIs require `T: Facet<'static>`; default APIs include `from_str_borrowed` and `from_slice_borrowed`. | Decide whether borrowed output is a Weavy lifetime mode or a compatibility adapter. |
+| JSONC APIs | Gap | Default APIs have `from_str_jsonc`, `from_slice_jsonc`, and borrowed JSONC variants; Weavy has no JSONC entrypoint. | Add JSONC parser mode to Weavy plans or leave JSONC on a named adapter. |
+| Scalar roots | Partial | The lowerer has a scalar root path, but direct tests mainly exercise scalars inside structs, options, lists, and maps. | Add direct root scalar parity tests for bool, integer, float, string, char, and unit/null. |
+| Named structs with scalar fields | Covered | `weavy_deserializes_named_struct_scalars`, wide scalar tests, ordered/out-of-order tests, and fuzz oracle shapes. | Keep extending generated oracle shapes as scalar policies change. |
+| Named structs with nested fields | Covered | `Person`, `PointList`, `MapHolder`, and recursive `Node` tests cover nested options, lists, maps, structs, and pointers. | Add larger mixed nesting to the fuzz shape bank. |
+| Field matching: rename, alias, escaped keys | Partial | Lowering uses `effective_name()` and `alias`; direct tests cover alias and escaped field names. | Add direct Weavy tests for `rename`, `rename_all`, and rename-vs-alias precedence. |
+| Unknown fields and strict skip | Covered | Tests cover skipped unknown containers, raw-key UTF-8 validation, and invalid skipped values from fuzz replay. | Expand fuzz input around skipped strings, nested arrays, and malformed numeric tokens. |
+| `deny_unknown_fields` | Covered | `weavy_reports_unknown_field_after_raw_key_matching` exercises the strict path. | Add nested strict-struct coverage. |
+| Duplicate fields | Covered | Tests cover duplicate fields after ordered matching and duplicate defaulted fields. | Keep duplicate cases in the fuzz shape bank once more shapes are added. |
+| Missing fields and defaults | Partial | Default trait fields, absent options, absent required vec/map fields, and null scalar defaults are covered. | Add direct custom default function coverage. |
+| Scalar coercions and range checks | Covered | Tests cover numeric strings, null scalar defaults, float-as-string, and out-of-range narrowing parity. | Add root-scalar coercion cases with the scalar-root tests. |
+| `Option<T>` | Covered | Top-level null option, absent option field, `Option<String>`, and `Vec<Option<u16>>` are covered. | Add `Option<struct>` and `Option<map>` oracle shapes. |
+| Lists / `Vec<T>` | Covered | Scalar lists, struct lists, nullable scalar lists, direct-list adoption, and drop-on-error tests are covered. | Add nested list-of-list and list-of-map oracle shapes. |
+| String-key maps | Covered | `HashMap<String, String>`, map values as vectors/structs, duplicate keys, replacement drops, and value-error drops are covered. | Add `BTreeMap` / `IndexMap` parity rows if those vtables differ materially. |
+| Non-string scalar map keys | Gap | The lowerer rejects map keys unless they are `String` or `Cow<str>`; default path has integer map-key tests. | Implement key parsing through the typed scalar writers, then add integer-key map parity tests. |
+| Sets | Gap | The Weavy lowerer has list and map branches, but no set branch. | Add set descriptors/adoption or choose an adapter boundary. |
+| Smart pointers | Partial | Pointer lowering is generic when `new_into` exists; recursive `Box<Node>` is covered. | Add `Box<T>`, `Rc<T>`, `Arc<T>`, `Box<str>`, `Rc<str>`, `Arc<str>`, and `Arc<[T]>` parity tests. |
+| Recursive shapes | Covered | `Node { child: Option<Box<Node>> }` and stats tests cover recursive block calls. | Add recursive list/map payloads when those shapes enter the oracle bank. |
+| Tuple structs, tuple values, newtypes | Gap | The lowerer rejects non-named structs. | Decide JSON shape for tuple/newtype lowering and add format-suite parity cases. |
+| Enums: externally tagged | Gap | The lowerer has no enum branch. Default path covers unit, newtype, tuple, and struct variants. | First enum PR should implement externally tagged unit/newtype/struct variants. |
+| Enums: internally tagged | Gap | Default path covers internal tags, nested internal tags, rename rules, and flatten inside variants. | Implement after basic enum dispatch exists; preserve tag-order-independent matching. |
+| Enums: adjacently tagged | Gap | Default path covers `tag` + `content` layouts and rename rules. | Implement after internal/external dispatch machinery is reusable. |
+| Enums: untagged and mixed tagged/untagged | Gap | Default path has untagged and mixed tagged/untagged tests. | Needs replayable candidate decoding and rollback semantics in Weavy. |
+| `#[facet(other)]` fallback variants | Gap | Default path has unknown-tag fallback tests. | Add after tagged enum dispatch can preserve unknown tag payloads. |
+| Flattened fields and flattened maps | Gap | The lowerer rejects flattened fields; default path has struct flatten, optional flatten, nested flatten maps, and flattened enum cases. | Implement object-field routing before or alongside enum work. |
+| Skipped deserialize fields | Gap | The lowerer rejects skipped fields with flattened fields. | Add missing-field synthesis that respects skip-deserializing policy. |
+| Proxies and format-specific proxies | Gap | The lowerer rejects container and format proxies. Default path has field/container/json-specific proxy tests. | Decide whether proxy lowering goes through Weavy child programs or an adapter call. |
+| Transparent wrappers | Gap | Transparent/newtype-like wrappers are not handled because non-named structs/proxies are rejected. | Fold into newtype/transparent lowering design. |
+| Raw JSON capture | Gap | Default path has `RawJson` tests for scalar, array, object, nested, and optional capture. | Add parser span capture as a Weavy intrinsic or adapter operation. |
+| Parsed/custom scalar-like types | Partial | Scalar writers can use parse hooks, but there is no broad Weavy test row for third-party scalar-like types. | Add representative `FromStr`/parse-hook types from the format suite. |
+| Third-party reflected types | Partial | Default path covers chrono, time, uuid, camino, compact strings, tendril, bytes, decimal, and more. | Split into scalar-like, collection-like, and proxy-like rows as each enters Weavy. |
+| Error diagnostics and paths | Partial | Weavy tests mostly assert success/failure parity or selected error kinds, not exact message/path parity. | Define which diagnostics must match before the default switch. |
+| Fuzz oracle shape bank | Partial | The current bank covers points, wide scalars, defaults, person/options/lists, point lists, string maps, and map holders. | Add enums, flatten, non-string maps, pointers, raw JSON, and proxy shapes as each surface lands. |
+
+## Native JIT grid
+
+Native JIT support is narrower than Weavy interpreter support. `build_jit()` may
+still run through the interpreter, and that fallback must remain visible.
+
+| Surface | Status | Current evidence | Next action |
+|---|---|---|---|
+| Native availability | Covered | Tests expect native JIT on `aarch64-apple-darwin` and `x86_64-unknown-linux-gnu`; other targets report fallback. | Keep platform checks in CI as new native backends appear. |
+| Root scalar struct, ordered fields | Covered | `weavy_jit_plan_uses_native_for_root_scalar_struct_when_available`, wide scalar JIT tests. | Keep stax/CodSpeed tracking against serde and interpreter. |
+| Root list of scalar structs, ordered fields | Covered | `weavy_jit_plan_uses_native_for_root_scalar_struct_list_when_available`, float/wide list JIT tests. | Add larger list shapes to reduce microbench bias. |
+| Out-of-order fields and unknown fields | Partial | JIT-requested plans replay/fall back to interpreter for non-ordered objects and skipped unknowns. | Move field dispatch and unknown skip into native stencils. |
+| Defaults, missing fields, duplicates | Partial | JIT-requested plans fall back for defaulted structs and duplicate detection. | Add native default/duplicate handling or make fallback costs explicit in benches. |
+| Nested structs, options, maps, pointers | Gap | Native root support is scalar structs or scalar-struct lists only. | Share native field/write stencils before adding nested continuation support. |
+| Enums, flatten, proxies, raw JSON | Gap | Interpreter support is also missing today. | Do not JIT these until the interpreter parity rows exist. |
+| Scanner work inside JIT | Partial | Native path uses JSON stencils but still relies on host/parser behavior for many decisions. | Move punctuation, field-key matching, scalar validation/parsing, and skip primitives into native stencils. |
+
+## Existing performance coverage
+
+| Benchmark file | What it covers | Notes |
+|---|---|---|
+| `benches/typeplan_reuse.rs` | Reused default type plans, Weavy interpreter, Weavy JIT-requested plans, serde baselines, scalar structs, defaults, lists, skipped unknowns, maps, and batch reuse. | Main microbench suite; report Weavy-vs-serde ratios. |
+| `benches/citm.rs` | Large nested object/list workload with rename-all field names. | Good for parser/object traversal and JIT fallback pressure. |
+| `benches/twitter.rs` | Larger real-ish object graph with defaults, renames, strings, and lists. | Good for owned-string and defaults pressure. |
+| `benches/canada.rs` | GeoJSON-like nested arrays and renamed `type` fields. | Good for list-heavy object graphs. |
+
+## Suggested next grid rows to make green
+
+1. Add explicit Weavy tests for root scalars, `rename` / `rename_all`, custom
+   defaults, and representative parsed scalar-like types. These are likely
+   already close to supported and reduce uncertainty cheaply.
+2. Implement non-string map keys. This is isolated, clearly tested by the
+   current default path, and pressures map-key scalar parsing without touching
+   enum dispatch yet.
+3. Start enum lowering with externally tagged variants. This is the first major
+   JSON-specific surface needed before `facet-json` can move away from
+   `facet-format` for real.

--- a/facet-json/src/weavy_deser.rs
+++ b/facet-json/src/weavy_deser.rs
@@ -21,7 +21,7 @@ use core::sync::atomic::{AtomicU8, Ordering};
 
 use facet_core::{
     Characteristic, Def, DefaultInPlaceFn, DefaultSource, Facet, Field, ListDef, MapDef, OptionDef,
-    PointerDef, PtrConst, PtrMut, PtrUninit, ScalarType, Shape, StructKind, Type, UserType,
+    PointerDef, PtrConst, PtrMut, PtrUninit, ScalarType, SetDef, Shape, StructKind, Type, UserType,
 };
 use facet_format::{DeserializeError, DeserializeErrorKind, ParseError};
 use facet_reflect::Span;
@@ -61,6 +61,7 @@ enum JsonBlockId {
     Shape(&'static Shape),
     StructLoop(&'static Shape),
     ListLoop(&'static Shape),
+    SetLoop(&'static Shape),
     MapLoop(&'static Shape),
 }
 
@@ -1666,6 +1667,19 @@ enum JsonOp<Block> {
         element_layout: Layout,
         loop_id: Block,
     },
+    ReadSet {
+        set_shape: &'static Shape,
+        set: SetDef,
+        loop_id: Block,
+    },
+    SetNext {
+        set: SetDef,
+        element_program: Program<JsonOp<Block>>,
+        element_scalar: Option<ScalarType>,
+        element_option_scalar: Option<ListOptionScalar>,
+        element_layout: Layout,
+        loop_id: Block,
+    },
     ReadMap {
         map_shape: &'static Shape,
         map: MapDef,
@@ -2092,12 +2106,33 @@ impl Lowering {
                     loop_id,
                 }])
             }
+            Def::Set(set) => {
+                let element_layout = sized_layout(set.t())?;
+                let element_program = self.lower_shape(set.t())?;
+                let element_scalar = ScalarType::try_from_shape(set.t());
+                let element_option_scalar = list_option_scalar(set.t())?;
+                let loop_id = JsonBlockId::SetLoop(shape);
+                let loop_program = vec![JsonOp::SetNext {
+                    set,
+                    element_program: element_program.clone(),
+                    element_scalar,
+                    element_option_scalar,
+                    element_layout,
+                    loop_id,
+                }];
+                self.lowered.blocks.insert(loop_id, loop_program);
+                Ok(vec![JsonOp::ReadSet {
+                    set_shape: shape,
+                    set,
+                    loop_id,
+                }])
+            }
             Def::Map(map) => {
                 let Some(key_scalar) = ScalarType::try_from_shape(map.k()) else {
                     return Err(unsupported(shape, "scalar map key"));
                 };
-                if !matches!(key_scalar, ScalarType::String | ScalarType::CowStr) {
-                    return Err(unsupported(shape, "string map key"));
+                if !map_key_scalar_supported(key_scalar) {
+                    return Err(unsupported(shape, "string or integer map key"));
                 }
 
                 let key_layout = sized_layout(map.k())?;
@@ -2317,6 +2352,30 @@ fn resolve_json_op(
             element_layout,
             loop_id: resolve_block_ref(loop_id, refs)?,
         },
+        JsonOp::ReadSet {
+            set_shape,
+            set,
+            loop_id,
+        } => JsonOp::ReadSet {
+            set_shape,
+            set,
+            loop_id: resolve_block_ref(loop_id, refs)?,
+        },
+        JsonOp::SetNext {
+            set,
+            element_program,
+            element_scalar,
+            element_option_scalar,
+            element_layout,
+            loop_id,
+        } => JsonOp::SetNext {
+            set,
+            element_program: resolve_json_program(element_program, refs)?,
+            element_scalar,
+            element_option_scalar,
+            element_layout,
+            loop_id: resolve_block_ref(loop_id, refs)?,
+        },
         JsonOp::ReadMap {
             map_shape,
             map,
@@ -2421,6 +2480,26 @@ fn list_option_scalar(shape: &'static Shape) -> Result<Option<ListOptionScalar>,
     }))
 }
 
+fn map_key_scalar_supported(scalar: ScalarType) -> bool {
+    matches!(
+        scalar,
+        ScalarType::String
+            | ScalarType::CowStr
+            | ScalarType::I8
+            | ScalarType::I16
+            | ScalarType::I32
+            | ScalarType::I64
+            | ScalarType::I128
+            | ScalarType::ISize
+            | ScalarType::U8
+            | ScalarType::U16
+            | ScalarType::U32
+            | ScalarType::U64
+            | ScalarType::U128
+            | ScalarType::USize
+    )
+}
+
 fn sized_layout(shape: &'static Shape) -> Result<Layout, DeserializeError> {
     shape
         .layout
@@ -2456,6 +2535,7 @@ struct JsonInterp<'parser, 'de, 'program, const TRUSTED_UTF8: bool> {
         InlineStack<StructFrame<'program, FieldPlan<ExecBlock>, InitializedLedger<Span>>>,
     large_structs: Option<Box<LargeStructStack<'program>>>,
     lists: InlineStack<ListFrame>,
+    sets: InlineStack<SetFrame>,
     maps: InlineStack<MapFrame>,
     scratch: ScratchSession,
     success: bool,
@@ -2473,6 +2553,7 @@ where
             inline_structs: InlineStack::new(),
             large_structs: None,
             lists: InlineStack::new(),
+            sets: InlineStack::new(),
             maps: InlineStack::new(),
             scratch: ScratchSession::new(),
             success: false,
@@ -2738,12 +2819,101 @@ where
         }
     }
 
+    fn insert_set_element(&mut self, set: SetDef, scratch: &ScratchSlot) {
+        let set_ptr = self
+            .sets
+            .last()
+            .expect("set frame is present while inserting element");
+        unsafe {
+            (set.vtable.insert)(PtrMut::new(set_ptr.guard.ptr()), scratch_ptr_mut(scratch));
+        }
+    }
+
+    fn step_set_next(
+        &mut self,
+        plan: SetStepPlan<'program>,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, Continuation>, DeserializeError> {
+        loop {
+            if let Some(scalar) = plan.element_scalar {
+                let step = self.parser.next_sequence_scalar_or_end()?;
+                let JsonSequenceScalarStep::Value { value } = step else {
+                    return Ok(Control::Continue);
+                };
+
+                let scratch = self.scratch.reserve(plan.element_layout);
+                unsafe {
+                    write_scalar_input(
+                        self.parser,
+                        plan.set.t(),
+                        scalar,
+                        scratch_ptr_uninit(&scratch),
+                        value,
+                    )?;
+                }
+                self.insert_set_element(plan.set, &scratch);
+                self.scratch.release(scratch);
+                continue;
+            }
+
+            if let Some(option_scalar) = plan.element_option_scalar {
+                let step = self.parser.next_sequence_scalar_or_end()?;
+                let JsonSequenceScalarStep::Value { value } = step else {
+                    return Ok(Control::Continue);
+                };
+
+                let scratch = self.scratch.reserve(plan.element_layout);
+                if value.is_null() {
+                    unsafe {
+                        (option_scalar.option.vtable.init_none)(scratch_ptr_uninit(&scratch));
+                    }
+                } else {
+                    let inner = self.scratch.reserve(option_scalar.inner_layout);
+                    unsafe {
+                        write_scalar_input(
+                            self.parser,
+                            option_scalar.option.t(),
+                            option_scalar.scalar,
+                            scratch_ptr_uninit(&inner),
+                            value,
+                        )?;
+                        (option_scalar.option.vtable.init_some)(
+                            scratch_ptr_uninit(&scratch),
+                            scratch_ptr_mut(&inner),
+                        );
+                    }
+                    self.scratch.release(inner);
+                }
+                self.insert_set_element(plan.set, &scratch);
+                self.scratch.release(scratch);
+                continue;
+            }
+
+            if self.parser.consume_sequence_end_if_next()? {
+                return Ok(Control::Continue);
+            }
+
+            let scratch = self.scratch.reserve(plan.element_layout);
+            let old_base = self.base;
+            self.base = scratch_ptr_uninit(&scratch);
+            return Ok(call_program_or_block_then(
+                plan.element_program,
+                Continuation::InsertedSetElement {
+                    set: plan.set,
+                    old_base,
+                    scratch,
+                    loop_id: plan.loop_id,
+                },
+            ));
+        }
+    }
+
     fn insert_map_entry(
         &mut self,
         map: MapDef,
         key_scalar: ScalarType,
         key_layout: Layout,
         mut key: String,
+        key_span: Span,
         value_scratch: ScratchSlot,
     ) -> Result<(), DeserializeError> {
         let map_ptr = self
@@ -2772,8 +2942,15 @@ where
         }
 
         let key_scratch = self.scratch.reserve(key_layout);
-        let key_result =
-            unsafe { write_map_key(map.k(), key_scalar, scratch_ptr_uninit(&key_scratch), key) };
+        let key_result = unsafe {
+            write_map_key(
+                map.k(),
+                key_scalar,
+                scratch_ptr_uninit(&key_scratch),
+                key,
+                key_span,
+            )
+        };
         if let Err(err) = key_result {
             unsafe {
                 drop_shape_value(map.v() as *const Shape as *const (), value_scratch.ptr());
@@ -2801,6 +2978,7 @@ where
         key_scalar: ScalarType,
         key_layout: Layout,
         key: JsonFieldKeyInput<'de>,
+        key_span: Span,
         value_scratch: ScratchSlot,
     ) -> Result<(), DeserializeError> {
         if key_scalar == ScalarType::String
@@ -2846,7 +3024,7 @@ where
                 return Err(err.into());
             }
         };
-        self.insert_map_entry(map, key_scalar, key_layout, key, value_scratch)
+        self.insert_map_entry(map, key_scalar, key_layout, key, key_span, value_scratch)
     }
 
     fn try_insert_borrowed_str_map_entry(
@@ -2886,9 +3064,9 @@ where
         &mut self,
         plan: MapStepPlan<'program>,
     ) -> Result<Control<'program, ExecBlock, ExecOp, Continuation>, DeserializeError> {
-        let key_input = match self.parser.next_object_key_or_end()? {
+        let (key_input, key_span) = match self.parser.next_object_key_or_end()? {
             JsonObjectKeyStep::End => return Ok(Control::Continue),
-            JsonObjectKeyStep::Field { key, span: _ } => key,
+            JsonObjectKeyStep::Field { key, span } => (key, span),
         };
 
         if let Some(scalar) = plan.value_scalar {
@@ -2913,6 +3091,7 @@ where
                 plan.key_scalar,
                 plan.key_layout,
                 key_input,
+                key_span,
                 value_scratch,
             )?;
             return Ok(Control::CallBlock(plan.loop_id));
@@ -2933,6 +3112,7 @@ where
                 key_scalar: plan.key_scalar,
                 key_layout: plan.key_layout,
                 key,
+                key_span,
                 value_scratch,
                 old_base,
                 loop_id: plan.loop_id,
@@ -3432,6 +3612,27 @@ struct MapStepPlan<'program> {
     loop_id: ExecBlock,
 }
 
+#[derive(Clone, Copy)]
+struct SetStepPlan<'program> {
+    set: SetDef,
+    element_program: &'program [ExecOp],
+    element_scalar: Option<ScalarType>,
+    element_option_scalar: Option<ListOptionScalar>,
+    element_layout: Layout,
+    loop_id: ExecBlock,
+}
+
+struct SetFrame {
+    guard: HandleGuard,
+}
+
+impl SetFrame {
+    fn finish(mut self) -> Result<(), DeserializeError> {
+        self.guard.disarm();
+        Ok(())
+    }
+}
+
 struct MapFrame {
     guard: HandleGuard,
 }
@@ -3455,6 +3656,7 @@ impl<const TRUSTED_UTF8: bool> Drop for JsonInterp<'_, '_, '_, TRUSTED_UTF8> {
         }
 
         while self.maps.pop().is_some() {}
+        while self.sets.pop().is_some() {}
         while self.lists.pop().is_some() {}
     }
 }
@@ -3697,6 +3899,37 @@ where
                     },
                 ));
             },
+            JsonOp::ReadSet {
+                set_shape,
+                set,
+                loop_id,
+            } => {
+                self.parser.consume_array_start_fast()?;
+                let set_ptr = unsafe { (set.vtable.init_in_place_with_capacity)(self.base, 0) };
+                self.sets.push(SetFrame {
+                    guard: HandleGuard::new(
+                        set_ptr.as_mut_byte_ptr(),
+                        *set_shape as *const Shape as *const (),
+                        drop_shape_value,
+                    ),
+                });
+                Ok(Control::CallBlockThen(*loop_id, Continuation::FinishSet))
+            }
+            JsonOp::SetNext {
+                set,
+                element_program,
+                element_scalar,
+                element_option_scalar,
+                element_layout,
+                loop_id,
+            } => self.step_set_next(SetStepPlan {
+                set: *set,
+                element_program,
+                element_scalar: *element_scalar,
+                element_option_scalar: *element_option_scalar,
+                element_layout: *element_layout,
+                loop_id: *loop_id,
+            }),
             JsonOp::ReadMap {
                 map_shape,
                 map,
@@ -3836,6 +4069,14 @@ where
                 list.finish()?;
                 Ok(Control::Continue)
             }
+            Continuation::FinishSet => {
+                let set = self
+                    .sets
+                    .pop()
+                    .expect("set frame is present after set program");
+                set.finish()?;
+                Ok(Control::Continue)
+            }
             Continuation::FinishMap => {
                 let map = self
                     .maps
@@ -3849,11 +4090,12 @@ where
                 key_scalar,
                 key_layout,
                 key,
+                key_span,
                 value_scratch,
                 old_base,
                 loop_id,
             } => {
-                self.insert_map_entry(map, key_scalar, key_layout, key, value_scratch)?;
+                self.insert_map_entry(map, key_scalar, key_layout, key, key_span, value_scratch)?;
                 self.base = old_base;
                 Ok(Control::CallBlock(loop_id))
             }
@@ -3864,6 +4106,17 @@ where
                 loop_id,
             } => {
                 self.push_list_element(list, &scratch)?;
+                self.scratch.release(scratch);
+                self.base = old_base;
+                Ok(Control::CallBlock(loop_id))
+            }
+            Continuation::InsertedSetElement {
+                set,
+                old_base,
+                scratch,
+                loop_id,
+            } => {
+                self.insert_set_element(set, &scratch);
                 self.scratch.release(scratch);
                 self.base = old_base;
                 Ok(Control::CallBlock(loop_id))
@@ -3924,18 +4177,26 @@ enum Continuation {
         scratch: ScratchSlot,
     },
     FinishList,
+    FinishSet,
     FinishMap,
     MapValueDone {
         map: MapDef,
         key_scalar: ScalarType,
         key_layout: Layout,
         key: String,
+        key_span: Span,
         value_scratch: ScratchSlot,
         old_base: PtrUninit,
         loop_id: ExecBlock,
     },
     PushedListElement {
         list: ListDef,
+        old_base: PtrUninit,
+        scratch: ScratchSlot,
+        loop_id: ExecBlock,
+    },
+    InsertedSetElement {
+        set: SetDef,
         old_base: PtrUninit,
         scratch: ScratchSlot,
         loop_id: ExecBlock,
@@ -4724,7 +4985,18 @@ unsafe fn write_map_key(
     scalar: ScalarType,
     dst: PtrUninit,
     key: String,
+    span: Span,
 ) -> Result<(), DeserializeError> {
+    macro_rules! write_parsed_key {
+        ($ty:ty, $expected:literal) => {{
+            let value = parse_map_key::<$ty>(&key, span, $expected)?;
+            unsafe {
+                dst.put(value);
+            }
+            Ok(())
+        }};
+    }
+
     match scalar {
         ScalarType::String => {
             unsafe {
@@ -4738,8 +5010,35 @@ unsafe fn write_map_key(
             }
             Ok(())
         }
-        _ => Err(unsupported(shape, "string map key")),
+        ScalarType::I8 => write_parsed_key!(i8, "valid integer for map key"),
+        ScalarType::I16 => write_parsed_key!(i16, "valid integer for map key"),
+        ScalarType::I32 => write_parsed_key!(i32, "valid integer for map key"),
+        ScalarType::I64 => write_parsed_key!(i64, "valid integer for map key"),
+        ScalarType::I128 => write_parsed_key!(i128, "valid integer for map key"),
+        ScalarType::ISize => write_parsed_key!(isize, "valid integer for map key"),
+        ScalarType::U8 => write_parsed_key!(u8, "valid unsigned integer for map key"),
+        ScalarType::U16 => write_parsed_key!(u16, "valid unsigned integer for map key"),
+        ScalarType::U32 => write_parsed_key!(u32, "valid unsigned integer for map key"),
+        ScalarType::U64 => write_parsed_key!(u64, "valid unsigned integer for map key"),
+        ScalarType::U128 => write_parsed_key!(u128, "valid unsigned integer for map key"),
+        ScalarType::USize => write_parsed_key!(usize, "valid unsigned integer for map key"),
+        _ => Err(unsupported(shape, "string or integer map key")),
     }
+}
+
+fn parse_map_key<T>(key: &str, span: Span, expected: &'static str) -> Result<T, DeserializeError>
+where
+    T: FromStr,
+{
+    key.parse().map_err(|_| {
+        vm_error(
+            Some(span),
+            DeserializeErrorKind::UnexpectedToken {
+                expected,
+                got: format!("string '{}'", key).into(),
+            },
+        )
+    })
 }
 
 fn write_unit_input<'de, const TRUSTED_UTF8: bool>(

--- a/facet-json/tests/integration/weavy_deser.rs
+++ b/facet-json/tests/integration/weavy_deser.rs
@@ -1,10 +1,11 @@
 use facet::Facet;
 use facet_format::DeserializeErrorKind;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static DROPPED_LIST_ELEMENTS: AtomicUsize = AtomicUsize::new(0);
+static DROPPED_SET_ELEMENTS: AtomicUsize = AtomicUsize::new(0);
 static DROPPED_BULK_MAP_VALUES: AtomicUsize = AtomicUsize::new(0);
 static DROPPED_DUPLICATE_MAP_VALUES: AtomicUsize = AtomicUsize::new(0);
 
@@ -40,6 +41,12 @@ struct FloatPoint {
     z: f64,
 }
 
+#[derive(Facet, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct OrderedPoint {
+    x: i32,
+    y: i32,
+}
+
 #[derive(Facet, Debug, PartialEq)]
 struct Person {
     name: String,
@@ -66,8 +73,41 @@ struct MapHolder {
 }
 
 #[derive(Facet, Debug, PartialEq)]
+struct IntegerMapKeys {
+    i8s: BTreeMap<i8, String>,
+    i32s: BTreeMap<i32, String>,
+    u16s: BTreeMap<u16, String>,
+    u128s: BTreeMap<u128, String>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct SetHolder {
+    names: BTreeMap<String, String>,
+    ordered: BTreeSet<String>,
+    hashed: HashSet<u16>,
+    maybe: BTreeSet<Option<u16>>,
+    points: BTreeSet<OrderedPoint>,
+}
+
+#[derive(Facet, Debug, PartialEq)]
 struct DroppyMap {
     items: HashMap<String, BulkMapDroppy>,
+}
+
+#[derive(Facet, Debug, Eq, Hash, PartialEq)]
+struct SetDroppy {
+    value: u8,
+}
+
+impl Drop for SetDroppy {
+    fn drop(&mut self) {
+        DROPPED_SET_ELEMENTS.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct DroppySet {
+    items: HashSet<SetDroppy>,
 }
 
 #[derive(Facet, Debug, PartialEq)]
@@ -281,6 +321,55 @@ fn weavy_hash_map_duplicate_keys_keep_latest_value() {
 
     assert_eq!(got.len(), 1);
     assert_eq!(got["same"], "second");
+}
+
+#[test]
+fn weavy_deserializes_integer_map_keys_at_every_width() {
+    assert_default_weavy_parity::<IntegerMapKeys>(
+        r#"{
+            "i8s": {"-3": "a"},
+            "i32s": {"100000": "b"},
+            "u16s": {"65535": "c"},
+            "u128s": {"340282366920938463463374607431768211455": "d"}
+        }"#,
+    );
+}
+
+#[test]
+fn weavy_rejects_out_of_range_integer_map_key() {
+    let err = facet_json::from_str_weavy::<BTreeMap<i8, String>>(r#"{"300": "x"}"#)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("valid integer for map key"), "got: {err}");
+}
+
+#[test]
+fn weavy_deserializes_sets() {
+    assert_default_weavy_parity::<SetHolder>(
+        r#"{
+            "names": {"alpha": "a"},
+            "ordered": ["beta", "alpha", "alpha"],
+            "hashed": [2, 1, 2],
+            "maybe": [null, 3, null],
+            "points": [{"x": 1, "y": 2}, {"x": 0, "y": 0}, {"x": 1, "y": 2}]
+        }"#,
+    );
+}
+
+#[test]
+fn weavy_drops_set_values_after_later_element_error() {
+    DROPPED_SET_ELEMENTS.store(0, Ordering::SeqCst);
+
+    let err = facet_json::from_str_weavy::<DroppySet>(r#"{"items":[{"value":1},{"value":"bad"}]}"#)
+        .unwrap_err();
+
+    assert!(matches!(
+        err.kind,
+        DeserializeErrorKind::UnexpectedToken { .. }
+            | DeserializeErrorKind::InvalidValue { .. }
+            | DeserializeErrorKind::NumberOutOfRange { .. }
+    ));
+    assert_eq!(DROPPED_SET_ELEMENTS.load(Ordering::SeqCst), 1);
 }
 
 #[test]

--- a/facet-json/tests/integration/weavy_oracle_fuzz.rs
+++ b/facet-json/tests/integration/weavy_oracle_fuzz.rs
@@ -1,10 +1,10 @@
 use facet::Facet;
 use proptest::prelude::*;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::OnceLock;
 
-#[derive(Facet, Clone, Debug, PartialEq)]
+#[derive(Facet, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 struct OraclePoint {
     x: i32,
     y: i32,
@@ -65,6 +65,14 @@ struct OracleMaybeScores {
 struct OracleMapHolder {
     names: HashMap<String, String>,
     points: HashMap<String, OraclePoint>,
+}
+
+#[derive(Facet, Clone, Debug, PartialEq)]
+struct OracleSetHolder {
+    ordered: BTreeSet<String>,
+    hashed: HashSet<u16>,
+    maybe: BTreeSet<Option<u16>>,
+    points: BTreeSet<OraclePoint>,
 }
 
 type OraclePointList = Vec<OraclePoint>;
@@ -148,6 +156,16 @@ fn map_holder_plan() -> &'static facet_json::JsonWeavyPlan<OracleMapHolder> {
 fn map_holder_jit_plan() -> &'static facet_json::JsonWeavyPlan<OracleMapHolder> {
     static PLAN: OnceLock<facet_json::JsonWeavyPlan<OracleMapHolder>> = OnceLock::new();
     PLAN.get_or_init(|| facet_json::JsonWeavyPlan::<OracleMapHolder>::build_jit().unwrap())
+}
+
+fn set_holder_plan() -> &'static facet_json::JsonWeavyPlan<OracleSetHolder> {
+    static PLAN: OnceLock<facet_json::JsonWeavyPlan<OracleSetHolder>> = OnceLock::new();
+    PLAN.get_or_init(|| facet_json::JsonWeavyPlan::<OracleSetHolder>::build().unwrap())
+}
+
+fn set_holder_jit_plan() -> &'static facet_json::JsonWeavyPlan<OracleSetHolder> {
+    static PLAN: OnceLock<facet_json::JsonWeavyPlan<OracleSetHolder>> = OnceLock::new();
+    PLAN.get_or_init(|| facet_json::JsonWeavyPlan::<OracleSetHolder>::build_jit().unwrap())
 }
 
 fn assert_str_parity<T>(
@@ -305,6 +323,21 @@ fn map_holder_strategy() -> impl Strategy<Value = OracleMapHolder> {
         .prop_map(|(names, points)| OracleMapHolder { names, points })
 }
 
+fn set_holder_strategy() -> impl Strategy<Value = OracleSetHolder> {
+    (
+        prop::collection::btree_set(small_string(), 0..8),
+        prop::collection::hash_set(any::<u16>(), 0..8),
+        prop::collection::btree_set(prop::option::of(any::<u16>()), 0..8),
+        prop::collection::btree_set(point_strategy(), 0..8),
+    )
+        .prop_map(|(ordered, hashed, maybe, points)| OracleSetHolder {
+            ordered,
+            hashed,
+            maybe,
+            points,
+        })
+}
+
 fn assert_serialized_value_parity<T>(
     value: &T,
     plan: &facet_json::JsonWeavyPlan<T>,
@@ -317,7 +350,7 @@ fn assert_serialized_value_parity<T>(
 }
 
 fn assert_shape_bank_slice_parity(selector: u8, input: &[u8]) {
-    match selector % 8 {
+    match selector % 9 {
         0 => assert_slice_parity(input, point_plan(), point_jit_plan()),
         1 => assert_slice_parity(input, wide_plan(), wide_jit_plan()),
         2 => assert_slice_parity(input, defaults_plan(), defaults_jit_plan()),
@@ -325,7 +358,8 @@ fn assert_shape_bank_slice_parity(selector: u8, input: &[u8]) {
         4 => assert_slice_parity(input, maybe_scores_plan(), maybe_scores_jit_plan()),
         5 => assert_slice_parity(input, point_list_plan(), point_list_jit_plan()),
         6 => assert_slice_parity(input, string_map_plan(), string_map_jit_plan()),
-        _ => assert_slice_parity(input, map_holder_plan(), map_holder_jit_plan()),
+        7 => assert_slice_parity(input, map_holder_plan(), map_holder_jit_plan()),
+        _ => assert_slice_parity(input, set_holder_plan(), set_holder_jit_plan()),
     }
 }
 
@@ -398,6 +432,11 @@ proptest! {
     #[test]
     fn generated_map_holders_match_all_weavy_backends(value in map_holder_strategy()) {
         assert_serialized_value_parity(&value, map_holder_plan(), map_holder_jit_plan());
+    }
+
+    #[test]
+    fn generated_set_holders_match_all_weavy_backends(value in set_holder_strategy()) {
+        assert_serialized_value_parity(&value, set_holder_plan(), set_holder_jit_plan());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `facet-json/WEAVY_PARITY.md` as the living grid for making Weavy the main `facet-json` deserialization backend
- add Weavy support for exact-width signed/unsigned integer map keys, including key-span diagnostics matching the default path
- add Weavy set lowering through `SetDef` init/insert vtables, with direct `BTreeSet` / `HashSet` coverage and drop-on-error coverage
- extend the Weavy oracle shape bank with set-holder shapes so interpreter and JIT-requested plans stay checked against the default path

## Notes

The set path deliberately uses `init_in_place_with_capacity` + `insert` instead of `SetDef::from_slice` for now. `from_slice` moves values out of the scratch buffer but does not own that buffer, so a bulk path should wait until the raw-builder ownership API makes “move values, still free allocation” explicit.

## Verification

- `git diff --check`
- `cargo check -p facet-json --all-features --all-targets --message-format=short`
- `cargo nextest run -p facet-json`
- `cargo nextest run -p facet-json --all-features`
- push hooks: clippy, docs, build tests, run tests
