### PR TITLE
Fix facet-default derive for generic types

### DIFF
--- a/facet-default/src/lib.rs
+++ b/facet-default/src/lib.rs
@@ -86,7 +86,7 @@ macro_rules! __facet_invoke {
                 @plugin {
                     @name { "Default" }
                     @template {
-                        impl ::core::default::Default for @Self {
+                        impl @GenericParams ::core::default::Default for @Self @WhereClause {
                             fn default() -> Self {
                                 @if_struct {
                                     Self {

--- a/facet-default/tests/integration.rs
+++ b/facet-default/tests/integration.rs
@@ -2,6 +2,7 @@
 
 use facet::Facet;
 use facet_default as default;
+use std::marker::PhantomData;
 
 /// Test struct with various default attributes
 #[test]
@@ -225,4 +226,33 @@ fn test_string_literal_default() {
 
     let blah = Blah::default();
     assert_eq!(blah.field, "ha");
+}
+
+/// Repro for issue #2398: `@Self` in plugin templates must include generic
+/// arguments without their bounds, e.g. `IdType<TKind>` rather than `IdType`.
+#[test]
+fn test_derive_default_with_bounded_generic() {
+    mod private {
+        use facet::Facet;
+
+        pub(super) trait Sealed {
+            type Associated: for<'facet> Facet<'facet>;
+        }
+    }
+
+    #[derive(Facet)]
+    pub struct IdMarker;
+    impl private::Sealed for IdMarker {
+        type Associated = String;
+    }
+
+    #[derive(Facet)]
+    #[facet(derive(Default))]
+    pub struct IdType<TKind: private::Sealed> {
+        something: String,
+        _kind: PhantomData<TKind>,
+    }
+
+    let id = IdType::<IdMarker>::default();
+    assert_eq!(id.something, String::default());
 }

--- a/facet-macros-impl/src/plugin.rs
+++ b/facet-macros-impl/src/plugin.rs
@@ -815,6 +815,8 @@ fn handle_directive(
     match directive.as_str() {
         // === Type-level directives ===
         "Self" => emit_self_type(ctx, output),
+        "GenericParams" => emit_generic_params(ctx, output),
+        "WhereClause" => emit_where_clause(ctx, output),
 
         // === Looping directives ===
         "for_variant" => handle_for_variant(iter, ctx, output),
@@ -862,7 +864,25 @@ fn handle_directive(
 
 fn emit_self_type(ctx: &EvalContext<'_>, output: &mut TokenStream) {
     let name = ctx.parsed_type.name();
-    output.extend(quote! { #name });
+    let generics = match ctx.parsed_type {
+        facet_macro_parse::PType::Struct(s) => s.container.bgp.display_without_bounds(),
+        facet_macro_parse::PType::Enum(e) => e.container.bgp.display_without_bounds(),
+    };
+    output.extend(quote! { #name #generics });
+}
+
+fn emit_generic_params(ctx: &EvalContext<'_>, output: &mut TokenStream) {
+    let generics = match ctx.parsed_type {
+        facet_macro_parse::PType::Struct(s) => s.container.bgp.display_with_bounds(),
+        facet_macro_parse::PType::Enum(e) => e.container.bgp.display_with_bounds(),
+    };
+    output.extend(quote! { #generics });
+}
+
+fn emit_where_clause(_ctx: &EvalContext<'_>, _output: &mut TokenStream) {
+    // TODO: facet-macro-parse does not currently expose user where-clauses in
+    // PContainer. This directive is reserved so plugin templates can place a
+    // where-clause once parsing support is available.
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- emit generic parameters in facet-default plugin-generated impl headers
- expand `@Self` to include generic arguments without bounds
- add a regression test for #2398 using a sealed generic bound

Fixes #2398.

## Tests

- `cargo test -p facet-default --test integration test_derive_default_with_bounded_generic`
- `cargo test -p facet-default`
- `cargo fmt --check`