### PR TITLE
picante: use typed Facet runtime keys

### DIFF
--- a/picante/src/ingredient/derived.rs
+++ b/picante/src/ingredient/derived.rs
@@ -2,8 +2,8 @@ use crate::db::{DynIngredient, IngredientLookup, Touch};
 use crate::error::{PicanteError, PicanteResult};
 use crate::frame::{self, ActiveFrameHandle};
 use crate::inflight::{self, InFlightKey, InFlightState, SharedCacheRecord, TryLeadResult};
-use crate::key::{Dep, DynKey, Key, QueryKindId};
-use crate::persist::{PersistableIngredient, SectionType};
+use crate::key::{Dep, DynKey, Key, KeyFactory, QueryKindId};
+use crate::persist::{KeyDecodeFn, PersistableIngredient, SectionType};
 use crate::revision::Revision;
 use facet::Facet;
 use facet_core::Shape;
@@ -12,7 +12,6 @@ use futures_util::FutureExt;
 use futures_util::future::BoxFuture;
 use parking_lot::RwLock;
 use std::any::Any;
-use std::hash::Hash;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use tokio::sync::{Mutex, Notify};
@@ -58,7 +57,11 @@ type EncodeRecordFn = fn(
 
 /// Decode a single record from bytes (called from erased load_records)
 /// Takes owned `Vec<u8>` because facet_postcard::from_slice requires 'static
-type DecodeRecordFn = fn(kind: QueryKindId, bytes: Vec<u8>) -> PicanteResult<ErasedRecordData>;
+type DecodeRecordFn = fn(
+    kind: QueryKindId,
+    bytes: Vec<u8>,
+    decode_key: &KeyDecodeFn<'_>,
+) -> PicanteResult<ErasedRecordData>;
 
 /// Encode incremental record (key + optional value) for WAL
 type EncodeIncrementalFn = fn(
@@ -76,6 +79,7 @@ type ApplyWalEntryFn = fn(
     kind: QueryKindId,
     key_bytes: Vec<u8>,
     value_bytes: Option<Vec<u8>>,
+    decode_key: &KeyDecodeFn<'_>,
 ) -> PicanteResult<ApplyWalResult>;
 
 /// Result of applying a WAL entry
@@ -151,6 +155,7 @@ trait ErasedCompute<DB>: Send + Sync {
 /// The state machine in DerivedCore stays monomorphic by calling through the trait.
 struct TypedCompute<DB, K, V> {
     f: Arc<ComputeFn<DB, K, V>>,
+    key_factory: KeyFactory<K>,
     _phantom: PhantomData<(K, V)>,
 }
 
@@ -159,13 +164,13 @@ struct TypedCompute<DB, K, V> {
 impl<DB, K, V> ErasedCompute<DB> for TypedCompute<DB, K, V>
 where
     DB: IngredientLookup + Send + Sync + 'static,
-    K: Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Send + Sync + 'static,
 {
     fn compute<'a>(&'a self, db: &'a DB, key: Key) -> ComputeFut<'a> {
         // Tradeoffs: vtable dispatch, boxed future allocation, and key decode per compute.
         Box::pin(async move {
-            let k: K = key.decode_facet()?;
+            let k: K = self.key_factory.decode_key(&key)?;
             let v: V = (self.f)(db, k).await?;
             Ok(Arc::new(v) as ArcAny)
         })
@@ -849,10 +854,14 @@ impl DerivedCore {
     }
 
     /// Load records using type-erased callbacks
-    fn load_records_erased(&self, records: Vec<Vec<u8>>) -> PicanteResult<()> {
+    fn load_records_erased(
+        &self,
+        records: Vec<Vec<u8>>,
+        decode_key: &KeyDecodeFn<'_>,
+    ) -> PicanteResult<()> {
         for bytes in records {
             // Call through function pointer (takes owned Vec<u8>)
-            let data = (self.decode_record)(self.kind, bytes)?;
+            let data = (self.decode_record)(self.kind, bytes, decode_key)?;
 
             let cell = Arc::new(ErasedCell::new_ready(
                 data.value,
@@ -924,9 +933,10 @@ impl DerivedCore {
         _revision: u64,
         key_bytes: Vec<u8>,
         value_bytes: Option<Vec<u8>>,
+        decode_key: &KeyDecodeFn<'_>,
     ) -> PicanteResult<()> {
         // Pass owned bytes (callback needs 'static for deserialization)
-        let result = (self.apply_wal_entry)(self.kind, key_bytes, value_bytes)?;
+        let result = (self.apply_wal_entry)(self.kind, key_bytes, value_bytes, decode_key)?;
 
         let mut cells = self.cells.write();
         if let Some(cell) = result.cell {
@@ -1069,7 +1079,7 @@ impl DerivedCore {
 /// Create an encode_record function pointer for a specific K, V
 fn make_encode_record<K, V>() -> EncodeRecordFn
 where
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     |kind_name, dyn_key, value, verified_at, changed_at, deps| {
@@ -1098,11 +1108,13 @@ where
 
         let deps = deps
             .iter()
-            .map(|d| DepRecord {
-                kind_id: d.kind.as_u32(),
-                key_bytes: d.key.bytes().to_vec(),
+            .map(|d| {
+                Ok(DepRecord {
+                    kind_id: d.kind.as_u32(),
+                    key_bytes: d.key.to_bytes()?.to_vec(),
+                })
             })
-            .collect();
+            .collect::<PicanteResult<Vec<_>>>()?;
 
         let rec = DerivedRecord::<K, V> {
             key,
@@ -1120,10 +1132,10 @@ where
 /// Create a decode_record function pointer for a specific K, V
 fn make_decode_record<K, V>() -> DecodeRecordFn
 where
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
-    |kind, bytes| {
+    |kind, bytes, decode_key| {
         // SAFETY: <DerivedRecord<K, V>>::SHAPE is the correct shape for DerivedRecord<K, V>
         let heap_value = unsafe {
             decode_to_heap_value(&bytes, <DerivedRecord<K, V>>::SHAPE, "derived record")
@@ -1138,16 +1150,19 @@ where
         let deps: Arc<[Dep]> = rec
             .deps
             .into_iter()
-            .map(|d| Dep {
-                kind: QueryKindId(d.kind_id),
-                key: Key::from_bytes(d.key_bytes),
+            .map(|d| {
+                let kind = QueryKindId(d.kind_id);
+                Ok(Dep {
+                    kind,
+                    key: decode_key(kind, d.key_bytes)?,
+                })
             })
-            .collect::<Vec<_>>()
+            .collect::<PicanteResult<Vec<_>>>()?
             .into();
 
         let dyn_key = DynKey {
             kind,
-            key: Key::encode_facet(&rec.key)?,
+            key: KeyFactory::<K>::new().key(rec.key)?,
         };
 
         let value = Arc::new(rec.value) as ArcAny;
@@ -1165,7 +1180,7 @@ where
 /// Create an encode_incremental function pointer for a specific K, V
 fn make_encode_incremental<K, V>() -> EncodeIncrementalFn
 where
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     |kind_name, dyn_key, value, verified_at, changed_at, deps| {
@@ -1194,11 +1209,13 @@ where
 
         let dep_records = deps
             .iter()
-            .map(|d| DepRecord {
-                kind_id: d.kind.as_u32(),
-                key_bytes: d.key.bytes().to_vec(),
+            .map(|d| {
+                Ok(DepRecord {
+                    kind_id: d.kind.as_u32(),
+                    key_bytes: d.key.to_bytes()?.to_vec(),
+                })
             })
-            .collect();
+            .collect::<PicanteResult<Vec<_>>>()?;
 
         let rec = DerivedRecord::<K, V> {
             key: key.clone(),
@@ -1209,7 +1226,7 @@ where
         };
 
         // Peek::new is tiny and generic, encode_with_peek is non-generic
-        let key_bytes = encode_with_peek(Peek::new(&key), "derived key")?;
+        let key_bytes = dyn_key.key.to_bytes()?.to_vec();
         let value_bytes = encode_with_peek(Peek::new(&rec), "derived record")?;
 
         Ok((key_bytes, value_bytes))
@@ -1219,23 +1236,13 @@ where
 /// Create an apply_wal_entry function pointer for a specific K, V
 fn make_apply_wal_entry<K, V>() -> ApplyWalEntryFn
 where
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
-    |kind, key_bytes, value_bytes| {
-        // SAFETY: K::SHAPE is the correct shape for K
-        let heap_value =
-            unsafe { decode_to_heap_value(&key_bytes, K::SHAPE, "derived key from WAL") }?;
-        let key: K = heap_value.materialize().map_err(|e| {
-            Arc::new(PicanteError::Decode {
-                what: "derived key from WAL (materialize)",
-                message: format!("{e:?}"),
-            })
-        })?;
-
+    |kind, key_bytes, value_bytes, decode_key| {
         let dyn_key = DynKey {
             kind,
-            key: Key::encode_facet(&key)?,
+            key: KeyFactory::<K>::new().key_from_bytes(key_bytes)?,
         };
 
         if let Some(value_bytes) = value_bytes {
@@ -1257,11 +1264,14 @@ where
             let deps: Arc<[Dep]> = rec
                 .deps
                 .into_iter()
-                .map(|d| Dep {
-                    kind: QueryKindId(d.kind_id),
-                    key: Key::from_bytes(d.key_bytes),
+                .map(|d| {
+                    let kind = QueryKindId(d.kind_id);
+                    Ok(Dep {
+                        kind,
+                        key: decode_key(kind, d.key_bytes)?,
+                    })
                 })
-                .collect::<Vec<_>>()
+                .collect::<PicanteResult<Vec<_>>>()?
                 .into();
 
             let erased_value = Arc::new(rec.value) as ArcAny;
@@ -1300,10 +1310,11 @@ where
 /// is compiled once instead of per (DB, K, V) combination.
 pub struct DerivedIngredient<DB, K, V>
 where
-    K: Clone + Eq + Hash,
+    K: Clone + Facet<'static>,
 {
     /// Non-generic core containing the type-erased state machine
     core: DerivedCore,
+    key_factory: KeyFactory<K>,
     /// Type information for K and V
     _phantom: PhantomData<(K, V)>,
     /// Type-erased compute function (trait object for dyn dispatch)
@@ -1315,7 +1326,7 @@ where
 impl<DB, K, V> DerivedIngredient<DB, K, V>
 where
     DB: IngredientLookup + Send + Sync + 'static,
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     /// Create a new derived ingredient.
@@ -1327,6 +1338,7 @@ where
         // Create typed adapter and erase to trait object
         let typed_compute = TypedCompute {
             f: Arc::new(compute),
+            key_factory: KeyFactory::new(),
             _phantom: PhantomData,
         };
         let compute_erased: Arc<dyn ErasedCompute<DB>> = Arc::new(typed_compute);
@@ -1346,6 +1358,7 @@ where
                 encode_incremental,
                 apply_wal_entry,
             ),
+            key_factory: KeyFactory::new(),
             _phantom: PhantomData,
             compute: compute_erased,
             eq_erased: eq_erased_for::<V>,
@@ -1369,7 +1382,7 @@ where
         // Encode key once (avoids re-encoding on every lookup)
         let dyn_key = DynKey {
             kind: self.core.kind,
-            key: Key::encode_facet(&key)?,
+            key: self.key_factory.key(key)?,
         };
 
         // Use the type-erased get helper (compiled once per DB, not per K/V)
@@ -1401,7 +1414,7 @@ where
         // Encode key once
         let dyn_key = DynKey {
             kind: self.core.kind,
-            key: Key::encode_facet(&key)?,
+            key: self.key_factory.key(key)?,
         };
 
         // Use the type-erased touch helper (compiled once per DB, not per K/V)
@@ -1434,7 +1447,7 @@ where
     pub fn cell_for_key(&self, key: &K) -> PicanteResult<Option<Arc<ErasedCell>>> {
         let dyn_key = DynKey {
             kind: self.core.kind,
-            key: Key::encode_facet(key)?,
+            key: self.key_factory.key(key.clone())?,
         };
         Ok(self.core.cells.read().get(&dyn_key).cloned())
     }
@@ -1445,7 +1458,7 @@ where
     pub fn insert_ready_record(&self, key: &K, record: ErasedReadyRecord) -> PicanteResult<()> {
         let dyn_key = DynKey {
             kind: self.core.kind,
-            key: Key::encode_facet(key)?,
+            key: self.key_factory.key(key.clone())?,
         };
         let cell = Arc::new(ErasedCell::new_ready(
             record.value,
@@ -1635,7 +1648,7 @@ struct DerivedRecord<K, V> {
 impl<DB, K, V> PersistableIngredient for DerivedIngredient<DB, K, V>
 where
     DB: IngredientLookup + Send + Sync + 'static,
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     fn kind(&self) -> QueryKindId {
@@ -1660,9 +1673,22 @@ where
         Box::pin(self.core.save_records_erased())
     }
 
+    fn key_from_bytes(&self, bytes: Vec<u8>) -> PicanteResult<Key> {
+        self.key_factory.key_from_bytes(bytes)
+    }
+
     fn load_records(&self, records: Vec<Vec<u8>>) -> PicanteResult<()> {
+        let decode_key = |_kind: QueryKindId, bytes: Vec<u8>| Ok(Key::from_bytes(bytes));
+        self.core.load_records_erased(records, &decode_key)
+    }
+
+    fn load_records_with_key_decoder(
+        &self,
+        records: Vec<Vec<u8>>,
+        decode_key: &KeyDecodeFn<'_>,
+    ) -> PicanteResult<()> {
         // Delegate to type-erased core (compiled once, uses function pointers)
-        self.core.load_records_erased(records)
+        self.core.load_records_erased(records, decode_key)
     }
 
     fn restore_runtime_state<'a>(
@@ -1687,21 +1713,35 @@ where
         key: Vec<u8>,
         value: Option<Vec<u8>>,
     ) -> PicanteResult<()> {
+        let decode_key = |_kind: QueryKindId, bytes: Vec<u8>| Ok(Key::from_bytes(bytes));
+        self.core
+            .apply_wal_entry_erased(revision, key, value, &decode_key)
+    }
+
+    fn apply_wal_entry_with_key_decoder(
+        &self,
+        revision: u64,
+        key: Vec<u8>,
+        value: Option<Vec<u8>>,
+        decode_key: &KeyDecodeFn<'_>,
+    ) -> PicanteResult<()> {
         // Delegate to type-erased core (compiled once, uses function pointers)
-        self.core.apply_wal_entry_erased(revision, key, value)
+        self.core
+            .apply_wal_entry_erased(revision, key, value, decode_key)
     }
 }
 
 impl<DB, K, V> DynIngredient<DB> for DerivedIngredient<DB, K, V>
 where
     DB: IngredientLookup + Send + Sync + 'static,
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     fn touch<'a>(&'a self, db: &'a DB, key: Key) -> BoxFuture<'a, PicanteResult<Touch>> {
-        // Use the type-erased touch directly to avoid decode/encode round-trip.
-        // The key is already encoded as bytes; we just wrap it in a DynKey.
-        // Returns the boxed future directly to avoid monomorphizing another async block.
+        let key = match self.key_factory.normalize_key(key) {
+            Ok(key) => key,
+            Err(e) => return Box::pin(async move { Err(e) }),
+        };
         let dyn_key = DynKey {
             kind: self.core.kind,
             key,

--- a/picante/src/ingredient/input.rs
+++ b/picante/src/ingredient/input.rs
@@ -1,7 +1,7 @@
 use crate::db::{DynIngredient, Touch};
 use crate::error::{PicanteError, PicanteResult};
 use crate::frame;
-use crate::key::{Dep, DynKey, Key, QueryKindId};
+use crate::key::{Dep, DynKey, Key, KeyFactory, QueryKindId};
 use crate::persist::{PersistableIngredient, SectionType};
 use crate::revision::Revision;
 use crate::runtime::HasRuntime;
@@ -164,7 +164,7 @@ impl InputCore {
 // r[input.constraints]
 fn make_encode_input_record<K, V>() -> EncodeInputRecordFn
 where
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     |dyn_key, value, changed_at| {
@@ -203,7 +203,7 @@ where
 
 fn make_decode_input_record<K, V>() -> DecodeInputRecordFn
 where
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     |kind, bytes| {
@@ -216,7 +216,7 @@ where
 
         let dyn_key = DynKey {
             kind,
-            key: Key::encode_facet(&rec.key)?,
+            key: KeyFactory::<K>::new().key(rec.key)?,
         };
 
         let value: Option<ArcAny> = rec.value.map(|v| Arc::new(v) as ArcAny);
@@ -231,20 +231,12 @@ where
     }
 }
 
-fn make_encode_input_incremental<K, V>() -> EncodeInputIncrementalFn
+fn make_encode_input_incremental<V>() -> EncodeInputIncrementalFn
 where
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     |dyn_key, value| {
-        let key: K = dyn_key.key.decode_facet()?;
-
-        let key_bytes = facet_postcard::to_vec(&key).map_err(|e| {
-            Arc::new(PicanteError::Encode {
-                what: "input key",
-                message: format!("{e:?}"),
-            })
-        })?;
+        let key_bytes = dyn_key.key.to_bytes()?.to_vec();
 
         let value_bytes = match value {
             Some(arc_any) => {
@@ -272,17 +264,10 @@ where
 
 fn make_apply_input_wal_entry<K, V>() -> ApplyInputWalEntryFn
 where
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     |kind, key_bytes, value_bytes| {
-        let key: K = facet_postcard::from_slice(&key_bytes).map_err(|e| {
-            Arc::new(PicanteError::Decode {
-                what: "input key from WAL",
-                message: format!("{e:?}"),
-            })
-        })?;
-
         let value: Option<ArcAny> = match value_bytes {
             Some(bytes) => {
                 let v: V = facet_postcard::from_slice(&bytes).map_err(|e| {
@@ -298,7 +283,7 @@ where
 
         let dyn_key = DynKey {
             kind,
-            key: Key::encode_facet(&key)?,
+            key: KeyFactory::<K>::new().key_from_bytes(key_bytes)?,
         };
 
         Ok((
@@ -338,18 +323,19 @@ pub struct InputEntry<V> {
 /// persistence code to be compiled once instead of per (K, V) combination.
 pub struct InputIngredient<K, V>
 where
-    K: Clone + Eq + Hash,
+    K: Clone + Facet<'static>,
     V: Clone,
 {
     /// Type-erased core with persistence logic
     core: InputCore,
+    key_factory: KeyFactory<K>,
     /// Phantom data for K and V types
     _phantom: std::marker::PhantomData<(K, V)>,
 }
 
 impl<K, V> InputIngredient<K, V>
 where
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     /// Create an empty input ingredient.
@@ -360,9 +346,10 @@ where
                 kind_name,
                 make_encode_input_record::<K, V>(),
                 make_decode_input_record::<K, V>(),
-                make_encode_input_incremental::<K, V>(),
+                make_encode_input_incremental::<V>(),
                 make_apply_input_wal_entry::<K, V>(),
             ),
+            key_factory: KeyFactory::new(),
             _phantom: std::marker::PhantomData,
         }
     }
@@ -386,7 +373,7 @@ where
         let _span = tracing::debug_span!("set", kind = self.core.kind.0).entered();
 
         // Encode key for storage
-        let dyn_key = match Key::encode_facet(&key) {
+        let dyn_key = match self.key_factory.key(key.clone()) {
             Ok(encoded) => DynKey {
                 kind: self.core.kind,
                 key: encoded,
@@ -440,7 +427,7 @@ where
         let _span = tracing::debug_span!("remove", kind = self.core.kind.0).entered();
 
         // Encode key for storage
-        let dyn_key = match Key::encode_facet(key) {
+        let dyn_key = match self.key_factory.key(key.clone()) {
             Ok(encoded) => DynKey {
                 kind: self.core.kind,
                 key: encoded,
@@ -494,7 +481,7 @@ where
     pub fn get<DB: HasRuntime>(&self, _db: &DB, key: &K) -> PicanteResult<Option<V>> {
         let _span = tracing::trace_span!("get", kind = self.core.kind.0).entered();
 
-        let encoded_key = Key::encode_facet(key)?;
+        let encoded_key = self.key_factory.key(key.clone())?;
         let key_hash = encoded_key.hash();
         let dyn_key = DynKey {
             kind: self.core.kind,
@@ -521,7 +508,7 @@ where
     pub fn changed_at(&self, key: &K) -> Option<Revision> {
         let dyn_key = DynKey {
             kind: self.core.kind,
-            key: Key::encode_facet(key).ok()?,
+            key: self.key_factory.key(key.clone()).ok()?,
         };
         let entries = self.core.entries.read();
         entries.get(&dyn_key).map(|e| e.changed_at)
@@ -533,7 +520,10 @@ where
     /// This is an O(1) operation due to structural sharing in `im::HashMap`.
     /// The returned map is immutable and can be used for consistent reads
     /// while the live ingredient continues to be modified.
-    pub fn snapshot(&self) -> im::HashMap<K, InputEntry<V>> {
+    pub fn snapshot(&self) -> im::HashMap<K, InputEntry<V>>
+    where
+        K: Eq + Hash,
+    {
         let entries = self.core.entries.read();
         entries
             .iter()
@@ -563,21 +553,26 @@ where
         kind: QueryKindId,
         kind_name: &'static str,
         entries: im::HashMap<K, InputEntry<V>>,
-    ) -> Self {
+    ) -> Self
+    where
+        K: Eq + Hash,
+    {
         let core = InputCore::new(
             kind,
             kind_name,
             make_encode_input_record::<K, V>(),
             make_decode_input_record::<K, V>(),
-            make_encode_input_incremental::<K, V>(),
+            make_encode_input_incremental::<V>(),
             make_apply_input_wal_entry::<K, V>(),
         );
+
+        let key_factory = KeyFactory::<K>::new();
 
         // Convert typed entries to type-erased storage
         {
             let mut erased_entries = core.entries.write();
             for (key, entry) in entries {
-                if let Ok(encoded_key) = Key::encode_facet(&key) {
+                if let Ok(encoded_key) = key_factory.key(key) {
                     let dyn_key = DynKey {
                         kind,
                         key: encoded_key,
@@ -596,6 +591,7 @@ where
 
         Self {
             core,
+            key_factory,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -610,7 +606,7 @@ struct InputRecord<K, V> {
 
 impl<K, V> PersistableIngredient for InputIngredient<K, V>
 where
-    K: Clone + Eq + Hash + Facet<'static> + Send + Sync + 'static,
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
     fn kind(&self) -> QueryKindId {
@@ -628,6 +624,10 @@ where
     fn clear(&self) {
         let mut entries = self.core.entries.write();
         *entries = im::HashMap::new();
+    }
+
+    fn key_from_bytes(&self, bytes: Vec<u8>) -> PicanteResult<Key> {
+        self.key_factory.key_from_bytes(bytes)
     }
 
     fn save_records(&self) -> BoxFuture<'_, PicanteResult<Vec<Vec<u8>>>> {
@@ -662,11 +662,12 @@ where
 impl<DB, K, V> DynIngredient<DB> for InputIngredient<K, V>
 where
     DB: HasRuntime + Send + Sync + 'static,
-    K: Clone + Eq + Hash + facet::Facet<'static> + Send + Sync + 'static,
+    K: Clone + facet::Facet<'static> + Send + Sync + 'static,
     V: Clone + facet::Facet<'static> + Send + Sync + 'static,
 {
     fn touch<'a>(&'a self, _db: &'a DB, key: Key) -> BoxFuture<'a, PicanteResult<Touch>> {
         Box::pin(async move {
+            let key = self.key_factory.normalize_key(key)?;
             let dyn_key = DynKey {
                 kind: self.core.kind,
                 key,

--- a/picante/src/ingredient/interned.rs
+++ b/picante/src/ingredient/interned.rs
@@ -1,7 +1,7 @@
 use crate::db::{DynIngredient, Touch};
 use crate::error::{PicanteError, PicanteResult};
 use crate::frame;
-use crate::key::{Dep, Key, QueryKindId};
+use crate::key::{Dep, Key, KeyFactory, QueryKindId};
 use crate::persist::{PersistableIngredient, SectionType};
 use crate::revision::Revision;
 use crate::runtime::HasRuntime;
@@ -29,6 +29,8 @@ pub struct InternedIngredient<K> {
     next_id: AtomicU32,
     by_value: DashMap<Key, InternId>,
     by_id: DashMap<InternId, Arc<K>>,
+    value_key_factory: KeyFactory<K>,
+    id_key_factory: KeyFactory<InternId>,
 }
 
 // r[interned.constraints]
@@ -44,6 +46,8 @@ where
             next_id: AtomicU32::new(0),
             by_value: DashMap::new(),
             by_id: DashMap::new(),
+            value_key_factory: KeyFactory::new(),
+            id_key_factory: KeyFactory::new(),
         }
     }
 
@@ -61,14 +65,15 @@ where
     /// Intern `value` and return its stable id.
     pub fn intern(&self, value: K) -> PicanteResult<InternId> {
         let _span = tracing::debug_span!("intern", kind = self.kind.0).entered();
-        let key = Key::encode_facet(&value)?;
+        let value = Arc::new(value);
+        let key = self.value_key_factory.key_arc(value.clone())?;
         let key_hash = key.hash();
 
         match self.by_value.entry(key) {
             dashmap::mapref::entry::Entry::Occupied(e) => Ok(*e.get()),
             dashmap::mapref::entry::Entry::Vacant(e) => {
                 let id = InternId(self.next_id.fetch_add(1, Ordering::AcqRel));
-                self.by_id.insert(id, Arc::new(value));
+                self.by_id.insert(id, value);
                 e.insert(id);
                 trace!(
                     kind = self.kind.0,
@@ -89,7 +94,7 @@ where
         let _span = tracing::trace_span!("get", kind = self.kind.0, id = id.0).entered();
         let mut key_hash = None;
         if frame::record_dep_result(|| {
-            let key = Key::encode_facet(&id)?;
+            let key = self.id_key_factory.key(id)?;
             key_hash = Some(key.hash());
             Ok::<Dep, Arc<PicanteError>>(Dep {
                 kind: self.kind,
@@ -139,6 +144,10 @@ where
         self.by_value.clear();
         self.by_id.clear();
         self.next_id.store(0, Ordering::Release);
+    }
+
+    fn key_from_bytes(&self, bytes: Vec<u8>) -> PicanteResult<Key> {
+        self.id_key_factory.key_from_bytes(bytes)
     }
 
     fn save_records(&self) -> BoxFuture<'_, PicanteResult<Vec<Vec<u8>>>> {
@@ -194,7 +203,7 @@ where
                 }));
             }
 
-            let key = Key::encode_facet(rec.value.as_ref())?;
+            let key = self.value_key_factory.key_arc(rec.value.clone())?;
             if let Some(existing) = self.by_value.insert(key, id) {
                 return Err(Arc::new(PicanteError::Cache {
                     message: format!(
@@ -262,7 +271,7 @@ where
             })?;
 
             let id = InternId(rec.id);
-            let key = Key::encode_facet(rec.value.as_ref())?;
+            let key = self.value_key_factory.key_arc(rec.value.clone())?;
 
             // Insert into both maps
             self.by_id.insert(id, rec.value);

--- a/picante/src/key.rs
+++ b/picante/src/key.rs
@@ -2,9 +2,11 @@
 
 use crate::error::{PicanteError, PicanteResult};
 use facet::Facet;
+use std::any::Any;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 // r[kind.type]
 /// Stable identifier for a query/input kind.
@@ -41,15 +43,78 @@ impl QueryKindId {
 }
 
 // r[key.encoding]
-/// Postcard-encoded bytes for a key, plus a deterministic hash for tracing/debugging.
+/// Erased runtime key plus a deterministic cached hash for indexing/tracing.
 #[derive(Clone)]
 pub struct Key {
-    bytes: Arc<[u8]>,
+    repr: Arc<KeyRepr>,
     // r[key.hash]
     hash: u64,
 }
 
+enum KeyRepr {
+    Typed(Arc<dyn ErasedFacetKey>),
+    Bytes(Arc<[u8]>),
+}
+
+trait ErasedFacetKey: Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+    fn eq_typed(&self, other: &dyn ErasedFacetKey) -> bool;
+    fn bytes(&self) -> PicanteResult<&[u8]>;
+    fn to_bytes(&self) -> PicanteResult<Arc<[u8]>>;
+}
+
+struct FacetKey<T> {
+    value: Arc<T>,
+    bytes: OnceLock<PicanteResult<Arc<[u8]>>>,
+}
+
+impl<T> ErasedFacetKey for FacetKey<T>
+where
+    T: Facet<'static> + Send + Sync + 'static,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn eq_typed(&self, other: &dyn ErasedFacetKey) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<FacetKey<T>>()
+            .is_some_and(|other| crate::facet_eq::facet_eq_direct(&*self.value, &*other.value))
+    }
+
+    fn bytes(&self) -> PicanteResult<&[u8]> {
+        self.bytes
+            .get_or_init(|| encode_key_bytes(&*self.value))
+            .as_ref()
+            .map(|bytes| bytes.as_ref())
+            .map_err(Clone::clone)
+    }
+
+    fn to_bytes(&self) -> PicanteResult<Arc<[u8]>> {
+        self.bytes
+            .get_or_init(|| encode_key_bytes(&*self.value))
+            .clone()
+    }
+}
+
 impl Key {
+    /// Build a runtime key from a Facet value.
+    pub fn from_facet<T>(value: T) -> PicanteResult<Self>
+    where
+        T: Facet<'static> + Send + Sync + 'static,
+    {
+        KeyFactory::<T>::new().key(value)
+    }
+
+    /// Build a runtime key from an already-shared Facet value.
+    pub fn from_facet_arc<T>(value: Arc<T>) -> PicanteResult<Self>
+    where
+        T: Facet<'static> + Send + Sync + 'static,
+    {
+        KeyFactory::<T>::new().key_arc(value)
+    }
+
     /// Encode a key using `facet-postcard`.
     pub fn encode_facet<T: Facet<'static>>(value: &T) -> PicanteResult<Self> {
         let bytes = facet_postcard::to_vec(value).map_err(|e| {
@@ -58,12 +123,41 @@ impl Key {
                 message: format!("{e:?}"),
             })
         })?;
-        Ok(Self::from_bytes(bytes))
+        let hash = if let Ok(plan) = facet_hash::HashPlan::<T>::build() {
+            plan.hash64(value).map_err(|e| {
+                Arc::new(PicanteError::Encode {
+                    what: "key hash",
+                    message: e.to_string(),
+                })
+            })?
+        } else {
+            stable_hash(&bytes)
+        };
+        Ok(Self {
+            repr: Arc::new(KeyRepr::Bytes(bytes.into())),
+            hash,
+        })
+    }
+
+    fn typed_value<T>(&self) -> Option<T>
+    where
+        T: Clone + Facet<'static> + Send + Sync + 'static,
+    {
+        if let KeyRepr::Typed(typed) = &*self.repr
+            && let Some(value) = typed
+                .as_any()
+                .downcast_ref::<FacetKey<T>>()
+                .map(|key| (*key.value).clone())
+        {
+            return Some(value);
+        }
+        None
     }
 
     /// Decode a key using `facet-postcard`.
     pub fn decode_facet<T: Facet<'static>>(&self) -> PicanteResult<T> {
-        facet_postcard::from_slice(self.bytes()).map_err(|e| {
+        let bytes = self.to_bytes()?;
+        facet_postcard::from_slice(&bytes).map_err(|e| {
             Arc::new(PicanteError::Decode {
                 what: "key",
                 message: format!("{e:?}"),
@@ -75,37 +169,60 @@ impl Key {
     pub fn from_bytes(bytes: Vec<u8>) -> Self {
         let hash = stable_hash(&bytes);
         Self {
-            bytes: bytes.into(),
+            repr: Arc::new(KeyRepr::Bytes(bytes.into())),
             hash,
         }
     }
 
-    /// Access the encoded bytes.
+    /// Access the encoded bytes, materializing them for typed keys if needed.
     pub fn bytes(&self) -> &[u8] {
-        &self.bytes
+        self.try_bytes()
+            .unwrap_or_else(|e| panic!("encode key bytes failed: {e}"))
     }
 
-    /// Deterministic hash of the encoded bytes.
+    /// Try to access the encoded bytes without panicking on materialization errors.
+    pub fn try_bytes(&self) -> PicanteResult<&[u8]> {
+        match &*self.repr {
+            KeyRepr::Typed(typed) => typed.bytes(),
+            KeyRepr::Bytes(bytes) => Ok(bytes),
+        }
+    }
+
+    /// Return the persistent byte representation of this key.
+    pub fn to_bytes(&self) -> PicanteResult<Arc<[u8]>> {
+        match &*self.repr {
+            KeyRepr::Typed(typed) => typed.to_bytes(),
+            KeyRepr::Bytes(bytes) => Ok(bytes.clone()),
+        }
+    }
+
+    /// Cached hash used for runtime indexing/tracing.
     pub fn hash(&self) -> u64 {
         self.hash
     }
 
     /// Length in bytes of the encoded key.
     pub fn len(&self) -> usize {
-        self.bytes.len()
+        self.bytes().len()
     }
 
     /// Returns `true` if the encoded key is empty.
     pub fn is_empty(&self) -> bool {
-        self.bytes.is_empty()
+        self.bytes().is_empty()
     }
 }
 
 // r[key.equality]
 impl PartialEq for Key {
     fn eq(&self, other: &Self) -> bool {
-        // exact byte equality, not hash
-        self.bytes == other.bytes
+        match (&*self.repr, &*other.repr) {
+            (KeyRepr::Typed(left), KeyRepr::Typed(right)) => left.eq_typed(&**right),
+            (KeyRepr::Bytes(left), KeyRepr::Bytes(right)) => left == right,
+            _ => match (self.to_bytes(), other.to_bytes()) {
+                (Ok(left), Ok(right)) => left == right,
+                _ => false,
+            },
+        }
     }
 }
 
@@ -121,7 +238,6 @@ impl fmt::Debug for Key {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Key")
             .field("hash", &format_args!("{:016x}", self.hash))
-            .field("len", &self.bytes.len())
             .finish()
     }
 }
@@ -148,4 +264,148 @@ pub struct Dep {
 
 fn stable_hash(bytes: &[u8]) -> u64 {
     facet_hash::hash_bytes_fnv1a64(bytes)
+}
+
+/// Reusable key builder for one Facet key type.
+pub struct KeyFactory<T> {
+    plan: Option<facet_hash::HashPlan<T>>,
+}
+
+impl<T> KeyFactory<T>
+where
+    T: Facet<'static>,
+{
+    /// Build a key factory for `T`.
+    pub fn new() -> Self {
+        Self {
+            plan: facet_hash::HashPlan::<T>::build().ok(),
+        }
+    }
+
+    /// Build a key from an owned value.
+    pub fn key(&self, value: T) -> PicanteResult<Key>
+    where
+        T: Send + Sync + 'static,
+    {
+        self.key_arc(Arc::new(value))
+    }
+
+    /// Build a key from an already-shared value.
+    pub fn key_arc(&self, value: Arc<T>) -> PicanteResult<Key>
+    where
+        T: Send + Sync + 'static,
+    {
+        let mut bytes = None;
+        let hash = if let Some(plan) = &self.plan {
+            plan.hash64(&*value).map_err(|e| {
+                Arc::new(PicanteError::Encode {
+                    what: "key hash",
+                    message: e.to_string(),
+                })
+            })?
+        } else {
+            let encoded = encode_key_bytes(&*value)?;
+            let hash = stable_hash(&encoded);
+            bytes = Some(encoded);
+            hash
+        };
+
+        let key = FacetKey {
+            value,
+            bytes: once_lock_from_option(bytes.map(Ok)),
+        };
+
+        Ok(Key {
+            repr: Arc::new(KeyRepr::Typed(Arc::new(key))),
+            hash,
+        })
+    }
+
+    /// Decode persistent key bytes and rehydrate them as a typed runtime key.
+    pub fn key_from_bytes(&self, bytes: Vec<u8>) -> PicanteResult<Key>
+    where
+        T: Send + Sync + 'static,
+    {
+        let value: T = facet_postcard::from_slice(&bytes).map_err(|e| {
+            Arc::new(PicanteError::Decode {
+                what: "key",
+                message: format!("{e:?}"),
+            })
+        })?;
+        let bytes: Arc<[u8]> = bytes.into();
+        let hash = if let Some(plan) = &self.plan {
+            plan.hash64(&value).map_err(|e| {
+                Arc::new(PicanteError::Encode {
+                    what: "key hash",
+                    message: e.to_string(),
+                })
+            })?
+        } else {
+            stable_hash(&bytes)
+        };
+        let key = FacetKey {
+            value: Arc::new(value),
+            bytes: once_lock_from_option(Some(Ok(bytes))),
+        };
+        Ok(Key {
+            repr: Arc::new(KeyRepr::Typed(Arc::new(key))),
+            hash,
+        })
+    }
+
+    /// Normalize an erased key into this factory's typed runtime representation.
+    pub fn normalize_key(&self, key: Key) -> PicanteResult<Key>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        let already_typed = match &*key.repr {
+            KeyRepr::Typed(typed) => typed.as_any().is::<FacetKey<T>>(),
+            KeyRepr::Bytes(_) => false,
+        };
+        if already_typed {
+            return Ok(key);
+        }
+
+        self.key(key.decode_facet::<T>()?)
+    }
+
+    /// Decode a key, reusing the typed value when the erased key already has one.
+    pub fn decode_key(&self, key: &Key) -> PicanteResult<T>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        if let Some(value) = key.typed_value::<T>() {
+            return Ok(value);
+        }
+        key.decode_facet::<T>()
+    }
+}
+
+impl<T> Default for KeyFactory<T>
+where
+    T: Facet<'static>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn encode_key_bytes<T>(value: &T) -> PicanteResult<Arc<[u8]>>
+where
+    T: Facet<'static>,
+{
+    facet_postcard::to_vec(value).map(Arc::from).map_err(|e| {
+        Arc::new(PicanteError::Encode {
+            what: "key",
+            message: format!("{e:?}"),
+        })
+    })
+}
+
+fn once_lock_from_option<T>(value: Option<T>) -> OnceLock<T> {
+    let lock = OnceLock::new();
+    if let Some(value) = value {
+        let _ = lock.set(value);
+    }
+    lock
 }

--- a/picante/src/persist.rs
+++ b/picante/src/persist.rs
@@ -1,7 +1,7 @@
 //! Cache persistence for Picante ingredients.
 
 use crate::error::{PicanteError, PicanteResult};
-use crate::key::QueryKindId;
+use crate::key::{Key, QueryKindId};
 use crate::revision::Revision;
 use crate::runtime::Runtime;
 use crate::wal::{WalEntry, WalOperation, WalReader, WalWriter};
@@ -100,6 +100,9 @@ pub enum SectionType {
     Interned,
 }
 
+/// Decoder for persisted dependency key bytes.
+pub type KeyDecodeFn<'a> = dyn Fn(QueryKindId, Vec<u8>) -> PicanteResult<Key> + 'a;
+
 /// An ingredient that can be saved to / loaded from a cache file.
 pub trait PersistableIngredient: Send + Sync {
     /// Stable kind id (must be unique within a database).
@@ -110,10 +113,23 @@ pub trait PersistableIngredient: Send + Sync {
     fn section_type(&self) -> SectionType;
     /// Clear all in-memory data for this ingredient.
     fn clear(&self);
+    /// Decode persistent key bytes into this ingredient's runtime key shape.
+    fn key_from_bytes(&self, bytes: Vec<u8>) -> PicanteResult<Key> {
+        Ok(Key::from_bytes(bytes))
+    }
     /// Serialize this ingredient's records.
     fn save_records(&self) -> BoxFuture<'_, PicanteResult<Vec<Vec<u8>>>>;
     /// Load this ingredient from raw record bytes.
     fn load_records(&self, records: Vec<Vec<u8>>) -> PicanteResult<()>;
+    /// Load this ingredient, decoding dependency keys through their owning ingredients.
+    fn load_records_with_key_decoder(
+        &self,
+        records: Vec<Vec<u8>>,
+        decode_key: &KeyDecodeFn<'_>,
+    ) -> PicanteResult<()> {
+        let _ = decode_key;
+        self.load_records(records)
+    }
     /// Restore any runtime-side state derived from loaded records.
     fn restore_runtime_state<'a>(
         &'a self,
@@ -154,6 +170,18 @@ pub trait PersistableIngredient: Send + Sync {
     ) -> PicanteResult<()> {
         // Default: not implemented
         Ok(())
+    }
+
+    /// Apply a WAL entry, decoding dependency keys through their owning ingredients.
+    fn apply_wal_entry_with_key_decoder(
+        &self,
+        revision: u64,
+        key: Vec<u8>,
+        value: Option<Vec<u8>>,
+        decode_key: &KeyDecodeFn<'_>,
+    ) -> PicanteResult<()> {
+        let _ = decode_key;
+        self.apply_wal_entry(revision, key, value)
     }
 }
 
@@ -413,7 +441,19 @@ async fn load_cache_inner(
             }));
         }
 
-        ingredient.load_records(section.records)?;
+        let decode_key = |kind: QueryKindId, bytes: Vec<u8>| {
+            let Some(ingredient) = by_kind.get(&kind.as_u32()).copied() else {
+                return Err(Arc::new(PicanteError::Cache {
+                    message: format!(
+                        "record references unknown dependency kind {}",
+                        kind.as_u32()
+                    ),
+                }));
+            };
+            ingredient.key_from_bytes(bytes)
+        };
+
+        ingredient.load_records_with_key_decoder(section.records, &decode_key)?;
     }
     let load_elapsed = load_start.elapsed();
 
@@ -687,6 +727,18 @@ pub async fn replay_wal(
         ingredient_map.insert(ingredient.kind().0, *ingredient);
     }
 
+    let decode_key = |kind: QueryKindId, bytes: Vec<u8>| {
+        let Some(ingredient) = ingredient_map.get(&kind.as_u32()).copied() else {
+            return Err(Arc::new(PicanteError::Cache {
+                message: format!(
+                    "WAL record references unknown dependency kind {}",
+                    kind.as_u32()
+                ),
+            }));
+        };
+        ingredient.key_from_bytes(bytes)
+    };
+
     let mut entry_count = 0;
     let mut max_revision = base_revision;
 
@@ -705,10 +757,20 @@ pub async fn replay_wal(
         // Apply the operation
         match entry.operation {
             WalOperation::Set { key, value } => {
-                ingredient.apply_wal_entry(entry.revision, key, Some(value))?;
+                ingredient.apply_wal_entry_with_key_decoder(
+                    entry.revision,
+                    key,
+                    Some(value),
+                    &decode_key,
+                )?;
             }
             WalOperation::Delete { key } => {
-                ingredient.apply_wal_entry(entry.revision, key, None)?;
+                ingredient.apply_wal_entry_with_key_decoder(
+                    entry.revision,
+                    key,
+                    None,
+                    &decode_key,
+                )?;
             }
         }
 

--- a/picante/tests/cache_graph.rs
+++ b/picante/tests/cache_graph.rs
@@ -43,6 +43,12 @@ impl TestDb {
     }
 }
 
+#[derive(Clone, Debug, facet::Facet)]
+struct FacetOnlyKey {
+    shard: u32,
+    slot: u32,
+}
+
 #[tokio_test_lite::test]
 async fn load_cache_restores_reverse_deps_for_invalidation_events() {
     init_tracing();
@@ -132,6 +138,105 @@ async fn load_cache_restores_reverse_deps_for_invalidation_events() {
         }
     }
     assert!(saw, "expected QueryInvalidated event after input set");
+
+    let _ = tokio::fs::remove_file(&cache_path).await;
+}
+
+#[tokio_test_lite::test]
+async fn typed_facet_keys_do_not_require_rust_hash_or_eq_after_cache_load() {
+    init_tracing();
+
+    let cache_path = temp_file("picante-typed-key-cache-graph.bin");
+
+    let mut db = TestDb::default();
+    let input: Arc<InputIngredient<FacetOnlyKey, String>> =
+        Arc::new(InputIngredient::new(QueryKindId(10), "FacetOnlyInput"));
+    db.register(input.clone());
+
+    let derived: Arc<DerivedIngredient<TestDb, FacetOnlyKey, u64>> = {
+        let input = input.clone();
+        Arc::new(DerivedIngredient::new(
+            QueryKindId(11),
+            "FacetOnlyLen",
+            move |db, key| {
+                let input = input.clone();
+                Box::pin(async move {
+                    let s = input.get(db, &key)?.unwrap_or_default();
+                    Ok(s.len() as u64)
+                })
+            },
+        ))
+    };
+    db.register(derived.clone());
+
+    let key = FacetOnlyKey { shard: 7, slot: 3 };
+    input.set(&db, key.clone(), "hello".to_string());
+    assert_eq!(derived.get(&db, key.clone()).await.unwrap(), 5);
+
+    save_cache(&cache_path, db.runtime(), &[&*input, &*derived])
+        .await
+        .unwrap();
+
+    let mut db2 = TestDb::default();
+    let input2: Arc<InputIngredient<FacetOnlyKey, String>> =
+        Arc::new(InputIngredient::new(QueryKindId(10), "FacetOnlyInput"));
+    db2.register(input2.clone());
+
+    let derived2: Arc<DerivedIngredient<TestDb, FacetOnlyKey, u64>> = {
+        let input2 = input2.clone();
+        Arc::new(DerivedIngredient::new(
+            QueryKindId(11),
+            "FacetOnlyLen",
+            move |db, key| {
+                let input2 = input2.clone();
+                Box::pin(async move {
+                    let s = input2.get(db, &key)?.unwrap_or_default();
+                    Ok(s.len() as u64)
+                })
+            },
+        ))
+    };
+    db2.register(derived2.clone());
+
+    let mut events = db2.runtime().subscribe_events();
+
+    let loaded = load_cache(&cache_path, db2.runtime(), &[&*input2, &*derived2])
+        .await
+        .unwrap();
+    assert!(loaded);
+
+    match events.recv().await.unwrap() {
+        RuntimeEvent::RevisionSet { revision } => assert_eq!(revision, Revision(1)),
+        other => panic!("expected RevisionSet, got {other:?}"),
+    }
+
+    input2.set(&db2, key.clone(), "hello!".to_string());
+
+    let mut saw = false;
+    for _ in 0..8 {
+        if let RuntimeEvent::QueryInvalidated {
+            kind,
+            key,
+            by_kind,
+            by_key,
+            ..
+        } = events.recv().await.unwrap()
+        {
+            let key = key.decode_facet::<FacetOnlyKey>().unwrap();
+            let by_key = by_key.decode_facet::<FacetOnlyKey>().unwrap();
+            assert_eq!(kind, QueryKindId(11));
+            assert_eq!(key.shard, 7);
+            assert_eq!(key.slot, 3);
+            assert_eq!(by_kind, QueryKindId(10));
+            assert_eq!(by_key.shard, 7);
+            assert_eq!(by_key.slot, 3);
+            saw = true;
+            break;
+        }
+    }
+    assert!(saw, "expected typed-key invalidation after input set");
+
+    assert_eq!(derived2.get(&db2, key).await.unwrap(), 6);
 
     let _ = tokio::fs::remove_file(&cache_path).await;
 }


### PR DESCRIPTION
## Summary
- Moves Picante runtime identity from serialized-byte keys to typed Facet-backed runtime keys with cached Facet hashes and lazy byte materialization for persistence.
- Adds per-ingredient `KeyFactory` usage for inputs, derived queries, and interned tables, so key bounds no longer require Rust `Eq + Hash` on the main runtime path.
- Rehydrates persisted dependency keys through their owning ingredient during cache load/WAL replay, while keeping the old public persistence entry points and adding decoder-aware internal hooks.

## Testing
- `cargo check -p picante`
- `cargo nextest list -p picante -E 'binary(cache_graph)'`
- `cargo nextest run -p picante -E 'binary(cache_graph)'`
- `cargo nextest run -p picante`
- `cargo clippy --all-features --all-targets --message-format=short -- -D warnings`
- `cargo semver-checks -p picante`
- pre-push hook: clippy, docs, build tests, run tests all passed

## Bench Notes
Local machine: Apple M4 Pro, 14 cores, 24 GB memory.

| bench | median | mean |
|---|---:|---:|
| `input_get_hit` | 58.54 ns | 57.78 ns |
| `derived_hot_hit` | 249.6 ns | 267.6 ns |
| `derived_wide_revalidate_512_deps` | 26.49 us | 25.94 us |

Stax: `stax record` run 8 on `derived_hot_hit`; profiled median was 291.7 ns under sampling, with `facet_hash::HashPlan<T>::hash64` visible on the hot lookup path.