### PR TITLE
Fix Dibs generated borrowed params

### DIFF
--- a/dibs-cli/CHANGELOG.md
+++ b/dibs-cli/CHANGELOG.md
@@ -48,9 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - unified TUI with schema/diff/migrations tabs, dotenvy support
 - use dibs.styx config file with facet-styx
 - generate Rust migration files instead of SQL
-- wire migrate and status commands to roam service
-- wire dibs CLI to spawn db crate via roam
-- add roam service API for CLI-to-db-crate communication
+- wire migrate and status commands to Vox service
+- wire dibs CLI to spawn db crate via Vox
+- add Vox service API for CLI-to-db-crate communication
 - add schema diff command and integration tests
 - add schema introspection and diff infrastructure
 - auto-detect Zed terminal and open in Zed
@@ -67,9 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(lsp)* recognize shorthand param refs in unused param detection
 - *(lsp)* inlay hints for numeric literals and expand test coverage
-- *(dibs-cli)* remove sample tables and use roam for schema command
+- *(dibs-cli)* remove sample tables and use Vox for schema command
 - respect db.crate config for migrations directory
-- update for roam Context parameter changes
+- update for Vox Context parameter changes
 - clippy warnings (needless borrows, manual_strip)
 - formatting and comment out local styx patch for CI
 - *(codegen)* use closure param for first column in relation mapping

