### PR TITLE
fix: propagate user where-clauses into plugin-derived impls

### DIFF
--- a/facet-default/tests/integration.rs
+++ b/facet-default/tests/integration.rs
@@ -256,3 +256,38 @@ fn test_derive_default_with_bounded_generic() {
     let id = IdType::<IdMarker>::default();
     assert_eq!(id.something, String::default());
 }
+
+/// Repro for where-clause bounds on a generic container: `#[facet(derive(Default))]`
+/// must propagate user `where` clauses (not just inline bounds) into the generated
+/// impl, otherwise `impl Default for Registry<TId>` is ill-formed because the struct
+/// requires `TId: SealedIdVariant`.
+#[test]
+fn test_derive_default_with_where_clause() {
+    mod private {
+        use facet::Facet;
+
+        pub(super) trait SealedIdVariant {
+            type Associated: for<'facet> Facet<'facet>;
+        }
+    }
+
+    #[derive(Facet)]
+    pub struct IdMarker;
+    impl private::SealedIdVariant for IdMarker {
+        type Associated = String;
+    }
+
+    #[derive(Facet, Clone)]
+    #[must_use]
+    #[facet(derive(Default))]
+    pub struct Registry<TId>
+    where
+        TId: private::SealedIdVariant,
+    {
+        something: String,
+        _marker: PhantomData<TId>,
+    }
+
+    let r = Registry::<IdMarker>::default();
+    assert_eq!(r.something, String::default());
+}

--- a/facet-macro-parse/src/parsed.rs
+++ b/facet-macro-parse/src/parsed.rs
@@ -1,4 +1,4 @@
-use crate::{BoundedGenericParams, RenameRule, unescape};
+use crate::{BoundedGenericParams, RenameRule, WhereClauses, unescape};
 use crate::{Ident, KWhere, ReprInner, ToTokens, TokenStream};
 use proc_macro2::Span;
 use quote::{quote, quote_spanned};
@@ -829,6 +829,9 @@ pub struct PContainer {
 
     /// Generic parameters of the container
     pub bgp: BoundedGenericParams,
+
+    /// User-written `where` clauses on the type, e.g. `where T: Trait`.
+    pub where_clauses: Option<WhereClauses>,
 }
 
 /// Parse struct
@@ -868,6 +871,7 @@ impl PEnum {
             rename: attrs.rename.clone(),
             attrs,
             bgp: BoundedGenericParams::parse(e.generics.as_ref()),
+            where_clauses: e.clauses.clone(),
         };
 
         // Parse variants, passing the container's rename_all rule
@@ -1029,12 +1033,21 @@ impl PStruct {
         // Extract the rename_all rule *after* parsing all attributes.
         let rename_all_rule = attrs.rename_all;
 
+        // Extract user `where` clauses (carried by every StructKind variant) before
+        // the container borrows `attrs`.
+        let where_clauses = match &s.kind {
+            crate::StructKind::Struct { clauses, .. }
+            | crate::StructKind::TupleStruct { clauses, .. }
+            | crate::StructKind::UnitStruct { clauses, .. } => clauses.clone(),
+        };
+
         // Build PContainer from struct's name and attributes.
         let container = PContainer {
             name: s.name.clone(),
             rename: attrs.rename.clone(),
             attrs,
             bgp: BoundedGenericParams::parse(s.generics.as_ref()),
+            where_clauses,
         };
 
         // Pass the container's rename_all rule (extracted above) as argument to PStructKind::parse

--- a/facet-macros-impl/src/plugin.rs
+++ b/facet-macros-impl/src/plugin.rs
@@ -16,7 +16,7 @@
 //! `#[facet(derive(Foo))]` maps to `::facet_foo::__facet_derive!`
 //! (lowercase the trait name, prefix with `facet_`)
 
-use crate::{Attribute, AttributeInner, FacetInner, IParse, Ident, ToTokenIter, TokenStream};
+use crate::{Attribute, AttributeInner, FacetInner, IParse, Ident, ToTokenIter, ToTokens, TokenStream};
 use quote::quote;
 
 /// A plugin reference - either a simple name or a full path.
@@ -879,10 +879,31 @@ fn emit_generic_params(ctx: &EvalContext<'_>, output: &mut TokenStream) {
     output.extend(quote! { #generics });
 }
 
-fn emit_where_clause(_ctx: &EvalContext<'_>, _output: &mut TokenStream) {
-    // TODO: facet-macro-parse does not currently expose user where-clauses in
-    // PContainer. This directive is reserved so plugin templates can place a
-    // where-clause once parsing support is available.
+fn emit_where_clause(ctx: &EvalContext<'_>, output: &mut TokenStream) {
+    // Emit the user-written `where` clauses (e.g. `where T: Trait`) so plugin
+    // templates like `impl @GenericParams Default for @Self @WhereClause` produce
+    // well-formed impls for generic types. Only user predicates are emitted —
+    // Facet-specific bounds (`T: Facet<'ʄ>`, lifetime constraints) belong to the
+    // Facet impl, not to derived traits like Default.
+    let clauses = match ctx.parsed_type {
+        facet_macro_parse::PType::Struct(s) => &s.container.where_clauses,
+        facet_macro_parse::PType::Enum(e) => &e.container.where_clauses,
+    };
+    let Some(wc) = clauses else {
+        return;
+    };
+    let mut predicates = TokenStream::new();
+    let mut first = true;
+    for c in wc.clauses.iter() {
+        if !first {
+            predicates.extend(quote! { , });
+        }
+        predicates.extend(c.value.to_token_stream());
+        first = false;
+    }
+    if !first {
+        output.extend(quote! { where #predicates });
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
The Facet derive's plugin template engine (used by #[facet(derive(Default))]
and friends) emits `impl @GenericParams Trait for @Self @WhereClause`, but
the @WhereClause directive was a no-op stub: PContainer didn't carry the
user's where-clauses at all (PStructKind::parse discarded them), and
emit_where_clause returned nothing.

Result: a generic container like

```rust
  #[derive(Facet)]
  #[facet(derive(Default))]
  pub struct Registry<TId>
  where
    TId: SealedIdVariant,
```

failed to compile because the generated `impl Default for Registry<TId>`
dropped the `where TId: SealedIdVariant` bound, so Registry<TId> was not
even nameable. Inline bounds (`<TId: SealedIdVariant>`) worked only because
@GenericParams already emitted them.

Fix:
- PContainer now stores where_clauses: Option<WhereClauses>.
- PStruct::parse extracts clauses from every StructKind variant; PEnum::parse
  takes them from Enum.clauses.
- emit_where_clause emits `where <predicates>` from those clauses (user
  predicates only; Facet-specific 'facet bounds stay on the Facet impl).

Regression test added to facet-default.
