### PR TITLE
picante: reuse planned equality for values

### DIFF
--- a/picante/src/facet_eq.rs
+++ b/picante/src/facet_eq.rs
@@ -13,33 +13,91 @@ use facet::Facet;
 use facet_core::{Def, StructKind, Type, UserType};
 use facet_reflect::Peek;
 use std::any::Any;
+use std::sync::Arc;
 
-/// Check if two type-erased Facet values are equal.
-///
-/// This function:
-/// - Downcasts both `dyn Any` values to the concrete type `V`
-/// - Performs structural comparison using facet reflection
-/// - Works even when inner types don't implement PartialEq
-///
-/// # Type Parameters
-/// - `V`: Must implement `Facet<'static>` for shape information
-///
-/// # Returns
-/// - `true` if values are structurally equal
-/// - `false` if types don't match or values differ
-pub fn facet_eq<V>(a: &dyn Any, b: &dyn Any) -> bool
+pub(crate) struct PlannedEquality<T> {
+    plan: Option<Arc<facet_hash::EqualityPlan<T>>>,
+}
+
+impl<T> Clone for PlannedEquality<T> {
+    fn clone(&self) -> Self {
+        Self {
+            plan: self.plan.clone(),
+        }
+    }
+}
+
+impl<T> PlannedEquality<T>
 where
-    V: Facet<'static> + 'static,
+    T: Facet<'static>,
 {
-    // Downcast to concrete type
-    let Some(a) = a.downcast_ref::<V>() else {
-        return false;
-    };
-    let Some(b) = b.downcast_ref::<V>() else {
-        return false;
-    };
+    pub(crate) fn new() -> Self {
+        Self {
+            plan: facet_hash::EqualityPlan::<T>::build().ok().map(Arc::new),
+        }
+    }
 
-    facet_eq_direct(a, b)
+    #[cfg(test)]
+    pub(crate) fn has_plan(&self) -> bool {
+        self.plan.is_some()
+    }
+}
+
+impl<T> PlannedEquality<T>
+where
+    T: Facet<'static> + 'static,
+{
+    pub(crate) fn eq(&self, a: &T, b: &T) -> bool {
+        if let Some(equal) = known_eq(a, b) {
+            return equal;
+        }
+        if let Some(plan) = &self.plan
+            && let Ok(equal) = plan.eq(a, b)
+        {
+            return equal;
+        }
+        facet_eq_direct(a, b)
+    }
+}
+
+impl<T> Default for PlannedEquality<T>
+where
+    T: Facet<'static>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub(crate) fn known_eq<T: 'static>(left: &T, right: &T) -> Option<bool> {
+    let left = left as &dyn Any;
+    let right = right as &dyn Any;
+
+    macro_rules! eq_as {
+        ($ty:ty) => {
+            if let Some(left) = left.downcast_ref::<$ty>() {
+                return Some(left == right.downcast_ref::<$ty>()?);
+            }
+        };
+    }
+
+    eq_as!(u32);
+    eq_as!(());
+    eq_as!(String);
+    eq_as!(u64);
+    eq_as!(bool);
+    eq_as!(u16);
+    eq_as!(u8);
+    eq_as!(u128);
+    eq_as!(usize);
+    eq_as!(i32);
+    eq_as!(i64);
+    eq_as!(i16);
+    eq_as!(i8);
+    eq_as!(i128);
+    eq_as!(isize);
+
+    None
 }
 
 /// Check if two concrete Facet values are structurally equal.

--- a/picante/src/ingredient/derived.rs
+++ b/picante/src/ingredient/derived.rs
@@ -1,5 +1,6 @@
 use crate::db::{DynIngredient, IngredientLookup, Touch};
 use crate::error::{PicanteError, PicanteResult};
+use crate::facet_eq::PlannedEquality;
 use crate::frame::{self, ActiveFrameHandle};
 use crate::inflight::{self, InFlightKey, InFlightState, SharedCacheRecord, TryLeadResult};
 use crate::key::{Dep, DynKey, Key, KeyFactory, KeyMap, QueryKindId, key_map};
@@ -88,8 +89,9 @@ struct ApplyWalResult {
     cell: Option<Arc<ErasedCell>>, // None = delete
 }
 
