### PR TITLE
Fix derived FromStr parsing capability

### DIFF
--- a/facet-core/src/lib.rs
+++ b/facet-core/src/lib.rs
@@ -185,6 +185,26 @@ pub mod 𝟋 {
         clone_into::<T>
     }
 
+    /// Returns a parse function pointer for VTableDirect.
+    /// # Safety
+    /// The pointer must point to uninitialized memory of sufficient size and alignment for T.
+    pub const fn 𝟋parse_for<T: ::core::str::FromStr>()
+    -> unsafe fn(&str, *mut T) -> ::core::result::Result<(), crate::ParseError> {
+        unsafe fn parse<T: ::core::str::FromStr>(
+            s: &str,
+            dst: *mut T,
+        ) -> ::core::result::Result<(), crate::ParseError> {
+            match <T as ::core::str::FromStr>::from_str(s) {
+                Ok(value) => {
+                    unsafe { dst.write(value) };
+                    Ok(())
+                }
+                Err(_) => Err(crate::ParseError::from_str("parse error")),
+            }
+        }
+        parse::<T>
+    }
+
     // === TypeOpsIndirect helpers ===
     // These take OxPtrMut/OxPtrConst and work with wide pointers
 

--- a/facet-core/src/types/vtable.rs
+++ b/facet-core/src/types/vtable.rs
@@ -180,6 +180,9 @@ impl Hasher for HashProxy<'_> {
 // VTableDirect - For concrete types
 //////////////////////////////////////////////////////////////////////
 
+/// Parse function for direct vtables.
+pub type DirectParseFn<T> = unsafe fn(&str, *mut T) -> Result<(), crate::ParseError>;
+
 /// VTable for concrete types with compile-time known traits.
 ///
 /// Uses thin pointers (`*const ()`, `*mut ()`) as receivers.
