### PR TITLE
Make PHON canonical value lowering authoritative

### DIFF
--- a/phon/rust/phon-engine/src/plan.rs
+++ b/phon/rust/phon-engine/src/plan.rs
@@ -27,8 +27,8 @@ use phon_schema::{
 };
 
 use phon_ir::ir::{
-    CanonicalEnumArm, CanonicalProgram, CanonicalValueProgram, ControlOp, EnumArm, Op, Program,
-    ValueIntrinsic, ValueProgram, WeavyOp,
+    CanonicalEnumArm, CanonicalProgram, CanonicalValueProgram, ControlOp, ValueIntrinsic,
+    ValueProgram, WeavyOp, value_lowered_from_canonical,
 };
 
 use crate::compact::{self, CompactError, Registry, Resolved};
@@ -580,84 +580,15 @@ fn add_ref_targets(r: &SchemaRef, out: &mut Vec<SchemaId>) {
 // Lowering the plan to the linear IR
 // ============================================================================
 
-/// Flatten a built plan's `Node` tree into a linear [`Program`]. Every
-/// type-directed decision the tree encodes is resolved here, once; what the
-/// interpreter runs carries only data-directed control flow. A struct of structs
-/// of scalars lowers to a single branch-free run of ops.
+/// Flatten a built plan into the legacy dynamic-value [`ValueProgram`].
+///
+/// Canonical Weavy IR is the source of truth; this projects it back into the old
+/// public value IR for callers that still inspect that form.
 // r[impl ir.two-forms]
 #[must_use]
 pub fn lower(plan: &Plan) -> ValueProgram {
-    let mut out = Vec::new();
-    lower_node(&plan.root, &mut out);
-    let blocks = plan
-        .blocks
-        .iter()
-        .map(|(id, node)| (*id, lower_subtree(node)))
-        .collect();
-    ValueProgram {
-        program: out,
-        blocks,
-    }
-}
-
-fn lower_subtree(node: &Node) -> Program {
-    let mut out = Vec::new();
-    lower_node(node, &mut out);
-    out
-}
-
-/// Append the ops for `node`. A complete node nets one value on the stack.
-fn lower_node(node: &Node, out: &mut Program) {
-    match node {
-        Node::Scalar(p) => out.push(Op::Scalar(*p)),
-        Node::Dynamic => out.push(Op::Dynamic),
-        Node::CallBlock(schema) => out.push(Op::CallBlock { schema: *schema }),
-        Node::Struct(sp) => lower_struct(sp, out),
-        Node::Enum(by_index) => {
-            let mut arms: Vec<EnumArm> = by_index
-                .iter()
-                .map(|(idx, vp)| EnumArm {
-                    writer_index: *idx,
-                    reader_name: vp.reader.clone(),
-                    payload: lower_payload(&vp.payload),
-                })
-                .collect();
-            // Deterministic order; the interpreter dispatches by writer_index.
-            arms.sort_by_key(|a| a.writer_index);
-            out.push(Op::Enum { arms });
-        }
-        Node::Tuple(nodes) => {
-            for n in nodes {
-                lower_node(n, out);
-            }
-            out.push(Op::Array { count: nodes.len() });
-        }
-        Node::Seq {
-            set,
-            element,
-            min_wire,
-        } => out.push(Op::Seq {
-            set: *set,
-            min_wire: *min_wire,
-            body: lower_subtree(element),
-        }),
-        Node::Map { key, value } => out.push(Op::Map {
-            key: lower_subtree(key),
-            value: lower_subtree(value),
-        }),
-        Node::Array {
-            element,
-            dims,
-            min_wire,
-        } => out.push(Op::FixedArray {
-            dimensions: dims.clone(),
-            min_wire: *min_wire,
-            body: lower_subtree(element),
-        }),
-        Node::Option(element) => out.push(Op::Option {
-            some: lower_subtree(element),
-        }),
-    }
+    value_lowered_from_canonical(lower_canonical(plan))
+        .expect("canonical PHON value lowering must project to legacy value IR")
 }
 
 /// Flatten a built plan directly into canonical Weavy IR.
@@ -778,47 +709,6 @@ fn lower_canonical_payload(payload: &Payload) -> CanonicalProgram {
             }));
         }
         Payload::Struct(sp) => lower_canonical_struct(sp, &mut out),