-/// Function pointer for deep equality check without knowing V
-type EqErasedFn = fn(&dyn Any, &dyn Any) -> bool;
+trait ErasedEquality: Send + Sync {
+    fn eq(&self, a: &dyn Any, b: &dyn Any) -> bool;
+}
 
 // ============================================================================
 // Non-generic helpers for type-erased serialization/deserialization
@@ -177,16 +179,23 @@ where
     }
 }
 
-/// Deep equality helper for type-erased values
-///
-/// Uses autoref specialization to prefer PartialEq when available,
-/// falling back to byte-wise comparison otherwise.
-/// This avoids pulling in facet-diff and all its transitive feature dependencies.
-fn eq_erased_for<V>(a: &dyn Any, b: &dyn Any) -> bool
+struct TypedEquality<V> {
+    equality: PlannedEquality<V>,
+}
+
+impl<V> ErasedEquality for TypedEquality<V>
 where
-    V: Facet<'static> + 'static,
+    V: Facet<'static> + Send + Sync + 'static,
 {
-    crate::facet_eq::facet_eq::<V>(a, b)
+    fn eq(&self, a: &dyn Any, b: &dyn Any) -> bool {
+        let Some(a) = a.downcast_ref::<V>() else {
+            return false;
+        };
+        let Some(b) = b.downcast_ref::<V>() else {
+            return false;
+        };
+        self.equality.eq(a, b)
+    }
 }
 
 // ============================================================================
@@ -243,7 +252,7 @@ impl DerivedCore {
         requested: DynKey,
         want_value: bool,
         compute: &dyn ErasedCompute<DB>,
-        eq_erased: EqErasedFn,
+        equality: &dyn ErasedEquality,
     ) -> PicanteResult<ErasedAccessResult>
     where
         DB: IngredientLookup + Send + Sync + 'static,
@@ -653,9 +662,9 @@ impl DerivedCore {
                             let changed_at = match prev {
                                 Some((prev_value, prev_changed_at)) => {
                                     // Fast path: pointer equality (values are literally the same Arc)
-                                    // Slow path: deep equality via eq_erased function pointer
+                                    // Slow path: deep equality via the cached typed plan
                                     let is_same = Arc::ptr_eq(&prev_value, &out)
-                                        || eq_erased(prev_value.as_ref(), out.as_ref());
+                                        || equality.eq(prev_value.as_ref(), out.as_ref());
 
                                     if is_same { prev_changed_at } else { rev }
                                 }
@@ -996,14 +1005,14 @@ impl DerivedCore {
         db: &'a DB,
         dyn_key: DynKey,
         compute: &'a dyn ErasedCompute<DB>,
-        eq_erased: EqErasedFn,
+        equality: &'a dyn ErasedEquality,
     ) -> BoxFuture<'a, PicanteResult<Touch>>
     where
         DB: IngredientLookup + Send + Sync + 'static,
     {
         Box::pin(async move {
             let result = frame::scope_if_needed_boxed(Box::pin(
-                self.access_scoped_erased(db, dyn_key, false, compute, eq_erased),
+                self.access_scoped_erased(db, dyn_key, false, compute, equality),
             ))
             .await?;
             Ok(Touch {
@@ -1021,7 +1030,7 @@ impl DerivedCore {
         db: &'a DB,
         dyn_key: DynKey,
         compute: &'a dyn ErasedCompute<DB>,
-        eq_erased: EqErasedFn,
+        equality: &'a dyn ErasedEquality,
     ) -> BoxFuture<'a, PicanteResult<ArcAny>>
     where
         DB: IngredientLookup + Send + Sync + 'static,
@@ -1032,7 +1041,7 @@ impl DerivedCore {
                 dyn_key.clone(),
                 true,
                 compute,
-                eq_erased,
+                equality,
             )))
             .await?;
 
@@ -1335,8 +1344,8 @@ where
     _phantom: PhantomData<(K, V)>,
     /// Type-erased compute function (trait object for dyn dispatch)
     compute: Arc<dyn ErasedCompute<DB>>,
-    /// Deep equality function for detecting value changes
-    eq_erased: EqErasedFn,
+    /// Deep equality checker for detecting value changes
+    equality: Arc<dyn ErasedEquality>,
 }
 
 impl<DB, K, V> DerivedIngredient<DB, K, V>
@@ -1378,7 +1387,9 @@ where
             key_factory,
             _phantom: PhantomData,
             compute: compute_erased,
-            eq_erased: eq_erased_for::<V>,
+            equality: Arc::new(TypedEquality::<V> {
+                equality: PlannedEquality::new(),
+            }),
         }
     }
 
@@ -1405,7 +1416,7 @@ where
         // Use the type-erased get helper (compiled once per DB, not per K/V)
         let arc_any = self
             .core
-            .get_erased(db, dyn_key, self.compute.as_ref(), self.eq_erased)
+            .get_erased(db, dyn_key, self.compute.as_ref(), self.equality.as_ref())
             .await?;
 
         // Downcast Arc<dyn Any> → Arc<V>
@@ -1437,7 +1448,7 @@ where
         // Use the type-erased touch helper (compiled once per DB, not per K/V)
         let touch = self
             .core
-            .touch_erased(db, dyn_key, self.compute.as_ref(), self.eq_erased)
+            .touch_erased(db, dyn_key, self.compute.as_ref(), self.equality.as_ref())
             .await?;
 
         Ok(touch.changed_at)
@@ -1774,7 +1785,7 @@ where
             key,
         };
         self.core
-            .touch_erased(db, dyn_key, self.compute.as_ref(), self.eq_erased)
+            .touch_erased(db, dyn_key, self.compute.as_ref(), self.equality.as_ref())
     }
 }
 

