### PR TITLE
Share facet-hash Weavy analysis

### DIFF
--- a/facet-hash/src/lib.rs
+++ b/facet-hash/src/lib.rs
@@ -21,8 +21,8 @@ use facet_core::{
     ResultDef, ScalarType, SetDef, Shape, SliceDef, StructKind, Type, UserType,
 };
 use weavy::ir::{
-    ControlOp, EffectContract, EffectResource, EffectStats, IntrinsicDescriptor, IntrinsicOp,
-    LoweredEffectStats, MemoryRegion, TypedMemoryAccess, WeavyOp,
+    ControlOp, EffectContract, EffectResource, IntrinsicChildren, IntrinsicDescriptor, IntrinsicOp,
+    LoweredAnalysis, LoweredEffectStats, MemoryRegion, TypedMemoryAccess, WeavyOp,
 };
 use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStats, Step};
 
@@ -104,7 +104,12 @@ where
 
     /// Return conservative effect counters for the lowered hash program.
     pub fn effect_stats(&self) -> LoweredEffectStats {
-        hash_lowered_effect_stats(&self.lowered)
+        self.analysis().effect_stats
+    }
+
+    /// Return static Weavy analysis for the lowered hash program.
+    pub fn analysis(&self) -> LoweredAnalysis {
+        hash_lowered_analysis(&self.lowered)
     }
 
     /// Hash `value` with [`std::collections::hash_map::DefaultHasher`].
@@ -302,18 +307,96 @@ impl<Block> IntrinsicOp for HashIntrinsic<Block> {
                 if !fields.is_empty() {
                     effect = effect.barrier();
                 }
+                for field in fields {
+                    effect.accumulate(struct_field_direct_effect(field));
+                }
                 effect
             }
-            HashIntrinsic::Option { .. } | HashIntrinsic::Result { .. } => {
-                thunked_read_effect().barrier()
+            HashIntrinsic::Option { some, .. } => {
+                let mut effect = thunked_read_effect().barrier();
+                effect.accumulate(child_direct_effect(some));
+                effect
             }
-            HashIntrinsic::List { .. }
-            | HashIntrinsic::Array { .. }
-            | HashIntrinsic::Slice { .. }
-            | HashIntrinsic::Pointer { .. } => thunked_read_effect().barrier(),
-            HashIntrinsic::Set { .. } | HashIntrinsic::Map { .. } => {
-                thunked_read_effect().may_allocate().barrier()
+            HashIntrinsic::Result { ok, err, .. } => {
+                let mut effect = thunked_read_effect().barrier();
+                effect.accumulate(child_direct_effect(ok));
+                effect.accumulate(child_direct_effect(err));
+                effect
             }
+            HashIntrinsic::List { element, .. }
+            | HashIntrinsic::Array { element, .. }
+            | HashIntrinsic::Slice { element, .. } => {
+                let mut effect = thunked_read_effect().barrier();
+                effect.accumulate(child_direct_effect(element));
+                effect
+            }
+            HashIntrinsic::Set { element, .. } => {
+                let mut effect = thunked_read_effect().may_allocate().barrier();
+                effect.accumulate(child_direct_effect(element));
+                effect
+            }
+            HashIntrinsic::Map { key, value, .. } => {
+                let mut effect = thunked_read_effect().may_allocate().barrier();
+                effect.accumulate(child_direct_effect(key));
+                effect.accumulate(child_direct_effect(value));
+                effect
+            }
+            HashIntrinsic::Pointer { pointee, .. } => {
+                let mut effect = thunked_read_effect().barrier();
+                effect.accumulate(child_direct_effect(pointee));
+                effect
+            }
+        }
+    }
+}
+
+impl<Block> IntrinsicChildren<Block> for HashIntrinsic<Block> {
+    fn visit_child_programs<'a>(&'a self, visit: &mut dyn FnMut(&'a [WeavyOp<Block, Self>])) {
+        match self {
+            HashIntrinsic::Struct { fields, .. } => {
+                for field in fields {
+                    field.visit_child_programs(visit);
+                }
+            }
+            HashIntrinsic::Option { some, .. } => some.visit_child_programs(visit),
+            HashIntrinsic::Result { ok, err, .. } => {
+                ok.visit_child_programs(visit);
+                err.visit_child_programs(visit);
+            }
+            HashIntrinsic::List { element, .. }
+            | HashIntrinsic::Array { element, .. }
+            | HashIntrinsic::Slice { element, .. }
+            | HashIntrinsic::Set { element, .. } => element.visit_child_programs(visit),
+            HashIntrinsic::Map { key, value, .. } => {
+                key.visit_child_programs(visit);
+                value.visit_child_programs(visit);
+            }
+            HashIntrinsic::Pointer { pointee, .. } => pointee.visit_child_programs(visit),
+            HashIntrinsic::Shape(_) | HashIntrinsic::Scalar { .. } => {}
+        }
+    }
+}
+
+impl<Block> ChildPlan<Block> {
+    fn visit_child_programs<'a>(
+        &'a self,
+        visit: &mut dyn FnMut(&'a [WeavyOp<Block, HashIntrinsic<Block>>]),
+    ) {
+        match self {
+            ChildPlan::Program(program) => visit(program),
+            ChildPlan::Scalar { .. } => {}
+        }
+    }
+}
+
+impl<Block> StructFieldPlan<Block> {
+    fn visit_child_programs<'a>(
+        &'a self,
+        visit: &mut dyn FnMut(&'a [WeavyOp<Block, HashIntrinsic<Block>>]),
+    ) {
+        match self {
+            StructFieldPlan::Field(field) => field.child.visit_child_programs(visit),
+            StructFieldPlan::ScalarRun(_) => {}
         }
     }
 }
