### PR TITLE
Extend facet urlencoded with partial updates, flattened fields and simple enum support

### DIFF
--- a/facet-urlencoded/src/lib.rs
+++ b/facet-urlencoded/src/lib.rs
@@ -130,7 +130,7 @@ pub fn from_str_owned<T: Facet<'static>>(urlencoded: &str) -> Result<T, UrlEncod
 /// Deserializes a URL encoded form data string into an heap-allocated value.
 ///
 /// This is the lower-level function that works with `Partial` directly.
-fn from_str_value<'facet, const BORROW: bool>(
+pub fn from_str_value<'facet, const BORROW: bool>(
     mut wip: Partial<'facet, BORROW>,
     urlencoded: &str,
 ) -> Result<Partial<'facet, BORROW>, UrlEncodedError> {
@@ -150,7 +150,7 @@ fn from_str_value<'facet, const BORROW: bool>(
     initialize_nested_structures(&mut nested_values);
 
     // Process the deserialization
-    wip = deserialize_value(wip, &nested_values)?;
+    wip = deserialize_value(wip, &nested_values, None)?;
     Ok(wip)
 }
 
@@ -208,40 +208,25 @@ impl NestedValues {
         // If we get here, it's a flat key-value pair
         self.flat.insert(key.to_string(), value);
     }
-
-    fn get(&self, key: &str) -> Option<&String> {
-        self.flat.get(key)
-    }
-
-    #[expect(dead_code)]
-    fn get_nested(&self, key: &str) -> Option<&NestedValues> {
-        self.nested.get(key)
-    }
-
-    fn keys(&self) -> impl Iterator<Item = &String> {
-        self.flat.keys()
-    }
-
-    #[expect(dead_code)]
-    fn nested_keys(&self) -> impl Iterator<Item = &String> {
-        self.nested.keys()
-    }
 }
 
 /// Deserialize a value recursively using the nested values
 fn deserialize_value<'facet, const BORROW: bool>(
     mut wip: Partial<'facet, BORROW>,
     values: &NestedValues,
+    key: Option<&str>,
 ) -> Result<Partial<'facet, BORROW>, UrlEncodedError> {
     let shape = wip.shape();
     match shape.ty {
-        Type::User(UserType::Struct(_)) => {
-            trace!("Deserializing struct");
+        Type::User(UserType::Struct(struct_type)) => {
+            match key {
+                None => trace!("Deserializing struct"),
+                Some(key) => trace!("Deserializing nested struct field: {key}"),
+            }
 
             // Process flat fields
-            for key in values.keys() {
+            for (key, value) in values.flat.iter() {
                 if let Some(index) = wip.field_index(key) {
-                    let value = values.get(key).unwrap(); // Safe because we're iterating over keys
                     wip = wip.begin_nth_field(index)?;
                     wip = deserialize_scalar_field(key, value, wip)?;
                     wip = wip.end()?;
@@ -251,26 +236,42 @@ fn deserialize_value<'facet, const BORROW: bool>(
             }
 
             // Process nested fields
-            for key in values.nested.keys() {
+            for (key, nested_values) in values.nested.iter() {
                 if let Some(index) = wip.field_index(key) {
-                    let nested_values = values.nested.get(key).unwrap(); // Safe because we're iterating over keys
                     wip = wip.begin_nth_field(index)?;
-                    wip = deserialize_nested_field(key, nested_values, wip)?;
+                    wip = deserialize_value(wip, nested_values, Some(key))?;
                     wip = wip.end()?;
                 } else {
                     trace!("Unknown nested field: {key}");
                 }
             }
 
+            // Process flattended fields
+            for (index, field) in struct_type.fields.iter().enumerate() {
+                if field.is_flattened() {
+                    wip = wip.begin_nth_field(index)?;
+                    wip = deserialize_value(wip, values, key)?;
+                    wip = wip.end()?;
+                }
+            }
+
             trace!("Finished deserializing struct");
             Ok(wip)
         }
-        _ => {
-            error!("Unsupported root type");
-            Err(UrlEncodedError::UnsupportedShape(
-                "Unsupported root type".to_string(),
-            ))
-        }
+        _ => match key {
+            None => {
+                error!("Unsupported root type");
+                Err(UrlEncodedError::UnsupportedShape(
+                    "Unsupported root type".to_string(),
+                ))
+            }
+            Some(key) => {
+                error!("Expected struct field for nested value");
+                Err(UrlEncodedError::UnsupportedShape(format!(
+                    "Expected struct for nested field '{key}'"
+                )))
+            }
+        },
     }
 }
 
@@ -336,60 +337,23 @@ fn deserialize_scalar_field<'facet, const BORROW: bool>(
             }
             // Pop the `begin_some` frame opened above so the caller's
             // `.end()` can pop the field cleanly.
-            if is_option {
-                wip = wip.end()?;
-            }
-            Ok(wip)
+        }
+        Def::Undefined if let Type::User(UserType::Enum(_)) = wip.shape().ty => {
+            wip = wip.select_variant_named(value)?;
         }
         _ => {
-            error!("Expected scalar field");
-            Err(UrlEncodedError::UnsupportedShape(format!(
-                "Expected scalar for field '{key}'"
-            )))
+            error!("Expected scalar or enum field");
+            return Err(UrlEncodedError::UnsupportedShape(format!(
+                "Expected scalar or enum for field '{key}'"
+            )));
         }
     }
-}
 
