### PR TITLE
picante: slim runtime key lookups

### DIFF
--- a/picante/src/ingredient/derived.rs
+++ b/picante/src/ingredient/derived.rs
@@ -155,7 +155,7 @@ trait ErasedCompute<DB>: Send + Sync {
 /// The state machine in DerivedCore stays monomorphic by calling through the trait.
 struct TypedCompute<DB, K, V> {
     f: Arc<ComputeFn<DB, K, V>>,
-    key_factory: KeyFactory<K>,
+    key_factory: Arc<KeyFactory<K>>,
     _phantom: PhantomData<(K, V)>,
 }
 
@@ -202,7 +202,7 @@ where
 struct DerivedCore {
     kind: QueryKindId,
     kind_name: &'static str,
-    cells: RwLock<im::HashMap<DynKey, Arc<ErasedCell>>>,
+    cells: RwLock<im::HashMap<Key, Arc<ErasedCell>>>,
     // Type-erased persistence callbacks (function pointers, not closures)
     encode_record: EncodeRecordFn,
     decode_record: DecodeRecordFn,
@@ -274,16 +274,16 @@ impl DerivedCore {
         // Get or create the cell for this key
         let cell = {
             // Fast path: read lock
-            if let Some(cell) = self.cells.read().get(&requested) {
+            if let Some(cell) = self.cells.read().get(&requested.key) {
                 cell.clone()
             } else {
                 // Slow path: write lock, double-check after acquiring lock
                 let mut cells = self.cells.write();
-                if let Some(cell) = cells.get(&requested) {
+                if let Some(cell) = cells.get(&requested.key) {
                     cell.clone()
                 } else {
                     let cell = Arc::new(ErasedCell::new());
-                    cells.insert(requested.clone(), cell.clone());
+                    cells.insert(requested.key.clone(), cell.clone());
                     cell
                 }
             }
@@ -816,13 +816,13 @@ impl DerivedCore {
     /// Save all records using type-erased callbacks
     async fn save_records_erased(&self) -> PicanteResult<Vec<Vec<u8>>> {
         // Collect snapshot under lock, then release before async work
-        let snapshot: Vec<(DynKey, Arc<ErasedCell>)> = {
+        let snapshot: Vec<(Key, Arc<ErasedCell>)> = {
             let cells = self.cells.read();
             cells.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
         };
         let mut records = Vec::with_capacity(snapshot.len());
 
-        for (dyn_key, cell) in snapshot {
+        for (key, cell) in snapshot {
             let state = cell.state.lock().await;
             let ErasedState::Ready {
                 value,
@@ -834,6 +834,10 @@ impl DerivedCore {
                 continue;
             };
 
+            let dyn_key = DynKey {
+                kind: self.kind,
+                key,
+            };
             // Call through function pointer (monomorphized once per K,V at construction)
             let bytes = (self.encode_record)(
                 self.kind_name,
@@ -870,7 +874,7 @@ impl DerivedCore {
                 data.deps,
             ));
             let mut cells = self.cells.write();
-            cells.insert(data.dyn_key, cell);
+            cells.insert(data.dyn_key.key, cell);
         }
         Ok(())
     }
@@ -881,13 +885,13 @@ impl DerivedCore {
         since_revision: u64,
     ) -> PicanteResult<Vec<(u64, Vec<u8>, Option<Vec<u8>>)>> {
         // Collect snapshot under lock, then release before async work
-        let snapshot: Vec<(DynKey, Arc<ErasedCell>)> = {
+        let snapshot: Vec<(Key, Arc<ErasedCell>)> = {
             let cells = self.cells.read();
             cells.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
         };
         let mut changes = Vec::new();
 
-        for (dyn_key, cell) in snapshot {
+        for (key, cell) in snapshot {
             let state = cell.state.lock().await;
             let ErasedState::Ready {
                 value,
@@ -904,6 +908,10 @@ impl DerivedCore {
                 continue;
             }
 
+            let dyn_key = DynKey {
+                kind: self.kind,
+                key,
+            };
             // Call through function pointer
             let (key_bytes, value_bytes) = (self.encode_incremental)(
                 self.kind_name,
@@ -940,9 +948,9 @@ impl DerivedCore {
 
         let mut cells = self.cells.write();
         if let Some(cell) = result.cell {
-            cells.insert(result.dyn_key, cell);
+            cells.insert(result.dyn_key.key, cell);
         } else {
-            cells.remove(&result.dyn_key);
+            cells.remove(&result.dyn_key.key);
         }
 
         Ok(())
@@ -957,17 +965,21 @@ impl DerivedCore {
         runtime: &crate::runtime::Runtime,
     ) -> PicanteResult<()> {
         // Collect snapshot under lock, then release before async work
-        let snapshot: Vec<(DynKey, Arc<ErasedCell>)> = {
+        let snapshot: Vec<(Key, Arc<ErasedCell>)> = {
             let cells = self.cells.read();
             cells.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
         };
 
-        for (dyn_key, cell) in snapshot {
+        for (key, cell) in snapshot {
             let state = cell.state.lock().await;
             let ErasedState::Ready { deps, .. } = &*state else {
                 continue;
             };
 
+            let dyn_key = DynKey {
+                kind: self.kind,
+                key,
+            };
             runtime.update_query_deps(dyn_key, deps.clone());
         }
 
@@ -1039,14 +1051,14 @@ impl DerivedCore {
     /// `Arc<dyn Any>` (bumping refcount, not actually cloning V).
     async fn snapshot_cells_deep_inner(&self) -> im::HashMap<DynKey, Arc<ErasedCell>> {
         // Collect all cells under lock, then release before async work
-        let cells_snapshot: Vec<(DynKey, Arc<ErasedCell>)> = {
+        let cells_snapshot: Vec<(Key, Arc<ErasedCell>)> = {
             let cells = self.cells.read();
             cells.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
         };
 
         let mut result = im::HashMap::new();
 
-        for (dyn_key, cell) in cells_snapshot {
+        for (key, cell) in cells_snapshot {
             let state = cell.state.lock().await;
             if let ErasedState::Ready {
                 value,
@@ -1064,6 +1076,10 @@ impl DerivedCore {
                     *changed_at,
                     deps.clone(),
                 ));
+                let dyn_key = DynKey {
+                    kind: self.kind,
+                    key,
+                };
                 result.insert(dyn_key, new_cell);
             }
         }
@@ -1314,7 +1330,7 @@ where
 {
     /// Non-generic core containing the type-erased state machine
     core: DerivedCore,
-    key_factory: KeyFactory<K>,
+    key_factory: Arc<KeyFactory<K>>,
     /// Type information for K and V
     _phantom: PhantomData<(K, V)>,
     /// Type-erased compute function (trait object for dyn dispatch)
@@ -1335,10 +1351,11 @@ where
         kind_name: &'static str,
         compute: impl for<'db> Fn(&'db DB, K) -> ComputeFuture<'db, V> + Send + Sync + 'static,
     ) -> Self {
+        let key_factory = Arc::new(KeyFactory::new());
         // Create typed adapter and erase to trait object
         let typed_compute = TypedCompute {
             f: Arc::new(compute),
-            key_factory: KeyFactory::new(),
+            key_factory: key_factory.clone(),
             _phantom: PhantomData,
         };
         let compute_erased: Arc<dyn ErasedCompute<DB>> = Arc::new(typed_compute);
@@ -1358,7 +1375,7 @@ where
                 encode_incremental,
                 apply_wal_entry,
             ),
-            key_factory: KeyFactory::new(),
+            key_factory,
             _phantom: PhantomData,
             compute: compute_erased,
             eq_erased: eq_erased_for::<V>,
@@ -1428,38 +1445,48 @@ where
 
     /// Create a snapshot of this ingredient's cells.
     ///
-    /// This is an O(1) operation due to structural sharing in `im::HashMap`.
-    /// The returned map shares structure with the live ingredient.
+    /// The returned map contains the erased runtime key shape expected by debug
+    /// and snapshot callers; the live per-kind cell map stores bare `Key`s.
     pub fn snapshot(&self) -> im::HashMap<DynKey, Arc<ErasedCell>> {
-        self.core.cells.read().clone()
+        self.core
+            .cells
+            .read()
+            .iter()
+            .map(|(key, cell)| {
+                (
+                    DynKey {
+                        kind: self.core.kind,
+                        key: key.clone(),
+                    },
+                    cell.clone(),
+                )
+            })
+            .collect()
     }
 
     /// Load cells from a snapshot into this ingredient.
     ///
     /// This is used when creating database snapshots. Existing cells are replaced.
     pub fn load_cells(&self, cells: im::HashMap<DynKey, Arc<ErasedCell>>) {
-        *self.core.cells.write() = cells;
+        *self.core.cells.write() = cells
+            .into_iter()
+            .map(|(dyn_key, cell)| (dyn_key.key, cell))
+            .collect();
     }
 
     /// Look up the raw (type-erased) cell for `key`.
     ///
     /// This is intended for cache promotion across runtimes/snapshots.
     pub fn cell_for_key(&self, key: &K) -> PicanteResult<Option<Arc<ErasedCell>>> {
-        let dyn_key = DynKey {
-            kind: self.core.kind,
-            key: self.key_factory.key(key.clone())?,
-        };
-        Ok(self.core.cells.read().get(&dyn_key).cloned())
+        let key = self.key_factory.key(key.clone())?;
+        Ok(self.core.cells.read().get(&key).cloned())
     }
 
     /// Insert a ready cell record into this ingredient (overwriting any existing cell).
     ///
     /// This is intended for cache promotion (e.g. from a snapshot back into a live DB).
     pub fn insert_ready_record(&self, key: &K, record: ErasedReadyRecord) -> PicanteResult<()> {
-        let dyn_key = DynKey {
-            kind: self.core.kind,
-            key: self.key_factory.key(key.clone())?,
-        };
+        let key = self.key_factory.key(key.clone())?;
         let cell = Arc::new(ErasedCell::new_ready(
             record.value,
             record.verified_at,
@@ -1468,7 +1495,7 @@ where
         ));
 
         let mut cells = self.core.cells.write();
-        cells.insert(dyn_key, cell);
+        cells.insert(key, cell);
         Ok(())
     }
 

--- a/picante/src/ingredient/input.rs
+++ b/picante/src/ingredient/input.rs
@@ -56,7 +56,7 @@ type ApplyInputWalEntryFn = fn(
 struct InputCore {
     kind: QueryKindId,
     kind_name: &'static str,
-    entries: RwLock<im::HashMap<DynKey, ErasedInputEntry>>,
+    entries: RwLock<im::HashMap<Key, ErasedInputEntry>>,
     // Type-erased persistence callbacks
     encode_record: EncodeInputRecordFn,
     decode_record: DecodeInputRecordFn,
@@ -91,8 +91,12 @@ impl InputCore {
     fn save_records_erased(&self) -> PicanteResult<Vec<Vec<u8>>> {
         let entries = self.entries.read();
         let mut records = Vec::with_capacity(entries.len());
-        for (dyn_key, entry) in entries.iter() {
-            let bytes = (self.encode_record)(dyn_key, entry.value.as_ref(), entry.changed_at)?;
+        for (key, entry) in entries.iter() {
+            let dyn_key = DynKey {
+                kind: self.kind,
+                key: key.clone(),
+            };
+            let bytes = (self.encode_record)(&dyn_key, entry.value.as_ref(), entry.changed_at)?;
             records.push(bytes);
         }
         trace!(
@@ -108,7 +112,7 @@ impl InputCore {
         for bytes in records {
             // Pass owned Vec<u8> (callback needs 'static for deserialization)
             let (dyn_key, entry) = (self.decode_record)(self.kind, bytes)?;
-            entries.insert(dyn_key, entry);
+            entries.insert(dyn_key.key, entry);
         }
         Ok(())
     }
@@ -121,10 +125,14 @@ impl InputCore {
         let entries = self.entries.read();
         let mut changes = Vec::new();
 
-        for (dyn_key, entry) in entries.iter() {
+        for (key, entry) in entries.iter() {
             if entry.changed_at.0 > since_revision {
+                let dyn_key = DynKey {
+                    kind: self.kind,
+                    key: key.clone(),
+                };
                 let (key_bytes, value_bytes) =
-                    (self.encode_incremental)(dyn_key, entry.value.as_ref())?;
+                    (self.encode_incremental)(&dyn_key, entry.value.as_ref())?;
                 changes.push((entry.changed_at.0, key_bytes, value_bytes));
             }
         }
@@ -151,7 +159,7 @@ impl InputCore {
         entry.changed_at = Revision(revision);
 
         let mut entries = self.entries.write();
-        entries.insert(dyn_key, entry);
+        entries.insert(dyn_key.key, entry);
 
         Ok(())
     }
@@ -319,7 +327,7 @@ pub struct InputEntry<V> {
 /// lock-free `DashMap`). The trade-off favors snapshot efficiency for database
 /// state capture and time-travel debugging scenarios.
 ///
-/// Storage is type-erased internally (using `DynKey` and `Arc<dyn Any>`) to enable
+/// Storage is type-erased internally (using `Key` and `Arc<dyn Any>`) to enable
 /// persistence code to be compiled once instead of per (K, V) combination.
 pub struct InputIngredient<K, V>
 where
@@ -372,19 +380,15 @@ where
     pub fn set<DB: HasRuntime>(&self, db: &DB, key: K, value: V) -> Revision {
         let _span = tracing::debug_span!("set", kind = self.core.kind.0).entered();
 
-        // Encode key for storage
-        let dyn_key = match self.key_factory.key(key.clone()) {
-            Ok(encoded) => DynKey {
-                kind: self.core.kind,
-                key: encoded,
-            },
+        let encoded_key = match self.key_factory.key(key.clone()) {
+            Ok(encoded) => encoded,
             Err(_) => return Revision(0), // Can't encode key, no-op
         };
 
         // Check if value is unchanged (read lock)
         {
             let entries = self.core.entries.read();
-            if let Some(existing) = entries.get(&dyn_key)
+            if let Some(existing) = entries.get(&encoded_key)
                 && let Some(existing_value) = existing.value.as_ref()
                 && let Some(typed_existing) = existing_value.downcast_ref::<V>()
                 && crate::facet_eq::facet_eq_direct(typed_existing, &value)
@@ -407,7 +411,7 @@ where
         {
             let mut entries = self.core.entries.write();
             entries.insert(
-                dyn_key.clone(),
+                encoded_key.clone(),
                 ErasedInputEntry {
                     value: Some(Arc::new(value) as ArcAny),
                     changed_at: rev,
@@ -415,7 +419,7 @@ where
             );
         }
         db.runtime()
-            .notify_input_set(rev, self.core.kind, dyn_key.key);
+            .notify_input_set(rev, self.core.kind, encoded_key);
         rev
     }
 
@@ -426,19 +430,15 @@ where
     pub fn remove<DB: HasRuntime>(&self, db: &DB, key: &K) -> Revision {
         let _span = tracing::debug_span!("remove", kind = self.core.kind.0).entered();
 
-        // Encode key for storage
-        let dyn_key = match self.key_factory.key(key.clone()) {
-            Ok(encoded) => DynKey {
-                kind: self.core.kind,
-                key: encoded,
-            },
+        let encoded_key = match self.key_factory.key(key.clone()) {
+            Ok(encoded) => encoded,
             Err(_) => return Revision(0), // Can't encode key, no-op
         };
 
         // Check current state (read lock)
         {
             let entries = self.core.entries.read();
-            match entries.get(&dyn_key) {
+            match entries.get(&encoded_key) {
                 Some(existing) if existing.value.is_none() => {
                     trace!(
                         kind = self.core.kind.0,
@@ -462,7 +462,7 @@ where
         {
             let mut entries = self.core.entries.write();
             entries.insert(
-                dyn_key.clone(),
+                encoded_key.clone(),
                 ErasedInputEntry {
                     value: None,
                     changed_at: rev,
@@ -470,7 +470,7 @@ where
             );
         }
         db.runtime()
-            .notify_input_removed(rev, self.core.kind, dyn_key.key);
+            .notify_input_removed(rev, self.core.kind, encoded_key);
         rev
     }
 
@@ -483,20 +483,16 @@ where
 
         let encoded_key = self.key_factory.key(key.clone())?;
         let key_hash = encoded_key.hash();
-        let dyn_key = DynKey {
-            kind: self.core.kind,
-            key: encoded_key.clone(),
-        };
 
         if frame::record_dep_if_active(Dep {
             kind: self.core.kind,
-            key: encoded_key,
+            key: encoded_key.clone(),
         }) {
             trace!(kind = self.core.kind.0, key_hash = %format!("{:016x}", key_hash), "input dep");
         }
 
         let entries = self.core.entries.read();
-        Ok(entries.get(&dyn_key).and_then(|e| {
+        Ok(entries.get(&encoded_key).and_then(|e| {
             e.value
                 .as_ref()
                 .and_then(|v| v.downcast_ref::<V>())
@@ -506,12 +502,9 @@ where
 
     /// The last revision at which this input was changed.
     pub fn changed_at(&self, key: &K) -> Option<Revision> {
-        let dyn_key = DynKey {
-            kind: self.core.kind,
-            key: self.key_factory.key(key.clone()).ok()?,
-        };
+        let encoded_key = self.key_factory.key(key.clone()).ok()?;
         let entries = self.core.entries.read();
-        entries.get(&dyn_key).map(|e| e.changed_at)
+        entries.get(&encoded_key).map(|e| e.changed_at)
     }
 
     // r[snapshot.input]
@@ -527,8 +520,8 @@ where
         let entries = self.core.entries.read();
         entries
             .iter()
-            .filter_map(|(dyn_key, entry)| {
-                let key: K = dyn_key.key.decode_facet().ok()?;
+            .filter_map(|(encoded_key, entry)| {
+                let key: K = encoded_key.decode_facet().ok()?;
                 let value = entry
                     .value
                     .as_ref()
@@ -573,13 +566,9 @@ where
             let mut erased_entries = core.entries.write();
             for (key, entry) in entries {
                 if let Ok(encoded_key) = key_factory.key(key) {
-                    let dyn_key = DynKey {
-                        kind,
-                        key: encoded_key,
-                    };
                     let erased_value = entry.value.map(|v| Arc::new(v) as ArcAny);
                     erased_entries.insert(
-                        dyn_key,
+                        encoded_key,
                         ErasedInputEntry {
                             value: erased_value,
                             changed_at: entry.changed_at,
@@ -668,13 +657,9 @@ where
     fn touch<'a>(&'a self, _db: &'a DB, key: Key) -> BoxFuture<'a, PicanteResult<Touch>> {
         Box::pin(async move {
             let key = self.key_factory.normalize_key(key)?;
-            let dyn_key = DynKey {
-                kind: self.core.kind,
-                key,
-            };
             let entries = self.core.entries.read();
             let changed_at = entries
-                .get(&dyn_key)
+                .get(&key)
                 .map(|e| e.changed_at)
                 .unwrap_or(Revision(0));
             Ok(Touch { changed_at })

--- a/picante/src/key.rs
+++ b/picante/src/key.rs
@@ -46,11 +46,12 @@ impl QueryKindId {
 /// Erased runtime key plus a deterministic cached hash for indexing/tracing.
 #[derive(Clone)]
 pub struct Key {
-    repr: Arc<KeyRepr>,
+    repr: KeyRepr,
     // r[key.hash]
     hash: u64,
 }
 
+#[derive(Clone)]
 enum KeyRepr {
     Typed(Arc<dyn ErasedFacetKey>),
     Bytes(Arc<[u8]>),
@@ -80,7 +81,11 @@ where
         other
             .as_any()
             .downcast_ref::<FacetKey<T>>()
-            .is_some_and(|other| crate::facet_eq::facet_eq_direct(&*self.value, &*other.value))
+            .is_some_and(|other| {
+                eq_known_key_type(&*self.value, &*other.value).unwrap_or_else(|| {
+                    crate::facet_eq::facet_eq_direct(&*self.value, &*other.value)
+                })
+            })
     }
 
     fn bytes(&self) -> PicanteResult<&[u8]> {
@@ -134,7 +139,7 @@ impl Key {
             stable_hash(&bytes)
         };
         Ok(Self {
-            repr: Arc::new(KeyRepr::Bytes(bytes.into())),
+            repr: KeyRepr::Bytes(bytes.into()),
             hash,
         })
     }
@@ -143,7 +148,7 @@ impl Key {
     where
         T: Clone + Facet<'static> + Send + Sync + 'static,
     {
-        if let KeyRepr::Typed(typed) = &*self.repr
+        if let KeyRepr::Typed(typed) = &self.repr
             && let Some(value) = typed
                 .as_any()
                 .downcast_ref::<FacetKey<T>>()
@@ -169,7 +174,7 @@ impl Key {
     pub fn from_bytes(bytes: Vec<u8>) -> Self {
         let hash = stable_hash(&bytes);
         Self {
-            repr: Arc::new(KeyRepr::Bytes(bytes.into())),
+            repr: KeyRepr::Bytes(bytes.into()),
             hash,
         }
     }
@@ -182,7 +187,7 @@ impl Key {
 
     /// Try to access the encoded bytes without panicking on materialization errors.
     pub fn try_bytes(&self) -> PicanteResult<&[u8]> {
-        match &*self.repr {
+        match &self.repr {
             KeyRepr::Typed(typed) => typed.bytes(),
             KeyRepr::Bytes(bytes) => Ok(bytes),
         }
@@ -190,7 +195,7 @@ impl Key {
 
     /// Return the persistent byte representation of this key.
     pub fn to_bytes(&self) -> PicanteResult<Arc<[u8]>> {
-        match &*self.repr {
+        match &self.repr {
             KeyRepr::Typed(typed) => typed.to_bytes(),
             KeyRepr::Bytes(bytes) => Ok(bytes.clone()),
         }
@@ -215,7 +220,7 @@ impl Key {
 // r[key.equality]
 impl PartialEq for Key {
     fn eq(&self, other: &Self) -> bool {
-        match (&*self.repr, &*other.repr) {
+        match (&self.repr, &other.repr) {
             (KeyRepr::Typed(left), KeyRepr::Typed(right)) => left.eq_typed(&**right),
             (KeyRepr::Bytes(left), KeyRepr::Bytes(right)) => left == right,
             _ => match (self.to_bytes(), other.to_bytes()) {
@@ -264,6 +269,37 @@ pub struct Dep {
 
 fn stable_hash(bytes: &[u8]) -> u64 {
     facet_hash::hash_bytes_fnv1a64(bytes)
+}
+
+fn eq_known_key_type<T: 'static>(left: &T, right: &T) -> Option<bool> {
+    let left = left as &dyn Any;
+    let right = right as &dyn Any;
+
+    macro_rules! eq_as {
+        ($ty:ty) => {
+            if let Some(left) = left.downcast_ref::<$ty>() {
+                return Some(left == right.downcast_ref::<$ty>()?);
+            }
+        };
+    }
+
+    eq_as!(u32);
+    eq_as!(());
+    eq_as!(String);
+    eq_as!(u64);
+    eq_as!(bool);
+    eq_as!(u16);
+    eq_as!(u8);
+    eq_as!(u128);
+    eq_as!(usize);
+    eq_as!(i32);
+    eq_as!(i64);
+    eq_as!(i16);
+    eq_as!(i8);
+    eq_as!(i128);
+    eq_as!(isize);
+
+    None
 }
 
 /// Reusable key builder for one Facet key type.
@@ -316,7 +352,7 @@ where
         };
 
         Ok(Key {
-            repr: Arc::new(KeyRepr::Typed(Arc::new(key))),
+            repr: KeyRepr::Typed(Arc::new(key)),
             hash,
         })
     }
@@ -348,7 +384,7 @@ where
             bytes: once_lock_from_option(Some(Ok(bytes))),
         };
         Ok(Key {
-            repr: Arc::new(KeyRepr::Typed(Arc::new(key))),
+            repr: KeyRepr::Typed(Arc::new(key)),
             hash,
         })
     }
@@ -358,7 +394,7 @@ where
     where
         T: Clone + Send + Sync + 'static,
     {
-        let already_typed = match &*key.repr {
+        let already_typed = match &key.repr {
             KeyRepr::Typed(typed) => typed.as_any().is::<FacetKey<T>>(),
             KeyRepr::Bytes(_) => false,
         };


### PR DESCRIPTION
## Summary

This slims the Picante runtime key path without changing the public dependency identity model. Per-ingredient input and derived maps now use bare `Key` internally, and only rebuild `DynKey` at runtime graph, persistence, and snapshot boundaries.

It also shares the derived `KeyFactory` between the wrapper and erased compute adapter, removes the extra outer `Arc<KeyRepr>` allocation from every `Key`, and adds a fast equality path for common key types before falling back to reflective Facet equality.

## Benchmarks

Hardware: Apple M4 Pro, 14-core, 24 GB.

Command shape:

```sh
target/release/deps/derived-494a4f81a0073ee3 --bench --min-time 2 --sample-count 25 --threads 1 \
  input_get_hit input_set_noop_small_value input_set_noop_large_value \
  derived_hot_hit derived_cold_unique_keys derived_wide_revalidate_512_deps \
  derived_wide_recompute_512_deps derived_deep_chain_hot_hit_32 \
  derived_deep_chain_revalidate_32
```

Baseline: `origin/main` at `ea52f5f93`. Head: `89819ab48`.

| benchmark | main median | head median | speed |
|---|---:|---:|---:|
| `input_get_hit` | 57.92 ns | 44.16 ns | 1.31x |
| `input_set_noop_small_value` | 62.81 ns | 46.45 ns | 1.35x |
| `input_set_noop_large_value` | 38.79 us | 39.66 us | 0.98x |
| `derived_hot_hit` | 257.4 ns | 254.8 ns | 1.01x |
| `derived_cold_unique_keys` | 1.624 us | 1.624 us | 1.00x |
| `derived_deep_chain_hot_hit_32` | 231.4 ns | 220.9 ns | 1.05x |
| `derived_deep_chain_revalidate_32` | 6.916 us | 6.708 us | 1.03x |
| `derived_wide_revalidate_512_deps` | 29.08 us | 20.83 us | 1.40x |
| `derived_wide_recompute_512_deps` | 57.04 us | 39.79 us | 1.43x |

stax: recorded `input_get_hit` as run 11. The finished branch no longer has `facet_eq` in the top frames for that row; residual samples are in key hashing, HAMT hashing, frame dependency recording, and Arc lifecycle.

## Verification

```sh
cargo check -p picante
cargo nextest run -p picante
cargo clippy -p picante --all-features --all-targets --message-format=short -- -D warnings
cargo bench -p picante --bench derived --no-run
```
