### PR TITLE
facet-hash: add equality plans

### DIFF
--- a/facet-hash/src/lib.rs
+++ b/facet-hash/src/lib.rs
@@ -51,6 +51,18 @@ pub struct HashPlan<T> {
     _marker: PhantomData<fn() -> T>,
 }
 
+/// A reusable Weavy-backed equality plan for `T`.
+///
+/// This uses the same shape lowering as [`HashPlan`] and interprets the lowered
+/// walk over two values. It gives consumers one cached typed-identity surface:
+/// hash a value with [`HashPlan`], then resolve rare hash collisions with
+/// `EqualityPlan` without falling back to ad hoc reflection code.
+#[derive(Clone, Debug)]
+pub struct EqualityPlan<T> {
+    lowered: DenseLowered<ExecOp>,
+    _marker: PhantomData<fn() -> T>,
+}
+
 impl<T> HashPlan<T>
 where
     T: Facet<'static>,
@@ -120,6 +132,44 @@ where
     }
 }
 
+impl<T> EqualityPlan<T>
+where
+    T: Facet<'static>,
+{
+    /// Lower `T::SHAPE` into value-equality bytecode.
+    pub fn build() -> Result<Self, HashError> {
+        let symbolic = Lowering::new(HashMode::Value).lower(T::SHAPE)?;
+        Ok(Self {
+            lowered: resolve_hash_lowered(symbolic)?,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Compare two values through this pre-lowered plan.
+    pub fn eq(&self, left: &T, right: &T) -> Result<bool, HashError> {
+        let left = PtrConst::new_sized(left as *const T);
+        let right = PtrConst::new_sized(right as *const T);
+        let mut interp = EqInterp::new(left, right);
+        weavy::run_dense(&self.lowered, &mut interp).map_err(eq_run_error)?;
+        Ok(interp.equal)
+    }
+
+    /// Compare two values and return Weavy runner counters.
+    pub fn eq_with_stats(&self, left: &T, right: &T) -> Result<(bool, RunStats), HashError> {
+        let left = PtrConst::new_sized(left as *const T);
+        let right = PtrConst::new_sized(right as *const T);
+        let mut interp = EqInterp::new(left, right);
+        let stats =
+            weavy::run_dense_with_stats(&self.lowered, &mut interp).map_err(eq_run_error)?;
+        Ok((interp.equal, stats))
+    }
+
+    /// Return static Weavy analysis for the lowered equality program.
+    pub fn analysis(&self) -> LoweredAnalysis {
+        hash_lowered_analysis(&self.lowered)
+    }
+}
+
 /// Hash stream shape for a [`HashPlan`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HashMode {
@@ -147,6 +197,17 @@ where
     T: Facet<'static>,
 {
     HashPlan::<T>::build()?.hash64(value)
+}
+
+/// Build a temporary equality plan for `T` and compare two values.
+///
+/// Use [`EqualityPlan`] directly when comparing more than one pair of the same
+/// type.
+pub fn facet_eq<T>(left: &T, right: &T) -> Result<bool, HashError>
+where
+    T: Facet<'static>,
+{
+    EqualityPlan::<T>::build()?.eq(left, right)
 }
 
 /// Hash a raw byte sequence into a caller-supplied [`Hasher`] using the byte
@@ -239,6 +300,23 @@ fn run_error(err: RunError<ExecBlock, HashError>) -> HashError {
     match err {
         RunError::Step(err) => err,
         RunError::MissingBlock(block) => HashError::MissingBlock { block },
+    }
+}
+
+fn eq_run_error(err: RunError<ExecBlock, EqRunError>) -> HashError {
+    match err {
+        RunError::Step(EqRunError::Hash(err)) => err,
+        RunError::MissingBlock(block) => HashError::MissingBlock { block },
+    }
+}
+
+enum EqRunError {
+    Hash(HashError),
+}
+
+impl From<HashError> for EqRunError {
+    fn from(value: HashError) -> Self {
+        Self::Hash(value)
     }
 }
 
@@ -1011,6 +1089,603 @@ where
     }
 }
 
+struct EqInterp {
+    left: PtrConst,
+    right: PtrConst,
+    equal: bool,
+}
+
+impl EqInterp {
+    fn new(left: PtrConst, right: PtrConst) -> Self {
+        Self {
+            left,
+            right,
+            equal: true,
+        }
+    }
+
+    fn mark_not_equal<'program>(
+        &mut self,
+    ) -> Control<'program, ExecBlock, ExecOp, EqContinuation<'program>> {
+        self.equal = false;
+        Control::Return
+    }
+}
+
+enum EqContinuation<'program> {
+    RestoreBase {
+        left: PtrConst,
+        right: PtrConst,
+    },
+    StructFields {
+        left: PtrConst,
+        right: PtrConst,
+        fields: &'program [StructFieldPlan<ExecBlock>],
+        next_index: usize,
+    },
+    Sequence(EqSequenceState<'program>),
+    MapAfterValue {
+        left: PtrConst,
+        right: PtrConst,
+        iter: PtrMut,
+        map: MapDef,
+        value: &'program ChildPlan<ExecBlock>,
+    },
+}
+
+#[derive(Clone, Copy)]
+struct EqSequenceState<'program> {
+    left: PtrConst,
+    right: PtrConst,
+    left_data: PtrConst,
+    right_data: PtrConst,
+    len: usize,
+    next_index: usize,
+    stride: usize,
+    element_program: &'program Program<ExecOp>,
+}
+
+impl<'program> Step<'program, ExecBlock, ExecOp> for EqInterp {
+    type Error = EqRunError;
+    type Continuation = EqContinuation<'program>;
+
+    fn step(
+        &mut self,
+        op: &'program ExecOp,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, Self::Continuation>, Self::Error> {
+        if !self.equal {
+            return Ok(Control::Return);
+        }
+
+        match op {
+            WeavyOp::Control(ControlOp::CallBlock { block, base_offset }) => {
+                if *base_offset != 0 {
+                    return Err(HashError::MalformedProgram {
+                        reason: "equality block calls must not adjust base",
+                    }
+                    .into());
+                }
+                Ok(Control::CallBlock(*block))
+            }
+            WeavyOp::Control(ControlOp::Return) => Ok(Control::Return),
+            WeavyOp::Intrinsic(intrinsic) => self.step_intrinsic(intrinsic),
+            WeavyOp::Memory(_) | WeavyOp::Init(_) | WeavyOp::Aggregate(_) => {
+                Err(HashError::MalformedProgram {
+                    reason: "equality interpreter only accepts control and hash intrinsic ops",
+                }
+                .into())
+            }
+            _ => Err(HashError::MalformedProgram {
+                reason: "equality interpreter saw an unknown canonical op",
+            }
+            .into()),
+        }
+    }
+
+    fn after_return(
+        &mut self,
+        continuation: Self::Continuation,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, Self::Continuation>, Self::Error> {
+        match continuation {
+            EqContinuation::RestoreBase { left, right } => {
+                self.left = left;
+                self.right = right;
+                if self.equal {
+                    Ok(Control::Continue)
+                } else {
+                    Ok(Control::Return)
+                }
+            }
+            EqContinuation::StructFields {
+                left,
+                right,
+                fields,
+                next_index,
+            } => {
+                if self.equal {
+                    self.call_next_struct_field(left, right, fields, next_index)
+                } else {
+                    self.left = left;
+                    self.right = right;
+                    Ok(Control::Return)
+                }
+            }
+            EqContinuation::Sequence(state) => {
+                if self.equal {
+                    self.call_next_sequence(state)
+                } else {
+                    self.left = state.left;
+                    self.right = state.right;
+                    Ok(Control::Return)
+                }
+            }
+            EqContinuation::MapAfterValue {
+                left,
+                right,
+                iter,
+                map,
+                value,
+            } => {
+                if self.equal {
+                    self.call_next_map(left, right, iter, map, value)
+                } else {
+                    unsafe { (map.vtable.iter_vtable.dealloc)(iter) };
+                    self.left = left;
+                    self.right = right;
+                    Ok(Control::Return)
+                }
+            }
+        }
+    }
+}
+
+impl<'program> EqInterp {
+    fn step_intrinsic(
+        &mut self,
+        intrinsic: &'program HashIntrinsic<ExecBlock>,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, EqContinuation<'program>>, EqRunError> {
+        match intrinsic {
+            HashIntrinsic::Shape(_) => Ok(Control::Continue),
+            HashIntrinsic::Scalar { shape, scalar } => {
+                if unsafe { scalar_eq(shape, *scalar, self.left, self.right) } {
+                    Ok(Control::Continue)
+                } else {
+                    Ok(self.mark_not_equal())
+                }
+            }
+            HashIntrinsic::Struct { fields, .. } => {
+                self.call_next_struct_field(self.left, self.right, fields, 0)
+            }
+            HashIntrinsic::Option { option, some } => {
+                let left_some = unsafe { (option.vtable.is_some)(self.left) };
+                let right_some = unsafe { (option.vtable.is_some)(self.right) };
+                if left_some != right_some {
+                    return Ok(self.mark_not_equal());
+                }
+                if left_some {
+                    let left = unsafe { (option.vtable.get_value)(self.left) };
+                    let right = unsafe { (option.vtable.get_value)(self.right) };
+                    self.call_child(some, PtrConst::new_sized(left), PtrConst::new_sized(right))
+                } else {
+                    Ok(Control::Continue)
+                }
+            }
+            HashIntrinsic::Result { result, ok, err } => {
+                let left_ok = unsafe { (result.vtable.is_ok)(self.left) };
+                let right_ok = unsafe { (result.vtable.is_ok)(self.right) };
+                if left_ok != right_ok {
+                    return Ok(self.mark_not_equal());
+                }
+                if left_ok {
+                    let left = unsafe { (result.vtable.get_ok)(self.left) };
+                    let right = unsafe { (result.vtable.get_ok)(self.right) };
+                    self.call_child(ok, PtrConst::new_sized(left), PtrConst::new_sized(right))
+                } else {
+                    let left = unsafe { (result.vtable.get_err)(self.left) };
+                    let right = unsafe { (result.vtable.get_err)(self.right) };
+                    self.call_child(err, PtrConst::new_sized(left), PtrConst::new_sized(right))
+                }
+            }
+            HashIntrinsic::Bytes(source) => {
+                if unsafe { self.eq_byte_source(source)? } {
+                    Ok(Control::Continue)
+                } else {
+                    Ok(self.mark_not_equal())
+                }
+            }
+            HashIntrinsic::List {
+                list_shape,
+                list,
+                element_layout,
+                element,
+            } => {
+                let left_len = unsafe { (list.vtable.len)(self.left) };
+                let right_len = unsafe { (list.vtable.len)(self.right) };
+                if left_len != right_len {
+                    return Ok(self.mark_not_equal());
+                }
+                if left_len == 0 {
+                    return Ok(Control::Continue);
+                }
+                let as_ptr = list
+                    .vtable
+                    .as_ptr
+                    .ok_or_else(|| unsupported(list_shape, "list as_ptr"))?;
+                let left_data = unsafe { as_ptr(self.left) };
+                let right_data = unsafe { as_ptr(self.right) };
+                self.eq_or_call_sequence(
+                    left_data,
+                    right_data,
+                    left_len,
+                    element_layout.size(),
+                    element,
+                )
+            }
+            HashIntrinsic::Array {
+                array,
+                element_layout,
+                element,
+            } => {
+                if array.n == 0 {
+                    return Ok(Control::Continue);
+                }
+                let left_data = unsafe { (array.vtable.as_ptr)(self.left) };
+                let right_data = unsafe { (array.vtable.as_ptr)(self.right) };
+                self.eq_or_call_sequence(
+                    left_data,
+                    right_data,
+                    array.n,
+                    element_layout.size(),
+                    element,
+                )
+            }
+            HashIntrinsic::Slice {
+                slice,
+                element_layout,
+                element,
+            } => {
+                let left_len = unsafe { (slice.vtable.len)(self.left) };
+                let right_len = unsafe { (slice.vtable.len)(self.right) };
+                if left_len != right_len {
+                    return Ok(self.mark_not_equal());
+                }
+                if left_len == 0 {
+                    return Ok(Control::Continue);
+                }
+                let left_data = unsafe { (slice.vtable.as_ptr)(self.left) };
+                let right_data = unsafe { (slice.vtable.as_ptr)(self.right) };
+                self.eq_or_call_sequence(
+                    left_data,
+                    right_data,
+                    left_len,
+                    element_layout.size(),
+                    element,
+                )
+            }
+            HashIntrinsic::Set { set, .. } => {
+                let left_len = unsafe { (set.vtable.len)(self.left) };
+                let right_len = unsafe { (set.vtable.len)(self.right) };
+                if left_len != right_len {
+                    return Ok(self.mark_not_equal());
+                }
+                let iter_init = set
+                    .vtable
+                    .iter_vtable
+                    .init_with_value
+                    .ok_or_else(|| unsupported(set.t(), "set iterator init"))?;
+                let iter = unsafe { iter_init(self.left) };
+                self.call_next_set(iter, *set)
+            }
+            HashIntrinsic::Map { map, value, .. } => {
+                let left_len = unsafe { (map.vtable.len)(self.left) };
+                let right_len = unsafe { (map.vtable.len)(self.right) };
+                if left_len != right_len {
+                    return Ok(self.mark_not_equal());
+                }
+                let iter_init = map
+                    .vtable
+                    .iter_vtable
+                    .init_with_value
+                    .ok_or_else(|| unsupported(map.k(), "map iterator init"))?;
+                let iter = unsafe { iter_init(self.left) };
+                self.call_next_map(self.left, self.right, iter, *map, value)
+            }
+            HashIntrinsic::Pointer { pointer, pointee } => {
+                let borrow = pointer.vtable.borrow_fn.ok_or_else(|| {
+                    unsupported(
+                        pointer.pointee().expect("lowering rejects opaque pointers"),
+                        "pointer borrow",
+                    )
+                })?;
+                let left = unsafe { borrow(self.left) };
+                let right = unsafe { borrow(self.right) };
+                self.call_child(pointee, left, right)
+            }
+        }
+    }
+
+    unsafe fn eq_byte_source(&mut self, source: &ByteSource) -> Result<bool, HashError> {
+        Ok(match source {
+            ByteSource::List { list_shape, list } => {
+                let left_len = unsafe { (list.vtable.len)(self.left) };
+                let right_len = unsafe { (list.vtable.len)(self.right) };
+                if left_len != right_len {
+                    return Ok(false);
+                }
+                if left_len == 0 {
+                    return Ok(true);
+                }
+                let as_ptr = list
+                    .vtable
+                    .as_ptr
+                    .ok_or_else(|| unsupported(list_shape, "list as_ptr"))?;
+                let left_data = unsafe { as_ptr(self.left) };
+                let right_data = unsafe { as_ptr(self.right) };
+                let left =
+                    unsafe { core::slice::from_raw_parts(left_data.as_byte_ptr(), left_len) };
+                let right =
+                    unsafe { core::slice::from_raw_parts(right_data.as_byte_ptr(), right_len) };
+                left == right
+            }
+            ByteSource::Array { array } => {
+                if array.n == 0 {
+                    return Ok(true);
+                }
+                let left_data = unsafe { (array.vtable.as_ptr)(self.left) };
+                let right_data = unsafe { (array.vtable.as_ptr)(self.right) };
+                let left = unsafe { core::slice::from_raw_parts(left_data.as_byte_ptr(), array.n) };
+                let right =
+                    unsafe { core::slice::from_raw_parts(right_data.as_byte_ptr(), array.n) };
+                left == right
+            }
+            ByteSource::Slice { slice } => {
+                let left_len = unsafe { (slice.vtable.len)(self.left) };
+                let right_len = unsafe { (slice.vtable.len)(self.right) };
+                if left_len != right_len {
+                    return Ok(false);
+                }
+                if left_len == 0 {
+                    return Ok(true);
+                }
+                let left_data = unsafe { (slice.vtable.as_ptr)(self.left) };
+                let right_data = unsafe { (slice.vtable.as_ptr)(self.right) };
+                let left =
+                    unsafe { core::slice::from_raw_parts(left_data.as_byte_ptr(), left_len) };
+                let right =
+                    unsafe { core::slice::from_raw_parts(right_data.as_byte_ptr(), right_len) };
+                left == right
+            }
+        })
+    }
+
+    fn call_child(
+        &mut self,
+        child: &'program ChildPlan<ExecBlock>,
+        left_child: PtrConst,
+        right_child: PtrConst,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, EqContinuation<'program>>, EqRunError> {
+        match child {
+            ChildPlan::Scalar {
+                include_shape,
+                shape,
+                scalar,
+            } => {
+                if *include_shape {
+                    return Err(HashError::MalformedProgram {
+                        reason: "value equality child scalar should not include shape",
+                    }
+                    .into());
+                }
+                if unsafe { scalar_eq(shape, *scalar, left_child, right_child) } {
+                    Ok(Control::Continue)
+                } else {
+                    Ok(self.mark_not_equal())
+                }
+            }
+            ChildPlan::Program(program) => {
+                let left = self.left;
+                let right = self.right;
+                self.left = left_child;
+                self.right = right_child;
+                Ok(Control::CallProgramThen(
+                    program,
+                    EqContinuation::RestoreBase { left, right },
+                ))
+            }
+        }
+    }
+
+    fn eq_or_call_sequence(
+        &mut self,
+        left_data: PtrConst,
+        right_data: PtrConst,
+        len: usize,
+        stride: usize,
+        element: &'program ChildPlan<ExecBlock>,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, EqContinuation<'program>>, EqRunError> {
+        match element {
+            ChildPlan::Scalar {
+                include_shape,
+                shape,
+                scalar,
+            } => {
+                if *include_shape {
+                    return Err(HashError::MalformedProgram {
+                        reason: "value equality sequence scalar should not include shape",
+                    }
+                    .into());
+                }
+                for index in 0..len {
+                    let left = unsafe { sequence_element(left_data, index, stride) };
+                    let right = unsafe { sequence_element(right_data, index, stride) };
+                    if !unsafe { scalar_eq(shape, *scalar, left, right) } {
+                        return Ok(self.mark_not_equal());
+                    }
+                }
+                Ok(Control::Continue)
+            }
+            ChildPlan::Program(program) => self.call_next_sequence(EqSequenceState {
+                left: self.left,
+                right: self.right,
+                left_data,
+                right_data,
+                len,
+                next_index: 0,
+                stride,
+                element_program: program,
+            }),
+        }
+    }
+
+    fn call_next_sequence(
+        &mut self,
+        state: EqSequenceState<'program>,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, EqContinuation<'program>>, EqRunError> {
+        if state.next_index >= state.len {
+            self.left = state.left;
+            self.right = state.right;
+            return Ok(Control::Continue);
+        }
+
+        self.left = unsafe { sequence_element(state.left_data, state.next_index, state.stride) };
+        self.right = unsafe { sequence_element(state.right_data, state.next_index, state.stride) };
+        let next_state = EqSequenceState {
+            next_index: state.next_index + 1,
+            ..state
+        };
+        Ok(Control::CallProgramThen(
+            state.element_program,
+            EqContinuation::Sequence(next_state),
+        ))
+    }
+
+    fn call_next_struct_field(
+        &mut self,
+        left: PtrConst,
+        right: PtrConst,
+        fields: &'program [StructFieldPlan<ExecBlock>],
+        next_index: usize,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, EqContinuation<'program>>, EqRunError> {
+        let mut index = next_index;
+        while index < fields.len() {
+            match &fields[index] {
+                StructFieldPlan::ScalarRun(run) => {
+                    if !unsafe { eq_scalar_field_run(left, right, run) } {
+                        return Ok(self.mark_not_equal());
+                    }
+                    index += 1;
+                }
+                StructFieldPlan::Field(field) => {
+                    let left_field = unsafe { left.field(field.offset) };
+                    let right_field = unsafe { right.field(field.offset) };
+                    let ChildPlan::Program(program) = &field.child else {
+                        return Err(HashError::MalformedProgram {
+                            reason: "scalar struct fields must be lowered into scalar runs",
+                        }
+                        .into());
+                    };
+                    self.left = left_field;
+                    self.right = right_field;
+                    return Ok(Control::CallProgramThen(
+                        program,
+                        EqContinuation::StructFields {
+                            left,
+                            right,
+                            fields,
+                            next_index: index + 1,
+                        },
+                    ));
+                }
+            }
+        }
+
+        self.left = left;
+        self.right = right;
+        Ok(Control::Continue)
+    }
+
+    fn call_next_set(
+        &mut self,
+        iter: PtrMut,
+        set: SetDef,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, EqContinuation<'program>>, EqRunError> {
+        loop {
+            match unsafe { (set.vtable.iter_vtable.next)(iter) } {
+                Some(value) => {
+                    if !unsafe { (set.vtable.contains)(self.right, value) } {
+                        unsafe { (set.vtable.iter_vtable.dealloc)(iter) };
+                        return Ok(self.mark_not_equal());
+                    }
+                }
+                None => {
+                    unsafe { (set.vtable.iter_vtable.dealloc)(iter) };
+                    return Ok(Control::Continue);
+                }
+            }
+        }
+    }
+
+    fn call_next_map(
+        &mut self,
+        left: PtrConst,
+        right: PtrConst,
+        iter: PtrMut,
+        map: MapDef,
+        value: &'program ChildPlan<ExecBlock>,
+    ) -> Result<Control<'program, ExecBlock, ExecOp, EqContinuation<'program>>, EqRunError> {
+        loop {
+            match unsafe { (map.vtable.iter_vtable.next)(iter) } {
+                Some((key_ptr, left_value)) => {
+                    let right_value = unsafe { (map.vtable.get_value_ptr)(right, key_ptr) };
+                    if right_value.is_null() {
+                        unsafe { (map.vtable.iter_vtable.dealloc)(iter) };
+                        return Ok(self.mark_not_equal());
+                    }
+                    match value {
+                        ChildPlan::Scalar {
+                            include_shape,
+                            shape,
+                            scalar,
+                        } => {
+                            if *include_shape {
+                                return Err(HashError::MalformedProgram {
+                                    reason: "value equality map scalar should not include shape",
+                                }
+                                .into());
+                            }
+                            let right_value = PtrConst::new_sized(right_value);
+                            if !unsafe { scalar_eq(shape, *scalar, left_value, right_value) } {
+                                unsafe { (map.vtable.iter_vtable.dealloc)(iter) };
+                                return Ok(self.mark_not_equal());
+                            }
+                        }
+                        ChildPlan::Program(program) => {
+                            self.left = left_value;
+                            self.right = PtrConst::new_sized(right_value);
+                            return Ok(Control::CallProgramThen(
+                                program,
+                                EqContinuation::MapAfterValue {
+                                    left,
+                                    right,
+                                    iter,
+                                    map,
+                                    value,
+                                },
+                            ));
+                        }
+                    }
+                }
+                None => {
+                    unsafe { (map.vtable.iter_vtable.dealloc)(iter) };
+                    self.left = left;
+                    self.right = right;
+                    return Ok(Control::Continue);
+                }
+            }
+        }
+    }
+}
+
 enum HashContinuation<'program> {
     RestoreBase(PtrConst),
     StructFields {
@@ -1641,6 +2316,69 @@ where
     }
 }
 
+unsafe fn eq_scalar_field_run(left: PtrConst, right: PtrConst, run: &[ScalarFieldPlan]) -> bool {
+    for field in run {
+        let left = unsafe { left.field(field.offset) };
+        let right = unsafe { right.field(field.offset) };
+        if !unsafe { scalar_eq(field.shape, field.scalar, left, right) } {
+            return false;
+        }
+    }
+    true
+}
+
+unsafe fn scalar_eq(
+    shape: &'static Shape,
+    scalar: ScalarType,
+    left: PtrConst,
+    right: PtrConst,
+) -> bool {
+    match scalar {
+        ScalarType::Unit => true,
+        ScalarType::Bool => unsafe { left.get::<bool>() == right.get::<bool>() },
+        ScalarType::Char => unsafe { left.get::<char>() == right.get::<char>() },
+        ScalarType::Str => unsafe { str_scalar_eq(shape, left, right) },
+        ScalarType::String => unsafe { left.get::<String>() == right.get::<String>() },
+        ScalarType::CowStr => unsafe {
+            left.get::<Cow<'static, str>>() == right.get::<Cow<'static, str>>()
+        },
+        ScalarType::F32 => unsafe { left.get::<f32>().to_bits() == right.get::<f32>().to_bits() },
+        ScalarType::F64 => unsafe { left.get::<f64>().to_bits() == right.get::<f64>().to_bits() },
+        ScalarType::U8 => unsafe { left.get::<u8>() == right.get::<u8>() },
+        ScalarType::U16 => unsafe { left.get::<u16>() == right.get::<u16>() },
+        ScalarType::U32 => unsafe { left.get::<u32>() == right.get::<u32>() },
+        ScalarType::U64 => unsafe { left.get::<u64>() == right.get::<u64>() },
+        ScalarType::U128 => unsafe { left.get::<u128>() == right.get::<u128>() },
+        ScalarType::USize => unsafe { left.get::<usize>() == right.get::<usize>() },
+        ScalarType::I8 => unsafe { left.get::<i8>() == right.get::<i8>() },
+        ScalarType::I16 => unsafe { left.get::<i16>() == right.get::<i16>() },
+        ScalarType::I32 => unsafe { left.get::<i32>() == right.get::<i32>() },
+        ScalarType::I64 => unsafe { left.get::<i64>() == right.get::<i64>() },
+        ScalarType::I128 => unsafe { left.get::<i128>() == right.get::<i128>() },
+        ScalarType::ISize => unsafe { left.get::<isize>() == right.get::<isize>() },
+        ScalarType::ConstTypeId => unsafe {
+            left.get::<ConstTypeId>() == right.get::<ConstTypeId>()
+        },
+        #[cfg(feature = "net")]
+        ScalarType::SocketAddr => unsafe {
+            left.get::<core::net::SocketAddr>() == right.get::<core::net::SocketAddr>()
+        },
+        #[cfg(feature = "net")]
+        ScalarType::IpAddr => unsafe {
+            left.get::<core::net::IpAddr>() == right.get::<core::net::IpAddr>()
+        },
+        #[cfg(feature = "net")]
+        ScalarType::Ipv4Addr => unsafe {
+            left.get::<core::net::Ipv4Addr>() == right.get::<core::net::Ipv4Addr>()
+        },
+        #[cfg(feature = "net")]
+        ScalarType::Ipv6Addr => unsafe {
+            left.get::<core::net::Ipv6Addr>() == right.get::<core::net::Ipv6Addr>()
+        },
+        _ => unreachable!("unsupported scalar types are rejected while lowering"),
+    }
+}
+
 unsafe fn hash_str_scalar<H>(shape: &'static Shape, ptr: PtrConst, hasher: &mut H)
 where
     H: Hasher,
@@ -1649,6 +2387,14 @@ where
         unsafe { ptr.get::<&'static str>() }.hash(hasher);
     } else {
         unsafe { ptr.get::<str>() }.hash(hasher);
+    }
+}
+
+unsafe fn str_scalar_eq(shape: &'static Shape, left: PtrConst, right: PtrConst) -> bool {
+    if shape.is_type::<&'static str>() {
+        unsafe { left.get::<&'static str>() == right.get::<&'static str>() }
+    } else {
+        unsafe { left.get::<str>() == right.get::<str>() }
     }
 }
 

--- a/facet-hash/tests/basic.rs
+++ b/facet-hash/tests/basic.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 
 use facet::Facet;
+use facet_hash::EqualityPlan;
 use facet_hash::HashPlan;
 #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
 use facet_hash::NativeHashPlan;
@@ -383,6 +384,115 @@ fn hashes_floats_by_bits() {
         plan.hash64(&negative_zero).unwrap(),
         plan.hash64(&positive_zero).unwrap()
     );
+}
+
+#[test]
+fn equality_plan_compares_scalar_structs() {
+    let plan = EqualityPlan::<Point>::build().unwrap();
+
+    assert!(
+        plan.eq(&Point { x: 10, y: -4 }, &Point { x: 10, y: -4 })
+            .unwrap()
+    );
+    assert!(
+        !plan
+            .eq(&Point { x: 10, y: -4 }, &Point { x: 10, y: -5 })
+            .unwrap()
+    );
+}
+
+#[test]
+fn equality_plan_compares_nested_supported_shapes_without_partial_eq() {
+    let plan = EqualityPlan::<Nested>::build().unwrap();
+    let left = Nested {
+        people: vec![Person {
+            name: "Ada".to_owned(),
+            age: 36,
+            email: Some("ada@example.test".to_owned()),
+            scores: vec![1, 1, 2, 3, 5],
+        }],
+        points: [Point { x: 1, y: 2 }, Point { x: 3, y: 4 }],
+        label: "math".into(),
+        maybe: Ok(Some(42)),
+    };
+    let mut right = left.clone();
+
+    assert!(plan.eq(&left, &right).unwrap());
+
+    right.people[0].scores.push(8);
+    assert!(!plan.eq(&left, &right).unwrap());
+}
+
+#[test]
+fn equality_plan_compares_byte_sequences_in_bulk() {
+    let plan = EqualityPlan::<Vec<u8>>::build().unwrap();
+    let (equal, stats) = plan
+        .eq_with_stats(&vec![0, 1, 2, 3, 255], &vec![0, 1, 2, 3, 255])
+        .unwrap();
+
+    assert!(equal);
+    assert_eq!(stats.step_count, 1);
+    assert_eq!(
+        plan.analysis().intrinsic_counts[&IntrinsicDescriptor {
+            dialect: "facet-hash",
+            name: "bytes",
+        }],
+        1
+    );
+    assert!(
+        !plan
+            .eq(&vec![0, 1, 2, 3, 255], &vec![0, 1, 2, 4, 255])
+            .unwrap()
+    );
+}
+
+#[test]
+fn equality_plan_uses_map_lookup_semantics() {
+    let plan = EqualityPlan::<Collections>::build().unwrap();
+    let mut left_set = BTreeSet::new();
+    left_set.insert(1);
+    left_set.insert(2);
+    let mut left_map = BTreeMap::new();
+    left_map.insert("ada".to_owned(), 36);
+    left_map.insert("grace".to_owned(), 37);
+
+    let mut right_set = BTreeSet::new();
+    right_set.insert(2);
+    right_set.insert(1);
+    let mut right_map = BTreeMap::new();
+    right_map.insert("grace".to_owned(), 37);
+    right_map.insert("ada".to_owned(), 36);
+
+    let left = Collections {
+        set: left_set,
+        map: left_map,
+    };
+    let mut right = Collections {
+        set: right_set,
+        map: right_map,
+    };
+
+    assert!(plan.eq(&left, &right).unwrap());
+    right.map.insert("grace".to_owned(), 38);
+    assert!(!plan.eq(&left, &right).unwrap());
+}
+
+#[test]
+fn equality_plan_compares_floats_by_bits() {
+    let plan = EqualityPlan::<Floaty>::build().unwrap();
+    let negative_zero = Floaty { x: -0.0, y: -0.0 };
+    let positive_zero = Floaty { x: 0.0, y: 0.0 };
+    let nan_a = Floaty {
+        x: f64::from_bits(0x7ff8_0000_0000_0001),
+        y: f32::from_bits(0x7fc0_0001),
+    };
+    let nan_b = Floaty {
+        x: f64::from_bits(0x7ff8_0000_0000_0001),
+        y: f32::from_bits(0x7fc0_0001),
+    };
+
+    assert!(!plan.eq(&negative_zero, &positive_zero).unwrap());
+    assert!(plan.eq(&nan_a, &nan_b).unwrap());
 }
 
 #[test]