-    }
-    out
-}
-
-/// Each writer field in wire order (a matched field's value, or a skip for a
-/// writer-only one), then a null per reader-only default, then assemble the
-/// object. The `keys` track the stack values the `Object` op will name.
-///
-/// A field that is itself a fixed structure splices its ops inline here (via
-/// `lower_node`); only dynamic-length and branching children become sub-programs.
-// r[impl ir.inlining]
-fn lower_struct(sp: &StructPlan, out: &mut Program) {
-    let mut keys = Vec::new();
-    for step in &sp.steps {
-        match step {
-            Step::Take { reader, node } => {
-                lower_node(node, out);
-                keys.push(reader.clone());
-            }
-            Step::Skip(writer_ref) => out.push(Op::Skip(writer_ref.clone())),
-        }
-    }
-    for name in &sp.defaults {
-        out.push(Op::Null);
-        keys.push(name.clone());
-    }
-    out.push(Op::Object { keys });
-}
-
-fn lower_payload(payload: &Payload) -> Program {
-    let mut out = Vec::new();
-    match payload {
-        Payload::Unit => out.push(Op::Null),
-        Payload::Newtype(node) => lower_node(node, &mut out),
-        Payload::Tuple(nodes) => {
-            for n in nodes {
-                lower_node(n, &mut out);
-            }
-            out.push(Op::Array { count: nodes.len() });
-        }
-        Payload::Struct(sp) => lower_struct(sp, &mut out),
     }
     out
 }
