### PR TITLE
Share intrinsic child traversal in Weavy

### DIFF
--- a/phon/rust/phon-ir/src/ir.rs
+++ b/phon/rust/phon-ir/src/ir.rs
@@ -31,9 +31,9 @@ use std::collections::BTreeMap;
 use phon_schema::bytes::{Reader, skip_pad};
 use phon_schema::{DecodeError, Primitive, SchemaId, SchemaRef};
 pub use weavy::ir::{
-    ControlOp, EffectContract, EffectOrdering, EffectResource, EffectStats, IntrinsicDescriptor,
-    IntrinsicOp, LoweredEffectStats, LoweredProgramStats, MemoryRegion, ProgramStats,
-    ResourceAccess, ResourceEffect, TypedMemoryAccess, TypedMemoryEffect, WeavyOp,
+    ControlOp, EffectContract, EffectOrdering, EffectResource, EffectStats, IntrinsicChildren,
+    IntrinsicDescriptor, IntrinsicOp, LoweredEffectStats, LoweredProgramStats, MemoryRegion,
+    ProgramStats, ResourceAccess, ResourceEffect, TypedMemoryAccess, TypedMemoryEffect, WeavyOp,
 };
 pub use weavy::mem::{
     BorrowOp, BorrowThunks, ByteValidator, BytesOp, CanonicalEnumOp, CanonicalEnumVariantOp,
@@ -217,6 +217,32 @@ impl IntrinsicOp for ValueIntrinsic {
     }
 }
 
+impl IntrinsicChildren<SchemaId> for ValueIntrinsic {
+    fn visit_child_programs<'a>(&'a self, visit: &mut dyn FnMut(&'a [WeavyOp<SchemaId, Self>])) {
+        match self {
+            ValueIntrinsic::Seq { body, .. } | ValueIntrinsic::FixedArray { body, .. } => {
+                visit(body);
+            }
+            ValueIntrinsic::Map { key, value } => {
+                visit(key);
+                visit(value);
+            }
+            ValueIntrinsic::Option { some } => visit(some),
+            ValueIntrinsic::Enum { arms } => {
+                for arm in arms {
+                    visit(&arm.payload);
+                }
+            }
+            ValueIntrinsic::Scalar(_)
+            | ValueIntrinsic::Dynamic
+            | ValueIntrinsic::Null
+            | ValueIntrinsic::Skip(_)
+            | ValueIntrinsic::Object { .. }
+            | ValueIntrinsic::Array { .. } => {}
+        }
+    }
+}
+
 fn value_stack_effect() -> EffectContract {
     EffectContract::new()
         .write_resource(EffectResource::SideChannel("phon.value_stack"))
@@ -252,32 +278,13 @@ pub fn canonical_value_program(lowered: &ValueProgram) -> CanonicalValueProgram 
 /// intrinsics with nested child programs.
 #[must_use]
 pub fn canonical_value_program_stats(program: &[ValueOp]) -> ProgramStats {
-    let mut stats = weavy::ir::program_stats(program);
-    for op in program {
-        if let WeavyOp::Intrinsic(intrinsic) = op {
-            add_canonical_value_intrinsic_stats(intrinsic, &mut stats);
-        }
-    }
-    stats
+    weavy::ir::program_stats_with_intrinsic_children(program)
 }
 
 /// Count a canonical PHON dynamic-value lowered program and its block table.
 #[must_use]
 pub fn canonical_value_lowered_stats(lowered: &CanonicalValueProgram) -> LoweredProgramStats {
-    let root = canonical_value_program_stats(&lowered.program);
-    let mut blocks = ProgramStats::default();
-    for block in lowered.blocks.values() {
-        blocks.accumulate(canonical_value_program_stats(block));
-    }
-    let mut total = root;
-    total.accumulate(blocks);
-
-    let mut stats = LoweredProgramStats::default();
-    stats.root = root;
-    stats.blocks = blocks;
-    stats.total = total;
-    stats.block_count = lowered.blocks.len();
-    stats
+    weavy::ir::lowered_program_stats_with_intrinsic_children(lowered)
 }
 
 /// Count PHON dynamic-value intrinsic descriptors in a canonical program,
@@ -286,13 +293,7 @@ pub fn canonical_value_lowered_stats(lowered: &CanonicalValueProgram) -> Lowered
 pub fn canonical_value_intrinsic_counts(
     program: &[ValueOp],
 ) -> BTreeMap<IntrinsicDescriptor, usize> {
-    let mut counts = weavy::ir::intrinsic_counts(program);
-    for op in program {
-        if let WeavyOp::Intrinsic(intrinsic) = op {
-            add_canonical_value_intrinsic_counts(intrinsic, &mut counts);
-        }
-    }
-    counts
+    weavy::ir::intrinsic_counts_with_intrinsic_children(program)
 }
 
 /// Count PHON dynamic-value intrinsic descriptors in a canonical lowered
@@ -301,38 +302,21 @@ pub fn canonical_value_intrinsic_counts(
 pub fn canonical_value_lowered_intrinsic_counts(
     lowered: &CanonicalValueProgram,
 ) -> BTreeMap<IntrinsicDescriptor, usize> {
-    let mut counts = canonical_value_intrinsic_counts(&lowered.program);
-    for block in lowered.blocks.values() {
-        for (descriptor, count) in canonical_value_intrinsic_counts(block) {
-            *counts.entry(descriptor).or_default() += count;
-        }
-    }
-    counts
+    weavy::ir::lowered_intrinsic_counts_with_intrinsic_children(lowered)
 }
 
 /// Count canonical PHON dynamic-value effects, recursively entering value
 /// intrinsics with nested child programs.
 #[must_use]
 pub fn canonical_value_program_effect_stats(program: &[ValueOp]) -> EffectStats {
-    let mut stats = weavy::ir::effect_stats(program);
-    for op in program {
-        if let WeavyOp::Intrinsic(intrinsic) = op {
-            add_canonical_value_intrinsic_effect_stats(intrinsic, &mut stats);
-        }
-    }
-    stats
+    weavy::ir::effect_stats_with_intrinsic_children(program)
 }
 
 /// Count canonical PHON dynamic-value effects in a lowered program and its
 /// block table.
 #[must_use]
 pub fn canonical_value_lowered_effect_stats(lowered: &CanonicalValueProgram) -> LoweredEffectStats {
-    let root = canonical_value_program_effect_stats(&lowered.program);
-    let mut blocks = EffectStats::default();
-    for block in lowered.blocks.values() {
-        blocks.accumulate(canonical_value_program_effect_stats(block));
-    }
-    LoweredEffectStats::new(root, blocks, lowered.blocks.len())
+    weavy::ir::lowered_effect_stats_with_intrinsic_children(lowered)
 }
 
 /// Canonical-to-legacy dynamic-value conversion failure.
@@ -520,96 +504,6 @@ fn value_op_from_intrinsic(intrinsic: ValueIntrinsic) -> Result<Op, CanonicalVal
                 .collect::<Result<_, CanonicalValueError>>()?,
         },
     })
