### PR TITLE
Improve Phon shape diagnostics

### DIFF
--- a/phon/rust/phon-engine/src/typed.rs
+++ b/phon/rust/phon-engine/src/typed.rs
@@ -1839,6 +1839,7 @@ pub unsafe fn decode_with(lowered: &Lowered, bytes: &[u8], base: *mut u8) -> Res
     let mut interp = DecodeInterp {
         reader: Reader::new(bytes),
         base,
+        retained: Vec::new(),
     };
     match weavy::run_program(&lowered.program, &lowered.blocks, &mut interp) {
         Ok(()) => {}
@@ -1852,7 +1853,62 @@ pub unsafe fn decode_with(lowered: &Lowered, bytes: &[u8], base: *mut u8) -> Res
             interp.reader.remaining(),
         )));
     }
+    if !interp.retained.is_empty() {
+        return Err(CompactError::Unsupported(
+            "typed: decode produced retained reference pointees; use decode_with_retention",
+        ));
+    }
     Ok(())
+}
+
+/// Engine-owned decoded pointees that borrowed reference handles point at.
+///
+/// Drop this after the decoded value, so references remain valid through the
+/// value's destructor.
+#[derive(Debug, Default)]
+pub struct DecodeRetention {
+    retained: Vec<RetainedScratch>,
+}
+
+impl DecodeRetention {
+    /// Whether this decode produced any retained pointee allocations.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.retained.is_empty()
+    }
+}
+
+/// Decode compact `bytes` and return any retained pointee storage needed by
+/// decoded reference handles.
+///
+/// # Safety
+/// As [`decode_with`]. On `Ok`, the caller must keep the returned
+/// [`DecodeRetention`] alive until after the decoded value at `base` is dropped.
+pub unsafe fn decode_with_retention(
+    lowered: &Lowered,
+    bytes: &[u8],
+    base: *mut u8,
+) -> Result<DecodeRetention> {
+    let mut interp = DecodeInterp {
+        reader: Reader::new(bytes),
+        base,
+        retained: Vec::new(),
+    };
+    match weavy::run_program(&lowered.program, &lowered.blocks, &mut interp) {
+        Ok(()) => {}
+        Err(RunError::Step(err)) => return Err(err),
+        Err(RunError::MissingBlock(_)) => {
+            panic!("CallBlock references a lowered recursion block")
+        }
+    }
+    if interp.reader.remaining() != 0 {
+        return Err(CompactError::Decode(DecodeError::TrailingBytes(
+            interp.reader.remaining(),
+        )));
+    }
+    Ok(DecodeRetention {
+        retained: interp.retained,
+    })
 }
 
 /// Decode compact `bytes` into `base` and return generic Weavy runner counters.
@@ -1870,6 +1926,7 @@ pub unsafe fn decode_with_stats(
     let mut interp = DecodeInterp {
         reader: Reader::new(bytes),
         base,
+        retained: Vec::new(),
     };
     let stats = match weavy::run_program_with_stats(&lowered.program, &lowered.blocks, &mut interp)
     {
@@ -1884,12 +1941,31 @@ pub unsafe fn decode_with_stats(
             interp.reader.remaining(),
         )));
     }
+    if !interp.retained.is_empty() {
+        return Err(CompactError::Unsupported(
+            "typed: decode produced retained reference pointees; use decode_with_retention",
+        ));
+    }
     Ok(stats)
 }
 
 struct DecodeInterp<'bytes> {
     reader: Reader<'bytes>,
     base: *mut u8,
+    retained: Vec<RetainedScratch>,
+}
+
+#[derive(Debug)]
+struct RetainedScratch {
+    scratch: RawScratch,
+    ctx: *const (),
+    drop_pointee: unsafe extern "C" fn(ctx: *const (), value: *mut u8),
+}
+
+impl Drop for RetainedScratch {
+    fn drop(&mut self) {
+        unsafe { (self.drop_pointee)(self.ctx, self.scratch.ptr()) };
+    }
 }
 
 enum DecodeContinuation<'program> {
@@ -2138,6 +2214,8 @@ impl<'program> Step<'program, SchemaId, MemOp> for DecodeInterp<'_> {
                                 ctx: o.thunks.ctx,
                                 handle: option,
                                 init: o.thunks.init_some,
+                                retain_value: false,
+                                drop_value: None,
                             },
                         )?
                     }
@@ -2199,6 +2277,8 @@ impl<'program> Step<'program, SchemaId, MemOp> for DecodeInterp<'_> {
                             ctx: rs.thunks.ctx,
                             handle: result,
                             init: rs.thunks.init_ok,
+                            retain_value: false,
+                            drop_value: None,
                         },
                     )?
                 } else if idx == rs.err_wire_index {
@@ -2210,6 +2290,8 @@ impl<'program> Step<'program, SchemaId, MemOp> for DecodeInterp<'_> {
                             ctx: rs.thunks.ctx,
                             handle: result,
                             init: rs.thunks.init_err,
+                            retain_value: false,
+                            drop_value: None,
                         },
                     )?
                 } else {
@@ -2225,6 +2307,8 @@ impl<'program> Step<'program, SchemaId, MemOp> for DecodeInterp<'_> {
                     ctx: p.thunks.ctx,
                     handle: unsafe { self.base.add(p.field_offset) },
                     init: p.thunks.init,
+                    retain_value: p.thunks.retain_decode_pointee,
+                    drop_value: p.thunks.drop_pointee,
                 },
             )?,
             // r[impl compat.skip-writer-only] — consume a writer-only value's wire
@@ -2382,7 +2466,18 @@ impl<'program> Step<'program, SchemaId, MemOp> for DecodeInterp<'_> {
                 scratch,
             } => {
                 unsafe { target.initialize(scratch.ptr()) };
-                drop(scratch);
+                if target.retain_value {
+                    let drop_pointee = target.drop_value.ok_or(CompactError::Unsupported(
+                        "typed: retained decode target without drop thunk",
+                    ))?;
+                    self.retained.push(RetainedScratch {
+                        scratch,
+                        ctx: target.ctx,
+                        drop_pointee,
+                    });
+                } else {
+                    drop(scratch);
+                }
                 self.base = previous_base;
                 Ok(Control::Continue)
             }

--- a/phon/rust/phon-jit/src/lower.rs
+++ b/phon/rust/phon-jit/src/lower.rs
@@ -496,6 +496,8 @@ mod tests {
             ctx: core::ptr::null(),
             borrow: box_u32_borrow,
             init: box_u32_init,
+            retain_decode_pointee: false,
+            drop_pointee: None,
         }
     }
 

--- a/phon/rust/phon/src/derive.rs
+++ b/phon/rust/phon/src/derive.rs
@@ -2048,27 +2048,18 @@ static INNER_PROGRAMS: LazyLock<ProgramCache> =
 /// double-build just drops the extra program.
 ///
 /// # Panics