--- a/picante/benches/derived.rs
+++ b/picante/benches/derived.rs
@@ -48,6 +48,14 @@ struct LargeValue {
     checksum: u64,
 }
 
+#[derive(Clone, Debug, Facet)]
+struct LargeKey {
+    shard: u32,
+    label: String,
+    rows: Vec<LargeRow>,
+    flags: [u16; 4],
+}
+
 type WideFixture = (
     tokio::runtime::Runtime,
     BenchDb,
@@ -102,6 +110,20 @@ fn large_value(rows: usize, seed: u64) -> LargeValue {
     }
 }
 
+fn large_key(rows: usize, seed: u64) -> LargeKey {
+    LargeKey {
+        shard: seed as u32,
+        label: format!("key-{seed}-{rows}"),
+        rows: large_value(rows, seed).rows,
+        flags: [
+            seed as u16,
+            seed.wrapping_mul(3) as u16,
+            seed.wrapping_mul(5) as u16,
+            seed.wrapping_mul(7) as u16,
+        ],
+    }
+}
+
 #[divan::bench]
 fn input_get_hit(bencher: Bencher) {
     let db = BenchDb::default();
@@ -115,6 +137,19 @@ fn input_get_hit(bencher: Bencher) {
 }
 
 #[divan::bench]
+fn input_get_hit_large_key(bencher: Bencher) {
+    let db = BenchDb::default();
+    let input: InputIngredient<LargeKey, u64> = InputIngredient::new(QueryKindId(5), "LargeKey");
+    let key = large_key(128, 7);
+    input.set(&db, key.clone(), 42);
+
+    bencher.bench(|| {
+        let value = input.get(&db, black_box(&key)).unwrap();
+        black_box(value);
+    });
+}
+
+#[divan::bench]
 fn input_set_noop_small_value(bencher: Bencher) {
     let db = BenchDb::default();
     let input: InputIngredient<u32, u64> = InputIngredient::new(QueryKindId(2), "Number");
@@ -122,6 +157,19 @@ fn input_set_noop_small_value(bencher: Bencher) {
 
     bencher.bench(|| {
         let revision = input.set(&db, black_box(7), black_box(42));
+        black_box(revision);
+    });
+}
+
+#[divan::bench]
+fn input_set_noop_large_key(bencher: Bencher) {
+    let db = BenchDb::default();
+    let input: InputIngredient<LargeKey, u64> = InputIngredient::new(QueryKindId(6), "LargeKey");
+    let key = large_key(128, 7);
+    input.set(&db, key.clone(), 42);
+
+    bencher.bench(|| {
+        let revision = input.set(&db, black_box(key.clone()), black_box(42));
         black_box(revision);
     });
 }

--- a/picante/src/key.rs
+++ b/picante/src/key.rs
@@ -88,6 +88,7 @@ trait ErasedFacetKey: Send + Sync {
 struct FacetKey<T> {
     value: Arc<T>,
     bytes: OnceLock<PicanteResult<Arc<[u8]>>>,
+    eq_plan: Option<Arc<facet_hash::EqualityPlan<T>>>,
 }
 
 trait ErasedKeyBytes: Send + Sync {
@@ -136,9 +137,15 @@ where
             .as_any()
             .downcast_ref::<FacetKey<T>>()
             .is_some_and(|other| {
-                eq_known_key_type(&*self.value, &*other.value).unwrap_or_else(|| {
-                    crate::facet_eq::facet_eq_direct(&*self.value, &*other.value)
-                })
+                if let Some(equal) = eq_known_key_type(&*self.value, &*other.value) {
+                    return equal;
+                }
+                if let Some(plan) = self.eq_plan.as_ref().or(other.eq_plan.as_ref())
+                    && let Ok(equal) = plan.eq(&*self.value, &*other.value)
+                {
+                    return equal;
+                }
+                crate::facet_eq::facet_eq_direct(&*self.value, &*other.value)
             })
     }
 
@@ -378,14 +385,25 @@ pub(crate) struct RuntimeKey<T> {
     value: T,
     hash: u64,
     bytes: Option<Arc<[u8]>>,
+    eq_plan: Option<Arc<facet_hash::EqualityPlan<T>>>,
 }
 
 impl<T> RuntimeKey<T>
 where
     T: Clone + Facet<'static> + Send + Sync + 'static,
 {
-    fn new(value: T, hash: u64, bytes: Option<Arc<[u8]>>) -> Self {
-        Self { value, hash, bytes }
+    fn new(
+        value: T,
+        hash: u64,
+        bytes: Option<Arc<[u8]>>,
+        eq_plan: Option<Arc<facet_hash::EqualityPlan<T>>>,
+    ) -> Self {
+        Self {
+            value,
+            hash,
+            bytes,
+            eq_plan,
+        }
     }
 
     pub(crate) fn value(&self) -> &T {
@@ -397,8 +415,15 @@ where
     }
 
     pub(crate) fn matches(&self, value: &T) -> bool {
-        eq_known_key_type(&self.value, value)
-            .unwrap_or_else(|| crate::facet_eq::facet_eq_direct(&self.value, value))
+        if let Some(equal) = eq_known_key_type(&self.value, value) {
+            return equal;
+        }
+        if let Some(plan) = &self.eq_plan
+            && let Ok(equal) = plan.eq(&self.value, value)
+        {
+            return equal;
+        }
+        crate::facet_eq::facet_eq_direct(&self.value, value)
     }
 
     pub(crate) fn to_key(&self) -> Key {
@@ -416,6 +441,7 @@ where
             repr: KeyRepr::Typed(Arc::new(FacetKey {
                 value: Arc::new(self.value.clone()),
                 bytes: once_lock_from_option(self.bytes.clone().map(Ok)),
+                eq_plan: self.eq_plan.clone(),
             })),
             hash: self.hash,
         }
@@ -431,6 +457,7 @@ where
             value: self.value.clone(),
             hash: self.hash,
             bytes: self.bytes.clone(),
+            eq_plan: self.eq_plan.clone(),
         }
     }
 }
@@ -631,6 +658,7 @@ where
 /// Reusable key builder for one Facet key type.
 pub struct KeyFactory<T> {
     plan: Option<KeyHashPlan<T>>,
+    eq_plan: Option<Arc<facet_hash::EqualityPlan<T>>>,
 }
 
 impl<T> KeyFactory<T>
@@ -641,6 +669,7 @@ where
     pub fn new() -> Self {
         Self {
             plan: KeyHashPlan::<T>::build().ok(),
+            eq_plan: facet_hash::EqualityPlan::<T>::build().ok().map(Arc::new),
         }
     }
 
@@ -674,7 +703,7 @@ where
     where
         T: Clone + Send + Sync + 'static,
     {
-        RuntimeKey::new(value, hash, bytes)
+        RuntimeKey::new(value, hash, bytes, self.eq_plan.clone())
     }
 
     /// Build a key from an owned value.
@@ -723,6 +752,7 @@ where
         let key = FacetKey {
             value,
             bytes: once_lock_from_option(bytes.map(Ok)),
+            eq_plan: self.eq_plan.clone(),
         };
 
         Key {
@@ -812,6 +842,7 @@ fn once_lock_from_option<T>(value: Option<T>) -> OnceLock<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use facet::Facet;
 
     #[test]
     fn scalar_key_hash_plan_uses_native_when_available() {
@@ -839,5 +870,38 @@ mod tests {
         assert_eq!(inline.to_bytes().unwrap(), encoded.to_bytes().unwrap());
         assert_eq!(inline.bytes(), encoded.bytes());
         assert_eq!(inline.decode_facet::<u32>().unwrap(), 7);
+    }
+
+    #[derive(Clone, Debug, Facet)]
+    struct PlannedKey {
+        shard: u32,
+        label: String,
+        bytes: Vec<u8>,
+    }
+
+    #[test]
+    fn aggregate_runtime_keys_use_cached_equality_plan() {
+        let factory = KeyFactory::<PlannedKey>::new();
+        assert!(factory.eq_plan.is_some());
+
+        let key = PlannedKey {
+            shard: 7,
+            label: "ada".to_owned(),
+            bytes: vec![1, 2, 3],
+        };
+        let same = PlannedKey {
+            shard: 7,
+            label: "ada".to_owned(),
+            bytes: vec![1, 2, 3],
+        };
+        let different = PlannedKey {
+            shard: 7,
+            label: "ada".to_owned(),
+            bytes: vec![1, 2, 4],
+        };
+        let runtime_key = factory.runtime_key(key).unwrap();
+
+        assert!(runtime_key.matches(&same));
+        assert!(!runtime_key.matches(&different));
     }
 }


### PR DESCRIPTION
## Summary
- Add `facet_hash::EqualityPlan<T>`, reusing the existing facet-hash Weavy lowering and running it over two typed base pointers.
- Compare structs, options/results, byte sequences, lists/arrays/slices, sets, maps, pointers, and scalars without moving this into a separate equality crate.
- Cache `EqualityPlan<T>` in Picante `KeyFactory<T>` so typed `RuntimeKey` and erased typed `Key` equality can use the shared planned path before falling back to the old Picante reflection walker.
- Add Picante aggregate-key benches for the key identity path.

## Benchmarks
Divan, one thread. Measured by switching the existing `~/oss/facet` checkout on each host.

Base: `d04ade6e9` (`chore: release`)
Head: `24a5754be` (`facet-hash: add equality plans`)

Command shape:

```sh
cargo bench -p picante --bench derived --no-run
target/release/deps/derived-* --bench --min-time 1 --sample-count 20 --threads 1 <filters>
```

### Apple M2 Max

| Bench | Base | Head | PR vs base |
|---|---:|---:|---:|
| `derived_changed_large_value` | 117.2 us | 114.3 us | 1.03x faster |
| `derived_equal_cutoff_large_value` | 101.0 us | 101.6 us | 0.99x |
| `derived_hot_hit` | 304.2 ns | 304.2 ns | 1.00x |
| `input_get_hit` | 23.15 ns | 22.20 ns | 1.04x faster |
| `input_set_changed_large_value` | 80.99 us | 80.95 us | 1.00x |
| `input_set_noop_large_value` | 75.62 us | 76.54 us | 0.99x |
| `input_set_noop_small_value` | 31.13 ns | 32.78 ns | 0.95x |

### AMD Ryzen 5 3600

| Bench | Base | Head | PR vs base |
|---|---:|---:|---:|
| `derived_changed_large_value` | 180.1 us | 174.1 us | 1.03x faster |
| `derived_equal_cutoff_large_value` | 141.8 us | 143.0 us | 0.99x |
| `derived_hot_hit` | 463.1 ns | 498.2 ns | 0.93x |
| `input_get_hit` | 44.53 ns | 48.13 ns | 0.93x |
| `input_set_changed_large_value` | 106.7 us | 106.6 us | 1.00x |
| `input_set_noop_large_value` | 103.3 us | 93.94 us | 1.10x faster |
| `input_set_noop_small_value` | 55.00 ns | 49.22 ns | 1.12x faster |

### New Aggregate-Key Coverage

These rows are introduced by this PR, so they are head-only under a pure branch-checkout before/after measurement.

| Bench | Apple M2 Max | AMD Ryzen 5 3600 |
|---|---:|---:|
| `input_get_hit_large_key` | 9.082 us | 14.88 us |
| `input_set_noop_large_key` | 10.87 us | 18.69 us |

## Verification
- `cargo check -p facet-hash -p picante`
- `cargo check -p facet-hash -p picante --features picante/jit`
- `cargo clippy -p facet-hash -p picante --all-features --all-targets --message-format=short -- -D warnings`
- `cargo nextest run -p facet-hash -p picante -E 'package(facet-hash) | (package(picante) & test(aggregate_runtime_keys_use_cached_equality_plan))'`
- `cargo nextest run -p picante`
- Remote Divan before/after on Apple M2 Max and AMD Ryzen 5 3600, using the command shape above.