-/// Helper function to deserialize a nested field
-fn deserialize_nested_field<'facet, const BORROW: bool>(
-    key: &str,
-    nested_values: &NestedValues,
-    mut wip: Partial<'facet, BORROW>,
-) -> Result<Partial<'facet, BORROW>, UrlEncodedError> {
-    let shape = wip.shape();
-    match shape.ty {
-        Type::User(UserType::Struct(_)) => {
-            trace!("Deserializing nested struct field: {key}");
-
-            // Process flat fields in the nested structure
-            for nested_key in nested_values.keys() {
-                if let Some(index) = wip.field_index(nested_key) {
-                    let value = nested_values.get(nested_key).unwrap(); // Safe because we're iterating over keys
-                    wip = wip.begin_nth_field(index)?;
-                    wip = deserialize_scalar_field(nested_key, value, wip)?;
-                    wip = wip.end()?;
-                }
-            }
-
-            // Process deeper nested fields
-            for nested_key in nested_values.nested.keys() {
-                if let Some(index) = wip.field_index(nested_key) {
-                    let deeper_nested = nested_values.nested.get(nested_key).unwrap(); // Safe because we're iterating over keys
-                    wip = wip.begin_nth_field(index)?;
-                    wip = deserialize_nested_field(nested_key, deeper_nested, wip)?;
-                    wip = wip.end()?;
-                }
-            }
-
-            Ok(wip)
-        }
-        _ => {
-            error!("Expected struct field for nested value");
-            Err(UrlEncodedError::UnsupportedShape(format!(
-                "Expected struct for nested field '{key}'"
-            )))
-        }
+    if is_option {
+        wip = wip.end()?;
     }
+
+    Ok(wip)
 }
 
 /// Errors that can occur during URL encoded form data deserialization.

--- a/facet-urlencoded/src/lib.rs
+++ b/facet-urlencoded/src/lib.rs
@@ -335,10 +335,8 @@ fn deserialize_scalar_field<'facet, const BORROW: bool>(
                 warn!("facet-urlencoded: unsupported scalar type: {}", wip.shape());
                 return Err(UrlEncodedError::UnsupportedType(format!("{}", wip.shape())));
             }
-            // Pop the `begin_some` frame opened above so the caller's
-            // `.end()` can pop the field cleanly.
         }
-        Def::Undefined if let Type::User(UserType::Enum(_)) = wip.shape().ty => {
+        Def::Undefined if matches!(wip.shape().ty, Type::User(UserType::Enum(_))) => {
             wip = wip.select_variant_named(value)?;
         }
         _ => {
@@ -349,6 +347,8 @@ fn deserialize_scalar_field<'facet, const BORROW: bool>(
         }
     }
 
+    // Pop the `begin_some` frame opened above so the caller's
+    // `.end()` can pop the field cleanly.
     if is_option {
         wip = wip.end()?;
     }

--- a/facet-urlencoded/src/tests.rs
+++ b/facet-urlencoded/src/tests.rs
@@ -1,5 +1,6 @@
-use crate::from_str;
+use crate::{from_str, from_str_value};
 use facet::Facet;
+use facet_reflect::TypePlan;
 use facet_testhelpers::test;
 
 #[derive(Debug, Facet, PartialEq)]
@@ -27,6 +28,23 @@ struct OrderForm {
     product_id: String,
     quantity: u64,
     user: User,
+}
+
+#[derive(Debug, Facet, PartialEq)]
+struct ExtendedSearchParams {
+    #[facet(flatten)]
+    search: SearchParams,
+
+    filter: Filter,
+}
+
+#[derive(Debug, Facet, PartialEq)]
+#[repr(C)]
+#[facet(rename_all = "kebab-case")]
+enum Filter {
+    All,
+    Cats,
+    Bears,
 }
 
 #[test]
@@ -254,4 +272,46 @@ fn test_option_default_none_on_missing() {
 fn test_option_all_default() {
     let q: OptionalParams = from_str("").unwrap();
     assert_eq!(q, OptionalParams::default());
+}
+
+#[test]
+fn test_partial_update() {
+    let default = SearchParams {
+        query: "default".to_string(),
+        page: 2,
+    };
+    let query_string = "query=rust+programming";
+
+    let params: SearchParams = {
+        let plan = TypePlan::<SearchParams>::build().unwrap();
+        let partial = plan.partial_owned().unwrap();
+        let partial = partial.set(default).unwrap();
+        let partial = from_str_value(partial, query_string).unwrap();
+        partial.build().unwrap().materialize().unwrap()
+    };
+
+    assert_eq!(
+        params,
+        SearchParams {
+            query: "rust programming".to_string(),
+            page: 2
+        }
+    );
+}
+
+#[test]
+fn test_flattened() {
+    let query_string = "query=rust+programming&page=2&filter=cats";
+
+    let params: ExtendedSearchParams = from_str(query_string).unwrap();
+    assert_eq!(
+        params,
+        ExtendedSearchParams {
+            search: SearchParams {
+                query: "rust programming".to_string(),
+                page: 2
+            },
+            filter: Filter::Cats
+        }
+    );
 }


### PR DESCRIPTION
This MR contains some changes I required for creating a `Configuration {A, B, C}` per CLI and create a `Request {A, B}` by updating the `Configuration` with the query. 

### New Features + Tests
- Make `from_str_value` public for partial updates
- Support flattened fields
- Support simple enums

### Open Questions
- This contains separable features, should I split this?
- Should `from_str_value` be public and/or should the doc comment be expanded?
- I don't know the internal enum logic and only tested with simple enums, is this enough enough for enums at the moment?
- The other code changes are not required, should I try to minimize the diff?

### Other Code Changes
- Use `(flat/nested).iter()` instead of `keys()` and `get(key).unwrap()`
- Combine `deserialize_value` and `deserialize_nested_field`
  - only difference was logging/error message with the key