-/// If the inner type is not phon-derivable or cannot be lowered: a programming error
-/// (the inner type of an opaque field must be a phon type).
+/// If the inner shape cannot be derived or lowered: a programming error (the
+/// inner shape of an opaque field must be supported by Phon).
 fn inner_program(shape: &'static Shape) -> Arc<CachedLowered> {
     let key = core::ptr::from_ref(shape) as usize;
     if let Some(p) = INNER_PROGRAMS.0.read().unwrap().get(&key) {
         return Arc::clone(p);
     }
-    let derived = of_shape(shape).unwrap_or_else(|e| {
-        panic!(
-            "opaque inner type {} is not phon-derivable: {e}",
-            shape.type_identifier
-        )
-    });
+    let derived = of_shape(shape)
+        .unwrap_or_else(|e| panic!("opaque inner facet shape {shape} cannot be derived: {e}",));
     let reg = Registry::new(derived.schemas);
     let program = typed::lower_typed(&derived.descriptor, &derived.descriptor_blocks, &reg)
-        .unwrap_or_else(|e| {
-            panic!(
-                "opaque inner type {} cannot be lowered: {e:?}",
-                shape.type_identifier
-            )
-        });
+        .unwrap_or_else(|e| panic!("opaque inner facet shape {shape} cannot be lowered: {e:?}",));
     let program = Arc::new(CachedLowered(program));
     Arc::clone(
         INNER_PROGRAMS
@@ -5273,6 +5264,33 @@ mod tests {
     }
 
     #[test]
+    fn opaque_inner_program_error_uses_shape_display() {
+        let shape = <(&'static String, String) as Facet>::SHAPE;
+
+        assert_eq!(shape.type_identifier, "(…)");
+        assert_eq!(shape.to_string(), "(&String, String)");
+
+        let panic = std::panic::catch_unwind(|| {
+            let _ = inner_program(shape);
+        })
+        .expect_err("&String tuple should not derive as an opaque inner program");
+
+        let message = panic_message(&panic);
+        assert!(
+            message.contains("opaque inner facet shape (&String, String) cannot be derived"),
+            "opaque panic should include Shape display, got: {message}"
+        );
+        assert!(
+            !message.contains("opaque inner type (…)"),
+            "opaque panic must not use Shape::type_identifier, got: {message}"
+        );
+        assert!(
+            !message.contains("phon-derivable"),
+            "opaque panic should use facet-derived wording, got: {message}"
+        );
+    }
+
+    #[test]
     fn derived_opaque_field_roundtrips_and_matches_bytes_oracle() {
         let d = of::<Envelope>().unwrap();
         let reg = Registry::new(d.schemas.clone());
@@ -5380,6 +5398,16 @@ mod tests {
         }
         .unwrap();
         assert_eq!(unsafe { islot.assume_init() }, inner);
+    }
+
+    fn panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
+        if let Some(message) = panic.downcast_ref::<String>() {
+            message.clone()
+        } else if let Some(message) = panic.downcast_ref::<&'static str>() {
+            (*message).to_string()
+        } else {
+            "<non-string panic>".to_string()
+        }
     }
 
     // r[verify exec.jit-optional]

--- a/phon/rust/phon/src/derive.rs
+++ b/phon/rust/phon/src/derive.rs
@@ -146,6 +146,23 @@ pub fn of_shape(shape: &'static Shape) -> Result<Derived, DeriveError> {
             descriptor: borrowed_descriptor(shape, kind)?,
         });
     }
