### PR TITLE
Speed up stable Picante dependency updates

### DIFF
--- a/picante/benches/derived.rs
+++ b/picante/benches/derived.rs
@@ -254,15 +254,33 @@ fn derived_wide_revalidate_64_deps(bencher: Bencher) {
 }
 
 #[divan::bench]
+fn derived_wide_recompute_64_deps(bencher: Bencher) {
+    let (rt, db, leaves, _noise, wide) = wide_sum_fixture(64);
+    bench_wide_recompute(bencher, rt, db, leaves, wide);
+}
+
+#[divan::bench]
 fn derived_wide_revalidate_512_deps(bencher: Bencher) {
     let (rt, db, _leaves, noise, wide) = wide_sum_fixture(512);
     bench_wide_revalidate(bencher, rt, db, noise, wide);
 }
 
 #[divan::bench]
+fn derived_wide_recompute_512_deps(bencher: Bencher) {
+    let (rt, db, leaves, _noise, wide) = wide_sum_fixture(512);
+    bench_wide_recompute(bencher, rt, db, leaves, wide);
+}
+
+#[divan::bench]
 fn derived_wide_revalidate_2048_deps(bencher: Bencher) {
     let (rt, db, _leaves, noise, wide) = wide_sum_fixture(2048);
     bench_wide_revalidate(bencher, rt, db, noise, wide);
+}
+
+#[divan::bench]
+fn derived_wide_recompute_2048_deps(bencher: Bencher) {
+    let (rt, db, leaves, _noise, wide) = wide_sum_fixture(2048);
+    bench_wide_recompute(bencher, rt, db, leaves, wide);
 }
 
 fn bench_wide_revalidate(
@@ -278,6 +296,24 @@ fn bench_wide_revalidate(
             .fetch_add(1, Ordering::Relaxed)
             .wrapping_add(1);
         noise.set(&db, (), next_noise);
+        rt.block_on(async {
+            let value = wide.get(&db, ()).await.unwrap();
+            black_box(value);
+        })
+    });
+}
+
+fn bench_wide_recompute(
+    bencher: Bencher,
+    rt: tokio::runtime::Runtime,
+    db: BenchDb,
+    leaves: Arc<InputIngredient<u32, u64>>,
+    wide: Arc<DerivedIngredient<BenchDb, (), u64>>,
+) {
+    let leaf_value = AtomicU64::new(0);
+    bencher.bench(|| {
+        let next_value = leaf_value.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
+        leaves.set(&db, black_box(0), next_value);
         rt.block_on(async {
             let value = wide.get(&db, ()).await.unwrap();
             black_box(value);

--- a/picante/src/runtime.rs
+++ b/picante/src/runtime.rs
@@ -193,7 +193,16 @@ impl Runtime {
     // r[runtime.update-deps]
     /// Update the dependency edges for `query`.
     pub fn update_query_deps(&self, query: DynKey, deps: Arc<[Dep]>) {
+        if let Some(old) = self.deps_by_query.get(&query)
+            && old.as_ref() == deps.as_ref()
+        {
+            return;
+        }
+
         let old = self.deps_by_query.insert(query.clone(), deps.clone());
+        if old.as_deref() == Some(deps.as_ref()) {
+            return;
+        }
 
         let new_set: HashSet<Dep> = deps.iter().cloned().collect();
 


### PR DESCRIPTION
## Summary
- add Divan rows for wide-dependency recomputation, where a real dependency changes and Picante must recompute plus update the dependency graph
- skip dependency graph rewrites when a recomputed query reports the exact same dependency slice as before
- leave revalidation behavior unchanged; the fast path only avoids rebuilding forward/reverse graph state that is already current

## Performance
Local Apple M4 Pro, `target/release/deps/derived-645ecbae58354355 --bench --threads 1`.

| Benchmark | Before median | After median | Speedup |
|---|---:|---:|---:|
| `derived_wide_recompute_64_deps` | 12.79 us | 7.332 us | 1.74x |
| `derived_wide_recompute_512_deps` | 92.7 us | 47.66 us | 1.95x |
| `derived_wide_recompute_2048_deps` | 368.1 us | 187.3 us | 1.97x |
| `derived_wide_revalidate_512_deps` | 20.41 us | 20.04 us | 1.02x |

The recompute rows mutate an actual leaf dependency each iteration, so they exercise compute, frame dependency capture, and `Runtime::update_query_deps`. The revalidate row is included as a control for the existing stable-dependency touch path.

`stax record` on `derived_wide_recompute_2048_deps` shows the remaining top samples in key encoding, postcard serialization, input lookup, and frame dependency recording; dependency set-building no longer dominates the row.

## Testing
- `cargo fmt --all`
- `cargo check -p picante --all-targets --message-format=short`
- `cargo nextest list -p picante -E 'binary(cache_graph) | binary(notifications) | binary(shared_cache) | binary(stress_cache)'`
- `cargo nextest run -p picante -E 'binary(cache_graph) | binary(notifications) | binary(shared_cache) | binary(stress_cache)'`
- `cargo bench -p picante --bench derived --no-run`
- `target/release/deps/derived-645ecbae58354355 --list`
- `target/release/deps/derived-645ecbae58354355 --bench --min-time 0.5 --sample-count 10 --threads 1 derived_wide_recompute_64_deps derived_wide_recompute_512_deps derived_wide_recompute_2048_deps derived_wide_revalidate_512_deps`
- `target/release/deps/derived-645ecbae58354355 --bench --min-time 1 --sample-count 20 --threads 1 derived_wide_recompute_64_deps derived_wide_recompute_512_deps derived_wide_recompute_2048_deps derived_wide_revalidate_512_deps`
- `stax record -F 1900 -l 20 -- target/release/deps/derived-645ecbae58354355 --bench --min-time 5 --threads 1 derived_wide_recompute_2048_deps`
- `stax top --limit 25`
- `cargo nextest run -p picante`
- `cargo clippy -p picante --all-targets --message-format=short -- -D warnings`
- `git diff --check`
- pre-push hook passed: metadata, git, affected, cargo-shear, clippy, docs, build tests, run tests