--- a/picante/src/ingredient/input.rs
+++ b/picante/src/ingredient/input.rs
@@ -1,5 +1,6 @@
 use crate::db::{DynIngredient, Touch};
 use crate::error::{PicanteError, PicanteResult};
+use crate::facet_eq::PlannedEquality;
 use crate::frame;
 use crate::key::{Dep, Key, KeyFactory, QueryKindId, RuntimeKeyMap, runtime_key_map};
 use crate::persist::{PersistableIngredient, SectionType};
@@ -329,6 +330,7 @@ where
 {
     core: InputCore<K>,
     key_factory: KeyFactory<K>,
+    value_equality: PlannedEquality<V>,
     /// Phantom data for K and V types
     _phantom: std::marker::PhantomData<(K, V)>,
 }
@@ -350,6 +352,7 @@ where
                 make_apply_input_wal_entry::<K, V>(),
             ),
             key_factory: KeyFactory::new(),
+            value_equality: PlannedEquality::new(),
             _phantom: std::marker::PhantomData,
         }
     }
@@ -385,7 +388,7 @@ where
                 .from_hash(key_hash, |stored| stored.matches(&key))
                 && let Some(existing_value) = existing.value.as_ref()
                 && let Some(typed_existing) = existing_value.downcast_ref::<V>()
