### PR TITLE
Parameterize facet-json integration backend tests

### DIFF
--- a/facet-json/tests/integration/backend_historical.rs
+++ b/facet-json/tests/integration/backend_historical.rs
@@ -1,0 +1,9 @@
+use facet::Facet;
+use facet_json::DeserializeError;
+
+pub(crate) fn from_str<T>(input: &str) -> Result<T, DeserializeError>
+where
+    T: Facet<'static>,
+{
+    facet_json::from_str(input)
+}

--- a/facet-json/tests/integration/backend_weavy.rs
+++ b/facet-json/tests/integration/backend_weavy.rs
@@ -1,0 +1,9 @@
+use facet::Facet;
+use facet_json::DeserializeError;
+
+pub(crate) fn from_str<T>(input: &str) -> Result<T, DeserializeError>
+where
+    T: Facet<'static>,
+{
+    facet_json::from_str_weavy(input)
+}

--- a/facet-json/tests/integration/flatten_in_externally_tagged_enum.rs
+++ b/facet-json/tests/integration/flatten_in_externally_tagged_enum.rs
@@ -1,8 +1,8 @@
 //! Test for flattened fields in externally-tagged enum struct variants.
 //! See https://github.com/facet-rs/facet/issues/1921
 
+use super::json_backend::from_str;
 use facet::Facet;
-use facet_json::from_str;
 use facet_testhelpers::test;
 
 #[derive(Facet, Debug, PartialEq, Default)]

--- a/facet-json/tests/integration/format_specific_proxy.rs
+++ b/facet-json/tests/integration/format_specific_proxy.rs
@@ -2,8 +2,9 @@
 //!
 //! This tests the `#[facet(json::proxy = ...)]` syntax for format-specific proxy types.
 
+use super::json_backend::from_str;
 use facet::Facet;
-use facet_json::{from_str, to_string};
+use facet_json::to_string;
 use facet_testhelpers::test;
 
 /// A proxy type that formats values as hex strings.

--- a/facet-json/tests/integration/int_map_keys.rs
+++ b/facet-json/tests/integration/int_map_keys.rs
@@ -8,8 +8,8 @@
 
 use std::collections::BTreeMap;
 
+use super::json_backend::from_str;
 use facet::Facet;
