### PR TITLE
docs: migrate dodeca config to the new source/site/mounts format

### DIFF
--- a/.config/dodeca.styx
+++ b/.config/dodeca.styx
@@ -50,8 +50,10 @@ site {
 
     // Link checking configuration
     link_check {
-        // Domains to skip (anti-bot policies)
-        // skip_domains (example.com)
+        // Domains to skip (anti-bot policies): patreon 403s automated checks.
+        skip_domains (
+            patreon.com
+        )
     }
 
     stable_assets (

--- a/.config/dodeca.styx
+++ b/.config/dodeca.styx
@@ -1,51 +1,61 @@
 @schema {id crate:dodeca-config@1, cli ddc}
 
-// Dodeca configuration for facet docs
-
-output docs/public
-
-// Multiple sources: the facet docs at /, plus the standalone subsites each
-// mounted under their own prefix so their root-absolute links localize
-// (e.g. styx's /tools/cli -> /styx/tools/cli) and they get a source identity
-// for cross-links ([[styx:...]]).
+// Dodeca configuration for the facet docs aggregator.
+//
+// The facet docs are the root `source` (served at /); every other subsite is a
+// `mounts` entry under its own URL prefix so its root-absolute links localize
+// (e.g. styx's /tools/cli -> /styx/tools/cli) and it gets a source identity for
+// cross-links ([[styx:...]]).
 //
 // Each source's chrome is its OWN: templates / sass / static resolve to the
 // content dir's sibling `../{templates,sass,static}`. styx points at its real
 // project `styx-docs/` (its own templates incl. the codemirror/monaco/quiz
 // playgrounds), so it keeps its full identity. facet/picante/dibs all live
-// under docs/ and so share docs/templates as the uniform facet baseline.
-// The *only* uniformized layer across every site is the nav + search (woven
-// into each base template) so the sites are mutually discoverable.
+// under docs/ and share docs/templates as the uniform facet baseline. The only
+// uniformized layer across every site is the nav + search (woven into each base
+// template) so the sites are mutually discoverable.
+//
+// `repo` is each mount's "view source" base URL. These are vendored content
+// dirs in this monorepo (no config of their own to compose from), so the URL is
+// declared on the mount; a cloned, standalone source would instead compose it
+// from its own `source { repo … }`.
 
-sources (
-    { name facet,   mount /,        local docs/content,          repo "https://github.com/facet-rs/facet" }
-    { name styx,    mount /styx,    local styx-docs/content,      repo "https://github.com/bearcove/styx" }
-    { name picante, mount /picante, local docs/picante-content,   repo "https://github.com/bearcove/picante" }
-    { name dibs,    mount /dibs,    local docs/dibs-content,      repo "https://github.com/bearcove/dibs" }
-    { name figue,   mount /figue,   local figue/docs/content,     repo "https://github.com/bearcove/figue" }
-    { name rediff,  mount /rediff,  local rediff/docs/content,    repo "https://github.com/bearcove/rediff" }
-    { name strid,   mount /strid,   local strid/docs/content,     repo "https://github.com/facet-rs/facet/tree/main/strid" }
-    { name fable,   mount /fable,   local fable/docs/content,     repo "https://github.com/facet-rs/facet/tree/main/fable" }
-    { name weavy,   mount /weavy,   local weavy/docs/content,     repo "https://github.com/facet-rs/facet/tree/main/weavy" }
-    { name vox,     mount /vox,     local vox/docs/content,       repo "https://github.com/bearcove/vox" }
-    { name facet-axum,       mount /facet-axum,       local facet-axum/docs/content,       repo "https://github.com/facet-rs/facet/tree/main/facet-axum" }
-    { name facet-cargo-toml, mount /facet-cargo-toml, local facet-cargo-toml/docs/content, repo "https://github.com/facet-rs/facet/tree/main/facet-cargo-toml" }
-    { name rusqlite-facet,   mount /rusqlite-facet,   local rusqlite-facet/docs/content,   repo "https://github.com/facet-rs/facet/tree/main/rusqlite-facet" }
-    { name facet-json,       mount /facet-json,       local facet-json/docs/content,       repo "https://github.com/facet-rs/facet/tree/main/facet-json" }
-    { name facet-pretty,     mount /facet-pretty,     local facet-pretty/docs/content,     repo "https://github.com/facet-rs/facet/tree/main/facet-pretty" }
-    { name facet-default,    mount /facet-default,    local facet-default/docs/content,    repo "https://github.com/facet-rs/facet/tree/main/facet-default" }
-    { name facet-error,      mount /facet-error,      local facet-error/docs/content,      repo "https://github.com/facet-rs/facet/tree/main/facet-error" }
-    { name facet-validate,   mount /facet-validate,   local facet-validate/docs/content,   repo "https://github.com/facet-rs/facet/tree/main/facet-validate" }
-)
-
-// Link checking configuration
-
-link_check {
-    // Domains to skip (anti-bot policies)
-    // skip_domains (example.com)
+source {
+    content docs/content
+    repo "https://github.com/facet-rs/facet"
 }
 
-stable_assets (
-    "docs/static/favicon.png favicon.png"
-    "docs/static/CNAME CNAME"
+mounts (
+    { name styx,    path /styx,    local styx-docs/content,      repo "https://github.com/bearcove/styx" }
+    { name picante, path /picante, local docs/picante-content,   repo "https://github.com/bearcove/picante" }
+    { name dibs,    path /dibs,    local docs/dibs-content,      repo "https://github.com/bearcove/dibs" }
+    { name figue,   path /figue,   local figue/docs/content,     repo "https://github.com/bearcove/figue" }
+    { name rediff,  path /rediff,  local rediff/docs/content,    repo "https://github.com/bearcove/rediff" }
+    { name strid,   path /strid,   local strid/docs/content,     repo "https://github.com/facet-rs/facet/tree/main/strid" }
+    { name fable,   path /fable,   local fable/docs/content,     repo "https://github.com/facet-rs/facet/tree/main/fable" }
+    { name weavy,   path /weavy,   local weavy/docs/content,     repo "https://github.com/facet-rs/facet/tree/main/weavy" }
+    { name vox,     path /vox,     local vox/docs/content,       repo "https://github.com/bearcove/vox" }
+    { name facet-axum,       path /facet-axum,       local facet-axum/docs/content,       repo "https://github.com/facet-rs/facet/tree/main/facet-axum" }
+    { name facet-cargo-toml, path /facet-cargo-toml, local facet-cargo-toml/docs/content, repo "https://github.com/facet-rs/facet/tree/main/facet-cargo-toml" }
+    { name rusqlite-facet,   path /rusqlite-facet,   local rusqlite-facet/docs/content,   repo "https://github.com/facet-rs/facet/tree/main/rusqlite-facet" }
+    { name facet-json,       path /facet-json,       local facet-json/docs/content,       repo "https://github.com/facet-rs/facet/tree/main/facet-json" }
+    { name facet-pretty,     path /facet-pretty,     local facet-pretty/docs/content,     repo "https://github.com/facet-rs/facet/tree/main/facet-pretty" }
+    { name facet-default,    path /facet-default,    local facet-default/docs/content,    repo "https://github.com/facet-rs/facet/tree/main/facet-default" }
+    { name facet-error,      path /facet-error,      local facet-error/docs/content,      repo "https://github.com/facet-rs/facet/tree/main/facet-error" }
+    { name facet-validate,   path /facet-validate,   local facet-validate/docs/content,   repo "https://github.com/facet-rs/facet/tree/main/facet-validate" }
 )
+
+site {
+    output docs/public
+
+    // Link checking configuration
+    link_check {
+        // Domains to skip (anti-bot policies)
+        // skip_domains (example.com)
+    }
+
+    stable_assets (
+        "docs/static/favicon.png favicon.png"
+        "docs/static/CNAME CNAME"
+    )
+}

--- a/styx-docs/package.json
+++ b/styx-docs/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build"
+    "dev": "pnpm --filter @bearcove/styx-webmd run build && vite",
+    "build": "pnpm --filter @bearcove/styx-webmd run build && vite build"
   },
   "dependencies": {
     "@bearcove/styx": "workspace:*",

--- a/vox/.config/dodeca.styx
+++ b/vox/.config/dodeca.styx
@@ -1,28 +1,35 @@
-content docs/content
-output docs/public
+@schema {id crate:dodeca-config@1, cli ddc}
 
-link_check {}
+// vox's standalone dodeca config. When vox is built on its own, `source` +
+// `site` apply; when it's mounted into the facet aggregator, the aggregator
+// composes this `source {}` (its location comes from the mount's `local`).
 
-stable_assets ()
+source {
+    content docs/content
+}
 
-code_execution {
-    enabled true
-    fail_on_error true
-    timeout_secs 30
-    cache_dir .cache/code-execution
+site {
+    output docs/public
 
-    rust {
-        command cargo
-        args (
-            run
-            --quiet
-            --release
-        )
-        extension rs
-        prepare_code true
-        auto_imports (
-            "use std::collections::HashMap;"
-        )
-        show_output true
+    code_execution {
+        enabled true
+        fail_on_error true
+        timeout_secs 30
+        cache_dir .cache/code-execution
+
+        rust {
+            command cargo
+            args (
+                run
+                --quiet
+                --release
+            )
+            extension rs
+            prepare_code true
+            auto_imports (
+                "use std::collections::HashMap;"
+            )
+            show_output true
+        }
     }
 }


### PR DESCRIPTION
Migrates the docs aggregator config to dodeca's new config format (requires **dodeca ≥ v0.17.0**, now the latest release — `website.yml` installs `releases/latest`, so this is safe to merge).

## What changed

- **`.config/dodeca.styx` → new format.** The flat `output` + `sources (...)` layout becomes `source {}` (the facet docs at `/`) + `site {}` (output, link-check, stable assets) + `mounts (...)` (the 17 subsites, with `path` instead of `mount` and a per-mount `repo`). Also adds `patreon.com` to `link_check.skip_domains` (it 403s automated checks).
- **`vox/.config/dodeca.styx` → new format**, so the aggregator actually composes vox's `source {}` instead of silently dropping an unparseable old-format config.
- **`styx-docs`: build the `styx-webmd` wasm dep before vite.** Its vite build aliases `@bearcove/styx-webmd` to `tools/styx-webmd/dist/` — a gitignored Rust→WASM artifact that a fresh checkout/CI never builds, so `vite build` failed on a bare "No such file or directory" and the codemirror/monaco playground pages rendered empty. Now `styx-docs` builds its wasm dependency first.

## Verification

`ddc build` (against this config + the released v0.17.0 `ddc`): **5719 internal links, 0 broken**, all 18 sources resolve, the styx playgrounds render. No old-format parse errors or orphaned-config warnings.

Dual-parse in v0.17 means even un-migrated configs keep building with a deprecation warning, so there's no flag-day; this PR is the clean migration for facet's own config.