-                && crate::facet_eq::facet_eq_direct(typed_existing, &value)
+                && self.value_equality.eq(typed_existing, &value)
             {
                 trace!(
                     kind = self.core.kind.0,
@@ -614,6 +617,7 @@ where
         Self {
             core,
             key_factory,
+            value_equality: PlannedEquality::new(),
             _phantom: std::marker::PhantomData,
         }
     }

--- a/picante/src/key.rs
+++ b/picante/src/key.rs
@@ -1,6 +1,7 @@
 //! Query key encoding and erased identifiers used for dependency graphs.
 
 use crate::error::{PicanteError, PicanteResult};
+use crate::facet_eq::PlannedEquality;
 use facet::Facet;
 use std::any::Any;
 use std::collections::hash_map::DefaultHasher;
@@ -88,7 +89,7 @@ trait ErasedFacetKey: Send + Sync {
 struct FacetKey<T> {
     value: Arc<T>,
     bytes: OnceLock<PicanteResult<Arc<[u8]>>>,
-    eq_plan: Option<Arc<facet_hash::EqualityPlan<T>>>,
+    equality: PlannedEquality<T>,
 }
 
 trait ErasedKeyBytes: Send + Sync {
@@ -136,17 +137,7 @@ where
         other
             .as_any()
             .downcast_ref::<FacetKey<T>>()
-            .is_some_and(|other| {
-                if let Some(equal) = eq_known_key_type(&*self.value, &*other.value) {
-                    return equal;
-                }
-                if let Some(plan) = self.eq_plan.as_ref().or(other.eq_plan.as_ref())
-                    && let Ok(equal) = plan.eq(&*self.value, &*other.value)
-                {
-                    return equal;
-                }
-                crate::facet_eq::facet_eq_direct(&*self.value, &*other.value)
-            })
+            .is_some_and(|other| self.equality.eq(&*self.value, &*other.value))
     }
 
     fn bytes(&self) -> PicanteResult<&[u8]> {
@@ -385,24 +376,19 @@ pub(crate) struct RuntimeKey<T> {
     value: T,
     hash: u64,
     bytes: Option<Arc<[u8]>>,
-    eq_plan: Option<Arc<facet_hash::EqualityPlan<T>>>,
+    equality: PlannedEquality<T>,
 }
 
 impl<T> RuntimeKey<T>
 where
     T: Clone + Facet<'static> + Send + Sync + 'static,
 {
-    fn new(
-        value: T,
-        hash: u64,
-        bytes: Option<Arc<[u8]>>,
-        eq_plan: Option<Arc<facet_hash::EqualityPlan<T>>>,
-    ) -> Self {
+    fn new(value: T, hash: u64, bytes: Option<Arc<[u8]>>, equality: PlannedEquality<T>) -> Self {
         Self {
             value,
             hash,
             bytes,
-            eq_plan,
+            equality,
         }
     }
 
@@ -415,15 +401,7 @@ where
     }
 
     pub(crate) fn matches(&self, value: &T) -> bool {
-        if let Some(equal) = eq_known_key_type(&self.value, value) {
-            return equal;
-        }
-        if let Some(plan) = &self.eq_plan
-            && let Ok(equal) = plan.eq(&self.value, value)
-        {
-            return equal;
-        }
-        crate::facet_eq::facet_eq_direct(&self.value, value)
+        self.equality.eq(&self.value, value)
     }
 
     pub(crate) fn to_key(&self) -> Key {
@@ -441,7 +419,7 @@ where
             repr: KeyRepr::Typed(Arc::new(FacetKey {
                 value: Arc::new(self.value.clone()),
                 bytes: once_lock_from_option(self.bytes.clone().map(Ok)),
-                eq_plan: self.eq_plan.clone(),
+                equality: self.equality.clone(),
             })),
             hash: self.hash,
         }
@@ -457,7 +435,7 @@ where
             value: self.value.clone(),
             hash: self.hash,
             bytes: self.bytes.clone(),
-            eq_plan: self.eq_plan.clone(),
+            equality: self.equality.clone(),
         }
     }
 }
@@ -596,37 +574,6 @@ where
     KeyHashPlan::<T>::build()?.hash64(value)
 }
 