@@ -338,6 +421,47 @@ fn scalar_hash_effect(shape: &'static Shape, scalar: ScalarType) -> EffectContra
             .ordered(),
         _ => effect.typed_memory(shape_memory_region(shape), TypedMemoryAccess::Read),
     }
+}
+
+fn struct_field_direct_effect<Block>(field: &StructFieldPlan<Block>) -> EffectContract {
+    match field {
+        StructFieldPlan::ScalarRun(run) => {
+            let mut effect = EffectContract::new();
+            for field in run {
+                effect.accumulate(scalar_field_direct_effect(field));
+            }
+            effect
+        }
+        StructFieldPlan::Field(field) => child_direct_effect(&field.child),
+    }
+}
+
+fn scalar_field_direct_effect(field: &ScalarFieldPlan) -> EffectContract {
+    scalar_child_direct_effect(field.include_shape, field.shape, field.scalar)
+}
+
+fn child_direct_effect<Block>(child: &ChildPlan<Block>) -> EffectContract {
+    match child {
+        ChildPlan::Scalar {
+            include_shape,
+            shape,
+            scalar,
+        } => scalar_child_direct_effect(*include_shape, shape, *scalar),
+        ChildPlan::Program(_) => EffectContract::new(),
+    }
+}
+
+fn scalar_child_direct_effect(
+    include_shape: bool,
+    shape: &'static Shape,
+    scalar: ScalarType,
+) -> EffectContract {
+    let mut effect = EffectContract::new();
+    if include_shape {
+        effect.accumulate(hash_sink_effect());
+    }
+    effect.accumulate(scalar_hash_effect(shape, scalar));
+    effect
 }
 
 fn thunked_read_effect() -> EffectContract {
@@ -732,97 +856,8 @@ fn resolve_block_ref(
     })
 }
 