+    if let Some((ptr, pointee)) = reference_pointer_def(shape) {
+        let inner = of_shape(pointee)?;
+        let (size, align) = layout_of(shape)?;
+        return Ok(Derived {
+            root: inner.root,
+            schemas: inner.schemas,
+            descriptor_blocks: inner.descriptor_blocks,
+            descriptor: Descriptor {
+                schema: inner.descriptor.schema.clone(),
+                layout: Layout { size, align },
+                access: Access::Pointer(PointerAccess {
+                    pointee: Box::new(inner.descriptor),
+                    thunks: reference_pointer_thunks(ptr),
+                }),
+            },
+        });
+    }
     if let Some((ptr, pointee)) = owned_pointer_def(shape) {
         let inner = of_shape(pointee)?;
         let (size, align) = layout_of(shape)?;
@@ -319,6 +336,9 @@ impl Builder {
         // (`String`/`Vec<u8>`), so the schema id matches an owned peer's exactly.
         if let Some(kind) = borrowed_kind(shape)? {
             return Ok(SchemaRef::concrete(primitive_id(borrow_primitive(kind))));
+        }
+        if let Some((_, pointee)) = reference_pointer_def(shape) {
+            return self.ref_of(pointee);
         }
         if let Some((_, pointee)) = owned_pointer_def(shape) {
             return self.ref_of(pointee);
@@ -678,6 +698,17 @@ fn build_descriptor(
     if let Some(kind) = borrowed_kind(shape)? {
         return borrowed_descriptor(shape, kind);
     }
+    if let Some((ptr, pointee_shape)) = reference_pointer_def(shape) {
+        let pointee = build_descriptor(pointee_shape, by_shape, real_ids, rec)?;
+        return Ok(Descriptor {
+            schema: pointee.schema.clone(),
+            layout: Layout { size, align },
+            access: Access::Pointer(PointerAccess {
+                pointee: Box::new(pointee),
+                thunks: reference_pointer_thunks(ptr),
+            }),
+        });
+    }
     if let Some((ptr, pointee_shape)) = owned_pointer_def(shape) {
         let pointee = build_descriptor(pointee_shape, by_shape, real_ids, rec)?;
         return Ok(Descriptor {
@@ -944,6 +975,28 @@ fn result_def(shape: &'static Shape) -> Option<&'static ResultDef> {
         Def::Result(result_def) => Some(result_def),
         _ => None,
     }
+}
+
+/// A shared/exclusive Rust reference whose wire identity is its pointee's schema.
+/// Encode borrows through the facet pointer vtable. Decode into arbitrary `&T` is
+/// intentionally not supported; use owned reader shapes for RPC args/results.
+// r[impl descriptors.thunk-binding]
+fn reference_pointer_def(shape: &'static Shape) -> Option<(&'static PointerDef, &'static Shape)> {
+    let Def::Pointer(ptr) = &shape.def else {
+        return None;
+    };
+    if !matches!(
+        ptr.known,
+        Some(KnownPointer::SharedReference | KnownPointer::ExclusiveReference)
+    ) {
+        return None;
+    }
+    let pointee = ptr.pointee()?;
+    ptr.vtable.borrow_fn?;
+    if layout_of(shape).ok()?.0 != core::mem::size_of::<*const ()>() {
+        return None;
+    }
+    Some((ptr, pointee))
 }
 
 /// A strong owning pointer whose wire identity is the pointee's schema. The
@@ -1497,7 +1550,7 @@ unsafe extern "C" fn res_init_err(ctx: *const (), result: *mut u8, value: *mut u
 }
 
 // ============================================================================
-// Owned pointer thunks
+// Pointer thunks
 // ============================================================================
 //
 // `Box<T>`, `Rc<T>`, and `Arc<T>` are local ownership details: the wire carries
@@ -1522,10 +1575,28 @@ fn pointer_thunks(ptr: &'static PointerDef) -> PointerThunks {
         ctx: core::ptr::from_ref(ptr).cast::<()>(),
         borrow: pointer_borrow,
         init: pointer_init,
+        retain_decode_pointee: false,
+        drop_pointee: None,
     }
 }
 
-/// Borrow the pointee behind an initialized owning pointer.
+/// Build the [`PointerThunks`] for a Rust reference field/root.
+// r[impl descriptors.thunk-binding]
+fn reference_pointer_thunks(ptr: &'static PointerDef) -> PointerThunks {
+    assert!(
+        ptr.vtable.borrow_fn.is_some(),
+        "reference pointer has no borrow op; cannot encode through the typed path"
+    );
+    PointerThunks {
+        ctx: core::ptr::from_ref(ptr).cast::<()>(),
+        borrow: pointer_borrow,
+        init: reference_pointer_init,
+        retain_decode_pointee: true,
+        drop_pointee: Some(pointer_pointee_drop),
+    }
+}
+
+/// Borrow the pointee behind an initialized pointer/reference.
 ///
 /// # Safety
 /// `ctx` must be a `&'static PointerDef`; `pointer` must point to an initialized
@@ -1540,6 +1611,18 @@ unsafe extern "C" fn pointer_borrow(ctx: *const (), pointer: *const u8) -> *cons
     // Safety: `pointer` is an initialized pointer handle for this pointer def.
     let pointee = unsafe { borrow(PtrConst::new(pointer)) };
     pointee.as_byte_ptr()
+}
+
+unsafe extern "C" fn reference_pointer_init(_ctx: *const (), pointer: *mut u8, value: *mut u8) {
+    unsafe { pointer.cast::<*const u8>().write(value.cast_const()) };
+}
+
+unsafe extern "C" fn pointer_pointee_drop(ctx: *const (), value: *mut u8) {
+    let ptr = unsafe { &*ctx.cast::<PointerDef>() };
+    let Some(pointee) = ptr.pointee() else {
+        return;
+    };
+    let _ = unsafe { pointee.call_drop_in_place(PtrMut::new(value)) };
 }
 
 /// Initialize an owning pointer from a scratch-decoded pointee value.
@@ -2308,6 +2391,12 @@ mod tests {
         pairs: Vec<(String, u32)>,
     }
 
+    #[derive(Facet)]
+    struct RefStringHolder<'a> {
+        name: &'a String,
+        label: String,
+    }
+
     fn pt_object(a: u8, b: u64, c: u16, flag: bool) -> Value {
         let mut o = VObject::new();
         o.insert(VString::new("a"), Value::from(a));
@@ -2357,6 +2446,60 @@ mod tests {
             )),
             "anonymous tuples must not be emitted as numeric-field structs"
         );
+    }
+
+    #[test]
+    fn reference_field_derives_as_pointee_schema() {
+        let d = of::<RefStringHolder>().unwrap();
+        let root = d
+            .schemas
+            .iter()
+            .find(|schema| schema.id == d.root)
+            .expect("root schema should be emitted");
+        let SchemaKind::Struct { fields, .. } = &root.kind else {
+            panic!("RefStringHolder must derive as a struct schema, got {root:?}");
+        };
+        let name = fields
+            .iter()
+            .find(|field| field.name == "name")
+            .expect("name field should be present");
+        assert_eq!(
+            name.schema,
+            SchemaRef::concrete(primitive_id(Primitive::String))
+        );
+    }
+
+    #[test]
+    fn reference_tuple_typed_encoding_matches_owned_tuple() {
+        let borrowed = String::from("facet");
+        let borrowed_tuple = (&borrowed, String::from("phon"));
+        let borrowed_d = of::<(&String, String)>().unwrap();
+        let borrowed_reg = Registry::new(borrowed_d.schemas.clone());
+        let borrowed_bytes = unsafe {
+            typed::encode(
+                core::ptr::from_ref(&borrowed_tuple).cast::<u8>(),
+                &borrowed_d.descriptor,
+                &borrowed_d.descriptor_blocks,
+                &borrowed_reg,
+            )
+        }
+        .unwrap();
+
+        let owned_tuple = (String::from("facet"), String::from("phon"));
+        let owned_d = of::<(String, String)>().unwrap();
+        let owned_reg = Registry::new(owned_d.schemas.clone());
+        let owned_bytes = unsafe {
+            typed::encode(
+                core::ptr::from_ref(&owned_tuple).cast::<u8>(),
+                &owned_d.descriptor,
+                &owned_d.descriptor_blocks,
+                &owned_reg,
+            )
+        }
+        .unwrap();
+
+        assert_eq!(borrowed_d.root, owned_d.root);
+        assert_eq!(borrowed_bytes, owned_bytes);
     }
 
     #[test]
@@ -5265,19 +5408,19 @@ mod tests {
 
     #[test]
     fn opaque_inner_program_error_uses_shape_display() {
-        let shape = <(&'static String, String) as Facet>::SHAPE;
+        let shape = <(*const u8, String) as Facet>::SHAPE;
 
         assert_eq!(shape.type_identifier, "(…)");
-        assert_eq!(shape.to_string(), "(&String, String)");
+        assert_eq!(shape.to_string(), "(*const T, String)");
 
         let panic = std::panic::catch_unwind(|| {
             let _ = inner_program(shape);
         })
-        .expect_err("&String tuple should not derive as an opaque inner program");
+        .expect_err("raw pointer tuple should not derive as an opaque inner program");
 
         let message = panic_message(&panic);
         assert!(
-            message.contains("opaque inner facet shape (&String, String) cannot be derived"),
+            message.contains("opaque inner facet shape (*const T, String) cannot be derived"),
             "opaque panic should include Shape display, got: {message}"
         );
         assert!(

--- a/phon/rust/phon/src/derive.rs
+++ b/phon/rust/phon/src/derive.rs
@@ -2397,6 +2397,12 @@ mod tests {
         label: String,
     }
 
+    #[derive(Facet)]
+    struct OwnedStringHolder {
+        name: String,
+        label: String,
+    }
+
     fn pt_object(a: u8, b: u64, c: u16, flag: bool) -> Value {
         let mut o = VObject::new();
         o.insert(VString::new("a"), Value::from(a));
@@ -2500,6 +2506,67 @@ mod tests {
 
         assert_eq!(borrowed_d.root, owned_d.root);
         assert_eq!(borrowed_bytes, owned_bytes);
+    }
+
+    #[test]
+    fn reference_tuple_typed_decode_retains_pointee() {
+        let writer_value = (String::from("facet"), String::from("phon"));
+        let writer = of::<(String, String)>().unwrap();
+        let reader = of::<(&String, String)>().unwrap();
+        let reg = merged_registry(&writer, &reader);
+        let bytes = encode_writer(&writer_value, &writer, &reg);
+        let program = typed::lower_decode(
+            writer.root,
+            &reader.descriptor,
+            &reader.descriptor_blocks,
+            &reg,
+        )
+        .unwrap();
+
+        let mut slot = std::mem::MaybeUninit::<(&String, String)>::uninit();
+        let retention = unsafe {
+            typed::decode_with_retention(&program, &bytes, slot.as_mut_ptr().cast::<u8>())
+        }
+        .unwrap();
+        let decoded = unsafe { slot.assume_init() };
+
+        assert_eq!(decoded.0.as_str(), "facet");
+        assert_eq!(decoded.1, "phon");
+
+        drop(decoded);
+        drop(retention);
+    }
+
+    #[test]
+    fn reference_field_typed_decode_retains_pointee() {
+        let writer_value = OwnedStringHolder {
+            name: String::from("facet"),
+            label: String::from("phon"),
+        };
+        let writer = of::<OwnedStringHolder>().unwrap();
+        let reader = of::<RefStringHolder>().unwrap();
+        let reg = merged_registry(&writer, &reader);
+        let bytes = encode_writer(&writer_value, &writer, &reg);
+        let program = typed::lower_decode(
+            writer.root,
+            &reader.descriptor,
+            &reader.descriptor_blocks,
+            &reg,
+        )
+        .unwrap();
+
+        let mut slot = std::mem::MaybeUninit::<RefStringHolder>::uninit();
+        let retention = unsafe {
+            typed::decode_with_retention(&program, &bytes, slot.as_mut_ptr().cast::<u8>())
+        }
+        .unwrap();
+        let decoded = unsafe { slot.assume_init() };
+
+        assert_eq!(decoded.name.as_str(), "facet");
+        assert_eq!(decoded.label, "phon");
+
+        drop(decoded);
+        drop(retention);
     }
 
     #[test]

--- a/phon/rust/phon/src/lib.rs
+++ b/phon/rust/phon/src/lib.rs
@@ -607,7 +607,9 @@ pub mod api {
                 .all(|variant| decode_program_supported(&variant.payload)),
             MemOp::Map(m) => decode_program_supported(&m.key) && decode_program_supported(&m.value),
             MemOp::Result(r) => decode_program_supported(&r.ok) && decode_program_supported(&r.err),
-            MemOp::Pointer(p) => decode_program_supported(&p.pointee),
+            MemOp::Pointer(p) => {
+                !p.thunks.retain_decode_pointee && decode_program_supported(&p.pointee)
+            }
             MemOp::Opaque(_) | MemOp::Dynamic { .. } | MemOp::CallBlock { .. } => true,
         })
     }

--- a/vox/rust/vox-macros-core/src/lib.rs
+++ b/vox/rust/vox-macros-core/src/lib.rs
@@ -204,6 +204,20 @@ fn type_is_tx(ty: &Type) -> bool {
     }
 }
 
+fn type_has_reference(ty: &Type) -> bool {
+    match ty {
+        Type::Reference(_) => true,
+        Type::Tuple(TypeTuple(group)) => group
+            .content
+            .iter()
+            .any(|entry| type_has_reference(&entry.value)),
+        Type::PathWithGenerics(PathWithGenerics { args, .. }) => args.iter().any(|entry| {
+            matches!(&entry.value, GenericArgument::Type(inner) if type_has_reference(inner))
+        }),
+        Type::Path(_) => false,
+    }
+}
+
 /// For a `Tx<X>`/`Rx<X>` argument type, the element type `X`. `None` otherwise.
 ///
 /// `Tx`/`Rx` are `#[facet(opaque)]`, so their `Shape` carries no `type_params`
@@ -775,6 +789,7 @@ fn generate_dispatch_arm(
         .args()
         .map(|a| format_ident!("{}", a.name().to_snake_case()))
         .collect();
+    let args_have_reference = method.args().any(|a| type_has_reference(&a.ty));
     let destructure = match arg_names.len() {
         0 => quote! { let () = args; },
         1 => {
@@ -785,8 +800,6 @@ fn generate_dispatch_arm(
     };
 
     let _ = idx;
-
-    let args_let = quote! { let args: #args_tuple_type };
 
     let return_type = method.return_type();
     let (ok_ty_ref, err_ty_ref) = method_ok_and_err_types(&return_type);
@@ -803,6 +816,59 @@ fn generate_dispatch_arm(
     let err_ty = err_ty_ref
         .map(Type::to_token_stream)
         .unwrap_or_else(|| quote! { ::core::convert::Infallible });
+
+    let decode_args = if args_have_reference {
+        quote! {
+            let decoded_args_result = #vox::provide_channels_for_method(
+                request_call.channels.clone(),
+                #descriptor_fn_name().methods[#idx],
+                &schemas,
+                || #vox::schema_deser::schema_deserialize_args_retained::<#args_tuple_type>(
+                    args_bytes,
+                    method_id,
+                    &schemas,
+                ),
+            );
+            drop(_binder_guard);
+            let decoded_args = match decoded_args_result {
+                Ok(v) => v,
+                Err(e) => {
+                    reply
+                        .send_typed_error::<#ok_ty_dispatch, ::core::convert::Infallible>(
+                            #vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
+                        )
+                        .await;
+                    return;
+                }
+            };
+            let args: #args_tuple_type = *decoded_args.get();
+        }
+    } else {
+        quote! {
+            let deser_result: ::core::result::Result<#args_tuple_type, _> = #vox::provide_channels_for_method(
+                request_call.channels.clone(),
+                #descriptor_fn_name().methods[#idx],
+                &schemas,
+                || #vox::schema_deser::schema_deserialize_args_borrowed(
+                    args_bytes,
+                    method_id,
+                    &schemas,
+                ),
+            );
+            drop(_binder_guard);
+            let args: #args_tuple_type = match deser_result {
+                Ok(v) => v,
+                Err(e) => {
+                    reply
+                        .send_typed_error::<#ok_ty_dispatch, ::core::convert::Infallible>(
+                            #vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
+                        )
+                        .await;
+                    return;
+                }
+            };
+        }
+    };
 
     let context_setup = {
         quote! {
@@ -904,28 +970,7 @@ fn generate_dispatch_arm(
             // r[impl rpc.channel.binding] each handle's inline index selects its
             // ChannelId from the out-of-band `request_call.channels` list.
             let _binder_guard = reply.channel_binder().map(#vox::set_channel_binder);
-            let deser_result: ::core::result::Result<#args_tuple_type, _> = #vox::provide_channels_for_method(
-                request_call.channels.clone(),
-                #descriptor_fn_name().methods[#idx],
-                &schemas,
-                || #vox::schema_deser::schema_deserialize_args_borrowed(
-                    args_bytes,
-                    method_id,
-                    &schemas,
-                ),
-            );
-            drop(_binder_guard);
-            #args_let = match deser_result {
-                Ok(v) => v,
-                Err(e) => {
-                    reply
-                        .send_typed_error::<#ok_ty_dispatch, ::core::convert::Infallible>(
-                            #vox::VoxError::<::core::convert::Infallible>::InvalidPayload(e.to_string())
-                        )
-                        .await;
-                    return;
-                }
-            };
+            #decode_args
             #context_setup
             #destructure
             #invoke_and_reply

--- a/vox/rust/vox-macros-core/src/lib.rs
+++ b/vox/rust/vox-macros-core/src/lib.rs
@@ -204,15 +204,19 @@ fn type_is_tx(ty: &Type) -> bool {
     }
 }
 
-fn type_has_reference(ty: &Type) -> bool {
+fn reference_needs_retained_decode(reference: &TypeRef) -> bool {
+    !matches!(reference.inner.as_ref(), Type::Path(path) if path.last_segment() == "str")
+}
+
+fn type_needs_retained_decode(ty: &Type) -> bool {
     match ty {
-        Type::Reference(_) => true,
+        Type::Reference(reference) => reference_needs_retained_decode(reference),
         Type::Tuple(TypeTuple(group)) => group
             .content
             .iter()
-            .any(|entry| type_has_reference(&entry.value)),
+            .any(|entry| type_needs_retained_decode(&entry.value)),
         Type::PathWithGenerics(PathWithGenerics { args, .. }) => args.iter().any(|entry| {
-            matches!(&entry.value, GenericArgument::Type(inner) if type_has_reference(inner))
+            matches!(&entry.value, GenericArgument::Type(inner) if type_needs_retained_decode(inner))
         }),
         Type::Path(_) => false,
     }
@@ -789,7 +793,7 @@ fn generate_dispatch_arm(
         .args()
         .map(|a| format_ident!("{}", a.name().to_snake_case()))
         .collect();
-    let args_have_reference = method.args().any(|a| type_has_reference(&a.ty));
+    let args_need_retained_decode = method.args().any(|a| type_needs_retained_decode(&a.ty));
     let destructure = match arg_names.len() {
         0 => quote! { let () = args; },
         1 => {
@@ -817,7 +821,7 @@ fn generate_dispatch_arm(
         .map(Type::to_token_stream)
         .unwrap_or_else(|| quote! { ::core::convert::Infallible });
 
-    let decode_args = if args_have_reference {
+    let decode_args = if args_need_retained_decode {
         quote! {
             let decoded_args_result = #vox::provide_channels_for_method(
                 request_call.channels.clone(),
@@ -841,7 +845,9 @@ fn generate_dispatch_arm(
                     return;
                 }
             };
-            let args: #args_tuple_type = *decoded_args.get();
+            let decoded_args_parts = decoded_args.into_retention_and_value();
+            let _args_retention = decoded_args_parts.0;
+            let args: #args_tuple_type = decoded_args_parts.1;
         }
     } else {
         quote! {
@@ -1348,6 +1354,41 @@ mod tests {
         assert!(output.contains("pub struct PingDispatcher"));
         assert!(output.contains("pub struct PingClient"));
         assert_eq!(output.matches("#[cfg(feature = \"runtime\")]").count(), 6);
+    }
+
+    #[test]
+    fn borrowed_str_args_use_borrowed_decode() {
+        let output = generate(quote! {
+            trait BorrowedText { async fn classify(&self, word: &str) -> bool; }
+        });
+
+        assert!(output.contains("schema_deserialize_args_borrowed"));
+        assert!(!output.contains("schema_deserialize_args_retained"));
+        assert!(!output.contains("into_retention_and_value"));
+    }
+
+    #[test]
+    fn reference_string_args_use_retained_decode() {
+        let output = generate(quote! {
+            trait ReferenceText { async fn classify(&self, word: &String) -> bool; }
+        });
+
+        assert!(output.contains("schema_deserialize_args_retained"));
+        assert!(output.contains("into_retention_and_value"));
+        assert!(output.contains("let _args_retention = decoded_args_parts.0;"));
+    }
+
+    #[test]
+    fn retained_reference_args_can_mix_with_channels() {
+        let output = generate(quote! {
+            trait ReferenceChannel {
+                async fn stream(&self, prefix: &String, output: Tx<String>) -> u32;
+            }
+        });
+
+        assert!(output.contains("schema_deserialize_args_retained"));
+        assert!(output.contains("let _args_retention = decoded_args_parts.0;"));
+        assert!(output.contains("let args: (&'_ String, Tx<String>) = decoded_args_parts.1;"));
     }
 
     #[test]

--- a/vox/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__borrowed_return_mixed_with_borrowed_args_and_channels_compiles_to_expected_shapes.snap
+++ b/vox/rust/vox-macros-core/src/snapshots/vox_macros_core__tests__borrowed_return_mixed_with_borrowed_args_and_channels_compiles_to_expected_shapes.snap
@@ -1,5 +1,5 @@
 ---
-source: rust/vox-macros-core/src/lib.rs
+source: vox/rust/vox-macros-core/src/lib.rs
 expression: "generate(quote!\n{\n    trait WordLab\n    {\n        async fn is_short(&self, word: &str) -> bool; async fn\n        classify(&self, word: String) -> &'vox str; async fn\n        transform(&self, prefix: &str, input: Rx<String>, output: Tx<String>)\n        -> u32;\n    }\n})"
 ---
 #[allow(non_snake_case, clippy::all)]

--- a/vox/rust/vox-phon/src/lib.rs
+++ b/vox/rust/vox-phon/src/lib.rs
@@ -30,10 +30,11 @@ use vox_rt::sync::SyncMutex;
 
 pub mod schema;
 pub use schema::{
-    AuxiliaryRoot, DecodeProgram, SchemaBundle, build_decode_program, decode_compat,
-    decode_owned_with_program, decode_with_program, from_self_describing, parse_schema_bytes,
-    recursive_schema_ids_for_shape, schema_bytes, schema_bytes_for_shape,
-    schema_bytes_for_shape_with_auxiliary_roots, schema_id_for_shape, to_self_describing,
+    AuxiliaryRoot, DecodeProgram, Decoded, SchemaBundle, build_decode_program, decode_compat,
+    decode_owned_with_program, decode_with_program, decode_with_program_retained,
+    from_self_describing, parse_schema_bytes, recursive_schema_ids_for_shape, schema_bytes,
+    schema_bytes_for_shape, schema_bytes_for_shape_with_auxiliary_roots, schema_id_for_shape,
+    to_self_describing,
 };
 
 /// Opaque-passthrough sentinel: build an `OpaqueSerialize` that emits already-encoded

--- a/vox/rust/vox-phon/src/lib.rs
+++ b/vox/rust/vox-phon/src/lib.rs
@@ -21,7 +21,7 @@ pub use phon::api::{
     JitFallbackRecord, JitFallbackReport, JitShapeReport, MethodJitFallbackReport,
     MethodJitShapeRecord, MethodJitShapeReport, MethodJitShapeSummary, NativeJitStats,
 };
-use phon::derive::{Derived, of_shape};
+use phon::derive::{DeriveError, Derived, of_shape};
 use phon_engine::{Registry, typed};
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use phon_ir::MemOp;
@@ -73,6 +73,14 @@ fn lower_derived(type_name: &str, derived: &Derived) -> Result<Lowered, Error> {
         .map_err(|e| Error(format!("lower {type_name}: {e:?}")))
 }
 
+fn shape_name(shape: &'static Shape) -> String {
+    shape.to_string()
+}
+
+fn derive_error(shape: &'static Shape, error: DeriveError) -> Error {
+    Error(format!("derive {}: {error}", shape_name(shape)))
+}
+
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 struct NativeEncodeProgram(phon_jit::native::NativeEncode);
 
@@ -98,9 +106,9 @@ struct TypedProgram {
 
 impl TypedProgram {
     fn for_shape(shape: &'static Shape) -> Result<Self, Error> {
-        let type_name = shape.type_identifier;
-        let derived = of_shape(shape).map_err(|e| Error(format!("derive {type_name}: {e}")))?;
-        let lowered = lower_derived(type_name, &derived)?;
+        let type_name = shape_name(shape);
+        let derived = of_shape(shape).map_err(|e| derive_error(shape, e))?;
+        let lowered = lower_derived(&type_name, &derived)?;
 
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
@@ -390,14 +398,14 @@ pub fn method_jit_shape_report_for_shape(
 /// # Errors
 /// [`Error`] if `T` cannot be lowered, or the bytes are malformed for it.
 pub fn from_slice_borrowed<'a, T: Facet<'a>>(bytes: &'a [u8]) -> Result<T, Error> {
-    let type_name = T::SHAPE.type_identifier;
+    let type_name = shape_name(T::SHAPE);
     let program = typed_program_for_shape(T::SHAPE)?;
     let mut slot = MaybeUninit::<T>::uninit();
     // Safety: `program` was built from `T`'s descriptor; on `Ok`, decode has fully
     // initialized the slot. Borrowed fields point into `bytes`, which outlives the
     // returned `T` by the `'a` tie.
     unsafe {
-        program.decode_into(bytes, slot.as_mut_ptr().cast::<u8>(), type_name)?;
+        program.decode_into(bytes, slot.as_mut_ptr().cast::<u8>(), &type_name)?;
         Ok(slot.assume_init())
     }
 }
@@ -408,13 +416,13 @@ pub fn from_slice_borrowed<'a, T: Facet<'a>>(bytes: &'a [u8]) -> Result<T, Error
 /// # Errors
 /// [`Error`] if `T` cannot be lowered, or the bytes are malformed for it.
 pub fn from_slice<'a, T: Facet<'a>>(bytes: &[u8]) -> Result<T, Error> {
-    let type_name = T::SHAPE.type_identifier;
+    let type_name = shape_name(T::SHAPE);
     let program = typed_program_for_shape(T::SHAPE)?;
     let mut slot = MaybeUninit::<T>::uninit();
     // Safety: `program` was built from `T`'s descriptor; on `Ok`, decode has fully
     // initialized the slot.
     unsafe {
-        program.decode_into(bytes, slot.as_mut_ptr().cast::<u8>(), type_name)?;
+        program.decode_into(bytes, slot.as_mut_ptr().cast::<u8>(), &type_name)?;
         Ok(slot.assume_init())
     }
 }
@@ -672,9 +680,9 @@ mod tests {
     }
 
     fn interpreter_to_vec<'a, T: Facet<'a>>(value: &T) -> Vec<u8> {
-        let type_name = T::SHAPE.type_identifier;
+        let type_name = shape_name(T::SHAPE);
         let derived = of::<T>().expect("derive");
-        let lowered = lower_derived(type_name, &derived).expect("lower");
+        let lowered = lower_derived(&type_name, &derived).expect("lower");
         // Safety: `value` is a live `T`; `lowered` was built from `T`.
         unsafe { typed::encode_with(&lowered, (value as *const T).cast::<u8>()) }
     }

--- a/vox/rust/vox-phon/src/schema.rs
+++ b/vox/rust/vox-phon/src/schema.rs
@@ -254,19 +254,46 @@ pub struct DecodeProgram {
 
 pub struct Decoded<T> {
     value: ManuallyDrop<T>,
-    retention: ManuallyDrop<typed::DecodeRetention>,
+    retention: ManuallyDrop<DecodeRetention>,
+}
+
+unsafe impl<T: Send> Send for Decoded<T> {}
+
+pub struct DecodeRetention {
+    inner: typed::DecodeRetention,
+}
+
+unsafe impl Send for DecodeRetention {}
+
+impl DecodeRetention {
+    pub fn new(inner: typed::DecodeRetention) -> Self {
+        Self { inner }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
 }
 
 impl<T> Decoded<T> {
     pub fn new(value: T, retention: typed::DecodeRetention) -> Self {
         Self {
             value: ManuallyDrop::new(value),
-            retention: ManuallyDrop::new(retention),
+            retention: ManuallyDrop::new(DecodeRetention::new(retention)),
         }
     }
 
     pub fn get(&self) -> &T {
         &self.value
+    }
+
+    pub fn into_retention_and_value(self) -> (DecodeRetention, T) {
+        let mut this = ManuallyDrop::new(self);
+        unsafe {
+            let retention = ManuallyDrop::take(&mut this.retention);
+            let value = ManuallyDrop::take(&mut this.value);
+            (retention, value)
+        }
     }
 }
 

--- a/vox/rust/vox-phon/src/schema.rs
+++ b/vox/rust/vox-phon/src/schema.rs
@@ -14,7 +14,7 @@
 //! `u32` UTF-8 byte length + bytes, followed by the auxiliary `u64` root.
 
 use std::collections::BTreeSet;
-use std::mem::MaybeUninit;
+use std::mem::{ManuallyDrop, MaybeUninit};
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use std::sync::Arc;
 
@@ -252,6 +252,33 @@ pub struct DecodeProgram {
     native: Option<Arc<NativeDecodeProgram>>,
 }
 
+pub struct Decoded<T> {
+    value: ManuallyDrop<T>,
+    retention: ManuallyDrop<typed::DecodeRetention>,
+}
+
+impl<T> Decoded<T> {
+    pub fn new(value: T, retention: typed::DecodeRetention) -> Self {
+        Self {
+            value: ManuallyDrop::new(value),
+            retention: ManuallyDrop::new(retention),
+        }
+    }
+
+    pub fn get(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<T> Drop for Decoded<T> {
+    fn drop(&mut self) {
+        unsafe {
+            ManuallyDrop::drop(&mut self.value);
+            ManuallyDrop::drop(&mut self.retention);
+        }
+    }
+}
+
 impl DecodeProgram {
     fn new(lowered: Lowered) -> Self {
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -285,6 +312,25 @@ impl DecodeProgram {
         }
 
         unsafe { typed::decode_with(&self.lowered, bytes, base) }
+            .map_err(|e| Error(format!("decode {type_name}: {e:?}")))
+    }
+
+    unsafe fn decode_into_retaining(
+        &self,
+        bytes: &[u8],
+        base: *mut u8,
+        type_name: &str,
+    ) -> Result<typed::DecodeRetention, Error> {
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        {
+            if let Some(native) = &self.native {
+                return unsafe { native.0.run(bytes, base) }
+                    .map(|()| typed::DecodeRetention::default())
+                    .map_err(|e| Error(format!("decode {type_name}: {e:?}")));
+            }
+        }
+
+        unsafe { typed::decode_with_retention(&self.lowered, bytes, base) }
             .map_err(|e| Error(format!("decode {type_name}: {e:?}")))
     }
 
@@ -331,7 +377,9 @@ fn decode_program_supported(program: &[MemOp]) -> bool {
             .all(|variant| decode_program_supported(&variant.payload)),
         MemOp::Map(m) => decode_program_supported(&m.key) && decode_program_supported(&m.value),
         MemOp::Result(r) => decode_program_supported(&r.ok) && decode_program_supported(&r.err),
-        MemOp::Pointer(p) => decode_program_supported(&p.pointee),
+        MemOp::Pointer(p) => {
+            !p.thunks.retain_decode_pointee && decode_program_supported(&p.pointee)
+        }
         MemOp::Opaque(_) | MemOp::Dynamic { .. } | MemOp::CallBlock { .. } => true,
     })
 }
@@ -388,6 +436,21 @@ pub fn decode_with_program<'a, T: Facet<'a>>(
     unsafe {
         program.decode_into(bytes, slot.as_mut_ptr().cast::<u8>(), &shape_name(T::SHAPE))?;
         Ok(slot.assume_init())
+    }
+}
+
+pub fn decode_with_program_retained<'a, T: Facet<'a>>(
+    program: &DecodeProgram,
+    bytes: &'a [u8],
+) -> Result<Decoded<T>, Error> {
+    let mut slot = MaybeUninit::<T>::uninit();
+    unsafe {
+        let retention = program.decode_into_retaining(
+            bytes,
+            slot.as_mut_ptr().cast::<u8>(),
+            &shape_name(T::SHAPE),
+        )?;
+        Ok(Decoded::new(slot.assume_init(), retention))
     }
 }
 

--- a/vox/rust/vox-phon/src/schema.rs
+++ b/vox/rust/vox-phon/src/schema.rs
@@ -27,7 +27,7 @@ use phon_ir::MemOp;
 use phon_schema::bytes::Reader;
 use phon_schema::{Schema, SchemaId, schema_from_bytes, schema_to_bytes};
 
-use crate::Error;
+use crate::{Error, derive_error, shape_name};
 
 /// A decoded schema closure: the root type's id and every reachable composite
 /// schema. The writer's view of a type, used to build a compat decode program.
@@ -55,7 +55,7 @@ pub struct AuxiliaryRoot {
 // r[impl schema.format.self-contained]
 // r[impl schema.principles.once-per-type]
 pub fn schema_bytes<'a, T: Facet<'a>>() -> Result<Vec<u8>, Error> {
-    let d = of::<T>().map_err(|e| Error(format!("derive {}: {e}", T::SHAPE.type_identifier)))?;
+    let d = of::<T>().map_err(|e| derive_error(T::SHAPE, e))?;
     Ok(encode_bundle(d.root, &d.schemas))
 }
 
@@ -68,7 +68,7 @@ pub fn schema_bytes<'a, T: Facet<'a>>() -> Result<Vec<u8>, Error> {
 // r[impl schema.format.self-contained]
 // r[impl schema.principles.once-per-type]
 pub fn schema_bytes_for_shape(shape: &'static Shape) -> Result<Vec<u8>, Error> {
-    let d = of_shape(shape).map_err(|e| Error(format!("derive {}: {e}", shape.type_identifier)))?;
+    let d = of_shape(shape).map_err(|e| derive_error(shape, e))?;
     Ok(encode_bundle(d.root, &d.schemas))
 }
 
@@ -82,8 +82,7 @@ pub fn schema_bytes_for_shape_with_auxiliary_roots(
     shape: &'static Shape,
     auxiliary_roots: &[(&str, &'static Shape)],
 ) -> Result<Vec<u8>, Error> {
-    let primary =
-        of_shape(shape).map_err(|e| Error(format!("derive {}: {e}", shape.type_identifier)))?;
+    let primary = of_shape(shape).map_err(|e| derive_error(shape, e))?;
     let mut schemas = primary.schemas;
     let mut seen: BTreeSet<u64> = schemas.iter().map(|s| s.id.0).collect();
     let mut roots = Vec::with_capacity(auxiliary_roots.len());
@@ -92,8 +91,7 @@ pub fn schema_bytes_for_shape_with_auxiliary_roots(
         if role.is_empty() {
             return Err(Error("auxiliary schema root role must not be empty".into()));
         }
-        let derived = of_shape(aux_shape)
-            .map_err(|e| Error(format!("derive {}: {e}", aux_shape.type_identifier)))?;
+        let derived = of_shape(aux_shape).map_err(|e| derive_error(aux_shape, e))?;
         for schema in derived.schemas {
             if seen.insert(schema.id.0) {
                 schemas.push(schema);
@@ -119,7 +117,7 @@ pub fn schema_bytes_for_shape_with_auxiliary_roots(
 /// # Errors
 /// [`Error`] if the shape cannot be lowered to a phon schema.
 pub fn schema_id_for_shape(shape: &'static Shape) -> Result<SchemaId, Error> {
-    let d = of_shape(shape).map_err(|e| Error(format!("derive {}: {e}", shape.type_identifier)))?;
+    let d = of_shape(shape).map_err(|e| derive_error(shape, e))?;
     Ok(d.root)
 }
 
@@ -134,7 +132,7 @@ pub fn schema_id_for_shape(shape: &'static Shape) -> Result<SchemaId, Error> {
 pub fn recursive_schema_ids_for_shape(
     shape: &'static Shape,
 ) -> Result<std::collections::BTreeSet<u64>, Error> {
-    let d = of_shape(shape).map_err(|e| Error(format!("derive {}: {e}", shape.type_identifier)))?;
+    let d = of_shape(shape).map_err(|e| derive_error(shape, e))?;
     Ok(d.descriptor_blocks.keys().map(|id| id.0).collect())
 }
 
@@ -356,8 +354,7 @@ unsafe impl Sync for DecodeProgram {}
 pub fn build_decode_program<'a, T: Facet<'a>>(
     writer: &SchemaBundle,
 ) -> Result<DecodeProgram, Error> {
-    let reader =
-        of::<T>().map_err(|e| Error(format!("derive {}: {e}", T::SHAPE.type_identifier)))?;
+    let reader = of::<T>().map_err(|e| derive_error(T::SHAPE, e))?;
     // The registry must resolve both the writer's refs and the reader's refs.
     let mut schemas = writer.schemas.clone();
     for s in &reader.schemas {
@@ -372,7 +369,7 @@ pub fn build_decode_program<'a, T: Facet<'a>>(
         &reader.descriptor_blocks,
         &reg,
     )
-    .map_err(|e| Error(format!("lower_decode {}: {e:?}", T::SHAPE.type_identifier)))?;
+    .map_err(|e| Error(format!("lower_decode {}: {e:?}", shape_name(T::SHAPE))))?;
     Ok(DecodeProgram::new(program))
 }
 
@@ -389,11 +386,7 @@ pub fn decode_with_program<'a, T: Facet<'a>>(
     // Safety: `program` was lowered for `T`'s descriptor; on `Ok`, `decode_with`
     // fully initializes the slot. Borrowed fields point into `bytes` (the `'a` tie).
     unsafe {
-        program.decode_into(
-            bytes,
-            slot.as_mut_ptr().cast::<u8>(),
-            T::SHAPE.type_identifier,
-        )?;
+        program.decode_into(bytes, slot.as_mut_ptr().cast::<u8>(), &shape_name(T::SHAPE))?;
         Ok(slot.assume_init())
     }
 }
@@ -414,11 +407,7 @@ pub fn decode_owned_with_program<T: Facet<'static>>(
     // the descriptor is fully owned (no borrowed leaves), so the decoded value owns
     // its data and does not reference `bytes`.
     unsafe {
-        program.decode_into(
-            bytes,
-            slot.as_mut_ptr().cast::<u8>(),
-            T::SHAPE.type_identifier,
-        )?;
+        program.decode_into(bytes, slot.as_mut_ptr().cast::<u8>(), &shape_name(T::SHAPE))?;
         Ok(slot.assume_init())
     }
 }

--- a/vox/rust/vox-phon/tests/schema_diagnostics.rs
+++ b/vox/rust/vox-phon/tests/schema_diagnostics.rs
@@ -1,22 +1,35 @@
 use facet::Facet;
 
 #[test]
-fn schema_error_for_tuple_shape_uses_shape_display() {
+fn schema_for_reference_tuple_uses_shape_display_not_identifier() {
     let shape = <(&'static String, String) as Facet>::SHAPE;
 
     assert_eq!(shape.type_identifier, "(…)");
     assert_eq!(shape.to_string(), "(&String, String)");
 
-    let err = vox_phon::schema_bytes_for_shape(shape)
-        .expect_err("&String is a Facet reference shape Phon does not derive yet")
-        .to_string();
+    let bytes = vox_phon::schema_bytes_for_shape(shape)
+        .expect("&String tuple should derive through its pointee schema");
 
     assert!(
-        err.contains("derive (&String, String):"),
-        "schema error should include Shape display, got: {err}"
+        !bytes.is_empty(),
+        "schema bytes should be emitted for reference tuple"
     );
-    assert!(
-        !err.contains("derive (…):"),
-        "schema error must not use Shape::type_identifier, got: {err}"
-    );
+}
+
+#[test]
+fn reference_tuple_encodes_and_decodes() {
+    let name = String::from("facet");
+    let value = (&name, String::from("phon"));
+    let writer =
+        vox_phon::parse_schema_bytes(&vox_phon::schema_bytes::<(&String, String)>().unwrap())
+            .unwrap();
+    let bytes = vox_phon::to_vec(&value).unwrap();
+    let program = vox_phon::build_decode_program::<(&String, String)>(&writer).unwrap();
+
+    let decoded =
+        vox_phon::decode_with_program_retained::<(&String, String)>(&program, &bytes).unwrap();
+    let decoded = decoded.get();
+
+    assert_eq!(decoded.0, "facet");
+    assert_eq!(decoded.1, "phon");
 }

--- a/vox/rust/vox-phon/tests/schema_diagnostics.rs
+++ b/vox/rust/vox-phon/tests/schema_diagnostics.rs
@@ -1,0 +1,22 @@
+use facet::Facet;
+
+#[test]
+fn schema_error_for_tuple_shape_uses_shape_display() {
+    let shape = <(&'static String, String) as Facet>::SHAPE;
+
+    assert_eq!(shape.type_identifier, "(…)");
+    assert_eq!(shape.to_string(), "(&String, String)");
+
+    let err = vox_phon::schema_bytes_for_shape(shape)
+        .expect_err("&String is a Facet reference shape Phon does not derive yet")
+        .to_string();
+
+    assert!(
+        err.contains("derive (&String, String):"),
+        "schema error should include Shape display, got: {err}"
+    );
+    assert!(
+        !err.contains("derive (…):"),
+        "schema error must not use Shape::type_identifier, got: {err}"
+    );
+}

--- a/vox/rust/vox/src/schema_deser.rs
+++ b/vox/rust/vox/src/schema_deser.rs
@@ -27,6 +27,18 @@ where
     vox_phon::decode_with_program::<T>(&program, bytes)
 }
 
+pub fn schema_deserialize_args_retained<'input, 'facet, T: Facet<'facet>>(
+    bytes: &'input [u8],
+    method_id: MethodId,
+    tracker: &SchemaRecvTracker,
+) -> Result<vox_phon::Decoded<T>, Error>
+where
+    'input: 'facet,
+{
+    let program = resolve_program::<T>(method_id, BindingDirection::Args, tracker)?;
+    vox_phon::decode_with_program_retained::<T>(&program, bytes)
+}
+
 /// Deserialize a response (callee → caller direction), borrowed variant.
 // r[impl schema.exchange.required]
 pub fn schema_deserialize_response_borrowed<'input, 'facet, T: Facet<'facet>>(

--- a/vox/rust/vox/tests/service_macro_shared.rs
+++ b/vox/rust/vox/tests/service_macro_shared.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::ptr_arg)]
+
 use std::convert::Infallible;
 use std::sync::{Arc, Mutex};
 
@@ -124,8 +126,17 @@ trait MiddlewareProbe {
     async fn inspect(&self) -> String;
 }
 
+#[allow(clippy::ptr_arg)]
+#[vox::service]
+trait ReferenceArgsProbe {
+    async fn join(&self, name: &String, version: &String) -> String;
+}
+
 #[derive(Clone)]
 struct MiddlewareProbeService;
+
+#[derive(Clone)]
+struct ReferenceArgsProbeService;
 
 #[repr(u8)]
 #[derive(Clone, Copy, facet::Facet)]
@@ -196,6 +207,13 @@ impl MiddlewareProbe for MiddlewareProbeService {
     }
 }
 
+impl ReferenceArgsProbe for ReferenceArgsProbeService {
+    async fn join(&self, name: &String, version: &String) -> String {
+        tokio::task::yield_now().await;
+        format!("{name}@{version}")
+    }
+}
+
 #[derive(Clone)]
 struct RecordingMiddleware {
     name: &'static str,
@@ -246,6 +264,11 @@ struct ArgsRecordingMiddleware {
     seen: Arc<Mutex<Vec<(i32, i32)>>>,
 }
 
+#[derive(Clone)]
+struct ReferenceArgsRecordingMiddleware {
+    seen: Arc<Mutex<Vec<(String, String)>>>,
+}
+
 impl vox::ServerMiddleware for ArgsRecordingMiddleware {
     fn pre<'a>(&'a self, request: vox::ServerRequest<'_>) -> vox::BoxMiddlewareFuture<'a> {
         let tuple = request
@@ -263,6 +286,32 @@ impl vox::ServerMiddleware for ArgsRecordingMiddleware {
             .get::<i32>()
             .expect("second adder arg should be i32");
         record_args(&self.seen, (a, b));
+        Box::pin(async {})
+    }
+}
+
+impl vox::ServerMiddleware for ReferenceArgsRecordingMiddleware {
+    fn pre<'a>(&'a self, request: vox::ServerRequest<'_>) -> vox::BoxMiddlewareFuture<'a> {
+        let tuple = request
+            .args()
+            .into_tuple()
+            .expect("reference args should be exposed as a tuple");
+        let name = tuple
+            .field(0)
+            .expect("first reference arg should exist")
+            .get::<&String>()
+            .expect("first reference arg should be &String")
+            .to_string();
+        let version = tuple
+            .field(1)
+            .expect("second reference arg should exist")
+            .get::<&String>()
+            .expect("second reference arg should be &String")
+            .to_string();
+        self.seen
+            .lock()
+            .expect("reference args mutex poisoned")
+            .push((name, version));
         Box::pin(async {})
     }
 }
@@ -576,6 +625,67 @@ pub async fn run_server_request_peek_end_to_end<L>(
 
     let seen = seen.lock().expect("args mutex poisoned").clone();
     assert_eq!(seen, vec![(20, 22)]);
+
+    server_task.abort();
+}
+
+pub async fn run_reference_string_args_end_to_end<L>(
+    message_conduit_pair: impl FnOnce() -> (MessageConduit<L>, MessageConduit<L>),
+) where
+    L: Link + Send + 'static,
+    L::Tx: Send + 'static,
+    L::Rx: Send + 'static,
+{
+    let (client_conduit, server_conduit) = message_conduit_pair();
+    let seen = Arc::new(Mutex::new(Vec::new()));
+
+    let (server_ready_tx, server_ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let server_seen = Arc::clone(&seen);
+    let server_task = tokio::task::spawn(async move {
+        let dispatcher = ReferenceArgsProbeDispatcher::new(ReferenceArgsProbeService)
+            .with_middleware(ReferenceArgsRecordingMiddleware {
+                seen: Arc::clone(&server_seen),
+            });
+        let server_caller_guard = acceptor_conduit(
+            server_conduit,
+            test_acceptor_handshake("ReferenceArgsProbe"),
+        )
+        .on_lane(dispatcher)
+        .establish_connection()
+        .await
+        .expect("server handshake failed");
+        let _ = server_ready_tx.send(());
+        let _server_caller_guard = server_caller_guard;
+        std::future::pending::<()>().await;
+    });
+
+    let client = initiator_conduit(
+        client_conduit,
+        test_initiator_handshake("ReferenceArgsProbe"),
+    )
+    .establish::<ReferenceArgsProbeClient>()
+    .await
+    .expect("client handshake failed");
+
+    server_ready_rx.await.expect("server setup failed");
+
+    let name = String::from("facet");
+    let version = String::from("0.50.0-rc.1");
+    let joined = client
+        .join(&name, &version)
+        .await
+        .expect("reference args call should succeed");
+    assert_eq!(joined, "facet@0.50.0-rc.1");
+
+    for _ in 0..32 {
+        if seen.lock().expect("reference args mutex poisoned").len() == 1 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    let seen = seen.lock().expect("reference args mutex poisoned").clone();
+    assert_eq!(seen, vec![("facet".to_string(), "0.50.0-rc.1".to_string())]);
 
     server_task.abort();
 }

--- a/vox/rust/vox/tests/service_macro_tests.rs
+++ b/vox/rust/vox/tests/service_macro_tests.rs
@@ -31,6 +31,11 @@ async fn server_request_peek_end_to_end() {
 }
 
 #[tokio::test]
+async fn reference_string_args_end_to_end() {
+    service_macro_shared::run_reference_string_args_end_to_end(message_conduit_pair).await;
+}
+
+#[tokio::test]
 async fn server_response_peek_end_to_end() {
     service_macro_shared::run_server_response_peek_end_to_end(message_conduit_pair).await;
 }

--- a/weavy/src/mem.rs
+++ b/weavy/src/mem.rs
@@ -198,6 +198,10 @@ pub struct PointerThunks {
     pub borrow: unsafe extern "C" fn(ctx: *const (), pointer: *const u8) -> *const u8,
     /// Initialize `pointer` from `*value`, moving the pointee out of engine scratch.
     pub init: unsafe extern "C" fn(ctx: *const (), pointer: *mut u8, value: *mut u8),
+    /// Whether decode must keep the scratch pointee alive after `init`.
+    pub retain_decode_pointee: bool,
+    /// Drop a retained decoded pointee before its backing storage is freed.
+    pub drop_pointee: Option<unsafe extern "C" fn(ctx: *const (), value: *mut u8)>,
 }
 
 /// Type-erased operations on an opaque field, supplied by the front door,

--- a/weavy/src/mem/runtime.rs
+++ b/weavy/src/mem/runtime.rs
@@ -625,6 +625,10 @@ pub struct InitTarget {
     pub handle: *mut u8,
     /// Move `*value` into `handle`.
     pub init: unsafe extern "C" fn(ctx: *const (), handle: *mut u8, value: *mut u8),
+    /// Whether the initialized handle borrows from `value` instead of consuming it.
+    pub retain_value: bool,
+    /// Drop a retained `value` before its backing storage is freed.
+    pub drop_value: Option<unsafe extern "C" fn(ctx: *const (), value: *mut u8)>,
 }
 
 impl InitTarget {


### PR DESCRIPTION
## Summary
- report Facet shape display instead of lossy type_identifier in vox-phon schema/codec diagnostics
- make opaque-inner Phon failures name the actual Facet shape and drop the 'phon-derivable' wording
- add regressions for tuple-shaped failures so diagnostics show e.g. (&String, String) instead of (...)

## Testing
- cargo nextest run -p phon -p vox-phon
- push-time checks passed: clippy, docs, build tests, run tests