@@ -972,6 +862,7 @@ fn exec_payload(
 mod tests {
     use super::*;
     use crate::compact;
+    use phon_ir::ir::Op;
     use phon_schema::{Schema, primitive_id};
 
     fn prim(p: Primitive) -> SchemaRef {

--- a/phon/rust/phon-ir/src/ir.rs
+++ b/phon/rust/phon-ir/src/ir.rs
@@ -246,6 +246,70 @@ pub fn canonical_value_program(lowered: &ValueProgram) -> CanonicalValueProgram 
     }
 }
 
+/// Canonical-to-legacy dynamic-value conversion failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CanonicalValueError {
+    /// Canonical `return` has no legacy [`Op`] equivalent.
+    Return,
+    /// Legacy [`Op::CallBlock`] cannot represent a base-relative block call.
+    NonzeroBaseOffset,
+    /// Canonical control operations other than block calls are not legacy value ops.
+    Control,
+    /// Canonical typed-memory operations are not dynamic-value ops.
+    Memory,
+    /// Canonical initialization operations are not dynamic-value ops.
+    Init,
+    /// Canonical aggregate operations are not dynamic-value ops.
+    Aggregate,
+    /// A future canonical op variant is not representable in legacy value IR.
+    Unknown,
+}
+
+impl core::fmt::Display for CanonicalValueError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Return => write!(f, "canonical return has no Op equivalent"),
+            Self::NonzeroBaseOffset => {
+                write!(f, "canonical block call base offset has no Op equivalent")
+            }
+            Self::Control => write!(f, "canonical control op has no Op equivalent"),
+            Self::Memory => write!(f, "canonical memory op has no Op equivalent"),
+            Self::Init => write!(f, "canonical init op has no Op equivalent"),
+            Self::Aggregate => write!(f, "canonical aggregate op has no Op equivalent"),
+            Self::Unknown => write!(f, "unknown canonical op has no Op equivalent"),
+        }
+    }
+}
+
+impl std::error::Error for CanonicalValueError {}
+
+/// Convert canonical PHON dynamic-value IR back into the legacy public [`Op`]
+/// form.
+///
+/// This is a compatibility projection for callers still inspecting the old
+/// value IR. New execution and analysis should consume [`CanonicalProgram`]
+/// directly.
+pub fn value_program_from_canonical(
+    program: CanonicalProgram,
+) -> Result<Program, CanonicalValueError> {
+    program.into_iter().map(value_op_from_canonical).collect()
+}
+
+/// Convert canonical lowered PHON dynamic-value IR back into the legacy public
+/// [`ValueProgram`] form.
+pub fn value_lowered_from_canonical(
+    lowered: CanonicalValueProgram,
+) -> Result<ValueProgram, CanonicalValueError> {
+    let program = value_program_from_canonical(lowered.program)?;
+    let blocks = lowered
+        .blocks
+        .into_iter()
+        .map(|(id, block)| Ok((id, value_program_from_canonical(block)?)))
+        .collect::<Result<_, CanonicalValueError>>()?;
+    Ok(ValueProgram { program, blocks })
+}
+
 fn canonical_op(op: &Op) -> ValueOp {
     match op {
         Op::CallBlock { schema } => WeavyOp::Control(ControlOp::CallBlock {
@@ -301,6 +365,72 @@ fn canonical_intrinsic(op: &Op) -> ValueIntrinsic {
                 .collect(),
         },
     }
+}
+
+fn value_op_from_canonical(op: ValueOp) -> Result<Op, CanonicalValueError> {
+    Ok(match op {
+        WeavyOp::Control(ControlOp::CallBlock { block, base_offset }) => {
+            if base_offset != 0 {
+                return Err(CanonicalValueError::NonzeroBaseOffset);
+            }
+            Op::CallBlock { schema: block }
+        }
+        WeavyOp::Control(ControlOp::Return) => return Err(CanonicalValueError::Return),
+        WeavyOp::Control(_) => return Err(CanonicalValueError::Control),
+        WeavyOp::Memory(_) => return Err(CanonicalValueError::Memory),
+        WeavyOp::Init(_) => return Err(CanonicalValueError::Init),
+        WeavyOp::Aggregate(_) => return Err(CanonicalValueError::Aggregate),
+        WeavyOp::Intrinsic(intrinsic) => return value_op_from_intrinsic(intrinsic),
+        _ => return Err(CanonicalValueError::Unknown),
+    })
+}
+
+fn value_op_from_intrinsic(intrinsic: ValueIntrinsic) -> Result<Op, CanonicalValueError> {
+    Ok(match intrinsic {
+        ValueIntrinsic::Scalar(p) => Op::Scalar(p),
+        ValueIntrinsic::Dynamic => Op::Dynamic,
+        ValueIntrinsic::Null => Op::Null,
+        ValueIntrinsic::Skip(writer_ref) => Op::Skip(writer_ref),
+        ValueIntrinsic::Object { keys } => Op::Object { keys },
+        ValueIntrinsic::Array { count } => Op::Array { count },
+        ValueIntrinsic::Seq {
+            set,
+            min_wire,
+            body,
+        } => Op::Seq {
+            set,
+            min_wire,
+            body: value_program_from_canonical(body)?,
+        },
+        ValueIntrinsic::Map { key, value } => Op::Map {
+            key: value_program_from_canonical(key)?,
+            value: value_program_from_canonical(value)?,
+        },
+        ValueIntrinsic::FixedArray {
+            dimensions,
+            min_wire,
+            body,
+        } => Op::FixedArray {
+            dimensions,
+            min_wire,
+            body: value_program_from_canonical(body)?,
+        },
+        ValueIntrinsic::Option { some } => Op::Option {
+            some: value_program_from_canonical(some)?,
+        },
+        ValueIntrinsic::Enum { arms } => Op::Enum {
+            arms: arms
+                .into_iter()
+                .map(|arm| {
+                    Ok(EnumArm {
+                        writer_index: arm.writer_index,
+                        reader_name: arm.reader_name,
+                        payload: value_program_from_canonical(arm.payload)?,
+                    })
+                })
+                .collect::<Result<_, CanonicalValueError>>()?,
+        },
+    })
 }
 
 /// A lowered *typed* program: the memory side of the IR. Where [`Program`] builds
@@ -407,4 +537,72 @@ pub fn skip(r: &mut Reader, op: &SkipOp) -> Result<(), DecodeError> {
 #[must_use]
 pub fn fuse(program: MemProgram) -> MemProgram {
     weavy::mem::fuse(program)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn canonical_value_projection_preserves_nested_legacy_ops() {
+        let legacy = ValueProgram {
+            program: vec![
+                Op::Seq {
+                    set: true,
+                    min_wire: 1,
+                    body: vec![Op::Option {
+                        some: vec![Op::Scalar(Primitive::U8)],
+                    }],
+                },
+                Op::CallBlock {
+                    schema: SchemaId(9),
+                },
+            ],
+            blocks: BTreeMap::from([(SchemaId(9), vec![Op::Null])]),
+        };
+
+        let projected = value_lowered_from_canonical(canonical_value_program(&legacy)).unwrap();
+
+        match projected.program.as_slice() {
+            [
+                Op::Seq {
+                    set,
+                    min_wire,
+                    body,
+                },
+                Op::CallBlock { schema },
+            ] => {
+                assert!(*set);
+                assert_eq!(*min_wire, 1);
+                assert_eq!(*schema, SchemaId(9));
+                match body.as_slice() {
+                    [Op::Option { some }] => match some.as_slice() {
+                        [Op::Scalar(Primitive::U8)] => {}
+                        other => panic!("unexpected option payload: {other:?}"),
+                    },
+                    other => panic!("unexpected sequence body: {other:?}"),
+                }
+            }
+            other => panic!("unexpected projected program: {other:?}"),
+        }
+        match projected.blocks.get(&SchemaId(9)).map(Vec::as_slice) {
+            Some([Op::Null]) => {}
+            other => panic!("unexpected projected block: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn canonical_value_projection_rejects_non_legacy_control() {
+        let err = value_program_from_canonical(vec![WeavyOp::Control(ControlOp::Return)])
+            .expect_err("return should not project to legacy value IR");
+        assert_eq!(err, CanonicalValueError::Return);
+
+        let err = value_program_from_canonical(vec![WeavyOp::Control(ControlOp::CallBlock {
+            block: SchemaId(1),
+            base_offset: 4,
+        })])
+        .expect_err("offset block call should not project to legacy value IR");
+        assert_eq!(err, CanonicalValueError::NonzeroBaseOffset);
+    }
 }

--- a/phon/rust/phon-ir/src/lib.rs
+++ b/phon/rust/phon-ir/src/lib.rs
@@ -27,9 +27,9 @@ pub use ir::{
     BorrowOp, BorrowThunks, ByteValidator, BytesOp, CanonicalEnumArm, CanonicalEnumOp,
     CanonicalEnumVariantOp, CanonicalMapOp, CanonicalMemError, CanonicalMemLowered,
     CanonicalMemProgram, CanonicalOptionOp, CanonicalPointerOp, CanonicalProgram,
-    CanonicalResultOp, CanonicalSeqOp, CanonicalSetOp, CanonicalValueProgram, DefaultOp,
-    DefaultThunk, EffectContract, EffectOrdering, EffectResource, EffectStats, EnumArm, EnumOp,
-    EnumVariantOp, Lowered, LoweredEffectStats, LoweredMemProgramStats, MapOp, MapThunks,
+    CanonicalResultOp, CanonicalSeqOp, CanonicalSetOp, CanonicalValueError, CanonicalValueProgram,
+    DefaultOp, DefaultThunk, EffectContract, EffectOrdering, EffectResource, EffectStats, EnumArm,
+    EnumOp, EnumVariantOp, Lowered, LoweredEffectStats, LoweredMemProgramStats, MapOp, MapThunks,
     MemIntrinsic, MemOp, MemProgram, MemProgramStats, MemoryRegion, Op, OpaqueOp, OpaqueThunks,
     OptionOp, OptionThunks, PointerOp, PointerThunks, Program, ResourceAccess, ResourceEffect,
     ResultOp, ResultThunks, ScalarRunOp, ScalarSegment, SeqOp, SeqThunks, SetOp, SetThunks, SkipOp,
@@ -38,7 +38,8 @@ pub use ir::{
     canonical_mem_lowered_intrinsic_counts, canonical_mem_lowered_stats, canonical_mem_program,
     canonical_mem_program_effect_stats, canonical_mem_program_stats, canonical_program,
     canonical_value_program, lowered_mem_program_stats, mem_lowered_from_canonical,
-    mem_program_from_canonical, mem_program_stats,
+    mem_program_from_canonical, mem_program_stats, value_lowered_from_canonical,
+    value_program_from_canonical,
 };
 
 /// Thunk bindings: resolving thunk names to process-local function pointers


### PR DESCRIPTION
## Summary
- add `CanonicalValueError` plus `value_program_from_canonical` / `value_lowered_from_canonical` in `phon-ir`
- make `plan::lower` project from `lower_canonical` instead of maintaining a second tree-walking lowering implementation
- add tests for nested legacy projection and non-legacy canonical control rejection

## Testing
- cargo check -p phon-ir -p phon-engine --all-features --all-targets --message-format=short
- cargo nextest run -p phon-ir -p phon-engine -E package(phon-ir) | test(lower_canonical_emits_weavy_block_calls_directly) | test(canonical_lowered_runs_recursive_block_calls) | test(ir_roundtrips_containers) | test(reconciliation_matches_expectation)
- cargo nextest run -p phon-ir -p phon-engine
- cargo check -p phon -p phon-ir -p phon-engine --all-features --all-targets --message-format=short
- cargo nextest run -p phon
- git push pre-push hooks: clippy, docs, build tests, run tests