-}
-
-fn add_canonical_value_intrinsic_stats(intrinsic: &ValueIntrinsic, stats: &mut ProgramStats) {
-    match intrinsic {
-        ValueIntrinsic::Seq { body, .. } | ValueIntrinsic::FixedArray { body, .. } => {
-            stats.accumulate(canonical_value_program_stats(body));
-        }
-        ValueIntrinsic::Map { key, value } => {
-            stats.accumulate(canonical_value_program_stats(key));
-            stats.accumulate(canonical_value_program_stats(value));
-        }
-        ValueIntrinsic::Option { some } => {
-            stats.accumulate(canonical_value_program_stats(some));
-        }
-        ValueIntrinsic::Enum { arms } => {
-            for arm in arms {
-                stats.accumulate(canonical_value_program_stats(&arm.payload));
-            }
-        }
-        ValueIntrinsic::Scalar(_)
-        | ValueIntrinsic::Dynamic
-        | ValueIntrinsic::Null
-        | ValueIntrinsic::Skip(_)
-        | ValueIntrinsic::Object { .. }
-        | ValueIntrinsic::Array { .. } => {}
-    }
-}
-
-fn add_canonical_value_intrinsic_counts(
-    intrinsic: &ValueIntrinsic,
-    counts: &mut BTreeMap<IntrinsicDescriptor, usize>,
-) {
-    match intrinsic {
-        ValueIntrinsic::Seq { body, .. } | ValueIntrinsic::FixedArray { body, .. } => {
-            add_canonical_value_program_intrinsic_counts(body, counts);
-        }
-        ValueIntrinsic::Map { key, value } => {
-            add_canonical_value_program_intrinsic_counts(key, counts);
-            add_canonical_value_program_intrinsic_counts(value, counts);
-        }
-        ValueIntrinsic::Option { some } => {
-            add_canonical_value_program_intrinsic_counts(some, counts);
-        }
-        ValueIntrinsic::Enum { arms } => {
-            for arm in arms {
-                add_canonical_value_program_intrinsic_counts(&arm.payload, counts);
-            }
-        }
-        ValueIntrinsic::Scalar(_)
-        | ValueIntrinsic::Dynamic
-        | ValueIntrinsic::Null
-        | ValueIntrinsic::Skip(_)
-        | ValueIntrinsic::Object { .. }
-        | ValueIntrinsic::Array { .. } => {}
-    }
-}
-
-fn add_canonical_value_intrinsic_effect_stats(intrinsic: &ValueIntrinsic, stats: &mut EffectStats) {
-    match intrinsic {
-        ValueIntrinsic::Seq { body, .. } | ValueIntrinsic::FixedArray { body, .. } => {
-            stats.accumulate(canonical_value_program_effect_stats(body));
-        }
-        ValueIntrinsic::Map { key, value } => {
-            stats.accumulate(canonical_value_program_effect_stats(key));
-            stats.accumulate(canonical_value_program_effect_stats(value));
-        }
-        ValueIntrinsic::Option { some } => {
-            stats.accumulate(canonical_value_program_effect_stats(some));
-        }
-        ValueIntrinsic::Enum { arms } => {
-            for arm in arms {
-                stats.accumulate(canonical_value_program_effect_stats(&arm.payload));
-            }
-        }
-        ValueIntrinsic::Scalar(_)
-        | ValueIntrinsic::Dynamic
-        | ValueIntrinsic::Null
-        | ValueIntrinsic::Skip(_)
-        | ValueIntrinsic::Object { .. }
-        | ValueIntrinsic::Array { .. } => {}
-    }
-}
-
-fn add_canonical_value_program_intrinsic_counts(
-    program: &[ValueOp],
-    counts: &mut BTreeMap<IntrinsicDescriptor, usize>,
-) {
-    for (descriptor, count) in canonical_value_intrinsic_counts(program) {
-        *counts.entry(descriptor).or_default() += count;
-    }
 }
 
 /// A lowered *typed* program: the memory side of the IR. Where [`Program`] builds

