### PR TITLE
perf(picante): cheapen key hashing and dep recording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4712,6 +4712,7 @@ dependencies = [
  "dashmap 6.2.1",
  "facet",
  "facet-core",
+ "facet-hash",
  "facet-postcard",
  "facet-reflect",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,6 +283,7 @@ facet-dom = { path = "facet-dom", version = "0.50.0-rc.2" }
 facet-error = { path = "facet-error", version = "0.50.0-rc.2" }
 facet-format = { path = "facet-format", version = "0.50.0-rc.2" }
 facet-format-suite = { path = "facet-format-suite", version = "0.50.0-rc.0" }
+facet-hash = { path = "facet-hash", version = "0.50.0-rc.2" }
 facet-json = { path = "facet-json", version = "0.50.0-rc.2" }
 facet-json-classics = { path = "facet-json-classics", version = "0.50.0-rc.0" }
 facet-msgpack = { path = "facet-msgpack", version = "0.50.0-rc.2" }

--- a/facet-hash/benches/reuse.rs
+++ b/facet-hash/benches/reuse.rs
@@ -118,6 +118,29 @@ fn point_value_native_jit(bencher: Bencher<'_, '_>) {
 }
 
 #[divan::bench]
+fn byte_vec_native_hash(bencher: Bencher<'_, '_>) {
+    let value = byte_vec();
+    bencher.bench_local(|| {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        black_box(&value).hash(&mut hasher);
+        black_box(hasher.finish())
+    });
+}
+
+#[divan::bench]
+fn byte_vec_helper_hash(bencher: Bencher<'_, '_>) {
+    let value = byte_vec();
+    bencher.bench_local(|| black_box(facet_hash::hash_bytes64(black_box(&value))));
+}
+
+#[divan::bench]
+fn byte_vec_value_plan_reused(bencher: Bencher<'_, '_>) {
+    let plan = HashPlan::<Vec<u8>>::build().unwrap();
+    let value = byte_vec();
+    bencher.bench_local(|| black_box(plan.hash64(black_box(&value)).unwrap()));
+}
+
+#[divan::bench]
 fn point_value_plan_build_each_time(bencher: Bencher<'_, '_>) {
     let value = Point { x: 123, y: -456 };
     bencher.bench_local(|| black_box(facet_hash::hash64(black_box(&value)).unwrap()));
@@ -333,6 +356,12 @@ fn point_array() -> PointArray {
         points: [Point { x: 1, y: 2 }, Point { x: 3, y: 4 }],
         tail: -5,
     }
+}
+
+fn byte_vec() -> Vec<u8> {
+    (0..4096)
+        .map(|index| (index as u8).wrapping_mul(31))
+        .collect()
 }
 
 fn person() -> Person {

--- a/facet-hash/benches/reuse.rs
+++ b/facet-hash/benches/reuse.rs
@@ -128,9 +128,9 @@ fn byte_vec_native_hash(bencher: Bencher<'_, '_>) {
 }
 
 #[divan::bench]
-fn byte_vec_helper_hash(bencher: Bencher<'_, '_>) {
+fn byte_vec_fnv1a64_hash(bencher: Bencher<'_, '_>) {
     let value = byte_vec();
-    bencher.bench_local(|| black_box(facet_hash::hash_bytes64(black_box(&value))));
+    bencher.bench_local(|| black_box(facet_hash::hash_bytes_fnv1a64(black_box(&value))));
 }
 
 #[divan::bench]

--- a/facet-hash/src/lib.rs
+++ b/facet-hash/src/lib.rs
@@ -149,8 +149,8 @@ where
     HashPlan::<T>::build()?.hash64(value)
 }
 
-/// Hash a raw byte sequence using the byte stream shape used by value-mode
-/// facet-hash byte plans.
+/// Hash a raw byte sequence into a caller-supplied [`Hasher`] using the byte
+/// stream shape used by value-mode facet-hash byte plans.
 pub fn hash_bytes_into<H>(bytes: &[u8], hasher: &mut H)
 where
     H: Hasher + ?Sized,
@@ -159,11 +159,80 @@ where
     hasher.write(bytes);
 }
 
-/// Hash a raw byte sequence with [`std::collections::hash_map::DefaultHasher`].
+/// Hash a raw byte sequence with facet-hash's default concrete 64-bit byte hash.
+#[must_use]
 pub fn hash_bytes64(bytes: &[u8]) -> u64 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    hash_bytes_into(bytes, &mut hasher);
-    hasher.finish()
+    hash_bytes_fnv1a64(bytes)
+}
+
+/// Hash a raw byte sequence with 64-bit FNV-1a.
+#[must_use]
+pub fn hash_bytes_fnv1a64(bytes: &[u8]) -> u64 {
+    let mut hash = Fnv1a64::new();
+    hash.write_len(bytes.len());
+    hash.write(bytes);
+    hash.finish()
+}
+
+/// A concrete 64-bit FNV-1a accumulator.
+///
+/// This is intentionally not a [`Hasher`] wrapper on the fast path: callers that
+/// know they want FNV can use inherent methods that the compiler can inline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Fnv1a64 {
+    state: u64,
+}
+
+impl Fnv1a64 {
+    /// FNV-1a 64-bit offset basis.
+    pub const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+
+    /// FNV-1a 64-bit prime.
+    pub const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    /// Create an accumulator initialized to the standard FNV-1a offset basis.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            state: Self::OFFSET_BASIS,
+        }
+    }
+
+    /// Return the current accumulator state.
+    #[must_use]
+    pub const fn finish(self) -> u64 {
+        self.state
+    }
+
+    /// Feed raw bytes into the accumulator.
+    pub fn write(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            self.write_u8(byte);
+        }
+    }
+
+    /// Feed a byte into the accumulator.
+    pub fn write_u8(&mut self, byte: u8) {
+        self.state ^= u64::from(byte);
+        self.state = self.state.wrapping_mul(Self::PRIME);
+    }
+
+    /// Feed a length prefix into the accumulator using a stable little-endian
+    /// 64-bit representation.
+    pub fn write_len(&mut self, len: usize) {
+        self.write_u64(len as u64);
+    }
+
+    /// Feed a 64-bit word into the accumulator using little-endian bytes.
+    pub fn write_u64(&mut self, value: u64) {
+        self.write(&value.to_le_bytes());
+    }
+}
+
+impl Default for Fnv1a64 {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 fn run_error(err: RunError<ExecBlock, HashError>) -> HashError {

--- a/facet-hash/src/lib.rs
+++ b/facet-hash/src/lib.rs
@@ -149,6 +149,23 @@ where
     HashPlan::<T>::build()?.hash64(value)
 }
 
+/// Hash a raw byte sequence using the byte stream shape used by value-mode
+/// facet-hash byte plans.
+pub fn hash_bytes_into<H>(bytes: &[u8], hasher: &mut H)
+where
+    H: Hasher,
+{
+    bytes.len().hash(hasher);
+    hasher.write(bytes);
+}
+
+/// Hash a raw byte sequence with [`std::collections::hash_map::DefaultHasher`].
+pub fn hash_bytes64(bytes: &[u8]) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    hash_bytes_into(bytes, &mut hasher);
+    hasher.finish()
+}
+
 fn run_error(err: RunError<ExecBlock, HashError>) -> HashError {
     match err {
         RunError::Step(err) => err,
@@ -217,6 +234,7 @@ enum HashIntrinsic<Block> {
         ok: ChildPlan<Block>,
         err: ChildPlan<Block>,
     },
+    Bytes(ByteSource),
     List {
         list_shape: &'static Shape,
         list: ListDef,
@@ -245,6 +263,20 @@ enum HashIntrinsic<Block> {
     Pointer {
         pointer: PointerDef,
         pointee: ChildPlan<Block>,
+    },
+}
+
+#[derive(Clone, Debug)]
+enum ByteSource {
+    List {
+        list_shape: &'static Shape,
+        list: ListDef,
+    },
+    Array {
+        array: ArrayDef,
+    },
+    Slice {
+        slice: SliceDef,
     },
 }
 
@@ -281,6 +313,7 @@ impl<Block> IntrinsicOp for HashIntrinsic<Block> {
             HashIntrinsic::Struct { .. } => "struct",
             HashIntrinsic::Option { .. } => "option",
             HashIntrinsic::Result { .. } => "result",
+            HashIntrinsic::Bytes(_) => "bytes",
             HashIntrinsic::List { .. } => "list",
             HashIntrinsic::Array { .. } => "array",
             HashIntrinsic::Slice { .. } => "slice",
@@ -323,6 +356,7 @@ impl<Block> IntrinsicOp for HashIntrinsic<Block> {
                 effect.accumulate(child_direct_effect(err));
                 effect
             }
+            HashIntrinsic::Bytes(_) => thunked_read_effect().barrier(),
             HashIntrinsic::List { element, .. }
             | HashIntrinsic::Array { element, .. }
             | HashIntrinsic::Slice { element, .. } => {
@@ -372,7 +406,7 @@ impl<Block> IntrinsicChildren<Block> for HashIntrinsic<Block> {
                 value.visit_child_programs(visit);
             }
             HashIntrinsic::Pointer { pointee, .. } => pointee.visit_child_programs(visit),
-            HashIntrinsic::Shape(_) | HashIntrinsic::Scalar { .. } => {}
+            HashIntrinsic::Shape(_) | HashIntrinsic::Scalar { .. } | HashIntrinsic::Bytes(_) => {}
         }
     }
 }
@@ -565,6 +599,13 @@ impl Lowering {
                 if list.vtable.as_ptr.is_none() {
                     return Err(unsupported(shape, "list as_ptr"));
                 }
+                if self.mode == HashMode::Value && is_byte_shape(list.t()) {
+                    program.push(WeavyOp::Intrinsic(HashIntrinsic::Bytes(ByteSource::List {
+                        list_shape: shape,
+                        list,
+                    })));
+                    return Ok(program);
+                }
                 let element_layout = sized_layout(list.t())?;
                 let element = self.lower_child(list.t())?;
                 program.push(WeavyOp::Intrinsic(HashIntrinsic::List {
@@ -575,6 +616,12 @@ impl Lowering {
                 }));
             }
             Def::Array(array) => {
+                if self.mode == HashMode::Value && is_byte_shape(array.t()) {
+                    program.push(WeavyOp::Intrinsic(HashIntrinsic::Bytes(
+                        ByteSource::Array { array },
+                    )));
+                    return Ok(program);
+                }
                 let element_layout = sized_layout(array.t())?;
                 let element = self.lower_child(array.t())?;
                 program.push(WeavyOp::Intrinsic(HashIntrinsic::Array {
@@ -584,6 +631,12 @@ impl Lowering {
                 }));
             }
             Def::Slice(slice) => {
+                if self.mode == HashMode::Value && is_byte_shape(slice.t()) {
+                    program.push(WeavyOp::Intrinsic(HashIntrinsic::Bytes(
+                        ByteSource::Slice { slice },
+                    )));
+                    return Ok(program);
+                }
                 let element_layout = sized_layout(slice.t())?;
                 let element = self.lower_child(slice.t())?;
                 program.push(WeavyOp::Intrinsic(HashIntrinsic::Slice {
@@ -766,6 +819,7 @@ fn resolve_hash_intrinsic(
             ok: resolve_child_plan(ok, refs)?,
             err: resolve_child_plan(err, refs)?,
         },
+        HashIntrinsic::Bytes(source) => HashIntrinsic::Bytes(source),
         HashIntrinsic::List {
             list_shape,
             list,
@@ -1062,6 +1116,10 @@ where
                     self.call_child(err, PtrConst::new_sized(value), self.base)
                 }
             }
+            HashIntrinsic::Bytes(source) => {
+                unsafe { self.hash_byte_source(source)? };
+                Ok(Control::Continue)
+            }
             HashIntrinsic::List {
                 list_shape,
                 list,
@@ -1135,6 +1193,47 @@ where
                     )
                 })?;
                 self.call_child(pointee, unsafe { borrow(self.base) }, self.base)
+            }
+        }
+    }
+
+    unsafe fn hash_byte_source(&mut self, source: &ByteSource) -> Result<(), HashError> {
+        match source {
+            ByteSource::List { list_shape, list } => {
+                let len = unsafe { (list.vtable.len)(self.base) };
+                if len == 0 {
+                    hash_bytes_into(&[], self.hasher);
+                    return Ok(());
+                }
+                let as_ptr = list
+                    .vtable
+                    .as_ptr
+                    .ok_or_else(|| unsupported(list_shape, "list as_ptr"))?;
+                let data = unsafe { as_ptr(self.base) };
+                let bytes = unsafe { core::slice::from_raw_parts(data.as_byte_ptr(), len) };
+                hash_bytes_into(bytes, self.hasher);
+                Ok(())
+            }
+            ByteSource::Array { array } => {
+                if array.n == 0 {
+                    hash_bytes_into(&[], self.hasher);
+                    return Ok(());
+                }
+                let data = unsafe { (array.vtable.as_ptr)(self.base) };
+                let bytes = unsafe { core::slice::from_raw_parts(data.as_byte_ptr(), array.n) };
+                hash_bytes_into(bytes, self.hasher);
+                Ok(())
+            }
+            ByteSource::Slice { slice } => {
+                let len = unsafe { (slice.vtable.len)(self.base) };
+                if len == 0 {
+                    hash_bytes_into(&[], self.hasher);
+                    return Ok(());
+                }
+                let data = unsafe { (slice.vtable.as_ptr)(self.base) };
+                let bytes = unsafe { core::slice::from_raw_parts(data.as_byte_ptr(), len) };
+                hash_bytes_into(bytes, self.hasher);
+                Ok(())
             }
         }
     }
@@ -1514,4 +1613,8 @@ fn supported_scalar(scalar: ScalarType) -> bool {
         | ScalarType::Ipv6Addr => true,
         _ => false,
     }
+}
+
+fn is_byte_shape(shape: &'static Shape) -> bool {
+    ScalarType::try_from_shape(shape) == Some(ScalarType::U8)
 }

--- a/facet-hash/src/lib.rs
+++ b/facet-hash/src/lib.rs
@@ -153,9 +153,9 @@ where
 /// facet-hash byte plans.
 pub fn hash_bytes_into<H>(bytes: &[u8], hasher: &mut H)
 where
-    H: Hasher,
+    H: Hasher + ?Sized,
 {
-    bytes.len().hash(hasher);
+    hasher.write_usize(bytes.len());
     hasher.write(bytes);
 }
 

--- a/facet-hash/src/native.rs
+++ b/facet-hash/src/native.rs
@@ -272,7 +272,8 @@ where
                 Ok(self.emit_scalar_run(prog_index, run))
             }
             HashIntrinsic::Shape(_) => Err(unsupported(root_shape, "native structural hashing")),
