### PR TITLE
picante: add opt-in native key hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,6 +4716,7 @@ dependencies = [
  "facet-postcard",
  "facet-reflect",
  "futures-util",
+ "hashbrown 0.17.1",
  "im",
  "parking_lot",
  "picante-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -386,6 +386,7 @@ futures-channel = "0.3"
 futures-util = { version = "^0.3.31", default-features = false, features = ["std", "async-await", "async-await-macro"] }
 glob = "^0.3"
 goblin = "^0.9"
+hashbrown = { version = "0.17", features = ["raw-entry"] }
 heck = "^0.5.0"
 hex = "^0.4"
 http = "^1.4.0"

--- a/facet-hash/src/native.rs
+++ b/facet-hash/src/native.rs
@@ -27,6 +27,13 @@ pub struct NativeHashPlan<T, H = std::collections::hash_map::DefaultHasher> {
     _marker: PhantomData<fn() -> (T, H)>,
 }
 
+// SAFETY: the executable buffer and side tables are fully materialized before
+// the plan is returned. `hash` only reads them and uses the caller-owned hasher.
+unsafe impl<T, H> Send for NativeHashPlan<T, H> {}
+// SAFETY: the executable buffer and side tables are fully materialized before
+// the plan is returned. `hash` only reads them and uses the caller-owned hasher.
+unsafe impl<T, H> Sync for NativeHashPlan<T, H> {}
+
 impl<T, H> NativeHashPlan<T, H>
 where
     T: Facet<'static>,

--- a/picante/Cargo.toml
+++ b/picante/Cargo.toml
@@ -34,6 +34,7 @@ picante-macros = { workspace = true, optional = true }
 
 [features]
 default = ["macros"]
+jit = ["facet-hash/jit"]
 macros = ["dep:picante-macros"]
 
 [dev-dependencies]

--- a/picante/Cargo.toml
+++ b/picante/Cargo.toml
@@ -27,6 +27,7 @@ facet-hash.workspace = true
 facet-reflect.workspace = true
 facet-postcard.workspace = true
 futures-util.workspace = true
+hashbrown.workspace = true
 parking_lot.workspace = true
 tokio = { workspace = true, features = ["fs", "sync", "time"] }
 tracing.workspace = true

--- a/picante/src/frame.rs
+++ b/picante/src/frame.rs
@@ -2,59 +2,78 @@
 
 use crate::key::{Dep, DynKey};
 use crate::revision::Revision;
-use parking_lot::Mutex;
 use std::cell::RefCell;
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::trace;
 
 // r[frame.task-local]
 // r[frame.cycle-stack]
 tokio::task_local! {
-    static ACTIVE_STACK: RefCell<Vec<ActiveFrameHandle>>;
+    static ACTIVE_STACK: RefCell<ActiveStack>;
 }
+
+static NEXT_FRAME_ID: AtomicU64 = AtomicU64::new(1);
 
 // r[frame.purpose]
 /// A cheap, clonable handle for the currently-running query frame.
 #[derive(Clone)]
-pub struct ActiveFrameHandle(Arc<ActiveFrameInner>);
-
-// r[frame.no-lock-await]
-struct ActiveFrameInner {
+pub struct ActiveFrameHandle {
+    id: u64,
     dyn_key: DynKey,
     started_at: Revision,
-    deps: Mutex<Vec<Dep>>,
+}
+
+struct ActiveStack {
+    frames: Vec<ActiveFrame>,
+}
+
+// r[frame.no-lock-await]
+struct ActiveFrame {
+    id: u64,
+    dyn_key: DynKey,
+    deps: Vec<Dep>,
 }
 
 impl ActiveFrameHandle {
     /// Create a new frame for `dyn_key`, recording dependencies at `started_at`.
     pub fn new(dyn_key: DynKey, started_at: Revision) -> Self {
-        Self(Arc::new(ActiveFrameInner {
+        Self {
+            id: NEXT_FRAME_ID.fetch_add(1, Ordering::Relaxed),
             dyn_key,
             started_at,
-            deps: Mutex::new(Vec::new()),
-        }))
+        }
     }
 
     /// The erased key for this frame.
     pub fn dyn_key(&self) -> &DynKey {
-        &self.0.dyn_key
+        &self.dyn_key
     }
 
     /// The revision at which the frame started.
     pub fn started_at(&self) -> Revision {
-        self.0.started_at
+        self.started_at
     }
 
     /// Drain the recorded dependency list.
     pub fn take_deps(&self) -> Vec<Dep> {
-        let mut deps = self.0.deps.lock();
-        std::mem::take(&mut *deps)
+        ACTIVE_STACK
+            .try_with(|stack| {
+                let mut stack = stack.borrow_mut();
+                stack
+                    .frames
+                    .iter_mut()
+                    .find(|frame| frame.id == self.id)
+                    .map(|frame| std::mem::take(&mut frame.deps))
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default()
     }
 }
 
 /// Guard that pops the active frame when dropped.
 pub struct FrameGuard {
+    id: u64,
     popped: bool,
 }
 
@@ -64,7 +83,16 @@ impl Drop for FrameGuard {
             return;
         }
         let _ = ACTIVE_STACK.try_with(|stack| {
-            let popped = stack.borrow_mut().pop();
+            let mut stack = stack.borrow_mut();
+            let popped = if stack.frames.last().is_some_and(|frame| frame.id == self.id) {
+                stack.frames.pop()
+            } else {
+                stack
+                    .frames
+                    .iter()
+                    .rposition(|frame| frame.id == self.id)
+                    .map(|index| stack.frames.remove(index))
+            };
             trace!(popped = popped.is_some(), "pop_frame");
         });
         self.popped = true;
@@ -80,7 +108,9 @@ where
     if ACTIVE_STACK.try_with(|_| ()).is_ok() {
         f().await
     } else {
-        ACTIVE_STACK.scope(RefCell::new(Vec::new()), f()).await
+        ACTIVE_STACK
+            .scope(RefCell::new(ActiveStack { frames: Vec::new() }), f())
+            .await
     }
 }
 
@@ -95,14 +125,16 @@ pub async fn scope_if_needed_boxed<R>(
     if ACTIVE_STACK.try_with(|_| ()).is_ok() {
         fut.await
     } else {
-        ACTIVE_STACK.scope(RefCell::new(Vec::new()), fut).await
+        ACTIVE_STACK
+            .scope(RefCell::new(ActiveStack { frames: Vec::new() }), fut)
+            .await
     }
 }
 
 /// Returns `true` if there is a current query frame.
 pub fn has_active_frame() -> bool {
     ACTIVE_STACK
-        .try_with(|stack| !stack.borrow().is_empty())
+        .try_with(|stack| !stack.borrow().frames.is_empty())
         .unwrap_or(false)
 }
 
@@ -116,12 +148,12 @@ pub fn record_dep(dep: Dep) {
 pub(crate) fn record_dep_if_active(dep: Dep) -> bool {
     ACTIVE_STACK
         .try_with(|stack| {
-            let stack = stack.borrow();
-            let Some(top) = stack.last() else {
+            let mut stack = stack.borrow_mut();
+            let Some(top) = stack.frames.last_mut() else {
                 return false;
             };
 
-            top.0.deps.lock().push(dep);
+            top.deps.push(dep);
             true
         })
         .unwrap_or(false)
@@ -130,12 +162,12 @@ pub(crate) fn record_dep_if_active(dep: Dep) -> bool {
 pub(crate) fn record_dep_with(make_dep: impl FnOnce() -> Dep) -> bool {
     ACTIVE_STACK
         .try_with(|stack| {
-            let stack = stack.borrow();
-            let Some(top) = stack.last() else {
+            let mut stack = stack.borrow_mut();
+            let Some(top) = stack.frames.last_mut() else {
                 return false;
             };
 
-            top.0.deps.lock().push(make_dep());
+            top.deps.push(make_dep());
             true
         })
         .unwrap_or(false)
@@ -144,12 +176,12 @@ pub(crate) fn record_dep_with(make_dep: impl FnOnce() -> Dep) -> bool {
 pub(crate) fn record_dep_result<E>(make_dep: impl FnOnce() -> Result<Dep, E>) -> Result<bool, E> {
     ACTIVE_STACK
         .try_with(|stack| {
-            let stack = stack.borrow();
-            let Some(top) = stack.last() else {
+            let mut stack = stack.borrow_mut();
+            let Some(top) = stack.frames.last_mut() else {
                 return Ok(false);
             };
 
-            top.0.deps.lock().push(make_dep()?);
+            top.deps.push(make_dep()?);
             Ok(true)
         })
         .unwrap_or(Ok(false))
@@ -162,11 +194,11 @@ pub fn find_cycle(requested: &DynKey) -> Option<Vec<DynKey>> {
     ACTIVE_STACK
         .try_with(|stack| {
             let stack = stack.borrow();
-            let has_cycle = stack.iter().any(|f| f.dyn_key() == requested);
+            let has_cycle = stack.frames.iter().any(|f| &f.dyn_key == requested);
             if !has_cycle {
                 return None;
             }
-            Some(stack.iter().map(|f| f.dyn_key().clone()).collect())
+            Some(stack.frames.iter().map(|f| f.dyn_key.clone()).collect())
         })
         .ok()
         .flatten()
@@ -174,8 +206,14 @@ pub fn find_cycle(requested: &DynKey) -> Option<Vec<DynKey>> {
 
 /// Push a frame onto the task-local stack. Requires an active scope (see [`scope_if_needed`]).
 pub fn push_frame(frame: ActiveFrameHandle) -> FrameGuard {
+    let id = frame.id;
     let _ = ACTIVE_STACK.try_with(|stack| {
-        stack.borrow_mut().push(frame);
+        let mut stack = stack.borrow_mut();
+        stack.frames.push(ActiveFrame {
+            id,
+            dyn_key: frame.dyn_key.clone(),
+            deps: Vec::new(),
+        });
     });
-    FrameGuard { popped: false }
+    FrameGuard { id, popped: false }
 }

--- a/picante/src/ingredient/derived.rs
+++ b/picante/src/ingredient/derived.rs
@@ -2,7 +2,7 @@ use crate::db::{DynIngredient, IngredientLookup, Touch};
 use crate::error::{PicanteError, PicanteResult};
 use crate::frame::{self, ActiveFrameHandle};
 use crate::inflight::{self, InFlightKey, InFlightState, SharedCacheRecord, TryLeadResult};
-use crate::key::{Dep, DynKey, Key, KeyFactory, QueryKindId};
+use crate::key::{Dep, DynKey, Key, KeyFactory, KeyMap, QueryKindId, key_map};
 use crate::persist::{KeyDecodeFn, PersistableIngredient, SectionType};
 use crate::revision::Revision;
 use facet::Facet;
@@ -202,7 +202,7 @@ where
 struct DerivedCore {
     kind: QueryKindId,
     kind_name: &'static str,
-    cells: RwLock<im::HashMap<Key, Arc<ErasedCell>>>,
+    cells: RwLock<KeyMap<Arc<ErasedCell>>>,
     // Type-erased persistence callbacks (function pointers, not closures)
     encode_record: EncodeRecordFn,
     decode_record: DecodeRecordFn,
@@ -222,7 +222,7 @@ impl DerivedCore {
         Self {
             kind,
             kind_name,
-            cells: RwLock::new(im::HashMap::new()),
+            cells: RwLock::new(key_map()),
             encode_record,
             decode_record,
             encode_incremental,
@@ -1692,7 +1692,7 @@ where
 
     fn clear(&self) {
         let mut cells = self.core.cells.write();
-        *cells = im::HashMap::new();
+        *cells = key_map();
     }
 
     fn save_records(&self) -> BoxFuture<'_, PicanteResult<Vec<Vec<u8>>>> {

--- a/picante/src/ingredient/input.rs
+++ b/picante/src/ingredient/input.rs
@@ -1,12 +1,13 @@
 use crate::db::{DynIngredient, Touch};
 use crate::error::{PicanteError, PicanteResult};
 use crate::frame;
-use crate::key::{Dep, DynKey, Key, KeyFactory, QueryKindId};
+use crate::key::{Dep, Key, KeyFactory, QueryKindId, RuntimeKeyMap, runtime_key_map};
 use crate::persist::{PersistableIngredient, SectionType};
 use crate::revision::Revision;
 use crate::runtime::HasRuntime;
 use facet::Facet;
 use futures_util::future::BoxFuture;
+use hashbrown::hash_map::RawEntryMut;
 use parking_lot::RwLock;
 use std::any::Any;
 use std::hash::Hash;
@@ -28,55 +29,52 @@ struct ErasedInputEntry {
 }
 
 /// Encode a single record to bytes
-type EncodeInputRecordFn =
-    fn(dyn_key: &DynKey, value: Option<&ArcAny>, changed_at: Revision) -> PicanteResult<Vec<u8>>;
+type EncodeInputRecordFn<K> =
+    fn(key: &K, value: Option<&ArcAny>, changed_at: Revision) -> PicanteResult<Vec<u8>>;
 
 /// Decode a single record from bytes
 /// Takes owned `Vec<u8>` because facet_postcard::from_slice requires 'static
-type DecodeInputRecordFn =
-    fn(kind: QueryKindId, bytes: Vec<u8>) -> PicanteResult<(DynKey, ErasedInputEntry)>;
+type DecodeInputRecordFn<K> = fn(bytes: Vec<u8>) -> PicanteResult<(K, ErasedInputEntry)>;
 
 /// Encode key and optional value for incremental save
-type EncodeInputIncrementalFn =
-    fn(dyn_key: &DynKey, value: Option<&ArcAny>) -> PicanteResult<(Vec<u8>, Option<Vec<u8>>)>;
+type EncodeInputIncrementalFn<K> =
+    fn(key: &K, value: Option<&ArcAny>) -> PicanteResult<(Vec<u8>, Option<Vec<u8>>)>;
 
 /// Apply a WAL entry (insert or delete)
 /// Takes owned bytes because facet_postcard::from_slice requires 'static
-type ApplyInputWalEntryFn = fn(
-    kind: QueryKindId,
-    key_bytes: Vec<u8>,
-    value_bytes: Option<Vec<u8>>,
-) -> PicanteResult<(DynKey, ErasedInputEntry)>;
+type ApplyInputWalEntryFn<K> =
+    fn(key_bytes: Vec<u8>, value_bytes: Option<Vec<u8>>) -> PicanteResult<(K, ErasedInputEntry)>;
 
 // ============================================================================
-// Non-generic core: persistence logic compiled ONCE
+// Typed core: hot storage stays in the user's key type.
 // ============================================================================
 
-/// Non-generic core containing type-erased storage and persistence logic.
-struct InputCore {
+struct InputCore<K> {
     kind: QueryKindId,
     kind_name: &'static str,
-    entries: RwLock<im::HashMap<Key, ErasedInputEntry>>,
-    // Type-erased persistence callbacks
-    encode_record: EncodeInputRecordFn,
-    decode_record: DecodeInputRecordFn,
-    encode_incremental: EncodeInputIncrementalFn,
-    apply_wal_entry: ApplyInputWalEntryFn,
+    entries: RwLock<RuntimeKeyMap<K, ErasedInputEntry>>,
+    encode_record: EncodeInputRecordFn<K>,
+    decode_record: DecodeInputRecordFn<K>,
+    encode_incremental: EncodeInputIncrementalFn<K>,
+    apply_wal_entry: ApplyInputWalEntryFn<K>,
 }
 
-impl InputCore {
+impl<K> InputCore<K>
+where
+    K: Clone + Facet<'static> + Send + Sync + 'static,
+{
     fn new(
         kind: QueryKindId,
         kind_name: &'static str,
-        encode_record: EncodeInputRecordFn,
-        decode_record: DecodeInputRecordFn,
-        encode_incremental: EncodeInputIncrementalFn,
-        apply_wal_entry: ApplyInputWalEntryFn,
+        encode_record: EncodeInputRecordFn<K>,
+        decode_record: DecodeInputRecordFn<K>,
+        encode_incremental: EncodeInputIncrementalFn<K>,
+        apply_wal_entry: ApplyInputWalEntryFn<K>,
     ) -> Self {
         Self {
             kind,
             kind_name,
-            entries: RwLock::new(im::HashMap::new()),
+            entries: RwLock::new(runtime_key_map()),
             encode_record,
             decode_record,
             encode_incremental,
@@ -92,11 +90,7 @@ impl InputCore {
         let entries = self.entries.read();
         let mut records = Vec::with_capacity(entries.len());
         for (key, entry) in entries.iter() {
-            let dyn_key = DynKey {
-                kind: self.kind,
-                key: key.clone(),
-            };
-            let bytes = (self.encode_record)(&dyn_key, entry.value.as_ref(), entry.changed_at)?;
+            let bytes = (self.encode_record)(key.value(), entry.value.as_ref(), entry.changed_at)?;
             records.push(bytes);
         }
         trace!(
@@ -107,12 +101,15 @@ impl InputCore {
         Ok(records)
     }
 
-    fn load_records_erased(&self, records: Vec<Vec<u8>>) -> PicanteResult<()> {
+    fn load_records_erased(
+        &self,
+        records: Vec<Vec<u8>>,
+        key_factory: &KeyFactory<K>,
+    ) -> PicanteResult<()> {
         let mut entries = self.entries.write();
         for bytes in records {
-            // Pass owned Vec<u8> (callback needs 'static for deserialization)
-            let (dyn_key, entry) = (self.decode_record)(self.kind, bytes)?;
-            entries.insert(dyn_key.key, entry);
+            let (key, entry) = (self.decode_record)(bytes)?;
+            entries.insert(key_factory.runtime_key(key)?, entry);
         }
         Ok(())
     }
@@ -127,12 +124,8 @@ impl InputCore {
 
         for (key, entry) in entries.iter() {
             if entry.changed_at.0 > since_revision {
-                let dyn_key = DynKey {
-                    kind: self.kind,
-                    key: key.clone(),
-                };
                 let (key_bytes, value_bytes) =
-                    (self.encode_incremental)(&dyn_key, entry.value.as_ref())?;
+                    (self.encode_incremental)(key.value(), entry.value.as_ref())?;
                 changes.push((entry.changed_at.0, key_bytes, value_bytes));
             }
         }
@@ -152,14 +145,14 @@ impl InputCore {
         revision: u64,
         key_bytes: Vec<u8>,
         value_bytes: Option<Vec<u8>>,
+        key_factory: &KeyFactory<K>,
     ) -> PicanteResult<()> {
-        // Pass owned bytes (callback needs 'static for deserialization)
-        let (dyn_key, mut entry) = (self.apply_wal_entry)(self.kind, key_bytes, value_bytes)?;
+        let (key, mut entry) = (self.apply_wal_entry)(key_bytes, value_bytes)?;
         // Override with the exact revision from WAL
         entry.changed_at = Revision(revision);
 
         let mut entries = self.entries.write();
-        entries.insert(dyn_key.key, entry);
+        entries.insert(key_factory.runtime_key(key)?, entry);
 
         Ok(())
     }
@@ -170,13 +163,12 @@ impl InputCore {
 // ============================================================================
 
 // r[input.constraints]
-fn make_encode_input_record<K, V>() -> EncodeInputRecordFn
+fn make_encode_input_record<K, V>() -> EncodeInputRecordFn<K>
 where
     K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
-    |dyn_key, value, changed_at| {
-        let key: K = dyn_key.key.decode_facet()?;
+    |key, value, changed_at| {
         let typed_value: Option<V> = match value {
             Some(arc_any) => Some(
                 arc_any
@@ -195,7 +187,7 @@ where
         };
 
         let rec = InputRecord::<K, V> {
-            key,
+            key: key.clone(),
             value: typed_value,
             changed_at: changed_at.0,
         };
@@ -209,12 +201,12 @@ where
     }
 }
 
-fn make_decode_input_record<K, V>() -> DecodeInputRecordFn
+fn make_decode_input_record<K, V>() -> DecodeInputRecordFn<K>
 where
     K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
-    |kind, bytes| {
+    |bytes| {
         let rec: InputRecord<K, V> = facet_postcard::from_slice(&bytes).map_err(|e| {
             Arc::new(PicanteError::Decode {
                 what: "input record",
@@ -222,15 +214,10 @@ where
             })
         })?;
 
-        let dyn_key = DynKey {
-            kind,
-            key: KeyFactory::<K>::new().key(rec.key)?,
-        };
-
         let value: Option<ArcAny> = rec.value.map(|v| Arc::new(v) as ArcAny);
 
         Ok((
-            dyn_key,
+            rec.key,
             ErasedInputEntry {
                 value,
                 changed_at: Revision(rec.changed_at),
@@ -239,12 +226,18 @@ where
     }
 }
 
-fn make_encode_input_incremental<V>() -> EncodeInputIncrementalFn
+fn make_encode_input_incremental<K, V>() -> EncodeInputIncrementalFn<K>
 where
+    K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
-    |dyn_key, value| {
-        let key_bytes = dyn_key.key.to_bytes()?.to_vec();
+    |key, value| {
+        let key_bytes = facet_postcard::to_vec(key).map_err(|e| {
+            Arc::new(PicanteError::Encode {
+                what: "input key",
+                message: format!("{e:?}"),
+            })
+        })?;
 
         let value_bytes = match value {
             Some(arc_any) => {
@@ -270,12 +263,19 @@ where
     }
 }
 
-fn make_apply_input_wal_entry<K, V>() -> ApplyInputWalEntryFn
+fn make_apply_input_wal_entry<K, V>() -> ApplyInputWalEntryFn<K>
 where
     K: Clone + Facet<'static> + Send + Sync + 'static,
     V: Clone + Facet<'static> + Send + Sync + 'static,
 {
-    |kind, key_bytes, value_bytes| {
+    |key_bytes, value_bytes| {
+        let key: K = facet_postcard::from_slice(&key_bytes).map_err(|e| {
+            Arc::new(PicanteError::Decode {
+                what: "input key from WAL",
+                message: format!("{e:?}"),
+            })
+        })?;
+
         let value: Option<ArcAny> = match value_bytes {
             Some(bytes) => {
                 let v: V = facet_postcard::from_slice(&bytes).map_err(|e| {
@@ -289,13 +289,8 @@ where
             None => None,
         };
 
-        let dyn_key = DynKey {
-            kind,
-            key: KeyFactory::<K>::new().key_from_bytes(key_bytes)?,
-        };
-
         Ok((
-            dyn_key,
+            key,
             ErasedInputEntry {
                 value,
                 changed_at: Revision(0), // Will be overridden by caller
@@ -327,15 +322,12 @@ pub struct InputEntry<V> {
 /// lock-free `DashMap`). The trade-off favors snapshot efficiency for database
 /// state capture and time-travel debugging scenarios.
 ///
-/// Storage is type-erased internally (using `Key` and `Arc<dyn Any>`) to enable
-/// persistence code to be compiled once instead of per (K, V) combination.
 pub struct InputIngredient<K, V>
 where
     K: Clone + Facet<'static>,
     V: Clone,
 {
-    /// Type-erased core with persistence logic
-    core: InputCore,
+    core: InputCore<K>,
     key_factory: KeyFactory<K>,
     /// Phantom data for K and V types
     _phantom: std::marker::PhantomData<(K, V)>,
@@ -354,7 +346,7 @@ where
                 kind_name,
                 make_encode_input_record::<K, V>(),
                 make_decode_input_record::<K, V>(),
-                make_encode_input_incremental::<V>(),
+                make_encode_input_incremental::<K, V>(),
                 make_apply_input_wal_entry::<K, V>(),
             ),
             key_factory: KeyFactory::new(),
@@ -380,15 +372,17 @@ where
     pub fn set<DB: HasRuntime>(&self, db: &DB, key: K, value: V) -> Revision {
         let _span = tracing::debug_span!("set", kind = self.core.kind.0).entered();
 
-        let encoded_key = match self.key_factory.key(key.clone()) {
-            Ok(encoded) => encoded,
+        let (key_hash, key_bytes) = match self.key_factory.hash_parts(&key) {
+            Ok(parts) => parts,
             Err(_) => return Revision(0), // Can't encode key, no-op
         };
 
         // Check if value is unchanged (read lock)
         {
             let entries = self.core.entries.read();
-            if let Some(existing) = entries.get(&encoded_key)
+            if let Some((_, existing)) = entries
+                .raw_entry()
+                .from_hash(key_hash, |stored| stored.matches(&key))
                 && let Some(existing_value) = existing.value.as_ref()
                 && let Some(typed_existing) = existing_value.downcast_ref::<V>()
                 && crate::facet_eq::facet_eq_direct(typed_existing, &value)
@@ -402,6 +396,12 @@ where
             }
         }
 
+        let runtime_key = self
+            .key_factory
+            .runtime_key_from_parts(key, key_hash, key_bytes);
+        let notify_key = runtime_key.to_key();
+        let runtime_key_hash = runtime_key.hash();
+
         // Value changed, take write lock
         let rev = db.runtime().bump_revision();
         // r[snapshot.divergent]
@@ -410,16 +410,24 @@ where
         db.runtime().mark_divergent();
         {
             let mut entries = self.core.entries.write();
-            entries.insert(
-                encoded_key.clone(),
-                ErasedInputEntry {
-                    value: Some(Arc::new(value) as ArcAny),
-                    changed_at: rev,
-                },
-            );
+            let entry = ErasedInputEntry {
+                value: Some(Arc::new(value) as ArcAny),
+                changed_at: rev,
+            };
+            match entries
+                .raw_entry_mut()
+                .from_hash(runtime_key_hash, |stored| stored == &runtime_key)
+            {
+                RawEntryMut::Occupied(mut occupied) => {
+                    *occupied.get_mut() = entry;
+                }
+                RawEntryMut::Vacant(vacant) => {
+                    vacant.insert_hashed_nocheck(runtime_key_hash, runtime_key, entry);
+                }
+            }
+            db.runtime()
+                .notify_input_set(rev, self.core.kind, notify_key);
         }
-        db.runtime()
-            .notify_input_set(rev, self.core.kind, encoded_key);
         rev
     }
 
@@ -430,16 +438,19 @@ where
     pub fn remove<DB: HasRuntime>(&self, db: &DB, key: &K) -> Revision {
         let _span = tracing::debug_span!("remove", kind = self.core.kind.0).entered();
 
-        let encoded_key = match self.key_factory.key(key.clone()) {
-            Ok(encoded) => encoded,
+        let (key_hash, key_bytes) = match self.key_factory.hash_parts(key) {
+            Ok(parts) => parts,
             Err(_) => return Revision(0), // Can't encode key, no-op
         };
 
         // Check current state (read lock)
         {
             let entries = self.core.entries.read();
-            match entries.get(&encoded_key) {
-                Some(existing) if existing.value.is_none() => {
+            match entries
+                .raw_entry()
+                .from_hash(key_hash, |stored| stored.matches(key))
+            {
+                Some((_, existing)) if existing.value.is_none() => {
                     trace!(
                         kind = self.core.kind.0,
                         changed_at = existing.changed_at.0,
@@ -455,22 +466,36 @@ where
             }
         }
 
+        let runtime_key = self
+            .key_factory
+            .runtime_key_from_parts(key.clone(), key_hash, key_bytes);
+        let notify_key = runtime_key.to_key();
+        let runtime_key_hash = runtime_key.hash();
+
         // Need to remove, take write lock
         let rev = db.runtime().bump_revision();
         // r[snapshot.divergent]
         db.runtime().mark_divergent();
         {
             let mut entries = self.core.entries.write();
-            entries.insert(
-                encoded_key.clone(),
-                ErasedInputEntry {
-                    value: None,
-                    changed_at: rev,
-                },
-            );
+            let entry = ErasedInputEntry {
+                value: None,
+                changed_at: rev,
+            };
+            match entries
+                .raw_entry_mut()
+                .from_hash(runtime_key_hash, |stored| stored == &runtime_key)
+            {
+                RawEntryMut::Occupied(mut occupied) => {
+                    *occupied.get_mut() = entry;
+                }
+                RawEntryMut::Vacant(vacant) => {
+                    vacant.insert_hashed_nocheck(runtime_key_hash, runtime_key, entry);
+                }
+            }
+            db.runtime()
+                .notify_input_removed(rev, self.core.kind, notify_key);
         }
-        db.runtime()
-            .notify_input_removed(rev, self.core.kind, encoded_key);
         rev
     }
 
@@ -481,30 +506,39 @@ where
     pub fn get<DB: HasRuntime>(&self, _db: &DB, key: &K) -> PicanteResult<Option<V>> {
         let _span = tracing::trace_span!("get", kind = self.core.kind.0).entered();
 
-        let encoded_key = self.key_factory.key(key.clone())?;
-        let key_hash = encoded_key.hash();
+        let (key_hash, key_bytes) = self.key_factory.hash_parts(key)?;
 
-        if frame::record_dep_if_active(Dep {
-            kind: self.core.kind,
-            key: encoded_key.clone(),
-        }) {
+        if frame::record_dep_result(|| -> PicanteResult<Dep> {
+            Ok(Dep {
+                kind: self.core.kind,
+                key: self
+                    .key_factory
+                    .key_with_parts(key.clone(), key_hash, key_bytes.clone()),
+            })
+        })? {
             trace!(kind = self.core.kind.0, key_hash = %format!("{:016x}", key_hash), "input dep");
         }
 
         let entries = self.core.entries.read();
-        Ok(entries.get(&encoded_key).and_then(|e| {
-            e.value
-                .as_ref()
-                .and_then(|v| v.downcast_ref::<V>())
-                .cloned()
-        }))
+        Ok(entries
+            .raw_entry()
+            .from_hash(key_hash, |stored| stored.matches(key))
+            .and_then(|(_, e)| {
+                e.value
+                    .as_ref()
+                    .and_then(|v| v.downcast_ref::<V>())
+                    .cloned()
+            }))
     }
 
     /// The last revision at which this input was changed.
     pub fn changed_at(&self, key: &K) -> Option<Revision> {
-        let encoded_key = self.key_factory.key(key.clone()).ok()?;
+        let key_hash = self.key_factory.hash_borrowed(key).ok()?;
         let entries = self.core.entries.read();
-        entries.get(&encoded_key).map(|e| e.changed_at)
+        entries
+            .raw_entry()
+            .from_hash(key_hash, |stored| stored.matches(key))
+            .map(|(_, e)| e.changed_at)
     }
 
     // r[snapshot.input]
@@ -520,20 +554,19 @@ where
         let entries = self.core.entries.read();
         entries
             .iter()
-            .filter_map(|(encoded_key, entry)| {
-                let key: K = encoded_key.decode_facet().ok()?;
+            .map(|(runtime_key, entry)| {
                 let value = entry
                     .value
                     .as_ref()
                     .and_then(|v| v.downcast_ref::<V>())
                     .cloned();
-                Some((
-                    key,
+                (
+                    runtime_key.value().clone(),
                     InputEntry {
                         value,
                         changed_at: entry.changed_at,
                     },
-                ))
+                )
             })
             .collect()
     }
@@ -555,7 +588,7 @@ where
             kind_name,
             make_encode_input_record::<K, V>(),
             make_decode_input_record::<K, V>(),
-            make_encode_input_incremental::<V>(),
+            make_encode_input_incremental::<K, V>(),
             make_apply_input_wal_entry::<K, V>(),
         );
 
@@ -565,10 +598,10 @@ where
         {
             let mut erased_entries = core.entries.write();
             for (key, entry) in entries {
-                if let Ok(encoded_key) = key_factory.key(key) {
+                if let Ok(runtime_key) = key_factory.runtime_key(key) {
                     let erased_value = entry.value.map(|v| Arc::new(v) as ArcAny);
                     erased_entries.insert(
-                        encoded_key,
+                        runtime_key,
                         ErasedInputEntry {
                             value: erased_value,
                             changed_at: entry.changed_at,
@@ -612,7 +645,7 @@ where
 
     fn clear(&self) {
         let mut entries = self.core.entries.write();
-        *entries = im::HashMap::new();
+        *entries = runtime_key_map();
     }
 
     fn key_from_bytes(&self, bytes: Vec<u8>) -> PicanteResult<Key> {
@@ -625,8 +658,7 @@ where
     }
 
     fn load_records(&self, records: Vec<Vec<u8>>) -> PicanteResult<()> {
-        // Delegate to type-erased core (compiled once)
-        self.core.load_records_erased(records)
+        self.core.load_records_erased(records, &self.key_factory)
     }
 
     fn save_incremental_records(
@@ -643,8 +675,8 @@ where
         key: Vec<u8>,
         value: Option<Vec<u8>>,
     ) -> PicanteResult<()> {
-        // Delegate to type-erased core (compiled once)
-        self.core.apply_wal_entry_erased(revision, key, value)
+        self.core
+            .apply_wal_entry_erased(revision, key, value, &self.key_factory)
     }
 }
 
@@ -656,11 +688,13 @@ where
 {
     fn touch<'a>(&'a self, _db: &'a DB, key: Key) -> BoxFuture<'a, PicanteResult<Touch>> {
         Box::pin(async move {
-            let key = self.key_factory.normalize_key(key)?;
+            let key = self.key_factory.decode_key(&key)?;
+            let key_hash = self.key_factory.hash_borrowed(&key)?;
             let entries = self.core.entries.read();
             let changed_at = entries
-                .get(&key)
-                .map(|e| e.changed_at)
+                .raw_entry()
+                .from_hash(key_hash, |stored| stored.matches(&key))
+                .map(|(_, e)| e.changed_at)
                 .unwrap_or(Revision(0));
             Ok(Touch { changed_at })
         })

--- a/picante/src/key.rs
+++ b/picante/src/key.rs
@@ -3,7 +3,9 @@
 use crate::error::{PicanteError, PicanteResult};
 use facet::Facet;
 use std::any::Any;
+use std::collections::hash_map::DefaultHasher;
 use std::fmt;
+use std::hash::BuildHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -53,8 +55,27 @@ pub struct Key {
 
 #[derive(Clone)]
 enum KeyRepr {
+    Inline(InlineKey, Arc<dyn ErasedKeyBytes>),
     Typed(Arc<dyn ErasedFacetKey>),
     Bytes(Arc<[u8]>),
+}
+
+#[derive(Clone, Eq, PartialEq)]
+enum InlineKey {
+    Unit,
+    Bool(bool),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    U128(u128),
+    Usize(usize),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    I128(i128),
+    Isize(isize),
 }
 
 trait ErasedFacetKey: Send + Sync {
@@ -67,6 +88,39 @@ trait ErasedFacetKey: Send + Sync {
 struct FacetKey<T> {
     value: Arc<T>,
     bytes: OnceLock<PicanteResult<Arc<[u8]>>>,
+}
+
+trait ErasedKeyBytes: Send + Sync {
+    fn bytes(&self) -> PicanteResult<&[u8]>;
+    fn to_bytes(&self) -> PicanteResult<Arc<[u8]>>;
+}
+
+struct InlineKeyBytes {
+    key: InlineKey,
+    bytes: OnceLock<PicanteResult<Arc<[u8]>>>,
+}
+
+impl InlineKeyBytes {
+    fn new(key: InlineKey, bytes: Option<Arc<[u8]>>) -> Self {
+        Self {
+            key,
+            bytes: once_lock_from_option(bytes.map(Ok)),
+        }
+    }
+}
+
+impl ErasedKeyBytes for InlineKeyBytes {
+    fn bytes(&self) -> PicanteResult<&[u8]> {
+        self.bytes
+            .get_or_init(|| self.key.to_bytes())
+            .as_ref()
+            .map(|bytes| bytes.as_ref())
+            .map_err(Clone::clone)
+    }
+
+    fn to_bytes(&self) -> PicanteResult<Arc<[u8]>> {
+        self.bytes.get_or_init(|| self.key.to_bytes()).clone()
+    }
 }
 
 impl<T> ErasedFacetKey for FacetKey<T>
@@ -143,15 +197,14 @@ impl Key {
     where
         T: Clone + Facet<'static> + Send + Sync + 'static,
     {
-        if let KeyRepr::Typed(typed) = &self.repr
-            && let Some(value) = typed
+        match &self.repr {
+            KeyRepr::Inline(inline, _) => inline.typed_value(),
+            KeyRepr::Typed(typed) => typed
                 .as_any()
                 .downcast_ref::<FacetKey<T>>()
-                .map(|key| (*key.value).clone())
-        {
-            return Some(value);
+                .map(|key| (*key.value).clone()),
+            KeyRepr::Bytes(_) => None,
         }
-        None
     }
 
     /// Decode a key using `facet-postcard`.
@@ -183,6 +236,7 @@ impl Key {
     /// Try to access the encoded bytes without panicking on materialization errors.
     pub fn try_bytes(&self) -> PicanteResult<&[u8]> {
         match &self.repr {
+            KeyRepr::Inline(_, bytes) => bytes.bytes(),
             KeyRepr::Typed(typed) => typed.bytes(),
             KeyRepr::Bytes(bytes) => Ok(bytes),
         }
@@ -191,6 +245,7 @@ impl Key {
     /// Return the persistent byte representation of this key.
     pub fn to_bytes(&self) -> PicanteResult<Arc<[u8]>> {
         match &self.repr {
+            KeyRepr::Inline(_, bytes) => bytes.to_bytes(),
             KeyRepr::Typed(typed) => typed.to_bytes(),
             KeyRepr::Bytes(bytes) => Ok(bytes.clone()),
         }
@@ -216,6 +271,7 @@ impl Key {
 impl PartialEq for Key {
     fn eq(&self, other: &Self) -> bool {
         match (&self.repr, &other.repr) {
+            (KeyRepr::Inline(left, _), KeyRepr::Inline(right, _)) => left == right,
             (KeyRepr::Typed(left), KeyRepr::Typed(right)) => left.eq_typed(&**right),
             (KeyRepr::Bytes(left), KeyRepr::Bytes(right)) => left == right,
             _ => match (self.to_bytes(), other.to_bytes()) {
@@ -237,6 +293,7 @@ impl Hash for Key {
 impl fmt::Debug for Key {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Key")
+            .field("repr", &self.repr.kind_name())
             .field("hash", &format_args!("{:016x}", self.hash))
             .finish()
     }
@@ -264,6 +321,238 @@ pub struct Dep {
 
 fn stable_hash(bytes: &[u8]) -> u64 {
     facet_hash::hash_bytes_fnv1a64(bytes)
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct KeyBuildHasher;
+
+#[derive(Default)]
+pub(crate) struct KeyHasher {
+    hash: u64,
+    fallback: Option<DefaultHasher>,
+}
+
+impl BuildHasher for KeyBuildHasher {
+    type Hasher = KeyHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        KeyHasher::default()
+    }
+}
+
+impl Hasher for KeyHasher {
+    fn finish(&self) -> u64 {
+        self.fallback
+            .as_ref()
+            .map_or(self.hash, DefaultHasher::finish)
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.fallback
+            .get_or_insert_with(DefaultHasher::new)
+            .write(bytes);
+    }
+
+    fn write_u64(&mut self, i: u64) {
+        if let Some(fallback) = &mut self.fallback {
+            fallback.write_u64(i);
+        } else {
+            self.hash = i;
+        }
+    }
+}
+
+pub(crate) type KeyMap<V> = im::HashMap<Key, V, KeyBuildHasher>;
+
+pub(crate) fn key_map<V>() -> KeyMap<V> {
+    im::HashMap::with_hasher(KeyBuildHasher)
+}
+
+pub(crate) type RuntimeKeyMap<K, V> = hashbrown::HashMap<RuntimeKey<K>, V, KeyBuildHasher>;
+
+pub(crate) fn runtime_key_map<K, V>() -> RuntimeKeyMap<K, V> {
+    hashbrown::HashMap::with_hasher(KeyBuildHasher)
+}
+
+pub(crate) struct RuntimeKey<T> {
+    value: T,
+    hash: u64,
+    bytes: Option<Arc<[u8]>>,
+}
+
+impl<T> RuntimeKey<T>
+where
+    T: Clone + Facet<'static> + Send + Sync + 'static,
+{
+    fn new(value: T, hash: u64, bytes: Option<Arc<[u8]>>) -> Self {
+        Self { value, hash, bytes }
+    }
+
+    pub(crate) fn value(&self) -> &T {
+        &self.value
+    }
+
+    pub(crate) fn hash(&self) -> u64 {
+        self.hash
+    }
+
+    pub(crate) fn matches(&self, value: &T) -> bool {
+        eq_known_key_type(&self.value, value)
+            .unwrap_or_else(|| crate::facet_eq::facet_eq_direct(&self.value, value))
+    }
+
+    pub(crate) fn to_key(&self) -> Key {
+        if let Some(inline) = InlineKey::from_value(&self.value) {
+            return Key {
+                repr: KeyRepr::Inline(
+                    inline.clone(),
+                    Arc::new(InlineKeyBytes::new(inline, self.bytes.clone())),
+                ),
+                hash: self.hash,
+            };
+        }
+
+        Key {
+            repr: KeyRepr::Typed(Arc::new(FacetKey {
+                value: Arc::new(self.value.clone()),
+                bytes: once_lock_from_option(self.bytes.clone().map(Ok)),
+            })),
+            hash: self.hash,
+        }
+    }
+}
+
+impl<T> Clone for RuntimeKey<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+            hash: self.hash,
+            bytes: self.bytes.clone(),
+        }
+    }
+}
+
+impl<T> PartialEq for RuntimeKey<T>
+where
+    T: Clone + Facet<'static> + Send + Sync + 'static,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.hash == other.hash && self.matches(&other.value)
+    }
+}
+
+impl<T> Eq for RuntimeKey<T> where T: Clone + Facet<'static> + Send + Sync + 'static {}
+
+impl<T> Hash for RuntimeKey<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.hash);
+    }
+}
+
+impl KeyRepr {
+    fn kind_name(&self) -> &'static str {
+        match self {
+            KeyRepr::Inline(_, _) => "inline",
+            KeyRepr::Typed(_) => "typed",
+            KeyRepr::Bytes(_) => "bytes",
+        }
+    }
+}
+
+impl InlineKey {
+    fn from_value<T>(value: &T) -> Option<Self>
+    where
+        T: 'static,
+    {
+        let value = value as &dyn Any;
+
+        macro_rules! copy_as {
+            ($ty:ty, $variant:ident) => {
+                if let Some(value) = value.downcast_ref::<$ty>() {
+                    return Some(Self::$variant(*value));
+                }
+            };
+        }
+
+        if value.is::<()>() {
+            return Some(Self::Unit);
+        }
+        copy_as!(bool, Bool);
+        copy_as!(u8, U8);
+        copy_as!(u16, U16);
+        copy_as!(u32, U32);
+        copy_as!(u64, U64);
+        copy_as!(u128, U128);
+        copy_as!(usize, Usize);
+        copy_as!(i8, I8);
+        copy_as!(i16, I16);
+        copy_as!(i32, I32);
+        copy_as!(i64, I64);
+        copy_as!(i128, I128);
+        copy_as!(isize, Isize);
+
+        None
+    }
+
+    fn typed_value<T>(&self) -> Option<T>
+    where
+        T: Clone + 'static,
+    {
+        macro_rules! clone_as {
+            ($value:expr) => {{
+                let value = $value;
+                return (value as &dyn Any).downcast_ref::<T>().cloned();
+            }};
+        }
+
+        match self {
+            Self::Unit => {
+                let value = ();
+                clone_as!(&value);
+            }
+            Self::Bool(value) => clone_as!(value),
+            Self::U8(value) => clone_as!(value),
+            Self::U16(value) => clone_as!(value),
+            Self::U32(value) => clone_as!(value),
+            Self::U64(value) => clone_as!(value),
+            Self::U128(value) => clone_as!(value),
+            Self::Usize(value) => clone_as!(value),
+            Self::I8(value) => clone_as!(value),
+            Self::I16(value) => clone_as!(value),
+            Self::I32(value) => clone_as!(value),
+            Self::I64(value) => clone_as!(value),
+            Self::I128(value) => clone_as!(value),
+            Self::Isize(value) => clone_as!(value),
+        }
+    }
+
+    fn to_bytes(&self) -> PicanteResult<Arc<[u8]>> {
+        macro_rules! encode {
+            ($value:expr) => {
+                encode_key_bytes($value)
+            };
+        }
+
+        match self {
+            Self::Unit => encode!(&()),
+            Self::Bool(value) => encode!(value),
+            Self::U8(value) => encode!(value),
+            Self::U16(value) => encode!(value),
+            Self::U32(value) => encode!(value),
+            Self::U64(value) => encode!(value),
+            Self::U128(value) => encode!(value),
+            Self::Usize(value) => encode!(value),
+            Self::I8(value) => encode!(value),
+            Self::I16(value) => encode!(value),
+            Self::I32(value) => encode!(value),
+            Self::I64(value) => encode!(value),
+            Self::I128(value) => encode!(value),
+            Self::Isize(value) => encode!(value),
+        }
+    }
 }
 
 fn key_hash_error(error: facet_hash::HashError) -> Arc<PicanteError> {
@@ -355,12 +644,60 @@ where
         }
     }
 
+    pub(crate) fn hash_parts(&self, value: &T) -> PicanteResult<(u64, Option<Arc<[u8]>>)> {
+        if let Some(plan) = &self.plan {
+            return Ok((plan.hash64(value).map_err(key_hash_error)?, None));
+        }
+
+        let bytes = encode_key_bytes(value)?;
+        Ok((stable_hash(&bytes), Some(bytes)))
+    }
+
+    pub(crate) fn hash_borrowed(&self, value: &T) -> PicanteResult<u64> {
+        self.hash_parts(value).map(|(hash, _)| hash)
+    }
+
+    pub(crate) fn runtime_key(&self, value: T) -> PicanteResult<RuntimeKey<T>>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        let (hash, bytes) = self.hash_parts(&value)?;
+        Ok(self.runtime_key_from_parts(value, hash, bytes))
+    }
+
+    pub(crate) fn runtime_key_from_parts(
+        &self,
+        value: T,
+        hash: u64,
+        bytes: Option<Arc<[u8]>>,
+    ) -> RuntimeKey<T>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        RuntimeKey::new(value, hash, bytes)
+    }
+
     /// Build a key from an owned value.
     pub fn key(&self, value: T) -> PicanteResult<Key>
     where
         T: Send + Sync + 'static,
     {
-        self.key_arc(Arc::new(value))
+        let (hash, bytes) = self.hash_parts(&value)?;
+        Ok(self.key_with_parts(value, hash, bytes))
+    }
+
+    pub(crate) fn key_with_parts(&self, value: T, hash: u64, bytes: Option<Arc<[u8]>>) -> Key
+    where
+        T: Send + Sync + 'static,
+    {
+        if let Some(inline) = InlineKey::from_value(&value) {
+            return Key {
+                repr: KeyRepr::Inline(inline.clone(), Arc::new(InlineKeyBytes::new(inline, bytes))),
+                hash,
+            };
+        }
+
+        self.key_arc_with_hash(Arc::new(value), hash, bytes)
     }
 
     /// Build a key from an already-shared value.
@@ -368,25 +705,30 @@ where
     where
         T: Send + Sync + 'static,
     {
-        let mut bytes = None;
-        let hash = if let Some(plan) = &self.plan {
-            plan.hash64(&*value).map_err(key_hash_error)?
-        } else {
-            let encoded = encode_key_bytes(&*value)?;
-            let hash = stable_hash(&encoded);
-            bytes = Some(encoded);
-            hash
-        };
+        let (hash, bytes) = self.hash_parts(&*value)?;
+        if let Some(inline) = InlineKey::from_value(&*value) {
+            return Ok(Key {
+                repr: KeyRepr::Inline(inline.clone(), Arc::new(InlineKeyBytes::new(inline, bytes))),
+                hash,
+            });
+        }
 
+        Ok(self.key_arc_with_hash(value, hash, bytes))
+    }
+
+    fn key_arc_with_hash(&self, value: Arc<T>, hash: u64, bytes: Option<Arc<[u8]>>) -> Key
+    where
+        T: Send + Sync + 'static,
+    {
         let key = FacetKey {
             value,
             bytes: once_lock_from_option(bytes.map(Ok)),
         };
 
-        Ok(Key {
+        Key {
             repr: KeyRepr::Typed(Arc::new(key)),
             hash,
-        })
+        }
     }
 
     /// Decode persistent key bytes and rehydrate them as a typed runtime key.
@@ -406,14 +748,7 @@ where
         } else {
             stable_hash(&bytes)
         };
-        let key = FacetKey {
-            value: Arc::new(value),
-            bytes: once_lock_from_option(Some(Ok(bytes))),
-        };
-        Ok(Key {
-            repr: KeyRepr::Typed(Arc::new(key)),
-            hash,
-        })
+        Ok(self.key_with_parts(value, hash, Some(bytes)))
     }
 
     /// Normalize an erased key into this factory's typed runtime representation.
@@ -422,6 +757,7 @@ where
         T: Clone + Send + Sync + 'static,
     {
         let already_typed = match &key.repr {
+            KeyRepr::Inline(_, _) => key.typed_value::<T>().is_some(),
             KeyRepr::Typed(typed) => typed.as_any().is::<FacetKey<T>>(),
             KeyRepr::Bytes(_) => false,
         };
@@ -492,5 +828,16 @@ mod tests {
     fn aggregate_key_hash_plan_falls_back_to_interpreted() {
         let plan = KeyHashPlan::<Vec<u8>>::build().unwrap();
         assert!(matches!(plan, KeyHashPlan::Interpreted(_)));
+    }
+
+    #[test]
+    fn inline_scalar_key_keeps_persistent_bytes_and_decode_parity() {
+        let inline = Key::from_facet(7u32).unwrap();
+        let encoded = Key::encode_facet(&7u32).unwrap();
+
+        assert_eq!(inline, encoded);
+        assert_eq!(inline.to_bytes().unwrap(), encoded.to_bytes().unwrap());
+        assert_eq!(inline.bytes(), encoded.bytes());
+        assert_eq!(inline.decode_facet::<u32>().unwrap(), 7);
     }
 }

--- a/picante/src/key.rs
+++ b/picante/src/key.rs
@@ -128,13 +128,8 @@ impl Key {
                 message: format!("{e:?}"),
             })
         })?;
-        let hash = if let Ok(plan) = facet_hash::HashPlan::<T>::build() {
-            plan.hash64(value).map_err(|e| {
-                Arc::new(PicanteError::Encode {
-                    what: "key hash",
-                    message: e.to_string(),
-                })
-            })?
+        let hash = if let Ok(hash) = hash_with_temp_plan(value) {
+            hash
         } else {
             stable_hash(&bytes)
         };
@@ -271,6 +266,20 @@ fn stable_hash(bytes: &[u8]) -> u64 {
     facet_hash::hash_bytes_fnv1a64(bytes)
 }
 
+fn key_hash_error(error: facet_hash::HashError) -> Arc<PicanteError> {
+    Arc::new(PicanteError::Encode {
+        what: "key hash",
+        message: error.to_string(),
+    })
+}
+
+fn hash_with_temp_plan<T>(value: &T) -> Result<u64, facet_hash::HashError>
+where
+    T: Facet<'static>,
+{
+    KeyHashPlan::<T>::build()?.hash64(value)
+}
+
 fn eq_known_key_type<T: 'static>(left: &T, right: &T) -> Option<bool> {
     let left = left as &dyn Any;
     let right = right as &dyn Any;
@@ -302,9 +311,37 @@ fn eq_known_key_type<T: 'static>(left: &T, right: &T) -> Option<bool> {
     None
 }
 
+enum KeyHashPlan<T> {
+    #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+    Native(facet_hash::NativeHashPlan<T>),
+    Interpreted(facet_hash::HashPlan<T>),
+}
+
+impl<T> KeyHashPlan<T>
+where
+    T: Facet<'static>,
+{
+    fn build() -> Result<Self, facet_hash::HashError> {
+        #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+        if let Ok(plan) = facet_hash::NativeHashPlan::<T>::build() {
+            return Ok(Self::Native(plan));
+        }
+
+        facet_hash::HashPlan::<T>::build().map(Self::Interpreted)
+    }
+
+    fn hash64(&self, value: &T) -> Result<u64, facet_hash::HashError> {
+        match self {
+            #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+            Self::Native(plan) => plan.hash64(value),
+            Self::Interpreted(plan) => plan.hash64(value),
+        }
+    }
+}
+
 /// Reusable key builder for one Facet key type.
 pub struct KeyFactory<T> {
-    plan: Option<facet_hash::HashPlan<T>>,
+    plan: Option<KeyHashPlan<T>>,
 }
 
 impl<T> KeyFactory<T>
@@ -314,7 +351,7 @@ where
     /// Build a key factory for `T`.
     pub fn new() -> Self {
         Self {
-            plan: facet_hash::HashPlan::<T>::build().ok(),
+            plan: KeyHashPlan::<T>::build().ok(),
         }
     }
 
@@ -333,12 +370,7 @@ where
     {
         let mut bytes = None;
         let hash = if let Some(plan) = &self.plan {
-            plan.hash64(&*value).map_err(|e| {
-                Arc::new(PicanteError::Encode {
-                    what: "key hash",
-                    message: e.to_string(),
-                })
-            })?
+            plan.hash64(&*value).map_err(key_hash_error)?
         } else {
             let encoded = encode_key_bytes(&*value)?;
             let hash = stable_hash(&encoded);
@@ -370,12 +402,7 @@ where
         })?;
         let bytes: Arc<[u8]> = bytes.into();
         let hash = if let Some(plan) = &self.plan {
-            plan.hash64(&value).map_err(|e| {
-                Arc::new(PicanteError::Encode {
-                    what: "key hash",
-                    message: e.to_string(),
-                })
-            })?
+            plan.hash64(&value).map_err(key_hash_error)?
         } else {
             stable_hash(&bytes)
         };
@@ -444,4 +471,26 @@ fn once_lock_from_option<T>(value: Option<T>) -> OnceLock<T> {
         let _ = lock.set(value);
     }
     lock
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalar_key_hash_plan_uses_native_when_available() {
+        let plan = KeyHashPlan::<u32>::build().unwrap();
+
+        #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+        assert!(matches!(plan, KeyHashPlan::Native(_)));
+
+        #[cfg(not(all(feature = "jit", target_os = "macos", target_arch = "aarch64")))]
+        assert!(matches!(plan, KeyHashPlan::Interpreted(_)));
+    }
+
+    #[test]
+    fn aggregate_key_hash_plan_falls_back_to_interpreted() {
+        let plan = KeyHashPlan::<Vec<u8>>::build().unwrap();
+        assert!(matches!(plan, KeyHashPlan::Interpreted(_)));
+    }
 }

--- a/picante/tests/cache_graph.rs
+++ b/picante/tests/cache_graph.rs
@@ -2,7 +2,7 @@ use picante::Revision;
 use picante::db::{DynIngredient, IngredientLookup, IngredientRegistry};
 use picante::ingredient::{DerivedIngredient, InputIngredient};
 use picante::key::QueryKindId;
-use picante::persist::{load_cache, save_cache};
+use picante::persist::{CacheFile, Section, SectionType, load_cache, save_cache};
 use picante::runtime::{HasRuntime, Runtime, RuntimeEvent};
 use std::sync::Arc;
 
@@ -47,6 +47,28 @@ impl TestDb {
 struct FacetOnlyKey {
     shard: u32,
     slot: u32,
+}
+
+#[derive(Clone, Debug, facet::Facet)]
+struct LegacyInputRecord<K, V> {
+    key: K,
+    value: Option<V>,
+    changed_at: u64,
+}
+
+#[derive(Clone, Debug, facet::Facet)]
+struct LegacyDepRecord {
+    kind_id: u32,
+    key_bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug, facet::Facet)]
+struct LegacyDerivedRecord<K, V> {
+    key: K,
+    value: V,
+    verified_at: u64,
+    changed_at: u64,
+    deps: Vec<LegacyDepRecord>,
 }
 
 #[tokio_test_lite::test]
@@ -237,6 +259,123 @@ async fn typed_facet_keys_do_not_require_rust_hash_or_eq_after_cache_load() {
     assert!(saw, "expected typed-key invalidation after input set");
 
     assert_eq!(derived2.get(&db2, key).await.unwrap(), 6);
+
+    let _ = tokio::fs::remove_file(&cache_path).await;
+}
+
+#[tokio_test_lite::test]
+async fn legacy_persistent_key_bytes_rehydrate_into_current_runtime_keys() {
+    init_tracing();
+
+    let cache_path = temp_file("picante-legacy-key-bytes-cache-graph.bin");
+    let key = FacetOnlyKey { shard: 42, slot: 9 };
+    let key_bytes = facet_postcard::to_vec(&key).unwrap();
+
+    let input_record = LegacyInputRecord {
+        key: key.clone(),
+        value: Some("hello".to_string()),
+        changed_at: 1,
+    };
+    let derived_record = LegacyDerivedRecord {
+        key: key.clone(),
+        value: 5_u64,
+        verified_at: 1,
+        changed_at: 1,
+        deps: vec![LegacyDepRecord {
+            kind_id: 20,
+            key_bytes,
+        }],
+    };
+
+    let cache = CacheFile {
+        format_version: 1,
+        current_revision: 1,
+        sections: vec![
+            Section {
+                kind_id: 20,
+                kind_name: "LegacyFacetOnlyInput".to_string(),
+                section_type: SectionType::Input,
+                records: vec![facet_postcard::to_vec(&input_record).unwrap()],
+            },
+            Section {
+                kind_id: 21,
+                kind_name: "LegacyFacetOnlyLen".to_string(),
+                section_type: SectionType::Derived,
+                records: vec![facet_postcard::to_vec(&derived_record).unwrap()],
+            },
+        ],
+    };
+    tokio::fs::write(&cache_path, facet_postcard::to_vec(&cache).unwrap())
+        .await
+        .unwrap();
+
+    let mut db = TestDb::default();
+    let input: Arc<InputIngredient<FacetOnlyKey, String>> = Arc::new(InputIngredient::new(
+        QueryKindId(20),
+        "LegacyFacetOnlyInput",
+    ));
+    db.register(input.clone());
+
+    let derived: Arc<DerivedIngredient<TestDb, FacetOnlyKey, u64>> = {
+        let input = input.clone();
+        Arc::new(DerivedIngredient::new(
+            QueryKindId(21),
+            "LegacyFacetOnlyLen",
+            move |db, key| {
+                let input = input.clone();
+                Box::pin(async move {
+                    let s = input.get(db, &key)?.unwrap_or_default();
+                    Ok(s.len() as u64)
+                })
+            },
+        ))
+    };
+    db.register(derived.clone());
+
+    let mut events = db.runtime().subscribe_events();
+
+    let loaded = load_cache(&cache_path, db.runtime(), &[&*input, &*derived])
+        .await
+        .unwrap();
+    assert!(loaded);
+
+    match events.recv().await.unwrap() {
+        RuntimeEvent::RevisionSet { revision } => assert_eq!(revision, Revision(1)),
+        other => panic!("expected RevisionSet, got {other:?}"),
+    }
+
+    assert_eq!(derived.get(&db, key.clone()).await.unwrap(), 5);
+
+    input.set(&db, key.clone(), "hello!".to_string());
+
+    let mut saw = false;
+    for _ in 0..8 {
+        if let RuntimeEvent::QueryInvalidated {
+            kind,
+            key,
+            by_kind,
+            by_key,
+            ..
+        } = events.recv().await.unwrap()
+        {
+            let key = key.decode_facet::<FacetOnlyKey>().unwrap();
+            let by_key = by_key.decode_facet::<FacetOnlyKey>().unwrap();
+            assert_eq!(kind, QueryKindId(21));
+            assert_eq!(key.shard, 42);
+            assert_eq!(key.slot, 9);
+            assert_eq!(by_kind, QueryKindId(20));
+            assert_eq!(by_key.shard, 42);
+            assert_eq!(by_key.slot, 9);
+            saw = true;
+            break;
+        }
+    }
+    assert!(
+        saw,
+        "expected invalidation from rehydrated persistent key bytes"
+    );
+
+    assert_eq!(derived.get(&db, key).await.unwrap(), 6);
 
     let _ = tokio::fs::remove_file(&cache_path).await;
 }


### PR DESCRIPTION
## Summary

- add an opt-in `picante/jit` feature that enables `facet-hash/jit`
- use `facet_hash::NativeHashPlan` from Picante key factories when the backend is available, with interpreted `HashPlan` and byte hashing as fallbacks
- move input ingredient hot storage to typed `RuntimeKey<K>` entries backed by cached Facet hashes and raw hashbrown lookup
- keep public graph/persistence keys byte-compatible, but make their byte materialization lazy behind erased helpers so map keys stay lint-clean
- store active frame deps directly in the task-local frame stack instead of pushing each dep through an `Arc<Mutex<Vec<Dep>>>`
- cover old persistent key bytes loading through the current typed key factory and still restoring reverse-dep invalidation
- mark `NativeHashPlan` as `Send + Sync` once built, since the executable buffer and side tables are immutable during hashing

The default Picante feature set still does not enable native hashing.

## Benchmarks

Apple M4 Pro, 14-core CPU, 24 GB RAM. Medians from `picante/benches/derived.rs`, direct Divan binary, `--threads 1`, `--min-time 1`, `--sample-count 20`.

Baseline is `origin/main` at `8e36a4b5a`; HEAD is this PR after the typed runtime-key/frame work.

| Benchmark | Baseline | HEAD default | Speedup |
|---|---:|---:|---:|
| `input_get_hit` | 47.59 ns | 18.95 ns | 2.51x |
| `input_set_noop_small_value` | 46.62 ns | 25.95 ns | 1.80x |
| `derived_hot_hit` | 275.7 ns | 241.9 ns | 1.14x |
| `derived_wide_recompute_512_deps` | 40.49 us | 24.54 us | 1.65x |
| `derived_wide_revalidate_512_deps` | 21.08 us | 18.58 us | 1.13x |
| `derived_deep_chain_hot_hit_32` | 249.7 ns | 210.6 ns | 1.19x |
| `derived_deep_chain_revalidate_32` | 6.916 us | 6.999 us | 0.99x |
| `input_set_noop_large_value` | 41.41 us | 39.24 us | 1.06x |

With `--all-features` on this PR:

| Benchmark | Baseline | HEAD `jit` | Speedup |
|---|---:|---:|---:|
| `input_get_hit` | 49.23 ns | 15.70 ns | 3.14x |
| `input_set_noop_small_value` | 45.98 ns | 22.21 ns | 2.07x |
| `derived_hot_hit` | 273.1 ns | 239.3 ns | 1.14x |
| `derived_wide_recompute_512_deps` | 39.20 us | 23.49 us | 1.67x |
| `derived_wide_revalidate_512_deps` | 20.79 us | 16.37 us | 1.27x |
| `derived_deep_chain_hot_hit_32` | 249.7 ns | 208.7 ns | 1.20x |
| `derived_deep_chain_revalidate_32` | 6.874 us | 7.041 us | 0.98x |
| `input_set_noop_large_value` | 40.79 us | 40.58 us | 1.01x |

`stax record` on the final JIT `derived_wide_recompute_512_deps` lane (run 20) shows the remaining cost in `InputIngredient::get`, `record_dep_result`, `NativeHashPlan::hash64`, and public `Key` equality/allocation for graph compatibility. The old per-dep frame mutex path is gone.

## Verification

- `cargo fmt -p picante`
- `cargo fmt -p facet-hash`
- `git diff --check`
- `cargo check -p picante --features jit`
- `cargo nextest run -p picante -E 'test(legacy_persistent_key_bytes_rehydrate_into_current_runtime_keys)'`
- `cargo clippy -p picante --all-features --all-targets --message-format=short -- -D warnings`
- `cargo clippy -p facet-hash --all-features --all-targets --message-format=short -- -D warnings`
- `cargo nextest run -p picante --all-features`
- `cargo nextest run -p facet-hash --all-features`