--- a/weavy/src/ir.rs
+++ b/weavy/src/ir.rs
@@ -426,6 +426,22 @@ pub trait IntrinsicOp {
     }
 }
 
+/// Intrinsic hook for nested child programs.
+///
+/// Some domain intrinsics carry executable child programs inside their payload:
+/// a sequence element body, an option payload, a map key/value pair, and so on.
+/// Flat helpers such as [`program_stats`] count only the explicit outer op
+/// stream. The `*_with_intrinsic_children` helpers also enter programs exposed
+/// through this trait.
+pub trait IntrinsicChildren<Block>: IntrinsicOp {
+    /// Visit each child program owned by this intrinsic.
+    fn visit_child_programs<'a>(&'a self, _visit: &mut dyn FnMut(&'a [WeavyOp<Block, Self>]))
+    where
+        Self: Sized,
+    {
+    }
+}
+
 /// Error while resolving symbolic canonical block ids into dense refs.
 #[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -634,6 +650,20 @@ pub fn program_stats<Block, Intrinsic>(program: &[WeavyOp<Block, Intrinsic>]) ->
     stats
 }
 
+/// Count the canonical IR shape for one program, recursively entering child
+/// programs exposed by intrinsics.
+#[must_use]
+pub fn program_stats_with_intrinsic_children<Block, Intrinsic>(
+    program: &[WeavyOp<Block, Intrinsic>],
+) -> ProgramStats
+where
+    Intrinsic: IntrinsicChildren<Block>,
+{
+    let mut stats = ProgramStats::default();
+    add_program_stats_with_intrinsic_children(program, &mut stats);
+    stats
+}
+
 /// Count the canonical IR shape for a lowered program and its block table.
 #[must_use]
 pub fn lowered_program_stats<Block, Intrinsic>(
@@ -658,6 +688,32 @@ where
     }
 }
 
+/// Count the canonical IR shape for a lowered program and its block table,
+/// recursively entering child programs exposed by intrinsics.
+#[must_use]
+pub fn lowered_program_stats_with_intrinsic_children<Block, Intrinsic>(
+    lowered: &WeavyLowered<Block, Intrinsic>,
+) -> LoweredProgramStats
+where
+    Block: Ord,
+    Intrinsic: IntrinsicChildren<Block>,
+{
+    let root = program_stats_with_intrinsic_children(&lowered.program);
+    let mut blocks = ProgramStats::default();
+    for block in lowered.blocks.values() {
+        blocks.accumulate(program_stats_with_intrinsic_children(block));
+    }
+    let mut total = root;
+    total.accumulate(blocks);
+
+    LoweredProgramStats {
+        root,
+        blocks,
+        total,
+        block_count: lowered.blocks.len(),
+    }
+}
+
 /// Count the canonical IR shape for a dense lowered program and its block table.
 #[must_use]
 pub fn dense_lowered_program_stats<Intrinsic>(
@@ -667,6 +723,31 @@ pub fn dense_lowered_program_stats<Intrinsic>(
     let mut blocks = ProgramStats::default();
     for block in &lowered.blocks {
         blocks.accumulate(program_stats(block));
+    }
+    let mut total = root;
+    total.accumulate(blocks);
+
+    LoweredProgramStats {
+        root,
+        blocks,
+        total,
+        block_count: lowered.blocks.len(),
+    }
+}
+
+/// Count the canonical IR shape for a dense lowered program and its block table,
+/// recursively entering child programs exposed by intrinsics.
+#[must_use]
+pub fn dense_lowered_program_stats_with_intrinsic_children<Intrinsic>(
+    lowered: &DenseWeavyLowered<Intrinsic>,
+) -> LoweredProgramStats
+where
+    Intrinsic: IntrinsicChildren<BlockRef>,
+{
+    let root = program_stats_with_intrinsic_children(&lowered.program);
+    let mut blocks = ProgramStats::default();
+    for block in &lowered.blocks {
+        blocks.accumulate(program_stats_with_intrinsic_children(block));
     }
     let mut total = root;
     total.accumulate(blocks);
@@ -705,6 +786,20 @@ where
     stats
 }
 
+/// Count effect contracts for one canonical program, recursively entering child
+/// programs exposed by intrinsics.
+#[must_use]
+pub fn effect_stats_with_intrinsic_children<Block, Intrinsic>(
+    program: &[WeavyOp<Block, Intrinsic>],
+) -> EffectStats
+where
+    Intrinsic: IntrinsicChildren<Block>,
+{
+    let mut stats = EffectStats::default();
+    add_effect_stats_with_intrinsic_children(program, &mut stats);
+    stats
+}
+
 /// Count effect contracts for a canonical lowered program and its block table.
 #[must_use]
 pub fn lowered_effect_stats<Block, Intrinsic>(
@@ -730,6 +825,24 @@ where
     }
 }
 