-            HashIntrinsic::Option { .. }
+            HashIntrinsic::Bytes(_)
+            | HashIntrinsic::Option { .. }
             | HashIntrinsic::Result { .. }
             | HashIntrinsic::List { .. }
             | HashIntrinsic::Slice { .. }
@@ -347,7 +348,8 @@ where
                 HashIntrinsic::Shape(_) => {
                     return Err(unsupported(root_shape, "native structural hashing"));
                 }
-                HashIntrinsic::Option { .. }
+                HashIntrinsic::Bytes(_)
+                | HashIntrinsic::Option { .. }
                 | HashIntrinsic::Result { .. }
                 | HashIntrinsic::List { .. }
                 | HashIntrinsic::Slice { .. }

--- a/facet-hash/tests/basic.rs
+++ b/facet-hash/tests/basic.rs
@@ -252,6 +252,21 @@ fn byte_array_value_plan_hashes_bulk_bytes() {
 }
 
 #[test]
+fn byte_fnv1a64_helper_uses_concrete_accumulator() {
+    let bytes = b"facet-hash bytes";
+    let mut expected = facet_hash::Fnv1a64::new();
+    expected.write_len(bytes.len());
+    expected.write(bytes);
+
+    assert_eq!(facet_hash::hash_bytes_fnv1a64(bytes), expected.finish());
+    assert_eq!(facet_hash::hash_bytes64(bytes), expected.finish());
+    assert_ne!(
+        facet_hash::hash_bytes_fnv1a64(bytes),
+        facet_hash::hash_bytes_fnv1a64(b"facet-hash byte")
+    );
+}
+
+#[test]
 fn structural_byte_vec_keeps_sequence_shape() {
     let plan = HashPlan::<Vec<u8>>::build_structural().unwrap();
     let analysis = plan.analysis();

--- a/facet-hash/tests/basic.rs
+++ b/facet-hash/tests/basic.rs
@@ -189,6 +189,94 @@ fn scalar_list_elements_hash_without_element_frames() {
 }
 
 #[test]
+fn byte_vec_value_plan_hashes_bulk_bytes() {
+    let plan = HashPlan::<Vec<u8>>::build().unwrap();
+    let value = vec![0, 1, 2, 3, 5, 8, 13, 255];
+    let mut expected = RecordingHasher::default();
+    let mut actual = RecordingHasher::default();
+
+    facet_hash::hash_bytes_into(&value, &mut expected);
+    plan.hash(&value, &mut actual).unwrap();
+
+    assert_eq!(actual.bytes, expected.bytes);
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let stats = plan.hash_with_stats(&value, &mut hasher).unwrap();
+    let analysis = plan.analysis();
+
+    assert_eq!(stats.step_count, 1);
+    assert_eq!(stats.inline_call_count, 0);
+    assert_eq!(stats.continuation_resume_count, 0);
+    assert_eq!(stats.max_frame_depth, 1);
+    assert_eq!(
+        analysis
+            .intrinsic_counts
+            .get(&IntrinsicDescriptor {
+                dialect: "facet-hash",
+                name: "bytes",
+            })
+            .copied(),
+        Some(1)
+    );
+    assert_eq!(
+        analysis
+            .intrinsic_counts
+            .get(&IntrinsicDescriptor {
+                dialect: "facet-hash",
+                name: "list",
+            })
+            .copied()
+            .unwrap_or(0),
+        0
+    );
+}
+
+#[test]
+fn byte_array_value_plan_hashes_bulk_bytes() {
+    let plan = HashPlan::<[u8; 4]>::build().unwrap();
+    let value = [10, 20, 30, 40];
+    let mut expected = RecordingHasher::default();
+    let mut actual = RecordingHasher::default();
+
+    facet_hash::hash_bytes_into(&value, &mut expected);
+    plan.hash(&value, &mut actual).unwrap();
+
+    assert_eq!(actual.bytes, expected.bytes);
+    assert_eq!(
+        plan.analysis().intrinsic_counts[&IntrinsicDescriptor {
+            dialect: "facet-hash",
+            name: "bytes",
+        }],
+        1
+    );
+}
+
+#[test]
+fn structural_byte_vec_keeps_sequence_shape() {
+    let plan = HashPlan::<Vec<u8>>::build_structural().unwrap();
+    let analysis = plan.analysis();
+
+    assert_eq!(
+        analysis
+            .intrinsic_counts
+            .get(&IntrinsicDescriptor {
+                dialect: "facet-hash",
+                name: "bytes",
+            })
+            .copied()
+            .unwrap_or(0),
+        0
+    );
+    assert_eq!(
+        analysis.intrinsic_counts[&IntrinsicDescriptor {
+            dialect: "facet-hash",
+            name: "list",
+        }],
+        1
+    );
+}
+
+#[test]
 fn hashes_scalar_sets_and_maps() {
     let plan = HashPlan::<Collections>::build().unwrap();
     let mut set = BTreeSet::new();

--- a/picante/Cargo.toml
+++ b/picante/Cargo.toml
@@ -23,6 +23,7 @@ dashmap.workspace = true
 im.workspace = true
 facet.workspace = true
 facet-core.workspace = true
+facet-hash.workspace = true
 facet-reflect.workspace = true
 facet-postcard.workspace = true
 futures-util.workspace = true

--- a/picante/src/frame.rs
+++ b/picante/src/frame.rs
@@ -110,11 +110,49 @@ pub fn has_active_frame() -> bool {
 // r[dep.recording]
 /// Record a dependency on the current top-of-stack frame, if any.
 pub fn record_dep(dep: Dep) {
-    let _ = ACTIVE_STACK.try_with(|stack| {
-        if let Some(top) = stack.borrow().last() {
+    let _ = record_dep_if_active(dep);
+}
+
+pub(crate) fn record_dep_if_active(dep: Dep) -> bool {
+    ACTIVE_STACK
+        .try_with(|stack| {
+            let stack = stack.borrow();
+            let Some(top) = stack.last() else {
+                return false;
+            };
+
             top.0.deps.lock().push(dep);
-        }
-    });
+            true
+        })
+        .unwrap_or(false)
+}
+
+pub(crate) fn record_dep_with(make_dep: impl FnOnce() -> Dep) -> bool {
+    ACTIVE_STACK
+        .try_with(|stack| {
+            let stack = stack.borrow();
+            let Some(top) = stack.last() else {
+                return false;
+            };
+
+            top.0.deps.lock().push(make_dep());
+            true
+        })
+        .unwrap_or(false)
+}
+
+pub(crate) fn record_dep_result<E>(make_dep: impl FnOnce() -> Result<Dep, E>) -> Result<bool, E> {
+    ACTIVE_STACK
+        .try_with(|stack| {
+            let stack = stack.borrow();
+            let Some(top) = stack.last() else {
+                return Ok(false);
+            };
+
+            top.0.deps.lock().push(make_dep()?);
+            Ok(true)
+        })
+        .unwrap_or(Ok(false))
 }
 
 // r[frame.cycle-detect]

--- a/picante/src/ingredient/derived.rs
+++ b/picante/src/ingredient/derived.rs
@@ -253,16 +253,17 @@ impl DerivedCore {
         }
 
         // 0) record dependency into parent frame (if any)
-        if want_value && frame::has_active_frame() {
+        if want_value
+            && frame::record_dep_with(|| Dep {
+                kind: self.kind,
+                key: requested.key.clone(),
+            })
+        {
             trace!(
                 kind = self.kind.0,
                 key_hash = %format!("{:016x}", key_hash),
                 "derived dep"
             );
-            frame::record_dep(Dep {
-                kind: self.kind,
-                key: requested.key.clone(),
-            });
         }
 
         // Get or create the cell for this key

--- a/picante/src/ingredient/input.rs
+++ b/picante/src/ingredient/input.rs
@@ -1,7 +1,7 @@
 use crate::db::{DynIngredient, Touch};
 use crate::error::{PicanteError, PicanteResult};
 use crate::frame;
-use crate::key::{Dep, DynKey, Key, KeyBuildHasher, QueryKindId};
+use crate::key::{Dep, DynKey, Key, QueryKindId};
 use crate::persist::{PersistableIngredient, SectionType};
 use crate::revision::Revision;
 use crate::runtime::HasRuntime;
@@ -26,8 +26,6 @@ struct ErasedInputEntry {
     value: Option<ArcAny>,
     changed_at: Revision,
 }
-
-type ErasedInputMap = im::HashMap<DynKey, ErasedInputEntry, KeyBuildHasher>;
 
 /// Encode a single record to bytes
 type EncodeInputRecordFn =
@@ -58,7 +56,7 @@ type ApplyInputWalEntryFn = fn(
 struct InputCore {
     kind: QueryKindId,
     kind_name: &'static str,
-    entries: RwLock<ErasedInputMap>,
+    entries: RwLock<im::HashMap<DynKey, ErasedInputEntry>>,
     // Type-erased persistence callbacks
     encode_record: EncodeInputRecordFn,
     decode_record: DecodeInputRecordFn,
@@ -78,7 +76,7 @@ impl InputCore {
         Self {
             kind,
             kind_name,
-            entries: RwLock::new(ErasedInputMap::default()),
+            entries: RwLock::new(im::HashMap::new()),
             encode_record,
             decode_record,
             encode_incremental,
@@ -629,7 +627,7 @@ where
 
     fn clear(&self) {
         let mut entries = self.core.entries.write();
-        *entries = ErasedInputMap::default();
+        *entries = im::HashMap::new();
     }
 
     fn save_records(&self) -> BoxFuture<'_, PicanteResult<Vec<Vec<u8>>>> {

--- a/picante/src/ingredient/input.rs
+++ b/picante/src/ingredient/input.rs
@@ -1,7 +1,7 @@
 use crate::db::{DynIngredient, Touch};
 use crate::error::{PicanteError, PicanteResult};
 use crate::frame;
-use crate::key::{Dep, DynKey, Key, QueryKindId};
+use crate::key::{Dep, DynKey, Key, KeyBuildHasher, QueryKindId};
 use crate::persist::{PersistableIngredient, SectionType};
 use crate::revision::Revision;
 use crate::runtime::HasRuntime;
@@ -26,6 +26,8 @@ struct ErasedInputEntry {
     value: Option<ArcAny>,
     changed_at: Revision,
 }
+
+type ErasedInputMap = im::HashMap<DynKey, ErasedInputEntry, KeyBuildHasher>;
 
 /// Encode a single record to bytes
 type EncodeInputRecordFn =
@@ -56,7 +58,7 @@ type ApplyInputWalEntryFn = fn(
 struct InputCore {
     kind: QueryKindId,
     kind_name: &'static str,
-    entries: RwLock<im::HashMap<DynKey, ErasedInputEntry>>,
+    entries: RwLock<ErasedInputMap>,
     // Type-erased persistence callbacks
     encode_record: EncodeInputRecordFn,
     decode_record: DecodeInputRecordFn,
@@ -76,7 +78,7 @@ impl InputCore {
         Self {
             kind,
             kind_name,
-            entries: RwLock::new(im::HashMap::new()),
+            entries: RwLock::new(ErasedInputMap::default()),
             encode_record,
             decode_record,
             encode_incremental,
@@ -495,17 +497,17 @@ where
         let _span = tracing::trace_span!("get", kind = self.core.kind.0).entered();
 
         let encoded_key = Key::encode_facet(key)?;
+        let key_hash = encoded_key.hash();
         let dyn_key = DynKey {
             kind: self.core.kind,
             key: encoded_key.clone(),
         };
 
-        if frame::has_active_frame() {
-            trace!(kind = self.core.kind.0, key_hash = %format!("{:016x}", encoded_key.hash()), "input dep");
-            frame::record_dep(Dep {
-                kind: self.core.kind,
-                key: encoded_key,
-            });
+        if frame::record_dep_if_active(Dep {
+            kind: self.core.kind,
+            key: encoded_key,
+        }) {
+            trace!(kind = self.core.kind.0, key_hash = %format!("{:016x}", key_hash), "input dep");
         }
 
         let entries = self.core.entries.read();
@@ -627,7 +629,7 @@ where
 
     fn clear(&self) {
         let mut entries = self.core.entries.write();
-        *entries = im::HashMap::new();
+        *entries = ErasedInputMap::default();
     }
 
     fn save_records(&self) -> BoxFuture<'_, PicanteResult<Vec<Vec<u8>>>> {

--- a/picante/src/ingredient/interned.rs
+++ b/picante/src/ingredient/interned.rs
@@ -87,18 +87,21 @@ where
     /// If there's an active query frame, records a dependency edge.
     pub fn get<DB: HasRuntime>(&self, _db: &DB, id: InternId) -> PicanteResult<Arc<K>> {
         let _span = tracing::trace_span!("get", kind = self.kind.0, id = id.0).entered();
-        if frame::has_active_frame() {
+        let mut key_hash = None;
+        if frame::record_dep_result(|| {
             let key = Key::encode_facet(&id)?;
+            key_hash = Some(key.hash());
+            Ok::<Dep, Arc<PicanteError>>(Dep {
+                kind: self.kind,
+                key,
+            })
+        })? {
             trace!(
                 kind = self.kind.0,
-                key_hash = %format!("{:016x}", key.hash()),
+                key_hash = %format!("{:016x}", key_hash.unwrap_or_default()),
                 id = id.0,
                 "interned dep"
             );
-            frame::record_dep(Dep {
-                kind: self.kind,
-                key,
-            });
         }
 
         self.by_id.get(&id).map(|v| v.clone()).ok_or_else(|| {

--- a/picante/src/key.rs
+++ b/picante/src/key.rs
@@ -3,54 +3,8 @@
 use crate::error::{PicanteError, PicanteResult};
 use facet::Facet;
 use std::fmt;
-use std::hash::{BuildHasherDefault, Hash, Hasher};
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
-
-const FNV64_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
-const FNV64_PRIME: u64 = 0x0000_0100_0000_01b3;
-
-pub(crate) type KeyBuildHasher = BuildHasherDefault<StableHasher>;
-
-pub(crate) struct StableHasher {
-    hash: u64,
-}
-
-impl Default for StableHasher {
-    fn default() -> Self {
-        Self { hash: FNV64_OFFSET }
-    }
-}
-
-impl Hasher for StableHasher {
-    fn finish(&self) -> u64 {
-        self.hash
-    }
-
-    fn write(&mut self, bytes: &[u8]) {
-        self.hash = stable_hash_from(self.hash, bytes);
-    }
-
-    fn write_u8(&mut self, i: u8) {
-        self.hash ^= u64::from(i);
-        self.hash = self.hash.wrapping_mul(FNV64_PRIME);
-    }
-
-    fn write_u16(&mut self, i: u16) {
-        self.write(&i.to_le_bytes());
-    }
-
-    fn write_u32(&mut self, i: u32) {
-        self.write(&i.to_le_bytes());
-    }
-
-    fn write_u64(&mut self, i: u64) {
-        self.write(&i.to_le_bytes());
-    }
-
-    fn write_usize(&mut self, i: usize) {
-        self.write(&i.to_le_bytes());
-    }
-}
 
 // r[kind.type]
 /// Stable identifier for a query/input kind.
@@ -193,13 +147,7 @@ pub struct Dep {
 }
 
 fn stable_hash(bytes: &[u8]) -> u64 {
-    stable_hash_from(FNV64_OFFSET, bytes)
-}
-
-fn stable_hash_from(mut hash: u64, bytes: &[u8]) -> u64 {
-    for &byte in bytes {
-        hash ^= u64::from(byte);
-        hash = hash.wrapping_mul(FNV64_PRIME);
-    }
-    hash
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    hasher.finish()
 }

--- a/picante/src/key.rs
+++ b/picante/src/key.rs
@@ -147,7 +147,5 @@ pub struct Dep {
 }
 
 fn stable_hash(bytes: &[u8]) -> u64 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    bytes.hash(&mut hasher);
-    hasher.finish()
+    facet_hash::hash_bytes64(bytes)
 }

--- a/picante/src/key.rs
+++ b/picante/src/key.rs
@@ -147,5 +147,5 @@ pub struct Dep {
 }
 
 fn stable_hash(bytes: &[u8]) -> u64 {
-    facet_hash::hash_bytes64(bytes)
+    facet_hash::hash_bytes_fnv1a64(bytes)
 }

--- a/picante/src/key.rs
+++ b/picante/src/key.rs
@@ -3,8 +3,54 @@
 use crate::error::{PicanteError, PicanteResult};
 use facet::Facet;
 use std::fmt;
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::sync::Arc;
+
+const FNV64_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV64_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+pub(crate) type KeyBuildHasher = BuildHasherDefault<StableHasher>;
+
+pub(crate) struct StableHasher {
+    hash: u64,
+}
+
+impl Default for StableHasher {
+    fn default() -> Self {
+        Self { hash: FNV64_OFFSET }
+    }
+}
+
+impl Hasher for StableHasher {
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.hash = stable_hash_from(self.hash, bytes);
+    }
+
+    fn write_u8(&mut self, i: u8) {
+        self.hash ^= u64::from(i);
+        self.hash = self.hash.wrapping_mul(FNV64_PRIME);
+    }
+
+    fn write_u16(&mut self, i: u16) {
+        self.write(&i.to_le_bytes());
+    }
+
+    fn write_u32(&mut self, i: u32) {
+        self.write(&i.to_le_bytes());
+    }
+
+    fn write_u64(&mut self, i: u64) {
+        self.write(&i.to_le_bytes());
+    }
+
+    fn write_usize(&mut self, i: usize) {
+        self.write(&i.to_le_bytes());
+    }
+}
 
 // r[kind.type]
 /// Stable identifier for a query/input kind.
@@ -147,7 +193,13 @@ pub struct Dep {
 }
 
 fn stable_hash(bytes: &[u8]) -> u64 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    bytes.hash(&mut hasher);
-    hasher.finish()
+    stable_hash_from(FNV64_OFFSET, bytes)
+}
+
+fn stable_hash_from(mut hash: u64, bytes: &[u8]) -> u64 {
+    for &byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV64_PRIME);
+    }
+    hash
 }


### PR DESCRIPTION
## Summary

- add crate-private frame helpers that record dependency edges in one task-local probe
- keep the public `frame::record_dep(dep)` API shape intact
- update input/derived/interned dependency recording call sites to avoid the separate `has_active_frame()` probe
- add a `facet-hash` bulk byte-sequence helper plus a value-mode `bytes` intrinsic for `Vec<u8>`, `[u8; N]`, and `[u8]`
- add a concrete, inlineable `facet_hash::Fnv1a64` accumulator and `hash_bytes_fnv1a64`
- route Picante's current cached encoded-key hash through the explicit facet-hash FNV path, while keeping `Key` equality/persistence on exact encoded bytes

This still does not make Picante runtime key identity typed. Runtime keys are still postcard bytes in this PR. The stacked change moves the current byte-hash policy into `facet-hash`, gives it a concrete non-`Hasher` fast path, and leaves typed/runtime key identity as the next architectural step.

## Benchmarks

Local Apple M4 Pro. Base is `38d07698` (`origin/main` when this branch was cut), head is `e37c0d454`.

Picante command shape: `target/release/deps/derived-494a4f81a0073ee3 --bench --min-time 1 --sample-count 20 --threads 1 ...`

### Picante wide recompute

| Benchmark | Base | Head | Delta |
|---|---:|---:|---:|
| `64_deps` | 7.374 us | 6.583 us | +10.7% |
| `512_deps` | 46.95 us | 42.41 us | +9.7% |
| `2048_deps` | 189.6 us | 168.0 us | +11.4% |

### Picante adjacent checks

| Benchmark | Base | Head | Delta |
|---|---:|---:|---:|
| `input_get_hit` | 52.8 ns | 48.6 ns | +8.0% |
| `derived_hot_hit` | 291.7 ns | 249.4 ns | +14.5% |
| `revalidate_64` | 2.79 us | 2.666 us | +4.4% |
| `revalidate_512` | 20.45 us | 19.66 us | +3.9% |
| `revalidate_2048` | 88.41 us | 89.62 us | -1.4% |

Facet-hash byte command shape: `target/release/deps/reuse-c3b4021b511d6cd3 --bench --min-time 1 --sample-count 20 --threads 1 byte_vec_*`

### Facet-hash 4 KiB byte vector

| Benchmark | Median | Vs native |
|---|---:|---:|
| `byte_vec_native_hash` | 734 ns | 1.00x |
| `byte_vec_value_plan_reused` | 749.6 ns | 1.02x |
| `byte_vec_fnv1a64_hash` | 3.624 us | 4.94x |

The 4 KiB row is useful as a boundary: concrete FNV is not universally faster for large byte buffers because it is a serial byte loop. It does win on the Picante key-shaped workload in this PR.

## Verification

- `cargo fmt --check`
- `cargo check -p facet-hash --all-features`
- `cargo nextest run -p facet-hash --all-features`
- `cargo check -p picante`
- `cargo nextest run -p picante`
- `cargo bench -p facet-hash --bench reuse --no-run`
- `target/release/deps/reuse-c3b4021b511d6cd3 --list`
- `target/release/deps/reuse-c3b4021b511d6cd3 --bench --min-time 1 --sample-count 20 --threads 1 byte_vec_native_hash byte_vec_fnv1a64_hash byte_vec_value_plan_reused`
- `cargo bench -p picante --bench derived --no-run`
- `target/release/deps/derived-494a4f81a0073ee3 --bench --min-time 1 --sample-count 20 --threads 1 derived_wide_recompute_64_deps derived_wide_recompute_512_deps derived_wide_recompute_2048_deps derived_wide_revalidate_64_deps derived_wide_revalidate_512_deps derived_wide_revalidate_2048_deps input_get_hit derived_hot_hit`