--- a/dibs-cli/src/main.rs
+++ b/dibs-cli/src/main.rs
@@ -1411,10 +1411,10 @@ pub async fn migrate(ctx: &mut MigrationContext<'_>) -> MigrationResult<()> {{
 
 fn run_generate_from_diff(config: &Config, name: &str) {
     let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
-    rt.block_on(run_generate_from_diff_via_roam(config, name));
+    rt.block_on(run_generate_from_diff_via_vox(config, name));
 }
 
-async fn run_generate_from_diff_via_roam(config: &Config, name: &str) {
+async fn run_generate_from_diff_via_vox(config: &Config, name: &str) {
     use dibs_proto::DiffRequest;
     #[allow(unused_imports)]
     use owo_colors::OwoColorize as _;

--- a/dibs-proto/README.md
+++ b/dibs-proto/README.md
@@ -3,7 +3,7 @@
 Protocol definitions for dibs service communication.
 
 This crate defines the RPC protocol used by the dibs CLI to communicate with
-database crates via roam. Includes:
+database crates via Vox. Includes:
 - Service trait definitions
 - Request/response types
 - Error types

--- a/dibs-proto/README.md.in
+++ b/dibs-proto/README.md.in
@@ -3,7 +3,7 @@
 Protocol definitions for dibs service communication.
 
 This crate defines the RPC protocol used by the dibs CLI to communicate with
-database crates via roam. Includes:
+database crates via Vox. Includes:
 - Service trait definitions
 - Request/response types
 - Error types

--- a/dibs-qgen/Cargo.toml
+++ b/dibs-qgen/Cargo.toml
@@ -25,6 +25,6 @@ indexmap.workspace = true
 tracing.workspace = true
 facet-testhelpers = { path = "../facet-testhelpers" }
 dockside = { path = "../dockside" }
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "time"] }
 tokio-postgres.workspace = true
 insta.workspace = true

--- a/dibs-qgen/src/rustgen/mod.rs
+++ b/dibs-qgen/src/rustgen/mod.rs
@@ -558,11 +558,7 @@ fn generate_query_body(
     if params.is_empty() {
         block.line("let rows = client.query(SQL, &[]).await?;");
     } else {
-        let params_str = params
-            .iter()
-            .map(|p| p.as_str())
-            .collect::<Vec<_>>()
-            .join(", ");
+        let params_str = bind_param_list(params.iter().map(|p| p.as_str()));
         block.line(format!(
             "let rows = client.query(SQL, &[{}]).await?;",
             params_str
@@ -988,7 +984,7 @@ fn generate_raw_query_body(query: &Select, raw_sql: &str) -> Block {
     if let Some(params) = &query.params {
         let param_names: Vec<&str> = params.iter().map(|(meta, _)| meta.value.as_str()).collect();
         if !param_names.is_empty() {
-            let params_str = param_names.join(", ");
+            let params_str = bind_param_list(param_names);
             block.line(format!(
                 "let rows = client.query(SQL, &[{}]).await?;",
                 params_str
@@ -1044,6 +1040,7 @@ fn param_type_to_function_arg_rust(ty: &dibs_query_schema::ParamType) -> String 
     use dibs_query_schema::ParamType;
     match ty {
         ParamType::String | ParamType::Jsonb => "str".to_string(),
+        ParamType::Bytes => "[u8]".to_string(),
         _ => param_type_to_rust(ty),
     }
 }
@@ -1056,6 +1053,18 @@ fn add_params_to_function(func: &mut Function, params: Option<&Params>) {
             func.arg(param_name, format!("&{}", rust_ty));
         }
     }
+}
+
+fn bind_param_expr(param_name: &str) -> String {
+    format!("&{param_name}")
+}
+
+fn bind_param_list<'a>(params: impl IntoIterator<Item = &'a str>) -> String {
+    params
+        .into_iter()
+        .map(bind_param_expr)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Helper to format a Block to a String.
@@ -1572,11 +1581,7 @@ fn generate_mutation_body(
         if params.is_empty() {
             block.line("let affected = client.execute(SQL, &[]).await?;");
         } else {
-            let params_str = params
-                .iter()
-                .map(|p| p.as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
+            let params_str = bind_param_list(params.iter().map(|p| p.as_str()));
             block.line(format!(
                 "let affected = client.execute(SQL, &[{}]).await?;",
                 params_str
@@ -1588,11 +1593,7 @@ fn generate_mutation_body(
         if params.is_empty() {
             block.line("let rows = client.query(SQL, &[]).await?;");
         } else {
-            let params_str = params
-                .iter()
-                .map(|p| p.as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
+            let params_str = bind_param_list(params.iter().map(|p| p.as_str()));
             block.line(format!(
                 "let rows = client.query(SQL, &[{}]).await?;",
                 params_str

--- a/dibs-qgen/src/rustgen/mod.rs
+++ b/dibs-qgen/src/rustgen/mod.rs
@@ -508,13 +508,7 @@ fn generate_select_function(
     // Allow clone_on_copy since we generate .clone() calls on parent IDs that might be Copy types
     func.attr("allow(clippy::clone_on_copy)");
 
-    if let Some(params) = &query.params {
-        for (param_name_meta, param_type) in &params.params {
-            let param_name = &param_name_meta.value;
-            let rust_ty = param_type_to_rust(param_type);
-            func.arg(param_name, format!("&{}", rust_ty));
-        }
-    }
+    add_params_to_function(&mut func, query.params.as_ref());
 
     func.ret(&return_ty);
     func.bound("C", "tokio_postgres::GenericClient");
@@ -1046,6 +1040,24 @@ fn param_type_to_rust(ty: &dibs_query_schema::ParamType) -> String {
     }
 }
 
+fn param_type_to_function_arg_rust(ty: &dibs_query_schema::ParamType) -> String {
+    use dibs_query_schema::ParamType;
+    match ty {
+        ParamType::String | ParamType::Jsonb => "str".to_string(),
+        _ => param_type_to_rust(ty),
+    }
+}
+
+fn add_params_to_function(func: &mut Function, params: Option<&Params>) {
+    if let Some(params) = params {
+        for (param_name_meta, param_type) in &params.params {
+            let param_name = param_name_meta.value.as_str();
+            let rust_ty = param_type_to_function_arg_rust(param_type);
+            func.arg(param_name, format!("&{}", rust_ty));
+        }
+    }
+}
+
 /// Helper to format a Block to a String.
 fn block_to_string(block: &Block) -> String {
     let mut output = String::new();
@@ -1135,13 +1147,7 @@ fn generate_insert_code(
     func.generic("C");
     func.arg("client", "&C");
 
-    if let Some(params) = &insert.params {
-        for (param_name_meta, param_type) in &params.params {
-            let param_name = param_name_meta.value.as_str();
-            let rust_ty = param_type_to_rust(param_type);
-            func.arg(param_name, format!("&{}", rust_ty));
-        }
-    }
+    add_params_to_function(&mut func, insert.params.as_ref());
 
     func.ret(&return_ty);
     func.bound("C", "tokio_postgres::GenericClient");
@@ -1194,13 +1200,7 @@ fn generate_upsert_code(
     func.generic("C");
     func.arg("client", "&C");
 
-    if let Some(params) = &upsert.params {
-        for (param_name_meta, param_type) in &params.params {
-            let param_name = param_name_meta.value.as_str();
-            let rust_ty = param_type_to_rust(param_type);
-            func.arg(param_name, format!("&{}", rust_ty));
-        }
-    }
+    add_params_to_function(&mut func, upsert.params.as_ref());
 
     func.ret(&return_ty);
     func.bound("C", "tokio_postgres::GenericClient");
@@ -1456,13 +1456,7 @@ fn generate_update_code(
     func.generic("C");
     func.arg("client", "&C");
 
-    if let Some(params) = &update.params {
-        for (param_name_meta, param_type) in &params.params {
-            let param_name = param_name_meta.value.as_str();
-            let rust_ty = param_type_to_rust(param_type);
-            func.arg(param_name, format!("&{}", rust_ty));
-        }
-    }
+    add_params_to_function(&mut func, update.params.as_ref());
 
     func.ret(&return_ty);
     func.bound("C", "tokio_postgres::GenericClient");
@@ -1516,13 +1510,7 @@ fn generate_delete_code(
     func.generic("C");
     func.arg("client", "&C");
 
-    if let Some(params) = &delete.params {
-        for (param_name_meta, param_type) in &params.params {
-            let param_name = param_name_meta.value.as_str();
-            let rust_ty = param_type_to_rust(param_type);
-            func.arg(param_name, format!("&{}", rust_ty));
-        }
-    }
+    add_params_to_function(&mut func, delete.params.as_ref());
 
     func.ret(&return_ty);
     func.bound("C", "tokio_postgres::GenericClient");

--- a/dibs-qgen/src/rustgen/tests.rs
+++ b/dibs-qgen/src/rustgen/tests.rs
@@ -108,6 +108,10 @@ ProductByHandle @select{
 
     assert!(code.code.contains("handle: &str"));
     assert!(!code.code.contains("handle: &String"));
+    assert!(
+        code.code
+            .contains("let rows = client.query(SQL, &[&handle]).await?;")
+    );
     // Uses direct struct construction for Option-returning queries
     assert!(code.code.contains("Ok(None)"));
     assert!(code.code.contains("ProductByHandleResult {"));
@@ -222,7 +226,31 @@ CreateEvent @insert{
     assert!(code.code.contains("event_type: &str"));
     assert!(code.code.contains("payload: &str"));
     assert!(!code.code.contains("payload: &String"));
+    assert!(
+        code.code
+            .contains("let affected = client.execute(SQL, &[&event_type, &payload]).await?;")
+    );
     assert!(code.code.contains("$2::text::jsonb"));
+}
+
+#[test]
+fn test_generate_bytes_param_takes_slice() {
+    let source = r#"
+CreatePasskey @insert{
+  params { user_id @int, credential_id @bytes, public_key @bytes }
+  into passkey
+  values { user_id $user_id, credential_id $credential_id, public_key $public_key }
+}
+"#;
+    let (file, qsource) = parse_test(source);
+    let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
+
+    assert!(code.code.contains("credential_id: &[u8]"));
+    assert!(code.code.contains("public_key: &[u8]"));
+    assert!(!code.code.contains("credential_id: &Vec<u8>"));
+    assert!(code.code.contains(
+        "let affected = client.execute(SQL, &[&user_id, &credential_id, &public_key]).await?;"
+    ));
 }
 
 #[test]
@@ -614,6 +642,10 @@ CreateUser @insert{
     assert!(code.code.contains("email: &str"));
     assert!(!code.code.contains("name: &String"));
     assert!(!code.code.contains("email: &String"));
+    assert!(
+        code.code
+            .contains("let rows = client.query(SQL, &[&name, &email]).await?;")
+    );
     assert!(code.code.contains("INSERT INTO"));
     assert!(code.code.contains("RETURNING"));
     assert!(
@@ -653,6 +685,10 @@ UpsertProduct @upsert{
     assert!(code.code.contains("pub async fn upsert_product"));
     assert!(code.code.contains("id: &Uuid"));
     assert!(code.code.contains("name: &str"));
+    assert!(
+        code.code
+            .contains("let rows = client.query(SQL, &[&id, &name, &price]).await?;")
+    );
     assert!(code.code.contains("ON CONFLICT"));
     assert!(code.code.contains("DO UPDATE SET"));
 }
@@ -683,6 +719,10 @@ UpdateUserEmail @update{
     assert!(code.code.contains("pub struct UpdateUserEmailResult"));
     assert!(code.code.contains("pub async fn update_user_email"));
     assert!(code.code.contains("email: &str"));
+    assert!(
+        code.code
+            .contains("let rows = client.query(SQL, &[&email, &id]).await?;")
+    );
     assert!(code.code.contains("UPDATE"));
     assert!(code.code.contains("SET"));
     assert!(code.code.contains("WHERE"));

--- a/dibs-qgen/src/rustgen/tests.rs
+++ b/dibs-qgen/src/rustgen/tests.rs
@@ -106,7 +106,8 @@ ProductByHandle @select{
     )]);
     let code = generate_rust_code(&file, &schema, qsource).unwrap();
 
-    assert!(code.code.contains("handle: &String"));
+    assert!(code.code.contains("handle: &str"));
+    assert!(!code.code.contains("handle: &String"));
     // Uses direct struct construction for Option-returning queries
     assert!(code.code.contains("Ok(None)"));
     assert!(code.code.contains("ProductByHandleResult {"));
@@ -199,11 +200,29 @@ TrendingProducts @select{
     // Raw SQL queries don't need schema - types come from explicit `returns` clause
     let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
 
-    assert!(code.code.contains("locale: &String"));
+    assert!(code.code.contains("locale: &str"));
     assert!(code.code.contains("days: &i64"));
     assert!(code.code.contains("pub id: i64"));
     assert!(code.code.contains("pub title: String"));
     assert!(code.code.contains("SELECT id, title FROM products"));
+}
+
+#[test]
+fn test_generate_jsonb_param_takes_str() {
+    let source = r#"
+CreateEvent @insert{
+  params { event_type @string, payload @jsonb }
+  into events
+  values { event_type $event_type, payload $payload }
+}
+"#;
+    let (file, qsource) = parse_test(source);
+    let code = generate_rust_code(&file, &empty_schema(), qsource).unwrap();
+
+    assert!(code.code.contains("event_type: &str"));
+    assert!(code.code.contains("payload: &str"));
+    assert!(!code.code.contains("payload: &String"));
+    assert!(code.code.contains("$2::text::jsonb"));
 }
 
 #[test]
@@ -591,8 +610,10 @@ CreateUser @insert{
 
     assert!(code.code.contains("pub struct CreateUserResult"));
     assert!(code.code.contains("pub async fn create_user"));
-    assert!(code.code.contains("name: &String"));
-    assert!(code.code.contains("email: &String"));
+    assert!(code.code.contains("name: &str"));
+    assert!(code.code.contains("email: &str"));
+    assert!(!code.code.contains("name: &String"));
+    assert!(!code.code.contains("email: &String"));
     assert!(code.code.contains("INSERT INTO"));
     assert!(code.code.contains("RETURNING"));
     assert!(
@@ -631,6 +652,7 @@ UpsertProduct @upsert{
     assert!(code.code.contains("pub struct UpsertProductResult"));
     assert!(code.code.contains("pub async fn upsert_product"));
     assert!(code.code.contains("id: &Uuid"));
+    assert!(code.code.contains("name: &str"));
     assert!(code.code.contains("ON CONFLICT"));
     assert!(code.code.contains("DO UPDATE SET"));
 }
@@ -660,6 +682,7 @@ UpdateUserEmail @update{
 
     assert!(code.code.contains("pub struct UpdateUserEmailResult"));
     assert!(code.code.contains("pub async fn update_user_email"));
+    assert!(code.code.contains("email: &str"));
     assert!(code.code.contains("UPDATE"));
     assert!(code.code.contains("SET"));
     assert!(code.code.contains("WHERE"));

--- a/docs/dibs-content/internals/_index.md
+++ b/docs/dibs-content/internals/_index.md
@@ -67,7 +67,7 @@ Most dibs commands follow the same steps:
 
 ## Architecture
 
-Your "db crate" is a small process that speaks <abbr title="Remote Procedure Call">RPC</abbr> to the CLI (via [Roam](https://github.com/bearcove/roam)):
+Your "db crate" is a small process that speaks <abbr title="Remote Procedure Call">RPC</abbr> to the CLI (via [Vox](/vox/)):
 
 <div class="flow flow-vertical">
   <div class="flow-step">

--- a/examples/dibs-my-app-workspace/my-app-db/src/main.rs
+++ b/examples/dibs-my-app-workspace/my-app-db/src/main.rs
@@ -1,7 +1,7 @@
 //! Database service binary for my-app (ecommerce).
 //!
 //! Usage:
-//!   my-app-db          - Run the dibs service (connects back to CLI via roam)
+//!   my-app-db          - Run the dibs service (connects back to CLI via Vox)
 //!   my-app-db seed     - Seed the database with sample data (~2000 products)
 
 use my_app_db::{Product, ProductSource, ProductTranslation, ProductVariant, VariantPrice};

--- a/examples/dibs-my-app-workspace/my-app-queries/Cargo.toml
+++ b/examples/dibs-my-app-workspace/my-app-queries/Cargo.toml
@@ -21,6 +21,6 @@ my-app-db = { path = "../my-app-db" }
 
 [dev-dependencies]
 dockside = { path = "../../../dockside" }
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros"] }
 tokio-postgres.workspace = true
 dibs = { path = "../../../dibs" }

--- a/facet-postcard/tests/integration/mod.rs
+++ b/facet-postcard/tests/integration/mod.rs
@@ -5,4 +5,4 @@ mod issue_2098;
 mod issue_2108;
 mod issue_2118;
 mod opaque_adapter;
-mod roam_wire;
+mod vox_wire;

--- a/facet-postcard/tests/integration/vox_wire.rs
+++ b/facet-postcard/tests/integration/vox_wire.rs
@@ -1,16 +1,16 @@
-//! Test for roam-wire Message enum pattern.
+//! Test for vox-wire Message enum pattern.
 //!
-//! This reproduces the failure seen in roam where decoding a Message::Goodbye
+//! This reproduces the failure seen in Vox where decoding a Message::Goodbye
 //! fails with "got struct start, expected field key, ordered field, or struct end".
 //!
-//! IMPORTANT: roam-wire types only derive Facet, NOT serde. This means facet-postcard
+//! IMPORTANT: vox-wire types only derive Facet, NOT serde. This means facet-postcard
 //! uses the pure Facet deserialization path, not the serde compatibility path.
 
 use facet::Facet;
 use facet_postcard::{from_slice, to_vec};
 
 // ============================================================================
-// Types that ONLY derive Facet (matching roam-wire exactly)
+// Types that ONLY derive Facet (matching vox-wire exactly)
 // ============================================================================
 
 /// Newtype for connection ID (Facet only, no serde).
@@ -28,7 +28,7 @@ pub struct RequestId(pub u64);
 #[repr(transparent)]
 pub struct MethodId(pub u64);
 
-/// Simplified Hello enum matching roam-wire (Facet only).
+/// Simplified Hello enum matching vox-wire (Facet only).
 #[repr(u8)]
 #[derive(Debug, Clone, PartialEq, Eq, Facet)]
 pub enum Hello {
@@ -58,7 +58,7 @@ pub enum MetadataValue {
 /// Metadata is a list of (key, value, flags) tuples.
 pub type Metadata = Vec<(String, MetadataValue, u64)>;
 
-/// Simplified Message enum matching roam-wire structure (Facet only).
+/// Simplified Message enum matching vox-wire structure (Facet only).
 /// The key is having multiple struct variants with different field counts.
 #[repr(u8)]
 #[derive(Debug, Clone, PartialEq, Eq, Facet)]
@@ -199,12 +199,12 @@ fn test_message_goodbye_roundtrip() {
     assert_eq!(decoded, msg);
 }
 
-/// Test decoding exact bytes from roam failure
+/// Test decoding exact bytes from Vox failure
 #[test]
 fn test_decode_exact_goodbye_bytes() {
     facet_testhelpers::setup();
 
-    // These are the exact bytes that failed in roam:
+    // These are the exact bytes that failed in Vox:
     // 04 = variant 4 (Goodbye)
     // 00 = conn_id varint (0)
     // 14 = string length varint (20)
@@ -348,7 +348,7 @@ fn test_transparent_newtype_in_struct() {
 }
 
 /// Test transparent newtype as first field in enum struct variant
-/// This is the exact pattern that was failing in roam-wire
+/// This is the exact pattern that was failing in vox-wire
 #[test]
 fn test_transparent_newtype_first_field_in_enum_struct_variant() {
     facet_testhelpers::setup();
@@ -592,10 +592,10 @@ fn test_nested_enum_with_transparent_newtypes() {
 }
 
 // ============================================================================
-// Full roam-wire Message enum with typed IDs (matching actual roam-wire)
+// Full vox-wire Message enum with typed IDs (matching actual vox-wire)
 // ============================================================================
 
-/// Full Message enum matching roam-wire exactly, with typed ID fields.
+/// Full Message enum matching vox-wire exactly, with typed ID fields.
 #[repr(u8)]
 #[derive(Debug, Clone, PartialEq, Eq, Facet)]
 pub enum FullMessage {

--- a/phon/docs/content/vox-ecosystem-compat-roadmap.md
+++ b/phon/docs/content/vox-ecosystem-compat-roadmap.md
@@ -953,7 +953,7 @@ Verified in the Vox checkout during the bridge audit:
   mutation roots `tracey_forward`, `tracey_reverse`, `tracey_file`,
   `tracey_spec_content`, `tracey_search`, `tracey_update_file_range`,
   `tracey_config_add_exclude`, and `tracey_config_add_include`, now pass the
-  focused 64-case Vox spec matrix. This covers the current roam-to-Vox
+  focused 64-case Vox spec matrix. This covers the current Vox
   migration target shape:
   `RuleId`, `usize` counts and source locations as fixed-width wire integers,
   validation enum/options/vectors, uncovered/untested/stale/unmapped rule
@@ -1066,7 +1066,7 @@ closure:
   1.0 gate.
   Tracey migration generated bridge coverage now mirrors the
   current LSP, core/control, dashboard/query-model, and config mutation surface
-  from the current roam protocol.
+  from the current Vox protocol.
   Hotmeal payload roots and the exact callback-style `subscribe` / `on_event`
   service shape are covered as generated bridge smoke roots.
 - External values such as `vox::Fd` now have explicit Rust transport and
@@ -1584,9 +1584,8 @@ gap.
 
 ### Tracey
 
-In the current `~/tracey` checkout, `tracey-proto` uses `roam`, not Vox. It is
-still a useful migration target because it has the shape of a large
-dashboard/LSP service.
+The Tracey protocol surface is still a useful Vox migration target because it
+has the shape of a large dashboard/LSP service.
 
 Expected migration shapes:
 
@@ -1602,7 +1601,7 @@ Tracey should be used as a future generated-service breadth target, not as proof
 of current Vox coverage.
 
 Tracey migration fixture work should model the target Vox service from the
-current roam protocol shapes. The point is to cover dashboard/LSP breadth and a
+current Vox protocol shapes. The point is to cover dashboard/LSP breadth and a
 `Tx<DataUpdate>` style subscription, not to claim the current Tracey checkout is
 already a Vox consumer.
 
@@ -1840,7 +1839,7 @@ Create Phon/Vox fixture definitions extracted from real consumer protocols:
    metadata.
 6. Helix fixture: representative trace query and subscription payloads.
 7. Hotmeal fixture: browser live reload smoke surface.
-8. Tracey migration fixture: current roam proto shape represented as the target
+8. Tracey migration fixture: current Vox proto shape represented as the target
    Vox service surface.
 
 Fixtures should live close to the Phon/Vox integration tests and be generated

--- a/phon/rust/phon/tests/ecosystem_surface.rs
+++ b/phon/rust/phon/tests/ecosystem_surface.rs
@@ -2879,7 +2879,7 @@ struct HotmealLiveReloadFixture {
 }
 
 // Migration target for /Users/amos/tracey/crates/tracey-proto/src/lib.rs.
-// The current roam DTOs use usize in several fields; this target Vox fixture
+// The current Vox DTOs use usize in several fields; this target Vox fixture
 // uses fixed-width integers because phon schemas are cross-language.
 #[derive(Debug, Clone, PartialEq, Eq, Facet)]
 struct TraceyRuleId {

--- a/vox/README.md
+++ b/vox/README.md
@@ -4,7 +4,7 @@
 [![documentation](https://docs.rs/vox/badge.svg)](https://docs.rs/vox)
 [![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/vox.svg)](https://github.com/facet-rs/facet/blob/main/LICENSE-MIT)
 
-vox (formerly **roam**) is a Rust-native RPC framework where Rust traits *are*
+vox is a Rust-native RPC framework where Rust traits *are*
 the schema. There is
 no separate IDL, no code-generation pipeline to wire up: you define an async
 trait, annotate it with `#[vox::service]`, and get a type-safe client and

--- a/vox/spec/spec-proto/src/lib.rs
+++ b/vox/spec/spec-proto/src/lib.rs
@@ -474,7 +474,7 @@ pub trait Testbed {
     /// query return families as one generated bridge root.
     async fn helix_trace_service_surface(&self) -> HelixTraceServiceSurface;
 
-    /// Tracey daemon status query, mirrored from the current roam
+    /// Tracey daemon status query, mirrored from the current Vox
     /// `TraceyDaemon::status` migration surface.
     async fn tracey_status(&self) -> TraceyStatusResponse;
 
@@ -490,7 +490,7 @@ pub trait Testbed {
     /// Tracey unmapped-code query.
     async fn tracey_unmapped(&self, req: TraceyUnmappedRequest) -> TraceyUnmappedResponse;
 
-    /// Tracey rule detail query, mirrored from the current roam
+    /// Tracey rule detail query, mirrored from the current Vox
     /// `TraceyDaemon::rule` migration surface.
     async fn tracey_rule(&self, rule_id: TraceyRuleId) -> Option<TraceyRuleInfo>;
 
@@ -557,7 +557,7 @@ pub trait Testbed {
     /// Tracey daemon shutdown notification.
     async fn tracey_shutdown(&self);
 
-    /// Tracey validation query, mirrored from the current roam
+    /// Tracey validation query, mirrored from the current Vox
     /// `TraceyDaemon::validate` migration surface.
     async fn tracey_validate(&self, req: TraceyValidateRequest) -> TraceyValidationResult;
 

--- a/vox/typescript/generated/testbed.generated.ts
+++ b/vox/typescript/generated/testbed.generated.ts
@@ -5228,7 +5228,7 @@ export interface TestbedCaller {
    */
   helixTraceServiceSurface(): Promise<HelixTraceServiceSurface>;
   /**
-   * Tracey daemon status query, mirrored from the current roam
+   * Tracey daemon status query, mirrored from the current Vox
    * `TraceyDaemon::status` migration surface.
    */
   traceyStatus(): Promise<TraceyStatusResponse>;
@@ -5241,7 +5241,7 @@ export interface TestbedCaller {
   /** Tracey unmapped-code query. */
   traceyUnmapped(req: TraceyUnmappedRequest): Promise<TraceyUnmappedResponse>;
   /**
-   * Tracey rule detail query, mirrored from the current roam
+   * Tracey rule detail query, mirrored from the current Vox
    * `TraceyDaemon::rule` migration surface.
    */
   traceyRule(ruleId: TraceyRuleId): Promise<TraceyRuleInfo | null>;
@@ -5278,7 +5278,7 @@ export interface TestbedCaller {
   /** Tracey daemon shutdown notification. */
   traceyShutdown(): Promise<void>;
   /**
-   * Tracey validation query, mirrored from the current roam
+   * Tracey validation query, mirrored from the current Vox
    * `TraceyDaemon::validate` migration surface.
    */
   traceyValidate(req: TraceyValidateRequest): Promise<TraceyValidationResult>;
@@ -6679,7 +6679,7 @@ export class TestbedClient implements TestbedCaller {
   }
 
   /**
-   * Tracey daemon status query, mirrored from the current roam
+   * Tracey daemon status query, mirrored from the current Vox
    * `TraceyDaemon::status` migration surface.
    */
   async traceyStatus(): Promise<TraceyStatusResponse> {
@@ -6742,7 +6742,7 @@ export class TestbedClient implements TestbedCaller {
   }
 
   /**
-   * Tracey rule detail query, mirrored from the current roam
+   * Tracey rule detail query, mirrored from the current Vox
    * `TraceyDaemon::rule` migration surface.
    */
   async traceyRule(ruleId: TraceyRuleId): Promise<TraceyRuleInfo | null> {
@@ -6970,7 +6970,7 @@ export class TestbedClient implements TestbedCaller {
   }
 
   /**
-   * Tracey validation query, mirrored from the current roam
+   * Tracey validation query, mirrored from the current Vox
    * `TraceyDaemon::validate` migration surface.
    */
   async traceyValidate(req: TraceyValidateRequest): Promise<TraceyValidationResult> {


### PR DESCRIPTION
## Summary
- generate Dibs function params as borrowed `&str` for `@string` and `@jsonb`, and `&[u8]` for `@bytes`
- render generated postgres bind arrays as `&param` so borrowed params compile through `ToSql`
- replace stale `roam` references with `vox` and regenerate Vox generated outputs
- enable Tokio test macros for Dibs qgen/example integration tests so those suites compile

## Verification
- `cargo nextest run -p dibs-qgen`
- `cargo nextest run -p my-app-queries`
- `cargo check -p my-app-queries`
- `cargo check -p dibs-cli`
- `cargo nextest run -p facet-postcard -E 'test(vox_wire)'`
- `cargo fmt --check -p dibs-qgen -p my-app-queries -p dibs-cli -p facet-postcard -p phon -p spec-proto`
- `git diff --check`
- `rg -n "\\broam\\b|\\bRoam\\b|\\bROAM\\b|roam-wire|roam_wire" -S`