+/// Count effect contracts for a canonical lowered program and its block table,
+/// recursively entering child programs exposed by intrinsics.
+#[must_use]
+pub fn lowered_effect_stats_with_intrinsic_children<Block, Intrinsic>(
+    lowered: &WeavyLowered<Block, Intrinsic>,
+) -> LoweredEffectStats
+where
+    Block: Ord,
+    Intrinsic: IntrinsicChildren<Block>,
+{
+    let root = effect_stats_with_intrinsic_children(&lowered.program);
+    let mut blocks = EffectStats::default();
+    for block in lowered.blocks.values() {
+        blocks.accumulate(effect_stats_with_intrinsic_children(block));
+    }
+    LoweredEffectStats::new(root, blocks, lowered.blocks.len())
+}
+
 /// Count effect contracts for a dense canonical lowered program and its block table.
 #[must_use]
 pub fn dense_lowered_effect_stats<Intrinsic>(
@@ -742,6 +855,23 @@ where
     let mut blocks = EffectStats::default();
     for block in &lowered.blocks {
         blocks.accumulate(effect_stats(block));
+    }
+    LoweredEffectStats::new(root, blocks, lowered.blocks.len())
+}
+
+/// Count effect contracts for a dense canonical lowered program and its block
+/// table, recursively entering child programs exposed by intrinsics.
+#[must_use]
+pub fn dense_lowered_effect_stats_with_intrinsic_children<Intrinsic>(
+    lowered: &DenseWeavyLowered<Intrinsic>,
+) -> LoweredEffectStats
+where
+    Intrinsic: IntrinsicChildren<BlockRef>,
+{
+    let root = effect_stats_with_intrinsic_children(&lowered.program);
+    let mut blocks = EffectStats::default();
+    for block in &lowered.blocks {
+        blocks.accumulate(effect_stats_with_intrinsic_children(block));
     }
     LoweredEffectStats::new(root, blocks, lowered.blocks.len())
 }
@@ -760,6 +890,22 @@ fn add_program_stats<Block, Intrinsic>(
             WeavyOp::Intrinsic(_) => {
                 stats.intrinsic_op_count += 1;
             }
+        }
+    }
+}
+
+fn add_program_stats_with_intrinsic_children<Block, Intrinsic>(
+    program: &[WeavyOp<Block, Intrinsic>],
+    stats: &mut ProgramStats,
+) where
+    Intrinsic: IntrinsicChildren<Block>,
+{
+    add_program_stats(program, stats);
+    for op in program {
+        if let WeavyOp::Intrinsic(intrinsic) = op {
+            intrinsic.visit_child_programs(&mut |child| {
+                add_program_stats_with_intrinsic_children(child, stats);
+            });
         }
     }
 }
@@ -911,6 +1057,22 @@ fn add_effect_stats<Block, Intrinsic>(
     }
 }
 
+fn add_effect_stats_with_intrinsic_children<Block, Intrinsic>(
+    program: &[WeavyOp<Block, Intrinsic>],
+    stats: &mut EffectStats,
+) where
+    Intrinsic: IntrinsicChildren<Block>,
+{
+    add_effect_stats(program, stats);
+    for op in program {
+        if let WeavyOp::Intrinsic(intrinsic) = op {
+            intrinsic.visit_child_programs(&mut |child| {
+                add_effect_stats_with_intrinsic_children(child, stats);
+            });
+        }
+    }
+}
+
 fn add_contract_stats(contract: &EffectContract, stats: &mut EffectStats) {
     if contract.opaque {
         stats.opaque_count += 1;
@@ -1010,6 +1172,20 @@ where
     counts
 }
 
+/// Count intrinsic descriptors in one canonical program, recursively entering
+/// child programs exposed by intrinsics.
+#[must_use]
+pub fn intrinsic_counts_with_intrinsic_children<Block, Intrinsic>(
+    program: &[WeavyOp<Block, Intrinsic>],
+) -> BTreeMap<IntrinsicDescriptor, usize>
+where
+    Intrinsic: IntrinsicChildren<Block>,
+{
+    let mut counts = BTreeMap::new();
+    add_intrinsic_counts_with_intrinsic_children(program, &mut counts);
+    counts
+}
+
 /// Count intrinsic descriptors in a lowered canonical program.
 #[must_use]
 pub fn lowered_intrinsic_counts<Block, Intrinsic>(
@@ -1022,6 +1198,23 @@ where
     let mut counts = intrinsic_counts(&lowered.program);
     for block in lowered.blocks.values() {
         add_intrinsic_counts(block, &mut counts);
+    }
+    counts
+}
+
+/// Count intrinsic descriptors in a lowered canonical program, recursively
+/// entering child programs exposed by intrinsics.
+#[must_use]
+pub fn lowered_intrinsic_counts_with_intrinsic_children<Block, Intrinsic>(
+    lowered: &WeavyLowered<Block, Intrinsic>,
+) -> BTreeMap<IntrinsicDescriptor, usize>
+where
+    Block: Ord,
+    Intrinsic: IntrinsicChildren<Block>,
+{
+    let mut counts = intrinsic_counts_with_intrinsic_children(&lowered.program);
+    for block in lowered.blocks.values() {
+        add_intrinsic_counts_with_intrinsic_children(block, &mut counts);
     }
     counts
 }
@@ -1041,6 +1234,22 @@ where
     counts
 }
 