-fn hash_lowered_effect_stats(lowered: &DenseLowered<ExecOp>) -> LoweredEffectStats {
-    let root = hash_program_effect_stats(&lowered.program);
-    let mut blocks = EffectStats::default();
-    for block in &lowered.blocks {
-        blocks.accumulate(hash_program_effect_stats(block));
-    }
-    LoweredEffectStats::new(root, blocks, lowered.blocks.len())
-}
-
-fn hash_program_effect_stats(program: &[ExecOp]) -> EffectStats {
-    let mut stats = weavy::ir::effect_stats(program);
-    for op in program {
-        if let WeavyOp::Intrinsic(intrinsic) = op {
-            add_hash_intrinsic_effect_stats(intrinsic, &mut stats);
-        }
-    }
-    stats
-}
-
-fn add_hash_intrinsic_effect_stats(intrinsic: &HashIntrinsic<ExecBlock>, stats: &mut EffectStats) {
-    match intrinsic {
-        HashIntrinsic::Shape(_) | HashIntrinsic::Scalar { .. } => {}
-        HashIntrinsic::Struct { fields, .. } => {
-            for field in fields {
-                stats.accumulate(hash_struct_field_effect_stats(field));
-            }
-        }
-        HashIntrinsic::Option { some, .. } => {
-            stats.accumulate(hash_child_effect_stats(some));
-        }
-        HashIntrinsic::Result { ok, err, .. } => {
-            stats.accumulate(hash_child_effect_stats(ok));
-            stats.accumulate(hash_child_effect_stats(err));
-        }
-        HashIntrinsic::List { element, .. }
-        | HashIntrinsic::Array { element, .. }
-        | HashIntrinsic::Slice { element, .. }
-        | HashIntrinsic::Set { element, .. } => {
-            stats.accumulate(hash_child_effect_stats(element));
-        }
-        HashIntrinsic::Map { key, value, .. } => {
-            stats.accumulate(hash_child_effect_stats(key));
-            stats.accumulate(hash_child_effect_stats(value));
-        }
-        HashIntrinsic::Pointer { pointee, .. } => {
-            stats.accumulate(hash_child_effect_stats(pointee));
-        }
-    }
-}
-
-fn hash_struct_field_effect_stats(field: &StructFieldPlan<ExecBlock>) -> EffectStats {
-    match field {
-        StructFieldPlan::ScalarRun(run) => {
-            let mut stats = EffectStats::default();
-            for scalar in run {
-                stats.accumulate(hash_scalar_field_effect_stats(scalar));
-            }
-            stats
-        }
-        StructFieldPlan::Field(field) => hash_child_effect_stats(&field.child),
-    }
-}
-
-fn hash_scalar_field_effect_stats(field: &ScalarFieldPlan) -> EffectStats {
-    hash_scalar_child_effect_stats(field.include_shape, field.shape, field.scalar)
-}
-
-fn hash_scalar_child_effect_stats(
-    include_shape: bool,
-    shape: &'static Shape,
-    scalar: ScalarType,
-) -> EffectStats {
-    let mut stats = EffectStats::default();
-    if include_shape {
-        let shape_op: ExecOp = WeavyOp::Intrinsic(HashIntrinsic::Shape(shape));
-        stats.accumulate(weavy::ir::effect_stats(core::slice::from_ref(&shape_op)));
-    }
-    let scalar_op: ExecOp = WeavyOp::Intrinsic(HashIntrinsic::Scalar { shape, scalar });
-    stats.accumulate(weavy::ir::effect_stats(core::slice::from_ref(&scalar_op)));
-    stats
-}
-
-fn hash_child_effect_stats(child: &ChildPlan<ExecBlock>) -> EffectStats {
-    match child {
-        ChildPlan::Scalar {
-            include_shape,
-            shape,
-            scalar,
-        } => hash_scalar_child_effect_stats(*include_shape, shape, *scalar),
-        ChildPlan::Program(program) => hash_program_effect_stats(program),
-    }
+fn hash_lowered_analysis(lowered: &DenseLowered<ExecOp>) -> LoweredAnalysis {
+    weavy::ir::dense_lowered_analysis_with_intrinsic_children(lowered)
 }
 
 fn sized_layout(shape: &'static Shape) -> Result<Layout, HashError> {

--- a/facet-hash/tests/basic.rs
+++ b/facet-hash/tests/basic.rs
@@ -6,6 +6,7 @@ use facet::Facet;
 use facet_hash::HashPlan;
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
 use facet_hash::NativeHashPlan;
+use weavy::ir::IntrinsicDescriptor;
 
 #[derive(Clone, Debug, Facet)]
 struct Point {
@@ -322,9 +323,39 @@ fn plan_writes_through_supplied_hasher() {
 fn plan_reports_canonical_effect_stats() {
     let plan = HashPlan::<Nested>::build().unwrap();
 
-    let stats = plan.effect_stats();
+    let analysis = plan.analysis();
+    let stats = analysis.effect_stats;
 
+    assert_eq!(plan.effect_stats(), stats);
+    assert_eq!(analysis.program_stats.block_count, 0);
     assert_eq!(stats.block_count, 0);
+    assert!(
+        analysis.intrinsic_counts[&IntrinsicDescriptor {
+            dialect: "facet-hash",
+            name: "struct",
+        }] >= 2
+    );
+    assert_eq!(
+        analysis.intrinsic_counts[&IntrinsicDescriptor {
+            dialect: "facet-hash",
+            name: "list",
+        }],
+        2
+    );
+    assert_eq!(
+        analysis.intrinsic_counts[&IntrinsicDescriptor {
+            dialect: "facet-hash",
+            name: "array",
+        }],
+        1
+    );
+    assert_eq!(
+        analysis.intrinsic_counts[&IntrinsicDescriptor {
+            dialect: "facet-hash",
+            name: "pointer",
+        }],
+        1
+    );
     assert!(stats.total.intrinsic_op_count > 0);
     assert!(stats.total.sink_write_count > 0);
     assert!(stats.total.typed_memory_read_count > 0);
@@ -347,7 +378,7 @@ fn recursive_shapes_still_lower_blocks() {
         })),
     };
 
-    assert!(plan.effect_stats().block_count > 0);
+    assert!(plan.analysis().program_stats.block_count > 0);
     assert_ne!(plan.hash64(&short).unwrap(), plan.hash64(&long).unwrap());
 }
 

--- a/weavy/src/ir.rs
+++ b/weavy/src/ir.rs
@@ -413,6 +413,26 @@ impl EffectContract {
         self.opaque = true;
         self.barrier()
     }
+
+    /// Merge another contract into this one.
+    ///
+    /// This is useful for fused intrinsics that perform several logical
+    /// operations without materializing each one as a separate Weavy op.
+    pub fn accumulate(&mut self, other: EffectContract) {
+        self.resources.extend(other.resources);
+        self.typed_memory.extend(other.typed_memory);
+        self.may_fail |= other.may_fail;
+        self.may_allocate |= other.may_allocate;
+        self.calls_user_code |= other.calls_user_code;
+        self.opaque |= other.opaque;
+        self.ordering = match (self.ordering, other.ordering) {
+            (EffectOrdering::Barrier, _) | (_, EffectOrdering::Barrier) => EffectOrdering::Barrier,
+            (EffectOrdering::Ordered, _) | (_, EffectOrdering::Ordered) => EffectOrdering::Ordered,
+            (EffectOrdering::Reorderable, EffectOrdering::Reorderable) => {
+                EffectOrdering::Reorderable
+            }
+        };
+    }
 }
 
 /// Minimal intrinsic metadata hook.
