### PR TITLE
facet-hash: add native equality plans

### DIFF
--- a/facet-hash/benches/reuse.rs
+++ b/facet-hash/benches/reuse.rs
@@ -2,9 +2,15 @@ use core::hash::{Hash, Hasher};
 
 use divan::{Bencher, black_box};
 use facet::Facet;
-use facet_hash::HashPlan;
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
-use facet_hash::NativeHashPlan;
+use facet_hash::{EqualityPlan, HashPlan};
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+use facet_hash::{NativeEqualityPlan, NativeHashPlan};
 use facet_reflect::Peek;
 
 fn main() {
@@ -109,12 +115,64 @@ fn point_value_plan_reused(bencher: Bencher<'_, '_>) {
     bencher.bench_local(|| black_box(plan.hash64(black_box(&value)).unwrap()));
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[divan::bench]
+fn point_equality_plan_equal(bencher: Bencher<'_, '_>) {
+    let plan = EqualityPlan::<Point>::build().unwrap();
+    let left = Point { x: 123, y: -456 };
+    let right = Point { x: 123, y: -456 };
+    bencher.bench_local(|| black_box(plan.eq(black_box(&left), black_box(&right)).unwrap()));
+}
+
+#[divan::bench]
+fn point_equality_plan_different(bencher: Bencher<'_, '_>) {
+    let plan = EqualityPlan::<Point>::build().unwrap();
+    let left = Point { x: 123, y: -456 };
+    let right = Point { x: 123, y: -457 };
+    bencher.bench_local(|| black_box(plan.eq(black_box(&left), black_box(&right)).unwrap()));
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[divan::bench]
 fn point_value_native_jit(bencher: Bencher<'_, '_>) {
     let plan = NativeHashPlan::<Point>::build().unwrap();
     let value = Point { x: 123, y: -456 };
     bencher.bench_local(|| black_box(plan.hash64(black_box(&value)).unwrap()));
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+#[divan::bench]
+fn point_equality_native_jit_equal(bencher: Bencher<'_, '_>) {
+    let plan = NativeEqualityPlan::<Point>::build().unwrap();
+    let left = Point { x: 123, y: -456 };
+    let right = Point { x: 123, y: -456 };
+    bencher.bench_local(|| black_box(plan.eq(black_box(&left), black_box(&right)).unwrap()));
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+#[divan::bench]
+fn point_equality_native_jit_different(bencher: Bencher<'_, '_>) {
+    let plan = NativeEqualityPlan::<Point>::build().unwrap();
+    let left = Point { x: 123, y: -456 };
+    let right = Point { x: 123, y: -457 };
+    bencher.bench_local(|| black_box(plan.eq(black_box(&left), black_box(&right)).unwrap()));
 }
 
 #[divan::bench]
@@ -180,12 +238,41 @@ fn mixed_value_plan_reused(bencher: Bencher<'_, '_>) {
     bencher.bench_local(|| black_box(plan.hash64(black_box(&value)).unwrap()));
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[divan::bench]
+fn mixed_equality_plan_equal(bencher: Bencher<'_, '_>) {
+    let plan = EqualityPlan::<MixedScalarRuns>::build().unwrap();
+    let left = mixed_scalar_runs();
+    let right = mixed_scalar_runs();
+    bencher.bench_local(|| black_box(plan.eq(black_box(&left), black_box(&right)).unwrap()));
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[divan::bench]
 fn mixed_value_native_jit(bencher: Bencher<'_, '_>) {
     let plan = NativeHashPlan::<MixedScalarRuns>::build().unwrap();
     let value = mixed_scalar_runs();
     bencher.bench_local(|| black_box(plan.hash64(black_box(&value)).unwrap()));
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+#[divan::bench]
+fn mixed_equality_native_jit_equal(bencher: Bencher<'_, '_>) {
+    let plan = NativeEqualityPlan::<MixedScalarRuns>::build().unwrap();
+    let left = mixed_scalar_runs();
+    let right = mixed_scalar_runs();
+    bencher.bench_local(|| black_box(plan.eq(black_box(&left), black_box(&right)).unwrap()));
 }
 
 #[divan::bench]
@@ -205,12 +292,41 @@ fn point_array_value_plan_reused(bencher: Bencher<'_, '_>) {
     bencher.bench_local(|| black_box(plan.hash64(black_box(&value)).unwrap()));
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[divan::bench]
+fn point_array_equality_plan_equal(bencher: Bencher<'_, '_>) {
+    let plan = EqualityPlan::<PointArray>::build().unwrap();
+    let left = point_array();
+    let right = point_array();
+    bencher.bench_local(|| black_box(plan.eq(black_box(&left), black_box(&right)).unwrap()));
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[divan::bench]
 fn point_array_value_native_jit(bencher: Bencher<'_, '_>) {
     let plan = NativeHashPlan::<PointArray>::build().unwrap();
     let value = point_array();
     bencher.bench_local(|| black_box(plan.hash64(black_box(&value)).unwrap()));
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+#[divan::bench]
+fn point_array_equality_native_jit_equal(bencher: Bencher<'_, '_>) {
+    let plan = NativeEqualityPlan::<PointArray>::build().unwrap();
+    let left = point_array();
+    let right = point_array();
+    bencher.bench_local(|| black_box(plan.eq(black_box(&left), black_box(&right)).unwrap()));
 }
 
 #[divan::bench]
@@ -258,7 +374,29 @@ fn float_value_plan_reused(bencher: Bencher<'_, '_>) {
     bencher.bench_local(|| black_box(plan.hash64(black_box(&value)).unwrap()));
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[divan::bench]
+fn float_equality_plan_equal(bencher: Bencher<'_, '_>) {
+    let plan = EqualityPlan::<FloatPoint>::build().unwrap();
+    let left = FloatPoint {
+        x: 1.25,
+        y: -9.5,
+        z: f64::NAN,
+    };
+    let right = FloatPoint {
+        x: 1.25,
+        y: -9.5,
+        z: f64::from_bits(f64::NAN.to_bits()),
+    };
+    bencher.bench_local(|| black_box(plan.eq(black_box(&left), black_box(&right)).unwrap()));
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[divan::bench]
 fn float_value_native_jit(bencher: Bencher<'_, '_>) {
     let plan = NativeHashPlan::<FloatPoint>::build().unwrap();
@@ -268,6 +406,29 @@ fn float_value_native_jit(bencher: Bencher<'_, '_>) {
         z: f64::NAN,
     };
     bencher.bench_local(|| black_box(plan.hash64(black_box(&value)).unwrap()));
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+#[divan::bench]
+fn float_equality_native_jit_equal(bencher: Bencher<'_, '_>) {
+    let plan = NativeEqualityPlan::<FloatPoint>::build().unwrap();
+    let left = FloatPoint {
+        x: 1.25,
+        y: -9.5,
+        z: f64::NAN,
+    };
+    let right = FloatPoint {
+        x: 1.25,
+        y: -9.5,
+        z: f64::from_bits(f64::NAN.to_bits()),
+    };
+    bencher.bench_local(|| black_box(plan.eq(black_box(&left), black_box(&right)).unwrap()));
 }
 
 #[divan::bench]

--- a/facet-hash/build.rs
+++ b/facet-hash/build.rs
@@ -12,13 +12,21 @@ pub const SCALAR: &[u8] = &[];\n\
 pub const SCALAR_CONT: &[usize] = &[];\n\
 pub const SCALAR_RUN: &[u8] = &[];\n\
 pub const SCALAR_RUN_CONT: &[usize] = &[];\n\
-pub const DONE: &[u8] = &[];\n";
+pub const EQ_SCALAR: &[u8] = &[];\n\
+pub const EQ_SCALAR_CONT: &[usize] = &[];\n\
+pub const EQ_SCALAR_RUN: &[u8] = &[];\n\
+pub const EQ_SCALAR_RUN_CONT: &[usize] = &[];\n\
+pub const DONE: &[u8] = &[];\n\
+pub const EQ_DONE: &[u8] = &[];\n";
 
 #[cfg(feature = "jit")]
 const SYMBOLS: &[&str] = &[
     "facet_hash_stencil_scalar",
     "facet_hash_stencil_scalar_run",
+    "facet_hash_stencil_eq_scalar",
+    "facet_hash_stencil_eq_scalar_run",
     "facet_hash_stencil_done",
+    "facet_hash_stencil_eq_done",
 ];
 
 fn main() {
@@ -31,8 +39,8 @@ fn main() {
     {
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
-        if target_os == "macos" && target_arch == "aarch64" {
-            emit_arm64_macos(&out, &generated);
+        if native_copy_patch_target(&target_os, &target_arch) {
+            emit_native(&out, &generated, &target_os, &target_arch);
             return;
         }
     }
@@ -41,16 +49,29 @@ fn main() {
 }
 
 #[cfg(feature = "jit")]
-fn emit_arm64_macos(out: &Path, generated: &Path) {
+fn native_copy_patch_target(target_os: &str, target_arch: &str) -> bool {
+    matches!(
+        (target_os, target_arch),
+        ("macos", "aarch64") | ("linux", "x86_64")
+    )
+}
+
+#[cfg(feature = "jit")]
+fn emit_native(out: &Path, generated: &Path, target_os: &str, target_arch: &str) {
     println!("cargo:rerun-if-changed=stencils/stencils.rs");
+    println!("cargo:rerun-if-changed=stencils/stencils_tailcall.rs");
+    println!("cargo:rerun-if-changed=stencils/common.rs");
     println!("cargo:rerun-if-changed=build.rs");
 
     let target = env::var("TARGET").expect("TARGET set by cargo");
     let obj = out.join("stencils.o");
     let src = Path::new("stencils/stencils.rs");
+    let tailcall_src = Path::new("stencils/stencils_tailcall.rs");
 
-    let tailcall =
-        nightly_available() && compile_object("rustc", &["+nightly"], src, &obj, &target, true);
+    let try_tailcall = target_os == "macos" && target_arch == "aarch64";
+    let tailcall = try_tailcall
+        && nightly_available()
+        && compile_object("rustc", &["+nightly"], tailcall_src, &obj, &target, false);
     if tailcall {
         println!("cargo:rustc-cfg=facet_hash_jit_tailcall");
     } else {
@@ -63,9 +84,13 @@ fn emit_arm64_macos(out: &Path, generated: &Path) {
 
     let bytes = fs::read(&obj).unwrap();
     let get = |symbol: &str| extract_stencil(&bytes, SYMBOLS, symbol, "facet_hash_cont");
+    let get_eq = |symbol: &str| extract_stencil(&bytes, SYMBOLS, symbol, "facet_hash_eq_cont");
     let scalar = get("facet_hash_stencil_scalar");
     let scalar_run = get("facet_hash_stencil_scalar_run");
+    let eq_scalar = get_eq("facet_hash_stencil_eq_scalar");
+    let eq_scalar_run = get_eq("facet_hash_stencil_eq_scalar_run");
     let done = get("facet_hash_stencil_done");
+    let eq_done = get_eq("facet_hash_stencil_eq_done");
 
     let mode = if tailcall {
         "tail-call (nightly become)"
@@ -90,7 +115,27 @@ fn emit_arm64_macos(out: &Path, generated: &Path) {
         &scalar_run,
     );
     emit_cont(&mut out, "SCALAR_RUN_CONT", "SCALAR_RUN", &scalar_run);
+    emit(
+        &mut out,
+        "EQ_SCALAR",
+        "Compare one scalar field, then continue if still equal.",
+        &eq_scalar,
+    );
+    emit_cont(&mut out, "EQ_SCALAR_CONT", "EQ_SCALAR", &eq_scalar);
+    emit(
+        &mut out,
+        "EQ_SCALAR_RUN",
+        "Compare a grouped scalar field run, then continue if still equal.",
+        &eq_scalar_run,
+    );
+    emit_cont(
+        &mut out,
+        "EQ_SCALAR_RUN_CONT",
+        "EQ_SCALAR_RUN",
+        &eq_scalar_run,
+    );
     emit(&mut out, "DONE", "Terminal hash stencil.", &done);
+    emit(&mut out, "EQ_DONE", "Terminal equality stencil.", &eq_done);
 
     fs::write(generated, out).unwrap();
 }
@@ -106,7 +151,7 @@ fn emit(out: &mut String, name: &str, doc: &str, stencil: &Stencil) {
 #[cfg(feature = "jit")]
 fn emit_cont(out: &mut String, name: &str, of: &str, stencil: &Stencil) {
     out.push_str(&format!(
-        "/// Byte offsets within `{of}` of the continuation `BRANCH26` relocations to patch.\n\
+        "/// Byte offsets within `{of}` of the continuation relocations to patch.\n\
          pub const {name}: &[usize] = &{:?};\n",
         stencil.cont_relocs
     ));

--- a/facet-hash/src/lib.rs
+++ b/facet-hash/src/lib.rs
@@ -26,10 +26,24 @@ use weavy::ir::{
 };
 use weavy::{BlockRef, Control, DenseLowered, Lowered, Program, RunError, RunStats, Step};
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 mod native;
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
-pub use native::{NativeHashPlan, NativeHashPlanStats};
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+pub use native::{
+    NativeEqualityPlan, NativeEqualityPlanStats, NativeHashPlan, NativeHashPlanStats,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum HashBlockId {

--- a/facet-hash/src/native.rs
+++ b/facet-hash/src/native.rs
@@ -9,8 +9,8 @@ use weavy::ir::{ControlOp, WeavyOp};
 use weavy::jit::{Chain, NativeProgram, ProgSlot, StencilLayout};
 
 use crate::{
-    ChildPlan, ExecBlock, ExecOp, HashError, HashIntrinsic, HashMode, HashPlan, ScalarFieldPlan,
-    StructFieldPlan, unsupported,
+    ChildPlan, EqualityPlan, ExecBlock, ExecOp, HashError, HashIntrinsic, HashMode, HashPlan,
+    ScalarFieldPlan, StructFieldPlan, unsupported,
 };
 
 mod stencils {
@@ -27,12 +27,28 @@ pub struct NativeHashPlan<T, H = std::collections::hash_map::DefaultHasher> {
     _marker: PhantomData<fn() -> (T, H)>,
 }
 
+/// Native copy-and-patch equality plan for the supported value-mode scalar subset.
+pub struct NativeEqualityPlan<T> {
+    native: NativeProgram,
+    scalar_infos: Vec<EqScalarInfo>,
+    scalar_run_fields: Vec<Vec<EqScalarInfo>>,
+    scalar_run_infos: Vec<EqScalarRunInfo>,
+    _marker: PhantomData<fn() -> T>,
+}
+
 // SAFETY: the executable buffer and side tables are fully materialized before
 // the plan is returned. `hash` only reads them and uses the caller-owned hasher.
 unsafe impl<T, H> Send for NativeHashPlan<T, H> {}
 // SAFETY: the executable buffer and side tables are fully materialized before
 // the plan is returned. `hash` only reads them and uses the caller-owned hasher.
 unsafe impl<T, H> Sync for NativeHashPlan<T, H> {}
+
+// SAFETY: the executable buffer and side tables are fully materialized before
+// the plan is returned. `eq` only reads them and the two caller-owned values.
+unsafe impl<T> Send for NativeEqualityPlan<T> {}
+// SAFETY: the executable buffer and side tables are fully materialized before
+// the plan is returned. `eq` only reads them and the two caller-owned values.
+unsafe impl<T> Sync for NativeEqualityPlan<T> {}
 
 impl<T, H> NativeHashPlan<T, H>
 where
@@ -84,6 +100,43 @@ where
     }
 }
 
+impl<T> NativeEqualityPlan<T>
+where
+    T: Facet<'static>,
+{
+    /// Compile a value-mode native equality plan for `T`.
+    pub fn build() -> Result<Self, HashError> {
+        let plan = EqualityPlan::<T>::build()?;
+        EqualityCompiler::compile::<T>(T::SHAPE, &plan.lowered)
+    }
+
+    /// Compare two values through the compiled native plan.
+    pub fn eq(&self, left: &T, right: &T) -> Result<bool, HashError> {
+        let mut ctx = EqCtx {
+            left: (left as *const T).cast::<u8>(),
+            right: (right as *const T).cast::<u8>(),
+            prog: self.native.entry_prog(),
+            equal: true,
+        };
+        let entry = unsafe { self.native.entry_fn::<EqCtx>() };
+        unsafe { entry(&mut ctx) };
+        Ok(ctx.equal)
+    }
+
+    /// Return code-layout counters for this native plan.
+    #[must_use]
+    pub fn stats(&self) -> NativeEqualityPlanStats {
+        NativeEqualityPlanStats {
+            chain_count: self.native.chain_count(),
+            stencil_count: self.native.stencil_count(),
+            prog_slot_count: self.native.prog_slot_count(),
+            scalar_count: self.scalar_infos.len(),
+            scalar_run_count: self.scalar_run_infos.len(),
+            scalar_run_field_count: self.scalar_run_fields.iter().map(Vec::len).sum(),
+        }
+    }
+}
+
 /// Code-layout counters for a [`NativeHashPlan`].
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -104,6 +157,24 @@ pub struct NativeHashPlanStats {
     pub const_usize_count: usize,
 }
 
+/// Code-layout counters for a [`NativeEqualityPlan`].
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NativeEqualityPlanStats {
+    /// Number of compiled chains.
+    pub chain_count: usize,
+    /// Number of stencil copies.
+    pub stencil_count: usize,
+    /// Number of side program-stream words.
+    pub prog_slot_count: usize,
+    /// Number of standalone scalar ops.
+    pub scalar_count: usize,
+    /// Number of grouped scalar runs.
+    pub scalar_run_count: usize,
+    /// Total scalar fields inside grouped runs.
+    pub scalar_run_field_count: usize,
+}
+
 #[repr(C)]
 struct Ctx {
     base: *const u8,
@@ -111,7 +182,16 @@ struct Ctx {
     prog: *const u64,
 }
 
+#[repr(C)]
+struct EqCtx {
+    left: *const u8,
+    right: *const u8,
+    prog: *const u64,
+    equal: bool,
+}
+
 type HashFn = unsafe extern "C" fn(hasher: *mut (), ptr: *const u8);
+type EqFn = unsafe extern "C" fn(left: *const u8, right: *const u8) -> bool;
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -127,6 +207,19 @@ struct ScalarRunInfo {
     field_count: usize,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct EqScalarInfo {
+    offset: usize,
+    eq: EqFn,
+}
+
+#[repr(C)]
+struct EqScalarRunInfo {
+    fields: *const EqScalarInfo,
+    field_count: usize,
+}
+
 #[derive(Clone, Copy)]
 enum EmittedOp {
     Scalar,
@@ -139,6 +232,16 @@ struct ScalarFixup {
 }
 
 struct ScalarRunFixup {
+    slot: ProgSlot,
+    run_index: usize,
+}
+
+struct EqScalarFixup {
+    slot: ProgSlot,
+    scalar_index: usize,
+}
+
+struct EqScalarRunFixup {
     slot: ProgSlot,
     run_index: usize,
 }
@@ -164,6 +267,15 @@ struct Compiler<H> {
     scalar_run_fixups: Vec<ScalarRunFixup>,
     const_usizes: Vec<usize>,
     _marker: PhantomData<fn() -> H>,
+}
+
+struct EqualityCompiler {
+    layout: StencilLayout,
+    scalar_infos: Vec<EqScalarInfo>,
+    scalar_fixups: Vec<EqScalarFixup>,
+    scalar_run_fields: Vec<Vec<EqScalarInfo>>,
+    scalar_run_infos: Vec<EqScalarRunInfo>,
+    scalar_run_fixups: Vec<EqScalarRunFixup>,
 }
 
 impl<H> Compiler<H>
@@ -216,7 +328,7 @@ where
                 EmittedOp::ScalarRun => stencils::SCALAR_RUN_CONT,
             };
             for &rel in relocs {
-                self.layout.patch_branch26(op_start + rel, next);
+                self.layout.patch_continuation(op_start + rel, next);
             }
         }
 
@@ -487,6 +599,302 @@ where
     }
 }
 
+impl EqualityCompiler {
+    fn compile<T>(
+        root_shape: &'static Shape,
+        lowered: &weavy::DenseLowered<ExecOp>,
+    ) -> Result<NativeEqualityPlan<T>, HashError> {
+        if !lowered.blocks.is_empty() {
+            return Err(unsupported(root_shape, "native recursive blocks"));
+        }
+
+        let mut compiler = Self {
+            layout: StencilLayout::new(),
+            scalar_infos: Vec::new(),
+            scalar_fixups: Vec::new(),
+            scalar_run_fields: Vec::new(),
+            scalar_run_infos: Vec::new(),
+            scalar_run_fixups: Vec::new(),
+        };
+        let entry = compiler.compile_chain(root_shape, &lowered.program)?;
+        compiler.finish(entry)
+    }
+
+    fn compile_chain(
+        &mut self,
+        root_shape: &'static Shape,
+        program: &[ExecOp],
+    ) -> Result<Chain, HashError> {
+        let chain = self.layout.start_chain();
+        let mut starts = Vec::with_capacity(program.len());
+        let mut emitted = Vec::with_capacity(program.len());
+
+        for op in program {
+            starts.push(self.layout.code_len());
+            emitted.push(self.compile_op(root_shape, chain.prog_index, op)?);
+        }
+
+        let done_start = self.layout.code_len();
+        self.layout.emit_stencil(stencils::EQ_DONE);
+
+        for (index, &op_start) in starts.iter().enumerate() {
+            let next = starts.get(index + 1).copied().unwrap_or(done_start);
+            let relocs = match emitted[index] {
+                EmittedOp::Scalar => stencils::EQ_SCALAR_CONT,
+                EmittedOp::ScalarRun => stencils::EQ_SCALAR_RUN_CONT,
+            };
+            for &rel in relocs {
+                self.layout.patch_continuation(op_start + rel, next);
+            }
+        }
+
+        Ok(chain)
+    }
+
+    fn compile_op(
+        &mut self,
+        root_shape: &'static Shape,
+        prog_index: usize,
+        op: &ExecOp,
+    ) -> Result<EmittedOp, HashError> {
+        let WeavyOp::Intrinsic(intrinsic) = op else {
+            return match op {
+                WeavyOp::Control(ControlOp::Return) => Err(HashError::MalformedProgram {
+                    reason: "native equality root must not contain return",
+                }),
+                WeavyOp::Control(ControlOp::CallBlock { .. }) => {
+                    Err(unsupported(root_shape, "native recursive blocks"))
+                }
+                _ => Err(HashError::MalformedProgram {
+                    reason: "native equality compiler only accepts hash intrinsics",
+                }),
+            };
+        };
+
+        match intrinsic {
+            HashIntrinsic::Scalar { shape, scalar } => {
+                let info = eq_scalar_info(shape, *scalar, 0)?;
+                self.layout.emit_stencil(stencils::EQ_SCALAR);
+                let slot = self.layout.reserve_prog_slot(prog_index);
+                let scalar_index = self.scalar_infos.len();
+                self.scalar_infos.push(info);
+                self.scalar_fixups
+                    .push(EqScalarFixup { slot, scalar_index });
+                Ok(EmittedOp::Scalar)
+            }
+            HashIntrinsic::Struct { mode, fields, .. } => {
+                if *mode != HashMode::Value {
+                    return Err(unsupported(root_shape, "native structural equality"));
+                }
+
+                let mut run = Vec::new();
+                self.collect_struct_fields(root_shape, fields, 0, &mut run)?;
+                Ok(self.emit_scalar_run(prog_index, run))
+            }
+            HashIntrinsic::Array {
+                array,
+                element_layout,
+                element,
+            } => {
+                let mut run = Vec::new();
+                self.collect_array(
+                    root_shape,
+                    array.n,
+                    element_layout.size(),
+                    element,
+                    0,
+                    &mut run,
+                )?;
+                Ok(self.emit_scalar_run(prog_index, run))
+            }
+            HashIntrinsic::Shape(_) => Err(unsupported(root_shape, "native structural equality")),
+            HashIntrinsic::Bytes(_)
+            | HashIntrinsic::Option { .. }
+            | HashIntrinsic::Result { .. }
+            | HashIntrinsic::List { .. }
+            | HashIntrinsic::Slice { .. }
+            | HashIntrinsic::Set { .. }
+            | HashIntrinsic::Map { .. }
+            | HashIntrinsic::Pointer { .. } => {
+                Err(unsupported(root_shape, "native aggregate equality"))
+            }
+        }
+    }
+
+    fn emit_scalar_run(&mut self, prog_index: usize, run: Vec<EqScalarInfo>) -> EmittedOp {
+        self.layout.emit_stencil(stencils::EQ_SCALAR_RUN);
+        let slot = self.layout.reserve_prog_slot(prog_index);
+        let run_index = self.scalar_run_fields.len();
+        self.scalar_run_infos.push(EqScalarRunInfo {
+            fields: core::ptr::null(),
+            field_count: run.len(),
+        });
+        self.scalar_run_fields.push(run);
+        self.scalar_run_fixups
+            .push(EqScalarRunFixup { slot, run_index });
+        EmittedOp::ScalarRun
+    }
+
+    fn collect_program_scalars(
+        &mut self,
+        root_shape: &'static Shape,
+        program: &[ExecOp],
+        base_offset: usize,
+        run: &mut Vec<EqScalarInfo>,
+    ) -> Result<(), HashError> {
+        for op in program {
+            let WeavyOp::Intrinsic(intrinsic) = op else {
+                return match op {
+                    WeavyOp::Control(ControlOp::Return) => Err(HashError::MalformedProgram {
+                        reason: "native equality child must not contain return",
+                    }),
+                    WeavyOp::Control(ControlOp::CallBlock { .. }) => {
+                        Err(unsupported(root_shape, "native recursive blocks"))
+                    }
+                    _ => Err(HashError::MalformedProgram {
+                        reason: "native equality compiler only accepts hash intrinsics",
+                    }),
+                };
+            };
+
+            match intrinsic {
+                HashIntrinsic::Scalar { shape, scalar } => {
+                    run.push(eq_scalar_info(shape, *scalar, base_offset)?);
+                }
+                HashIntrinsic::Struct { mode, fields, .. } => {
+                    if *mode != HashMode::Value {
+                        return Err(unsupported(root_shape, "native structural equality"));
+                    }
+                    self.collect_struct_fields(root_shape, fields, base_offset, run)?;
+                }
+                HashIntrinsic::Array {
+                    array,
+                    element_layout,
+                    element,
+                } => {
+                    self.collect_array(
+                        root_shape,
+                        array.n,
+                        element_layout.size(),
+                        element,
+                        base_offset,
+                        run,
+                    )?;
+                }
+                HashIntrinsic::Shape(_) => {
+                    return Err(unsupported(root_shape, "native structural equality"));
+                }
+                HashIntrinsic::Bytes(_)
+                | HashIntrinsic::Option { .. }
+                | HashIntrinsic::Result { .. }
+                | HashIntrinsic::List { .. }
+                | HashIntrinsic::Slice { .. }
+                | HashIntrinsic::Set { .. }
+                | HashIntrinsic::Map { .. }
+                | HashIntrinsic::Pointer { .. } => {
+                    return Err(unsupported(root_shape, "native aggregate equality"));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn collect_struct_fields(
+        &mut self,
+        root_shape: &'static Shape,
+        fields: &[StructFieldPlan<ExecBlock>],
+        base_offset: usize,
+        run: &mut Vec<EqScalarInfo>,
+    ) -> Result<(), HashError> {
+        for field in fields {
+            match field {
+                StructFieldPlan::ScalarRun(fields) => {
+                    for field in fields.iter() {
+                        run.push(eq_scalar_field_info(field, base_offset)?);
+                    }
+                }
+                StructFieldPlan::Field(field) => {
+                    self.collect_child_scalars(
+                        root_shape,
+                        &field.child,
+                        base_offset + field.offset,
+                        run,
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn collect_array(
+        &mut self,
+        root_shape: &'static Shape,
+        len: usize,
+        stride: usize,
+        element: &ChildPlan<ExecBlock>,
+        base_offset: usize,
+        run: &mut Vec<EqScalarInfo>,
+    ) -> Result<(), HashError> {
+        for index in 0..len {
+            self.collect_child_scalars(root_shape, element, base_offset + index * stride, run)?;
+        }
+        Ok(())
+    }
+
+    fn collect_child_scalars(
+        &mut self,
+        root_shape: &'static Shape,
+        child: &ChildPlan<ExecBlock>,
+        base_offset: usize,
+        run: &mut Vec<EqScalarInfo>,
+    ) -> Result<(), HashError> {
+        match child {
+            ChildPlan::Scalar {
+                include_shape,
+                shape,
+                scalar,
+            } => {
+                if *include_shape {
+                    return Err(unsupported(shape, "native structural scalar field"));
+                }
+                run.push(eq_scalar_info(shape, *scalar, base_offset)?);
+                Ok(())
+            }
+            ChildPlan::Program(program) => {
+                self.collect_program_scalars(root_shape, program, base_offset, run)
+            }
+        }
+    }
+
+    fn finish<T>(mut self, entry: Chain) -> Result<NativeEqualityPlan<T>, HashError> {
+        let native = NativeProgram::new(core::mem::take(&mut self.layout), entry);
+        let mut plan = NativeEqualityPlan {
+            native,
+            scalar_infos: self.scalar_infos,
+            scalar_run_fields: self.scalar_run_fields,
+            scalar_run_infos: self.scalar_run_infos,
+            _marker: PhantomData,
+        };
+
+        let run_ptrs: Vec<*const EqScalarInfo> =
+            plan.scalar_run_fields.iter().map(Vec::as_ptr).collect();
+        for (info, &ptr) in plan.scalar_run_infos.iter_mut().zip(run_ptrs.iter()) {
+            info.fields = ptr;
+        }
+
+        for fixup in self.scalar_fixups {
+            let ptr: *const EqScalarInfo = &plan.scalar_infos[fixup.scalar_index];
+            plan.native.fill_prog_slot(fixup.slot, ptr as u64);
+        }
+        for fixup in self.scalar_run_fixups {
+            let ptr: *const EqScalarRunInfo = &plan.scalar_run_infos[fixup.run_index];
+            plan.native.fill_prog_slot(fixup.slot, ptr as u64);
+        }
+
+        Ok(plan)
+    }
+}
+
 fn scalar_field_info<H>(
     field: &ScalarFieldPlan,
     base_offset: usize,
@@ -571,6 +979,63 @@ where
     })
 }
 
+fn eq_scalar_field_info(
+    field: &ScalarFieldPlan,
+    base_offset: usize,
+) -> Result<EqScalarInfo, HashError> {
+    if field.include_shape {
+        return Err(unsupported(field.shape, "native structural scalar field"));
+    }
+    eq_scalar_info(field.shape, field.scalar, base_offset + field.offset)
+}
+
+fn eq_scalar_info(
+    shape: &'static Shape,
+    scalar: ScalarType,
+    offset: usize,
+) -> Result<EqScalarInfo, HashError> {
+    Ok(EqScalarInfo {
+        offset,
+        eq: scalar_eq_fn(shape, scalar)?,
+    })
+}
+
+fn scalar_eq_fn(shape: &'static Shape, scalar: ScalarType) -> Result<EqFn, HashError> {
+    Ok(match scalar {
+        ScalarType::Unit => eq_unit,
+        ScalarType::Bool => eq_value::<bool>,
+        ScalarType::Char => eq_value::<char>,
+        ScalarType::Str if shape.is_type::<&'static str>() => eq_value::<&'static str>,
+        ScalarType::Str => return Err(unsupported(shape, "native unsized str equality")),
+        ScalarType::String => eq_value::<String>,
+        ScalarType::CowStr => eq_value::<Cow<'static, str>>,
+        ScalarType::F32 => eq_f32,
+        ScalarType::F64 => eq_f64,
+        ScalarType::U8 => eq_value::<u8>,
+        ScalarType::U16 => eq_value::<u16>,
+        ScalarType::U32 => eq_value::<u32>,
+        ScalarType::U64 => eq_value::<u64>,
+        ScalarType::U128 => eq_value::<u128>,
+        ScalarType::USize => eq_value::<usize>,
+        ScalarType::I8 => eq_value::<i8>,
+        ScalarType::I16 => eq_value::<i16>,
+        ScalarType::I32 => eq_value::<i32>,
+        ScalarType::I64 => eq_value::<i64>,
+        ScalarType::I128 => eq_value::<i128>,
+        ScalarType::ISize => eq_value::<isize>,
+        ScalarType::ConstTypeId => eq_value::<ConstTypeId>,
+        #[cfg(feature = "net")]
+        ScalarType::SocketAddr => eq_value::<core::net::SocketAddr>,
+        #[cfg(feature = "net")]
+        ScalarType::IpAddr => eq_value::<core::net::IpAddr>,
+        #[cfg(feature = "net")]
+        ScalarType::Ipv4Addr => eq_value::<core::net::Ipv4Addr>,
+        #[cfg(feature = "net")]
+        ScalarType::Ipv6Addr => eq_value::<core::net::Ipv6Addr>,
+        _ => return Err(unsupported(shape, "native scalar equality")),
+    })
+}
+
 unsafe extern "C" fn hash_unit<H>(hasher: *mut (), _ptr: *const u8)
 where
     H: Hasher,
@@ -605,4 +1070,27 @@ where
     unsafe { PtrConst::new_sized(ptr.cast::<f64>()).get::<f64>() }
         .to_bits()
         .hash(hasher);
+}
+
+unsafe extern "C" fn eq_unit(_left: *const u8, _right: *const u8) -> bool {
+    true
+}
+
+unsafe extern "C" fn eq_value<T>(left: *const u8, right: *const u8) -> bool
+where
+    T: PartialEq,
+{
+    let left = unsafe { PtrConst::new_sized(left.cast::<T>()).get::<T>() };
+    let right = unsafe { PtrConst::new_sized(right.cast::<T>()).get::<T>() };
+    left == right
+}
+
+unsafe extern "C" fn eq_f32(left: *const u8, right: *const u8) -> bool {
+    unsafe { PtrConst::new_sized(left.cast::<f32>()).get::<f32>() }.to_bits()
+        == unsafe { PtrConst::new_sized(right.cast::<f32>()).get::<f32>() }.to_bits()
+}
+
+unsafe extern "C" fn eq_f64(left: *const u8, right: *const u8) -> bool {
+    unsafe { PtrConst::new_sized(left.cast::<f64>()).get::<f64>() }.to_bits()
+        == unsafe { PtrConst::new_sized(right.cast::<f64>()).get::<f64>() }.to_bits()
 }

--- a/facet-hash/stencils/common.rs
+++ b/facet-hash/stencils/common.rs
@@ -1,0 +1,131 @@
+#[repr(C)]
+pub struct Ctx {
+    pub base: *const u8,
+    pub hasher: *mut (),
+    pub prog: *const u64,
+}
+
+#[repr(C)]
+pub struct EqCtx {
+    pub left: *const u8,
+    pub right: *const u8,
+    pub prog: *const u64,
+    pub equal: bool,
+}
+
+pub type HashFn = unsafe extern "C" fn(hasher: *mut (), ptr: *const u8);
+pub type EqFn = unsafe extern "C" fn(left: *const u8, right: *const u8) -> bool;
+
+#[repr(C)]
+pub struct ScalarInfo {
+    pub offset: usize,
+    pub absolute: *const u8,
+    pub hash: HashFn,
+}
+
+#[repr(C)]
+pub struct ScalarRunInfo {
+    pub fields: *const ScalarInfo,
+    pub field_count: usize,
+}
+
+#[repr(C)]
+pub struct EqScalarInfo {
+    pub offset: usize,
+    pub eq: EqFn,
+}
+
+#[repr(C)]
+pub struct EqScalarRunInfo {
+    pub fields: *const EqScalarInfo,
+    pub field_count: usize,
+}
+
+extern "C" {
+    fn facet_hash_cont(cx: *mut Ctx);
+    fn facet_hash_eq_cont(cx: *mut EqCtx);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn facet_hash_stencil_scalar(cx: *mut Ctx) {
+    let c = &mut *cx;
+    let info = &*(*c.prog as *const ScalarInfo);
+    c.prog = c.prog.add(1);
+
+    let ptr = if info.absolute.is_null() {
+        c.base.add(info.offset)
+    } else {
+        info.absolute
+    };
+    (info.hash)(c.hasher, ptr);
+
+    continue_to!(facet_hash_cont, cx);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn facet_hash_stencil_scalar_run(cx: *mut Ctx) {
+    let c = &mut *cx;
+    let info = &*(*c.prog as *const ScalarRunInfo);
+    c.prog = c.prog.add(1);
+
+    let mut index = 0;
+    while index < info.field_count {
+        let field = &*info.fields.add(index);
+        let ptr = if field.absolute.is_null() {
+            c.base.add(field.offset)
+        } else {
+            field.absolute
+        };
+        (field.hash)(c.hasher, ptr);
+        index += 1;
+    }
+
+    continue_to!(facet_hash_cont, cx);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn facet_hash_stencil_done(_cx: *mut Ctx) {}
+
+#[no_mangle]
+pub unsafe extern "C" fn facet_hash_stencil_eq_scalar(cx: *mut EqCtx) {
+    let c = &mut *cx;
+    if !c.equal {
+        return;
+    }
+
+    let info = &*(*c.prog as *const EqScalarInfo);
+    c.prog = c.prog.add(1);
+
+    c.equal = (info.eq)(c.left.add(info.offset), c.right.add(info.offset));
+    if !c.equal {
+        return;
+    }
+
+    continue_to!(facet_hash_eq_cont, cx);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn facet_hash_stencil_eq_scalar_run(cx: *mut EqCtx) {
+    let c = &mut *cx;
+    if !c.equal {
+        return;
+    }
+
+    let info = &*(*c.prog as *const EqScalarRunInfo);
+    c.prog = c.prog.add(1);
+
+    let mut index = 0;
+    while index < info.field_count {
+        let field = &*info.fields.add(index);
+        if !(field.eq)(c.left.add(field.offset), c.right.add(field.offset)) {
+            c.equal = false;
+            return;
+        }
+        index += 1;
+    }
+
+    continue_to!(facet_hash_eq_cont, cx);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn facet_hash_stencil_eq_done(_cx: *mut EqCtx) {}

--- a/facet-hash/stencils/stencils.rs
+++ b/facet-hash/stencils/stencils.rs
@@ -5,77 +5,12 @@
 //! itself stays in monomorphized host calls so the stencil ABI is independent of
 //! the concrete `Hasher`.
 
-#![cfg_attr(tailcall, feature(explicit_tail_calls))]
 #![allow(clippy::missing_safety_doc)]
 
-#[repr(C)]
-pub struct Ctx {
-    pub base: *const u8,
-    pub hasher: *mut (),
-    pub prog: *const u64,
-}
-
-pub type HashFn = unsafe extern "C" fn(hasher: *mut (), ptr: *const u8);
-
-#[repr(C)]
-pub struct ScalarInfo {
-    pub offset: usize,
-    pub absolute: *const u8,
-    pub hash: HashFn,
-}
-
-#[repr(C)]
-pub struct ScalarRunInfo {
-    pub fields: *const ScalarInfo,
-    pub field_count: usize,
-}
-
-extern "C" {
-    fn facet_hash_cont(cx: *mut Ctx);
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn facet_hash_stencil_scalar(cx: *mut Ctx) {
-    let c = &mut *cx;
-    let info = &*(*c.prog as *const ScalarInfo);
-    c.prog = c.prog.add(1);
-
-    let ptr = if info.absolute.is_null() {
-        c.base.add(info.offset)
-    } else {
-        info.absolute
+macro_rules! continue_to {
+    ($target:ident, $cx:expr) => {
+        $target($cx)
     };
-    (info.hash)(c.hasher, ptr);
-
-    #[cfg(tailcall)]
-    become facet_hash_cont(cx);
-    #[cfg(not(tailcall))]
-    facet_hash_cont(cx);
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn facet_hash_stencil_scalar_run(cx: *mut Ctx) {
-    let c = &mut *cx;
-    let info = &*(*c.prog as *const ScalarRunInfo);
-    c.prog = c.prog.add(1);
-
-    let mut index = 0;
-    while index < info.field_count {
-        let field = &*info.fields.add(index);
-        let ptr = if field.absolute.is_null() {
-            c.base.add(field.offset)
-        } else {
-            field.absolute
-        };
-        (field.hash)(c.hasher, ptr);
-        index += 1;
-    }
-
-    #[cfg(tailcall)]
-    become facet_hash_cont(cx);
-    #[cfg(not(tailcall))]
-    facet_hash_cont(cx);
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn facet_hash_stencil_done(_cx: *mut Ctx) {}
+include!("common.rs");

--- a/facet-hash/stencils/stencils_tailcall.rs
+++ b/facet-hash/stencils/stencils_tailcall.rs
@@ -1,0 +1,12 @@
+//! facet-hash native stencils using explicit tail calls.
+
+#![feature(explicit_tail_calls)]
+#![allow(clippy::missing_safety_doc)]
+
+macro_rules! continue_to {
+    ($target:ident, $cx:expr) => {
+        become $target($cx)
+    };
+}
+
+include!("common.rs");

--- a/facet-hash/tests/basic.rs
+++ b/facet-hash/tests/basic.rs
@@ -5,8 +5,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use facet::Facet;
 use facet_hash::EqualityPlan;
 use facet_hash::HashPlan;
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
-use facet_hash::NativeHashPlan;
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+use facet_hash::{NativeEqualityPlan, NativeHashPlan};
 use weavy::ir::IntrinsicDescriptor;
 
 #[derive(Clone, Debug, Facet)]
@@ -611,7 +617,13 @@ fn unsupported_enums_fail_while_building() {
     assert!(err.to_string().contains("enum"));
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[test]
 fn native_plan_matches_interpreter_stream_for_scalar_struct() {
     let plan = HashPlan::<Point>::build().unwrap();
@@ -626,7 +638,13 @@ fn native_plan_matches_interpreter_stream_for_scalar_struct() {
     assert_eq!(expected.bytes, actual.bytes);
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[test]
 fn native_plan_matches_interpreter_stream_for_nested_scalar_struct() {
     let plan = HashPlan::<MixedScalarRuns>::build().unwrap();
@@ -646,7 +664,13 @@ fn native_plan_matches_interpreter_stream_for_nested_scalar_struct() {
     assert_eq!(expected.bytes, actual.bytes);
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[test]
 fn native_plan_matches_interpreter_stream_for_text_scalars() {
     let plan = HashPlan::<TextScalars>::build().unwrap();
@@ -665,7 +689,13 @@ fn native_plan_matches_interpreter_stream_for_text_scalars() {
     assert_eq!(expected.bytes, actual.bytes);
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[test]
 fn native_plan_matches_interpreter_stream_for_root_array() {
     let plan = HashPlan::<[u16; 4]>::build().unwrap();
@@ -680,7 +710,13 @@ fn native_plan_matches_interpreter_stream_for_root_array() {
     assert_eq!(expected.bytes, actual.bytes);
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[test]
 fn native_plan_matches_interpreter_stream_for_array_field() {
     let plan = HashPlan::<PointArray>::build().unwrap();
@@ -698,7 +734,13 @@ fn native_plan_matches_interpreter_stream_for_array_field() {
     assert_eq!(expected.bytes, actual.bytes);
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[test]
 fn native_plan_hashes_floats_by_bits() {
     let plan = HashPlan::<Floaty>::build().unwrap();
@@ -716,7 +758,13 @@ fn native_plan_hashes_floats_by_bits() {
     assert_eq!(expected.bytes, actual.bytes);
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[test]
 fn native_plan_reports_code_layout_stats() {
     let native = NativeHashPlan::<Point>::build().unwrap();
@@ -731,7 +779,13 @@ fn native_plan_reports_code_layout_stats() {
     assert_eq!(stats.stencil_count, 2);
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[test]
 fn native_array_plan_reports_const_layout_stats() {
     let native = NativeHashPlan::<PointArray>::build().unwrap();
@@ -746,7 +800,13 @@ fn native_array_plan_reports_const_layout_stats() {
     assert_eq!(stats.stencil_count, 2);
 }
 
-#[cfg(all(feature = "jit", target_os = "macos", target_arch = "aarch64"))]
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
 #[test]
 fn native_plan_rejects_aggregate_fields_for_now() {
     let Err(err) = NativeHashPlan::<Person>::build() else {
@@ -754,4 +814,170 @@ fn native_plan_rejects_aggregate_fields_for_now() {
     };
 
     assert!(err.to_string().contains("native aggregate hashing"));
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+#[test]
+fn native_equality_matches_interpreter_for_scalar_struct() {
+    let plan = EqualityPlan::<Point>::build().unwrap();
+    let native = NativeEqualityPlan::<Point>::build().unwrap();
+    let left = Point { x: 10, y: -4 };
+    let same = Point { x: 10, y: -4 };
+    let different = Point { x: 10, y: -5 };
+
+    assert_eq!(
+        plan.eq(&left, &same).unwrap(),
+        native.eq(&left, &same).unwrap()
+    );
+    assert_eq!(
+        plan.eq(&left, &different).unwrap(),
+        native.eq(&left, &different).unwrap()
+    );
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+#[test]
+fn native_equality_matches_interpreter_for_text_scalars() {
+    let plan = EqualityPlan::<TextScalars>::build().unwrap();
+    let native = NativeEqualityPlan::<TextScalars>::build().unwrap();
+    let left = TextScalars {
+        owned: "Ada".to_owned(),
+        borrowed: "Grace",
+        cow: Cow::Owned("Katherine".to_owned()),
+    };
+    let same = TextScalars {
+        owned: "Ada".to_owned(),
+        borrowed: "Grace",
+        cow: Cow::Borrowed("Katherine"),
+    };
+    let different = TextScalars {
+        owned: "Ada".to_owned(),
+        borrowed: "Grace",
+        cow: Cow::Borrowed("Hedy"),
+    };
+
+    assert_eq!(
+        plan.eq(&left, &same).unwrap(),
+        native.eq(&left, &same).unwrap()
+    );
+    assert_eq!(
+        plan.eq(&left, &different).unwrap(),
+        native.eq(&left, &different).unwrap()
+    );
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+#[test]
+fn native_equality_matches_interpreter_for_array_field() {
+    let plan = EqualityPlan::<PointArray>::build().unwrap();
+    let native = NativeEqualityPlan::<PointArray>::build().unwrap();
+    let left = PointArray {
+        points: [Point { x: 1, y: 2 }, Point { x: 3, y: 4 }],
+        tail: -5,
+    };
+    let same = PointArray {
+        points: [Point { x: 1, y: 2 }, Point { x: 3, y: 4 }],
+        tail: -5,
+    };
+    let different = PointArray {
+        points: [Point { x: 1, y: 2 }, Point { x: 3, y: 99 }],
+        tail: -5,
+    };
+
+    assert_eq!(
+        plan.eq(&left, &same).unwrap(),
+        native.eq(&left, &same).unwrap()
+    );
+    assert_eq!(
+        plan.eq(&left, &different).unwrap(),
+        native.eq(&left, &different).unwrap()
+    );
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+#[test]
+fn native_equality_compares_floats_by_bits() {
+    let plan = EqualityPlan::<Floaty>::build().unwrap();
+    let native = NativeEqualityPlan::<Floaty>::build().unwrap();
+    let left = Floaty {
+        x: -0.0,
+        y: f32::NAN,
+    };
+    let same_bits = Floaty {
+        x: -0.0,
+        y: f32::from_bits(f32::NAN.to_bits()),
+    };
+    let different_zero = Floaty {
+        x: 0.0,
+        y: f32::from_bits(f32::NAN.to_bits()),
+    };
+
+    assert_eq!(
+        plan.eq(&left, &same_bits).unwrap(),
+        native.eq(&left, &same_bits).unwrap()
+    );
+    assert_eq!(
+        plan.eq(&left, &different_zero).unwrap(),
+        native.eq(&left, &different_zero).unwrap()
+    );
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+#[test]
+fn native_equality_reports_code_layout_stats() {
+    let native = NativeEqualityPlan::<Point>::build().unwrap();
+    let stats = native.stats();
+
+    assert_eq!(stats.chain_count, 1);
+    assert_eq!(stats.scalar_count, 0);
+    assert_eq!(stats.scalar_run_count, 1);
+    assert_eq!(stats.scalar_run_field_count, 2);
+    assert_eq!(stats.prog_slot_count, 1);
+    assert_eq!(stats.stencil_count, 2);
+}
+
+#[cfg(all(
+    feature = "jit",
+    any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "linux", target_arch = "x86_64")
+    )
+))]
+#[test]
+fn native_equality_rejects_aggregate_fields_for_now() {
+    let Err(err) = NativeEqualityPlan::<Person>::build() else {
+        panic!("Person contains aggregate fields and should not compile natively yet");
+    };
+
+    assert!(err.to_string().contains("native aggregate equality"));
 }

--- a/picante/src/facet_eq.rs
+++ b/picante/src/facet_eq.rs
@@ -16,13 +16,43 @@ use std::any::Any;
 use std::sync::Arc;
 
 pub(crate) struct PlannedEquality<T> {
-    plan: Option<Arc<facet_hash::EqualityPlan<T>>>,
+    backend: PlannedEqualityBackend<T>,
+}
+
+enum PlannedEqualityBackend<T> {
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
+    Native(Arc<facet_hash::NativeEqualityPlan<T>>),
+    Interpreted(Arc<facet_hash::EqualityPlan<T>>),
+    None,
 }
 
 impl<T> Clone for PlannedEquality<T> {
     fn clone(&self) -> Self {
         Self {
-            plan: self.plan.clone(),
+            backend: self.backend.clone(),
+        }
+    }
+}
+
+impl<T> Clone for PlannedEqualityBackend<T> {
+    fn clone(&self) -> Self {
+        match self {
+            #[cfg(all(
+                feature = "jit",
+                any(
+                    all(target_os = "macos", target_arch = "aarch64"),
+                    all(target_os = "linux", target_arch = "x86_64")
+                )
+            ))]
+            Self::Native(plan) => Self::Native(plan.clone()),
+            Self::Interpreted(plan) => Self::Interpreted(plan.clone()),
+            Self::None => Self::None,
         }
     }
 }
@@ -32,14 +62,62 @@ where
     T: Facet<'static>,
 {
     pub(crate) fn new() -> Self {
-        Self {
-            plan: facet_hash::EqualityPlan::<T>::build().ok().map(Arc::new),
-        }
+        #[cfg(all(
+            feature = "jit",
+            any(
+                all(target_os = "macos", target_arch = "aarch64"),
+                all(target_os = "linux", target_arch = "x86_64")
+            )
+        ))]
+        let backend = if let Ok(native) = facet_hash::NativeEqualityPlan::<T>::build() {
+            PlannedEqualityBackend::Native(Arc::new(native))
+        } else if let Ok(plan) = facet_hash::EqualityPlan::<T>::build() {
+            PlannedEqualityBackend::Interpreted(Arc::new(plan))
+        } else {
+            PlannedEqualityBackend::None
+        };
+        #[cfg(not(all(
+            feature = "jit",
+            any(
+                all(target_os = "macos", target_arch = "aarch64"),
+                all(target_os = "linux", target_arch = "x86_64")
+            )
+        )))]
+        let backend = match facet_hash::EqualityPlan::<T>::build() {
+            Ok(plan) => PlannedEqualityBackend::Interpreted(Arc::new(plan)),
+            Err(_) => PlannedEqualityBackend::None,
+        };
+
+        Self { backend }
     }
 
     #[cfg(test)]
     pub(crate) fn has_plan(&self) -> bool {
-        self.plan.is_some()
+        !matches!(self.backend, PlannedEqualityBackend::None)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_native_plan(&self) -> bool {
+        #[cfg(all(
+            feature = "jit",
+            any(
+                all(target_os = "macos", target_arch = "aarch64"),
+                all(target_os = "linux", target_arch = "x86_64")
+            )
+        ))]
+        {
+            matches!(self.backend, PlannedEqualityBackend::Native(_))
+        }
+        #[cfg(not(all(
+            feature = "jit",
+            any(
+                all(target_os = "macos", target_arch = "aarch64"),
+                all(target_os = "linux", target_arch = "x86_64")
+            )
+        )))]
+        {
+            false
+        }
     }
 }
 
@@ -51,10 +129,26 @@ where
         if let Some(equal) = known_eq(a, b) {
             return equal;
         }
-        if let Some(plan) = &self.plan
-            && let Ok(equal) = plan.eq(a, b)
-        {
-            return equal;
+
+        match &self.backend {
+            #[cfg(all(
+                feature = "jit",
+                any(
+                    all(target_os = "macos", target_arch = "aarch64"),
+                    all(target_os = "linux", target_arch = "x86_64")
+                )
+            ))]
+            PlannedEqualityBackend::Native(plan) => {
+                if let Ok(equal) = plan.eq(a, b) {
+                    return equal;
+                }
+            }
+            PlannedEqualityBackend::Interpreted(plan) => {
+                if let Ok(equal) = plan.eq(a, b) {
+                    return equal;
+                }
+            }
+            PlannedEqualityBackend::None => {}
         }
         facet_eq_direct(a, b)
     }
@@ -410,6 +504,12 @@ mod tests {
         value: i32,
     }
 
+    #[derive(Facet, Debug, Clone)]
+    struct ScalarPair {
+        left: u32,
+        right: i64,
+    }
+
     #[derive(Facet, Debug, Clone, PartialEq)]
     struct Container {
         items: Vec<WithPartialEq>,
@@ -428,6 +528,25 @@ mod tests {
 
         assert!(facet_eq_direct(&a, &b));
         assert!(!facet_eq_direct(&a, &c));
+    }
+
+    #[cfg(all(
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
+    #[test]
+    fn planned_equality_uses_native_for_supported_scalar_structs() {
+        let equality = PlannedEquality::<ScalarPair>::new();
+        let left = ScalarPair { left: 1, right: -2 };
+        let same = ScalarPair { left: 1, right: -2 };
+        let different = ScalarPair { left: 1, right: -3 };
+
+        assert!(equality.has_native_plan());
+        assert!(equality.eq(&left, &same));
+        assert!(!equality.eq(&left, &different));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `NativeEqualityPlan<T>` beside `NativeHashPlan<T>` for the value-mode scalar/scalar-run/fixed-array subset
- expose facet-hash native plans on every Weavy native copy-patch target: macOS/aarch64 and Linux/x86_64
- split facet-hash stencil sources so stable call stencils are portable while Apple/aarch64 can still use the nightly tail-call source when available
- make Picante's cached equality choose one backend (`Native`, `Interpreted`, or `None`) so aggregate fallback does not pay a dead native-option branch

## Tests

- `cargo check -p facet-hash --features jit`
- `cargo check -p picante --features jit`
- `cargo nextest run -p facet-hash --features jit -E 'test(native_)'`
- `cargo nextest run -p facet-hash --features jit`
- `cargo nextest run -p picante --features jit`
- `cargo clippy -p facet-hash --all-features --all-targets --message-format=short -- -D warnings`
- `cargo clippy -p picante --all-features --all-targets --message-format=short -- -D warnings`
- Apple M2 Max: native facet-hash slice + Picante native/fallback equality tests pass
- AMD Ryzen 5 3600: native facet-hash slice + Picante native/fallback equality tests pass

## Benchmarks

### facet-hash equality, Apple M2 Max

Median times, head only, Divan direct binary with `--min-time 1 --sample-count 20 --threads 1`.

| Bench | Interpreted | Native JIT | Speedup |
|---|---:|---:|---:|
| `point_equal` | 15.86 ns | 3.98 ns | 3.98x faster |
| `point_different` | 15.70 ns | 3.94 ns | 3.98x faster |
| `mixed_equal` | 82.58 ns | 6.10 ns | 13.54x faster |
| `point_array_equal` | 95.94 ns | 7.48 ns | 12.82x faster |
| `float_equal` | 40.58 ns | 4.71 ns | 8.61x faster |

### facet-hash equality, AMD Ryzen 5 3600

| Bench | Interpreted | Native JIT | Speedup |
|---|---:|---:|---:|
| `point_equal` | 28.79 ns | 8.92 ns | 3.23x faster |
| `point_different` | 28.25 ns | 8.88 ns | 3.18x faster |
| `mixed_equal` | 99.75 ns | 15.01 ns | 6.65x faster |
| `point_array_equal` | 180.70 ns | 15.01 ns | 12.04x faster |
| `float_equal` | 49.75 ns | 10.87 ns | 4.58x faster |

### Picante existing rows, Apple M2 Max

Median times, base = `origin/main` at `541288a5c`, head = this PR at `62a649e22`, run through `cargo bench -p picante --bench derived --features jit -- --min-time 1 --sample-count 20 --threads 1 ...`.

| Bench | Base | Head | PR vs base |
|---|---:|---:|---:|
| `derived_changed_large_value` | 112.8 us | 112.9 us | 1.00x |
| `derived_equal_cutoff_large_value` | 68.49 us | 65.99 us | 1.04x faster |
| `input_get_hit` | 17.66 ns | 18.37 ns | 0.96x |
| `input_get_hit_large_key` | 9.165 us | 9.166 us | 1.00x |
| `input_set_changed_large_value` | 79.04 us | 80.45 us | 0.98x |
| `input_set_noop_large_key` | 10.87 us | 10.95 us | 0.99x |
| `input_set_noop_large_value` | 43.41 us | 43.66 us | 0.99x |
| `input_set_noop_small_value` | 17.33 ns | 17.88 ns | 0.97x |

### Picante existing rows, AMD Ryzen 5 3600

| Bench | Base | Head | PR vs base |
|---|---:|---:|---:|
| `derived_changed_large_value` | 177.9 us | 178.7 us | 1.00x |
| `derived_equal_cutoff_large_value` | 131.6 us | 130.1 us | 1.01x faster |
| `input_get_hit` | 45.61 ns | 45.78 ns | 1.00x |
| `input_get_hit_large_key` | 15.95 us | 15.07 us | 1.06x faster |
| `input_set_changed_large_value` | 103.5 us | 111.3 us | 0.93x |
| `input_set_noop_large_key` | 19.25 us | 18.99 us | 1.01x faster |
| `input_set_noop_large_value` | 83.72 us | 84.49 us | 0.99x |
| `input_set_noop_small_value` | 41.08 ns | 41.55 ns | 0.99x |

Longer rerun for `input_set_changed_large_value` on AMD Ryzen 5 3600 (`--min-time 2 --sample-count 30`) was 102.3 us base vs 103.6 us head, so I am treating the wider one-pass delta above as noise.