@@ -215,7 +218,7 @@ pub struct VTableDirect {
     pub invariants: Option<unsafe fn(*const ()) -> Result<(), String>>,
 
     /// Parse function - parses value from string into destination.
-    pub parse: Option<unsafe fn(&str, *mut ()) -> Result<(), crate::ParseError>>,
+    pub parse: Option<DirectParseFn<()>>,
 
     /// Parse bytes function - parses value from byte slice into destination.
     /// Used for binary formats where types have a more efficient representation.
@@ -523,16 +526,8 @@ impl<T> TypedVTableDirectBuilder<T> {
     }
 
     /// Set the parse function.
-    pub const fn parse(
-        mut self,
-        f: unsafe fn(&str, *mut T) -> Result<(), crate::ParseError>,
-    ) -> Self {
-        self.vtable.parse = Some(unsafe {
-            transmute::<
-                unsafe fn(&str, *mut T) -> Result<(), crate::ParseError>,
-                unsafe fn(&str, *mut ()) -> Result<(), crate::ParseError>,
-            >(f)
-        });
+    pub const fn parse(mut self, f: DirectParseFn<T>) -> Self {
+        self.vtable.parse = Some(unsafe { transmute::<DirectParseFn<T>, DirectParseFn<()>>(f) });
         self
     }
 
@@ -716,6 +711,16 @@ impl<T> TypedVTableDirectBuilder<T> {
                     unsafe fn(*const (), *const ()) -> cmp::Ordering,
                 >(f)
             }),
+            None => None,
+        };
+        self
+    }
+
+    /// Set the parse function from an Option.
+    /// Used for auto-detection where the function may not be available.
+    pub const fn parse_opt(mut self, f: Option<DirectParseFn<T>>) -> Self {
+        self.vtable.parse = match f {
+            Some(f) => Some(unsafe { transmute::<DirectParseFn<T>, DirectParseFn<()>>(f) }),
             None => None,
         };
         self

--- a/facet-macro-parse/src/parsed.rs
+++ b/facet-macro-parse/src/parsed.rs
@@ -517,6 +517,8 @@ pub struct DeclaredTraits {
     pub hash: bool,
     /// Default trait declared
     pub default: bool,
+    /// FromStr trait declared
+    pub from_str: bool,
     /// Send trait declared (marker)
     pub send: bool,
     /// Sync trait declared (marker)
@@ -538,6 +540,7 @@ impl DeclaredTraits {
             || self.ord
             || self.hash
             || self.default
+            || self.from_str
             || self.send
             || self.sync
             || self.unpin
@@ -561,6 +564,7 @@ impl DeclaredTraits {
                     "Ord" => result.ord = true,
                     "Hash" => result.hash = true,
                     "Default" => result.default = true,
+                    "FromStr" => result.from_str = true,
                     "Send" => result.send = true,
                     "Sync" => result.sync = true,
                     "Unpin" => result.unpin = true,
@@ -569,7 +573,7 @@ impl DeclaredTraits {
                             message: format!(
                                 "unknown trait `{unknown}` in #[facet(traits(...))]. \
                                  Valid traits: Display, Debug, Clone, Copy, PartialEq, Eq, \
-                                 PartialOrd, Ord, Hash, Default, Send, Sync, Unpin"
+                                 PartialOrd, Ord, Hash, Default, FromStr, Send, Sync, Unpin"
                             ),
                             span: ident.span(),
                         });

--- a/facet-macros-impl/src/process_struct.rs
+++ b/facet-macros-impl/src/process_struct.rs
@@ -396,6 +396,33 @@ fn gen_vtable_direct(
         quote! {}
     };
 
+    // FromStr: check declared, then auto-detect if possible
+    let parse_call = if sources.has_declared(|d| d.from_str) {
+        quote! { .parse(#facet_crate::𝟋::𝟋parse_for::<Self>()) }
+    } else if can_auto_detect {
+        quote! {
+            .parse_opt(
+                if #facet_crate::𝟋::impls!(Self: ::core::str::FromStr) {
+                    𝟋Some({
+                        unsafe fn __parse(s: &str, dst: *mut #struct_type) -> 𝟋Result<(), #facet_crate::ParseError> {
+                            let target = #facet_crate::PtrUninit::new(dst as *mut u8);
+                            unsafe {
+                                (&&&#facet_crate::𝟋::SpezEmpty::<#struct_type>::SPEZ)
+                                    .spez_parse(s, target)?;
+                            }
+                            𝟋Ok(())
+                        }
+                        __parse
+                    })
+                } else {
+                    𝟋None
+                }
+            )
+        }
+    } else {
+        quote! {}
+    };
+
     // Transparent type functions: try_borrow_inner
     // For transparent types (newtypes), we generate a function to borrow the inner value
     let try_borrow_inner_call = if let Some(info) = transparent {
@@ -462,6 +489,7 @@ fn gen_vtable_direct(
                 #partial_ord_call
                 #ord_call
                 #hash_call
+                #parse_call
                 #invariants_call
                 #try_borrow_inner_call
                 #try_from_call
@@ -723,6 +751,9 @@ pub(crate) fn gen_trait_bounds(
         }
         if declared.default {
             bounds.push(quote! { core::default::Default });
+        }
+        if declared.from_str {
+            bounds.push(quote! { core::str::FromStr });
         }
         if declared.send {
             bounds.push(quote! { core::marker::Send });

--- a/facet-reflect/tests/partial/misc.rs
+++ b/facet-reflect/tests/partial/misc.rs
@@ -69,6 +69,55 @@ fn readme_sample() -> Result<(), IPanic> {
     Ok(())
 }
 
+#[derive(Facet, Debug, PartialEq)]
+struct Port(u16);
+
+impl core::str::FromStr for Port {
+    type Err = core::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.parse()?))
+    }
+}
+
+#[test]
+fn derived_from_str_parse_from_str_auto_detects() -> Result<(), IPanic> {
+    assert!(Port::SHAPE.is_from_str());
+
+    let port = Partial::alloc::<Port>()?
+        .parse_from_str("8080")?
+        .build()?
+        .materialize::<Port>()?;
+
+    assert_eq!(port, Port(8080));
+    Ok(())
+}
+
+#[derive(Facet, Debug, PartialEq)]
+#[facet(traits(FromStr))]
+struct DeclaredPort(u16);
+
+impl core::str::FromStr for DeclaredPort {
+    type Err = core::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.parse()?))
+    }
+}
+
+#[test]
+fn derived_from_str_parse_from_str_declared_trait() -> Result<(), IPanic> {
+    assert!(DeclaredPort::SHAPE.is_from_str());
+
+    let port = Partial::alloc::<DeclaredPort>()?
+        .parse_from_str("8080")?
+        .build()?
+        .materialize::<DeclaredPort>()?;
+
+    assert_eq!(port, DeclaredPort(8080));
+    Ok(())
+}
+
 // Enum tests
 
 #[derive(Facet, PartialEq, Eq, Debug)]


### PR DESCRIPTION
## Summary
- restore `FromStr` as a recognized `#[facet(traits(...))]` capability
- teach derived direct vtables to expose parse support via declared traits or auto-detection
- add `Partial::parse_from_str` regression coverage for both paths

## Testing
- `cargo check --all-features --all-targets --message-format=short`
- `cargo nextest run -p facet-reflect -E 'test(derived_from_str_parse_from_str)'`
- `cargo nextest run -p facet-core -p facet-macro-parse -p facet-macros-impl -p facet-reflect`
- `cargo clippy -p facet-core -p facet-macro-parse -p facet-macros-impl -p facet-reflect --all-features --all-targets --message-format=short -- -D warnings`
- pre-push checks

Fixes #2388