@@ -1723,6 +1743,35 @@ mod tests {
         assert_eq!(stats.typed_memory_read_count, 1);
         assert_eq!(stats.typed_memory_initialize_count, 1);
         assert_eq!(stats.opaque_count, 0);
+    }
+
+    #[test]
+    fn effect_contract_accumulate_merges_resources_and_ordering() {
+        let mut contract = EffectContract::new()
+            .write_resource(EffectResource::Sink("hash"))
+            .typed_memory(MemoryRegion::base_relative(0, 4), TypedMemoryAccess::Read);
+
+        contract.accumulate(
+            EffectContract::new()
+                .read_resource(EffectResource::Input("json"))
+                .typed_memory(
+                    MemoryRegion::base_relative_unknown_size(8),
+                    TypedMemoryAccess::Initialize,
+                )
+                .may_fail()
+                .calls_user_code(),
+        );
+
+        let mut stats = EffectStats::default();
+        add_contract_stats(&contract, &mut stats);
+
+        assert_eq!(stats.input_read_count, 1);
+        assert_eq!(stats.sink_write_count, 1);
+        assert_eq!(stats.typed_memory_read_count, 1);
+        assert_eq!(stats.typed_memory_initialize_count, 1);
+        assert_eq!(stats.may_fail_count, 1);
+        assert_eq!(stats.calls_user_code_count, 1);
+        assert_eq!(stats.barrier_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `EffectContract::accumulate` so fused intrinsics can publish composed effects without materializing extra ops
- implement `IntrinsicChildren` for facet-hash plans and route `HashPlan::analysis()` through Weavy’s shared lowered analysis bundle
- keep `HashPlan::effect_stats()` as a compatibility accessor backed by the shared analysis result

## Testing
- `cargo fmt --all`
- `cargo check -p weavy -p facet-hash --all-features --all-targets --message-format=short`
- `cargo nextest list -p weavy -p facet-hash -E 'test(effect_contract_accumulate_merges_resources_and_ordering) | test(plan_reports_canonical_effect_stats) | test(recursive_shapes_still_lower_blocks)'`
- `cargo nextest run -p weavy -p facet-hash -E 'test(effect_contract_accumulate_merges_resources_and_ordering) | test(plan_reports_canonical_effect_stats) | test(recursive_shapes_still_lower_blocks)'`
- `cargo nextest list -p weavy -p facet-hash`
- `cargo nextest run -p weavy -p facet-hash`
- `cargo nextest list -p facet-hash --all-features`
- `cargo nextest run -p facet-hash --all-features`
- `cargo clippy -p facet-hash --all-targets --all-features --message-format=short -- -D warnings`
- pre-push hook passed: clippy, docs, build tests, run tests