+/// Count intrinsic descriptors in a dense lowered canonical program,
+/// recursively entering child programs exposed by intrinsics.
+#[must_use]
+pub fn dense_lowered_intrinsic_counts_with_intrinsic_children<Intrinsic>(
+    lowered: &DenseWeavyLowered<Intrinsic>,
+) -> BTreeMap<IntrinsicDescriptor, usize>
+where
+    Intrinsic: IntrinsicChildren<BlockRef>,
+{
+    let mut counts = intrinsic_counts_with_intrinsic_children(&lowered.program);
+    for block in &lowered.blocks {
+        add_intrinsic_counts_with_intrinsic_children(block, &mut counts);
+    }
+    counts
+}
+
 fn add_intrinsic_counts<Block, Intrinsic>(
     program: &[WeavyOp<Block, Intrinsic>],
     counts: &mut BTreeMap<IntrinsicDescriptor, usize>,
@@ -1054,6 +1263,22 @@ fn add_intrinsic_counts<Block, Intrinsic>(
     }
 }
 
+fn add_intrinsic_counts_with_intrinsic_children<Block, Intrinsic>(
+    program: &[WeavyOp<Block, Intrinsic>],
+    counts: &mut BTreeMap<IntrinsicDescriptor, usize>,
+) where
+    Intrinsic: IntrinsicChildren<Block>,
+{
+    add_intrinsic_counts(program, counts);
+    for op in program {
+        if let WeavyOp::Intrinsic(intrinsic) = op {
+            intrinsic.visit_child_programs(&mut |child| {
+                add_intrinsic_counts_with_intrinsic_children(child, counts);
+            });
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1062,6 +1287,7 @@ mod tests {
     enum TestIntrinsic {
         ReadI32,
         HashField,
+        Nested(Vec<WeavyOp<(), TestIntrinsic>>),
     }
 
     impl IntrinsicOp for TestIntrinsic {
@@ -1074,6 +1300,10 @@ mod tests {
                 TestIntrinsic::HashField => IntrinsicDescriptor {
                     dialect: "hash",
                     name: "feed_field",
+                },
+                TestIntrinsic::Nested(_) => IntrinsicDescriptor {
+                    dialect: "test",
+                    name: "nested",
                 },
             }
         }
@@ -1091,6 +1321,17 @@ mod tests {
                 TestIntrinsic::HashField => EffectContract::new()
                     .typed_memory(MemoryRegion::base_relative(4, 8), TypedMemoryAccess::Read)
                     .write_resource(EffectResource::Sink("hash")),
+                TestIntrinsic::Nested(_) => {
+                    EffectContract::new().write_resource(EffectResource::SideChannel("test.nested"))
+                }
+            }
+        }
+    }
+
+    impl IntrinsicChildren<()> for TestIntrinsic {
+        fn visit_child_programs<'a>(&'a self, visit: &mut dyn FnMut(&'a [WeavyOp<(), Self>])) {
+            if let TestIntrinsic::Nested(program) = self {
+                visit(program);
             }
         }
     }
@@ -1372,5 +1613,51 @@ mod tests {
         assert_eq!(stats.typed_memory_read_count, 1);
         assert_eq!(stats.typed_memory_initialize_count, 1);
         assert_eq!(stats.opaque_count, 0);
+    }
+
+    #[test]
+    fn intrinsic_child_helpers_enter_nested_programs() {
+        let child = vec![
+            WeavyOp::<(), _>::Intrinsic(TestIntrinsic::ReadI32),
+            WeavyOp::Intrinsic(TestIntrinsic::HashField),
+        ];
+        let program = vec![WeavyOp::Intrinsic(TestIntrinsic::Nested(child))];
+
+        let flat = program_stats(&program);
+        assert_eq!(flat.op_count, 1);
+        assert_eq!(flat.intrinsic_op_count, 1);
+
+        let recursive = program_stats_with_intrinsic_children(&program);
+        assert_eq!(recursive.op_count, 3);
+        assert_eq!(recursive.intrinsic_op_count, 3);
+
+        let effects = effect_stats_with_intrinsic_children(&program);
+        assert_eq!(effects.op_count, 3);
+        assert_eq!(effects.input_advance_count, 1);
+        assert_eq!(effects.sink_write_count, 1);
+        assert_eq!(effects.side_channel_count, 1);
+
+        let counts = intrinsic_counts_with_intrinsic_children(&program);
+        assert_eq!(
+            counts[&IntrinsicDescriptor {
+                dialect: "test",
+                name: "nested",
+            }],
+            1
+        );
+        assert_eq!(
+            counts[&IntrinsicDescriptor {
+                dialect: "json",
+                name: "read_i32",
+            }],
+            1
+        );
+        assert_eq!(
+            counts[&IntrinsicDescriptor {
+                dialect: "hash",
+                name: "feed_field",
+            }],
+            1
+        );
     }
 }

--- a/weavy/src/mem.rs
+++ b/weavy/src/mem.rs
@@ -10,8 +10,8 @@ pub mod runtime;
 use std::collections::BTreeMap;
 
 use crate::ir::{
-    ControlOp, EffectContract, EffectResource, IntrinsicDescriptor, IntrinsicOp, MemoryOp,
-    MemoryRegion, TypedMemoryAccess, WeavyLowered, WeavyOp, WeavyProgram,
+    ControlOp, EffectContract, EffectResource, IntrinsicChildren, IntrinsicDescriptor, IntrinsicOp,
+    MemoryOp, MemoryRegion, TypedMemoryAccess, WeavyLowered, WeavyOp, WeavyProgram,
 };
 
 /// A type-erased "write this field's default in place" operation, supplied by
@@ -1214,6 +1214,37 @@ impl<BlockId> IntrinsicOp for MemIntrinsic<BlockId> {
     }
 }
 