-use facet_json::from_str;
 
 #[derive(Facet, Debug, PartialEq)]
 struct Keys {

--- a/facet-json/tests/integration/issue_1236.rs
+++ b/facet-json/tests/integration/issue_1236.rs
@@ -44,7 +44,7 @@ impl From<&Option<Arc<HashMap<(String, String), f64>>>> for Proxy {
 #[test]
 fn test_repro_1236() {
     let json = r#"{"corr":[["a","b",0.95]]}"#;
-    let d: Data = facet_json::from_str(json).unwrap();
+    let d: Data = super::json_backend::from_str(json).unwrap();
     assert!(d.corr.is_some());
     let corr = d.corr.as_ref().unwrap();
     assert_eq!(corr.get(&("a".to_string(), "b".to_string())), Some(&0.95));
@@ -65,7 +65,7 @@ fn test_newtype_scalar_roundtrip() {
     let json = facet_json::to_string(&value).unwrap();
     assert_eq!(json, "42");
 
-    let parsed: ScalarNewtype = facet_json::from_str(&json).unwrap();
+    let parsed: ScalarNewtype = super::json_backend::from_str(&json).unwrap();
     assert_eq!(parsed, value);
 }
 
@@ -80,7 +80,7 @@ fn test_newtype_vec_roundtrip() {
     let json = facet_json::to_string(&value).unwrap();
     assert_eq!(json, "[1,2,3]");
 
-    let parsed: VecNewtype = facet_json::from_str(&json).unwrap();
+    let parsed: VecNewtype = super::json_backend::from_str(&json).unwrap();
     assert_eq!(parsed, value);
 }
 
@@ -91,7 +91,7 @@ fn test_newtype_empty_vec_roundtrip() {
     let json = facet_json::to_string(&value).unwrap();
     assert_eq!(json, "[]");
 
-    let parsed: VecNewtype = facet_json::from_str(&json).unwrap();
+    let parsed: VecNewtype = super::json_backend::from_str(&json).unwrap();
     assert_eq!(parsed, value);
 }
 
@@ -110,7 +110,7 @@ fn test_nested_newtypes_roundtrip() {
     let json = facet_json::to_string(&value).unwrap();
     assert_eq!(json, "42");
 
-    let parsed: OuterNewtype = facet_json::from_str(&json).unwrap();
+    let parsed: OuterNewtype = super::json_backend::from_str(&json).unwrap();
     assert_eq!(parsed, value);
 }
 
@@ -121,7 +121,7 @@ fn test_plain_tuple_not_transparent() {
     let json = facet_json::to_string(&value).unwrap();
     assert_eq!(json, "[42]");
 
-    let parsed: (i32,) = facet_json::from_str(&json).unwrap();
+    let parsed: (i32,) = super::json_backend::from_str(&json).unwrap();
     assert_eq!(parsed, value);
 }
 
@@ -135,7 +135,7 @@ fn test_multi_field_tuple_struct_not_transparent() {
     let json = facet_json::to_string(&value).unwrap();
     assert_eq!(json, "[1,2]");
 
-    let parsed: TwoFieldTuple = facet_json::from_str(&json).unwrap();
+    let parsed: TwoFieldTuple = super::json_backend::from_str(&json).unwrap();
     assert_eq!(parsed, value);
 }
 
@@ -150,6 +150,6 @@ fn test_newtype_containing_tuple_roundtrip() {
     let json = facet_json::to_string(&value).unwrap();
     assert_eq!(json, "[1,2]");
 
-    let parsed: TupleNewtype = facet_json::from_str(&json).unwrap();
+    let parsed: TupleNewtype = super::json_backend::from_str(&json).unwrap();
     assert_eq!(parsed, value);
 }

--- a/facet-json/tests/integration/issue_1721_1724.rs
+++ b/facet-json/tests/integration/issue_1721_1724.rs
@@ -1,7 +1,8 @@
 // Test cases for issues 1721 and 1724
 
+use super::json_backend::from_str as from_json;
 use facet::Facet;
-use facet_json::{from_str as from_json, to_string};
+use facet_json::to_string;
 use facet_testhelpers::test;
 use std::collections::HashMap;
 

--- a/facet-json/tests/integration/issue_1775.rs
+++ b/facet-json/tests/integration/issue_1775.rs
@@ -1,5 +1,6 @@
+use super::json_backend::from_str as from_json;
 use facet::Facet;
-use facet_json::{from_str as from_json, to_string as to_json};
+use facet_json::to_string as to_json;
 use facet_testhelpers::test;
 
 #[derive(Facet, Debug, Clone, PartialEq, Eq)]

--- a/facet-json/tests/integration/issue_1791.rs
+++ b/facet-json/tests/integration/issue_1791.rs
@@ -199,7 +199,7 @@ fn make_big() -> Big {
 fn test_roundtrip_89_fields() {
     let big = make_big();
     let big_json = facet_json::to_string(&big).unwrap();
-    let big_back: Big = facet_json::from_str(&big_json).unwrap();
+    let big_back: Big = super::json_backend::from_str(&big_json).unwrap();
     assert_eq!(big, big_back);
 }
 

--- a/facet-json/tests/integration/issue_1852.rs
+++ b/facet-json/tests/integration/issue_1852.rs
@@ -29,10 +29,10 @@ fn test_two_arrays_scientific_crlf() {
     );
     let json_lf = json_crlf.replace("\r\n", "\n");
 
-    let result_lf: Result<TwoVecs, _> = facet_json::from_str(&json_lf);
+    let result_lf: Result<TwoVecs, _> = super::json_backend::from_str(&json_lf);
     assert!(result_lf.is_ok(), "LF version should work");
 
-    let result_crlf: Result<TwoVecs, _> = facet_json::from_str(json_crlf);
+    let result_crlf: Result<TwoVecs, _> = super::json_backend::from_str(json_crlf);
     assert!(
         result_crlf.is_ok(),
         "CRLF version should also work: {:?}",
@@ -97,10 +97,10 @@ fn test_facet_crlf_scientific_notation_bug() {
     );
     let json_lf = json_crlf.replace("\r\n", "\n");
 
-    let result_lf: Result<Container, _> = facet_json::from_str(&json_lf);
+    let result_lf: Result<Container, _> = super::json_backend::from_str(&json_lf);
     assert!(result_lf.is_ok(), "LF version should work");
 
-    let result_crlf: Result<Container, _> = facet_json::from_str(json_crlf);
+    let result_crlf: Result<Container, _> = super::json_backend::from_str(json_crlf);
     assert!(
         result_crlf.is_ok(),
         "CRLF version should also work: {:?}",

--- a/facet-json/tests/integration/issue_1896.rs
+++ b/facet-json/tests/integration/issue_1896.rs
@@ -7,8 +7,9 @@
 //! The Borrowed/Owned distinction is purely an implementation detail for memory
 //! management and should not appear in the serialized output.
 
+use super::json_backend::from_str;
 use facet::Facet;
-use facet_json::{from_str, to_string};
+use facet_json::to_string;
 use facet_testhelpers::test;
 
 /// A cow-like enum that can hold either a borrowed or owned string.

--- a/facet-json/tests/integration/issue_1900.rs
+++ b/facet-json/tests/integration/issue_1900.rs
@@ -6,9 +6,10 @@
 //! The Borrowed/Owned distinction is an implementation detail for memory
 //! management, not part of the data model.
 
+use super::json_backend::from_str;
 use compact_str::CompactString;
 use facet::Facet;
-use facet_json::{from_str, to_string};
+use facet_json::to_string;
 use facet_testhelpers::test;
 
 /// Example from the issue - a cow-like enum using CompactString

--- a/facet-json/tests/integration/issue_1904.rs
+++ b/facet-json/tests/integration/issue_1904.rs
@@ -4,8 +4,8 @@
 //! extra fields in the JSON (that belong to other variants or are unknown)
 //! should be ignored rather than causing parse failures.
 
+use super::json_backend::from_str;
 use facet::Facet;
-use facet_json::from_str;
 use facet_testhelpers::test;
 
 #[derive(Facet, Clone, Debug, PartialEq, PartialOrd)]

--- a/facet-json/tests/integration/issue_1982.rs
+++ b/facet-json/tests/integration/issue_1982.rs
@@ -3,8 +3,9 @@
 //! `#[facet(flatten)]` on an externally-tagged enum field must not duplicate
 //! the variant key during serialization.
 
+use super::json_backend::from_str as from_json;
 use facet::Facet;
-use facet_json::{from_str as from_json, to_string as to_json};
+use facet_json::to_string as to_json;
 use facet_testhelpers::test;
 
 #[derive(Facet, Debug, PartialEq)]

--- a/facet-json/tests/integration/issue_1987.rs
+++ b/facet-json/tests/integration/issue_1987.rs
@@ -27,10 +27,10 @@ enum ThreeThenTwo {
 fn test_issue_1987_two_element_array_matches_two_element_variant() {
     let input = r#"[1,5]"#;
 
-    let a: TwoThenThree = facet_json::from_str(input).unwrap();
+    let a: TwoThenThree = super::json_backend::from_str(input).unwrap();
     assert_eq!(a, TwoThenThree::MinMaxList([1, 5]));
 
-    let b: ThreeThenTwo = facet_json::from_str(input).unwrap();
+    let b: ThreeThenTwo = super::json_backend::from_str(input).unwrap();
     assert_eq!(b, ThreeThenTwo::MinMaxList([1, 5]));
 }
 
@@ -38,9 +38,9 @@ fn test_issue_1987_two_element_array_matches_two_element_variant() {
 fn test_issue_1987_three_element_array_matches_three_element_variant() {
     let input = r#"[1,5,1]"#;
 
-    let a: TwoThenThree = facet_json::from_str(input).unwrap();
+    let a: TwoThenThree = super::json_backend::from_str(input).unwrap();
     assert_eq!(a, TwoThenThree::MinMaxStepList([1, 5, 1]));
 
-    let b: ThreeThenTwo = facet_json::from_str(input).unwrap();
+    let b: ThreeThenTwo = super::json_backend::from_str(input).unwrap();
     assert_eq!(b, ThreeThenTwo::MinMaxStepList([1, 5, 1]));
 }

--- a/facet-json/tests/integration/issue_1989.rs
+++ b/facet-json/tests/integration/issue_1989.rs
@@ -2,8 +2,8 @@
 //!
 //! Untagged enum struct variants must error on missing required fields.
 
+use super::json_backend::from_str;
 use facet::Facet;
-use facet_json::from_str;
 use facet_testhelpers::test;
 
 #[derive(Debug, Facet, PartialEq)]

--- a/facet-json/tests/integration/issue_1990.rs
+++ b/facet-json/tests/integration/issue_1990.rs
@@ -23,13 +23,13 @@ enum IntegerFirst {
 
 #[test]
 fn number_input_selects_integer_variant() {
-    let parsed: StringFirst = facet_json::from_str(r#"{"x":1,"y":2}"#).unwrap();
+    let parsed: StringFirst = super::json_backend::from_str(r#"{"x":1,"y":2}"#).unwrap();
     assert_eq!(parsed, StringFirst::Integer { x: 1, y: 2 });
 }
 
 #[test]
 fn numeric_strings_select_string_variant() {
-    let parsed: IntegerFirst = facet_json::from_str(r#"{"x":"1","y":"2"}"#).unwrap();
+    let parsed: IntegerFirst = super::json_backend::from_str(r#"{"x":"1","y":"2"}"#).unwrap();
     assert_eq!(
         parsed,
         IntegerFirst::Stringer {
@@ -41,7 +41,7 @@ fn numeric_strings_select_string_variant() {
 
 #[test]
 fn non_numeric_strings_still_select_string_variant() {
-    let parsed: IntegerFirst = facet_json::from_str(r#"{"x":"abc","y":"def"}"#).unwrap();
+    let parsed: IntegerFirst = super::json_backend::from_str(r#"{"x":"abc","y":"def"}"#).unwrap();
     assert_eq!(
         parsed,
         IntegerFirst::Stringer {

--- a/facet-json/tests/integration/issue_2004.rs
+++ b/facet-json/tests/integration/issue_2004.rs
@@ -6,8 +6,9 @@
 //! 2. Any unknown tag (including the variant's own name) falls back to this variant
 //! 3. The fallback path handles deserialization differently (e.g., captures the tag)
 
+use super::json_backend::from_str;
 use facet::Facet;
-use facet_json::{from_str, to_string};
+use facet_json::to_string;
 use facet_testhelpers::test;
 
 #[derive(Facet, Debug, PartialEq)]

--- a/facet-json/tests/integration/issue_2007.rs
+++ b/facet-json/tests/integration/issue_2007.rs
@@ -28,7 +28,7 @@ pub struct Outer {
 #[test]
 fn test_single_flattened_tagged_enum_deserialize() {
     let json_single = r#"{"type":"TypeA","value":42.0}"#;
-    let single: Outer = facet_json::from_str(json_single).expect("single should work");
+    let single: Outer = super::json_backend::from_str(json_single).expect("single should work");
     assert!(matches!(single.tagged, Tagged::TypeA(_)));
 
     if let Tagged::TypeA(inner) = &single.tagged {
@@ -39,7 +39,7 @@ fn test_single_flattened_tagged_enum_deserialize() {
 #[test]
 fn test_vec_flattened_tagged_enum_deserialize() {
     let json_vec = r#"[{"type":"TypeA","value":42.0},{"type":"TypeB","value":99.0}]"#;
-    let vec_result: Result<Vec<Outer>, _> = facet_json::from_str(json_vec);
+    let vec_result: Result<Vec<Outer>, _> = super::json_backend::from_str(json_vec);
     assert!(
         vec_result.is_ok(),
         "Vec deserialization should work but fails with: {:?}",
@@ -64,7 +64,7 @@ fn test_vec_flattened_tagged_enum_deserialize() {
 #[test]
 fn test_two_elements_same_variant() {
     let json = r#"[{"type":"TypeA","value":1.0},{"type":"TypeA","value":2.0}]"#;
-    let result: Result<Vec<Outer>, _> = facet_json::from_str(json);
+    let result: Result<Vec<Outer>, _> = super::json_backend::from_str(json);
     assert!(
         result.is_ok(),
         "Two elements with same variant should work but fails with: {:?}",
@@ -76,7 +76,7 @@ fn test_two_elements_same_variant() {
 #[test]
 fn test_single_element_in_vec() {
     let json = r#"[{"type":"TypeA","value":1.0}]"#;
-    let result: Result<Vec<Outer>, _> = facet_json::from_str(json);
+    let result: Result<Vec<Outer>, _> = super::json_backend::from_str(json);
     assert!(
         result.is_ok(),
         "Single element in Vec should work but fails with: {:?}",
@@ -126,7 +126,7 @@ pub struct OuterStruct {
 #[test]
 fn test_struct_variant_in_vec() {
     let json = r#"[{"type":"TypeA","value":1.0}]"#;
-    let result: Result<Vec<OuterStruct>, _> = facet_json::from_str(json);
+    let result: Result<Vec<OuterStruct>, _> = super::json_backend::from_str(json);
     assert!(
         result.is_ok(),
         "Struct variant in Vec should work but fails with: {:?}",
@@ -147,7 +147,7 @@ fn test_roundtrip_vec_flattened_tagged_enum() {
 
     let json = facet_json::to_string(&original).expect("serialization should work");
     let deserialized: Vec<Outer> =
-        facet_json::from_str(&json).expect("deserialization should work");
+        super::json_backend::from_str(&json).expect("deserialization should work");
 
     assert_eq!(original, deserialized);
 }

--- a/facet-json/tests/integration/issue_2010.rs
+++ b/facet-json/tests/integration/issue_2010.rs
@@ -49,7 +49,7 @@ fn tag_before_fields() {
         }
     }"#;
 
-    let outer: Outer = facet_json::from_str(json).expect("tag before fields should work");
+    let outer: Outer = super::json_backend::from_str(json).expect("tag before fields should work");
     assert_eq!(
         outer.container.items.as_ref().unwrap()["x"].inner,
         Inner::TypeB {
@@ -74,7 +74,7 @@ fn fields_before_tag() {
         }
     }"#;
 
-    let outer: Outer = facet_json::from_str(json).expect("fields before tag should work");
+    let outer: Outer = super::json_backend::from_str(json).expect("fields before tag should work");
     assert_eq!(
         outer.container.items.as_ref().unwrap()["x"].inner,
         Inner::TypeB {

--- a/facet-json/tests/integration/issue_2059.rs
+++ b/facet-json/tests/integration/issue_2059.rs
@@ -18,10 +18,12 @@ fn nested_struct_invariants_are_enforced() {
         point.x >= 0 && point.y >= 0
     }
 
-    let ok: TopLevel = facet_json::from_str(r#"{ "point": { "x": 5, "y": 12 } }"#).unwrap();
+    let ok: TopLevel =
+        super::json_backend::from_str(r#"{ "point": { "x": 5, "y": 12 } }"#).unwrap();
     assert_eq!(ok.point.x, 5);
     assert_eq!(ok.point.y, 12);
 
-    let bad: Result<TopLevel, _> = facet_json::from_str(r#"{ "point": { "x": -25, "y": 12 } }"#);
+    let bad: Result<TopLevel, _> =
+        super::json_backend::from_str(r#"{ "point": { "x": -25, "y": 12 } }"#);
     assert!(bad.is_err());
 }

--- a/facet-json/tests/integration/list_deferred_processing.rs
+++ b/facet-json/tests/integration/list_deferred_processing.rs
@@ -40,7 +40,7 @@ fn vec_flattened_tagged_enum_fields_in_order() {
     ]"#;
 
     let items: Vec<FlattenedItem> =
-        facet_json::from_str(json).expect("fields in order should work");
+        super::json_backend::from_str(json).expect("fields in order should work");
     assert_eq!(items.len(), 2);
     assert_eq!(
         items[0],
@@ -68,7 +68,7 @@ fn vec_flattened_tagged_enum_fields_out_of_order() {
     ]"#;
 
     let items: Vec<FlattenedItem> =
-        facet_json::from_str(json).expect("fields out of order should work");
+        super::json_backend::from_str(json).expect("fields out of order should work");
     assert_eq!(items.len(), 2);
     assert_eq!(
         items[0],
@@ -94,7 +94,8 @@ fn vec_flattened_tagged_enum_tag_last() {
         {"x": 2.0, "y": 3.0, "name": "second", "type": "VariantB"}
     ]"#;
 
-    let items: Vec<FlattenedItem> = facet_json::from_str(json).expect("tag last should work");
+    let items: Vec<FlattenedItem> =
+        super::json_backend::from_str(json).expect("tag last should work");
     assert_eq!(items.len(), 2);
 }
 
@@ -123,7 +124,7 @@ fn hashmap_of_vec_flattened_tagged_enum() {
     }"#;
 
     let container: NestedContainer =
-        facet_json::from_str(json).expect("nested HashMap<String, Vec<...>> should work");
+        super::json_backend::from_str(json).expect("nested HashMap<String, Vec<...>> should work");
     assert_eq!(container.groups.len(), 2);
     assert_eq!(container.groups["group1"].len(), 2);
     assert_eq!(container.groups["group2"].len(), 1);
@@ -153,7 +154,7 @@ fn nested_vec_of_vec_flattened_tagged_enum() {
         ]
     }"#;
 
-    let matrix: Matrix = facet_json::from_str(json).expect("Vec<Vec<...>> should work");
+    let matrix: Matrix = super::json_backend::from_str(json).expect("Vec<Vec<...>> should work");
     assert_eq!(matrix.rows.len(), 2);
     assert_eq!(matrix.rows[0].len(), 2);
     assert_eq!(matrix.rows[1].len(), 1);
@@ -193,7 +194,8 @@ fn large_vec_flattened_tagged_enum() {
     }
     let json = format!("[{}]", elements.join(","));
 
-    let items: Vec<FlattenedItem> = facet_json::from_str(&json).expect("large Vec should work");
+    let items: Vec<FlattenedItem> =
+        super::json_backend::from_str(&json).expect("large Vec should work");
     assert_eq!(items.len(), 100);
 
     // Verify a few elements
@@ -235,7 +237,7 @@ fn vec_with_optional_fields() {
     ]"#;
 
     let items: Vec<ItemWithOptionalFields> =
-        facet_json::from_str(json).expect("Vec with optional fields should work");
+        super::json_backend::from_str(json).expect("Vec with optional fields should work");
     assert_eq!(items.len(), 3);
     assert_eq!(items[0].optional_name, Some("has_name".into()));
     assert_eq!(items[0].optional_count, None);
@@ -282,7 +284,7 @@ fn vec_with_two_flattened_enums() {
     ]"#;
 
     let items: Vec<ItemWithTwoFlattened> =
-        facet_json::from_str(json).expect("Vec with two flattened enums should work");
+        super::json_backend::from_str(json).expect("Vec with two flattened enums should work");
     assert_eq!(items.len(), 2);
     assert_eq!(items[0].id, "first");
     assert_eq!(items[1].id, "second");
@@ -321,7 +323,7 @@ fn deeply_nested_vec_option_vec() {
     }"#;
 
     let nested: DeepNested =
-        facet_json::from_str(json).expect("deeply nested structure should work");
+        super::json_backend::from_str(json).expect("deeply nested structure should work");
     assert_eq!(nested.wrappers.len(), 3);
     assert_eq!(nested.wrappers[0].items.as_ref().unwrap().len(), 1);
     assert!(nested.wrappers[1].items.is_none());
@@ -355,7 +357,7 @@ fn vec_externally_tagged_enum() {
     ]"#;
 
     let items: Vec<ItemWithExternallyTagged> =
-        facet_json::from_str(json).expect("externally tagged enum in Vec should work");
+        super::json_backend::from_str(json).expect("externally tagged enum in Vec should work");
     assert_eq!(items.len(), 2);
 }
 
@@ -366,7 +368,8 @@ fn vec_externally_tagged_enum() {
 #[test]
 fn empty_vec() {
     let json = r#"[]"#;
-    let items: Vec<FlattenedItem> = facet_json::from_str(json).expect("empty Vec should work");
+    let items: Vec<FlattenedItem> =
+        super::json_backend::from_str(json).expect("empty Vec should work");
     assert!(items.is_empty());
 }
 
@@ -374,7 +377,7 @@ fn empty_vec() {
 fn single_element_vec_tag_last() {
     let json = r#"[{"value": 1.0, "name": "only", "type": "VariantA"}]"#;
     let items: Vec<FlattenedItem> =
-        facet_json::from_str(json).expect("single element Vec should work");
+        super::json_backend::from_str(json).expect("single element Vec should work");
     assert_eq!(items.len(), 1);
 }
 
@@ -397,6 +400,6 @@ fn roundtrip_vec_flattened_tagged_enum() {
 
     let json = facet_json::to_string(&original).expect("serialization should work");
     let deserialized: Vec<FlattenedItem> =
-        facet_json::from_str(&json).expect("deserialization should work");
+        super::json_backend::from_str(&json).expect("deserialization should work");
     assert_eq!(original, deserialized);
 }

--- a/facet-json/tests/integration/metadata_container_flatten_map.rs
+++ b/facet-json/tests/integration/metadata_container_flatten_map.rs
@@ -41,7 +41,7 @@ struct SpannedMap {
 #[test]
 fn metadata_container_as_flattened_map_key_deserialize() {
     let json = r#"{"foo": "bar", "baz": "qux"}"#;
-    let result: SpannedMap = facet_json::from_str(json).expect("should deserialize");
+    let result: SpannedMap = super::json_backend::from_str(json).expect("should deserialize");
 
     assert_eq!(result.items.len(), 2);
 

--- a/facet-json/tests/integration/mixed_tagged_untagged.rs
+++ b/facet-json/tests/integration/mixed_tagged_untagged.rs
@@ -1,5 +1,6 @@
+use super::json_backend::from_str;
 use facet::Facet;
-use facet_json::{from_str, to_string};
+use facet_json::to_string;
 use facet_testhelpers::test;
 
 /// Tests for internally-tagged enums with per-variant `#[facet(untagged)]`.

--- a/facet-json/tests/integration/mod.rs
+++ b/facet-json/tests/integration/mod.rs
@@ -1,3 +1,6 @@
+#[path = "backend_historical.rs"]
+pub(crate) mod json_backend;
+
 mod flatten_defaults;
 mod flatten_in_externally_tagged_enum;
 mod format_specific_proxy;

--- a/facet-json/tests/integration/nested_internal_tagging.rs
+++ b/facet-json/tests/integration/nested_internal_tagging.rs
@@ -1,5 +1,6 @@
+use super::json_backend::from_str;
 use facet::Facet;
-use facet_json::{from_str, to_string};
+use facet_json::to_string;
 use facet_testhelpers::test;
 
 /// Test nested internal tagging - an outer enum tagged by one field,

--- a/facet-json/tests/integration/option_enum_test.rs
+++ b/facet-json/tests/integration/option_enum_test.rs
@@ -1,5 +1,6 @@
+use super::json_backend::from_str;
 use facet::Facet;
-use facet_json::{from_str, to_string};
+use facet_json::to_string;
 use facet_testhelpers::test;
 
 #[derive(Debug, PartialEq, Facet, Default)]

--- a/facet-json/tests/integration/rename.rs
+++ b/facet-json/tests/integration/rename.rs
@@ -2,8 +2,9 @@
 
 #![allow(non_snake_case)]
 
+use super::json_backend::from_str;
 use facet::Facet;
-use facet_json::{from_str, to_vec};
+use facet_json::to_vec;
 use facet_testhelpers::test;
 
 // =============================================================================

--- a/facet-json/tests/integration/tendril.rs
+++ b/facet-json/tests/integration/tendril.rs
@@ -33,7 +33,7 @@ fn str_tendril_serialize() {
 #[test]
 fn str_tendril_deserialize() {
     let json = r#"{"title":"Hello","body":"World"}"#;
-    let doc: Document = facet_json::from_str(json).expect("should deserialize");
+    let doc: Document = super::json_backend::from_str(json).expect("should deserialize");
 
     assert_eq!(&*doc.title, "Hello");
     assert_eq!(&*doc.body, "World");
@@ -47,7 +47,7 @@ fn str_tendril_roundtrip() {
     };
 
     let json = facet_json::to_string(&original).expect("should serialize");
-    let restored: Document = facet_json::from_str(&json).expect("should deserialize");
+    let restored: Document = super::json_backend::from_str(&json).expect("should deserialize");
 
     assert_eq!(original, restored);
 }
@@ -66,7 +66,7 @@ fn atomic_str_tendril_serialize() {
 #[test]
 fn atomic_str_tendril_deserialize() {
     let json = r#"{"title":"Hello","body":"World"}"#;
-    let doc: AtomicDocument = facet_json::from_str(json).expect("should deserialize");
+    let doc: AtomicDocument = super::json_backend::from_str(json).expect("should deserialize");
 
     assert_eq!(&*doc.title, "Hello");
     assert_eq!(&*doc.body, "World");
@@ -80,7 +80,8 @@ fn atomic_str_tendril_roundtrip() {
     };
 
     let json = facet_json::to_string(&original).expect("should serialize");
-    let restored: AtomicDocument = facet_json::from_str(&json).expect("should deserialize");
+    let restored: AtomicDocument =
+        super::json_backend::from_str(&json).expect("should deserialize");
 
     assert_eq!(&*original.title, &*restored.title);
     assert_eq!(&*original.body, &*restored.body);
@@ -96,6 +97,6 @@ fn str_tendril_empty_string() {
     let json = facet_json::to_string(&doc).expect("should serialize");
     assert_eq!(json, r#"{"title":"","body":""}"#);
 
-    let restored: Document = facet_json::from_str(&json).expect("should deserialize");
+    let restored: Document = super::json_backend::from_str(&json).expect("should deserialize");
     assert_eq!(doc, restored);
 }

--- a/facet-json/tests/weavy_integration.rs
+++ b/facet-json/tests/weavy_integration.rs
@@ -1,0 +1,28 @@
+//! Weavy-backed replay of main integration tests that are currently supported
+//! by the owned Weavy deserializer.
+
+#[path = "integration/backend_weavy.rs"]
+mod json_backend;
+
+#[path = "integration/format_specific_proxy.rs"]
+mod format_specific_proxy;
+#[path = "integration/int_map_keys.rs"]
+mod int_map_keys;
+#[path = "integration/issue_1236.rs"]
+mod issue_1236;
+#[path = "integration/issue_1791.rs"]
+mod issue_1791;
+#[path = "integration/issue_1852.rs"]
+mod issue_1852;
+#[path = "integration/issue_1982.rs"]
+mod issue_1982;
+#[path = "integration/issue_1989.rs"]
+mod issue_1989;
+#[path = "integration/issue_2004.rs"]
+mod issue_2004;
+#[path = "integration/option_enum_test.rs"]
+mod option_enum_test;
+#[path = "integration/rename.rs"]
+mod rename;
+#[path = "integration/tendril.rs"]
+mod tendril;


### PR DESCRIPTION
## Summary
- Add a tiny integration-test backend adapter so deserialization calls can target either the historical facet-json path or the Weavy owned-deserializer path.
- Keep the existing main integration suite complete on the historical backend.
- Add a new weavy_integration test binary that reuses the same source files for the Weavy-supported subset instead of duplicating tests.

## Coverage shape
- Historical: full facet-json main integration suite still runs through facet_json::from_str.
- Weavy replay: format-specific proxies, integer map keys, transparent/newtype cases, wide structs, rename cases, option enum coverage, tendril strings, and selected enum fallback/missing-field regressions now run from the same files through facet_json::from_str_weavy.
- Existing format_suite and Weavy oracle/fuzz-style tests continue to run separately.

## Known remaining gaps
The shared-source Weavy replay intentionally does not include unsupported clusters yet: flattened tagged enums inside containers, transparent Cow-like enums, some untagged fixed-array/scalar scoring cases, nested internally tagged tuple variants, and invariant validation.

## Verification
- cargo fmt --check
- cargo check -p facet-json --tests
- cargo clippy -p facet-json --all-targets
- cargo nextest list -p facet-json -E 'binary(main) | binary(weavy_integration)'
- cargo nextest run -p facet-json --no-fail-fast (671 passed)