-fn eq_known_key_type<T: 'static>(left: &T, right: &T) -> Option<bool> {
-    let left = left as &dyn Any;
-    let right = right as &dyn Any;
-
-    macro_rules! eq_as {
-        ($ty:ty) => {
-            if let Some(left) = left.downcast_ref::<$ty>() {
-                return Some(left == right.downcast_ref::<$ty>()?);
-            }
-        };
-    }
-
-    eq_as!(u32);
-    eq_as!(());
-    eq_as!(String);
-    eq_as!(u64);
-    eq_as!(bool);
-    eq_as!(u16);
-    eq_as!(u8);
-    eq_as!(u128);
-    eq_as!(usize);
-    eq_as!(i32);
-    eq_as!(i64);
-    eq_as!(i16);
-    eq_as!(i8);
-    eq_as!(i128);
-    eq_as!(isize);
-
-    None
-}
-
 enum KeyHashPlan<T> {
     #[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
     Native(facet_hash::NativeHashPlan<T>),
@@ -658,7 +605,7 @@ where
 /// Reusable key builder for one Facet key type.
 pub struct KeyFactory<T> {
     plan: Option<KeyHashPlan<T>>,
-    eq_plan: Option<Arc<facet_hash::EqualityPlan<T>>>,
+    equality: PlannedEquality<T>,
 }
 
 impl<T> KeyFactory<T>
@@ -669,7 +616,7 @@ where
     pub fn new() -> Self {
         Self {
             plan: KeyHashPlan::<T>::build().ok(),
-            eq_plan: facet_hash::EqualityPlan::<T>::build().ok().map(Arc::new),
+            equality: PlannedEquality::new(),
         }
     }
 
@@ -703,7 +650,7 @@ where
     where
         T: Clone + Send + Sync + 'static,
     {
-        RuntimeKey::new(value, hash, bytes, self.eq_plan.clone())
+        RuntimeKey::new(value, hash, bytes, self.equality.clone())
     }
 
     /// Build a key from an owned value.
@@ -752,7 +699,7 @@ where
         let key = FacetKey {
             value,
             bytes: once_lock_from_option(bytes.map(Ok)),
-            eq_plan: self.eq_plan.clone(),
+            equality: self.equality.clone(),
         };
 
         Key {
@@ -882,7 +829,7 @@ mod tests {
     #[test]
     fn aggregate_runtime_keys_use_cached_equality_plan() {
         let factory = KeyFactory::<PlannedKey>::new();
-        assert!(factory.eq_plan.is_some());
+        assert!(factory.equality.has_plan());
 
         let key = PlannedKey {
             shard: 7,

--- a/picante/tests/basic.rs
+++ b/picante/tests/basic.rs
@@ -1,3 +1,4 @@
+use facet::Facet;
 use picante::db::{DynIngredient, IngredientLookup, IngredientRegistry};
 use picante::error::PicanteError;
 use picante::ingredient::{DerivedIngredient, InputIngredient};
@@ -6,6 +7,34 @@ use picante::persist::{load_cache, save_cache};
 use picante::runtime::{HasRuntime, Runtime};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Clone, Debug, Facet)]
+struct AggregateRow {
+    id: u32,
+    label: String,
+}
+
+#[derive(Clone, Debug, Facet)]
+struct AggregateValue {
+    name: String,
+    rows: Vec<AggregateRow>,
+    checksum: u64,
+}
+
+fn aggregate_value(seed: u64) -> AggregateValue {
+    let rows = (0..8)
+        .map(|i| AggregateRow {
+            id: i,
+            label: format!("row-{seed}-{i}"),
+        })
+        .collect();
+
+    AggregateValue {
+        name: format!("aggregate-{seed}"),
+        rows,
+        checksum: seed.wrapping_mul(31),
+    }
+}
 
 fn init_tracing() {
     static ONCE: std::sync::OnceLock<()> = std::sync::OnceLock::new();
@@ -509,4 +538,56 @@ async fn changed_at_stable_when_value_unchanged() {
         changed_at_2, changed_at_3,
         "changed_at should bump when value actually changes"
     );
+}
+
+#[tokio_test_lite::test]
+async fn aggregate_values_use_structural_equality_for_noop_paths() {
+    init_tracing();
+
+    let mut db = TestDb::default();
+    let input: Arc<InputIngredient<String, AggregateValue>> =
+        Arc::new(InputIngredient::new(QueryKindId(1), "AggregateInput"));
+    db.register(input.clone());
+
+    let r1 = input.set(&db, "x".into(), aggregate_value(1));
+    let r2 = input.set(&db, "x".into(), aggregate_value(1));
+    assert_eq!(r1, r2);
+
+    let r3 = input.set(&db, "x".into(), aggregate_value(2));
+    assert_ne!(r2, r3);
+
+    let seed_input: Arc<InputIngredient<String, u64>> =
+        Arc::new(InputIngredient::new(QueryKindId(2), "Seed"));
+    db.register(seed_input.clone());
+
+    let executions = Arc::new(AtomicUsize::new(0));
+    let seed_for_compute = seed_input.clone();
+    let executions_for_compute = executions.clone();
+    let derived: Arc<DerivedIngredient<TestDb, String, AggregateValue>> = Arc::new(
+        DerivedIngredient::new(QueryKindId(3), "AggregateDerived", move |db, key| {
+            let seed_input = seed_for_compute.clone();
+            let executions = executions_for_compute.clone();
+            Box::pin(async move {
+                executions.fetch_add(1, Ordering::SeqCst);
+                let seed = seed_input.get(db, &key)?.expect("missing seed");
+                Ok(aggregate_value(seed % 2))
+            })
+        }),
+    );
+    db.register(derived.clone());
+
+    seed_input.set(&db, "x".into(), 1);
+    let _ = derived.get(&db, "x".into()).await.unwrap();
+    let changed_at_1 = derived.touch(&db, "x".into()).await.unwrap();
+
+    seed_input.set(&db, "x".into(), 3);
+    let _ = derived.get(&db, "x".into()).await.unwrap();
+    let changed_at_2 = derived.touch(&db, "x".into()).await.unwrap();
+    assert_eq!(changed_at_1, changed_at_2);
+    assert_eq!(executions.load(Ordering::SeqCst), 2);
+
+    seed_input.set(&db, "x".into(), 4);
+    let _ = derived.get(&db, "x".into()).await.unwrap();
+    let changed_at_3 = derived.touch(&db, "x".into()).await.unwrap();
+    assert_ne!(changed_at_2, changed_at_3);
 }


### PR DESCRIPTION
## Summary
- Add a shared Picante `PlannedEquality<T>` helper that keeps the primitive fast path and reuses `facet_hash::EqualityPlan<T>` before falling back to the old reflection walker.
- Use the shared planned equality helper for runtime keys, input value no-op checks, and derived-query early cutoff values.
- Add an aggregate-value integration test that exercises input no-op and derived cutoff paths without relying on `PartialEq`.

## Benchmarks
Divan, one thread. Measured by switching the existing `~/oss/facet` checkout on each host.

Base: `origin/main` at `c5c97341b`
Head: `6980e0499`

Command shape:

```sh
cargo bench -p picante --bench derived --no-run
target/release/deps/derived-* --bench --min-time 1 --sample-count 20 --threads 1 <filters>
```

### Apple M2 Max

| Bench | Base | Head | PR vs base |
|---|---:|---:|---:|
| `derived_changed_large_value` | 114.2 us | 115.1 us | 0.99x |
| `derived_equal_cutoff_large_value` | 99.04 us | 68.85 us | 1.44x faster |
| `derived_hot_hit` | 317.1 ns | 299.0 ns | 1.06x faster |
| `input_get_hit` | 22.21 ns | 21.56 ns | 1.03x faster |
| `input_get_hit_large_key` | 9.166 us | 9.124 us | 1.00x |
| `input_set_changed_large_value` | 80.99 us | 79.16 us | 1.02x faster |
| `input_set_noop_large_key` | 10.91 us | 10.83 us | 1.01x faster |
| `input_set_noop_large_value` | 76.54 us | 43.37 us | 1.76x faster |
| `input_set_noop_small_value` | 31.65 ns | 20.58 ns | 1.54x faster |

### AMD Ryzen 5 3600

| Bench | Base | Head | PR vs base |
|---|---:|---:|---:|
| `derived_changed_large_value` | 179.2 us | 175.6 us | 1.02x faster |
| `derived_equal_cutoff_large_value` | 142.5 us | 131.8 us | 1.08x faster |
| `derived_hot_hit` | 453.1 ns | 480.7 ns | 0.94x |
| `input_get_hit` | 48.60 ns | 45.00 ns | 1.08x faster |
| `input_get_hit_large_key` | 14.58 us | 15.03 us | 0.97x |
| `input_set_changed_large_value` | 110.5 us | 105.4 us | 1.05x faster |
| `input_set_noop_large_key` | 18.21 us | 18.48 us | 0.99x |
| `input_set_noop_large_value` | 101.8 us | 85.95 us | 1.18x faster |
| `input_set_noop_small_value` | 47.17 ns | 40.92 ns | 1.15x faster |

## Verification
- `cargo check -p picante`
- `cargo check -p picante --features picante/jit`
- `cargo clippy -p picante --all-features --all-targets --message-format=short -- -D warnings`
- `cargo nextest run -p picante aggregate_values_use_structural_equality_for_noop_paths`
- `cargo nextest run -p picante`
- Push hook: clippy, docs, build tests, run tests
- Remote Divan before/after on Apple M2 Max and AMD Ryzen 5 3600, using the command shape above