+impl<BlockId> IntrinsicChildren<BlockId> for MemIntrinsic<BlockId> {
+    fn visit_child_programs<'a>(&'a self, visit: &mut dyn FnMut(&'a [WeavyOp<BlockId, Self>])) {
+        match self {
+            MemIntrinsic::Sequence(op) => visit(&op.element),
+            MemIntrinsic::Set(op) => visit(&op.element),
+            MemIntrinsic::Option(op) => visit(&op.some),
+            MemIntrinsic::Enum(op) => {
+                for variant in &op.variants {
+                    visit(&variant.payload);
+                }
+            }
+            MemIntrinsic::Map(op) => {
+                visit(&op.key);
+                visit(&op.value);
+            }
+            MemIntrinsic::Result(op) => {
+                visit(&op.ok);
+                visit(&op.err);
+            }
+            MemIntrinsic::Pointer(op) => visit(&op.pointee),
+            MemIntrinsic::NativeInt { .. }
+            | MemIntrinsic::Bytes(_)
+            | MemIntrinsic::Borrow(_)
+            | MemIntrinsic::Dynamic { .. }
+            | MemIntrinsic::SkipWire(_)
+            | MemIntrinsic::Default(_)
+            | MemIntrinsic::Opaque(_) => {}
+        }
+    }
+}
+
 fn stream_memory_effect(offset: usize, size: usize) -> EffectContract {
     EffectContract::new()
         .read_resource(EffectResource::Input("wire"))
@@ -1360,13 +1391,7 @@ where
 pub fn canonical_mem_program_stats<BlockId>(
     program: &[WeavyOp<BlockId, MemIntrinsic<BlockId>>],
 ) -> crate::ir::ProgramStats {
-    let mut stats = crate::ir::program_stats(program);
-    for op in program {
-        if let WeavyOp::Intrinsic(intrinsic) = op {
-            add_canonical_mem_intrinsic_stats(intrinsic, &mut stats);
-        }
-    }
-    stats
+    crate::ir::program_stats_with_intrinsic_children(program)
 }
 
 /// Count a canonical typed-memory lowered program, recursively entering mem intrinsics.
@@ -1377,20 +1402,7 @@ pub fn canonical_mem_lowered_stats<BlockId>(
 where
     BlockId: Ord,
 {
-    let root = canonical_mem_program_stats(&lowered.program);
-    let mut blocks = crate::ir::ProgramStats::default();
-    for block in lowered.blocks.values() {
-        blocks.accumulate(canonical_mem_program_stats(block));
-    }
-    let mut total = root;
-    total.accumulate(blocks);
-
-    crate::ir::LoweredProgramStats {
-        root,
-        blocks,
-        total,
-        block_count: lowered.blocks.len(),
-    }
+    crate::ir::lowered_program_stats_with_intrinsic_children(lowered)
 }
 
 /// Count mem intrinsic descriptors in a canonical program, including nested children.
@@ -1398,13 +1410,7 @@ where
 pub fn canonical_mem_intrinsic_counts<BlockId>(
     program: &[WeavyOp<BlockId, MemIntrinsic<BlockId>>],
 ) -> BTreeMap<IntrinsicDescriptor, usize> {
-    let mut counts = crate::ir::intrinsic_counts(program);
-    for op in program {
-        if let WeavyOp::Intrinsic(intrinsic) = op {
-            add_canonical_mem_intrinsic_counts(intrinsic, &mut counts);
-        }
-    }
-    counts
+    crate::ir::intrinsic_counts_with_intrinsic_children(program)
 }
 
 /// Count mem intrinsic descriptors in a canonical lowered program.
@@ -1415,13 +1421,7 @@ pub fn canonical_mem_lowered_intrinsic_counts<BlockId>(
 where
     BlockId: Ord,
 {
-    let mut counts = canonical_mem_intrinsic_counts(&lowered.program);
-    for block in lowered.blocks.values() {
-        for (descriptor, count) in canonical_mem_intrinsic_counts(block) {
-            *counts.entry(descriptor).or_default() += count;
-        }
-    }
-    counts
+    crate::ir::lowered_intrinsic_counts_with_intrinsic_children(lowered)
 }
 
 /// Count canonical typed-memory effects, recursively entering mem intrinsics.
@@ -1429,13 +1429,7 @@ where
 pub fn canonical_mem_program_effect_stats<BlockId>(
     program: &[WeavyOp<BlockId, MemIntrinsic<BlockId>>],
 ) -> crate::ir::EffectStats {
-    let mut stats = crate::ir::effect_stats(program);
-    for op in program {
-        if let WeavyOp::Intrinsic(intrinsic) = op {
-            add_canonical_mem_intrinsic_effect_stats(intrinsic, &mut stats);
-        }
-    }
-    stats
+    crate::ir::effect_stats_with_intrinsic_children(program)
 }
 
 /// Count canonical typed-memory effects in a lowered program.
@@ -1446,20 +1440,7 @@ pub fn canonical_mem_lowered_effect_stats<BlockId>(
 where
     BlockId: Ord,
 {
-    let root = canonical_mem_program_effect_stats(&lowered.program);
-    let mut blocks = crate::ir::EffectStats::default();
-    for block in lowered.blocks.values() {
-        blocks.accumulate(canonical_mem_program_effect_stats(block));
-    }
-    let mut total = root;
-    total.accumulate(blocks);
-
-    crate::ir::LoweredEffectStats {
-        root,
-        blocks,
-        total,
-        block_count: lowered.blocks.len(),
-    }
+    crate::ir::lowered_effect_stats_with_intrinsic_children(lowered)
 }
 
 fn canonical_mem_op<BlockId>(op: MemOp<BlockId>) -> WeavyOp<BlockId, MemIntrinsic<BlockId>> {
@@ -1692,119 +1673,6 @@ fn mem_op_from_intrinsic<BlockId>(
         MemIntrinsic::Default(op) => MemOp::Default(op),
         MemIntrinsic::Opaque(op) => MemOp::Opaque(op),
     })
-}
-
-fn add_canonical_mem_intrinsic_stats<BlockId>(
-    intrinsic: &MemIntrinsic<BlockId>,
-    stats: &mut crate::ir::ProgramStats,
-) {
-    match intrinsic {
-        MemIntrinsic::Sequence(op) => stats.accumulate(canonical_mem_program_stats(&op.element)),
-        MemIntrinsic::Set(op) => stats.accumulate(canonical_mem_program_stats(&op.element)),
-        MemIntrinsic::Option(op) => stats.accumulate(canonical_mem_program_stats(&op.some)),
-        MemIntrinsic::Enum(op) => {
-            for variant in &op.variants {
-                stats.accumulate(canonical_mem_program_stats(&variant.payload));
-            }
-        }
-        MemIntrinsic::Map(op) => {
-            stats.accumulate(canonical_mem_program_stats(&op.key));
-            stats.accumulate(canonical_mem_program_stats(&op.value));
-        }
-        MemIntrinsic::Result(op) => {
-            stats.accumulate(canonical_mem_program_stats(&op.ok));
-            stats.accumulate(canonical_mem_program_stats(&op.err));
-        }
-        MemIntrinsic::Pointer(op) => stats.accumulate(canonical_mem_program_stats(&op.pointee)),
-        MemIntrinsic::NativeInt { .. }
-        | MemIntrinsic::Bytes(_)
-        | MemIntrinsic::Borrow(_)
-        | MemIntrinsic::Dynamic { .. }
-        | MemIntrinsic::SkipWire(_)
-        | MemIntrinsic::Default(_)
-        | MemIntrinsic::Opaque(_) => {}
-    }
-}
-
-fn add_canonical_mem_intrinsic_counts<BlockId>(
-    intrinsic: &MemIntrinsic<BlockId>,
-    counts: &mut BTreeMap<IntrinsicDescriptor, usize>,
-) {
-    match intrinsic {
-        MemIntrinsic::Sequence(op) => {
-            add_canonical_mem_program_intrinsic_counts(&op.element, counts)
-        }
-        MemIntrinsic::Set(op) => add_canonical_mem_program_intrinsic_counts(&op.element, counts),
-        MemIntrinsic::Option(op) => add_canonical_mem_program_intrinsic_counts(&op.some, counts),
-        MemIntrinsic::Enum(op) => {
-            for variant in &op.variants {
-                add_canonical_mem_program_intrinsic_counts(&variant.payload, counts);
-            }
-        }
-        MemIntrinsic::Map(op) => {
-            add_canonical_mem_program_intrinsic_counts(&op.key, counts);
-            add_canonical_mem_program_intrinsic_counts(&op.value, counts);
-        }
-        MemIntrinsic::Result(op) => {
-            add_canonical_mem_program_intrinsic_counts(&op.ok, counts);
-            add_canonical_mem_program_intrinsic_counts(&op.err, counts);
-        }
-        MemIntrinsic::Pointer(op) => {
-            add_canonical_mem_program_intrinsic_counts(&op.pointee, counts)
-        }
-        MemIntrinsic::NativeInt { .. }
-        | MemIntrinsic::Bytes(_)
-        | MemIntrinsic::Borrow(_)
-        | MemIntrinsic::Dynamic { .. }
-        | MemIntrinsic::SkipWire(_)
-        | MemIntrinsic::Default(_)
-        | MemIntrinsic::Opaque(_) => {}
-    }
-}
-
-fn add_canonical_mem_intrinsic_effect_stats<BlockId>(
-    intrinsic: &MemIntrinsic<BlockId>,
-    stats: &mut crate::ir::EffectStats,
-) {
-    match intrinsic {
-        MemIntrinsic::Sequence(op) => {
-            stats.accumulate(canonical_mem_program_effect_stats(&op.element))
-        }
-        MemIntrinsic::Set(op) => stats.accumulate(canonical_mem_program_effect_stats(&op.element)),
-        MemIntrinsic::Option(op) => stats.accumulate(canonical_mem_program_effect_stats(&op.some)),
-        MemIntrinsic::Enum(op) => {
-            for variant in &op.variants {
-                stats.accumulate(canonical_mem_program_effect_stats(&variant.payload));
-            }
-        }
-        MemIntrinsic::Map(op) => {
-            stats.accumulate(canonical_mem_program_effect_stats(&op.key));
-            stats.accumulate(canonical_mem_program_effect_stats(&op.value));
-        }
-        MemIntrinsic::Result(op) => {
-            stats.accumulate(canonical_mem_program_effect_stats(&op.ok));
-            stats.accumulate(canonical_mem_program_effect_stats(&op.err));
-        }
-        MemIntrinsic::Pointer(op) => {
-            stats.accumulate(canonical_mem_program_effect_stats(&op.pointee))
-        }
-        MemIntrinsic::NativeInt { .. }
-        | MemIntrinsic::Bytes(_)
-        | MemIntrinsic::Borrow(_)
-        | MemIntrinsic::Dynamic { .. }
-        | MemIntrinsic::SkipWire(_)
-        | MemIntrinsic::Default(_)
-        | MemIntrinsic::Opaque(_) => {}
-    }
-}
-
-fn add_canonical_mem_program_intrinsic_counts<BlockId>(
-    program: &[WeavyOp<BlockId, MemIntrinsic<BlockId>>],
-    counts: &mut BTreeMap<IntrinsicDescriptor, usize>,
-) {
-    for (descriptor, count) in canonical_mem_intrinsic_counts(program) {
-        *counts.entry(descriptor).or_default() += count;
-    }
 }
 
 /// Errors from shape-only lowering helpers.


### PR DESCRIPTION
## Summary
- add `IntrinsicChildren` plus recursive Weavy stats, effect, and intrinsic-count helpers for intrinsics that own child programs
- migrate canonical Weavy typed-memory diagnostics to the shared recursive helpers
- migrate PHON dynamic-value canonical diagnostics to the same shared traversal

## Notes
- `facet-hash` keeps its custom effect walker for now because it also accounts for scalar shorthand children that are intentionally not represented as child programs.

## Testing
- `cargo fmt --all`
- `cargo check -p weavy -p phon-ir -p phon-engine --all-features --all-targets --message-format=short`
- `cargo nextest list -p weavy -p phon-ir -p phon-engine -E "test(intrinsic_child_helpers_enter_nested_programs) | test(canonical_mem_stats_enter_nested_intrinsic_programs) | test(canonical_mem_effect_stats_enter_nested_intrinsic_programs) | test(canonical_value_analysis_enters_nested_intrinsic_programs) | test(lowered_ir_report_includes_static_shape_and_runner_counters) | test(typed_lowering_roundtrips_through_canonical_weavy_ir)"`
- `cargo nextest run -p weavy -p phon-ir -p phon-engine -E "test(intrinsic_child_helpers_enter_nested_programs) | test(canonical_mem_stats_enter_nested_intrinsic_programs) | test(canonical_mem_effect_stats_enter_nested_intrinsic_programs) | test(canonical_value_analysis_enters_nested_intrinsic_programs) | test(lowered_ir_report_includes_static_shape_and_runner_counters) | test(typed_lowering_roundtrips_through_canonical_weavy_ir)"`
- `cargo nextest list -p weavy -p phon-ir -p phon-engine`
- `cargo nextest run -p weavy -p phon-ir -p phon-engine`
- `cargo check -p facet-hash -p fable --all-features --all-targets --message-format=short`
- pre-push hook passed: clippy, docs, build tests, run tests