### PR TITLE
Speed up Picante structural equality

### DIFF
--- a/picante/src/facet_eq.rs
+++ b/picante/src/facet_eq.rs
@@ -11,7 +11,7 @@
 
 use facet::Facet;
 use facet_core::{Def, StructKind, Type, UserType};
-use facet_reflect::{HasFields, Peek};
+use facet_reflect::Peek;
 use std::any::Any;
 
 /// Check if two type-erased Facet values are equal.
@@ -137,33 +137,22 @@ fn peek_eq<'mem, 'facet>(a: Peek<'mem, 'facet>, b: Peek<'mem, 'facet>) -> bool {
     }
 
     match a.shape().ty {
-        Type::User(UserType::Struct(_)) => {
-            let Ok(struct_a) = a.into_struct() else {
-                return false;
-            };
-            let Ok(struct_b) = b.into_struct() else {
-                return false;
-            };
-
-            // Compare each field
-            let fields_a: Vec<_> = struct_a
-                .fields()
-                .filter(|(field, _)| !field.is_metadata())
-                .collect();
-            let fields_b: Vec<_> = struct_b
-                .fields()
-                .filter(|(field, _)| !field.is_metadata())
-                .collect();
-
-            if fields_a.len() != fields_b.len() {
-                return false;
-            }
-
-            for ((field_a, peek_a), (field_b, peek_b)) in fields_a.iter().zip(fields_b.iter()) {
-                if field_a.name != field_b.name {
-                    return false;
+        Type::User(UserType::Struct(struct_def)) => {
+            for field in struct_def.fields {
+                if field.is_metadata() {
+                    continue;
                 }
-                if !peek_eq(*peek_a, *peek_b) {
+
+                let field_shape = field.shape();
+                // SAFETY: `a` and `b` have the same static shape, and `field.offset`
+                // comes from that shape's field definition.
+                let field_a =
+                    unsafe { Peek::unchecked_new(a.data().field(field.offset), field_shape) };
+                // SAFETY: same field definition and shape as above, applied to `b`.
+                let field_b =
+                    unsafe { Peek::unchecked_new(b.data().field(field.offset), field_shape) };
+
+                if !peek_eq(field_a, field_b) {
                     return false;
                 }
             }


### PR DESCRIPTION
## Summary
- speed up Picante's structural equality helper by walking struct fields directly from the shared `Shape`
- remove the per-struct temporary field vectors from equality checks
- avoid `facet_reflect::FieldIter` on ordinary structs by constructing field peeks from field offsets after shape equality has already been verified

## Performance
Local Apple M4 Pro, `target/release/deps/derived-645ecbae58354355 --bench --threads 1`.

| Benchmark | Before median | After median | Speedup |
|---|---:|---:|---:|
| `input_set_noop_large_value` | 153.8 us | 43.24 us | 3.56x |
| `derived_equal_cutoff_large_value` | 172.9 us | 62.45 us | 2.77x |
| `derived_changed_large_value` | 89.33 us | 94.45 us | 0.95x |

The changed-output row is a control where fresh `LargeValue` construction dominates. The targeted equality-heavy rows are the no-op input set and equal-cutoff derived recompute paths.

`stax record` on `input_set_noop_large_value` confirms the previous `facet_reflect::peek::fields::FieldIter::get_field_by_index` hotspot is gone from `stax top`; remaining samples are in `picante::facet_eq::peek_eq`, scalar `Peek::partial_eq`, and expected benchmark value/key cloning and allocation paths.

## Testing
- `cargo fmt --all`
- `cargo check -p picante --all-targets --message-format=short`
- `cargo nextest list -p picante -E 'test(facet_eq)'`
- `cargo nextest run -p picante -E 'test(facet_eq)'`
- `cargo bench -p picante --bench derived --no-run`
- `target/release/deps/derived-645ecbae58354355 --list`
- `target/release/deps/derived-645ecbae58354355 --bench --min-time 0.5 --sample-count 10 --threads 1 input_set_noop_large_value derived_equal_cutoff_large_value derived_changed_large_value`
- `target/release/deps/derived-645ecbae58354355 --bench --min-time 1 --sample-count 20 --threads 1 input_set_noop_large_value derived_equal_cutoff_large_value derived_changed_large_value`
- `stax record -F 1900 -l 20 -- target/release/deps/derived-645ecbae58354355 --bench --min-time 5 --threads 1 input_set_noop_large_value`
- `stax top --limit 20`
- `cargo nextest run -p picante`
- `cargo clippy -p picante --all-targets --message-format=short -- -D warnings`
- pre-push hook passed: metadata, git, affected, cargo-shear, clippy, docs, build tests, run tests
