### PR TITLE
Move gingembre + gingembre-syntax into facet workspace (step 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,6 +3027,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "gingembre"
+version = "0.0.0"
+dependencies = [
+ "ariadne",
+ "camino",
+ "facet",
+ "facet-value",
+ "futures",
+ "gingembre-syntax",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "gingembre-syntax"
+version = "0.0.0"
+dependencies = [
+ "cstree",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,10 @@ members = [
   "styx-xtask",
   "tree-sitter-styx",
 
+  # Gingembre Jinja-like template engine
+  "gingembre",
+  "gingembre-syntax",
+
   # async incremental query runtime
   "picante",
   "picante-macros",

--- a/gingembre-syntax/Cargo.toml
+++ b/gingembre-syntax/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "gingembre-syntax"
+version = "0.0.0"
+edition = "2024"
+description = "Lossless cstree syntax for gingembre templates, shared by the engine and the authoring LSP"
+license = "MIT OR Apache-2.0"
+
+[package.metadata]
+
+[package.metadata."docs.rs"]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[dependencies]
+cstree = { workspace = true }

--- a/gingembre-syntax/arborium-header.html
+++ b/gingembre-syntax/arborium-header.html
@@ -1,0 +1,2 @@
+<!-- Rustdoc doesn't highlight some languages natively -- let's do it ourselves: https://github.com/bearcove/arborium -->
+<script defer src="https://cdn.jsdelivr.net/npm/@arborium/arborium@2/dist/arborium.iife.js"></script>

--- a/gingembre-syntax/examples/check_ftl.rs
+++ b/gingembre-syntax/examples/check_ftl.rs
@@ -1,0 +1,40 @@
+//! Parse every .jinja template under a directory; report parse errors and any
+//! lossless violations. Usage: cargo run -p gingembre-syntax --example check_ftl -- <dir>
+use std::path::Path;
+
+fn walk(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    for e in std::fs::read_dir(dir).unwrap().flatten() {
+        let p = e.path();
+        if p.is_dir() {
+            walk(&p, out);
+        } else if p.extension().is_some_and(|x| x == "jinja") {
+            out.push(p);
+        }
+    }
+}
+
+fn main() {
+    let dir = std::env::args().nth(1).expect("need a dir");
+    let mut files = Vec::new();
+    walk(Path::new(&dir), &mut files);
+    files.sort();
+    let (mut ok, mut err_files) = (0usize, 0usize);
+    for f in &files {
+        let src = std::fs::read_to_string(f).unwrap();
+        let parse = gingembre_syntax::parse(&src);
+        let lossless = parse.syntax().to_string() == src;
+        if parse.errors.is_empty() && lossless {
+            ok += 1;
+        } else {
+            err_files += 1;
+            let rel = f.strip_prefix(&dir).unwrap_or(f).display();
+            if !lossless {
+                println!("LOSSLESS VIOLATION: {rel}");
+            }
+            for e in parse.errors.iter().take(4) {
+                println!("  {rel}:{} {}", e.offset, e.message);
+            }
+        }
+    }
+    println!("\n{} templates: {} clean, {} with issues", files.len(), ok, err_files);
+}

--- a/gingembre-syntax/src/ast.rs
+++ b/gingembre-syntax/src/ast.rs
@@ -1,0 +1,855 @@
+//! Typed views over the lossless CST.
+//!
+//! These are thin, zero-copy wrappers over [`crate::ResolvedNode`] (à la rust-analyzer's
+//! `ast` layer): each wrapper is just a tagged node, and its accessor methods navigate the
+//! CST. There is **no separate owned AST** — the engine and the LSP both evaluate directly
+//! off these typed views, so there is a single source of truth. Leaf values (int/float/bool
+//! literals, string-escape resolution, operator → enum) are decoded in the accessors.
+
+use crate::ResolvedNode;
+use crate::SyntaxKind::{self, *};
+
+/// A typed view over a CST node of a known [`SyntaxKind`].
+pub trait AstNode: Sized {
+    fn can_cast(kind: SyntaxKind) -> bool;
+    fn cast(node: ResolvedNode) -> Option<Self>;
+    fn syntax(&self) -> &ResolvedNode;
+}
+
+macro_rules! ast_node {
+    ($(#[$m:meta])* $name:ident = $kind:ident) => {
+        $(#[$m])*
+        #[derive(Debug, Clone)]
+        pub struct $name(ResolvedNode);
+        impl AstNode for $name {
+            fn can_cast(k: SyntaxKind) -> bool { k == SyntaxKind::$kind }
+            fn cast(node: ResolvedNode) -> Option<Self> {
+                if node.kind() == SyntaxKind::$kind { Some(Self(node)) } else { None }
+            }
+            fn syntax(&self) -> &ResolvedNode { &self.0 }
+        }
+    };
+}
+
+// ----- helpers on raw nodes -----
+
+/// Iterate the child *nodes* that cast to `T`.
+fn typed_children<T: AstNode>(node: &ResolvedNode) -> impl Iterator<Item = T> + '_ {
+    node.children().filter_map(|c| T::cast(c.clone()))
+}
+
+/// First child node that casts to `T`.
+fn typed_child<T: AstNode>(node: &ResolvedNode) -> Option<T> {
+    typed_children(node).next()
+}
+
+/// Text of the first child token of `kind`, if any.
+fn token_text(node: &ResolvedNode, kind: SyntaxKind) -> Option<&str> {
+    node.children_with_tokens().find_map(|e| {
+        let t = e.into_token()?;
+        (t.kind() == kind).then(|| t.text())
+    })
+}
+
+/// Kind of the first child token matching any operator kind in `kinds`.
+fn first_token_kind(node: &ResolvedNode, kinds: &[SyntaxKind]) -> Option<SyntaxKind> {
+    node.children_with_tokens().find_map(|e| {
+        let t = e.into_token()?;
+        kinds.contains(&t.kind()).then(|| t.kind())
+    })
+}
+
+// ===== expressions =====
+
+ast_node!(Literal = Literal);
+ast_node!(VarRef = VarRef);
+ast_node!(FieldExpr = FieldExpr);
+ast_node!(IndexExpr = IndexExpr);
+ast_node!(CallExpr = CallExpr);
+ast_node!(MacroCall = MacroCallExpr);
+ast_node!(FilterExpr = FilterExpr);
+ast_node!(TestExpr = TestExpr);
+ast_node!(TernaryExpr = TernaryExpr);
+ast_node!(BinaryExpr = BinaryExpr);
+ast_node!(UnaryExpr = UnaryExpr);
+ast_node!(OptionalExpr = OptionalExpr);
+ast_node!(ListLit = ListLit);
+ast_node!(DictLit = DictLit);
+ast_node!(ParenExpr = ParenExpr);
+ast_node!(ArgList = ArgList);
+ast_node!(Arg = Arg);
+ast_node!(KwArg = KwArg);
+
+/// Any expression node.
+#[derive(Debug, Clone)]
+pub enum Expr {
+    Literal(Literal),
+    Var(VarRef),
+    Field(FieldExpr),
+    Index(IndexExpr),
+    Call(CallExpr),
+    MacroCall(MacroCall),
+    Filter(FilterExpr),
+    Test(TestExpr),
+    Ternary(TernaryExpr),
+    Binary(BinaryExpr),
+    Unary(UnaryExpr),
+    Optional(OptionalExpr),
+    List(ListLit),
+    Dict(DictLit),
+    Paren(ParenExpr),
+}
+
+impl Expr {
+    pub fn cast(node: ResolvedNode) -> Option<Expr> {
+        Some(match node.kind() {
+            SyntaxKind::Literal => Expr::Literal(self::Literal(node)),
+            SyntaxKind::VarRef => Expr::Var(self::VarRef(node)),
+            SyntaxKind::FieldExpr => Expr::Field(self::FieldExpr(node)),
+            SyntaxKind::IndexExpr => Expr::Index(self::IndexExpr(node)),
+            SyntaxKind::CallExpr => Expr::Call(self::CallExpr(node)),
+            SyntaxKind::MacroCallExpr => Expr::MacroCall(self::MacroCall(node)),
+            SyntaxKind::FilterExpr => Expr::Filter(self::FilterExpr(node)),
+            SyntaxKind::TestExpr => Expr::Test(self::TestExpr(node)),
+            SyntaxKind::TernaryExpr => Expr::Ternary(self::TernaryExpr(node)),
+            SyntaxKind::BinaryExpr => Expr::Binary(self::BinaryExpr(node)),
+            SyntaxKind::UnaryExpr => Expr::Unary(self::UnaryExpr(node)),
+            SyntaxKind::OptionalExpr => Expr::Optional(self::OptionalExpr(node)),
+            SyntaxKind::ListLit => Expr::List(self::ListLit(node)),
+            SyntaxKind::DictLit => Expr::Dict(self::DictLit(node)),
+            SyntaxKind::ParenExpr => Expr::Paren(self::ParenExpr(node)),
+            _ => return None,
+        })
+    }
+
+    pub fn syntax(&self) -> &ResolvedNode {
+        match self {
+            Expr::Literal(n) => n.syntax(),
+            Expr::Var(n) => n.syntax(),
+            Expr::Field(n) => n.syntax(),
+            Expr::Index(n) => n.syntax(),
+            Expr::Call(n) => n.syntax(),
+            Expr::MacroCall(n) => n.syntax(),
+            Expr::Filter(n) => n.syntax(),
+            Expr::Test(n) => n.syntax(),
+            Expr::Ternary(n) => n.syntax(),
+            Expr::Binary(n) => n.syntax(),
+            Expr::Unary(n) => n.syntax(),
+            Expr::Optional(n) => n.syntax(),
+            Expr::List(n) => n.syntax(),
+            Expr::Dict(n) => n.syntax(),
+            Expr::Paren(n) => n.syntax(),
+        }
+    }
+}
+
+fn first_expr(node: &ResolvedNode) -> Option<Expr> {
+    node.children().find_map(|c| Expr::cast(c.clone()))
+}
+
+fn nth_expr(node: &ResolvedNode, n: usize) -> Option<Expr> {
+    node.children().filter_map(|c| Expr::cast(c.clone())).nth(n)
+}
+
+/// The kind of literal a [`Literal`] node holds.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LitValue {
+    Str(String),
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    None,
+}
+
+impl Literal {
+    pub fn value(&self) -> LitValue {
+        let tok = self.0.first_token();
+        let Some(tok) = tok else {
+            return LitValue::None;
+        };
+        match tok.kind() {
+            Int => LitValue::Int(tok.text().parse().unwrap_or(0)),
+            Float => LitValue::Float(tok.text().parse().unwrap_or(0.0)),
+            True => LitValue::Bool(true),
+            False => LitValue::Bool(false),
+            NoneKw => LitValue::None,
+            Str => LitValue::Str(unquote(tok.text())),
+            _ => LitValue::None,
+        }
+    }
+}
+
+impl VarRef {
+    pub fn name(&self) -> Option<&str> {
+        token_text(&self.0, Ident)
+    }
+}
+
+impl FieldExpr {
+    pub fn base(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+    pub fn field(&self) -> Option<&str> {
+        token_text(&self.0, Ident)
+    }
+}
+
+impl IndexExpr {
+    pub fn base(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+    /// `true` when this is a slice (`a[:n]` / `a[a:b]`) rather than a plain index.
+    pub fn is_slice(&self) -> bool {
+        self.0
+            .children_with_tokens()
+            .any(|e| e.into_token().is_some_and(|t| t.kind() == Colon))
+    }
+    /// The index expression (for a plain index), i.e. the second expression child.
+    pub fn index(&self) -> Option<Expr> {
+        nth_expr(&self.0, 1)
+    }
+}
+
+impl CallExpr {
+    pub fn callee(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+    pub fn args(&self) -> Option<ArgList> {
+        typed_child(&self.0)
+    }
+}
+
+impl MacroCall {
+    fn idents(&self) -> impl Iterator<Item = &str> + '_ {
+        self.0
+            .children_with_tokens()
+            .filter_map(|e| e.into_token())
+            .filter(|t| t.kind() == Ident)
+            .map(|t| t.text())
+    }
+    pub fn namespace(&self) -> Option<&str> {
+        self.idents().next()
+    }
+    pub fn name(&self) -> Option<&str> {
+        self.idents().nth(1)
+    }
+    pub fn args(&self) -> Option<ArgList> {
+        typed_child(&self.0)
+    }
+}
+
+impl ArgList {
+    pub fn positional(&self) -> impl Iterator<Item = Expr> + '_ {
+        typed_children::<Arg>(&self.0).filter_map(|a| first_expr(a.syntax()))
+    }
+    pub fn keyword(&self) -> impl Iterator<Item = (String, Expr)> + '_ {
+        typed_children::<KwArg>(&self.0).filter_map(|k| {
+            Some((
+                token_text(k.syntax(), Ident)?.to_owned(),
+                first_expr(k.syntax())?,
+            ))
+        })
+    }
+}
+
+impl FilterExpr {
+    pub fn base(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+    pub fn name(&self) -> Option<&str> {
+        // `expr | NAME` — the filter name is the Ident token directly under this node.
+        token_text(&self.0, Ident)
+    }
+    pub fn args(&self) -> Option<ArgList> {
+        typed_child(&self.0)
+    }
+}
+
+impl TestExpr {
+    pub fn base(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+    pub fn negated(&self) -> bool {
+        self.0
+            .children_with_tokens()
+            .any(|e| e.into_token().is_some_and(|t| t.kind() == NotKw))
+    }
+    pub fn name(&self) -> Option<&str> {
+        // Test name is an Ident, or the `none` keyword.
+        self.0.children_with_tokens().find_map(|e| {
+            let t = e.into_token()?;
+            matches!(t.kind(), Ident | NoneKw).then(|| t.text())
+        })
+    }
+    pub fn args(&self) -> Option<ArgList> {
+        typed_child(&self.0)
+    }
+}
+
+impl TernaryExpr {
+    /// `value if cond else otherwise`: the three expression children in source order.
+    pub fn value(&self) -> Option<Expr> {
+        nth_expr(&self.0, 0)
+    }
+    pub fn condition(&self) -> Option<Expr> {
+        nth_expr(&self.0, 1)
+    }
+    pub fn otherwise(&self) -> Option<Expr> {
+        nth_expr(&self.0, 2)
+    }
+}
+
+/// A binary operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    FloorDiv,
+    Mod,
+    Pow,
+    Concat,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    And,
+    Or,
+    In,
+    NotIn,
+}
+
+impl BinaryExpr {
+    pub fn lhs(&self) -> Option<Expr> {
+        nth_expr(&self.0, 0)
+    }
+    pub fn rhs(&self) -> Option<Expr> {
+        nth_expr(&self.0, 1)
+    }
+    pub fn op(&self) -> Option<BinOp> {
+        // `not in` is the only binary carrying a `not` token; detect it first.
+        let has = |k: SyntaxKind| {
+            self.0
+                .children_with_tokens()
+                .any(|e| e.into_token().is_some_and(|t| t.kind() == k))
+        };
+        if has(NotKw) && has(InKw) {
+            return Some(BinOp::NotIn);
+        }
+        let k = first_token_kind(
+            &self.0,
+            &[
+                Plus, Minus, Star, Slash, SlashSlash, Percent, StarStar, Tilde, EqEq, Neq, Lt, Le,
+                Gt, Ge, AndKw, OrKw, InKw,
+            ],
+        )?;
+        Some(match k {
+            Plus => BinOp::Add,
+            Minus => BinOp::Sub,
+            Star => BinOp::Mul,
+            Slash => BinOp::Div,
+            SlashSlash => BinOp::FloorDiv,
+            Percent => BinOp::Mod,
+            StarStar => BinOp::Pow,
+            Tilde => BinOp::Concat,
+            EqEq => BinOp::Eq,
+            Neq => BinOp::Ne,
+            Lt => BinOp::Lt,
+            Le => BinOp::Le,
+            Gt => BinOp::Gt,
+            Ge => BinOp::Ge,
+            AndKw => BinOp::And,
+            OrKw => BinOp::Or,
+            InKw => BinOp::In,
+            _ => return None,
+        })
+    }
+}
+
+/// A unary operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnOp {
+    Not,
+    Neg,
+}
+
+impl UnaryExpr {
+    pub fn op(&self) -> Option<UnOp> {
+        match first_token_kind(&self.0, &[NotKw, Minus])? {
+            NotKw => Some(UnOp::Not),
+            Minus => Some(UnOp::Neg),
+            _ => None,
+        }
+    }
+    pub fn operand(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+}
+
+impl OptionalExpr {
+    pub fn operand(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+}
+
+impl ListLit {
+    pub fn elements(&self) -> impl Iterator<Item = Expr> + '_ {
+        self.0.children().filter_map(|c| Expr::cast(c.clone()))
+    }
+}
+
+impl DictLit {
+    /// (key, value) pairs in source order.
+    pub fn entries(&self) -> Vec<(Expr, Expr)> {
+        let exprs: Vec<Expr> = self
+            .0
+            .children()
+            .filter_map(|c| Expr::cast(c.clone()))
+            .collect();
+        exprs
+            .chunks_exact(2)
+            .map(|c| (c[0].clone(), c[1].clone()))
+            .collect()
+    }
+}
+
+impl ParenExpr {
+    pub fn inner(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+}
+
+// ===== statements / template structure =====
+
+ast_node!(Template = Template);
+ast_node!(Interpolation = Interpolation);
+ast_node!(Body = Body);
+ast_node!(IfStmt = IfStmt);
+ast_node!(ElifClause = ElifClause);
+ast_node!(ElseClause = ElseClause);
+ast_node!(ForStmt = ForStmt);
+ast_node!(SetStmt = SetStmt);
+ast_node!(BlockStmt = BlockStmt);
+ast_node!(MacroStmt = MacroStmt);
+ast_node!(ExtendsStmt = ExtendsStmt);
+ast_node!(IncludeStmt = IncludeStmt);
+ast_node!(ImportStmt = ImportStmt);
+ast_node!(ParamList = ParamList);
+ast_node!(Param = Param);
+ast_node!(BreakStmt = BreakStmt);
+ast_node!(ContinueStmt = ContinueStmt);
+
+/// One item in a template body: literal text/trivia, an interpolation, or a statement.
+#[derive(Debug, Clone)]
+pub enum Item {
+    /// A run of literal text or trivia token (kept for lossless output; render trims it
+    /// per adjacent `{%- -%}` markers).
+    Text(crate::ResolvedToken),
+    Interpolation(Interpolation),
+    If(IfStmt),
+    For(ForStmt),
+    Set(SetStmt),
+    Block(BlockStmt),
+    Macro(MacroStmt),
+    Extends(ExtendsStmt),
+    Include(IncludeStmt),
+    Import(ImportStmt),
+    Break(BreakStmt),
+    Continue(ContinueStmt),
+}
+
+/// Iterate the items of a `Template` or `Body` node in source order.
+fn items_of(node: &ResolvedNode) -> Vec<Item> {
+    let mut out = Vec::new();
+    for el in node.children_with_tokens() {
+        match el {
+            cstree::syntax::ResolvedElementRef::Token(t) => {
+                // Text / Whitespace / Comment tokens become Text items (lossless).
+                out.push(Item::Text(t.clone()));
+            }
+            cstree::syntax::ResolvedElementRef::Node(n) => {
+                let item = match n.kind() {
+                    SyntaxKind::Interpolation => Item::Interpolation(Interpolation(n.clone())),
+                    SyntaxKind::IfStmt => Item::If(IfStmt(n.clone())),
+                    SyntaxKind::ForStmt => Item::For(ForStmt(n.clone())),
+                    SyntaxKind::SetStmt => Item::Set(SetStmt(n.clone())),
+                    SyntaxKind::BlockStmt => Item::Block(BlockStmt(n.clone())),
+                    SyntaxKind::MacroStmt => Item::Macro(MacroStmt(n.clone())),
+                    SyntaxKind::ExtendsStmt => Item::Extends(ExtendsStmt(n.clone())),
+                    SyntaxKind::IncludeStmt => Item::Include(IncludeStmt(n.clone())),
+                    SyntaxKind::ImportStmt => Item::Import(ImportStmt(n.clone())),
+                    SyntaxKind::BreakStmt => Item::Break(BreakStmt(n.clone())),
+                    SyntaxKind::ContinueStmt => Item::Continue(ContinueStmt(n.clone())),
+                    // Error/other nodes are skipped by the typed walk.
+                    _ => continue,
+                };
+                out.push(item);
+            }
+        }
+    }
+    out
+}
+
+impl Item {
+    /// The item's node, for non-text items.
+    fn node(&self) -> Option<&ResolvedNode> {
+        Some(match self {
+            Item::Text(_) => return None,
+            Item::Interpolation(n) => &n.0,
+            Item::If(n) => &n.0,
+            Item::For(n) => &n.0,
+            Item::Set(n) => &n.0,
+            Item::Block(n) => &n.0,
+            Item::Macro(n) => &n.0,
+            Item::Extends(n) => &n.0,
+            Item::Include(n) => &n.0,
+            Item::Import(n) => &n.0,
+            Item::Break(n) => &n.0,
+            Item::Continue(n) => &n.0,
+        })
+    }
+
+    /// Whether this item's leading delimiter is a trim variant (`{%-`/`{{-`) —
+    /// trims trailing whitespace of the text run before it.
+    pub fn opens_with_trim(&self) -> bool {
+        self.node().and_then(|n| n.first_token()).is_some_and(|t| {
+            matches!(
+                t.kind(),
+                SyntaxKind::OpenStmtTrim | SyntaxKind::OpenExprTrim
+            )
+        })
+    }
+
+    /// Whether this item's trailing delimiter is a trim variant (`-%}`/`-}}`) —
+    /// trims leading whitespace of the text run after it.
+    pub fn closes_with_trim(&self) -> bool {
+        self.node().and_then(|n| n.last_token()).is_some_and(|t| {
+            matches!(
+                t.kind(),
+                SyntaxKind::CloseStmtTrim | SyntaxKind::CloseExprTrim
+            )
+        })
+    }
+}
+
+impl Template {
+    pub fn items(&self) -> Vec<Item> {
+        items_of(&self.0)
+    }
+}
+
+impl Body {
+    pub fn items(&self) -> Vec<Item> {
+        items_of(&self.0)
+    }
+}
+
+impl Interpolation {
+    pub fn expr(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+}
+
+impl IfStmt {
+    pub fn condition(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+    /// The `then` body is the first direct `Body` child.
+    pub fn then_body(&self) -> Option<Body> {
+        typed_child(&self.0)
+    }
+    pub fn elif_clauses(&self) -> impl Iterator<Item = ElifClause> + '_ {
+        typed_children(&self.0)
+    }
+    pub fn else_clause(&self) -> Option<ElseClause> {
+        typed_child(&self.0)
+    }
+}
+
+impl ElifClause {
+    pub fn condition(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+    pub fn body(&self) -> Option<Body> {
+        typed_child(&self.0)
+    }
+}
+
+impl ElseClause {
+    pub fn body(&self) -> Option<Body> {
+        typed_child(&self.0)
+    }
+}
+
+impl ForStmt {
+    /// Loop target names (one, or several for tuple unpacking).
+    pub fn targets(&self) -> Vec<String> {
+        // The Ident tokens before `in` are the targets; the iterator is an Expr child.
+        let mut names = Vec::new();
+        for el in self.0.children_with_tokens() {
+            if let Some(t) = el.into_token() {
+                match t.kind() {
+                    SyntaxKind::Ident => names.push(t.text().to_owned()),
+                    SyntaxKind::InKw => break,
+                    _ => {}
+                }
+            } else {
+                break;
+            }
+        }
+        names
+    }
+    pub fn iter_expr(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+    pub fn body(&self) -> Option<Body> {
+        typed_child(&self.0)
+    }
+    pub fn else_body(&self) -> Option<Body> {
+        // The for-else body lives inside an ElseClause child.
+        typed_child::<ElseClause>(&self.0).and_then(|e| e.body())
+    }
+}
+
+impl SetStmt {
+    pub fn name(&self) -> Option<String> {
+        token_text(&self.0, Ident).map(str::to_owned)
+    }
+    /// `{% set x = EXPR %}` — present for the assignment form.
+    pub fn value(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+    /// `{% set x %}…{% endset %}` — present for the block form.
+    pub fn body(&self) -> Option<Body> {
+        typed_child(&self.0)
+    }
+}
+
+impl BlockStmt {
+    pub fn name(&self) -> Option<String> {
+        token_text(&self.0, Ident).map(str::to_owned)
+    }
+    pub fn body(&self) -> Option<Body> {
+        typed_child(&self.0)
+    }
+}
+
+impl MacroStmt {
+    pub fn name(&self) -> Option<String> {
+        token_text(&self.0, Ident).map(str::to_owned)
+    }
+    pub fn params(&self) -> Vec<(String, Option<Expr>)> {
+        let Some(list) = typed_child::<ParamList>(&self.0) else {
+            return Vec::new();
+        };
+        typed_children::<Param>(list.syntax())
+            .filter_map(|p| {
+                Some((
+                    token_text(p.syntax(), Ident)?.to_owned(),
+                    first_expr(p.syntax()),
+                ))
+            })
+            .collect()
+    }
+    pub fn body(&self) -> Option<Body> {
+        typed_child(&self.0)
+    }
+}
+
+impl ExtendsStmt {
+    pub fn path(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+}
+
+impl IncludeStmt {
+    pub fn path(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+}
+
+impl ImportStmt {
+    pub fn path(&self) -> Option<Expr> {
+        first_expr(&self.0)
+    }
+    pub fn alias(&self) -> Option<String> {
+        // `import "p" as NAME` — the trailing Ident.
+        self.0
+            .children_with_tokens()
+            .filter_map(|e| e.into_token())
+            .filter(|t| t.kind() == Ident)
+            .last()
+            .map(|t| t.text().to_owned())
+    }
+}
+
+/// Resolve a quoted string literal to its value (strip quotes, process `\` escapes).
+fn unquote(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    if bytes.len() < 2 {
+        return raw.to_string();
+    }
+    let inner = &raw[1..raw.len() - 1];
+    let mut out = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('n') => out.push('\n'),
+                Some('t') => out.push('\t'),
+                Some('r') => out.push('\r'),
+                Some('\\') => out.push('\\'),
+                Some('"') => out.push('"'),
+                Some('\'') => out.push('\''),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse_expr_str;
+
+    /// Cast the single interpolation's expression out of a `{{ … }}` parse.
+    fn expr_of(src: &str) -> Expr {
+        let p = parse_expr_str(src);
+        assert!(p.errors.is_empty(), "errors: {:?}", p.errors);
+        // Template → Interpolation → Expr
+        let interp = p
+            .syntax()
+            .children()
+            .find(|n| n.kind() == SyntaxKind::Interpolation)
+            .unwrap();
+        first_expr(interp).expect("an expression")
+    }
+
+    #[test]
+    fn literals() {
+        assert!(matches!(expr_of("42"), Expr::Literal(l) if l.value() == LitValue::Int(42)));
+        assert!(
+            matches!(expr_of("\"a\\nb\""), Expr::Literal(l) if l.value() == LitValue::Str("a\nb".into()))
+        );
+        assert!(matches!(expr_of("true"), Expr::Literal(l) if l.value() == LitValue::Bool(true)));
+    }
+
+    #[test]
+    fn binary_op_and_operands() {
+        let Expr::Binary(b) = expr_of("a + b") else {
+            panic!()
+        };
+        assert_eq!(b.op(), Some(BinOp::Add));
+        assert!(matches!(b.lhs(), Some(Expr::Var(_))));
+        assert!(matches!(b.rhs(), Some(Expr::Var(_))));
+    }
+
+    #[test]
+    fn not_in_operator() {
+        let Expr::Binary(b) = expr_of("x not in xs") else {
+            panic!()
+        };
+        assert_eq!(b.op(), Some(BinOp::NotIn));
+    }
+
+    #[test]
+    fn call_with_field_arg_and_kwarg() {
+        let Expr::Call(c) = expr_of("f(a.b, k=c)") else {
+            panic!()
+        };
+        let args = c.args().unwrap();
+        assert_eq!(args.positional().count(), 1);
+        let kw: Vec<_> = args.keyword().collect();
+        assert_eq!(kw.len(), 1);
+        assert_eq!(kw[0].0, "k");
+        assert!(matches!(args.positional().next(), Some(Expr::Field(_))));
+    }
+
+    #[test]
+    fn field_and_optional() {
+        let Expr::Field(f) = expr_of("page.title") else {
+            panic!()
+        };
+        assert_eq!(f.field(), Some("title"));
+        assert!(matches!(expr_of("width?"), Expr::Optional(_)));
+    }
+
+    #[test]
+    fn slice_detected() {
+        let Expr::Index(i) = expr_of("xs[:3]") else {
+            panic!()
+        };
+        assert!(i.is_slice());
+    }
+
+    fn template(src: &str) -> Template {
+        let p = crate::parse(src);
+        assert!(p.errors.is_empty(), "errors: {:?}", p.errors);
+        Template::cast(p.syntax().clone()).expect("root is a Template")
+    }
+
+    #[test]
+    fn if_elif_else_structure() {
+        let t = template("{% if a %}x{% elif b %}y{% else %}z{% endif %}");
+        let Item::If(iff) = &t.items()[0] else {
+            panic!("{:?}", t.items())
+        };
+        assert!(matches!(iff.condition(), Some(Expr::Var(_))));
+        assert!(iff.then_body().is_some());
+        assert_eq!(iff.elif_clauses().count(), 1);
+        assert!(iff.else_clause().is_some());
+    }
+
+    #[test]
+    fn for_targets_and_iter() {
+        let t = template("{% for a, b in items %}{{ a }}{% endfor %}");
+        let Item::For(f) = &t.items()[0] else {
+            panic!()
+        };
+        assert_eq!(f.targets(), vec!["a".to_string(), "b".to_string()]);
+        assert!(matches!(f.iter_expr(), Some(Expr::Var(_))));
+        assert!(f.body().is_some());
+    }
+
+    #[test]
+    fn macro_params() {
+        let t = template("{% macro m(a, b=1) %}{{ a }}{% endmacro %}");
+        let Item::Macro(m) = &t.items()[0] else {
+            panic!()
+        };
+        assert_eq!(m.name().as_deref(), Some("m"));
+        let params = m.params();
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0].0, "a");
+        assert!(params[0].1.is_none());
+        assert_eq!(params[1].0, "b");
+        assert!(params[1].1.is_some());
+    }
+
+    #[test]
+    fn set_assign_vs_block() {
+        let t = template("{% set x = 1 %}");
+        let Item::Set(s) = &t.items()[0] else {
+            panic!()
+        };
+        assert_eq!(s.name().as_deref(), Some("x"));
+        assert!(s.value().is_some());
+
+        let t2 = template("{% set y %}hi{% endset %}");
+        let Item::Set(s2) = &t2.items()[0] else {
+            panic!()
+        };
+        assert!(s2.value().is_none());
+        assert!(s2.body().is_some());
+    }
+}

--- a/gingembre-syntax/src/lexer.rs
+++ b/gingembre-syntax/src/lexer.rs
@@ -1,0 +1,345 @@
+//! Lossless lexer for gingembre templates.
+//!
+//! Every byte of the source is covered by exactly one [`Lexeme`] (concatenating their
+//! text reproduces the input), so the cstree tree is lossless. Whitespace inside code,
+//! comments, and the `{%- -%}` trim dashes are all preserved as tokens; trimming is a
+//! *lowering* concern, not a lexing one.
+
+use crate::SyntaxKind;
+
+/// A single token: its kind and the exact source slice it covers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Lexeme<'src> {
+    pub kind: SyntaxKind,
+    pub text: &'src str,
+}
+
+#[derive(Clone, Copy)]
+enum Mode {
+    /// Outside delimiters — raw template text.
+    Text,
+    /// Inside `{{ … }}` or `{% … %}`.
+    Code,
+}
+
+/// Tokenise `src` into a lossless stream of lexemes.
+pub fn lex(src: &str) -> Vec<Lexeme<'_>> {
+    let mut out = Vec::new();
+    let bytes = src.as_bytes();
+    let mut pos = 0;
+    let mut mode = Mode::Text;
+
+    let starts_with = |pos: usize, s: &str| src[pos..].starts_with(s);
+
+    while pos < bytes.len() {
+        match mode {
+            Mode::Text => {
+                // A comment is text-level: lex the whole `{# … #}` (with nesting) as one
+                // token and stay in text mode.
+                if starts_with(pos, "{#") {
+                    let end = lex_comment_end(src, pos);
+                    out.push(Lexeme { kind: SyntaxKind::Comment, text: &src[pos..end] });
+                    pos = end;
+                    continue;
+                }
+                // An opening delimiter ends the current text run.
+                if let Some((kind, len)) = open_delim(src, pos) {
+                    out.push(Lexeme { kind, text: &src[pos..pos + len] });
+                    pos += len;
+                    mode = Mode::Code;
+                    continue;
+                }
+                // Otherwise accumulate text until the next `{{` / `{%` / `{#`.
+                let start = pos;
+                while pos < bytes.len() {
+                    if starts_with(pos, "{{") || starts_with(pos, "{%") || starts_with(pos, "{#")
+                    {
+                        break;
+                    }
+                    pos += next_char_len(src, pos);
+                }
+                out.push(Lexeme { kind: SyntaxKind::Text, text: &src[start..pos] });
+            }
+            Mode::Code => {
+                // Closing delimiter returns to text mode.
+                if let Some((kind, len)) = close_delim(src, pos) {
+                    out.push(Lexeme { kind, text: &src[pos..pos + len] });
+                    pos += len;
+                    mode = Mode::Text;
+                    continue;
+                }
+                let (kind, len) = lex_code_token(src, pos);
+                out.push(Lexeme { kind, text: &src[pos..pos + len] });
+                pos += len;
+            }
+        }
+    }
+
+    out
+}
+
+/// Match an opening delimiter at `pos`, returning `(kind, byte_len)`. Trim variants
+/// (`{{-`/`{%-`) are three bytes.
+fn open_delim(src: &str, pos: usize) -> Option<(SyntaxKind, usize)> {
+    let s = &src[pos..];
+    if s.starts_with("{{-") {
+        Some((SyntaxKind::OpenExprTrim, 3))
+    } else if s.starts_with("{{") {
+        Some((SyntaxKind::OpenExpr, 2))
+    } else if s.starts_with("{%-") {
+        Some((SyntaxKind::OpenStmtTrim, 3))
+    } else if s.starts_with("{%") {
+        Some((SyntaxKind::OpenStmt, 2))
+    } else {
+        None
+    }
+}
+
+/// Match a closing delimiter at `pos`.
+fn close_delim(src: &str, pos: usize) -> Option<(SyntaxKind, usize)> {
+    let s = &src[pos..];
+    if s.starts_with("-}}") {
+        Some((SyntaxKind::CloseExprTrim, 3))
+    } else if s.starts_with("}}") {
+        Some((SyntaxKind::CloseExpr, 2))
+    } else if s.starts_with("-%}") {
+        Some((SyntaxKind::CloseStmtTrim, 3))
+    } else if s.starts_with("%}") {
+        Some((SyntaxKind::CloseStmt, 2))
+    } else {
+        None
+    }
+}
+
+/// Find the byte offset just past the matching `#}` for a comment starting at `pos`
+/// (which is at `{#`). Comments nest. An unterminated comment runs to EOF.
+fn lex_comment_end(src: &str, pos: usize) -> usize {
+    let mut i = pos + 2; // past `{#`
+    let mut depth = 1usize;
+    let bytes = src.as_bytes();
+    while i < bytes.len() {
+        if src[i..].starts_with("#}") {
+            depth -= 1;
+            i += 2;
+            if depth == 0 {
+                return i;
+            }
+        } else if src[i..].starts_with("{#") {
+            depth += 1;
+            i += 2;
+        } else {
+            i += next_char_len(src, i);
+        }
+    }
+    src.len()
+}
+
+/// Lex one token in code mode at `pos`, returning `(kind, byte_len)`.
+fn lex_code_token(src: &str, pos: usize) -> (SyntaxKind, usize) {
+    let s = &src[pos..];
+    let first = s.as_bytes()[0];
+
+    // Whitespace run.
+    if first.is_ascii_whitespace() {
+        let len = s.bytes().take_while(|b| b.is_ascii_whitespace()).count();
+        return (SyntaxKind::Whitespace, len);
+    }
+
+    // Identifier / keyword.
+    if first == b'_' || first.is_ascii_alphabetic() {
+        let len = s
+            .bytes()
+            .take_while(|b| *b == b'_' || b.is_ascii_alphanumeric())
+            .count();
+        return (keyword_or_ident(&s[..len]), len);
+    }
+
+    // Number (int or float). A leading `-` is lexed as the Minus operator, not part of
+    // the number, so the parser handles unary minus uniformly.
+    if first.is_ascii_digit() {
+        let mut len = s.bytes().take_while(|b| b.is_ascii_digit()).count();
+        let mut is_float = false;
+        if s[len..].starts_with('.') && s[len + 1..].bytes().next().is_some_and(|b| b.is_ascii_digit())
+        {
+            is_float = true;
+            len += 1; // dot
+            len += s[len..].bytes().take_while(|b| b.is_ascii_digit()).count();
+        }
+        return (if is_float { SyntaxKind::Float } else { SyntaxKind::Int }, len);
+    }
+
+    // String literal (single or double quoted, with backslash escapes).
+    if first == b'"' || first == b'\'' {
+        let quote = first;
+        let mut i = 1;
+        let b = s.as_bytes();
+        while i < b.len() {
+            if b[i] == b'\\' && i + 1 < b.len() {
+                i += 2;
+                continue;
+            }
+            if b[i] == quote {
+                i += 1;
+                return (SyntaxKind::Str, i);
+            }
+            i += next_char_len(s, i);
+        }
+        return (SyntaxKind::Str, b.len()); // unterminated → to end of code
+    }
+
+    // Multi-char operators first, then single-char.
+    for (text, kind) in MULTI_OPS {
+        if s.starts_with(text) {
+            return (*kind, text.len());
+        }
+    }
+    if let Some(kind) = single_op(first) {
+        return (kind, 1);
+    }
+
+    // Anything else: one error char.
+    (SyntaxKind::Error, next_char_len(src, pos))
+}
+
+const MULTI_OPS: &[(&str, SyntaxKind)] = &[
+    ("::", SyntaxKind::ColonColon),
+    ("**", SyntaxKind::StarStar),
+    ("//", SyntaxKind::SlashSlash),
+    ("==", SyntaxKind::EqEq),
+    ("!=", SyntaxKind::Neq),
+    ("<=", SyntaxKind::Le),
+    (">=", SyntaxKind::Ge),
+];
+
+fn single_op(b: u8) -> Option<SyntaxKind> {
+    Some(match b {
+        b'.' => SyntaxKind::Dot,
+        b',' => SyntaxKind::Comma,
+        b':' => SyntaxKind::Colon,
+        b'|' => SyntaxKind::Pipe,
+        b'?' => SyntaxKind::Question,
+        b'(' => SyntaxKind::LParen,
+        b')' => SyntaxKind::RParen,
+        b'[' => SyntaxKind::LBracket,
+        b']' => SyntaxKind::RBracket,
+        b'{' => SyntaxKind::LBrace,
+        b'}' => SyntaxKind::RBrace,
+        b'=' => SyntaxKind::Assign,
+        b'+' => SyntaxKind::Plus,
+        b'-' => SyntaxKind::Minus,
+        b'*' => SyntaxKind::Star,
+        b'/' => SyntaxKind::Slash,
+        b'%' => SyntaxKind::Percent,
+        b'~' => SyntaxKind::Tilde,
+        b'<' => SyntaxKind::Lt,
+        b'>' => SyntaxKind::Gt,
+        _ => return None,
+    })
+}
+
+fn keyword_or_ident(word: &str) -> SyntaxKind {
+    match word {
+        "if" => SyntaxKind::IfKw,
+        "elif" => SyntaxKind::ElifKw,
+        "else" => SyntaxKind::ElseKw,
+        "endif" => SyntaxKind::EndifKw,
+        "for" => SyntaxKind::ForKw,
+        "endfor" => SyntaxKind::EndforKw,
+        "set" => SyntaxKind::SetKw,
+        "endset" => SyntaxKind::EndsetKw,
+        "block" => SyntaxKind::BlockKw,
+        "endblock" => SyntaxKind::EndblockKw,
+        "extends" => SyntaxKind::ExtendsKw,
+        "include" => SyntaxKind::IncludeKw,
+        "import" => SyntaxKind::ImportKw,
+        "macro" => SyntaxKind::MacroKw,
+        "endmacro" => SyntaxKind::EndmacroKw,
+        "break" => SyntaxKind::BreakKw,
+        "continue" => SyntaxKind::ContinueKw,
+        "as" => SyntaxKind::AsKw,
+        "in" => SyntaxKind::InKw,
+        "is" => SyntaxKind::IsKw,
+        "not" => SyntaxKind::NotKw,
+        "and" => SyntaxKind::AndKw,
+        "or" => SyntaxKind::OrKw,
+        "true" | "True" => SyntaxKind::True,
+        "false" | "False" => SyntaxKind::False,
+        "none" | "None" => SyntaxKind::NoneKw,
+        _ => SyntaxKind::Ident,
+    }
+}
+
+fn next_char_len(src: &str, pos: usize) -> usize {
+    src[pos..].chars().next().map_or(1, char::len_utf8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The lexer is lossless: the concatenation of all lexeme texts is the input.
+    fn assert_lossless(src: &str) -> Vec<Lexeme<'_>> {
+        let toks = lex(src);
+        let joined: String = toks.iter().map(|t| t.text).collect();
+        assert_eq!(joined, src, "lexer dropped/added bytes");
+        toks
+    }
+
+    fn kinds(src: &str) -> Vec<SyntaxKind> {
+        assert_lossless(src).iter().map(|t| t.kind).collect()
+    }
+
+    #[test]
+    fn plain_text() {
+        assert_eq!(kinds("hello world"), [SyntaxKind::Text]);
+    }
+
+    #[test]
+    fn interpolation_with_field_and_filter() {
+        use SyntaxKind::*;
+        assert_eq!(
+            kinds("a {{ page.title | upper }} b"),
+            [Text, OpenExpr, Whitespace, Ident, Dot, Ident, Whitespace, Pipe, Whitespace, Ident, Whitespace, CloseExpr, Text]
+        );
+    }
+
+    #[test]
+    fn statement_with_trim_and_keywords() {
+        use SyntaxKind::*;
+        assert_eq!(
+            kinds("{%- if x is not defined -%}"),
+            [OpenStmtTrim, Whitespace, IfKw, Whitespace, Ident, Whitespace, IsKw, Whitespace, NotKw, Whitespace, Ident, Whitespace, CloseStmtTrim]
+        );
+    }
+
+    #[test]
+    fn comment_is_one_token_and_nests() {
+        use SyntaxKind::*;
+        assert_eq!(kinds("a {# outer {# inner #} still #} b"), [Text, Comment, Text]);
+    }
+
+    #[test]
+    fn numbers_strings_operators_optional() {
+        use SyntaxKind::*;
+        assert_eq!(
+            kinds(r#"{{ a[:3] ~ "x" // 2 + b? }}"#),
+            [
+                OpenExpr, Whitespace, Ident, LBracket, Colon, Int, RBracket, Whitespace, Tilde,
+                Whitespace, Str, Whitespace, SlashSlash, Whitespace, Int, Whitespace, Plus,
+                Whitespace, Ident, Question, Whitespace, CloseExpr
+            ]
+        );
+    }
+
+    #[test]
+    fn macro_dotted_call() {
+        use SyntaxKind::*;
+        assert_eq!(
+            kinds("{{ macros.youtube_embed(id, alt=x) }}"),
+            [
+                OpenExpr, Whitespace, Ident, Dot, Ident, LParen, Ident, Comma, Whitespace, Ident,
+                Assign, Ident, RParen, Whitespace, CloseExpr
+            ]
+        );
+    }
+}

--- a/gingembre-syntax/src/lib.rs
+++ b/gingembre-syntax/src/lib.rs
@@ -1,0 +1,263 @@
+//! Lossless concrete syntax for gingembre templates.
+//!
+//! This crate defines the [`SyntaxKind`] tag set and cstree language for gingembre's
+//! template grammar. It is the single source of truth for parsing, shared by the engine
+//! (which lowers the CST to its AST) and the authoring LSP (which consumes the CST
+//! directly for completion / hover / diagnostics with full error recovery).
+//!
+//! See `notes/gingembre-cstree-parser.md` for the design and the grammar catalogue.
+
+mod lexer;
+pub use lexer::{Lexeme, lex};
+
+mod parser;
+pub use parser::{Parse, ParseError, parse, parse_expr_str};
+
+pub mod ast;
+
+/// A node in the resolved (text-bearing) syntax tree.
+pub type ResolvedNode = cstree::syntax::ResolvedNode<SyntaxKind>;
+/// A token in the resolved syntax tree.
+pub type ResolvedToken = cstree::syntax::ResolvedToken<SyntaxKind>;
+
+/// The kind of every token and node in a gingembre syntax tree.
+///
+/// A single flat tag set: variants up to (and including) [`SyntaxKind::Error`] are
+/// **tokens** (terminals produced by the lexer); the rest are **nodes** (interior).
+/// Ordering matters only for the token/node split documented by [`SyntaxKind::is_token`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, cstree::Syntax)]
+#[repr(u32)]
+pub enum SyntaxKind {
+    // ===== Tokens: trivia & raw text =====
+    /// Whitespace inside code (`{{ }}` / `{% %}`).
+    Whitespace,
+    /// A run of literal template text (outside delimiters).
+    Text,
+    /// A whole `{# … #}` comment (lexed as one token; nesting handled by the lexer).
+    Comment,
+
+    // ===== Tokens: delimiters (trim variants carry the `-`) =====
+    #[static_text("{{")]
+    OpenExpr,
+    #[static_text("{{-")]
+    OpenExprTrim,
+    #[static_text("}}")]
+    CloseExpr,
+    #[static_text("-}}")]
+    CloseExprTrim,
+    #[static_text("{%")]
+    OpenStmt,
+    #[static_text("{%-")]
+    OpenStmtTrim,
+    #[static_text("%}")]
+    CloseStmt,
+    #[static_text("-%}")]
+    CloseStmtTrim,
+
+    // ===== Tokens: literals & identifiers =====
+    Ident,
+    Int,
+    Float,
+    /// A quoted string literal (single or double quoted).
+    Str,
+    #[static_text("true")]
+    True,
+    #[static_text("false")]
+    False,
+    #[static_text("none")]
+    NoneKw,
+
+    // ===== Tokens: statement keywords =====
+    #[static_text("if")]
+    IfKw,
+    #[static_text("elif")]
+    ElifKw,
+    #[static_text("else")]
+    ElseKw,
+    #[static_text("endif")]
+    EndifKw,
+    #[static_text("for")]
+    ForKw,
+    #[static_text("endfor")]
+    EndforKw,
+    #[static_text("set")]
+    SetKw,
+    #[static_text("endset")]
+    EndsetKw,
+    #[static_text("block")]
+    BlockKw,
+    #[static_text("endblock")]
+    EndblockKw,
+    #[static_text("extends")]
+    ExtendsKw,
+    #[static_text("include")]
+    IncludeKw,
+    #[static_text("import")]
+    ImportKw,
+    #[static_text("macro")]
+    MacroKw,
+    #[static_text("endmacro")]
+    EndmacroKw,
+    #[static_text("break")]
+    BreakKw,
+    #[static_text("continue")]
+    ContinueKw,
+
+    // ===== Tokens: operator keywords =====
+    #[static_text("as")]
+    AsKw,
+    #[static_text("in")]
+    InKw,
+    #[static_text("is")]
+    IsKw,
+    #[static_text("not")]
+    NotKw,
+    #[static_text("and")]
+    AndKw,
+    #[static_text("or")]
+    OrKw,
+
+    // ===== Tokens: punctuation & operators =====
+    #[static_text(".")]
+    Dot,
+    #[static_text(",")]
+    Comma,
+    #[static_text(":")]
+    Colon,
+    #[static_text("::")]
+    ColonColon,
+    #[static_text("|")]
+    Pipe,
+    #[static_text("?")]
+    Question,
+    #[static_text("(")]
+    LParen,
+    #[static_text(")")]
+    RParen,
+    #[static_text("[")]
+    LBracket,
+    #[static_text("]")]
+    RBracket,
+    #[static_text("{")]
+    LBrace,
+    #[static_text("}")]
+    RBrace,
+    #[static_text("=")]
+    Assign,
+    #[static_text("+")]
+    Plus,
+    #[static_text("-")]
+    Minus,
+    #[static_text("*")]
+    Star,
+    #[static_text("**")]
+    StarStar,
+    #[static_text("/")]
+    Slash,
+    #[static_text("//")]
+    SlashSlash,
+    #[static_text("%")]
+    Percent,
+    #[static_text("~")]
+    Tilde,
+    #[static_text("==")]
+    EqEq,
+    #[static_text("!=")]
+    Neq,
+    #[static_text("<")]
+    Lt,
+    #[static_text(">")]
+    Gt,
+    #[static_text("<=")]
+    Le,
+    #[static_text(">=")]
+    Ge,
+
+    /// Lexer/parser error token (unrecognised input). Last token kind.
+    Error,
+
+    // ===== Nodes: document structure =====
+    /// Root of the tree.
+    Template,
+    /// A `{{ expr }}` interpolation.
+    Interpolation,
+    /// A `{% … %}` statement (specific kind given by the child statement node).
+    Statement,
+
+    // ===== Nodes: statements =====
+    IfStmt,
+    ElifClause,
+    ElseClause,
+    ForStmt,
+    SetStmt,
+    BlockStmt,
+    ExtendsStmt,
+    IncludeStmt,
+    ImportStmt,
+    MacroStmt,
+    BreakStmt,
+    ContinueStmt,
+    /// Body of a block-bearing statement (if/for/block/macro/set-block).
+    Body,
+    /// Macro parameter list `(a, b="x")` and a single parameter.
+    ParamList,
+    Param,
+
+    // ===== Nodes: expressions =====
+    Literal,
+    ListLit,
+    DictLit,
+    /// A bare identifier reference.
+    VarRef,
+    /// `base.field`
+    FieldExpr,
+    /// `base[index]`
+    IndexExpr,
+    /// `base[a:b]`
+    SliceExpr,
+    /// `func(args)`
+    CallExpr,
+    /// `namespace::macro(args)` — explicit macro call.
+    MacroCallExpr,
+    /// Argument list of a call, and its positional / keyword args.
+    ArgList,
+    Arg,
+    KwArg,
+    /// `expr | filter` / `expr | filter(args)`
+    FilterExpr,
+    /// `expr is [not] test`
+    TestExpr,
+    /// `a if cond else b`
+    TernaryExpr,
+    /// Binary operation.
+    BinaryExpr,
+    /// Unary operation (`not`, `-`).
+    UnaryExpr,
+    /// Postfix lenient access `expr?`.
+    OptionalExpr,
+    /// Parenthesised expression.
+    ParenExpr,
+}
+
+// `SyntaxKind` itself is the cstree `Syntax` type (via the derive above), so the tree
+// types are parameterised directly on it.
+
+/// A node in the (red) syntax tree.
+pub type SyntaxNode = cstree::syntax::SyntaxNode<SyntaxKind>;
+/// A token in the syntax tree.
+pub type SyntaxToken = cstree::syntax::SyntaxToken<SyntaxKind>;
+/// Either a node or a token.
+pub type SyntaxElement = cstree::syntax::SyntaxElement<SyntaxKind>;
+
+impl SyntaxKind {
+    /// Whether this kind is a token (terminal). Everything from [`SyntaxKind::Template`]
+    /// onward is an interior node.
+    pub fn is_token(self) -> bool {
+        self <= SyntaxKind::Error
+    }
+
+    /// Whether this kind is trivia (whitespace or comment) — skipped by the typed AST.
+    pub fn is_trivia(self) -> bool {
+        matches!(self, SyntaxKind::Whitespace | SyntaxKind::Comment)
+    }
+}

--- a/gingembre-syntax/src/parser.rs
+++ b/gingembre-syntax/src/parser.rs
@@ -1,0 +1,753 @@
+//! Recursive-descent + precedence parser that builds a lossless cstree from the lexer's
+//! token stream, with error recovery (it never bails — unexpected input becomes an
+//! `Error` token and parsing continues, which is what the LSP needs).
+//!
+//! Precedence (loosest → tightest), matching the legacy gingembre parser so lowering
+//! yields an identical AST:
+//! `ternary > or > and > not > comparison > add(+ - ~) > mul(* / // %) > unary(-) >
+//!  power(**) > filter(|) > postfix(. [] () ?) > primary`.
+
+use cstree::build::GreenNodeBuilder;
+use cstree::syntax::ResolvedNode;
+
+use crate::SyntaxKind::{self, *};
+use crate::lexer::{Lexeme, lex};
+
+/// A parse error: a message and the byte offset where it was detected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    pub message: String,
+    pub offset: usize,
+}
+
+/// The result of parsing: the resolved (red) tree plus any recovered errors.
+pub struct Parse {
+    root: ResolvedNode<SyntaxKind>,
+    pub errors: Vec<ParseError>,
+}
+
+impl Parse {
+    /// The root syntax node (text-resolving, so it `Display`s as the source).
+    pub fn syntax(&self) -> &ResolvedNode<SyntaxKind> {
+        &self.root
+    }
+}
+
+/// Parse a template source into a lossless CST.
+pub fn parse(src: &str) -> Parse {
+    let tokens = lex(src);
+    let mut p = Parser {
+        tokens,
+        pos: 0,
+        offset: 0,
+        builder: GreenNodeBuilder::new(),
+        errors: Vec::new(),
+    };
+    p.parse_template();
+    let (green, cache) = p.builder.finish();
+    let interner = cache.unwrap().into_interner().unwrap();
+    let root = ResolvedNode::new_root_with_resolver(green, interner);
+    Parse { root, errors: p.errors }
+}
+
+/// Convenience for parsing a bare expression (e.g. tests), wrapped in a `Template`.
+pub fn parse_expr_str(src: &str) -> Parse {
+    parse(&format!("{{{{ {src} }}}}"))
+}
+
+struct Parser<'src> {
+    tokens: Vec<Lexeme<'src>>,
+    pos: usize,
+    offset: usize,
+    builder: GreenNodeBuilder<'static, 'static, SyntaxKind>,
+    errors: Vec<ParseError>,
+}
+
+impl<'src> Parser<'src> {
+    // ----- token cursor (trivia-skipping for decisions, trivia-preserving in the tree) -----
+
+    fn is_trivia(k: SyntaxKind) -> bool {
+        matches!(k, Whitespace | Comment)
+    }
+
+    /// Kind of the n-th *non-trivia* token from the cursor, without consuming.
+    fn nth(&self, n: usize) -> Option<SyntaxKind> {
+        let mut seen = 0;
+        for t in &self.tokens[self.pos..] {
+            if Self::is_trivia(t.kind) {
+                continue;
+            }
+            if seen == n {
+                return Some(t.kind);
+            }
+            seen += 1;
+        }
+        None
+    }
+
+    fn at(&self, k: SyntaxKind) -> bool {
+        self.nth(0) == Some(k)
+    }
+
+    fn at_end(&self) -> bool {
+        self.nth(0).is_none()
+    }
+
+    /// Emit any pending trivia tokens into the tree.
+    fn eat_trivia(&mut self) {
+        while let Some(t) = self.tokens.get(self.pos) {
+            if !Self::is_trivia(t.kind) {
+                break;
+            }
+            self.builder.token(t.kind, t.text);
+            self.offset += t.text.len();
+            self.pos += 1;
+        }
+    }
+
+    /// Emit pending trivia, then the current (non-trivia) token, and advance.
+    fn bump(&mut self) {
+        self.eat_trivia();
+        if let Some(t) = self.tokens.get(self.pos) {
+            self.builder.token(t.kind, t.text);
+            self.offset += t.text.len();
+            self.pos += 1;
+        }
+    }
+
+    fn eat(&mut self, k: SyntaxKind) -> bool {
+        if self.at(k) {
+            self.bump();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn expect(&mut self, k: SyntaxKind) {
+        if !self.eat(k) {
+            self.error(format!("expected {k:?}, found {:?}", self.nth(0)));
+        }
+    }
+
+    fn error(&mut self, message: String) {
+        self.eat_trivia();
+        let offset = self.offset;
+        self.errors.push(ParseError { message, offset });
+        // Wrap the offending token (if any) in an Error node so the tree stays lossless.
+        if self.tokens.get(self.pos).is_some() {
+            self.builder.start_node(Error);
+            self.bump();
+            self.builder.finish_node();
+        }
+    }
+
+    fn start(&mut self, k: SyntaxKind) {
+        self.eat_trivia();
+        self.builder.start_node(k);
+    }
+
+    fn finish(&mut self) {
+        self.builder.finish_node();
+    }
+
+    // ----- template structure -----
+
+    fn parse_template(&mut self) {
+        self.builder.start_node(Template);
+        while !self.tokens.is_empty() && self.pos < self.tokens.len() {
+            match self.tokens[self.pos].kind {
+                Whitespace | Comment | Text => {
+                    let t = self.tokens[self.pos];
+                    self.builder.token(t.kind, t.text);
+                    self.offset += t.text.len();
+                    self.pos += 1;
+                }
+                OpenExpr | OpenExprTrim => self.parse_interpolation(),
+                OpenStmt | OpenStmtTrim => self.parse_statement(),
+                _ => {
+                    // Stray close-delimiter or other token in text position.
+                    let t = self.tokens[self.pos];
+                    self.builder.token(t.kind, t.text);
+                    self.offset += t.text.len();
+                    self.pos += 1;
+                }
+            }
+        }
+        self.builder.finish_node();
+    }
+
+    fn parse_interpolation(&mut self) {
+        self.builder.start_node(Interpolation);
+        self.bump(); // {{ or {{-
+        if !self.at(CloseExpr) && !self.at(CloseExprTrim) {
+            self.parse_expr();
+        }
+        if !self.eat(CloseExpr) {
+            self.expect(CloseExprTrim);
+        }
+        self.finish();
+    }
+
+    /// True if the next thing is `{%[-]` immediately followed by one of `kws`.
+    fn at_stmt_kw(&self, kws: &[SyntaxKind]) -> bool {
+        matches!(self.nth(0), Some(OpenStmt | OpenStmtTrim)) && matches!(self.nth(1), Some(k) if kws.contains(&k))
+    }
+
+    fn parse_statement(&mut self) {
+        let kw = self.nth(1);
+        match kw {
+            Some(IfKw) => self.parse_if(),
+            Some(ForKw) => self.parse_for(),
+            Some(SetKw) => self.parse_set(),
+            Some(BlockKw) => self.parse_block(),
+            Some(MacroKw) => self.parse_macro(),
+            Some(ExtendsKw) => self.parse_simple_stmt(ExtendsStmt),
+            Some(IncludeKw) => self.parse_simple_stmt(IncludeStmt),
+            Some(ImportKw) => self.parse_simple_stmt(ImportStmt),
+            Some(BreakKw) => self.parse_keyword_stmt(BreakStmt),
+            Some(ContinueKw) => self.parse_keyword_stmt(ContinueStmt),
+            _ => {
+                // Unknown / stray statement — consume the tag so we make progress.
+                self.builder.start_node(Statement);
+                self.open_tag();
+                self.close_tag();
+                self.finish();
+            }
+        }
+    }
+
+    /// Consume `{%` / `{%-` plus the keyword token.
+    fn open_tag(&mut self) {
+        self.bump(); // {% or {%-
+        self.bump(); // keyword
+    }
+
+    /// Consume `%}` / `-%}`.
+    fn close_tag(&mut self) {
+        if !self.eat(CloseStmt) {
+            self.expect(CloseStmtTrim);
+        }
+    }
+
+    fn parse_body(&mut self, terminators: &[SyntaxKind]) {
+        self.start(Body);
+        while self.pos < self.tokens.len() {
+            if self.at_stmt_kw(terminators) {
+                break;
+            }
+            match self.tokens[self.pos].kind {
+                Whitespace | Comment | Text => {
+                    let t = self.tokens[self.pos];
+                    self.builder.token(t.kind, t.text);
+                    self.offset += t.text.len();
+                    self.pos += 1;
+                }
+                OpenExpr | OpenExprTrim => self.parse_interpolation(),
+                OpenStmt | OpenStmtTrim => self.parse_statement(),
+                _ => {
+                    let t = self.tokens[self.pos];
+                    self.builder.token(t.kind, t.text);
+                    self.offset += t.text.len();
+                    self.pos += 1;
+                }
+            }
+        }
+        self.finish();
+    }
+
+    fn parse_if(&mut self) {
+        self.start(IfStmt);
+        self.open_tag(); // {% if
+        self.parse_expr();
+        self.close_tag();
+        self.parse_body(&[ElifKw, ElseKw, EndifKw]);
+        while self.at_stmt_kw(&[ElifKw]) {
+            self.start(ElifClause);
+            self.open_tag(); // {% elif
+            self.parse_expr();
+            self.close_tag();
+            self.parse_body(&[ElifKw, ElseKw, EndifKw]);
+            self.finish();
+        }
+        if self.at_stmt_kw(&[ElseKw]) {
+            self.start(ElseClause);
+            self.open_tag(); // {% else
+            self.close_tag();
+            self.parse_body(&[EndifKw]);
+            self.finish();
+        }
+        if self.at_stmt_kw(&[EndifKw]) {
+            self.open_tag();
+            self.close_tag();
+        } else {
+            self.error("unclosed {% if %} (expected {% endif %})".into());
+        }
+        self.finish();
+    }
+
+    fn parse_for(&mut self) {
+        self.start(ForStmt);
+        self.open_tag(); // {% for
+        self.expect(Ident); // loop var (could be `a, b` — accept a comma chain)
+        while self.eat(Comma) {
+            self.expect(Ident);
+        }
+        self.expect(InKw);
+        self.parse_expr();
+        self.close_tag();
+        self.parse_body(&[ElseKw, EndforKw]);
+        if self.at_stmt_kw(&[ElseKw]) {
+            self.start(ElseClause);
+            self.open_tag();
+            self.close_tag();
+            self.parse_body(&[EndforKw]);
+            self.finish();
+        }
+        if self.at_stmt_kw(&[EndforKw]) {
+            self.open_tag();
+            self.close_tag();
+        } else {
+            self.error("unclosed {% for %} (expected {% endfor %})".into());
+        }
+        self.finish();
+    }
+
+    fn parse_set(&mut self) {
+        self.start(SetStmt);
+        self.open_tag(); // {% set
+        self.expect(Ident);
+        if self.eat(Assign) {
+            // `{% set x = expr %}`
+            self.parse_expr();
+            self.close_tag();
+        } else {
+            // Block form: `{% set x %} … {% endset %}`
+            self.close_tag();
+            self.parse_body(&[EndsetKw]);
+            if self.at_stmt_kw(&[EndsetKw]) {
+                self.open_tag();
+                self.close_tag();
+            } else {
+                self.error("unclosed {% set %} block (expected {% endset %})".into());
+            }
+        }
+        self.finish();
+    }
+
+    fn parse_block(&mut self) {
+        self.start(BlockStmt);
+        self.open_tag(); // {% block
+        self.expect(Ident);
+        self.close_tag();
+        self.parse_body(&[EndblockKw]);
+        if self.at_stmt_kw(&[EndblockKw]) {
+            self.open_tag();
+            // optional trailing name before %}
+            self.eat(Ident);
+            self.close_tag();
+        } else {
+            self.error("unclosed {% block %} (expected {% endblock %})".into());
+        }
+        self.finish();
+    }
+
+    fn parse_macro(&mut self) {
+        self.start(MacroStmt);
+        self.open_tag(); // {% macro
+        self.expect(Ident);
+        self.parse_param_list();
+        self.close_tag();
+        self.parse_body(&[EndmacroKw]);
+        if self.at_stmt_kw(&[EndmacroKw]) {
+            self.open_tag();
+            self.close_tag();
+        } else {
+            self.error("unclosed {% macro %} (expected {% endmacro %})".into());
+        }
+        self.finish();
+    }
+
+    fn parse_param_list(&mut self) {
+        self.start(ParamList);
+        self.expect(LParen);
+        while !self.at(RParen) && !self.at_close_tag() && !self.at_end() {
+            self.start(Param);
+            self.expect(Ident);
+            if self.eat(Assign) {
+                self.parse_expr();
+            }
+            self.finish();
+            if !self.eat(Comma) {
+                break;
+            }
+        }
+        self.expect(RParen);
+        self.finish();
+    }
+
+    fn at_close_tag(&self) -> bool {
+        self.at(CloseStmt) || self.at(CloseStmtTrim)
+    }
+
+    /// `{% break %}` / `{% continue %}` — keyword-only statements.
+    fn parse_keyword_stmt(&mut self, kind: SyntaxKind) {
+        self.start(kind);
+        self.open_tag();
+        self.close_tag();
+        self.finish();
+    }
+
+    /// `{% extends/include/import EXPR [as name] %}`
+    fn parse_simple_stmt(&mut self, kind: SyntaxKind) {
+        self.start(kind);
+        self.open_tag();
+        if !self.at_close_tag() && !self.at_end() {
+            self.parse_expr();
+            if self.eat(AsKw) {
+                self.expect(Ident);
+            }
+        }
+        self.close_tag();
+        self.finish();
+    }
+
+    // ----- expressions (precedence climbing) -----
+
+    fn parse_expr(&mut self) {
+        self.parse_ternary();
+    }
+
+    fn parse_ternary(&mut self) {
+        let cp = self.builder.checkpoint();
+        self.parse_or();
+        if self.at(IfKw) {
+            self.start_at(cp, TernaryExpr);
+            self.bump(); // if
+            self.parse_or();
+            if self.eat(ElseKw) {
+                self.parse_expr();
+            }
+            self.finish();
+        }
+    }
+
+    /// Left-associative binary level: each `kinds` op wraps the running expr.
+    fn parse_binary(&mut self, kinds: &[SyntaxKind], next: fn(&mut Self)) {
+        let cp = self.builder.checkpoint();
+        next(self);
+        while self.nth(0).is_some_and(|k| kinds.contains(&k)) {
+            self.start_at(cp, BinaryExpr);
+            self.bump(); // operator
+            next(self);
+            self.finish();
+        }
+    }
+
+    fn parse_or(&mut self) {
+        self.parse_binary(&[OrKw], Self::parse_and);
+    }
+
+    fn parse_and(&mut self) {
+        self.parse_binary(&[AndKw], Self::parse_not);
+    }
+
+    fn parse_not(&mut self) {
+        if self.at(NotKw) {
+            self.start(UnaryExpr);
+            self.bump();
+            self.parse_not();
+            self.finish();
+        } else {
+            self.parse_comparison();
+        }
+    }
+
+    fn parse_comparison(&mut self) {
+        let cp = self.builder.checkpoint();
+        self.parse_add();
+        loop {
+            match self.nth(0) {
+                Some(EqEq | Neq | Lt | Gt | Le | Ge) => {
+                    self.start_at(cp, BinaryExpr);
+                    self.bump();
+                    self.parse_add();
+                    self.finish();
+                }
+                Some(InKw) => {
+                    self.start_at(cp, BinaryExpr);
+                    self.bump();
+                    self.parse_add();
+                    self.finish();
+                }
+                Some(NotKw) if self.nth(1) == Some(InKw) => {
+                    self.start_at(cp, BinaryExpr);
+                    self.bump(); // not
+                    self.bump(); // in
+                    self.parse_add();
+                    self.finish();
+                }
+                Some(IsKw) => {
+                    self.start_at(cp, TestExpr);
+                    self.bump(); // is
+                    self.eat(NotKw); // optional `not`
+                    // Test name is usually an Ident, but `none` lexes as a keyword.
+                    if !self.eat(Ident) && !self.eat(NoneKw) {
+                        self.error("expected a test name".into());
+                    }
+                    // optional test args `(...)`
+                    if self.at(LParen) {
+                        self.parse_arg_list();
+                    }
+                    self.finish();
+                }
+                _ => break,
+            }
+        }
+    }
+
+    fn parse_add(&mut self) {
+        self.parse_binary(&[Plus, Minus, Tilde], Self::parse_mul);
+    }
+
+    fn parse_mul(&mut self) {
+        self.parse_binary(&[Star, Slash, SlashSlash, Percent], Self::parse_unary);
+    }
+
+    fn parse_unary(&mut self) {
+        if self.at(Minus) {
+            self.start(UnaryExpr);
+            self.bump();
+            self.parse_unary();
+            self.finish();
+        } else {
+            self.parse_power();
+        }
+    }
+
+    fn parse_power(&mut self) {
+        let cp = self.builder.checkpoint();
+        self.parse_filter();
+        if self.at(StarStar) {
+            self.start_at(cp, BinaryExpr);
+            self.bump();
+            self.parse_unary(); // right-assoc-ish
+            self.finish();
+        }
+    }
+
+    fn parse_filter(&mut self) {
+        let cp = self.builder.checkpoint();
+        self.parse_postfix();
+        while self.at(Pipe) {
+            self.start_at(cp, FilterExpr);
+            self.bump(); // |
+            self.expect(Ident); // filter name
+            if self.at(LParen) {
+                self.parse_arg_list();
+            }
+            self.finish();
+        }
+    }
+
+    fn parse_postfix(&mut self) {
+        let cp = self.builder.checkpoint();
+        self.parse_primary();
+        loop {
+            match self.nth(0) {
+                Some(Dot) => {
+                    self.start_at(cp, FieldExpr);
+                    self.bump(); // .
+                    self.expect(Ident);
+                    self.finish();
+                }
+                Some(LBracket) => {
+                    // index or slice
+                    self.start_at(cp, IndexExpr);
+                    self.bump(); // [
+                    self.parse_subscript();
+                    self.expect(RBracket);
+                    self.finish();
+                }
+                Some(LParen) => {
+                    self.start_at(cp, CallExpr);
+                    self.parse_arg_list();
+                    self.finish();
+                }
+                Some(Question) => {
+                    self.start_at(cp, OptionalExpr);
+                    self.bump(); // ?
+                    self.finish();
+                }
+                _ => break,
+            }
+        }
+    }
+
+    /// Inside `[ … ]`: an index `expr`, or a slice `expr? : expr?`.
+    fn parse_subscript(&mut self) {
+        if !self.at(Colon) {
+            self.parse_expr();
+        }
+        if self.at(Colon) {
+            // turn the enclosing node into a slice by tagging a SliceExpr child marker:
+            // we simply consume `:` and an optional end expr; the IndexExpr node holding a
+            // Colon child is recognised as a slice during lowering.
+            self.bump(); // :
+            if !self.at(RBracket) {
+                self.parse_expr();
+            }
+        }
+    }
+
+    fn parse_arg_list(&mut self) {
+        self.start(ArgList);
+        self.expect(LParen);
+        while !self.at(RParen) && !self.at_end() {
+            // kwarg = `ident = expr`, detected by peeking `ident =`.
+            if self.nth(0) == Some(Ident) && self.nth(1) == Some(Assign) {
+                self.start(KwArg);
+                self.bump(); // ident
+                self.bump(); // =
+                self.parse_expr();
+                self.finish();
+            } else {
+                self.start(Arg);
+                self.parse_expr();
+                self.finish();
+            }
+            if !self.eat(Comma) {
+                break;
+            }
+        }
+        self.expect(RParen);
+        self.finish();
+    }
+
+    fn parse_primary(&mut self) {
+        match self.nth(0) {
+            Some(Int | Float | Str | True | False | NoneKw) => {
+                self.start(Literal);
+                self.bump();
+                self.finish();
+            }
+            Some(Ident) if self.nth(1) == Some(ColonColon) => {
+                // `namespace::macro(args)` explicit macro call.
+                self.start(MacroCallExpr);
+                self.bump(); // namespace
+                self.bump(); // ::
+                self.expect(Ident); // macro name
+                if self.at(LParen) {
+                    self.parse_arg_list();
+                }
+                self.finish();
+            }
+            Some(Ident) => {
+                self.start(VarRef);
+                self.bump();
+                self.finish();
+            }
+            Some(LParen) => {
+                self.start(ParenExpr);
+                self.bump(); // (
+                self.parse_expr();
+                self.expect(RParen);
+                self.finish();
+            }
+            Some(LBracket) => self.parse_list(),
+            Some(LBrace) => self.parse_dict(),
+            Some(Minus | NotKw) => {
+                // unary fell through (e.g. `-x` reached here): handle gracefully.
+                self.start(UnaryExpr);
+                self.bump();
+                self.parse_primary();
+                self.finish();
+            }
+            _ => self.error("expected an expression".into()),
+        }
+    }
+
+    fn parse_list(&mut self) {
+        self.start(ListLit);
+        self.expect(LBracket);
+        while !self.at(RBracket) && !self.at_end() {
+            self.parse_expr();
+            if !self.eat(Comma) {
+                break;
+            }
+        }
+        self.expect(RBracket);
+        self.finish();
+    }
+
+    fn parse_dict(&mut self) {
+        self.start(DictLit);
+        self.expect(LBrace);
+        while !self.at(RBrace) && !self.at_end() {
+            self.parse_expr(); // key
+            self.expect(Colon);
+            self.parse_expr(); // value
+            if !self.eat(Comma) {
+                break;
+            }
+        }
+        self.expect(RBrace);
+        self.finish();
+    }
+
+    fn start_at(&mut self, cp: cstree::build::Checkpoint, kind: SyntaxKind) {
+        self.builder.start_node_at(cp, kind);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Render the tree shape compactly for snapshotting.
+    fn tree(src: &str) -> String {
+        let p = parse(src);
+        assert!(p.errors.is_empty(), "unexpected errors: {:?}", p.errors);
+        // Lossless check: the resolved tree Displays as the source.
+        assert_eq!(p.syntax().to_string(), src, "tree not lossless");
+        format!("{:#?}", p.syntax())
+    }
+
+    #[test]
+    fn lossless_roundtrip() {
+        for src in [
+            "hello",
+            "a {{ x }} b",
+            "{%- if a is not defined -%}x{%- endif -%}",
+            "{{ macros.youtube_embed(id, alt=x) }}",
+            "{{ a.b.c | upper | safe }}",
+            "{{ items[:3] }}",
+            "{{ a + b * c ~ \"x\" }}",
+            "{{ a if cond else b }}",
+            "{% for x in xs %}{{ x }}{% else %}none{% endfor %}",
+            "{% set n = 1 %}",
+            "{% block content %}hi{% endblock %}",
+            "{% macro m(a, b=1) %}{{ a }}{% endmacro %}",
+            "{{ latest_article.reading_time }}",
+            "{{ f(a.b, k=c.d) }}",
+        ] {
+            let p = parse(src);
+            assert_eq!(p.syntax().to_string(), src, "not lossless: {src:?}");
+            assert!(p.errors.is_empty(), "errors for {src:?}: {:?}", p.errors);
+        }
+    }
+
+    #[test]
+    fn field_access_in_call_arg() {
+        // The exact construct the old parser choked on.
+        let p = parse("{{ render_reading_time(latest_article.reading_time) }}");
+        assert!(p.errors.is_empty(), "errors: {:?}", p.errors);
+    }
+
+    #[test]
+    fn snapshot_binary_precedence() {
+        // a + b * c  →  Binary(a, +, Binary(b, *, c))
+        let t = tree("{{ a + b * c }}");
+        assert!(t.contains("BinaryExpr"), "{t}");
+    }
+}

--- a/gingembre/Cargo.toml
+++ b/gingembre/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "gingembre"
+version = "0.0.0"
+edition = "2024"
+rust-version = "1.91"
+authors = ["Amos Wenger <amos@bearcove.eu>"]
+license = "MIT OR Apache-2.0"
+description = "A Jinja-like template engine with rich diagnostics"
+repository = "https://github.com/bearcove/dodeca"
+keywords = ["template", "jinja", "templating"]
+categories = ["template-engine", "web-programming"]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[package.metadata."docs.rs"]
+rustdoc-args = ["--html-in-header", "arborium-header.html"]
+
+[dependencies]
+gingembre-syntax = { path = "../gingembre-syntax" }
+camino.workspace = true
+facet.workspace = true
+facet-value.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+ariadne.workspace = true
+
+# Async support
+futures.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/gingembre/README.md
+++ b/gingembre/README.md
@@ -1,0 +1,53 @@
+# gingembre
+
+[![MIT + Apache 2.0](https://img.shields.io/badge/license-MIT%20%2B%20Apache%202.0-blue)](./LICENSE-MIT)
+[![salsa | yes please](https://img.shields.io/badge/salsa-yes%20please-green)](https://crates.io/crates/salsa)
+
+`gingembre` is a Jinja-like template engine with rich error diagnostics.
+
+It supports template inheritance, macros, filters, and lazy data resolution,
+and is used by dodeca for all HTML templating.
+
+This crate is part of the Dodeca workspace.
+
+
+## Sponsors
+
+Thanks to all individual sponsors:
+
+<p> <a href="https://github.com/sponsors/fasterthanlime">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="./static/sponsors-v3/github-dark.svg">
+<img src="./static/sponsors-v3/github-light.svg" height="40" alt="GitHub Sponsors">
+</picture>
+</a> <a href="https://patreon.com/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./static/sponsors-v3/patreon-dark.svg">
+    <img src="./static/sponsors-v3/patreon-light.svg" height="40" alt="Patreon">
+    </picture>
+</a> </p>
+
+...along with corporate sponsors:
+
+<p> <a href="https://aws.amazon.com">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="./static/sponsors-v3/aws-dark.svg">
+<img src="./static/sponsors-v3/aws-light.svg" height="40" alt="AWS">
+</picture>
+</a> <a href="https://zed.dev">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="./static/sponsors-v3/zed-dark.svg">
+<img src="./static/sponsors-v3/zed-light.svg" height="40" alt="Zed">
+</picture>
+</a> </p>
+
+...without whom this work could not exist.
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](./LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](./LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/gingembre/README.md.in
+++ b/gingembre/README.md.in
@@ -1,0 +1,6 @@
+`gingembre` is a Jinja-like template engine with rich error diagnostics.
+
+It supports template inheritance, macros, filters, and lazy data resolution,
+and is used by dodeca for all HTML templating.
+
+This crate is part of the Dodeca workspace.

--- a/gingembre/arborium-header.html
+++ b/gingembre/arborium-header.html
@@ -1,0 +1,2 @@
+<!-- Rustdoc doesn't highlight some languages natively -- let's do it ourselves: https://github.com/bearcove/arborium -->
+<script defer src="https://cdn.jsdelivr.net/npm/@arborium/arborium@2/dist/arborium.iife.js"></script>

--- a/gingembre/src/ast.rs
+++ b/gingembre/src/ast.rs
@@ -1,0 +1,507 @@
+//! AST nodes for the template language
+//!
+//! Every node carries a [`Span`] for precise error reporting.
+//! The AST is designed to be parsed once and evaluated many times.
+
+use super::error::SourceSpan;
+
+/// A span in the source (offset, length)
+pub type Span = SourceSpan;
+
+/// Create a span from offset and length
+pub fn span(offset: usize, len: usize) -> Span {
+    SourceSpan::new(offset, len)
+}
+
+/// A complete parsed template
+#[derive(Debug, Clone)]
+pub struct Template {
+    /// The template body (sequence of nodes)
+    pub body: Vec<Node>,
+    /// Full span of the template
+    pub span: Span,
+}
+
+/// A node in the template AST
+#[derive(Debug, Clone)]
+pub enum Node {
+    /// Raw text (passed through unchanged)
+    Text(TextNode),
+    /// Expression interpolation: {{ expr }}
+    Print(PrintNode),
+    /// If statement: {% if cond %}...{% endif %}
+    If(IfNode),
+    /// For loop: {% for item in items %}...{% endfor %}
+    For(ForNode),
+    /// Include: {% include "path" %}
+    Include(IncludeNode),
+    /// Block definition: {% block name %}...{% endblock %}
+    Block(BlockNode),
+    /// Extends: {% extends "path" %}
+    Extends(ExtendsNode),
+    /// Comment: {# comment #}
+    Comment(CommentNode),
+    /// Set statement: {% set var = expr %}
+    Set(SetNode),
+    /// Import: {% import "path" as name %}
+    Import(ImportNode),
+    /// Macro definition: {% macro name(args) %}...{% endmacro %}
+    Macro(MacroNode),
+    /// Continue statement: {% continue %}
+    Continue(ContinueNode),
+    /// Break statement: {% break %}
+    Break(BreakNode),
+    /// Call block: {% call func(kwargs) %}raw content{% endcall %}
+    CallBlock(CallBlockNode),
+}
+
+impl Node {
+    pub fn span(&self) -> Span {
+        match self {
+            Node::Text(n) => n.span,
+            Node::Print(n) => n.span,
+            Node::If(n) => n.span,
+            Node::For(n) => n.span,
+            Node::Include(n) => n.span,
+            Node::Block(n) => n.span,
+            Node::Extends(n) => n.span,
+            Node::Comment(n) => n.span,
+            Node::Set(n) => n.span,
+            Node::Import(n) => n.span,
+            Node::Macro(n) => n.span,
+            Node::Continue(n) => n.span,
+            Node::Break(n) => n.span,
+            Node::CallBlock(n) => n.span,
+        }
+    }
+}
+
+/// Raw text node
+#[derive(Debug, Clone)]
+pub struct TextNode {
+    pub text: String,
+    pub span: Span,
+}
+
+/// Expression print: {{ expr }}
+#[derive(Debug, Clone)]
+pub struct PrintNode {
+    pub expr: Expr,
+    pub span: Span,
+}
+
+/// If statement
+#[derive(Debug, Clone)]
+pub struct IfNode {
+    /// The condition expression
+    pub condition: Expr,
+    /// Body if condition is true
+    pub then_body: Vec<Node>,
+    /// Optional elif branches
+    pub elif_branches: Vec<ElifBranch>,
+    /// Optional else body
+    pub else_body: Option<Vec<Node>>,
+    /// Full span from {% if %} to {% endif %}
+    pub span: Span,
+}
+
+/// An elif branch
+#[derive(Debug, Clone)]
+pub struct ElifBranch {
+    pub condition: Expr,
+    pub body: Vec<Node>,
+    pub span: Span,
+}
+
+/// For loop
+#[derive(Debug, Clone)]
+pub struct ForNode {
+    /// Loop variable name (or names for tuple unpacking)
+    pub target: Target,
+    /// Expression to iterate over
+    pub iter: Expr,
+    /// Loop body
+    pub body: Vec<Node>,
+    /// Optional else body (if iter is empty)
+    pub else_body: Option<Vec<Node>>,
+    /// Full span from {% for %} to {% endfor %}
+    pub span: Span,
+}
+
+/// Loop target (variable binding)
+#[derive(Debug, Clone)]
+pub enum Target {
+    /// Single variable: `for item in items`
+    Single { name: String, span: Span },
+    /// Tuple unpacking: `for key, value in items`
+    Tuple {
+        names: Vec<(String, Span)>,
+        span: Span,
+    },
+}
+
+impl Target {
+    pub fn span(&self) -> Span {
+        match self {
+            Target::Single { span, .. } => *span,
+            Target::Tuple { span, .. } => *span,
+        }
+    }
+}
+
+/// Include another template
+#[derive(Debug, Clone)]
+pub struct IncludeNode {
+    pub path: StringLit,
+    /// Optional context override
+    pub context: Option<Expr>,
+    pub span: Span,
+}
+
+/// Block definition (for inheritance)
+#[derive(Debug, Clone)]
+pub struct BlockNode {
+    pub name: Ident,
+    pub body: Vec<Node>,
+    pub span: Span,
+}
+
+/// Extends a parent template
+#[derive(Debug, Clone)]
+pub struct ExtendsNode {
+    pub path: StringLit,
+    pub span: Span,
+}
+
+/// Comment node (for AST completeness, usually ignored)
+#[derive(Debug, Clone)]
+pub struct CommentNode {
+    pub text: String,
+    pub span: Span,
+}
+
+/// Set statement: `{% set var = expr %}` or `{% set var %}…{% endset %}`.
+#[derive(Debug, Clone)]
+pub struct SetNode {
+    pub name: Ident,
+    pub value: SetValue,
+    pub span: Span,
+}
+
+/// What a `{% set %}` binds its variable to.
+#[derive(Debug, Clone)]
+pub enum SetValue {
+    /// `{% set x = expr %}` — bind the evaluated expression.
+    Expr(Expr),
+    /// `{% set x %}…{% endset %}` — render the body and bind the resulting string.
+    Body(Vec<Node>),
+}
+
+/// Import statement: {% import "path" as name %}
+#[derive(Debug, Clone)]
+pub struct ImportNode {
+    pub path: StringLit,
+    pub alias: Ident,
+    pub span: Span,
+}
+
+/// Macro definition: {% macro name(args) %}...{% endmacro %}
+#[derive(Debug, Clone)]
+pub struct MacroNode {
+    pub name: Ident,
+    pub params: Vec<MacroParam>,
+    pub body: Vec<Node>,
+    pub span: Span,
+}
+
+/// A macro parameter with optional default value
+#[derive(Debug, Clone)]
+pub struct MacroParam {
+    pub name: Ident,
+    pub default: Option<Expr>,
+}
+
+/// Continue statement: {% continue %}
+#[derive(Debug, Clone)]
+pub struct ContinueNode {
+    pub span: Span,
+}
+
+/// Break statement: {% break %}
+#[derive(Debug, Clone)]
+pub struct BreakNode {
+    pub span: Span,
+}
+
+/// Call block: {% call func(kwargs) %}raw content{% endcall %}
+///
+/// Captures the raw text between the opening and closing tags and passes it
+/// to the named function as the `body` kwarg.
+#[derive(Debug, Clone)]
+pub struct CallBlockNode {
+    pub func_name: Ident,
+    pub kwargs: Vec<(Ident, Expr)>,
+    pub raw_content: String,
+    pub span: Span,
+}
+
+// ============================================================================
+// Expressions
+// ============================================================================
+
+/// An expression
+#[derive(Debug, Clone)]
+pub enum Expr {
+    /// Literal value
+    Literal(Literal),
+    /// Variable reference
+    Var(Ident),
+    /// Field access: expr.field
+    Field(FieldExpr),
+    /// Index access: `expr[index]`
+    Index(IndexExpr),
+    /// Filter application: expr | filter
+    Filter(FilterExpr),
+    /// Binary operation: expr op expr
+    Binary(BinaryExpr),
+    /// Unary operation: op expr
+    Unary(UnaryExpr),
+    /// Function/method call: func(args)
+    Call(CallExpr),
+    /// Ternary: expr if cond else expr
+    Ternary(TernaryExpr),
+    /// Test expression: expr is test_name or expr is not test_name
+    Test(TestExpr),
+    /// Macro call: namespace::macro(args) or self::macro(args)
+    MacroCall(MacroCallExpr),
+    /// Lenient access: `expr?` — yields null instead of raising if `expr` is undefined.
+    Optional(OptionalExpr),
+}
+
+impl Expr {
+    pub fn span(&self) -> Span {
+        match self {
+            Expr::Literal(l) => l.span(),
+            Expr::Var(i) => i.span,
+            Expr::Field(f) => f.span,
+            Expr::Index(i) => i.span,
+            Expr::Filter(f) => f.span,
+            Expr::Binary(b) => b.span,
+            Expr::Unary(u) => u.span,
+            Expr::Call(c) => c.span,
+            Expr::Ternary(t) => t.span,
+            Expr::Test(t) => t.span,
+            Expr::MacroCall(m) => m.span,
+            Expr::Optional(o) => o.span,
+        }
+    }
+}
+
+/// Lenient access expression: `expr?`
+#[derive(Debug, Clone)]
+pub struct OptionalExpr {
+    pub expr: Box<Expr>,
+    pub span: Span,
+}
+
+/// A literal value
+#[derive(Debug, Clone)]
+pub enum Literal {
+    String(StringLit),
+    Int(IntLit),
+    Float(FloatLit),
+    Bool(BoolLit),
+    None(NoneLit),
+    List(ListLit),
+    Dict(DictLit),
+}
+
+impl Literal {
+    pub fn span(&self) -> Span {
+        match self {
+            Literal::String(l) => l.span,
+            Literal::Int(l) => l.span,
+            Literal::Float(l) => l.span,
+            Literal::Bool(l) => l.span,
+            Literal::None(l) => l.span,
+            Literal::List(l) => l.span,
+            Literal::Dict(l) => l.span,
+        }
+    }
+}
+
+/// String literal
+#[derive(Debug, Clone)]
+pub struct StringLit {
+    pub value: String,
+    pub span: Span,
+}
+
+/// Integer literal
+#[derive(Debug, Clone)]
+pub struct IntLit {
+    pub value: i64,
+    pub span: Span,
+}
+
+/// Float literal
+#[derive(Debug, Clone)]
+pub struct FloatLit {
+    pub value: f64,
+    pub span: Span,
+}
+
+/// Boolean literal
+#[derive(Debug, Clone)]
+pub struct BoolLit {
+    pub value: bool,
+    pub span: Span,
+}
+
+/// None literal
+#[derive(Debug, Clone)]
+pub struct NoneLit {
+    pub span: Span,
+}
+
+/// List literal: [a, b, c]
+#[derive(Debug, Clone)]
+pub struct ListLit {
+    pub elements: Vec<Expr>,
+    pub span: Span,
+}
+
+/// Dict literal: {a: b, c: d}
+#[derive(Debug, Clone)]
+pub struct DictLit {
+    pub entries: Vec<(Expr, Expr)>,
+    pub span: Span,
+}
+
+/// An identifier
+#[derive(Debug, Clone)]
+pub struct Ident {
+    pub name: String,
+    pub span: Span,
+}
+
+/// Field access: expr.field
+#[derive(Debug, Clone)]
+pub struct FieldExpr {
+    pub base: Box<Expr>,
+    pub field: Ident,
+    pub span: Span,
+}
+
+/// Index access: `expr[index]`
+#[derive(Debug, Clone)]
+pub struct IndexExpr {
+    pub base: Box<Expr>,
+    pub index: Box<Expr>,
+    pub span: Span,
+}
+
+/// Filter application: expr | filter or expr | filter(args, key=value)
+#[derive(Debug, Clone)]
+pub struct FilterExpr {
+    pub expr: Box<Expr>,
+    pub filter: Ident,
+    pub args: Vec<Expr>,
+    pub kwargs: Vec<(Ident, Expr)>,
+    pub span: Span,
+}
+
+/// Binary expression
+#[derive(Debug, Clone)]
+pub struct BinaryExpr {
+    pub left: Box<Expr>,
+    pub op: BinaryOp,
+    pub right: Box<Expr>,
+    pub span: Span,
+}
+
+/// Binary operators
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOp {
+    // Arithmetic
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    FloorDiv,
+    Pow,
+    // Comparison
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    // Logical
+    And,
+    Or,
+    // Membership
+    In,
+    NotIn,
+    // String
+    Concat,
+}
+
+/// Unary expression
+#[derive(Debug, Clone)]
+pub struct UnaryExpr {
+    pub op: UnaryOp,
+    pub expr: Box<Expr>,
+    pub span: Span,
+}
+
+/// Unary operators
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnaryOp {
+    Not,
+    Neg,
+    Pos,
+}
+
+/// Function/method call
+#[derive(Debug, Clone)]
+pub struct CallExpr {
+    pub func: Box<Expr>,
+    pub args: Vec<Expr>,
+    pub kwargs: Vec<(Ident, Expr)>,
+    pub span: Span,
+}
+
+/// Ternary expression: value if cond else other
+#[derive(Debug, Clone)]
+pub struct TernaryExpr {
+    pub value: Box<Expr>,
+    pub condition: Box<Expr>,
+    pub otherwise: Box<Expr>,
+    pub span: Span,
+}
+
+/// Test expression: expr is test_name or expr is not test_name(args)
+#[derive(Debug, Clone)]
+pub struct TestExpr {
+    pub expr: Box<Expr>,
+    pub test_name: Ident,
+    pub args: Vec<Expr>,
+    pub negated: bool,
+    pub span: Span,
+}
+
+/// Macro call expression: namespace::macro_name(args) or self::macro_name(args)
+#[derive(Debug, Clone)]
+pub struct MacroCallExpr {
+    /// The namespace (e.g., "macros" or "self")
+    pub namespace: Ident,
+    /// The macro name
+    pub macro_name: Ident,
+    /// Positional arguments
+    pub args: Vec<Expr>,
+    /// Keyword arguments
+    pub kwargs: Vec<(Ident, Expr)>,
+    pub span: Span,
+}

--- a/gingembre/src/cst_lower.rs
+++ b/gingembre/src/cst_lower.rs
@@ -1,0 +1,519 @@
+//! Bridge: lower the cstree typed views (`gingembre_syntax::ast`) into the engine's
+//! existing `ast::Expr`/`Node` so the new parser drives the unchanged eval/render.
+//!
+//! INTERIM: the correctness bar is rendered output, not AST parity, so spans are derived
+//! from CST text ranges (more accurate than the old parser's) and need not match the old
+//! ones. The end state is to evaluate directly off the typed views and delete `ast.rs`;
+//! this bridge gets the engine green on the cstree parser first, then that follows.
+
+use gingembre_syntax::ResolvedNode;
+use gingembre_syntax::ast as cst;
+
+use crate::ast::{self, BinaryOp, Expr, Ident, Span, UnaryOp};
+
+/// Span covering a CST node.
+fn sp(node: &ResolvedNode) -> Span {
+    let r = node.text_range();
+    ast::span(usize::from(r.start()), usize::from(r.len()))
+}
+
+fn ident(name: &str, node: &ResolvedNode) -> Ident {
+    // Use the matching Ident token's own range (the semantic index / LSP keys references
+    // on ident spans), not the enclosing node's.
+    let span = node
+        .children_with_tokens()
+        .filter_map(|e| e.into_token())
+        .find(|t| t.kind() == gingembre_syntax::SyntaxKind::Ident && t.text() == name)
+        .map(|t| ast::span(usize::from(t.text_range().start()), t.text().len()))
+        .unwrap_or_else(|| sp(node));
+    Ident {
+        name: name.to_string(),
+        span,
+    }
+}
+
+/// Lower a typed-CST expression to an engine `Expr`.
+pub fn lower_expr(e: &cst::Expr) -> Expr {
+    let node = e.syntax();
+    let span = sp(node);
+    match e {
+        cst::Expr::Literal(l) => Expr::Literal(lower_literal(l, span)),
+        cst::Expr::Var(v) => Expr::Var(Ident {
+            name: v.name().unwrap_or_default().to_string(),
+            span,
+        }),
+        cst::Expr::Paren(p) => p
+            .inner()
+            .map(|i| lower_expr(&i))
+            .unwrap_or(Expr::Literal(ast::Literal::None(ast::NoneLit { span }))),
+        cst::Expr::Field(f) => Expr::Field(ast::FieldExpr {
+            base: Box::new(opt_expr(f.base(), span)),
+            field: ident(f.field().unwrap_or_default(), node),
+            span,
+        }),
+        cst::Expr::Index(i) => Expr::Index(ast::IndexExpr {
+            base: Box::new(opt_expr(i.base(), span)),
+            // Slices aren't a first-class engine Expr; use the (end) index expression, or
+            // a None placeholder for a bare `[:]`. (Refine when porting eval off the CST.)
+            index: Box::new(opt_expr(i.index(), span)),
+            span,
+        }),
+        cst::Expr::Call(c) => {
+            let (args, kwargs) = lower_args(c.args());
+            Expr::Call(ast::CallExpr {
+                func: Box::new(opt_expr(c.callee(), span)),
+                args,
+                kwargs,
+                span,
+            })
+        }
+        cst::Expr::MacroCall(m) => {
+            let (args, kwargs) = lower_args(m.args());
+            Expr::MacroCall(ast::MacroCallExpr {
+                namespace: ident(m.namespace().unwrap_or_default(), node),
+                macro_name: ident(m.name().unwrap_or_default(), node),
+                args,
+                kwargs,
+                span,
+            })
+        }
+        cst::Expr::Filter(f) => {
+            let (args, kwargs) = lower_args(f.args());
+            Expr::Filter(ast::FilterExpr {
+                expr: Box::new(opt_expr(f.base(), span)),
+                filter: ident(f.name().unwrap_or_default(), node),
+                args,
+                kwargs,
+                span,
+            })
+        }
+        cst::Expr::Test(t) => {
+            let (args, _) = lower_args(t.args());
+            Expr::Test(ast::TestExpr {
+                expr: Box::new(opt_expr(t.base(), span)),
+                test_name: ident(t.name().unwrap_or_default(), node),
+                args,
+                negated: t.negated(),
+                span,
+            })
+        }
+        cst::Expr::Ternary(t) => Expr::Ternary(ast::TernaryExpr {
+            value: Box::new(opt_expr(t.value(), span)),
+            condition: Box::new(opt_expr(t.condition(), span)),
+            otherwise: Box::new(opt_expr(t.otherwise(), span)),
+            span,
+        }),
+        cst::Expr::Binary(b) => Expr::Binary(ast::BinaryExpr {
+            left: Box::new(opt_expr(b.lhs(), span)),
+            op: lower_binop(b.op()),
+            right: Box::new(opt_expr(b.rhs(), span)),
+            span,
+        }),
+        cst::Expr::Unary(u) => Expr::Unary(ast::UnaryExpr {
+            op: match u.op() {
+                Some(cst::UnOp::Not) => UnaryOp::Not,
+                _ => UnaryOp::Neg,
+            },
+            expr: Box::new(opt_expr(u.operand(), span)),
+            span,
+        }),
+        cst::Expr::Optional(o) => Expr::Optional(ast::OptionalExpr {
+            expr: Box::new(opt_expr(o.operand(), span)),
+            span,
+        }),
+        cst::Expr::List(l) => Expr::Literal(ast::Literal::List(ast::ListLit {
+            elements: l.elements().map(|x| lower_expr(&x)).collect(),
+            span,
+        })),
+        cst::Expr::Dict(d) => Expr::Literal(ast::Literal::Dict(ast::DictLit {
+            entries: d
+                .entries()
+                .iter()
+                .map(|(k, v)| (lower_expr(k), lower_expr(v)))
+                .collect(),
+            span,
+        })),
+    }
+}
+
+fn opt_expr(e: Option<cst::Expr>, span: Span) -> Expr {
+    e.map(|x| lower_expr(&x))
+        .unwrap_or(Expr::Literal(ast::Literal::None(ast::NoneLit { span })))
+}
+
+fn lower_literal(l: &cst::Literal, span: Span) -> ast::Literal {
+    match l.value() {
+        cst::LitValue::Str(s) => ast::Literal::String(ast::StringLit { value: s, span }),
+        cst::LitValue::Int(i) => ast::Literal::Int(ast::IntLit { value: i, span }),
+        cst::LitValue::Float(f) => ast::Literal::Float(ast::FloatLit { value: f, span }),
+        cst::LitValue::Bool(b) => ast::Literal::Bool(ast::BoolLit { value: b, span }),
+        cst::LitValue::None => ast::Literal::None(ast::NoneLit { span }),
+    }
+}
+
+fn lower_args(args: Option<cst::ArgList>) -> (Vec<Expr>, Vec<(Ident, Expr)>) {
+    let Some(args) = args else {
+        return (Vec::new(), Vec::new());
+    };
+    let pos = args.positional().map(|e| lower_expr(&e)).collect();
+    let kw = args
+        .keyword()
+        .map(|(name, e)| {
+            let span = sp(e.syntax());
+            (Ident { name, span }, lower_expr(&e))
+        })
+        .collect();
+    (pos, kw)
+}
+
+use crate::ast::{
+    BlockNode, ElifBranch, ExtendsNode, ForNode, IfNode, ImportNode, IncludeNode, MacroNode,
+    MacroParam, Node, PrintNode, SetNode, SetValue, StringLit, Target, TextNode,
+};
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    /// Per-parse map: byte offset of each Text run → (trim_leading, trim_trailing),
+    /// computed from flat token adjacency (whitespace control crosses tree boundaries).
+    static TRIM: RefCell<HashMap<usize, (bool, bool)>> = RefCell::new(HashMap::new());
+}
+
+/// Compute whitespace-control trim flags for every Text run from the flat lexeme stream.
+fn compute_trim(src: &str) -> HashMap<usize, (bool, bool)> {
+    use gingembre_syntax::SyntaxKind::*;
+    let lex = gingembre_syntax::lex(src);
+    let mut map = HashMap::new();
+    let mut offset = 0usize;
+    for (i, lx) in lex.iter().enumerate() {
+        if lx.kind == Text {
+            let lead = i > 0 && matches!(lex[i - 1].kind, CloseStmtTrim | CloseExprTrim);
+            let trail = i + 1 < lex.len() && matches!(lex[i + 1].kind, OpenStmtTrim | OpenExprTrim);
+            map.insert(offset, (lead, trail));
+        }
+        offset += lx.text.len();
+    }
+    map
+}
+
+/// Parse a template via the cstree front-end, returning the engine AST or the first
+/// parse error as a `TemplateError`. This is the single parse entry shared by the engine
+/// (`Template::parse`) and the authoring LSP — there is no longer a separate hand-written
+/// parser doing the work.
+pub fn parse_template(
+    name: impl Into<String>,
+    src: impl AsRef<str>,
+) -> Result<crate::ast::Template, crate::error::TemplateError> {
+    let src = src.as_ref();
+    let (ast, errors) = parse_to_template(src);
+    if let Some(e) = errors.first() {
+        let ts = crate::error::TemplateSource::new(name.into(), src);
+        return Err(crate::error::SyntaxError {
+            found: "end of input".to_string(),
+            expected: e.message.clone(),
+            loc: crate::error::SourceLocation::new(ast::span(e.offset, 1), ts.named_source()),
+        }
+        .into());
+    }
+    Ok(ast)
+}
+
+/// Parse a standalone expression (REPL / `eval_expression`) via the cstree parser.
+pub fn parse_expression(src: &str) -> Result<Expr, crate::error::TemplateError> {
+    use gingembre_syntax::ast::AstNode;
+    let p = gingembre_syntax::parse_expr_str(src);
+    let expr = cst::Template::cast(p.syntax().clone()).and_then(|t| {
+        t.items().into_iter().find_map(|i| match i {
+            cst::Item::Interpolation(interp) => interp.expr(),
+            _ => None,
+        })
+    });
+    match expr {
+        Some(e) => Ok(lower_expr(&e)),
+        None => {
+            let ts = crate::error::TemplateSource::new("<expr>", src);
+            Err(crate::error::SyntaxError {
+                found: "end of input".to_string(),
+                expected: "an expression".to_string(),
+                loc: crate::error::SourceLocation::new(ast::span(0, src.len()), ts.named_source()),
+            }
+            .into())
+        }
+    }
+}
+
+/// Parse leniently (recovery): always returns a (best-effort) template, ignoring parse
+/// errors. Replaces the old `Parser::parse_recovered().template`.
+pub fn parse_template_recovered(src: impl AsRef<str>) -> crate::ast::Template {
+    parse_to_template(src.as_ref()).0
+}
+
+/// Parse `src` with the cstree parser and lower it to the engine's template AST.
+///
+/// The parser recovers (produces a usable tree even with errors); error *surfacing* to
+/// the engine's `TemplateError` is a follow-up. The bar is render output, and the real
+/// ftl corpus parses clean.
+pub fn parse_to_template(src: &str) -> (crate::ast::Template, Vec<gingembre_syntax::ParseError>) {
+    use gingembre_syntax::ast::AstNode;
+    let parse = gingembre_syntax::parse(src);
+    TRIM.with(|t| *t.borrow_mut() = compute_trim(src));
+    let body = cst::Template::cast(parse.syntax().clone())
+        .map(|t| lower_items(&t.items()))
+        .unwrap_or_default();
+    TRIM.with(|t| t.borrow_mut().clear());
+    (
+        crate::ast::Template {
+            body,
+            span: ast::span(0, src.len()),
+        },
+        parse.errors,
+    )
+}
+
+fn lower_items(items: &[cst::Item]) -> Vec<Node> {
+    let mut out = Vec::new();
+    for (i, item) in items.iter().enumerate() {
+        match item {
+            cst::Item::Text(tok) => {
+                if tok.kind() == gingembre_syntax::SyntaxKind::Comment {
+                    continue; // comments stripped from output
+                }
+                // Whitespace control via flat-adjacency trim flags (keyed by offset).
+                let off = usize::from(tok.text_range().start());
+                let (lead, trail) =
+                    TRIM.with(|t| t.borrow().get(&off).copied().unwrap_or((false, false)));
+                let mut text = tok.text();
+                if lead {
+                    text = text.trim_start();
+                }
+                if trail {
+                    text = text.trim_end();
+                }
+                let _ = i;
+                if text.is_empty() {
+                    continue;
+                }
+                out.push(Node::Text(TextNode {
+                    text: text.to_string(),
+                    span: ast::span(0, text.len()),
+                }));
+            }
+            other => {
+                if let Some(node) = lower_item(other) {
+                    out.push(node);
+                }
+            }
+        }
+    }
+    out
+}
+
+fn lower_body(body: Option<cst::Body>) -> Vec<Node> {
+    body.map(|b| lower_items(&b.items())).unwrap_or_default()
+}
+
+fn lower_item(item: &cst::Item) -> Option<Node> {
+    use gingembre_syntax::ast::AstNode;
+    Some(match item {
+        // Whitespace-control trimming (`{%- -%}`) is applied as a follow-up; text is
+        // passed through verbatim for now (affects only surrounding whitespace).
+        cst::Item::Text(tok) => {
+            // Comments are stripped from output (not rendered).
+            if tok.kind() == gingembre_syntax::SyntaxKind::Comment {
+                return None;
+            }
+            Node::Text(TextNode {
+                text: tok.text().to_string(),
+                span: ast::span(0, tok.text().len()),
+            })
+        }
+        cst::Item::Interpolation(i) => {
+            let span = sp(i.syntax());
+            Node::Print(PrintNode {
+                expr: opt_expr(i.expr(), span),
+                span,
+            })
+        }
+        cst::Item::If(iff) => {
+            let span = sp(iff.syntax());
+            Node::If(IfNode {
+                condition: opt_expr(iff.condition(), span),
+                then_body: lower_body(iff.then_body()),
+                elif_branches: iff
+                    .elif_clauses()
+                    .map(|e| ElifBranch {
+                        condition: opt_expr(e.condition(), sp(e.syntax())),
+                        body: lower_body(e.body()),
+                        span: sp(e.syntax()),
+                    })
+                    .collect(),
+                else_body: iff.else_clause().map(|e| lower_body(e.body())),
+                span,
+            })
+        }
+        cst::Item::For(f) => {
+            let span = sp(f.syntax());
+            let names = f.targets();
+            let target = if names.len() == 1 {
+                Target::Single {
+                    name: names[0].clone(),
+                    span,
+                }
+            } else {
+                Target::Tuple {
+                    names: names.into_iter().map(|n| (n, span)).collect(),
+                    span,
+                }
+            };
+            Node::For(ForNode {
+                target,
+                iter: opt_expr(f.iter_expr(), span),
+                body: lower_body(f.body()),
+                else_body: f.else_body().map(|b| lower_items(&b.items())),
+                span,
+            })
+        }
+        cst::Item::Set(s) => {
+            let span = sp(s.syntax());
+            // `{% set x = expr %}` binds an expression; `{% set x %}…{% endset %}`
+            // binds the rendered body.
+            let value = match s.value() {
+                Some(expr) => SetValue::Expr(lower_expr(&expr)),
+                None => SetValue::Body(lower_body(s.body())),
+            };
+            Node::Set(SetNode {
+                name: ident(&s.name().unwrap_or_default(), s.syntax()),
+                value,
+                span,
+            })
+        }
+        cst::Item::Block(b) => {
+            let span = sp(b.syntax());
+            Node::Block(BlockNode {
+                name: ident(&b.name().unwrap_or_default(), b.syntax()),
+                body: lower_body(b.body()),
+                span,
+            })
+        }
+        cst::Item::Macro(m) => {
+            let span = sp(m.syntax());
+            Node::Macro(MacroNode {
+                name: ident(&m.name().unwrap_or_default(), m.syntax()),
+                params: m
+                    .params()
+                    .into_iter()
+                    .map(|(name, default)| MacroParam {
+                        name: Ident { name, span },
+                        default: default.as_ref().map(lower_expr),
+                    })
+                    .collect(),
+                body: lower_body(m.body()),
+                span,
+            })
+        }
+        cst::Item::Extends(e) => Node::Extends(ExtendsNode {
+            path: str_lit(e.path(), sp(e.syntax())),
+            span: sp(e.syntax()),
+        }),
+        cst::Item::Include(i) => Node::Include(IncludeNode {
+            path: str_lit(i.path(), sp(i.syntax())),
+            context: None,
+            span: sp(i.syntax()),
+        }),
+        cst::Item::Import(im) => {
+            let span = sp(im.syntax());
+            Node::Import(ImportNode {
+                path: str_lit(im.path(), span),
+                alias: Ident {
+                    name: im.alias().unwrap_or_default(),
+                    span,
+                },
+                span,
+            })
+        }
+        cst::Item::Break(b) => Node::Break(crate::ast::BreakNode {
+            span: sp(b.syntax()),
+        }),
+        cst::Item::Continue(c) => Node::Continue(crate::ast::ContinueNode {
+            span: sp(c.syntax()),
+        }),
+    })
+}
+
+/// Extract a `StringLit` from a path expression (extends/include/import take string paths).
+fn str_lit(e: Option<cst::Expr>, span: Span) -> StringLit {
+    let value = match e {
+        Some(cst::Expr::Literal(l)) => match l.value() {
+            cst::LitValue::Str(s) => s,
+            _ => String::new(),
+        },
+        _ => String::new(),
+    };
+    StringLit { value, span }
+}
+
+fn lower_binop(op: Option<cst::BinOp>) -> BinaryOp {
+    match op {
+        Some(cst::BinOp::Add) => BinaryOp::Add,
+        Some(cst::BinOp::Sub) => BinaryOp::Sub,
+        Some(cst::BinOp::Mul) => BinaryOp::Mul,
+        Some(cst::BinOp::Div) => BinaryOp::Div,
+        Some(cst::BinOp::FloorDiv) => BinaryOp::FloorDiv,
+        Some(cst::BinOp::Mod) => BinaryOp::Mod,
+        Some(cst::BinOp::Pow) => BinaryOp::Pow,
+        Some(cst::BinOp::Concat) => BinaryOp::Concat,
+        Some(cst::BinOp::Eq) => BinaryOp::Eq,
+        Some(cst::BinOp::Ne) => BinaryOp::Ne,
+        Some(cst::BinOp::Lt) => BinaryOp::Lt,
+        Some(cst::BinOp::Le) => BinaryOp::Le,
+        Some(cst::BinOp::Gt) => BinaryOp::Gt,
+        Some(cst::BinOp::Ge) => BinaryOp::Ge,
+        Some(cst::BinOp::And) => BinaryOp::And,
+        Some(cst::BinOp::Or) => BinaryOp::Or,
+        Some(cst::BinOp::In) => BinaryOp::In,
+        Some(cst::BinOp::NotIn) => BinaryOp::NotIn,
+        None => BinaryOp::Add,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gingembre_syntax::SyntaxKind;
+    use gingembre_syntax::ast::AstNode;
+
+    /// Lower the expression inside a `{{ … }}` and check it lowers without panicking,
+    /// matching the expected engine Expr variant.
+    fn lower(src: &str) -> Expr {
+        let p = gingembre_syntax::parse(&format!("{{{{ {src} }}}}"));
+        assert!(p.errors.is_empty(), "{:?}", p.errors);
+        let interp = p
+            .syntax()
+            .children()
+            .find(|n| n.kind() == SyntaxKind::Interpolation)
+            .unwrap();
+        let cst_expr = cst::Interpolation::cast(interp.clone())
+            .unwrap()
+            .expr()
+            .unwrap();
+        lower_expr(&cst_expr)
+    }
+
+    #[test]
+    fn lowers_core_exprs() {
+        assert!(matches!(lower("42"), Expr::Literal(ast::Literal::Int(i)) if i.value == 42));
+        assert!(matches!(lower("a + b"), Expr::Binary(b) if b.op == BinaryOp::Add));
+        assert!(matches!(lower("x not in xs"), Expr::Binary(b) if b.op == BinaryOp::NotIn));
+        assert!(matches!(lower("page.title"), Expr::Field(_)));
+        assert!(
+            matches!(lower("f(a.b, k=c)"), Expr::Call(c) if c.args.len() == 1 && c.kwargs.len() == 1)
+        );
+        assert!(matches!(lower("x | upper | safe"), Expr::Filter(_)));
+        assert!(matches!(lower("width?"), Expr::Optional(_)));
+        assert!(matches!(lower("a if c else b"), Expr::Ternary(_)));
+        assert!(
+            matches!(lower("[1, 2]"), Expr::Literal(ast::Literal::List(l)) if l.elements.len() == 2)
+        );
+    }
+}

--- a/gingembre/src/error.rs
+++ b/gingembre/src/error.rs
@@ -1,0 +1,577 @@
+//! Error types for template parsing and evaluation
+//!
+//! Error types carry structured information for debugging.
+
+#![allow(unused_assignments)]
+
+use ariadne::{Color, Label, Report, ReportKind, Source};
+use facet::Facet;
+use std::sync::Arc;
+use thiserror::Error;
+
+/// A span in source code (offset, length)
+// r[impl error.span]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Facet)]
+pub struct SourceSpan {
+    offset: usize,
+    len: usize,
+}
+
+impl SourceSpan {
+    /// Create a new span from offset and length
+    pub fn new(offset: usize, len: usize) -> Self {
+        Self { offset, len }
+    }
+
+    /// Get the offset (start position)
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Get the length
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Check if the span is empty
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+/// A template source file for error reporting
+#[derive(Debug, Clone)]
+pub struct TemplateSource {
+    /// Name of the template (usually filename)
+    pub name: String,
+    /// The full source text
+    pub source: Arc<String>,
+}
+
+impl TemplateSource {
+    pub fn new(name: impl Into<String>, source: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            source: Arc::new(source.into()),
+        }
+    }
+
+    /// Create a NamedSource for error reporting
+    pub fn named_source(&self) -> NamedSource {
+        NamedSource::new(self.name.clone(), (*self.source).clone())
+    }
+}
+
+/// Named source for error reporting (simplified from miette)
+#[derive(Debug, Clone)]
+pub struct NamedSource {
+    pub name: String,
+    pub source: String,
+}
+
+/// Location in source code for error reporting
+#[derive(Debug, Clone)]
+pub struct SourceLocation {
+    pub span: SourceSpan,
+    pub src: NamedSource,
+}
+
+impl SourceLocation {
+    pub fn new(span: SourceSpan, src: NamedSource) -> Self {
+        Self { span, src }
+    }
+
+    /// Format as "file:line:col"
+    pub fn display(&self) -> String {
+        self.src.location(&self.span)
+    }
+}
+
+impl NamedSource {
+    pub fn new(name: impl Into<String>, source: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            source: source.into(),
+        }
+    }
+
+    /// Compute (line, column) from byte offset. Line and column are 1-based.
+    pub fn offset_to_line_col(&self, offset: usize) -> (usize, usize) {
+        let mut line = 1;
+        let mut col = 1;
+        for (i, ch) in self.source.char_indices() {
+            if i >= offset {
+                break;
+            }
+            if ch == '\n' {
+                line += 1;
+                col = 1;
+            } else {
+                col += 1;
+            }
+        }
+        (line, col)
+    }
+
+    /// Format the location as "name:line:col"
+    pub fn location(&self, span: &SourceSpan) -> String {
+        let (line, col) = self.offset_to_line_col(span.offset());
+        format!("{}:{}:{}", self.name, line, col)
+    }
+}
+
+/// All template errors
+#[derive(Error, Debug, Clone)]
+pub enum TemplateError {
+    #[error("Syntax error: {0}")]
+    Syntax(Box<SyntaxError>),
+
+    #[error("Unknown field: {0}")]
+    UnknownField(Box<UnknownFieldError>),
+
+    #[error("Type error: {0}")]
+    Type(Box<TypeError>),
+
+    #[error("Undefined variable: {0}")]
+    Undefined(Box<UndefinedError>),
+
+    #[error("Unknown filter: {0}")]
+    UnknownFilter(Box<UnknownFilterError>),
+
+    #[error("Unknown test: {0}")]
+    UnknownTest(Box<UnknownTestError>),
+
+    #[error("Macro not found: {0}")]
+    MacroNotFound(Box<MacroNotFoundError>),
+
+    #[error("Data path not found: {0}")]
+    DataPathNotFound(Box<DataPathNotFoundError>),
+
+    #[error("Function error: {0}")]
+    GlobalFn(String),
+}
+
+// Convenience From impls that auto-box
+impl From<SyntaxError> for TemplateError {
+    fn from(e: SyntaxError) -> Self {
+        Self::Syntax(Box::new(e))
+    }
+}
+
+impl From<UnknownFieldError> for TemplateError {
+    fn from(e: UnknownFieldError) -> Self {
+        Self::UnknownField(Box::new(e))
+    }
+}
+
+impl From<TypeError> for TemplateError {
+    fn from(e: TypeError) -> Self {
+        Self::Type(Box::new(e))
+    }
+}
+
+impl From<UndefinedError> for TemplateError {
+    fn from(e: UndefinedError) -> Self {
+        Self::Undefined(Box::new(e))
+    }
+}
+
+impl From<UnknownFilterError> for TemplateError {
+    fn from(e: UnknownFilterError) -> Self {
+        Self::UnknownFilter(Box::new(e))
+    }
+}
+
+impl From<UnknownTestError> for TemplateError {
+    fn from(e: UnknownTestError) -> Self {
+        Self::UnknownTest(Box::new(e))
+    }
+}
+
+impl From<MacroNotFoundError> for TemplateError {
+    fn from(e: MacroNotFoundError) -> Self {
+        Self::MacroNotFound(Box::new(e))
+    }
+}
+
+impl From<DataPathNotFoundError> for TemplateError {
+    fn from(e: DataPathNotFoundError) -> Self {
+        Self::DataPathNotFound(Box::new(e))
+    }
+}
+
+/// Macro not found error
+#[derive(Error, Debug, Clone)]
+#[error("{}: Macro `{}::{}` not found", self.loc.display(), self.namespace, self.name)]
+pub struct MacroNotFoundError {
+    pub namespace: String,
+    pub name: String,
+    pub loc: SourceLocation,
+}
+
+/// Data path not found error
+#[derive(Error, Debug, Clone)]
+#[error("{}: Data path `{}` not found", self.loc.display(), self.path)]
+pub struct DataPathNotFoundError {
+    pub path: String,
+    pub loc: SourceLocation,
+}
+
+/// Errors that can occur during rendering
+#[derive(Error, Debug, Clone)]
+pub enum RenderError {
+    /// Template not found
+    #[error("Template not found: {0}")]
+    NotFound(String),
+
+    /// Template error (parse or evaluation)
+    #[error("{0}")]
+    Template(#[from] TemplateError),
+
+    /// Other errors (e.g., from template functions)
+    #[error("{0}")]
+    Other(String),
+}
+
+impl RenderError {
+    /// Format the error with source context using ariadne (if applicable)
+    pub fn format_pretty(&self) -> String {
+        match self {
+            RenderError::Template(e) => format_template_error_pretty(e),
+            other => format!("{}", other),
+        }
+    }
+}
+
+/// Syntax error during parsing
+// r[impl error.syntax]
+#[derive(Error, Debug, Clone)]
+#[error("{}: Unexpected {found}, expected {expected}", self.loc.display())]
+pub struct SyntaxError {
+    /// What we found
+    pub found: String,
+    /// What we expected
+    pub expected: String,
+    /// Location in source
+    pub loc: SourceLocation,
+}
+
+/// Unknown field access on a type
+#[derive(Error, Debug, Clone)]
+#[error("{}: Type `{base_type}` has no field `{field}` (available: {})", self.loc.display(), known_fields.join(", "))]
+pub struct UnknownFieldError {
+    /// The type being accessed
+    pub base_type: String,
+    /// The field that doesn't exist
+    pub field: String,
+    /// Known fields on this type
+    pub known_fields: Vec<String>,
+    /// Location of the field access
+    pub loc: SourceLocation,
+}
+
+/// Type error (e.g., iterating over non-iterable)
+// r[impl error.type-mismatch]
+#[derive(Error, Debug, Clone)]
+#[error("{}: Expected {expected}, found {found} ({context})", self.loc.display())]
+pub struct TypeError {
+    /// What type was expected
+    pub expected: String,
+    /// What type was found
+    pub found: String,
+    /// Context for the error
+    pub context: String,
+    /// Location
+    pub loc: SourceLocation,
+}
+
+/// Undefined variable
+#[derive(Error, Debug, Clone)]
+#[error("{}: Variable `{name}` is not defined (available: {})", self.loc.display(), available.join(", "))]
+pub struct UndefinedError {
+    /// The undefined variable name
+    pub name: String,
+    /// Variables that are available in scope
+    pub available: Vec<String>,
+    /// Location
+    pub loc: SourceLocation,
+}
+
+/// Unknown filter
+// r[impl error.undefined-filter]
+#[derive(Error, Debug, Clone)]
+#[error("{}: Unknown filter `{name}` (available: {})", self.loc.display(), known_filters.join(", "))]
+pub struct UnknownFilterError {
+    /// The filter that doesn't exist
+    pub name: String,
+    /// Known filters
+    pub known_filters: Vec<String>,
+    /// Location
+    pub loc: SourceLocation,
+}
+
+/// Unknown test function
+// r[impl error.undefined-test]
+#[derive(Error, Debug, Clone)]
+#[error("{}: Unknown test `{name}` (available: starting_with, ending_with, containing, defined, undefined, none, string, number, odd, even, empty)", self.loc.display())]
+pub struct UnknownTestError {
+    /// The test that doesn't exist
+    pub name: String,
+    /// Location
+    pub loc: SourceLocation,
+}
+
+/// Unclosed delimiter (tag, block, etc.)
+#[derive(Error, Debug, Clone)]
+#[error("{}: Unclosed {kind}, add `{close_delim}` to close", self.loc.display())]
+pub struct UnclosedError {
+    /// What was left unclosed
+    pub kind: String,
+    /// The closing delimiter needed
+    pub close_delim: String,
+    /// Location where it was opened
+    pub loc: SourceLocation,
+}
+
+impl From<UnclosedError> for TemplateError {
+    fn from(e: UnclosedError) -> Self {
+        SyntaxError {
+            found: "end of input".to_string(),
+            expected: e.close_delim.clone(),
+            loc: e.loc,
+        }
+        .into()
+    }
+}
+
+// ============================================================================
+// Pretty error formatting with ariadne
+// ============================================================================
+
+/// Trait for errors that can be formatted with source context
+pub trait PrettyError {
+    /// Get the source location
+    fn source_loc(&self) -> &SourceLocation;
+    /// Get the error message (without location prefix)
+    fn message(&self) -> String;
+    /// Get an optional help message
+    fn help(&self) -> Option<String> {
+        None
+    }
+}
+
+impl PrettyError for SyntaxError {
+    fn source_loc(&self) -> &SourceLocation {
+        &self.loc
+    }
+    fn message(&self) -> String {
+        format!("Unexpected {}, expected {}", self.found, self.expected)
+    }
+}
+
+impl PrettyError for UnknownFieldError {
+    fn source_loc(&self) -> &SourceLocation {
+        &self.loc
+    }
+    fn message(&self) -> String {
+        format!("Type `{}` has no field `{}`", self.base_type, self.field)
+    }
+    fn help(&self) -> Option<String> {
+        if self.known_fields.is_empty() {
+            None
+        } else {
+            Some(format!(
+                "Available fields: {}",
+                self.known_fields.join(", ")
+            ))
+        }
+    }
+}
+
+impl PrettyError for TypeError {
+    fn source_loc(&self) -> &SourceLocation {
+        &self.loc
+    }
+    fn message(&self) -> String {
+        format!(
+            "Expected {}, found {} ({})",
+            self.expected, self.found, self.context
+        )
+    }
+}
+
+impl PrettyError for UndefinedError {
+    fn source_loc(&self) -> &SourceLocation {
+        &self.loc
+    }
+    fn message(&self) -> String {
+        format!("Variable `{}` is not defined", self.name)
+    }
+    fn help(&self) -> Option<String> {
+        if self.available.is_empty() {
+            None
+        } else {
+            Some(format!("Available: {}", self.available.join(", ")))
+        }
+    }
+}
+
+impl PrettyError for UnknownFilterError {
+    fn source_loc(&self) -> &SourceLocation {
+        &self.loc
+    }
+    fn message(&self) -> String {
+        format!("Unknown filter `{}`", self.name)
+    }
+    fn help(&self) -> Option<String> {
+        Some(format!("Available: {}", self.known_filters.join(", ")))
+    }
+}
+
+impl PrettyError for UnknownTestError {
+    fn source_loc(&self) -> &SourceLocation {
+        &self.loc
+    }
+    fn message(&self) -> String {
+        format!("Unknown test `{}`", self.name)
+    }
+    fn help(&self) -> Option<String> {
+        Some("Available: starting_with, ending_with, containing, defined, undefined, none, string, number, odd, even, empty".to_string())
+    }
+}
+
+impl PrettyError for MacroNotFoundError {
+    fn source_loc(&self) -> &SourceLocation {
+        &self.loc
+    }
+    fn message(&self) -> String {
+        format!("Macro `{}::{}` not found", self.namespace, self.name)
+    }
+}
+
+impl PrettyError for DataPathNotFoundError {
+    fn source_loc(&self) -> &SourceLocation {
+        &self.loc
+    }
+    fn message(&self) -> String {
+        format!("Data path `{}` not found", self.path)
+    }
+}
+
+/// Format an error with ariadne, producing a pretty string with source context
+pub fn format_error_pretty<E: PrettyError>(error: &E) -> String {
+    let loc = error.source_loc();
+
+    // Calculate the byte range for the span
+    let start = loc.span.offset();
+    let end = start + loc.span.len().max(1); // Ensure at least 1 char for visibility
+
+    // Build the report - use tuple (file_id, range) as span
+    let mut report =
+        Report::build(ReportKind::Error, (&loc.src.name, start..end)).with_message(error.message());
+
+    // Add the primary label
+    let label = Label::new((&loc.src.name, start..end))
+        .with_message(error.message())
+        .with_color(Color::Red);
+    report = report.with_label(label);
+
+    // Add help if available
+    if let Some(help) = error.help() {
+        report = report.with_help(help);
+    }
+
+    // Render to string
+    let mut output = Vec::new();
+    report
+        .finish()
+        .write((&loc.src.name, Source::from(&loc.src.source)), &mut output)
+        .expect("failed to write error report");
+
+    String::from_utf8(output).expect("ariadne produced invalid UTF-8")
+}
+
+/// Format a TemplateError with ariadne
+pub fn format_template_error_pretty(error: &TemplateError) -> String {
+    match error {
+        TemplateError::Syntax(e) => format_error_pretty(e.as_ref()),
+        TemplateError::UnknownField(e) => format_error_pretty(e.as_ref()),
+        TemplateError::Type(e) => format_error_pretty(e.as_ref()),
+        TemplateError::Undefined(e) => format_error_pretty(e.as_ref()),
+        TemplateError::UnknownFilter(e) => format_error_pretty(e.as_ref()),
+        TemplateError::UnknownTest(e) => format_error_pretty(e.as_ref()),
+        TemplateError::MacroNotFound(e) => format_error_pretty(e.as_ref()),
+        TemplateError::DataPathNotFound(e) => format_error_pretty(e.as_ref()),
+        TemplateError::GlobalFn(msg) => format!("Function error: {}", msg),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_type_error_pretty() {
+        let source = "{% if page.extra.description %}\n  {{ page.extra.description }}\n{% endif %}";
+        let error = TypeError {
+            expected: "object or dict".to_string(),
+            found: "none".to_string(),
+            context: "accessing field `description`".to_string(),
+            loc: SourceLocation::new(
+                SourceSpan::new(18, 11), // "description" in page.extra.description
+                NamedSource::new("section.html", source),
+            ),
+        };
+
+        let pretty = format_error_pretty(&error);
+        println!("Pretty error output:\n{}", pretty);
+
+        // Should contain the filename
+        assert!(pretty.contains("section.html"), "Should contain filename");
+        // Should contain the error message
+        assert!(
+            pretty.contains("Expected object or dict"),
+            "Should contain error message"
+        );
+        // Should contain the source line (ariadne shows it)
+        assert!(
+            pretty.contains("page.extra.description") || pretty.contains("│"),
+            "Should contain source context or ariadne formatting"
+        );
+    }
+
+    #[test]
+    fn test_render_error_format_pretty_with_template() {
+        let source = "{{ undefined_var }}";
+        let template_error: TemplateError = UndefinedError {
+            name: "undefined_var".to_string(),
+            available: vec!["page".to_string(), "section".to_string()],
+            loc: SourceLocation::new(
+                SourceSpan::new(3, 13),
+                NamedSource::new("test.html", source),
+            ),
+        }
+        .into();
+        let render_error = RenderError::Template(template_error);
+
+        let pretty = render_error.format_pretty();
+        println!("RenderError::Template pretty:\n{}", pretty);
+
+        // Should use ariadne formatting
+        assert!(
+            pretty.contains("test.html")
+                && (pretty.contains("│") || pretty.contains("undefined_var")),
+            "RenderError::Template should use ariadne formatting"
+        );
+    }
+
+    #[test]
+    fn test_render_error_format_pretty_with_other() {
+        let render_error = RenderError::Other("Some random error".to_string());
+
+        let pretty = render_error.format_pretty();
+        println!("RenderError::Other pretty:\n{}", pretty);
+
+        assert_eq!(pretty, "Some random error");
+    }
+}

--- a/gingembre/src/eval.rs
+++ b/gingembre/src/eval.rs
@@ -1,0 +1,1950 @@
+//! Expression evaluator
+//!
+//! Evaluates template expressions against a context using facet_value::Value.
+
+use super::ast::*;
+use super::error::{
+    SourceLocation, TemplateError, TemplateSource, TypeError, UndefinedError, UnknownFieldError,
+    UnknownFilterError, UnknownTestError,
+};
+use facet_value::{DestructuredRef, VArray, VObject, VString};
+use futures::future::BoxFuture;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BuiltinItemInfo {
+    pub name: &'static str,
+    pub detail: &'static str,
+    pub documentation: &'static str,
+}
+
+pub const BUILTIN_FILTERS: &[BuiltinItemInfo] = &[
+    BuiltinItemInfo {
+        name: "upper",
+        detail: "Gingembre filter",
+        documentation: "Converts text to uppercase.",
+    },
+    BuiltinItemInfo {
+        name: "lower",
+        detail: "Gingembre filter",
+        documentation: "Converts text to lowercase.",
+    },
+    BuiltinItemInfo {
+        name: "capitalize",
+        detail: "Gingembre filter",
+        documentation: "Uppercases the first character and leaves the remaining characters unchanged.",
+    },
+    BuiltinItemInfo {
+        name: "title",
+        detail: "Gingembre filter",
+        documentation: "Uppercases the first character of each whitespace-separated word.",
+    },
+    BuiltinItemInfo {
+        name: "trim",
+        detail: "Gingembre filter",
+        documentation: "Removes leading and trailing whitespace.",
+    },
+    BuiltinItemInfo {
+        name: "length",
+        detail: "Gingembre filter",
+        documentation: "Returns the length of a string, array, or mapping.",
+    },
+    BuiltinItemInfo {
+        name: "first",
+        detail: "Gingembre filter",
+        documentation: "Returns the first item from an array or the first character from a string.",
+    },
+    BuiltinItemInfo {
+        name: "last",
+        detail: "Gingembre filter",
+        documentation: "Returns the last item from an array or the last character from a string.",
+    },
+    BuiltinItemInfo {
+        name: "reverse",
+        detail: "Gingembre filter",
+        documentation: "Reverses an array or string.",
+    },
+    BuiltinItemInfo {
+        name: "sort",
+        detail: "Gingembre filter",
+        documentation: "Sorts an array, optionally by an object attribute with `attribute=`.",
+    },
+    BuiltinItemInfo {
+        name: "join",
+        detail: "Gingembre filter",
+        documentation: "Joins array items into a string, using the first argument as the separator.",
+    },
+    BuiltinItemInfo {
+        name: "split",
+        detail: "Gingembre filter",
+        documentation: "Splits a string into a list. Pass the separator as the first argument or `pat=`.",
+    },
+    BuiltinItemInfo {
+        name: "default",
+        detail: "Gingembre filter",
+        documentation: "Returns a fallback when the value is null or an empty string.",
+    },
+    BuiltinItemInfo {
+        name: "escape",
+        detail: "Gingembre filter",
+        documentation: "HTML-escapes `&`, `<`, `>`, double quotes, and single quotes.",
+    },
+    BuiltinItemInfo {
+        name: "safe",
+        detail: "Gingembre filter",
+        documentation: "Marks a string as safe HTML so it is not escaped during rendering.",
+    },
+    BuiltinItemInfo {
+        name: "typeof",
+        detail: "Gingembre filter",
+        documentation: "Returns Gingembre's runtime type name for the value.",
+    },
+    BuiltinItemInfo {
+        name: "slice",
+        detail: "Gingembre filter",
+        documentation: "Slices an array with `start` and `end` positional arguments or keyword arguments.",
+    },
+    BuiltinItemInfo {
+        name: "map",
+        detail: "Gingembre filter",
+        documentation: "Extracts `attribute=` from each object in an array.",
+    },
+    BuiltinItemInfo {
+        name: "selectattr",
+        detail: "Gingembre filter",
+        documentation: "Keeps array items whose named attribute passes a test.",
+    },
+    BuiltinItemInfo {
+        name: "rejectattr",
+        detail: "Gingembre filter",
+        documentation: "Drops array items whose named attribute passes a test.",
+    },
+    BuiltinItemInfo {
+        name: "groupby",
+        detail: "Gingembre filter",
+        documentation: "Groups array items by an object attribute and returns `[key, items]` pairs.",
+    },
+    BuiltinItemInfo {
+        name: "path_segments",
+        detail: "Gingembre filter",
+        documentation: "Splits a path into non-empty slash-separated segments.",
+    },
+    BuiltinItemInfo {
+        name: "path_first",
+        detail: "Gingembre filter",
+        documentation: "Returns the first non-empty segment of a path.",
+    },
+    BuiltinItemInfo {
+        name: "path_parent",
+        detail: "Gingembre filter",
+        documentation: "Returns the parent path: `/foo/bar` becomes `/foo`, `/foo` becomes `/`, and `/` stays `/`.",
+    },
+    BuiltinItemInfo {
+        name: "path_basename",
+        detail: "Gingembre filter",
+        documentation: "Returns the final non-empty segment of a path.",
+    },
+    BuiltinItemInfo {
+        name: "escape_for_attribute",
+        detail: "Gingembre filter",
+        documentation: "HTML-escapes a string for safe insertion into a quoted HTML attribute value.",
+    },
+    BuiltinItemInfo {
+        name: "basic_markdown",
+        detail: "Gingembre filter",
+        documentation: "Converts basic inline markdown (bold, italic, code, links) to HTML. Returns safe HTML.",
+    },
+];
+
+pub const BUILTIN_TESTS: &[BuiltinItemInfo] = &[
+    BuiltinItemInfo {
+        name: "starting_with",
+        detail: "Gingembre test",
+        documentation: "True when text starts with the argument.",
+    },
+    BuiltinItemInfo {
+        name: "startswith",
+        detail: "Gingembre test",
+        documentation: "Alias for `starting_with`.",
+    },
+    BuiltinItemInfo {
+        name: "ending_with",
+        detail: "Gingembre test",
+        documentation: "True when text ends with the argument.",
+    },
+    BuiltinItemInfo {
+        name: "endswith",
+        detail: "Gingembre test",
+        documentation: "Alias for `ending_with`.",
+    },
+    BuiltinItemInfo {
+        name: "containing",
+        detail: "Gingembre test",
+        documentation: "True when a string or array contains the argument.",
+    },
+    BuiltinItemInfo {
+        name: "contains",
+        detail: "Gingembre test",
+        documentation: "Alias for `containing`.",
+    },
+    BuiltinItemInfo {
+        name: "defined",
+        detail: "Gingembre test",
+        documentation: "True when the value is not null.",
+    },
+    BuiltinItemInfo {
+        name: "undefined",
+        detail: "Gingembre test",
+        documentation: "True when the value is null.",
+    },
+    BuiltinItemInfo {
+        name: "none",
+        detail: "Gingembre test",
+        documentation: "True when the value is null.",
+    },
+    BuiltinItemInfo {
+        name: "string",
+        detail: "Gingembre test",
+        documentation: "True when the value is a string.",
+    },
+    BuiltinItemInfo {
+        name: "number",
+        detail: "Gingembre test",
+        documentation: "True when the value is numeric.",
+    },
+    BuiltinItemInfo {
+        name: "integer",
+        detail: "Gingembre test",
+        documentation: "True when the value is an integer.",
+    },
+    BuiltinItemInfo {
+        name: "float",
+        detail: "Gingembre test",
+        documentation: "True when the value is a float.",
+    },
+    BuiltinItemInfo {
+        name: "mapping",
+        detail: "Gingembre test",
+        documentation: "True when the value is an object or mapping.",
+    },
+    BuiltinItemInfo {
+        name: "dict",
+        detail: "Gingembre test",
+        documentation: "Alias for `mapping`.",
+    },
+    BuiltinItemInfo {
+        name: "iterable",
+        detail: "Gingembre test",
+        documentation: "True when the value can be iterated.",
+    },
+    BuiltinItemInfo {
+        name: "sequence",
+        detail: "Gingembre test",
+        documentation: "Alias for `iterable`.",
+    },
+    BuiltinItemInfo {
+        name: "odd",
+        detail: "Gingembre test",
+        documentation: "True when an integer is odd.",
+    },
+    BuiltinItemInfo {
+        name: "even",
+        detail: "Gingembre test",
+        documentation: "True when an integer is even.",
+    },
+    BuiltinItemInfo {
+        name: "truthy",
+        detail: "Gingembre test",
+        documentation: "True when Gingembre treats the value as truthy.",
+    },
+    BuiltinItemInfo {
+        name: "falsy",
+        detail: "Gingembre test",
+        documentation: "True when Gingembre treats the value as false.",
+    },
+    BuiltinItemInfo {
+        name: "empty",
+        detail: "Gingembre test",
+        documentation: "True when the value has no items or text.",
+    },
+    BuiltinItemInfo {
+        name: "eq",
+        detail: "Gingembre test",
+        documentation: "Compares values for equality.",
+    },
+    BuiltinItemInfo {
+        name: "equalto",
+        detail: "Gingembre test",
+        documentation: "Alias for `eq`.",
+    },
+    BuiltinItemInfo {
+        name: "sameas",
+        detail: "Gingembre test",
+        documentation: "Alias for `eq`.",
+    },
+    BuiltinItemInfo {
+        name: "ne",
+        detail: "Gingembre test",
+        documentation: "Compares values for inequality.",
+    },
+    BuiltinItemInfo {
+        name: "lt",
+        detail: "Gingembre test",
+        documentation: "True when the value is less than the argument.",
+    },
+    BuiltinItemInfo {
+        name: "lessthan",
+        detail: "Gingembre test",
+        documentation: "Alias for `lt`.",
+    },
+    BuiltinItemInfo {
+        name: "gt",
+        detail: "Gingembre test",
+        documentation: "True when the value is greater than the argument.",
+    },
+    BuiltinItemInfo {
+        name: "greaterthan",
+        detail: "Gingembre test",
+        documentation: "Alias for `gt`.",
+    },
+];
+
+pub fn builtin_filter(name: &str) -> Option<&'static BuiltinItemInfo> {
+    BUILTIN_FILTERS.iter().find(|info| info.name == name)
+}
+
+pub fn builtin_test(name: &str) -> Option<&'static BuiltinItemInfo> {
+    BUILTIN_TESTS.iter().find(|info| info.name == name)
+}
+
+pub fn builtin_filter_names() -> impl Iterator<Item = &'static str> {
+    BUILTIN_FILTERS.iter().map(|info| info.name)
+}
+
+pub fn builtin_test_names() -> impl Iterator<Item = &'static str> {
+    BUILTIN_TESTS.iter().map(|info| info.name)
+}
+
+/// Re-export facet_value::Value as the template Value type
+pub use facet_value::Value;
+
+/// Helper trait to extend Value with template-specific operations
+pub trait ValueExt {
+    /// Check if the value is truthy (for conditionals)
+    fn is_truthy(&self) -> bool;
+
+    /// Get a human-readable type name
+    fn type_name(&self) -> &'static str;
+
+    /// Render the value to a string for output
+    fn render_to_string(&self) -> String;
+
+    /// Check if this value is marked as "safe" (should not be HTML-escaped)
+    fn is_safe(&self) -> bool;
+}
+
+impl ValueExt for Value {
+    fn is_truthy(&self) -> bool {
+        match self.destructure_ref() {
+            DestructuredRef::Null => false,
+            DestructuredRef::Bool(b) => b,
+            DestructuredRef::Number(n) => {
+                if let Some(i) = n.to_i64() {
+                    i != 0
+                } else if let Some(f) = n.to_f64() {
+                    f != 0.0
+                } else {
+                    true
+                }
+            }
+            DestructuredRef::String(s) => !s.is_empty(),
+            DestructuredRef::Bytes(b) => !b.is_empty(),
+            DestructuredRef::Array(arr) => !arr.is_empty(),
+            DestructuredRef::Object(obj) => !obj.is_empty(),
+            DestructuredRef::DateTime(_) => true,
+            DestructuredRef::QName(_) => true,
+            DestructuredRef::Uuid(_) => true,
+            DestructuredRef::Char(c) => c != '\0',
+            _ => true,
+        }
+    }
+
+    fn type_name(&self) -> &'static str {
+        match self.destructure_ref() {
+            DestructuredRef::Null => "none",
+            DestructuredRef::Bool(_) => "bool",
+            DestructuredRef::Number(_) => "number",
+            DestructuredRef::String(_) => "string",
+            DestructuredRef::Bytes(_) => "bytes",
+            DestructuredRef::Array(_) => "list",
+            DestructuredRef::Object(_) => "dict",
+            DestructuredRef::DateTime(_) => "datetime",
+            DestructuredRef::QName(_) => "qname",
+            DestructuredRef::Uuid(_) => "uuid",
+            DestructuredRef::Char(_) => "char",
+            _ => "unknown",
+        }
+    }
+
+    fn render_to_string(&self) -> String {
+        match self.destructure_ref() {
+            DestructuredRef::Null => String::new(),
+            DestructuredRef::Bool(b) => if b { "true" } else { "false" }.to_string(),
+            DestructuredRef::Number(n) => {
+                if let Some(i) = n.to_i64() {
+                    i.to_string()
+                } else if let Some(f) = n.to_f64() {
+                    f.to_string()
+                } else {
+                    // Fallback for numbers that don't fit i64 or f64
+                    "0".to_string()
+                }
+            }
+            DestructuredRef::String(s) => s.to_string(),
+            DestructuredRef::Bytes(b) => {
+                // Render bytes as hex or base64
+                format!("<bytes: {} bytes>", b.len())
+            }
+            DestructuredRef::Array(arr) => {
+                let items: Vec<String> = arr.iter().map(|v| v.render_to_string()).collect();
+                format!("[{}]", items.join(", "))
+            }
+            DestructuredRef::Object(_) => "[object]".to_string(),
+            DestructuredRef::DateTime(dt) => format!("{:?}", dt),
+            DestructuredRef::QName(qn) => format!("{:?}", qn),
+            DestructuredRef::Uuid(uuid) => format!("{:?}", uuid),
+            DestructuredRef::Char(c) => c.to_string(),
+            other => format!("{other:?}"),
+        }
+    }
+
+    fn is_safe(&self) -> bool {
+        // Check if this is a safe string using VSafeString's flag
+        self.as_string().is_some_and(|s| s.is_safe())
+    }
+}
+
+use crate::lazy::{DataPath, DataResolver, LazyValue};
+
+/// Error type for global function calls
+pub type GlobalFnError = Box<dyn std::error::Error + Send + Sync>;
+
+/// A global function that can be called from templates.
+/// Functions receive resolved (concrete) values and return a future that resolves to a value.
+/// This allows functions to make async calls (like RPC to the host).
+pub type GlobalFn = Box<
+    dyn Fn(&[Value], &[(String, Value)]) -> BoxFuture<'static, Result<Value, GlobalFnError>>
+        + Send
+        + Sync,
+>;
+
+/// Evaluation context (variables in scope)
+///
+/// The context stores [`LazyValue`]s, which can be either concrete values or
+/// lazy references that resolve on demand. This enables fine-grained dependency
+/// tracking for incremental computation.
+#[derive(Clone)]
+pub struct Context {
+    /// Variable scopes (innermost last)
+    scopes: Vec<HashMap<String, LazyValue>>,
+    /// Global functions available in this context (shared via Arc)
+    global_fns: std::sync::Arc<HashMap<String, std::sync::Arc<GlobalFn>>>,
+}
+
+impl std::fmt::Debug for Context {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Context")
+            .field("scopes", &self.scopes)
+            .field(
+                "global_fns",
+                &format!("<{} functions>", self.global_fns.len()),
+            )
+            .finish()
+    }
+}
+
+impl Context {
+    pub fn new() -> Self {
+        Self {
+            scopes: vec![HashMap::new()],
+            global_fns: std::sync::Arc::new(HashMap::new()),
+        }
+    }
+
+    /// Register a global function
+    pub fn register_fn(&mut self, name: impl Into<String>, f: GlobalFn) {
+        let fns = std::sync::Arc::make_mut(&mut self.global_fns);
+        fns.insert(name.into(), std::sync::Arc::new(f));
+    }
+
+    /// Call a global function by name
+    pub fn call_fn(
+        &self,
+        name: &str,
+        args: &[Value],
+        kwargs: &[(String, Value)],
+    ) -> Option<BoxFuture<'static, Result<Value, GlobalFnError>>> {
+        self.global_fns.get(name).map(|f| f(args, kwargs))
+    }
+
+    /// Set a variable in the current scope (concrete value)
+    pub fn set(&mut self, name: impl Into<String>, value: impl Into<LazyValue>) {
+        if let Some(scope) = self.scopes.last_mut() {
+            scope.insert(name.into(), value.into());
+        }
+    }
+
+    /// Get all variable names across all scopes
+    pub fn variable_names(&self) -> Vec<&str> {
+        self.scopes
+            .iter()
+            .flat_map(|scope| scope.keys().map(String::as_str))
+            .collect()
+    }
+
+    /// Set a variable as "safe" (won't be HTML-escaped when rendered)
+    /// If the value is a string, it will be converted to a VSafeString
+    pub fn set_safe(&mut self, name: impl Into<String>, value: Value) {
+        // Convert string values to safe strings
+        let safe_value = if let Some(s) = value.as_string() {
+            s.clone().into_safe().into_value()
+        } else {
+            value
+        };
+        self.set(name, safe_value);
+    }
+
+    /// Set a lazy data resolver as the "data" variable.
+    ///
+    /// This creates a lazy value at the root path that will resolve fields
+    /// on demand, enabling fine-grained dependency tracking.
+    pub fn set_data_resolver(&mut self, resolver: std::sync::Arc<dyn DataResolver>) {
+        self.set("data", LazyValue::lazy(resolver, DataPath::root()));
+    }
+
+    /// Get a variable (searches all scopes)
+    // r[impl scope.lexical]
+    pub fn get(&self, name: &str) -> Option<&LazyValue> {
+        for scope in self.scopes.iter().rev() {
+            if let Some(value) = scope.get(name) {
+                return Some(value);
+            }
+        }
+        None
+    }
+
+    /// Get all variable names (for error messages)
+    pub fn available_vars(&self) -> Vec<String> {
+        let mut vars: Vec<_> = self.scopes.iter().flat_map(|s| s.keys().cloned()).collect();
+        vars.sort();
+        vars.dedup();
+        vars
+    }
+
+    /// Push a new scope
+    // r[impl scope.block]
+    pub fn push_scope(&mut self) {
+        self.scopes.push(HashMap::new());
+    }
+
+    /// Pop the innermost scope
+    pub fn pop_scope(&mut self) {
+        if self.scopes.len() > 1 {
+            self.scopes.pop();
+        }
+    }
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Expression evaluator
+///
+/// The evaluator returns [`LazyValue`]s, which may be either concrete or lazy.
+/// Field and index access on lazy values extends the path without resolving.
+/// Operations that need concrete values (arithmetic, comparison) force resolution.
+pub struct Evaluator<'a> {
+    ctx: &'a Context,
+    source: &'a TemplateSource,
+}
+
+impl<'a> Evaluator<'a> {
+    pub fn new(ctx: &'a Context, source: &'a TemplateSource) -> Self {
+        Self { ctx, source }
+    }
+
+    /// Evaluate an expression to a (possibly lazy) value
+    pub fn eval<'b>(&'b self, expr: &'b Expr) -> BoxFuture<'b, Result<LazyValue, TemplateError>> {
+        Box::pin(async move {
+            match expr {
+                Expr::Literal(lit) => self.eval_literal(lit).await,
+                Expr::Var(ident) => self.eval_var(ident),
+                Expr::Field(field) => self.eval_field(field).await,
+                Expr::Index(index) => self.eval_index(index).await,
+                Expr::Filter(filter) => self.eval_filter(filter).await,
+                Expr::Binary(binary) => self.eval_binary(binary).await,
+                Expr::Unary(unary) => self.eval_unary(unary).await,
+                Expr::Call(call) => self.eval_call(call).await,
+                Expr::Ternary(ternary) => self.eval_ternary(ternary).await,
+                Expr::Test(test) => self.eval_test(test).await,
+                Expr::MacroCall(_macro_call) => {
+                    // Macro calls are evaluated during rendering, not expression evaluation
+                    Ok(LazyValue::concrete(Value::NULL))
+                }
+                // r[impl expr.optional]
+                // `expr?` resolves the inner expression, yielding null instead of raising
+                // when it (or a field/index within it) is undefined.
+                Expr::Optional(opt) => match self.eval_concrete(&opt.expr).await {
+                    Ok(v) => Ok(LazyValue::concrete(v)),
+                    Err(TemplateError::Undefined(_)) => Ok(LazyValue::concrete(Value::NULL)),
+                    Err(e) => Err(e),
+                },
+            }
+        })
+    }
+
+    /// Evaluate and resolve to a concrete value (forces lazy resolution)
+    pub async fn eval_concrete(&self, expr: &Expr) -> Result<Value, TemplateError> {
+        self.eval(expr).await?.resolve().await
+    }
+
+    async fn eval_literal(&self, lit: &Literal) -> Result<LazyValue, TemplateError> {
+        Ok(LazyValue::concrete(match lit {
+            Literal::None(_) => Value::NULL,
+            Literal::Bool(b) => Value::from(b.value),
+            Literal::Int(i) => Value::from(i.value),
+            Literal::Float(f) => Value::from(f.value),
+            Literal::String(s) => Value::from(s.value.as_str()),
+            // r[impl literal.list]
+            Literal::List(l) => {
+                // List elements are resolved to concrete values
+                let mut elements = Vec::with_capacity(l.elements.len());
+                for e in &l.elements {
+                    elements.push(self.eval_concrete(e).await?);
+                }
+                VArray::from_iter(elements).into()
+            }
+            // r[impl literal.dict]
+            Literal::Dict(d) => {
+                let mut obj = VObject::new();
+                for (k, v) in &d.entries {
+                    let key = self.eval(k).await?.render_to_string().await;
+                    let value = self.eval_concrete(v).await?;
+                    obj.insert(VString::from(key.as_str()), value);
+                }
+                obj.into()
+            }
+        }))
+    }
+
+    // r[impl expr.var.lookup]
+    fn eval_var(&self, ident: &Ident) -> Result<LazyValue, TemplateError> {
+        // r[impl expr.var.undefined]
+        self.ctx.get(&ident.name).cloned().ok_or_else(|| {
+            UndefinedError {
+                name: ident.name.clone(),
+                available: self.ctx.available_vars(),
+                loc: SourceLocation::new(ident.span, self.source.named_source()),
+            }
+            .into()
+        })
+    }
+
+    // r[impl expr.field.missing]
+    async fn eval_field(&self, field: &FieldExpr) -> Result<LazyValue, TemplateError> {
+        let base = self.eval(&field.base).await?;
+        // Use LazyValue's field method - extends path for lazy, normal access for concrete
+        base.field(&field.field.name, field.field.span, self.source)
+    }
+
+    async fn eval_index(&self, index: &IndexExpr) -> Result<LazyValue, TemplateError> {
+        let base = self.eval(&index.base).await?;
+        let idx = self.eval(&index.index).await?;
+
+        // For lazy base, we need to resolve the index to get a concrete key/index
+        match &base {
+            LazyValue::Lazy { .. } => {
+                // Resolve the index to get the key
+                let idx_resolved = idx.resolve().await?;
+                match idx_resolved.destructure_ref() {
+                    DestructuredRef::Number(n) => {
+                        let i = n.to_i64().unwrap_or(0);
+                        base.index(i, index.index.span(), self.source)
+                    }
+                    DestructuredRef::String(s) => {
+                        base.index_str(s.as_str(), index.index.span(), self.source)
+                    }
+                    _ => Err(TypeError {
+                        expected: "number or string".to_string(),
+                        found: idx.type_name().to_string(),
+                        context: "index".to_string(),
+                        loc: SourceLocation::new(index.index.span(), self.source.named_source()),
+                    }
+                    .into()),
+                }
+            }
+            LazyValue::Concrete(base_val) => {
+                // Original concrete logic
+                let idx_resolved = idx.resolve().await?;
+                match (base_val.destructure_ref(), idx_resolved.destructure_ref()) {
+                    (DestructuredRef::Array(arr), DestructuredRef::Number(n)) => {
+                        let i = n.to_i64().unwrap_or(0);
+                        let i = if i < 0 {
+                            (arr.len() as i64 + i) as usize
+                        } else {
+                            i as usize
+                        };
+                        // r[impl expr.index.out-of-bounds]
+                        arr.get(i).cloned().map(LazyValue::concrete).ok_or_else(|| {
+                            TypeError {
+                                expected: format!("index < {}", arr.len()),
+                                found: format!("index {i}"),
+                                context: "list index".to_string(),
+                                loc: SourceLocation::new(
+                                    index.index.span(),
+                                    self.source.named_source(),
+                                ),
+                            }
+                            .into()
+                        })
+                    }
+                    // r[impl expr.index.missing-key]
+                    (DestructuredRef::Object(obj), DestructuredRef::String(key)) => obj
+                        .get(key.as_str())
+                        .cloned()
+                        .map(LazyValue::concrete)
+                        .ok_or_else(|| {
+                            UnknownFieldError {
+                                base_type: "dict".to_string(),
+                                field: key.to_string(),
+                                known_fields: obj.keys().map(|k| k.to_string()).collect(),
+                                loc: SourceLocation::new(
+                                    index.index.span(),
+                                    self.source.named_source(),
+                                ),
+                            }
+                            .into()
+                        }),
+                    (DestructuredRef::String(s), DestructuredRef::Number(n)) => {
+                        let i = n.to_i64().unwrap_or(0);
+                        let len = s.len();
+                        let i = if i < 0 {
+                            (len as i64 + i) as usize
+                        } else {
+                            i as usize
+                        };
+                        s.as_str()
+                            .chars()
+                            .nth(i)
+                            .map(|c| LazyValue::concrete(Value::from(c)))
+                            .ok_or_else(|| {
+                                TypeError {
+                                    expected: format!("index < {}", len),
+                                    found: format!("index {i}"),
+                                    context: "string index".to_string(),
+                                    loc: SourceLocation::new(
+                                        index.index.span(),
+                                        self.source.named_source(),
+                                    ),
+                                }
+                                .into()
+                            })
+                    }
+                    _ => Err(TypeError {
+                        expected: "list, dict, or string".to_string(),
+                        found: base.type_name().to_string(),
+                        context: "index access".to_string(),
+                        loc: SourceLocation::new(index.base.span(), self.source.named_source()),
+                    })?,
+                }
+            }
+        }
+    }
+
+    async fn eval_filter(&self, filter: &FilterExpr) -> Result<LazyValue, TemplateError> {
+        // Filters always work on concrete values. The `default` filter is special:
+        // if the expression is undefined, treat it as NULL so `default(value=...)` works.
+        let value = match self.eval_concrete(&filter.expr).await {
+            Ok(v) => v,
+            Err(TemplateError::Undefined(_)) if filter.filter.name == "default" => Value::NULL,
+            Err(e) => return Err(e),
+        };
+        let mut args = Vec::with_capacity(filter.args.len());
+        for a in &filter.args {
+            args.push(self.eval_concrete(a).await?);
+        }
+
+        let mut kwargs = Vec::with_capacity(filter.kwargs.len());
+        for (ident, expr) in &filter.kwargs {
+            kwargs.push((ident.name.clone(), self.eval_concrete(expr).await?));
+        }
+
+        apply_filter(
+            &filter.filter.name,
+            value,
+            &args,
+            &kwargs,
+            filter.filter.span,
+            self.source,
+        )
+        .map(LazyValue::concrete)
+    }
+
+    async fn eval_binary(&self, binary: &BinaryExpr) -> Result<LazyValue, TemplateError> {
+        // Short-circuit for and/or - these can stay lazy
+        match binary.op {
+            BinaryOp::And => {
+                let left = self.eval(&binary.left).await?;
+                if !left.is_truthy().await {
+                    return Ok(left);
+                }
+                return self.eval(&binary.right).await;
+            }
+            BinaryOp::Or => {
+                let left = self.eval(&binary.left).await?;
+                if left.is_truthy().await {
+                    return Ok(left);
+                }
+                return self.eval(&binary.right).await;
+            }
+            _ => {}
+        }
+
+        // All other binary ops need concrete values
+        let left = self.eval_concrete(&binary.left).await?;
+        let right = self.eval_concrete(&binary.right).await?;
+
+        Ok(LazyValue::concrete(match binary.op {
+            BinaryOp::Add => binary_add(&left, &right),
+            BinaryOp::Sub => binary_sub(&left, &right),
+            BinaryOp::Mul => binary_mul(&left, &right),
+            BinaryOp::Div => binary_div(&left, &right),
+            BinaryOp::FloorDiv => binary_floor_div(&left, &right),
+            BinaryOp::Mod => binary_mod(&left, &right),
+            BinaryOp::Pow => binary_pow(&left, &right),
+            BinaryOp::Eq => Value::from(values_equal(&left, &right)),
+            BinaryOp::Ne => Value::from(!values_equal(&left, &right)),
+            BinaryOp::Lt => Value::from(
+                compare_values(&left, &right)
+                    .map(|o| o.is_lt())
+                    .unwrap_or(false),
+            ),
+            BinaryOp::Le => Value::from(
+                compare_values(&left, &right)
+                    .map(|o| o.is_le())
+                    .unwrap_or(false),
+            ),
+            BinaryOp::Gt => Value::from(
+                compare_values(&left, &right)
+                    .map(|o| o.is_gt())
+                    .unwrap_or(false),
+            ),
+            BinaryOp::Ge => Value::from(
+                compare_values(&left, &right)
+                    .map(|o| o.is_ge())
+                    .unwrap_or(false),
+            ),
+            BinaryOp::In => Value::from(value_in(&left, &right)),
+            BinaryOp::NotIn => Value::from(!value_in(&left, &right)),
+            BinaryOp::Concat => Value::from(
+                format!("{}{}", left.render_to_string(), right.render_to_string()).as_str(),
+            ),
+            BinaryOp::And | BinaryOp::Or => unreachable!(), // Handled above
+        }))
+    }
+
+    async fn eval_unary(&self, unary: &UnaryExpr) -> Result<LazyValue, TemplateError> {
+        // Unary ops need concrete values
+        let value = self.eval_concrete(&unary.expr).await?;
+
+        Ok(LazyValue::concrete(match unary.op {
+            UnaryOp::Not => Value::from(!value.is_truthy()),
+            UnaryOp::Neg => match value.destructure_ref() {
+                DestructuredRef::Number(n) => {
+                    if let Some(i) = n.to_i64() {
+                        Value::from(-i)
+                    } else if let Some(f) = n.to_f64() {
+                        Value::from(-f)
+                    } else {
+                        Value::NULL
+                    }
+                }
+                _ => Value::NULL,
+            },
+            UnaryOp::Pos => match value.destructure_ref() {
+                DestructuredRef::Number(_) => value,
+                _ => Value::NULL,
+            },
+        }))
+    }
+
+    async fn eval_call(&self, call: &CallExpr) -> Result<LazyValue, TemplateError> {
+        // Function calls require concrete argument values
+        let mut args = Vec::with_capacity(call.args.len());
+        for a in &call.args {
+            args.push(self.eval_concrete(a).await?);
+        }
+
+        let mut kwargs = Vec::with_capacity(call.kwargs.len());
+        for (ident, expr) in &call.kwargs {
+            kwargs.push((ident.name.clone(), self.eval_concrete(expr).await?));
+        }
+
+        // Check if this is a global function call
+        if let Expr::Var(ident) = &*call.func
+            && let Some(result_fut) = self.ctx.call_fn(&ident.name, &args, &kwargs)
+        {
+            return result_fut
+                .await
+                .map(LazyValue::concrete)
+                .map_err(|e| TemplateError::GlobalFn(e.to_string()));
+        }
+
+        // Check for method calls on special objects: obj.method()
+        // e.g., build.git_hash() -> calls "build" function with step name "git_hash"
+        if let Expr::Field(field) = &*call.func
+            && let Expr::Var(base_ident) = &*field.base
+        {
+            // Convert obj.method() to obj("method", ...kwargs)
+            let func_name = &base_ident.name;
+            let method_name = &field.field.name;
+
+            // Prepend method name as first positional arg
+            let mut full_args = vec![Value::from(method_name.as_str())];
+            full_args.extend(args.iter().cloned());
+
+            if let Some(result_fut) = self.ctx.call_fn(func_name, &full_args, &kwargs) {
+                return result_fut
+                    .await
+                    .map(LazyValue::concrete)
+                    .map_err(|e| TemplateError::GlobalFn(e.to_string()));
+            }
+        }
+
+        // Method call on an arbitrary value: `<expr>.method(args)` — e.g.
+        // `get_media(src).markup(...)`, where the receiver is itself a call result.
+        // Evaluate the receiver and dispatch to a host function named after the method,
+        // passing the receiver as the first positional argument.
+        if let Expr::Field(field) = &*call.func {
+            let receiver = self.eval_concrete(&field.base).await?;
+            let method_name = &field.field.name;
+            let mut full_args = Vec::with_capacity(args.len() + 1);
+            full_args.push(receiver);
+            full_args.extend(args);
+            if let Some(result_fut) = self.ctx.call_fn(method_name, &full_args, &kwargs) {
+                return result_fut
+                    .await
+                    .map(LazyValue::concrete)
+                    .map_err(|e| TemplateError::GlobalFn(e.to_string()));
+            }
+        }
+
+        // Unresolved method call.
+        Ok(LazyValue::concrete(Value::NULL))
+    }
+
+    async fn eval_ternary(&self, ternary: &TernaryExpr) -> Result<LazyValue, TemplateError> {
+        let condition = self.eval(&ternary.condition).await?;
+        if condition.is_truthy().await {
+            self.eval(&ternary.value).await
+        } else {
+            self.eval(&ternary.otherwise).await
+        }
+    }
+
+    async fn eval_test(&self, test: &TestExpr) -> Result<LazyValue, TemplateError> {
+        // Tests require concrete values.
+        //
+        // `defined`/`undefined` must tolerate an undefined operand — checking whether a
+        // variable exists is the whole point of the test, so an undefined variable reads
+        // as `null` here rather than raising. (Jinja2 semantics.)
+        let lenient_undefined = matches!(test.test_name.name.as_str(), "defined" | "undefined");
+        let value = match self.eval_concrete(&test.expr).await {
+            Ok(v) => v,
+            Err(TemplateError::Undefined(_)) if lenient_undefined => Value::NULL,
+            Err(e) => return Err(e),
+        };
+        let mut args = Vec::with_capacity(test.args.len());
+        for a in &test.args {
+            args.push(self.eval_concrete(a).await?);
+        }
+
+        let result = match test.test_name.name.as_str() {
+            // String tests
+            // r[impl test.starting-with]
+            "starting_with" | "startswith" => {
+                if let (DestructuredRef::String(s), Some(prefix)) =
+                    (value.destructure_ref(), args.first())
+                {
+                    if let DestructuredRef::String(p) = prefix.destructure_ref() {
+                        s.as_str().starts_with(p.as_str())
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+            // r[impl test.ending-with]
+            "ending_with" | "endswith" => {
+                if let (DestructuredRef::String(s), Some(suffix)) =
+                    (value.destructure_ref(), args.first())
+                {
+                    if let DestructuredRef::String(p) = suffix.destructure_ref() {
+                        s.as_str().ends_with(p.as_str())
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+            // r[impl test.containing]
+            "containing" | "contains" => match value.destructure_ref() {
+                DestructuredRef::String(s) => {
+                    if let Some(needle) = args.first() {
+                        if let DestructuredRef::String(n) = needle.destructure_ref() {
+                            s.as_str().contains(n.as_str())
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    }
+                }
+                DestructuredRef::Array(arr) => args
+                    .first()
+                    .map(|needle| arr.iter().any(|item| values_equal(item, needle)))
+                    .unwrap_or(false),
+                _ => false,
+            },
+            // Type tests
+            // r[impl test.defined]
+            "defined" => !value.is_null(),
+            // r[impl test.undefined]
+            "undefined" => value.is_null(),
+            // r[impl test.none]
+            "none" => value.is_null(),
+            // r[impl test.string]
+            "string" => value.is_string(),
+            // r[impl test.number]
+            "number" => value.is_number(),
+            // r[impl test.integer]
+            "integer" => {
+                if let DestructuredRef::Number(n) = value.destructure_ref() {
+                    n.to_i64().is_some() && n.to_f64().map(|f| f.fract() == 0.0).unwrap_or(false)
+                } else {
+                    false
+                }
+            }
+            // r[impl test.float]
+            "float" => {
+                if let DestructuredRef::Number(n) = value.destructure_ref() {
+                    n.to_f64().map(|f| f.fract() != 0.0).unwrap_or(false)
+                } else {
+                    false
+                }
+            }
+            // r[impl test.mapping]
+            "mapping" | "dict" => value.is_object(),
+            // r[impl test.iterable]
+            "iterable" | "sequence" => {
+                matches!(
+                    value.destructure_ref(),
+                    DestructuredRef::Array(_)
+                        | DestructuredRef::String(_)
+                        | DestructuredRef::Object(_)
+                )
+            }
+            // Value tests
+            // r[impl test.odd]
+            "odd" => {
+                if let DestructuredRef::Number(n) = value.destructure_ref() {
+                    n.to_i64().map(|i| i % 2 != 0).unwrap_or(false)
+                } else {
+                    false
+                }
+            }
+            // r[impl test.even]
+            "even" => {
+                if let DestructuredRef::Number(n) = value.destructure_ref() {
+                    n.to_i64().map(|i| i % 2 == 0).unwrap_or(false)
+                } else {
+                    false
+                }
+            }
+            // r[impl test.truthy]
+            "truthy" => value.is_truthy(),
+            // r[impl test.falsy]
+            "falsy" => !value.is_truthy(),
+            // r[impl test.empty]
+            "empty" => match value.destructure_ref() {
+                DestructuredRef::String(s) => s.is_empty(),
+                DestructuredRef::Array(arr) => arr.is_empty(),
+                DestructuredRef::Object(obj) => obj.is_empty(),
+                _ => false,
+            },
+            // Comparison tests
+            // r[impl test.eq]
+            "eq" | "equalto" | "sameas" => args
+                .first()
+                .map(|other| values_equal(&value, other))
+                .unwrap_or(false),
+            // r[impl test.ne]
+            "ne" => args
+                .first()
+                .map(|other| !values_equal(&value, other))
+                .unwrap_or(false),
+            // r[impl test.lt]
+            "lt" | "lessthan" => {
+                if let Some(other) = args.first() {
+                    compare_values(&value, other)
+                        .map(|o| o.is_lt())
+                        .unwrap_or(false)
+                } else {
+                    false
+                }
+            }
+            // r[impl test.gt]
+            "gt" | "greaterthan" => {
+                if let Some(other) = args.first() {
+                    compare_values(&value, other)
+                        .map(|o| o.is_gt())
+                        .unwrap_or(false)
+                } else {
+                    false
+                }
+            }
+            other => {
+                return Err(UnknownTestError {
+                    name: other.to_string(),
+                    loc: SourceLocation::new(test.test_name.span, self.source.named_source()),
+                })?;
+            }
+        };
+
+        Ok(LazyValue::concrete(Value::from(if test.negated {
+            !result
+        } else {
+            result
+        })))
+    }
+}
+
+// === Binary operation helpers ===
+
+fn binary_add(left: &Value, right: &Value) -> Value {
+    match (left.destructure_ref(), right.destructure_ref()) {
+        (DestructuredRef::Number(a), DestructuredRef::Number(b)) => {
+            if let (Some(ai), Some(bi)) = (a.to_i64(), b.to_i64()) {
+                Value::from(ai + bi)
+            } else if let (Some(af), Some(bf)) = (a.to_f64(), b.to_f64()) {
+                Value::from(af + bf)
+            } else {
+                Value::NULL
+            }
+        }
+        (DestructuredRef::String(a), DestructuredRef::String(b)) => {
+            Value::from(format!("{}{}", a.as_str(), b.as_str()).as_str())
+        }
+        (DestructuredRef::Array(a), DestructuredRef::Array(b)) => {
+            let mut result: Vec<Value> = a.iter().cloned().collect();
+            result.extend(b.iter().cloned());
+            VArray::from_iter(result).into()
+        }
+        _ => Value::NULL,
+    }
+}
+
+fn binary_sub(left: &Value, right: &Value) -> Value {
+    match (left.destructure_ref(), right.destructure_ref()) {
+        (DestructuredRef::Number(a), DestructuredRef::Number(b)) => {
+            if let (Some(ai), Some(bi)) = (a.to_i64(), b.to_i64()) {
+                Value::from(ai - bi)
+            } else if let (Some(af), Some(bf)) = (a.to_f64(), b.to_f64()) {
+                Value::from(af - bf)
+            } else {
+                Value::NULL
+            }
+        }
+        _ => Value::NULL,
+    }
+}
+
+fn binary_mul(left: &Value, right: &Value) -> Value {
+    match (left.destructure_ref(), right.destructure_ref()) {
+        (DestructuredRef::Number(a), DestructuredRef::Number(b)) => {
+            if let (Some(ai), Some(bi)) = (a.to_i64(), b.to_i64()) {
+                Value::from(ai * bi)
+            } else if let (Some(af), Some(bf)) = (a.to_f64(), b.to_f64()) {
+                Value::from(af * bf)
+            } else {
+                Value::NULL
+            }
+        }
+        (DestructuredRef::String(s), DestructuredRef::Number(n))
+        | (DestructuredRef::Number(n), DestructuredRef::String(s)) => {
+            if let Some(count) = n.to_i64() {
+                Value::from(s.as_str().repeat(count as usize).as_str())
+            } else {
+                Value::NULL
+            }
+        }
+        _ => Value::NULL,
+    }
+}
+
+fn binary_div(left: &Value, right: &Value) -> Value {
+    match (left.destructure_ref(), right.destructure_ref()) {
+        (DestructuredRef::Number(a), DestructuredRef::Number(b)) => {
+            if let (Some(af), Some(bf)) = (a.to_f64(), b.to_f64()) {
+                if bf != 0.0 {
+                    Value::from(af / bf)
+                } else {
+                    Value::NULL
+                }
+            } else {
+                Value::NULL
+            }
+        }
+        _ => Value::NULL,
+    }
+}
+
+fn binary_floor_div(left: &Value, right: &Value) -> Value {
+    match (left.destructure_ref(), right.destructure_ref()) {
+        (DestructuredRef::Number(a), DestructuredRef::Number(b)) => {
+            if let (Some(ai), Some(bi)) = (a.to_i64(), b.to_i64()) {
+                if bi != 0 {
+                    Value::from(ai / bi)
+                } else {
+                    Value::NULL
+                }
+            } else {
+                Value::NULL
+            }
+        }
+        _ => Value::NULL,
+    }
+}
+
+fn binary_mod(left: &Value, right: &Value) -> Value {
+    match (left.destructure_ref(), right.destructure_ref()) {
+        (DestructuredRef::Number(a), DestructuredRef::Number(b)) => {
+            if let (Some(ai), Some(bi)) = (a.to_i64(), b.to_i64()) {
+                if bi != 0 {
+                    Value::from(ai % bi)
+                } else {
+                    Value::NULL
+                }
+            } else {
+                Value::NULL
+            }
+        }
+        _ => Value::NULL,
+    }
+}
+
+fn binary_pow(left: &Value, right: &Value) -> Value {
+    match (left.destructure_ref(), right.destructure_ref()) {
+        (DestructuredRef::Number(a), DestructuredRef::Number(b)) => {
+            if let (Some(ai), Some(bi)) = (a.to_i64(), b.to_i64()) {
+                if bi >= 0 {
+                    Value::from(ai.pow(bi as u32))
+                } else {
+                    Value::NULL
+                }
+            } else if let (Some(af), Some(bf)) = (a.to_f64(), b.to_f64()) {
+                Value::from(af.powf(bf))
+            } else {
+                Value::NULL
+            }
+        }
+        _ => Value::NULL,
+    }
+}
+
+fn values_equal(a: &Value, b: &Value) -> bool {
+    a == b
+}
+
+fn compare_values(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
+    a.partial_cmp(b)
+}
+
+fn value_in(needle: &Value, haystack: &Value) -> bool {
+    match haystack.destructure_ref() {
+        DestructuredRef::Array(arr) => arr.iter().any(|v| values_equal(needle, v)),
+        DestructuredRef::Object(obj) => {
+            if let DestructuredRef::String(key) = needle.destructure_ref() {
+                obj.contains_key(key.as_str())
+            } else {
+                false
+            }
+        }
+        DestructuredRef::String(s) => {
+            if let DestructuredRef::String(sub) = needle.destructure_ref() {
+                s.as_str().contains(sub.as_str())
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Look up a (possibly dotted) attribute path on a value. Each segment must
+/// resolve to an object until the last; the last segment's value is returned.
+/// Returns `None` if any segment is missing or non-traversable.
+fn lookup_attr_path(root: &Value, path: &str) -> Option<Value> {
+    let mut current = root.clone();
+    for segment in path.split('.') {
+        let next = match current.destructure_ref() {
+            DestructuredRef::Object(obj) => obj.get(segment).cloned(),
+            _ => return None,
+        };
+        current = next?;
+    }
+    Some(current)
+}
+
+/// Helper for selectattr/rejectattr filters.
+///
+/// Accepts both positional and kwarg invocations:
+/// - `selectattr("field")` — keep items where field is truthy
+/// - `selectattr("field", "eq", value)` — keep items where field equals value
+/// - `selectattr(attribute="field", value=value)` — kwarg form, defaults test to "eq"
+/// - `selectattr("a.b.c", ...)` — dotted path traverses nested objects
+fn filter_by_attr<'a>(
+    value: &Value,
+    args: &[Value],
+    get_kwarg: impl Fn(&str) -> Option<&'a Value>,
+    reject: bool,
+) -> Value {
+    match value.destructure_ref() {
+        DestructuredRef::Array(arr) => {
+            // attribute: args[0] or kwarg "attribute" (required)
+            let attr_name = match args
+                .first()
+                .and_then(|v| v.as_string())
+                .map(|s| s.to_string())
+                .or_else(|| {
+                    get_kwarg("attribute")
+                        .and_then(|v| v.as_string())
+                        .map(|s| s.to_string())
+                }) {
+                Some(s) => s,
+                None => return value.clone(),
+            };
+
+            // value: args[2] or kwarg "value" (optional)
+            let test_value = args.get(2).cloned().or_else(|| get_kwarg("value").cloned());
+
+            // test: args[1] (optional); defaults to "eq" if a value is present,
+            // otherwise to "truthy". Matches Jinja2/Tera convention so that
+            // `selectattr("x", value=y)` and `selectattr("x", "eq", y)` agree.
+            let test_name = args
+                .get(1)
+                .and_then(|v| v.as_string())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| {
+                    if test_value.is_some() {
+                        "eq".to_string()
+                    } else {
+                        "truthy".to_string()
+                    }
+                });
+
+            let filtered: Vec<Value> = arr
+                .iter()
+                .filter(|item| {
+                    let attr_val = lookup_attr_path(item, attr_name.as_str());
+
+                    let passes = match test_name.as_str() {
+                        "truthy" => attr_val.as_ref().map(|v| v.is_truthy()).unwrap_or(false),
+                        "falsy" => attr_val.as_ref().map(|v| !v.is_truthy()).unwrap_or(true),
+                        "defined" => attr_val.is_some(),
+                        "undefined" => attr_val.is_none(),
+                        "none" => attr_val.as_ref().map(|v| v.is_null()).unwrap_or(true),
+                        "eq" => match (&attr_val, &test_value) {
+                            (Some(a), Some(b)) => values_equal(a, b),
+                            _ => false,
+                        },
+                        "ne" => match (&attr_val, &test_value) {
+                            (Some(a), Some(b)) => !values_equal(a, b),
+                            _ => true,
+                        },
+                        "gt" => match (&attr_val, &test_value) {
+                            (Some(a), Some(b)) => {
+                                compare_values(a, b) == Some(std::cmp::Ordering::Greater)
+                            }
+                            _ => false,
+                        },
+                        "ge" => match (&attr_val, &test_value) {
+                            (Some(a), Some(b)) => {
+                                matches!(
+                                    compare_values(a, b),
+                                    Some(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal)
+                                )
+                            }
+                            _ => false,
+                        },
+                        "lt" => match (&attr_val, &test_value) {
+                            (Some(a), Some(b)) => {
+                                compare_values(a, b) == Some(std::cmp::Ordering::Less)
+                            }
+                            _ => false,
+                        },
+                        "le" => match (&attr_val, &test_value) {
+                            (Some(a), Some(b)) => {
+                                matches!(
+                                    compare_values(a, b),
+                                    Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal)
+                                )
+                            }
+                            _ => false,
+                        },
+                        "starting_with" => match (&attr_val, &test_value) {
+                            (Some(a), Some(b)) => {
+                                a.render_to_string().starts_with(&b.render_to_string())
+                            }
+                            _ => false,
+                        },
+                        "ending_with" => match (&attr_val, &test_value) {
+                            (Some(a), Some(b)) => {
+                                a.render_to_string().ends_with(&b.render_to_string())
+                            }
+                            _ => false,
+                        },
+                        "containing" => match (&attr_val, &test_value) {
+                            (Some(a), Some(b)) => {
+                                a.render_to_string().contains(&b.render_to_string())
+                            }
+                            _ => false,
+                        },
+                        _ => attr_val.as_ref().map(|v| v.is_truthy()).unwrap_or(false),
+                    };
+
+                    if reject { !passes } else { passes }
+                })
+                .cloned()
+                .collect();
+
+            VArray::from_iter(filtered).into()
+        }
+        _ => value.clone(),
+    }
+}
+
+/// Convert basic inline markdown to HTML.
+///
+/// Handles: **bold**, *italic*, `code`, and [text](url) links.
+/// All other characters are HTML-escaped. Returns a Value string with
+/// HTML-safe content (caller should mark it safe with `| safe` if needed,
+/// or use `basic_markdown | safe`).
+fn basic_markdown_to_html(s: &str) -> Value {
+    let mut out = String::with_capacity(s.len() + 16);
+    let mut chars = s.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        match c {
+            '*' if s[i..].starts_with("**") => {
+                // **bold**
+                chars.next(); // skip second *
+                let rest = &s[i + 2..];
+                if let Some(end) = rest.find("**") {
+                    let inner = html_escape_str(&rest[..end]);
+                    out.push_str("<strong>");
+                    out.push_str(&inner);
+                    out.push_str("</strong>");
+                    // advance past the bold span
+                    for _ in 0..(end + 2) {
+                        chars.next();
+                    }
+                } else {
+                    out.push_str("**");
+                }
+            }
+            '*' => {
+                // *italic*
+                let rest = &s[i + 1..];
+                if let Some(end) = rest.find('*') {
+                    let inner = html_escape_str(&rest[..end]);
+                    out.push_str("<em>");
+                    out.push_str(&inner);
+                    out.push_str("</em>");
+                    for _ in 0..end {
+                        chars.next();
+                    }
+                    chars.next(); // closing *
+                } else {
+                    out.push('*');
+                }
+            }
+            '`' => {
+                // `code`
+                let rest = &s[i + 1..];
+                if let Some(end) = rest.find('`') {
+                    let inner = html_escape_str(&rest[..end]);
+                    out.push_str("<code>");
+                    out.push_str(&inner);
+                    out.push_str("</code>");
+                    for _ in 0..end {
+                        chars.next();
+                    }
+                    chars.next(); // closing `
+                } else {
+                    out.push('`');
+                }
+            }
+            '[' => {
+                // [text](url)
+                let rest = &s[i + 1..];
+                if let Some(text_end) = rest.find("](") {
+                    let text = &rest[..text_end];
+                    let after = &rest[text_end + 2..];
+                    if let Some(url_end) = after.find(')') {
+                        let url = &after[..url_end];
+                        out.push_str("<a href=\"");
+                        out.push_str(&html_escape_str(url));
+                        out.push_str("\">");
+                        out.push_str(&html_escape_str(text));
+                        out.push_str("</a>");
+                        // advance past the link
+                        let skip = text_end + 2 + url_end + 1;
+                        for _ in 0..skip {
+                            chars.next();
+                        }
+                        continue;
+                    }
+                }
+                out.push('[');
+            }
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            _ => out.push(c),
+        }
+    }
+    Value::from(out.as_str())
+}
+
+fn html_escape_str(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Apply a built-in filter
+fn apply_filter(
+    name: &str,
+    value: Value,
+    args: &[Value],
+    kwargs: &[(String, Value)],
+    span: Span,
+    source: &TemplateSource,
+) -> Result<Value, TemplateError> {
+    // Helper to get kwarg value
+    let get_kwarg =
+        |key: &str| -> Option<&Value> { kwargs.iter().find(|(k, _)| k == key).map(|(_, v)| v) };
+
+    Ok(match name {
+        // r[impl filter.upper]
+        "upper" => Value::from(value.render_to_string().to_uppercase().as_str()),
+        // r[impl filter.lower]
+        "lower" => Value::from(value.render_to_string().to_lowercase().as_str()),
+        // r[impl filter.capitalize]
+        "capitalize" => {
+            let s = value.render_to_string();
+            let mut chars = s.chars();
+            match chars.next() {
+                None => Value::from(""),
+                Some(first) => {
+                    let result: String = first.to_uppercase().chain(chars).collect();
+                    Value::from(result.as_str())
+                }
+            }
+        }
+        // r[impl filter.title]
+        "title" => {
+            let s = value.render_to_string();
+            let result = s
+                .split_whitespace()
+                .map(|word| {
+                    let mut chars = word.chars();
+                    match chars.next() {
+                        None => String::new(),
+                        Some(first) => first.to_uppercase().chain(chars).collect(),
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            Value::from(result.as_str())
+        }
+        // r[impl filter.trim]
+        "trim" => Value::from(value.render_to_string().trim()),
+        // r[impl filter.length]
+        "length" => match value.destructure_ref() {
+            DestructuredRef::String(s) => Value::from(s.len() as i64),
+            DestructuredRef::Array(arr) => Value::from(arr.len() as i64),
+            DestructuredRef::Object(obj) => Value::from(obj.len() as i64),
+            _ => Value::from(0i64),
+        },
+        // r[impl filter.first]
+        "first" => match value.destructure_ref() {
+            DestructuredRef::Array(arr) if !arr.is_empty() => {
+                arr.get(0).cloned().unwrap_or(Value::NULL)
+            }
+            DestructuredRef::String(s) => s
+                .as_str()
+                .chars()
+                .next()
+                .map(|c| Value::from(c.to_string().as_str()))
+                .unwrap_or(Value::NULL),
+            _ => Value::NULL,
+        },
+        // r[impl filter.last]
+        "last" => match value.destructure_ref() {
+            DestructuredRef::Array(arr) if !arr.is_empty() => {
+                arr.get(arr.len() - 1).cloned().unwrap_or(Value::NULL)
+            }
+            DestructuredRef::String(s) => s
+                .as_str()
+                .chars()
+                .last()
+                .map(|c| Value::from(c.to_string().as_str()))
+                .unwrap_or(Value::NULL),
+            _ => Value::NULL,
+        },
+        // r[impl filter.reverse]
+        "reverse" => match value.destructure_ref() {
+            DestructuredRef::Array(arr) => {
+                let reversed: Vec<Value> = arr.iter().rev().cloned().collect();
+                VArray::from_iter(reversed).into()
+            }
+            DestructuredRef::String(s) => {
+                let reversed: String = s.as_str().chars().rev().collect();
+                Value::from(reversed.as_str())
+            }
+            _ => value,
+        },
+        // r[impl filter.sort]
+        "sort" => match value.destructure_ref() {
+            DestructuredRef::Array(arr) => {
+                let mut items: Vec<Value> = arr.iter().cloned().collect();
+                // Check for attribute= kwarg for sorting objects by field
+                if let Some(attr_val) = get_kwarg("attribute") {
+                    if let DestructuredRef::String(attr) = attr_val.destructure_ref() {
+                        items.sort_by(|a, b| {
+                            let a_val = if let DestructuredRef::Object(obj) = a.destructure_ref() {
+                                obj.get(attr.as_str())
+                            } else {
+                                None
+                            };
+                            let b_val = if let DestructuredRef::Object(obj) = b.destructure_ref() {
+                                obj.get(attr.as_str())
+                            } else {
+                                None
+                            };
+                            match (a_val, b_val) {
+                                (Some(a), Some(b)) => {
+                                    compare_values(a, b).unwrap_or(std::cmp::Ordering::Equal)
+                                }
+                                (Some(_), None) => std::cmp::Ordering::Less,
+                                (None, Some(_)) => std::cmp::Ordering::Greater,
+                                (None, None) => std::cmp::Ordering::Equal,
+                            }
+                        });
+                    }
+                } else {
+                    items.sort_by(|a, b| compare_values(a, b).unwrap_or(std::cmp::Ordering::Equal));
+                }
+                VArray::from_iter(items).into()
+            }
+            _ => value,
+        },
+        // r[impl filter.join]
+        "join" => {
+            let sep = args
+                .first()
+                .map(|v| v.render_to_string())
+                .unwrap_or_default();
+            match value.destructure_ref() {
+                DestructuredRef::Array(arr) => {
+                    let strings: Vec<String> = arr.iter().map(|v| v.render_to_string()).collect();
+                    Value::from(strings.join(&sep).as_str())
+                }
+                _ => value,
+            }
+        }
+        // r[impl filter.split]
+        "split" => {
+            // Support both positional: split("/") and kwarg: split(pat="/")
+            let pat = get_kwarg("pat")
+                .map(|v| v.render_to_string())
+                .or_else(|| args.first().map(|v| v.render_to_string()))
+                .unwrap_or_else(|| " ".to_string());
+            let s = value.render_to_string();
+            let parts: Vec<Value> = s.split(&pat).map(Value::from).collect();
+            VArray::from_iter(parts).into()
+        }
+        // r[impl filter.default]
+        "default" => {
+            // Support both positional: default("fallback") and kwarg: default(value="fallback")
+            let default_val = get_kwarg("value")
+                .cloned()
+                .or_else(|| args.first().cloned())
+                .unwrap_or(Value::NULL);
+
+            if value.is_null() {
+                default_val
+            } else if let DestructuredRef::String(s) = value.destructure_ref() {
+                if s.is_empty() { default_val } else { value }
+            } else {
+                value
+            }
+        }
+        // r[impl filter.escape]
+        "escape" => {
+            let s = value.render_to_string();
+            let escaped = s
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;")
+                .replace('"', "&quot;")
+                .replace('\'', "&#x27;");
+            Value::from(escaped.as_str())
+        }
+        // r[impl filter.safe]
+        "safe" => {
+            // Convert string to safe string using VSafeString
+            if let Some(s) = value.as_string() {
+                s.clone().into_safe().into_value()
+            } else {
+                // Non-strings can't be marked safe, return as-is
+                value
+            }
+        }
+        // r[impl filter.typeof]
+        "typeof" => {
+            // Return the type name of the value
+            Value::from(value.type_name())
+        }
+        // r[impl filter.slice]
+        "slice" => {
+            // Slice a list: slice(start=0, end=N) or slice(0, N)
+            match value.destructure_ref() {
+                DestructuredRef::Array(arr) => {
+                    let start = get_kwarg("start")
+                        .and_then(|v| v.as_number().and_then(|n| n.to_i64()))
+                        .or_else(|| {
+                            args.first()
+                                .and_then(|v| v.as_number().and_then(|n| n.to_i64()))
+                        })
+                        .unwrap_or(0)
+                        .max(0) as usize;
+                    let end = get_kwarg("end")
+                        .and_then(|v| v.as_number().and_then(|n| n.to_i64()))
+                        .or_else(|| {
+                            args.get(1)
+                                .and_then(|v| v.as_number().and_then(|n| n.to_i64()))
+                        })
+                        .map(|e| e.max(0) as usize)
+                        .unwrap_or(arr.len());
+                    let end = end.min(arr.len());
+                    let start = start.min(end);
+                    VArray::from_iter(arr.iter().skip(start).take(end - start).cloned()).into()
+                }
+                _ => value,
+            }
+        }
+        // r[impl filter.map]
+        "map" => {
+            // Extract an attribute from each item: map(attribute="field")
+            // Dotted paths traverse nested objects: map(attribute="user.name").
+            match value.destructure_ref() {
+                DestructuredRef::Array(arr) => {
+                    if let Some(attr) = get_kwarg("attribute").and_then(|v| v.as_string()) {
+                        let mapped: Vec<Value> = arr
+                            .iter()
+                            .filter_map(|item| lookup_attr_path(item, attr.as_str()))
+                            .collect();
+                        VArray::from_iter(mapped).into()
+                    } else {
+                        value
+                    }
+                }
+                _ => value,
+            }
+        }
+        // r[impl filter.selectattr]
+        "selectattr" => {
+            // Filter items where attribute passes a test: selectattr("field", "eq", value)
+            filter_by_attr(&value, args, get_kwarg, false)
+        }
+        // r[impl filter.rejectattr]
+        "rejectattr" => {
+            // Filter items where attribute fails a test: rejectattr("field", "eq", value)
+            filter_by_attr(&value, args, get_kwarg, true)
+        }
+        // r[impl filter.groupby]
+        "groupby" => {
+            // Group items by attribute: groupby(attribute="field")
+            match value.destructure_ref() {
+                DestructuredRef::Array(arr) => {
+                    if let Some(attr) = get_kwarg("attribute").and_then(|v| v.as_string()) {
+                        // Use Vec to maintain insertion order
+                        let mut groups: Vec<(String, Vec<Value>)> = Vec::new();
+                        for item in arr.iter() {
+                            let key = lookup_attr_path(item, attr.as_str())
+                                .map(|v| v.render_to_string())
+                                .unwrap_or_default();
+                            // Find or create group
+                            if let Some((_, items)) = groups.iter_mut().find(|(k, _)| k == &key) {
+                                items.push(item.clone());
+                            } else {
+                                groups.push((key, vec![item.clone()]));
+                            }
+                        }
+                        // Return as array of [key, items] pairs for tuple unpacking
+                        let pairs: Vec<Value> = groups
+                            .into_iter()
+                            .map(|(k, v)| {
+                                let items_arr: Value = VArray::from_iter(v).into();
+                                let pair: Value =
+                                    VArray::from_iter([Value::from(k.as_str()), items_arr]).into();
+                                pair
+                            })
+                            .collect();
+                        VArray::from_iter(pairs).into()
+                    } else {
+                        value
+                    }
+                }
+                _ => value,
+            }
+        }
+        // Path manipulation filters
+        // r[impl filter.path-segments]
+        "path_segments" => {
+            // Split path into segments, removing empty strings from leading/trailing slashes
+            // "/foo/bar/" -> ["foo", "bar"]
+            let s = value.render_to_string();
+            let segments: Vec<Value> = s
+                .split('/')
+                .filter(|seg| !seg.is_empty())
+                .map(Value::from)
+                .collect();
+            VArray::from_iter(segments).into()
+        }
+        // r[impl filter.path-first]
+        "path_first" => {
+            // Get the first segment of a path
+            // "/foo/bar" -> "foo"
+            let s = value.render_to_string();
+            s.split('/')
+                .find(|seg| !seg.is_empty())
+                .map(Value::from)
+                .unwrap_or(Value::NULL)
+        }
+        // r[impl filter.path-parent]
+        "path_parent" => {
+            // Get the parent path
+            // "/foo/bar" -> "/foo", "/foo" -> "/", "/" -> "/"
+            let s = value.render_to_string();
+            let trimmed = s.trim_end_matches('/');
+            if trimmed.is_empty() {
+                return Ok(Value::from("/"));
+            }
+            match trimmed.rfind('/') {
+                Some(0) => Value::from("/"),
+                Some(idx) => Value::from(&trimmed[..idx]),
+                None => Value::from("/"),
+            }
+        }
+        // r[impl filter.path-basename]
+        "path_basename" => {
+            // Get the last segment of a path (basename)
+            // "/foo/bar" -> "bar", "/foo/" -> "foo"
+            let s = value.render_to_string();
+            s.trim_end_matches('/')
+                .rsplit('/')
+                .next()
+                .filter(|seg| !seg.is_empty())
+                .map(Value::from)
+                .unwrap_or(Value::NULL)
+        }
+        // r[impl filter.escape_for_attribute]
+        "escape_for_attribute" => {
+            let s = value.render_to_string();
+            let escaped = s
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;")
+                .replace('"', "&quot;")
+                .replace('\'', "&#x27;");
+            Value::from(escaped.as_str())
+        }
+        // r[impl filter.basic_markdown]
+        "basic_markdown" => {
+            // Minimal inline-only markdown pass: bold, italic, inline code, auto-links.
+            // Returns safe HTML so callers don't need `| safe`.
+            let s = value.render_to_string();
+            let html = basic_markdown_to_html(&s);
+            if let Some(sv) = html.as_string() {
+                sv.clone().into_safe().into_value()
+            } else {
+                html
+            }
+        }
+        _ => {
+            return Err(UnknownFilterError {
+                name: name.to_string(),
+                known_filters: builtin_filter_names().map(str::to_string).collect(),
+                loc: SourceLocation::new(span, source.named_source()),
+            }
+            .into());
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn builtin_filter_metadata_documents_runtime_filters() {
+        let names = builtin_filter_names().collect::<Vec<_>>();
+        assert!(names.contains(&"path_parent"));
+
+        let path_parent = builtin_filter("path_parent").expect("path_parent metadata");
+        assert_eq!(path_parent.detail, "Gingembre filter");
+        assert!(
+            path_parent
+                .documentation
+                .contains("Returns the parent path")
+        );
+
+        let unique = names.iter().copied().collect::<HashSet<_>>();
+        assert_eq!(unique.len(), names.len());
+    }
+
+    #[test]
+    fn builtin_test_metadata_documents_runtime_tests() {
+        let names = builtin_test_names().collect::<Vec<_>>();
+        assert!(names.contains(&"string"));
+        assert!(names.contains(&"startswith"));
+
+        let string = builtin_test("string").expect("string test metadata");
+        assert_eq!(string.detail, "Gingembre test");
+        assert!(string.documentation.contains("value is a string"));
+
+        let unique = names.iter().copied().collect::<HashSet<_>>();
+        assert_eq!(unique.len(), names.len());
+    }
+}

--- a/gingembre/src/lazy.rs
+++ b/gingembre/src/lazy.rs
@@ -1,0 +1,752 @@
+//! Lazy value system for fine-grained dependency tracking.
+//!
+//! This module provides [`LazyValue`], a wrapper around [`facet_value::Value`]
+//! that supports lazy resolution. Field access on lazy values extends a path
+//! rather than immediately resolving, allowing dependency tracking systems
+//! (like picante) to track exactly which values are accessed.
+//!
+//! # How It Works
+//!
+//! ```text
+//! data.versions.dodeca.version
+//!      ↓
+//! LazyValue { path: [] }
+//!      ↓ .versions
+//! LazyValue { path: ["versions"] }  ← no resolution yet!
+//!      ↓ .dodeca
+//! LazyValue { path: ["versions", "dodeca"] }
+//!      ↓ .version
+//! LazyValue { path: ["versions", "dodeca", "version"] }
+//!      ↓ print/compare/etc
+//! resolver.resolve(path).await → concrete value + dependency tracked
+//! ```
+
+use crate::error::{
+    DataPathNotFoundError, SourceLocation, SourceSpan, TemplateError, TemplateSource, TypeError,
+    UnknownFieldError,
+};
+use facet_value::DestructuredRef;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// A path through a data tree.
+///
+/// Paths are sequences of string segments representing navigation through
+/// nested objects and arrays. For example, `["versions", "dodeca", "version"]`
+/// represents `data.versions.dodeca.version`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct DataPath(pub Vec<String>);
+
+impl DataPath {
+    /// Create an empty (root) path.
+    pub fn root() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Create a new path by appending a segment.
+    pub fn push(&self, segment: impl Into<String>) -> Self {
+        let mut new_path = self.0.clone();
+        new_path.push(segment.into());
+        Self(new_path)
+    }
+
+    /// Get the path segments.
+    pub fn segments(&self) -> &[String] {
+        &self.0
+    }
+
+    /// Check if this is the root path.
+    pub fn is_root(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Display for DataPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.is_empty() {
+            write!(f, "(root)")
+        } else {
+            write!(f, "{}", self.0.join("."))
+        }
+    }
+}
+
+/// Trait for resolving lazy data values by path (async).
+///
+/// Implementations should track dependencies - each unique path that is
+/// resolved becomes a separate dependency in the tracking system.
+///
+/// # Example
+///
+/// A picante-backed resolver would create a tracked query for each path,
+/// allowing fine-grained cache invalidation when specific values change.
+///
+/// An RPC-backed resolver would call back to the host for each resolution,
+/// with the host tracking dependencies.
+pub trait DataResolver: Send + Sync {
+    /// Resolve a value at the given path.
+    ///
+    /// Returns `None` if the path doesn't exist in the data tree.
+    fn resolve(
+        &self,
+        path: &DataPath,
+    ) -> Pin<Box<dyn Future<Output = Option<facet_value::Value>> + Send + '_>>;
+
+    /// Get all child keys at a path (for iteration).
+    ///
+    /// Returns `None` if the path doesn't exist or points to a non-container value.
+    /// For objects, returns the field names.
+    /// For arrays, returns string indices ("0", "1", etc.).
+    fn keys_at(
+        &self,
+        path: &DataPath,
+    ) -> Pin<Box<dyn Future<Output = Option<Vec<String>>> + Send + '_>>;
+
+    /// Get the number of children at a path.
+    ///
+    /// Returns `None` if the path doesn't exist or isn't a container.
+    fn len_at(&self, path: &DataPath) -> Pin<Box<dyn Future<Output = Option<usize>> + Send + '_>> {
+        let path = path.clone();
+        Box::pin(async move {
+            // Default implementation calls keys_at
+            // Implementations can override for efficiency
+            self.keys_at(&path).await.map(|k| k.len())
+        })
+    }
+}
+
+/// A value that may be lazily resolved.
+///
+/// Field access on lazy values extends the path rather than immediately
+/// resolving. Resolution happens only when a concrete value is needed
+/// (printing, comparison, arithmetic, etc.).
+///
+/// This enables fine-grained dependency tracking: each unique path that
+/// is actually used becomes a separate tracked dependency.
+#[derive(Clone)]
+pub enum LazyValue {
+    /// A concrete, already-resolved value.
+    Concrete(facet_value::Value),
+
+    /// A lazy reference that will be resolved on demand.
+    Lazy {
+        /// The resolver that can fetch values by path.
+        resolver: Arc<dyn DataResolver>,
+        /// The path through the data tree.
+        path: DataPath,
+    },
+}
+
+impl std::fmt::Debug for LazyValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Concrete(v) => write!(f, "Concrete({:?})", v),
+            Self::Lazy { path, .. } => write!(f, "Lazy {{ path: {} }}", path),
+        }
+    }
+}
+
+impl LazyValue {
+    /// Create a concrete value (no lazy resolution).
+    pub fn concrete(value: facet_value::Value) -> Self {
+        Self::Concrete(value)
+    }
+
+    /// Create a lazy value with a resolver and path.
+    pub fn lazy(resolver: Arc<dyn DataResolver>, path: DataPath) -> Self {
+        Self::Lazy { resolver, path }
+    }
+
+    /// Create a lazy value at the root path.
+    pub fn lazy_root(resolver: Arc<dyn DataResolver>) -> Self {
+        Self::Lazy {
+            resolver,
+            path: DataPath::root(),
+        }
+    }
+
+    /// Check if this is a lazy (unresolved) value.
+    pub fn is_lazy(&self) -> bool {
+        matches!(self, Self::Lazy { .. })
+    }
+
+    /// Check if this is a concrete (resolved) value.
+    pub fn is_concrete(&self) -> bool {
+        matches!(self, Self::Concrete(_))
+    }
+
+    /// Force resolution to a concrete value.
+    ///
+    /// For concrete values, returns a clone.
+    /// For lazy values, calls the resolver and returns the result.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the path doesn't exist in the data tree.
+    /// Uses a default location for error reporting; use `resolve_at` for precise locations.
+    pub async fn resolve(&self) -> Result<facet_value::Value, TemplateError> {
+        match self {
+            Self::Concrete(value) => Ok(value.clone()),
+            Self::Lazy { resolver, path } => resolver.resolve(path).await.ok_or_else(|| {
+                DataPathNotFoundError {
+                    path: path.to_string(),
+                    loc: SourceLocation::new(
+                        SourceSpan::default(),
+                        crate::error::NamedSource::new("<unknown>", ""),
+                    ),
+                }
+                .into()
+            }),
+        }
+    }
+
+    /// Force resolution with source location for error reporting.
+    pub async fn resolve_at(
+        &self,
+        span: crate::ast::Span,
+        source: &TemplateSource,
+    ) -> Result<facet_value::Value, TemplateError> {
+        match self {
+            Self::Concrete(value) => Ok(value.clone()),
+            Self::Lazy { resolver, path } => resolver.resolve(path).await.ok_or_else(|| {
+                DataPathNotFoundError {
+                    path: path.to_string(),
+                    loc: SourceLocation::new(span, source.named_source()),
+                }
+                .into()
+            }),
+        }
+    }
+
+    /// Try to resolve, returning None if the path doesn't exist.
+    pub async fn try_resolve(&self) -> Option<facet_value::Value> {
+        match self {
+            Self::Concrete(value) => Some(value.clone()),
+            Self::Lazy { resolver, path } => resolver.resolve(path).await,
+        }
+    }
+
+    /// Access a field by name.
+    ///
+    /// For lazy values, this extends the path without resolving.
+    /// For concrete values, this performs normal field access.
+    pub fn field(
+        &self,
+        name: &str,
+        span: crate::ast::Span,
+        source: &TemplateSource,
+    ) -> Result<LazyValue, TemplateError> {
+        match self {
+            Self::Lazy { resolver, path } => {
+                // Extend the path - don't resolve yet!
+                Ok(Self::Lazy {
+                    resolver: resolver.clone(),
+                    path: path.push(name),
+                })
+            }
+            Self::Concrete(value) => {
+                // Normal field access on concrete value
+                match value.destructure_ref() {
+                    DestructuredRef::Object(obj) => {
+                        obj.get(name).cloned().map(Self::Concrete).ok_or_else(|| {
+                            UnknownFieldError {
+                                base_type: "dict".to_string(),
+                                field: name.to_string(),
+                                known_fields: obj.keys().map(|k| k.to_string()).collect(),
+                                loc: SourceLocation::new(span, source.named_source()),
+                            }
+                            .into()
+                        })
+                    }
+                    _ => Err(TypeError {
+                        expected: "object or dict".to_string(),
+                        found: self.type_name().to_string(),
+                        context: format!("accessing field `{}`", name),
+                        loc: SourceLocation::new(span, source.named_source()),
+                    }
+                    .into()),
+                }
+            }
+        }
+    }
+
+    /// Access an element by index.
+    ///
+    /// For lazy values, this extends the path with the index.
+    /// For concrete values, this performs normal index access.
+    pub fn index(
+        &self,
+        idx: i64,
+        span: crate::ast::Span,
+        source: &TemplateSource,
+    ) -> Result<LazyValue, TemplateError> {
+        match self {
+            Self::Lazy { resolver, path } => {
+                // Extend the path with the index
+                Ok(Self::Lazy {
+                    resolver: resolver.clone(),
+                    path: path.push(idx.to_string()),
+                })
+            }
+            Self::Concrete(value) => match value.destructure_ref() {
+                DestructuredRef::Array(arr) => {
+                    let i = if idx < 0 {
+                        (arr.len() as i64 + idx) as usize
+                    } else {
+                        idx as usize
+                    };
+                    arr.get(i).cloned().map(Self::Concrete).ok_or_else(|| {
+                        TypeError {
+                            expected: format!("index < {}", arr.len()),
+                            found: format!("index {i}"),
+                            context: "list index".to_string(),
+                            loc: SourceLocation::new(span, source.named_source()),
+                        }
+                        .into()
+                    })
+                }
+                _ => Err(TypeError {
+                    expected: "list".to_string(),
+                    found: self.type_name().to_string(),
+                    context: "index access".to_string(),
+                    loc: SourceLocation::new(span, source.named_source()),
+                }
+                .into()),
+            },
+        }
+    }
+
+    /// Access by string key (for object["key"] syntax).
+    pub fn index_str(
+        &self,
+        key: &str,
+        span: crate::ast::Span,
+        source: &TemplateSource,
+    ) -> Result<LazyValue, TemplateError> {
+        match self {
+            Self::Lazy { resolver, path } => Ok(Self::Lazy {
+                resolver: resolver.clone(),
+                path: path.push(key),
+            }),
+            Self::Concrete(value) => match value.destructure_ref() {
+                DestructuredRef::Object(obj) => {
+                    obj.get(key).cloned().map(Self::Concrete).ok_or_else(|| {
+                        UnknownFieldError {
+                            base_type: "dict".to_string(),
+                            field: key.to_string(),
+                            known_fields: obj.keys().map(|k| k.to_string()).collect(),
+                            loc: SourceLocation::new(span, source.named_source()),
+                        }
+                        .into()
+                    })
+                }
+                _ => Err(TypeError {
+                    expected: "dict".to_string(),
+                    found: self.type_name().to_string(),
+                    context: "string index access".to_string(),
+                    loc: SourceLocation::new(span, source.named_source()),
+                }
+                .into()),
+            },
+        }
+    }
+
+    /// Get an iterator over (key, value) pairs.
+    ///
+    /// For lazy values, this resolves the keys but keeps values lazy.
+    /// For concrete values, this iterates normally.
+    pub async fn iter_pairs(&self) -> Vec<(String, LazyValue)> {
+        match self {
+            Self::Lazy { resolver, path } => {
+                // Get keys at this path, but keep values lazy!
+                let keys = resolver.keys_at(path).await.unwrap_or_default();
+                keys.into_iter()
+                    .map(|key| {
+                        let child_path = path.push(&key);
+                        (
+                            key,
+                            Self::Lazy {
+                                resolver: resolver.clone(),
+                                path: child_path,
+                            },
+                        )
+                    })
+                    .collect()
+            }
+            Self::Concrete(value) => match value.destructure_ref() {
+                DestructuredRef::Object(obj) => obj
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), Self::Concrete(v.clone())))
+                    .collect(),
+                DestructuredRef::Array(arr) => arr
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| (i.to_string(), Self::Concrete(v.clone())))
+                    .collect(),
+                _ => Vec::new(),
+            },
+        }
+    }
+
+    /// Get an iterator over values only (for simple for loops).
+    pub async fn iter_values(&self) -> Vec<LazyValue> {
+        match self {
+            Self::Lazy { resolver, path } => {
+                let keys = resolver.keys_at(path).await.unwrap_or_default();
+                keys.into_iter()
+                    .map(|key| Self::Lazy {
+                        resolver: resolver.clone(),
+                        path: path.push(&key),
+                    })
+                    .collect()
+            }
+            Self::Concrete(value) => match value.destructure_ref() {
+                DestructuredRef::Array(arr) => arr.iter().cloned().map(Self::Concrete).collect(),
+                DestructuredRef::Object(obj) => {
+                    // For object iteration, return key-value pair objects
+                    obj.iter()
+                        .map(|(k, v)| {
+                            let mut entry = facet_value::VObject::new();
+                            entry.insert(
+                                facet_value::VString::from("key"),
+                                facet_value::Value::from(k.as_str()),
+                            );
+                            entry.insert(facet_value::VString::from("value"), v.clone());
+                            Self::Concrete(entry.into())
+                        })
+                        .collect()
+                }
+                DestructuredRef::String(s) => s
+                    .as_str()
+                    .chars()
+                    .map(|c| Self::Concrete(facet_value::Value::from(c)))
+                    .collect(),
+                _ => Vec::new(),
+            },
+        }
+    }
+
+    /// Check if the value is truthy (forces resolution for lazy values).
+    pub async fn is_truthy(&self) -> bool {
+        match self.try_resolve().await {
+            Some(v) => crate::eval::ValueExt::is_truthy(&v),
+            None => false,
+        }
+    }
+
+    /// Check if the value is null.
+    pub async fn is_null(&self) -> bool {
+        match self.try_resolve().await {
+            Some(v) => v.is_null(),
+            None => true, // Unresolvable paths are treated as null
+        }
+    }
+
+    /// Get a type name for error messages.
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Self::Lazy { .. } => "lazy",
+            Self::Concrete(v) => match v.destructure_ref() {
+                DestructuredRef::Null => "none",
+                DestructuredRef::Bool(_) => "bool",
+                DestructuredRef::Number(_) => "number",
+                DestructuredRef::String(_) => "string",
+                DestructuredRef::Bytes(_) => "bytes",
+                DestructuredRef::Array(_) => "list",
+                DestructuredRef::Object(_) => "dict",
+                DestructuredRef::DateTime(_) => "datetime",
+                DestructuredRef::QName(_) => "qname",
+                DestructuredRef::Uuid(_) => "uuid",
+                DestructuredRef::Char(_) => "char",
+                _ => "unknown",
+            },
+        }
+    }
+
+    /// Render the value to a string (forces resolution).
+    pub async fn render_to_string(&self) -> String {
+        match self.try_resolve().await {
+            Some(v) => crate::eval::ValueExt::render_to_string(&v),
+            None => String::new(),
+        }
+    }
+
+    /// Check if this value is marked as "safe" (forces resolution).
+    pub async fn is_safe(&self) -> bool {
+        match self.try_resolve().await {
+            Some(v) => crate::eval::ValueExt::is_safe(&v),
+            None => false,
+        }
+    }
+
+    /// Get the length of a container (may not require full resolution).
+    pub async fn len(&self) -> Option<usize> {
+        match self {
+            Self::Lazy { resolver, path } => resolver.len_at(path).await,
+            Self::Concrete(value) => match value.destructure_ref() {
+                DestructuredRef::Array(arr) => Some(arr.len()),
+                DestructuredRef::Object(obj) => Some(obj.len()),
+                DestructuredRef::String(s) => Some(s.len()),
+                _ => None,
+            },
+        }
+    }
+
+    /// Check if the container is empty.
+    pub async fn is_empty(&self) -> bool {
+        self.len().await.map(|l| l == 0).unwrap_or(true)
+    }
+}
+
+// Conversion from facet_value::Value
+impl From<facet_value::Value> for LazyValue {
+    fn from(value: facet_value::Value) -> Self {
+        Self::Concrete(value)
+    }
+}
+
+// Convenience conversions
+impl From<&str> for LazyValue {
+    fn from(s: &str) -> Self {
+        Self::Concrete(facet_value::Value::from(s))
+    }
+}
+
+impl From<String> for LazyValue {
+    fn from(s: String) -> Self {
+        Self::Concrete(facet_value::Value::from(s.as_str()))
+    }
+}
+
+impl From<i64> for LazyValue {
+    fn from(n: i64) -> Self {
+        Self::Concrete(facet_value::Value::from(n))
+    }
+}
+
+impl From<f64> for LazyValue {
+    fn from(n: f64) -> Self {
+        Self::Concrete(facet_value::Value::from(n))
+    }
+}
+
+impl From<bool> for LazyValue {
+    fn from(b: bool) -> Self {
+        Self::Concrete(facet_value::Value::from(b))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use facet_value::{VObject, VString, Value};
+    use std::sync::Mutex;
+
+    fn test_span() -> crate::ast::Span {
+        crate::ast::span(0, 0)
+    }
+
+    /// A simple in-memory data resolver for testing.
+    struct TestResolver {
+        data: Value,
+        /// Track which paths were resolved (for testing)
+        resolved_paths: Mutex<Vec<DataPath>>,
+    }
+
+    impl TestResolver {
+        fn new(data: Value) -> Arc<Self> {
+            Arc::new(Self {
+                data,
+                resolved_paths: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn resolved_paths(&self) -> Vec<DataPath> {
+            self.resolved_paths.lock().unwrap().clone()
+        }
+    }
+
+    impl DataResolver for TestResolver {
+        fn resolve(
+            &self,
+            path: &DataPath,
+        ) -> Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
+            let path = path.clone();
+            Box::pin(async move {
+                self.resolved_paths.lock().unwrap().push(path.clone());
+
+                let mut current = self.data.clone();
+                for segment in path.segments() {
+                    current = match current.destructure_ref() {
+                        DestructuredRef::Object(obj) => obj.get(segment.as_str())?.clone(),
+                        DestructuredRef::Array(arr) => {
+                            let idx: usize = segment.parse().ok()?;
+                            arr.get(idx)?.clone()
+                        }
+                        _ => return None,
+                    };
+                }
+                Some(current)
+            })
+        }
+
+        fn keys_at(
+            &self,
+            path: &DataPath,
+        ) -> Pin<Box<dyn Future<Output = Option<Vec<String>>> + Send + '_>> {
+            let path = path.clone();
+            Box::pin(async move {
+                let value = self.resolve(&path).await?;
+                match value.destructure_ref() {
+                    DestructuredRef::Object(obj) => {
+                        Some(obj.keys().map(|k| k.to_string()).collect())
+                    }
+                    DestructuredRef::Array(arr) => {
+                        Some((0..arr.len()).map(|i| i.to_string()).collect())
+                    }
+                    _ => None,
+                }
+            })
+        }
+    }
+
+    fn make_test_data() -> Value {
+        let mut versions = VObject::new();
+
+        let mut dodeca = VObject::new();
+        dodeca.insert(VString::from("version"), Value::from("0.1.0"));
+        dodeca.insert(VString::from("name"), Value::from("Dodeca"));
+        versions.insert(VString::from("dodeca"), Value::from(dodeca));
+
+        let mut facet = VObject::new();
+        facet.insert(VString::from("version"), Value::from("0.2.0"));
+        versions.insert(VString::from("facet"), Value::from(facet));
+
+        let mut root = VObject::new();
+        root.insert(VString::from("versions"), Value::from(versions));
+        Value::from(root)
+    }
+
+    #[test]
+    fn test_data_path() {
+        let root = DataPath::root();
+        assert!(root.is_root());
+        assert_eq!(root.segments(), &[] as &[String]);
+
+        let child = root.push("versions");
+        assert!(!child.is_root());
+        assert_eq!(child.segments(), &["versions"]);
+
+        let grandchild = child.push("dodeca");
+        assert_eq!(grandchild.segments(), &["versions", "dodeca"]);
+    }
+
+    #[tokio::test]
+    async fn test_lazy_field_access_extends_path() {
+        let resolver = TestResolver::new(make_test_data());
+        let lazy = LazyValue::lazy_root(resolver.clone());
+
+        // Field access should NOT resolve yet
+        let source = crate::error::TemplateSource::new("test", "");
+        let versions = lazy.field("versions", test_span(), &source).unwrap();
+
+        // Nothing should be resolved yet!
+        assert!(resolver.resolved_paths().is_empty());
+        assert!(versions.is_lazy());
+
+        // Further field access still doesn't resolve
+        let dodeca = versions.field("dodeca", test_span(), &source).unwrap();
+        assert!(resolver.resolved_paths().is_empty());
+
+        // Now resolve
+        let value = dodeca.field("version", test_span(), &source).unwrap();
+        let resolved = value.resolve().await.unwrap();
+
+        // NOW it should have resolved
+        assert_eq!(resolver.resolved_paths().len(), 1);
+        assert_eq!(
+            resolver.resolved_paths()[0].segments(),
+            &["versions", "dodeca", "version"]
+        );
+
+        // Check the value
+        if let DestructuredRef::String(s) = resolved.destructure_ref() {
+            assert_eq!(s.as_str(), "0.1.0");
+        } else {
+            panic!("Expected string");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_lazy_iteration() {
+        let resolver = TestResolver::new(make_test_data());
+        let lazy = LazyValue::lazy_root(resolver.clone());
+
+        let source = crate::error::TemplateSource::new("test", "");
+        let versions = lazy.field("versions", test_span(), &source).unwrap();
+
+        // Get pairs - this should resolve keys but NOT values
+        let pairs = versions.iter_pairs().await;
+        assert_eq!(pairs.len(), 2);
+
+        // Keys were resolved to get the list
+        assert_eq!(resolver.resolved_paths().len(), 1);
+
+        // But values are still lazy!
+        for (key, value) in &pairs {
+            assert!(value.is_lazy(), "Value for {} should be lazy", key);
+        }
+
+        // Now access one value
+        let (_, dodeca) = pairs.iter().find(|(k, _)| k == "dodeca").unwrap();
+        let version = dodeca.field("version", test_span(), &source).unwrap();
+        let _ = version.resolve().await.unwrap();
+
+        // Now we should have resolved the specific path
+        let paths = resolver.resolved_paths();
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.segments() == ["versions", "dodeca", "version"])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_concrete_value_access() {
+        let mut obj = VObject::new();
+        obj.insert(VString::from("name"), Value::from("test"));
+        let concrete = LazyValue::Concrete(Value::from(obj));
+
+        let source = crate::error::TemplateSource::new("test", "");
+        let name = concrete.field("name", test_span(), &source).unwrap();
+
+        // Should still be concrete
+        assert!(name.is_concrete());
+
+        let resolved = name.resolve().await.unwrap();
+        if let DestructuredRef::String(s) = resolved.destructure_ref() {
+            assert_eq!(s.as_str(), "test");
+        } else {
+            panic!("Expected string");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_render_to_string() {
+        let resolver = TestResolver::new(make_test_data());
+        let lazy = LazyValue::lazy_root(resolver.clone());
+
+        let source = crate::error::TemplateSource::new("test", "");
+        let version = lazy
+            .field("versions", test_span(), &source)
+            .unwrap()
+            .field("dodeca", test_span(), &source)
+            .unwrap()
+            .field("version", test_span(), &source)
+            .unwrap();
+
+        // render_to_string triggers resolution
+        assert_eq!(version.render_to_string().await, "0.1.0");
+    }
+}

--- a/gingembre/src/lib.rs
+++ b/gingembre/src/lib.rs
@@ -1,0 +1,74 @@
+// Template engine is a work in progress - many AST fields are for future error reporting
+#![allow(dead_code)]
+
+//! gingembre - A Jinja-like template engine
+//!
+//! A template language featuring:
+//! - Rich diagnostics
+//! - Parse once, run many times (compiled templates)
+//! - Template inheritance and includes
+//! - Macro system with imports
+//!
+//! # Syntax Overview
+//!
+//! ```text
+//! {{ expr }}              - Expression interpolation
+//! {% if cond %}...{% endif %}     - Conditionals
+//! {% for item in items %}...{% endfor %}  - Loops
+//! {{ value | filter }}    - Filters
+//! {{ object.field }}      - Field access
+//! {% extends "base.html" %}       - Template inheritance
+//! {% block name %}...{% endblock %} - Block definitions
+//! {% include "partial.html" %}    - Template includes
+//! {% macro name(args) %}...{% endmacro %} - Macro definitions
+//! ```
+//!
+//! # Example
+//!
+//! ```ignore
+//! use gingembre::{Engine, Context, Value, InMemoryLoader};
+//!
+//! let mut loader = InMemoryLoader::new();
+//! loader.add("hello.html", "Hello, {{ name }}!");
+//!
+//! let engine = Engine::new(loader);
+//! let mut ctx = Context::new();
+//! ctx.set("name", Value::String("World".into()));
+//!
+//! let output = engine.render("hello.html", &ctx)?;
+//! assert_eq!(output, "Hello, World!");
+//! ```
+
+pub mod ast;
+mod cst_lower;
+pub use cst_lower::{parse_template, parse_template_recovered};
+mod error;
+mod eval;
+mod lazy;
+mod render;
+pub mod semantic;
+
+pub use error::{
+    NamedSource, PrettyError, RenderError, SourceLocation, SourceSpan, TemplateError,
+    format_template_error_pretty,
+};
+pub use eval::{
+    BUILTIN_FILTERS, BUILTIN_TESTS, BuiltinItemInfo, Context, GlobalFn, Value, ValueExt,
+    builtin_filter, builtin_filter_names, builtin_test, builtin_test_names,
+};
+pub use lazy::{DataPath, DataResolver, LazyValue};
+pub use render::{Engine, InMemoryLoader, TemplateLoader};
+
+// Re-export facet_value types for convenience
+pub use facet_value::{VArray, VObject, VSafeString, VString};
+
+/// Evaluate a standalone expression string against a context.
+/// Useful for REPL-style evaluation.
+pub async fn eval_expression(expr: &str, ctx: &Context) -> Result<Value, TemplateError> {
+    use error::TemplateSource;
+
+    let source = TemplateSource::new("<repl>", expr);
+    let ast = cst_lower::parse_expression(expr)?;
+    let evaluator = eval::Evaluator::new(ctx, &source);
+    evaluator.eval_concrete(&ast).await
+}

--- a/gingembre/src/render.rs
+++ b/gingembre/src/render.rs
@@ -1,0 +1,2512 @@
+//! Template renderer
+//!
+//! Renders templates to strings using a context.
+//! This is the main public API for the template engine.
+
+use super::ast::{self, Expr, Node, Target};
+use super::error::{
+    MacroNotFoundError, RenderError, SourceLocation, TemplateError, TemplateSource,
+};
+use super::eval::{Context, Evaluator, Value};
+use super::lazy::LazyValue;
+use camino::{Utf8Path, Utf8PathBuf};
+use facet_value::{DestructuredRef, VObject, VString};
+use futures::future::BoxFuture;
+use std::collections::HashMap;
+
+/// Loop control flow signals
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoopControl {
+    /// Normal execution, continue to next node
+    None,
+    /// Skip to next loop iteration
+    Continue,
+    /// Exit the loop entirely
+    Break,
+}
+
+/// A stored macro definition
+#[derive(Debug, Clone)]
+struct MacroDef {
+    params: Vec<ast::MacroParam>,
+    body: Vec<Node>,
+}
+
+/// A block override with its source template (for error reporting)
+#[derive(Debug, Clone)]
+struct BlockDef {
+    nodes: Vec<Node>,
+    source: TemplateSource,
+}
+
+/// Stored macros organized by namespace
+/// Key is namespace ("self" for current template, or import alias)
+/// Value is map of macro_name -> MacroDef
+type MacroRegistry = HashMap<String, HashMap<String, MacroDef>>;
+
+/// Trait for loading templates by name (for inheritance and includes)
+///
+/// This trait is async to support loading templates from remote sources
+/// (e.g., via RPC in the cell architecture).
+pub trait TemplateLoader: Send + Sync {
+    /// Load a template by path/name, returning the source code
+    fn load(&self, name: &str) -> BoxFuture<'_, Option<String>>;
+}
+
+/// A null loader that never finds any templates.
+/// Used when rendering a template without inheritance/include support.
+#[derive(Default, Clone, Copy)]
+pub struct NullLoader;
+
+impl TemplateLoader for NullLoader {
+    fn load(&self, _name: &str) -> BoxFuture<'_, Option<String>> {
+        Box::pin(async { None })
+    }
+}
+
+/// A simple in-memory template loader
+#[derive(Default)]
+pub struct InMemoryLoader {
+    templates: HashMap<String, String>,
+}
+
+impl InMemoryLoader {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add(&mut self, name: impl Into<String>, source: impl Into<String>) {
+        self.templates.insert(name.into(), source.into());
+    }
+}
+
+impl TemplateLoader for InMemoryLoader {
+    fn load(&self, name: &str) -> BoxFuture<'_, Option<String>> {
+        let result = self.templates.get(name).cloned();
+        Box::pin(async move { result })
+    }
+}
+
+/// A file-based template loader that reads from a directory
+pub struct FileLoader {
+    root: Utf8PathBuf,
+}
+
+impl FileLoader {
+    /// Create a new file loader rooted at the given directory
+    pub fn new(root: impl AsRef<Utf8Path>) -> Self {
+        Self {
+            root: root.as_ref().to_owned(),
+        }
+    }
+
+    /// Get the root directory
+    pub fn root(&self) -> &Utf8Path {
+        &self.root
+    }
+}
+
+impl TemplateLoader for FileLoader {
+    fn load(&self, name: &str) -> BoxFuture<'_, Option<String>> {
+        let path = self.root.join(name);
+        Box::pin(async move { std::fs::read_to_string(&path).ok() })
+    }
+}
+
+/// A compiled template ready for rendering
+#[derive(Debug, Clone)]
+pub struct Template {
+    ast: ast::Template,
+    source: TemplateSource,
+}
+
+impl Template {
+    /// Parse a template from source
+    pub fn parse(
+        name: impl Into<String>,
+        source: impl Into<String>,
+    ) -> Result<Self, TemplateError> {
+        let name = name.into();
+        let source_str: String = source.into();
+        let template_source = TemplateSource::new(&name, &source_str);
+
+        // Parse with the cstree front-end and lower to the engine AST. The old
+        // hand-written parser stays only for the LSP until it's migrated.
+        let _ = &name;
+        let (ast, errors) = crate::cst_lower::parse_to_template(&source_str);
+        if let Some(e) = errors.first() {
+            return Err(crate::error::SyntaxError {
+                found: "end of input".to_string(),
+                expected: e.message.clone(),
+                loc: crate::error::SourceLocation::new(
+                    crate::ast::span(e.offset, 1),
+                    template_source.named_source(),
+                ),
+            }
+            .into());
+        }
+
+        Ok(Self {
+            ast,
+            source: template_source,
+        })
+    }
+
+    /// Get the extends path if this template extends another
+    pub fn extends_path(&self) -> Option<&str> {
+        for node in &self.ast.body {
+            match node {
+                Node::Extends(e) => return Some(&e.path.value),
+                Node::Text(t) if t.text.trim().is_empty() => continue,
+                _ => return None,
+            }
+        }
+        None
+    }
+
+    /// Extract block definitions from this template
+    pub fn blocks(&self) -> HashMap<String, &[Node]> {
+        let mut blocks = HashMap::new();
+        self.collect_blocks(&self.ast.body, &mut blocks);
+        blocks
+    }
+
+    fn collect_blocks<'a>(&'a self, nodes: &'a [Node], blocks: &mut HashMap<String, &'a [Node]>) {
+        for node in nodes {
+            if let Node::Block(block) = node {
+                blocks.insert(block.name.name.clone(), &block.body);
+            }
+        }
+    }
+
+    /// Extract import statements from this template
+    pub fn imports(&self) -> Vec<(&str, &str)> {
+        self.ast
+            .body
+            .iter()
+            .filter_map(|node| {
+                if let Node::Import(import) = node {
+                    Some((import.path.value.as_str(), import.alias.name.as_str()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Render the template with the given context (no inheritance support)
+    pub async fn render(&self, ctx: &Context) -> Result<String, TemplateError> {
+        let mut output = String::new();
+        let null_loader = NullLoader;
+        let mut renderer = Renderer {
+            ctx: ctx.clone(),
+            source: self.source.clone(),
+            output: &mut output,
+            blocks: HashMap::new(),
+            loader: Some(&null_loader),
+            macros: HashMap::new(),
+        };
+        renderer.collect_macros(&self.ast.body);
+        let _ = renderer.render_nodes(&self.ast.body).await?;
+        Ok(output)
+    }
+
+    /// Render the template with a simple key-value context
+    pub async fn render_with<I, K, V>(&self, vars: I) -> Result<String, TemplateError>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<Value>,
+    {
+        let mut ctx = Context::new();
+        for (k, v) in vars {
+            ctx.set(k, v.into());
+        }
+        self.render(&ctx).await
+    }
+}
+
+/// Template engine with support for inheritance and includes
+pub struct Engine<L: TemplateLoader> {
+    loader: L,
+}
+
+impl<L: TemplateLoader> Engine<L> {
+    /// Create a new engine with the given loader
+    pub fn new(loader: L) -> Self {
+        Self { loader }
+    }
+
+    /// Load a template, returning a RenderError on failure
+    pub async fn load(&self, name: &str) -> Result<Template, RenderError> {
+        let source = self.loader.load(name).await;
+        match source {
+            None => Err(RenderError::NotFound(name.to_string())),
+            Some(source) => Ok(Template::parse(name, source)?),
+        }
+    }
+
+    /// Render a template by name with inheritance support
+    pub async fn render(&mut self, name: &str, ctx: &Context) -> Result<String, RenderError> {
+        // Load the template
+        let template = self.load(name).await?;
+
+        // Check for extends
+        if let Some(parent_path) = template.extends_path() {
+            // Collect blocks from child template, along with the source for error reporting
+            let child_blocks: HashMap<String, BlockDef> = template
+                .blocks()
+                .into_iter()
+                .map(|(name, nodes)| {
+                    (
+                        name,
+                        BlockDef {
+                            nodes: nodes.to_vec(),
+                            source: template.source.clone(),
+                        },
+                    )
+                })
+                .collect();
+            let child_imports: Vec<(String, String)> = template
+                .imports()
+                .into_iter()
+                .map(|(p, a)| (p.to_string(), a.to_string()))
+                .collect();
+
+            // Recursively resolve the inheritance chain
+            self.render_with_blocks(parent_path, ctx, child_blocks, child_imports)
+                .await
+        } else {
+            // No inheritance, render directly
+            let context_vars = ctx.variable_names();
+            tracing::debug!(
+                template = %name,
+                context_vars = ?context_vars,
+                "Engine::render: rendering template"
+            );
+            let mut output = String::new();
+            let mut renderer = Renderer {
+                ctx: ctx.clone(),
+                source: template.source.clone(),
+                output: &mut output,
+                blocks: HashMap::new(),
+                loader: Some(&self.loader),
+                macros: HashMap::new(),
+            };
+            renderer.collect_macros(&template.ast.body);
+            let _ = renderer.render_nodes(&template.ast.body).await?;
+            Ok(output)
+        }
+    }
+
+    fn render_with_blocks<'a>(
+        &'a mut self,
+        name: &'a str,
+        ctx: &'a Context,
+        child_blocks: HashMap<String, BlockDef>,
+        child_imports: Vec<(String, String)>,
+    ) -> BoxFuture<'a, Result<String, RenderError>> {
+        Box::pin(async move {
+            let template = self.load(name).await?;
+
+            // Check if parent also extends
+            if let Some(grandparent_path) = template.extends_path() {
+                // Merge blocks: child blocks override parent blocks
+                let parent_blocks = template.blocks();
+                let mut merged_blocks: HashMap<String, BlockDef> = HashMap::new();
+
+                // Add parent blocks first (with this template's source)
+                for (name, nodes) in parent_blocks {
+                    merged_blocks.insert(
+                        name,
+                        BlockDef {
+                            nodes: nodes.to_vec(),
+                            source: template.source.clone(),
+                        },
+                    );
+                }
+                // Child blocks override (keeping their original source)
+                for (name, block_def) in child_blocks {
+                    merged_blocks.insert(name, block_def);
+                }
+
+                // Merge imports: add parent imports first, then child imports
+                let parent_imports: Vec<(String, String)> = template
+                    .imports()
+                    .into_iter()
+                    .map(|(p, a)| (p.to_string(), a.to_string()))
+                    .collect();
+                let mut all_imports = parent_imports;
+                all_imports.extend(child_imports);
+
+                self.render_with_blocks(grandparent_path, ctx, merged_blocks, all_imports)
+                    .await
+            } else {
+                // This is the root template, render it with block overrides
+                let mut output = String::new();
+                let mut renderer = Renderer {
+                    ctx: ctx.clone(),
+                    source: template.source.clone(),
+                    output: &mut output,
+                    blocks: child_blocks,
+                    loader: Some(&self.loader),
+                    macros: HashMap::new(),
+                };
+
+                // Process imports from child templates
+                for (path, alias) in &child_imports {
+                    renderer.load_macros_from(path, alias).await?;
+                }
+
+                renderer.collect_macros(&template.ast.body);
+                let _ = renderer.render_nodes(&template.ast.body).await?;
+                Ok(output)
+            }
+        })
+    }
+}
+
+/// Internal renderer state
+struct Renderer<'a, L: TemplateLoader> {
+    ctx: Context,
+    /// Current source for error reporting (may be swapped when rendering child blocks)
+    source: TemplateSource,
+    output: &'a mut String,
+    /// Block overrides from child templates (with their source for error reporting)
+    blocks: HashMap<String, BlockDef>,
+    /// Template loader for includes and imports
+    loader: Option<&'a L>,
+    /// Macro definitions by namespace
+    macros: MacroRegistry,
+}
+
+impl<'a, L: TemplateLoader> Renderer<'a, L> {
+    fn render_nodes<'b>(
+        &'b mut self,
+        nodes: &'b [Node],
+    ) -> BoxFuture<'b, Result<LoopControl, TemplateError>> {
+        Box::pin(async move {
+            for node in nodes {
+                let control = self.render_node(node).await?;
+                if control != LoopControl::None {
+                    return Ok(control);
+                }
+            }
+            Ok(LoopControl::None)
+        })
+    }
+
+    /// Render nodes with a different source (for block overrides from child templates)
+    fn render_nodes_with_source<'b>(
+        &'b mut self,
+        nodes: &'b [Node],
+        source: TemplateSource,
+    ) -> BoxFuture<'b, Result<LoopControl, TemplateError>> {
+        Box::pin(async move {
+            let original_source = std::mem::replace(&mut self.source, source);
+            let result = self.render_nodes(nodes).await;
+            self.source = original_source;
+            result
+        })
+    }
+
+    fn render_node<'b>(
+        &'b mut self,
+        node: &'b Node,
+    ) -> BoxFuture<'b, Result<LoopControl, TemplateError>> {
+        Box::pin(async move {
+            match node {
+                Node::Text(text) => {
+                    self.output.push_str(&text.text);
+                }
+                Node::Print(print) => {
+                    // Check if this is a macro call
+                    if let Expr::MacroCall(macro_call) = &print.expr {
+                        // Evaluate arguments (macros need concrete values)
+                        let eval = Evaluator::new(&self.ctx, &self.source);
+                        let mut args = Vec::with_capacity(macro_call.args.len());
+                        for a in &macro_call.args {
+                            args.push(eval.eval_concrete(a).await?);
+                        }
+                        let mut kwargs = Vec::with_capacity(macro_call.kwargs.len());
+                        for (ident, expr) in &macro_call.kwargs {
+                            kwargs.push((ident.name.clone(), eval.eval_concrete(expr).await?));
+                        }
+
+                        // Call the macro
+                        let result = self
+                            .call_macro(
+                                &macro_call.namespace.name,
+                                &macro_call.macro_name.name,
+                                &args,
+                                &kwargs,
+                                macro_call.span,
+                            )
+                            .await?;
+                        // Macro output is already HTML, don't escape it
+                        self.output.push_str(&result);
+                    } else if let Expr::Call(call) = &print.expr
+                        && let Expr::Field(field) = &*call.func
+                        && let Expr::Var(ns_ident) = &*field.base
+                        && self
+                            .macros
+                            .get(&ns_ident.name)
+                            .is_some_and(|m| m.contains_key(&field.field.name))
+                    {
+                        // Jinja-style dotted namespaced macro call: `macros.youtube_embed(...)`.
+                        // The parser only treats `ns::macro(...)` as a MacroCall; the dotted
+                        // form arrives here as a Call on a Field. Route it to the macro
+                        // registry like the `::` form (both work only in Print context).
+                        let namespace = ns_ident.name.clone();
+                        let macro_name = field.field.name.clone();
+                        let span = call.span;
+                        let eval = Evaluator::new(&self.ctx, &self.source);
+                        let mut args = Vec::with_capacity(call.args.len());
+                        for a in &call.args {
+                            args.push(eval.eval_concrete(a).await?);
+                        }
+                        let mut kwargs = Vec::with_capacity(call.kwargs.len());
+                        for (ident, expr) in &call.kwargs {
+                            kwargs.push((ident.name.clone(), eval.eval_concrete(expr).await?));
+                        }
+                        let result = self
+                            .call_macro(&namespace, &macro_name, &args, &kwargs, span)
+                            .await?;
+                        self.output.push_str(&result);
+                    } else {
+                        let eval = Evaluator::new(&self.ctx, &self.source);
+                        let value = eval.eval(&print.expr).await?;
+                        // Skip escaping for safe values, auto-escape everything else
+                        let s = if value.is_safe().await {
+                            value.render_to_string().await
+                        } else {
+                            html_escape(&value.render_to_string().await)
+                        };
+                        self.output.push_str(&s);
+                    }
+                }
+                Node::If(if_node) => {
+                    let eval = Evaluator::new(&self.ctx, &self.source);
+                    let condition = eval.eval(&if_node.condition).await?;
+
+                    // r[impl stmt.if.truthiness]
+                    if condition.is_truthy().await {
+                        let control = self.render_nodes(&if_node.then_body).await?;
+                        if control != LoopControl::None {
+                            return Ok(control);
+                        }
+                    } else {
+                        // Check elif branches
+                        let mut handled = false;
+                        for elif in &if_node.elif_branches {
+                            let eval = Evaluator::new(&self.ctx, &self.source);
+                            let cond = eval.eval(&elif.condition).await?;
+                            if cond.is_truthy().await {
+                                let control = self.render_nodes(&elif.body).await?;
+                                if control != LoopControl::None {
+                                    return Ok(control);
+                                }
+                                handled = true;
+                                break;
+                            }
+                        }
+
+                        // Else branch
+                        if !handled && let Some(else_body) = &if_node.else_body {
+                            let control = self.render_nodes(else_body).await?;
+                            if control != LoopControl::None {
+                                return Ok(control);
+                            }
+                        }
+                    }
+                }
+                Node::For(for_node) => {
+                    let eval = Evaluator::new(&self.ctx, &self.source);
+                    let iter_value = eval.eval(&for_node.iter).await?;
+
+                    // Use LazyValue's iteration which handles lazy/concrete uniformly
+                    let items: Vec<LazyValue> = iter_value.iter_values().await;
+
+                    if items.is_empty() {
+                        // Render else body if present
+                        if let Some(else_body) = &for_node.else_body {
+                            let control = self.render_nodes(else_body).await?;
+                            if control != LoopControl::None {
+                                return Ok(control);
+                            }
+                        }
+                    } else {
+                        let len = items.len();
+                        'for_loop: for (index, item) in items.into_iter().enumerate() {
+                            // r[impl scope.for-loop]
+                            self.ctx.push_scope();
+
+                            // Bind loop variable(s)
+                            match &for_node.target {
+                                Target::Single { name, .. } => {
+                                    self.ctx.set(name.clone(), item);
+                                }
+                                Target::Tuple { names, .. } => {
+                                    // For tuple unpacking, resolve to get the concrete value
+                                    let resolved = item.try_resolve().await.unwrap_or(Value::NULL);
+                                    match resolved.destructure_ref() {
+                                        DestructuredRef::Array(parts) => {
+                                            for (i, (name, _)) in names.iter().enumerate() {
+                                                let val =
+                                                    parts.get(i).cloned().unwrap_or(Value::NULL);
+                                                self.ctx.set(name.clone(), val);
+                                            }
+                                        }
+                                        // Special case: dict iteration gives key, value
+                                        DestructuredRef::Object(obj) if names.len() == 2 => {
+                                            if let Some(key) = obj.get("key") {
+                                                self.ctx.set(names[0].0.clone(), key.clone());
+                                            }
+                                            if let Some(value) = obj.get("value") {
+                                                self.ctx.set(names[1].0.clone(), value.clone());
+                                            }
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            }
+
+                            // Bind loop helper variables
+                            // r[impl stmt.for.loop-var]
+                            let mut loop_var = VObject::new();
+                            // r[impl stmt.for.loop-index]
+                            loop_var
+                                .insert(VString::from("index"), Value::from((index + 1) as i64));
+                            // r[impl stmt.for.loop-index0]
+                            loop_var.insert(VString::from("index0"), Value::from(index as i64));
+                            // r[impl stmt.for.loop-first]
+                            loop_var.insert(VString::from("first"), Value::from(index == 0));
+                            // r[impl stmt.for.loop-last]
+                            loop_var.insert(VString::from("last"), Value::from(index == len - 1));
+                            // r[impl stmt.for.loop-length]
+                            loop_var.insert(VString::from("length"), Value::from(len as i64));
+                            self.ctx.set("loop", Value::from(loop_var));
+
+                            let control = self.render_nodes(&for_node.body).await?;
+                            self.ctx.pop_scope();
+
+                            match control {
+                                LoopControl::None => {}
+                                LoopControl::Continue => continue 'for_loop,
+                                LoopControl::Break => break 'for_loop,
+                            }
+                        }
+                    }
+                }
+                // r[impl inherit.include.context]
+                Node::Include(_include) => {
+                    // TODO: Template loading/caching
+                    self.output.push_str("<!-- include not implemented -->");
+                }
+                Node::Block(block) => {
+                    // Check if we have an override for this block
+                    let control =
+                        if let Some(block_def) = self.blocks.get(&block.name.name).cloned() {
+                            // r[impl inherit.block.override]
+                            // Render the overridden block content with its original source
+                            // (for correct error reporting)
+                            self.render_nodes_with_source(&block_def.nodes, block_def.source)
+                                .await?
+                        } else {
+                            // r[impl inherit.block.default]
+                            // Render the default block content
+                            self.render_nodes(&block.body).await?
+                        };
+                    if control != LoopControl::None {
+                        return Ok(control);
+                    }
+                }
+                // r[impl inherit.extends.position]
+                // r[impl inherit.extends.single]
+                Node::Extends(_extends) => {
+                    // Extends is handled at the Engine level, not during node rendering
+                    // When we reach here, we're rendering the parent template
+                }
+                Node::Comment(_) => {
+                    // Comments are not rendered
+                }
+                // r[impl stmt.set.scope]
+                Node::Set(set_node) => {
+                    match &set_node.value {
+                        crate::ast::SetValue::Expr(expr) => {
+                            let eval = Evaluator::new(&self.ctx, &self.source);
+                            let value = eval.eval(expr).await?;
+                            self.ctx.set(set_node.name.name.clone(), value);
+                        }
+                        crate::ast::SetValue::Body(body) => {
+                            // Render the body into a fresh buffer and bind the
+                            // resulting string (Jinja `{% set x %}…{% endset %}`).
+                            // The inner `{{ }}` were already escaped while
+                            // rendering, so the assembled markup is bound *safe* —
+                            // printing `{{ x }}` emits it without double-escaping.
+                            let mut captured = String::new();
+                            std::mem::swap(self.output, &mut captured);
+                            let _ = self.render_nodes(body).await?;
+                            std::mem::swap(self.output, &mut captured);
+                            self.ctx
+                                .set_safe(set_node.name.name.clone(), Value::from(captured.as_str()));
+                        }
+                    }
+                }
+                Node::Import(import) => {
+                    // Load macros from the imported template
+                    let loader = &self.loader;
+                    if loader.is_none() {
+                        tracing::warn!(
+                            import_path = %import.path.value,
+                            "Import: no loader available"
+                        );
+                    }
+                    if let Some(loader) = loader
+                        && let Some(source) = loader.load(&import.path.value).await
+                        && let Ok(template) = Template::parse(&import.path.value, source)
+                    {
+                        // Extract macros from the imported template
+                        let mut namespace_macros = HashMap::new();
+                        for node in &template.ast.body {
+                            if let Node::Macro(m) = node {
+                                namespace_macros.insert(
+                                    m.name.name.clone(),
+                                    MacroDef {
+                                        params: m.params.clone(),
+                                        body: m.body.clone(),
+                                    },
+                                );
+                            }
+                        }
+                        tracing::debug!(
+                            import_path = %import.path.value,
+                            alias = %import.alias.name,
+                            macros = namespace_macros.len(),
+                            "Import: loaded macros"
+                        );
+                        self.macros
+                            .insert(import.alias.name.clone(), namespace_macros);
+                    } else {
+                        tracing::warn!(
+                            import_path = %import.path.value,
+                            "Import: failed to load template"
+                        );
+                    }
+                }
+                Node::Macro(_macro_def) => {
+                    // Macro definitions are collected by collect_macros before rendering
+                }
+                Node::CallBlock(call_block) => {
+                    // Evaluate kwargs to concrete values
+                    let eval = Evaluator::new(&self.ctx, &self.source);
+                    let mut kwargs = Vec::with_capacity(call_block.kwargs.len());
+                    for (ident, expr) in &call_block.kwargs {
+                        let value = eval.eval_concrete(expr).await?;
+                        kwargs.push((ident.name.clone(), value));
+                    }
+
+                    // Add the raw content as the "body" kwarg
+                    kwargs.push((
+                        "body".to_string(),
+                        Value::from(call_block.raw_content.as_str()),
+                    ));
+
+                    // Call the registered function
+                    let result = self
+                        .ctx
+                        .call_fn(&call_block.func_name.name, &[], &kwargs)
+                        .ok_or_else(|| {
+                            TemplateError::GlobalFn(format!(
+                                "Unknown function: {}",
+                                call_block.func_name.name
+                            ))
+                        })?
+                        .await
+                        .map_err(|e| TemplateError::GlobalFn(e.to_string()))?;
+
+                    // Output as safe HTML (function returns ready-to-use HTML)
+                    let s = match result.destructure_ref() {
+                        DestructuredRef::String(s) => s.to_string(),
+                        _ => format!("{result:?}"),
+                    };
+                    self.output.push_str(&s);
+                }
+                Node::Continue(_) => {
+                    return Ok(LoopControl::Continue);
+                }
+                Node::Break(_) => {
+                    return Ok(LoopControl::Break);
+                }
+            }
+
+            Ok(LoopControl::None)
+        })
+    }
+
+    /// Collect macro definitions from the template body into the "self" namespace
+    fn collect_macros(&mut self, nodes: &[Node]) {
+        let mut self_macros = HashMap::new();
+        for node in nodes {
+            if let Node::Macro(m) = node {
+                self_macros.insert(
+                    m.name.name.clone(),
+                    MacroDef {
+                        params: m.params.clone(),
+                        body: m.body.clone(),
+                    },
+                );
+            }
+        }
+        if !self_macros.is_empty() {
+            self.macros.insert("self".to_string(), self_macros);
+        }
+    }
+
+    /// Load macros from an imported template file into the given namespace
+    async fn load_macros_from(&mut self, path: &str, alias: &str) -> Result<(), TemplateError> {
+        if let Some(loader) = &self.loader
+            && let Some(source) = loader.load(path).await
+        {
+            let template = Template::parse(path, source)?;
+            // Extract macros from the imported template
+            let mut namespace_macros = HashMap::new();
+            for node in &template.ast.body {
+                if let Node::Macro(m) = node {
+                    namespace_macros.insert(
+                        m.name.name.clone(),
+                        MacroDef {
+                            params: m.params.clone(),
+                            body: m.body.clone(),
+                        },
+                    );
+                }
+            }
+            self.macros.insert(alias.to_string(), namespace_macros);
+        }
+        Ok(())
+    }
+
+    /// Call a macro and return its rendered output
+    // r[impl macro.call.syntax]
+    fn call_macro<'b>(
+        &'b mut self,
+        namespace: &'b str,
+        macro_name: &'b str,
+        args: &'b [Value],
+        kwargs: &'b [(String, Value)],
+        span: ast::Span,
+    ) -> BoxFuture<'b, Result<String, TemplateError>> {
+        Box::pin(async move {
+            // Find the macro
+            let macro_def = self
+                .macros
+                .get(namespace)
+                .and_then(|ns| ns.get(macro_name))
+                .cloned()
+                .ok_or_else(|| MacroNotFoundError {
+                    namespace: namespace.to_string(),
+                    name: macro_name.to_string(),
+                    loc: SourceLocation::new(span, self.source.named_source()),
+                })?;
+
+            // Save output and create new buffer for macro
+            let mut macro_output = String::new();
+            std::mem::swap(self.output, &mut macro_output);
+
+            // r[impl macro.call.self]
+            // Set up "self" namespace with macros from the called macro's namespace
+            // This allows macros to call other macros from the same file via self::
+            // Only do this if we're not already calling from the "self" namespace
+            let saved_self = if namespace != "self" {
+                let saved = self.macros.remove("self");
+                if let Some(ns_macros) = self.macros.get(namespace).cloned() {
+                    self.macros.insert("self".to_string(), ns_macros);
+                }
+                saved
+            } else {
+                None
+            };
+
+            // r[impl scope.macro]
+            // Push a new scope for macro arguments
+            self.ctx.push_scope();
+
+            // Bind positional arguments
+            for (i, param) in macro_def.params.iter().enumerate() {
+                let value: LazyValue = if i < args.len() {
+                    LazyValue::concrete(args[i].clone())
+                } else if let Some((_, v)) = kwargs.iter().find(|(k, _)| k == &param.name.name) {
+                    LazyValue::concrete(v.clone())
+                } else if let Some(ref default_expr) = param.default {
+                    // Evaluate default value
+                    let eval = Evaluator::new(&self.ctx, &self.source);
+                    eval.eval(default_expr).await?
+                } else {
+                    LazyValue::concrete(Value::NULL)
+                };
+                self.ctx.set(param.name.name.clone(), value);
+            }
+
+            // Render macro body (ignore loop control - macros don't propagate continue/break)
+            let _ = self.render_nodes(&macro_def.body).await?;
+
+            // Restore scope
+            self.ctx.pop_scope();
+
+            // Restore "self" namespace (only if we modified it)
+            if namespace != "self" {
+                self.macros.remove("self");
+                if let Some(saved) = saved_self {
+                    self.macros.insert("self".to_string(), saved);
+                }
+            }
+
+            // Swap back and return macro output
+            std::mem::swap(self.output, &mut macro_output);
+            Ok(macro_output)
+        })
+    }
+}
+
+/// HTML escape a string
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#x27;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::ValueExt;
+    use facet_value::{VArray, VObject, VString};
+
+    // r[verify whitespace.raw-text]
+    #[tokio::test]
+    async fn test_simple_text() {
+        let t = Template::parse("test", "Hello, world!").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "Hello, world!");
+    }
+
+    // r[verify delim.expression]
+    // r[verify expr.var.lookup]
+    #[tokio::test]
+    async fn test_variable() {
+        let t = Template::parse("test", "Hello, {{ name }}!").unwrap();
+        let result = t
+            .render_with([("name", Value::from("Alice"))])
+            .await
+            .unwrap();
+        assert_eq!(result, "Hello, Alice!");
+    }
+
+    // r[verify stmt.if.syntax]
+    // r[verify stmt.if.truthiness]
+    // r[verify literal.boolean]
+    #[tokio::test]
+    async fn test_if_true() {
+        let t = Template::parse("test", "{% if show %}visible{% endif %}").unwrap();
+        let result = t.render_with([("show", Value::from(true))]).await.unwrap();
+        assert_eq!(result, "visible");
+    }
+
+    // r[verify stmt.if.truthiness]
+    #[tokio::test]
+    async fn test_if_false() {
+        let t = Template::parse("test", "{% if show %}visible{% endif %}").unwrap();
+        let result = t.render_with([("show", Value::from(false))]).await.unwrap();
+        assert_eq!(result, "");
+    }
+
+    // r[verify stmt.if.else]
+    #[tokio::test]
+    async fn test_if_else() {
+        let t = Template::parse("test", "{% if show %}yes{% else %}no{% endif %}").unwrap();
+        let result = t.render_with([("show", Value::from(false))]).await.unwrap();
+        assert_eq!(result, "no");
+    }
+
+    // r[verify stmt.for.syntax]
+    // r[verify literal.list]
+    #[tokio::test]
+    async fn test_for_loop() {
+        let t = Template::parse("test", "{% for item in items %}{{ item }} {% endfor %}").unwrap();
+        let items: Value =
+            VArray::from_iter([Value::from("a"), Value::from("b"), Value::from("c")]).into();
+        let result = t.render_with([("items", items)]).await.unwrap();
+        assert_eq!(result, "a b c ");
+    }
+
+    // r[verify stmt.for.loop-index]
+    // r[verify stmt.for.loop-var]
+    #[tokio::test]
+    async fn test_loop_index() {
+        let t =
+            Template::parse("test", "{% for x in items %}{{ loop.index }}{% endfor %}").unwrap();
+        let items: Value = VArray::from_iter([Value::from("a"), Value::from("b")]).into();
+        let result = t.render_with([("items", items)]).await.unwrap();
+        assert_eq!(result, "12");
+    }
+
+    // r[verify filter.syntax]
+    // r[verify filter.upper]
+    #[tokio::test]
+    async fn test_filter() {
+        let t = Template::parse("test", "{{ name | upper }}").unwrap();
+        let result = t
+            .render_with([("name", Value::from("alice"))])
+            .await
+            .unwrap();
+        assert_eq!(result, "ALICE");
+    }
+
+    // r[verify expr.field.dot]
+    #[tokio::test]
+    async fn test_field_access() {
+        let t = Template::parse("test", "{{ user.name }}").unwrap();
+        let mut user = VObject::new();
+        user.insert(VString::from("name"), Value::from("Bob"));
+        let user_val: Value = user.into();
+        let result = t.render_with([("user", user_val)]).await.unwrap();
+        assert_eq!(result, "Bob");
+    }
+
+    // r[verify filter.escape]
+    #[tokio::test]
+    async fn test_html_escape() {
+        let t = Template::parse("test", "{{ content }}").unwrap();
+        let result = t
+            .render_with([("content", Value::from("<script>alert('xss')</script>"))])
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;"
+        );
+    }
+
+    // r[verify filter.safe]
+    #[tokio::test]
+    async fn test_safe_filter() {
+        let t = Template::parse("test", "{{ content | safe }}").unwrap();
+        let result = t
+            .render_with([("content", Value::from("<b>bold</b>"))])
+            .await
+            .unwrap();
+        // Note: safe filter doesn't work with facet_value since we can't track "safe" status
+        // This test just verifies the filter doesn't error
+        assert!(result.contains("bold"));
+    }
+
+    // r[verify filter.chaining]
+    // r[verify filter.safe]
+    #[tokio::test]
+    async fn test_safe_filter_with_other_filters() {
+        let t = Template::parse("test", "{{ content | upper | safe }}").unwrap();
+        let result = t
+            .render_with([("content", Value::from("<b>bold</b>"))])
+            .await
+            .unwrap();
+        assert!(result.contains("BOLD"));
+    }
+
+    // r[verify filter.split]
+    // r[verify filter.args]
+    #[tokio::test]
+    async fn test_split_filter() {
+        let t = Template::parse(
+            "test",
+            "{% for p in path | split(pat=\"/\") %}[{{ p }}]{% endfor %}",
+        )
+        .unwrap();
+        let result = t
+            .render_with([("path", Value::from("a/b/c"))])
+            .await
+            .unwrap();
+        assert_eq!(result, "[a][b][c]");
+    }
+
+    // r[verify expr.call.syntax]
+    #[tokio::test]
+    async fn test_global_function() {
+        let t = Template::parse("test", "{{ greet(name) }}").unwrap();
+        let mut ctx = Context::new();
+        ctx.set("name", Value::from("World"));
+        ctx.register_fn(
+            "greet",
+            Box::new(|args: &[Value], _kwargs| {
+                let name = args
+                    .first()
+                    .map(|v| v.render_to_string())
+                    .unwrap_or_default();
+                Box::pin(async move { Ok(Value::from(format!("Hello, {name}!").as_str())) })
+            }),
+        );
+        let result = t.render(&ctx).await.unwrap();
+        assert_eq!(result, "Hello, World!");
+    }
+
+    // r[verify stmt.set.syntax]
+    // r[verify literal.integer]
+    #[tokio::test]
+    async fn test_set() {
+        let t = Template::parse("test", "{% set x = 42 %}{{ x }}").unwrap();
+        let result = t.render(&Context::new()).await.unwrap();
+        assert_eq!(result, "42");
+    }
+
+    // r[verify stmt.set.scope]
+    // r[verify expr.op.add]
+    #[tokio::test]
+    async fn test_set_expression() {
+        let t = Template::parse("test", "{% set x = 2 + 3 %}{{ x }}").unwrap();
+        let result = t.render(&Context::new()).await.unwrap();
+        assert_eq!(result, "5");
+    }
+
+    // r[verify stmt.set.block]
+    #[tokio::test]
+    async fn test_set_block_captures_rendered_body() {
+        // `{% set x %}…{% endset %}` renders the body and binds the string —
+        // the body itself emits nothing inline.
+        let t = Template::parse(
+            "test",
+            "{% set x %}<b>{{ name }}</b>{% endset %}[{{ x }}]",
+        )
+        .unwrap();
+        let mut ctx = Context::new();
+        ctx.set("name", Value::from("hi"));
+        let result = t.render(&ctx).await.unwrap();
+        assert_eq!(result, "[<b>hi</b>]");
+    }
+
+    // r[verify macro.def.syntax]
+    // r[verify macro.def.params]
+    // r[verify macro.call.syntax]
+    // r[verify macro.call.self]
+    #[tokio::test]
+    async fn test_macro_simple() {
+        let t = Template::parse(
+            "test",
+            "{% macro greet(name) %}Hello, {{ name }}!{% endmacro %}{{ self::greet(\"World\") }}",
+        )
+        .unwrap();
+        let result = t.render(&Context::new()).await.unwrap();
+        assert_eq!(result, "Hello, World!");
+    }
+
+    // r[verify macro.def.params]
+    // r[verify scope.macro]
+    #[tokio::test]
+    async fn test_macro_with_default() {
+        let t = Template::parse(
+            "test",
+            "{% macro greet(name=\"Guest\") %}Hello, {{ name }}!{% endmacro %}{{ self::greet() }}",
+        )
+        .unwrap();
+        let result = t.render(&Context::new()).await.unwrap();
+        assert_eq!(result, "Hello, Guest!");
+    }
+
+    // r[verify macro.def.params]
+    #[tokio::test]
+    async fn test_macro_override_default() {
+        let t = Template::parse("test", "{% macro greet(name=\"Guest\") %}Hello, {{ name }}!{% endmacro %}{{ self::greet(\"Alice\") }}").unwrap();
+        let result = t.render(&Context::new()).await.unwrap();
+        assert_eq!(result, "Hello, Alice!");
+    }
+
+    // r[verify expr.call.kwargs]
+    #[tokio::test]
+    async fn test_macro_kwargs() {
+        let t = Template::parse("test", "{% macro greet(name) %}Hello, {{ name }}!{% endmacro %}{{ self::greet(name=\"Bob\") }}").unwrap();
+        let result = t.render(&Context::new()).await.unwrap();
+        assert_eq!(result, "Hello, Bob!");
+    }
+
+    // r[verify macro.call.syntax]
+    #[tokio::test]
+    async fn test_macro_multiple_calls() {
+        let t = Template::parse(
+            "test",
+            "{% macro twice(x) %}{{ x }}{{ x }}{% endmacro %}{{ self::twice(\"ab\") }}",
+        )
+        .unwrap();
+        let result = t.render(&Context::new()).await.unwrap();
+        assert_eq!(result, "abab");
+    }
+
+    // r[verify inherit.extends.syntax]
+    // r[verify inherit.block.syntax]
+    // r[verify inherit.block.override]
+    #[tokio::test]
+    async fn test_template_inheritance() {
+        let mut loader = InMemoryLoader::new();
+        loader.add(
+            "base.html",
+            "Header {% block content %}default{% endblock %} Footer",
+        );
+        loader.add(
+            "child.html",
+            "{% extends \"base.html\" %}{% block content %}CUSTOM{% endblock %}",
+        );
+
+        let mut engine = Engine::new(loader);
+        let result = engine.render("child.html", &Context::new()).await.unwrap();
+        assert_eq!(result, "Header CUSTOM Footer");
+    }
+
+    // r[verify inherit.extends.syntax]
+    // r[verify inherit.block.override]
+    #[tokio::test]
+    async fn test_template_inheritance_with_variables() {
+        let mut loader = InMemoryLoader::new();
+        loader.add("base.html", "{% block title %}Default{% endblock %}");
+        loader.add(
+            "child.html",
+            "{% extends \"base.html\" %}{% block title %}{{ page_title }}{% endblock %}",
+        );
+
+        let mut engine = Engine::new(loader);
+        let mut ctx = Context::new();
+        ctx.set("page_title", Value::from("My Page"));
+        let result = engine.render("child.html", &ctx).await.unwrap();
+        assert_eq!(result, "My Page");
+    }
+
+    // r[verify delim.expression]
+    #[tokio::test]
+    async fn test_template_no_extends() {
+        let mut loader = InMemoryLoader::new();
+        loader.add("simple.html", "Just {{ content }}");
+
+        let mut engine = Engine::new(loader);
+        let mut ctx = Context::new();
+        ctx.set("content", Value::from("text"));
+        let result = engine.render("simple.html", &ctx).await.unwrap();
+        assert_eq!(result, "Just text");
+    }
+
+    // r[verify inherit.block.default]
+    // r[verify inherit.extends.single]
+    #[tokio::test]
+    async fn test_block_default_content() {
+        let mut loader = InMemoryLoader::new();
+        loader.add("base.html", "{% block main %}DEFAULT{% endblock %}");
+        loader.add("child.html", "{% extends \"base.html\" %}");
+
+        let mut engine = Engine::new(loader);
+        let result = engine.render("child.html", &Context::new()).await.unwrap();
+        assert_eq!(result, "DEFAULT");
+    }
+
+    // r[verify inherit.block.override]
+    // r[verify inherit.block.default]
+    #[tokio::test]
+    async fn test_multiple_blocks() {
+        let mut loader = InMemoryLoader::new();
+        loader.add(
+            "base.html",
+            "[{% block a %}A{% endblock %}][{% block b %}B{% endblock %}]",
+        );
+        loader.add(
+            "child.html",
+            "{% extends \"base.html\" %}{% block a %}X{% endblock %}",
+        );
+
+        let mut engine = Engine::new(loader);
+        let result = engine.render("child.html", &Context::new()).await.unwrap();
+        assert_eq!(result, "[X][B]");
+    }
+
+    // r[verify macro.import.syntax]
+    // r[verify macro.call.syntax]
+    #[tokio::test]
+    async fn test_macro_import() {
+        let mut loader = InMemoryLoader::new();
+        loader.add(
+            "macros.html",
+            "{% macro hello(name) %}Hello, {{ name }}!{% endmacro %}",
+        );
+        loader.add(
+            "page.html",
+            "{% import \"macros.html\" as m %}{{ m::hello(\"World\") }}",
+        );
+
+        let mut engine = Engine::new(loader);
+        let result = engine.render("page.html", &Context::new()).await.unwrap();
+        assert_eq!(result, "Hello, World!");
+    }
+
+    // r[verify test.syntax]
+    // r[verify test.starting-with]
+    #[tokio::test]
+    async fn test_is_starting_with() {
+        let t = Template::parse(
+            "test",
+            "{% if path is starting_with(\"/admin\") %}admin{% else %}user{% endif %}",
+        )
+        .unwrap();
+        let result = t
+            .render_with([("path", Value::from("/admin/dashboard"))])
+            .await
+            .unwrap();
+        assert_eq!(result, "admin");
+    }
+
+    // r[verify test.containing]
+    #[tokio::test]
+    async fn test_is_containing() {
+        let t = Template::parse(
+            "test",
+            "{% if text is containing(\"foo\") %}yes{% else %}no{% endif %}",
+        )
+        .unwrap();
+        let result = t
+            .render_with([("text", Value::from("hello foo bar"))])
+            .await
+            .unwrap();
+        assert_eq!(result, "yes");
+    }
+
+    // r[verify test.negation]
+    // r[verify test.undefined]
+    #[tokio::test]
+    async fn test_is_not() {
+        // Note: "none" is a keyword, so we test with "defined" instead
+        let t = Template::parse("test", "{% if x is not undefined %}has_value{% endif %}").unwrap();
+        let result = t.render_with([("x", Value::from(42i64))]).await.unwrap();
+        assert_eq!(result, "has_value");
+    }
+
+    // r[verify stmt.continue]
+    // r[verify scope.for-loop]
+    #[tokio::test]
+    async fn test_continue_in_loop() {
+        let t = Template::parse(
+            "test",
+            "{% for i in items %}{% if i == 2 %}{% continue %}{% endif %}{{ i }}{% endfor %}",
+        )
+        .unwrap();
+        let items: Value =
+            VArray::from_iter([Value::from(1i64), Value::from(2i64), Value::from(3i64)]).into();
+        let result = t.render_with([("items", items)]).await.unwrap();
+        assert_eq!(result, "13");
+    }
+
+    // r[verify stmt.break]
+    #[tokio::test]
+    async fn test_break_in_loop() {
+        let t = Template::parse(
+            "test",
+            "{% for i in items %}{% if i == 2 %}{% break %}{% endif %}{{ i }}{% endfor %}",
+        )
+        .unwrap();
+        let items: Value =
+            VArray::from_iter([Value::from(1i64), Value::from(2i64), Value::from(3i64)]).into();
+        let result = t.render_with([("items", items)]).await.unwrap();
+        assert_eq!(result, "1");
+    }
+
+    // r[verify stmt.continue]
+    // r[verify stmt.for.loop-index]
+    #[tokio::test]
+    async fn test_continue_with_loop_index() {
+        let t = Template::parse("test", "{% for x in items %}{% if loop.index == 2 %}{% continue %}{% endif %}[{{ x }}]{% endfor %}").unwrap();
+        let items: Value =
+            VArray::from_iter([Value::from("a"), Value::from("b"), Value::from("c")]).into();
+        let result = t.render_with([("items", items)]).await.unwrap();
+        assert_eq!(result, "[a][c]");
+    }
+
+    // r[verify stmt.break]
+    // r[verify expr.op.gt]
+    #[tokio::test]
+    async fn test_break_in_nested_if() {
+        let t = Template::parse("test", "{% for i in items %}{% if i > 1 %}{% if i == 2 %}{% break %}{% endif %}{% endif %}{{ i }}{% endfor %}").unwrap();
+        let items: Value =
+            VArray::from_iter([Value::from(1i64), Value::from(2i64), Value::from(3i64)]).into();
+        let result = t.render_with([("items", items)]).await.unwrap();
+        assert_eq!(result, "1");
+    }
+
+    // r[verify expr.var.undefined]
+    // r[verify error.span]
+    #[tokio::test]
+    async fn test_error_source_in_inherited_block() {
+        let mut loader = InMemoryLoader::new();
+        loader.add("base.html", "{% block content %}{% endblock %}");
+        loader.add(
+            "child.html",
+            "{% extends \"base.html\" %}{% block content %}{{ undefined_var }}{% endblock %}",
+        );
+
+        let mut engine = Engine::new(loader);
+        let result = engine.render("child.html", &Context::new()).await;
+        assert!(result.is_err());
+        let err = format!("{:?}", result.unwrap_err());
+        // The error should reference child.html, not base.html
+        assert!(
+            err.contains("child.html"),
+            "Error should reference child.html: {}",
+            err
+        );
+    }
+
+    // ========================================================================
+    // New filter tests (#71, #72, #73, #74, #78)
+    // ========================================================================
+
+    // r[verify filter.typeof]
+    // r[verify literal.string]
+    // r[verify literal.none]
+    // r[verify literal.dict]
+    #[tokio::test]
+    async fn test_typeof_filter() {
+        let t = Template::parse("test", "{{ x | typeof }}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from("hello"))]).await.unwrap(),
+            "string"
+        );
+        assert_eq!(
+            t.render_with([("x", Value::from(42i64))]).await.unwrap(),
+            "number"
+        );
+        assert_eq!(t.render_with([("x", Value::NULL)]).await.unwrap(), "none");
+
+        let arr: Value = VArray::from_iter([Value::from(1i64)]).into();
+        assert_eq!(t.render_with([("x", arr)]).await.unwrap(), "list");
+
+        let obj: Value = VObject::new().into();
+        assert_eq!(t.render_with([("x", obj)]).await.unwrap(), "dict");
+    }
+
+    // r[verify filter.slice]
+    #[tokio::test]
+    async fn test_slice_filter_kwargs() {
+        let t = Template::parse(
+            "test",
+            "{% for x in items | slice(end=2) %}{{ x }}{% endfor %}",
+        )
+        .unwrap();
+        let items: Value =
+            VArray::from_iter([Value::from("a"), Value::from("b"), Value::from("c")]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "ab");
+    }
+
+    // r[verify filter.slice]
+    #[tokio::test]
+    async fn test_slice_filter_start_end() {
+        let t = Template::parse(
+            "test",
+            "{% for x in items | slice(start=1, end=3) %}{{ x }}{% endfor %}",
+        )
+        .unwrap();
+        let items: Value = VArray::from_iter([
+            Value::from("a"),
+            Value::from("b"),
+            Value::from("c"),
+            Value::from("d"),
+        ])
+        .into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "bc");
+    }
+
+    // r[verify filter.slice]
+    // r[verify filter.args]
+    #[tokio::test]
+    async fn test_slice_filter_positional() {
+        let t = Template::parse(
+            "test",
+            "{% for x in items | slice(1, 3) %}{{ x }}{% endfor %}",
+        )
+        .unwrap();
+        let items: Value = VArray::from_iter([
+            Value::from("a"),
+            Value::from("b"),
+            Value::from("c"),
+            Value::from("d"),
+        ])
+        .into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "bc");
+    }
+
+    // r[verify filter.slice]
+    #[tokio::test]
+    async fn test_slice_filter_empty() {
+        let t = Template::parse(
+            "test",
+            "{% for x in items | slice(end=0) %}{{ x }}{% endfor %}",
+        )
+        .unwrap();
+        let items: Value = VArray::from_iter([Value::from("a"), Value::from("b")]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "");
+    }
+
+    // r[verify filter.map]
+    // r[verify filter.join]
+    #[tokio::test]
+    async fn test_map_filter() {
+        let t = Template::parse(
+            "test",
+            "{{ items | map(attribute=\"name\") | join(\", \") }}",
+        )
+        .unwrap();
+
+        let mut item1 = VObject::new();
+        item1.insert(VString::from("name"), Value::from("Alice"));
+        let mut item2 = VObject::new();
+        item2.insert(VString::from("name"), Value::from("Bob"));
+
+        let items: Value = VArray::from_iter([Value::from(item1), Value::from(item2)]).into();
+        assert_eq!(
+            t.render_with([("items", items)]).await.unwrap(),
+            "Alice, Bob"
+        );
+    }
+
+    // r[verify filter.map]
+    // r[verify filter.length]
+    #[tokio::test]
+    async fn test_map_filter_missing_attr() {
+        let t =
+            Template::parse("test", "{{ items | map(attribute=\"missing\") | length }}").unwrap();
+
+        let mut item1 = VObject::new();
+        item1.insert(VString::from("name"), Value::from("Alice"));
+
+        let items: Value = VArray::from_iter([Value::from(item1)]).into();
+        // Items without the attribute are filtered out
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "0");
+    }
+
+    // r[verify filter.selectattr]
+    // r[verify test.truthy]
+    #[tokio::test]
+    async fn test_selectattr_truthy() {
+        let t = Template::parse(
+            "test",
+            "{% for x in items | selectattr(\"active\") %}{{ x.name }}{% endfor %}",
+        )
+        .unwrap();
+
+        let mut item1 = VObject::new();
+        item1.insert(VString::from("name"), Value::from("Alice"));
+        item1.insert(VString::from("active"), Value::from(true));
+        let mut item2 = VObject::new();
+        item2.insert(VString::from("name"), Value::from("Bob"));
+        item2.insert(VString::from("active"), Value::from(false));
+        let mut item3 = VObject::new();
+        item3.insert(VString::from("name"), Value::from("Carol"));
+        item3.insert(VString::from("active"), Value::from(true));
+
+        let items: Value =
+            VArray::from_iter([Value::from(item1), Value::from(item2), Value::from(item3)]).into();
+        assert_eq!(
+            t.render_with([("items", items)]).await.unwrap(),
+            "AliceCarol"
+        );
+    }
+
+    // r[verify filter.selectattr]
+    // r[verify test.eq]
+    #[tokio::test]
+    async fn test_selectattr_eq() {
+        let t = Template::parse("test", "{% for x in items | selectattr(\"status\", \"eq\", \"active\") %}{{ x.name }}{% endfor %}").unwrap();
+
+        let mut item1 = VObject::new();
+        item1.insert(VString::from("name"), Value::from("Alice"));
+        item1.insert(VString::from("status"), Value::from("active"));
+        let mut item2 = VObject::new();
+        item2.insert(VString::from("name"), Value::from("Bob"));
+        item2.insert(VString::from("status"), Value::from("inactive"));
+
+        let items: Value = VArray::from_iter([Value::from(item1), Value::from(item2)]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "Alice");
+    }
+
+    // r[verify filter.selectattr]
+    // r[verify test.gt]
+    #[tokio::test]
+    async fn test_selectattr_gt() {
+        let t = Template::parse(
+            "test",
+            "{% for x in items | selectattr(\"weight\", \"gt\", 5) %}{{ x.name }}{% endfor %}",
+        )
+        .unwrap();
+
+        let mut item1 = VObject::new();
+        item1.insert(VString::from("name"), Value::from("Heavy"));
+        item1.insert(VString::from("weight"), Value::from(10i64));
+        let mut item2 = VObject::new();
+        item2.insert(VString::from("name"), Value::from("Light"));
+        item2.insert(VString::from("weight"), Value::from(3i64));
+
+        let items: Value = VArray::from_iter([Value::from(item1), Value::from(item2)]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "Heavy");
+    }
+
+    // r[verify filter.rejectattr]
+    // r[verify test.falsy]
+    #[tokio::test]
+    async fn test_rejectattr_truthy() {
+        let t = Template::parse(
+            "test",
+            "{% for x in items | rejectattr(\"draft\") %}{{ x.name }}{% endfor %}",
+        )
+        .unwrap();
+
+        let mut item1 = VObject::new();
+        item1.insert(VString::from("name"), Value::from("Published"));
+        item1.insert(VString::from("draft"), Value::from(false));
+        let mut item2 = VObject::new();
+        item2.insert(VString::from("name"), Value::from("Draft"));
+        item2.insert(VString::from("draft"), Value::from(true));
+
+        let items: Value = VArray::from_iter([Value::from(item1), Value::from(item2)]).into();
+        assert_eq!(
+            t.render_with([("items", items)]).await.unwrap(),
+            "Published"
+        );
+    }
+
+    // r[verify filter.selectattr]
+    /// `selectattr(attribute="x", value=y)` is the kwarg-shaped equivalent of
+    /// `selectattr("x", "eq", y)`. When a value is supplied without an explicit
+    /// test name, the default becomes `eq` (Jinja2/Tera convention).
+    #[tokio::test]
+    async fn test_selectattr_kwargs_attribute_and_value() {
+        let t = Template::parse(
+            "test",
+            "{% for x in items | selectattr(attribute=\"status\", value=\"active\") %}{{ x.name }}{% endfor %}",
+        )
+        .unwrap();
+
+        let mut item1 = VObject::new();
+        item1.insert(VString::from("name"), Value::from("Alice"));
+        item1.insert(VString::from("status"), Value::from("active"));
+        let mut item2 = VObject::new();
+        item2.insert(VString::from("name"), Value::from("Bob"));
+        item2.insert(VString::from("status"), Value::from("inactive"));
+
+        let items: Value = VArray::from_iter([Value::from(item1), Value::from(item2)]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "Alice");
+    }
+
+    // r[verify filter.selectattr]
+    /// Dotted attribute paths traverse nested objects: `selectattr("a.b", ...)`
+    /// reads `item.a.b`. Critical for matching against frontmatter fields like
+    /// `extra.type` in dodeca pages.
+    #[tokio::test]
+    async fn test_selectattr_dotted_path() {
+        let t = Template::parse(
+            "test",
+            "{% for x in items | selectattr(\"meta.kind\", \"eq\", \"vision\") %}{{ x.name }}{% endfor %}",
+        )
+        .unwrap();
+
+        let mut meta1 = VObject::new();
+        meta1.insert(VString::from("kind"), Value::from("vision"));
+        let mut item1 = VObject::new();
+        item1.insert(VString::from("name"), Value::from("Alpha"));
+        item1.insert(VString::from("meta"), Value::from(meta1));
+
+        let mut meta2 = VObject::new();
+        meta2.insert(VString::from("kind"), Value::from("decision"));
+        let mut item2 = VObject::new();
+        item2.insert(VString::from("name"), Value::from("Beta"));
+        item2.insert(VString::from("meta"), Value::from(meta2));
+
+        let items: Value = VArray::from_iter([Value::from(item1), Value::from(item2)]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "Alpha");
+    }
+
+    // r[verify filter.selectattr]
+    // r[verify test.starting-with]
+    #[tokio::test]
+    async fn test_selectattr_starting_with() {
+        let t = Template::parse("test", "{% for x in items | selectattr(\"path\", \"starting_with\", \"/admin\") %}{{ x.name }}{% endfor %}").unwrap();
+
+        let mut item1 = VObject::new();
+        item1.insert(VString::from("name"), Value::from("Admin"));
+        item1.insert(VString::from("path"), Value::from("/admin/dashboard"));
+        let mut item2 = VObject::new();
+        item2.insert(VString::from("name"), Value::from("User"));
+        item2.insert(VString::from("path"), Value::from("/user/profile"));
+
+        let items: Value = VArray::from_iter([Value::from(item1), Value::from(item2)]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "Admin");
+    }
+
+    // r[verify filter.groupby]
+    // r[verify stmt.for.tuple-unpacking]
+    #[tokio::test]
+    async fn test_groupby_filter() {
+        // Use tuple unpacking to access category and items
+        let t = Template::parse("test", "{% for category, group_items in items | groupby(attribute=\"category\") %}[{{ category }}:{% for x in group_items %}{{ x.name }}{% endfor %}]{% endfor %}").unwrap();
+
+        let mut item1 = VObject::new();
+        item1.insert(VString::from("name"), Value::from("Apple"));
+        item1.insert(VString::from("category"), Value::from("fruit"));
+        let mut item2 = VObject::new();
+        item2.insert(VString::from("name"), Value::from("Carrot"));
+        item2.insert(VString::from("category"), Value::from("vegetable"));
+        let mut item3 = VObject::new();
+        item3.insert(VString::from("name"), Value::from("Banana"));
+        item3.insert(VString::from("category"), Value::from("fruit"));
+
+        let items: Value =
+            VArray::from_iter([Value::from(item1), Value::from(item2), Value::from(item3)]).into();
+        let result = t.render_with([("items", items)]).await.unwrap();
+        // Order is preserved: fruit first (Apple, Banana), then vegetable (Carrot)
+        assert_eq!(result, "[fruit:AppleBanana][vegetable:Carrot]");
+    }
+
+    // r[verify stmt.for.tuple-unpacking]
+    // r[verify filter.length]
+    #[tokio::test]
+    async fn test_groupby_tuple_unpacking() {
+        // Test using tuple unpacking syntax in for loop
+        let t = Template::parse("test", "{% for category, posts in items | groupby(attribute=\"cat\") %}{{ category }}:{{ posts | length }};{% endfor %}").unwrap();
+
+        let mut item1 = VObject::new();
+        item1.insert(VString::from("cat"), Value::from("A"));
+        let mut item2 = VObject::new();
+        item2.insert(VString::from("cat"), Value::from("B"));
+        let mut item3 = VObject::new();
+        item3.insert(VString::from("cat"), Value::from("A"));
+
+        let items: Value =
+            VArray::from_iter([Value::from(item1), Value::from(item2), Value::from(item3)]).into();
+        let result = t.render_with([("items", items)]).await.unwrap();
+        assert_eq!(result, "A:2;B:1;");
+    }
+
+    // r[verify filter.chaining]
+    // r[verify filter.selectattr]
+    // r[verify filter.map]
+    // r[verify filter.join]
+    #[tokio::test]
+    async fn test_filters_chained() {
+        // Test chaining multiple new filters
+        let t = Template::parse(
+            "test",
+            "{{ items | selectattr(\"active\") | map(attribute=\"name\") | join(\", \") }}",
+        )
+        .unwrap();
+
+        let mut item1 = VObject::new();
+        item1.insert(VString::from("name"), Value::from("Alice"));
+        item1.insert(VString::from("active"), Value::from(true));
+        let mut item2 = VObject::new();
+        item2.insert(VString::from("name"), Value::from("Bob"));
+        item2.insert(VString::from("active"), Value::from(false));
+        let mut item3 = VObject::new();
+        item3.insert(VString::from("name"), Value::from("Carol"));
+        item3.insert(VString::from("active"), Value::from(true));
+
+        let items: Value =
+            VArray::from_iter([Value::from(item1), Value::from(item2), Value::from(item3)]).into();
+        assert_eq!(
+            t.render_with([("items", items)]).await.unwrap(),
+            "Alice, Carol"
+        );
+    }
+
+    // r[verify error.syntax]
+    #[test]
+    fn test_unclosed_expression_error() {
+        // Unclosed {{ should produce a parse error
+        let result = Template::parse("test", "Hello {{ name");
+        assert!(
+            result.is_err(),
+            "Unclosed expression should produce parse error"
+        );
+    }
+
+    // r[verify error.syntax]
+    #[test]
+    fn test_unclosed_expression_in_html_template() {
+        // Test with content similar to the actual test case
+        let template = r#"<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ section.title</title>
+</head>
+<body>
+  <h1>{{ section.title</h1>
+  {{ section.content | safe }}
+</body>
+</html>"#;
+        let result = Template::parse("index.html", template);
+        println!("\n\nResult: {:?}\n\n", result);
+        assert!(
+            result.is_err(),
+            "Template with unclosed expression should produce parse error"
+        );
+    }
+
+    // ========================================================================
+    // Additional tests for verification coverage
+    // ========================================================================
+
+    // r[verify expr.op.sub]
+    #[tokio::test]
+    async fn test_subtraction() {
+        let t = Template::parse("test", "{{ 10 - 3 }}").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "7");
+    }
+
+    // r[verify expr.op.mul]
+    #[tokio::test]
+    async fn test_multiplication() {
+        let t = Template::parse("test", "{{ 4 * 5 }}").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "20");
+    }
+
+    // r[verify expr.op.div]
+    #[tokio::test]
+    async fn test_division() {
+        let t = Template::parse("test", "{{ 10 / 4 }}").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "2.5");
+    }
+
+    // r[verify expr.op.floordiv]
+    #[tokio::test]
+    async fn test_floor_division() {
+        let t = Template::parse("test", "{{ 10 // 3 }}").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "3");
+    }
+
+    // r[verify expr.op.mod]
+    #[tokio::test]
+    async fn test_modulo() {
+        let t = Template::parse("test", "{{ 10 % 3 }}").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "1");
+    }
+
+    // r[verify expr.op.pow]
+    #[tokio::test]
+    async fn test_power() {
+        let t = Template::parse("test", "{{ 2 ** 8 }}").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "256");
+    }
+
+    // r[verify expr.op.eq]
+    #[tokio::test]
+    async fn test_equality() {
+        let t = Template::parse("test", "{% if x == 5 %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(5i64))]).await.unwrap(),
+            "yes"
+        );
+        assert_eq!(
+            t.render_with([("x", Value::from(3i64))]).await.unwrap(),
+            "no"
+        );
+    }
+
+    // r[verify expr.op.ne]
+    #[tokio::test]
+    async fn test_not_equal() {
+        let t = Template::parse("test", "{% if x != 5 %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(3i64))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify expr.op.lt]
+    #[tokio::test]
+    async fn test_less_than() {
+        let t = Template::parse("test", "{% if x < 5 %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(3i64))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify expr.op.le]
+    #[tokio::test]
+    async fn test_less_than_or_equal() {
+        let t = Template::parse("test", "{% if x <= 5 %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(5i64))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify expr.op.ge]
+    #[tokio::test]
+    async fn test_greater_than_or_equal() {
+        let t = Template::parse("test", "{% if x >= 5 %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(5i64))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify expr.op.and]
+    #[tokio::test]
+    async fn test_logical_and() {
+        let t = Template::parse("test", "{% if a and b %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("a", Value::from(true)), ("b", Value::from(true))])
+                .await
+                .unwrap(),
+            "yes"
+        );
+        assert_eq!(
+            t.render_with([("a", Value::from(true)), ("b", Value::from(false))])
+                .await
+                .unwrap(),
+            "no"
+        );
+    }
+
+    // r[verify expr.op.or]
+    #[tokio::test]
+    async fn test_logical_or() {
+        let t = Template::parse("test", "{% if a or b %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("a", Value::from(false)), ("b", Value::from(true))])
+                .await
+                .unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify expr.op.not]
+    #[tokio::test]
+    async fn test_logical_not() {
+        let t = Template::parse("test", "{% if not x %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(false))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify expr.op.in]
+    #[tokio::test]
+    async fn test_in_operator() {
+        let t = Template::parse("test", "{% if x in items %}yes{% else %}no{% endif %}").unwrap();
+        let items: Value = VArray::from_iter([Value::from(1i64), Value::from(2i64)]).into();
+        assert_eq!(
+            t.render_with([("x", Value::from(2i64)), ("items", items)])
+                .await
+                .unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify expr.op.not-in]
+    #[tokio::test]
+    async fn test_not_in_operator() {
+        let t =
+            Template::parse("test", "{% if x not in items %}yes{% else %}no{% endif %}").unwrap();
+        let items: Value = VArray::from_iter([Value::from(1i64), Value::from(2i64)]).into();
+        assert_eq!(
+            t.render_with([("x", Value::from(5i64)), ("items", items)])
+                .await
+                .unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify expr.op.concat]
+    #[tokio::test]
+    async fn test_string_concat() {
+        let t = Template::parse("test", "{{ a ~ b }}").unwrap();
+        assert_eq!(
+            t.render_with([("a", Value::from("hello")), ("b", Value::from("world"))])
+                .await
+                .unwrap(),
+            "helloworld"
+        );
+    }
+
+    // r[verify expr.ternary]
+    #[tokio::test]
+    async fn test_ternary() {
+        let t = Template::parse("test", "{{ \"yes\" if x else \"no\" }}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(true))]).await.unwrap(),
+            "yes"
+        );
+        assert_eq!(
+            t.render_with([("x", Value::from(false))]).await.unwrap(),
+            "no"
+        );
+    }
+
+    // r[verify filter.first]
+    #[tokio::test]
+    async fn test_first_filter() {
+        let t = Template::parse("test", "{{ items | first }}").unwrap();
+        let items: Value = VArray::from_iter([Value::from("a"), Value::from("b")]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "a");
+    }
+
+    // r[verify filter.last]
+    #[tokio::test]
+    async fn test_last_filter() {
+        let t = Template::parse("test", "{{ items | last }}").unwrap();
+        let items: Value = VArray::from_iter([Value::from("a"), Value::from("b")]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "b");
+    }
+
+    // r[verify filter.reverse]
+    #[tokio::test]
+    async fn test_reverse_filter() {
+        let t = Template::parse("test", "{{ items | reverse | join(\",\") }}").unwrap();
+        let items: Value =
+            VArray::from_iter([Value::from("a"), Value::from("b"), Value::from("c")]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "c,b,a");
+    }
+
+    // r[verify filter.sort]
+    #[tokio::test]
+    async fn test_sort_filter() {
+        let t = Template::parse("test", "{{ items | sort | join(\",\") }}").unwrap();
+        let items: Value =
+            VArray::from_iter([Value::from("c"), Value::from("a"), Value::from("b")]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "a,b,c");
+    }
+
+    // r[verify filter.lower]
+    #[tokio::test]
+    async fn test_lower_filter() {
+        let t = Template::parse("test", "{{ x | lower }}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from("HELLO"))]).await.unwrap(),
+            "hello"
+        );
+    }
+
+    // r[verify filter.capitalize]
+    #[tokio::test]
+    async fn test_capitalize_filter() {
+        let t = Template::parse("test", "{{ x | capitalize }}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from("hello"))]).await.unwrap(),
+            "Hello"
+        );
+    }
+
+    // r[verify filter.title]
+    #[tokio::test]
+    async fn test_title_filter() {
+        let t = Template::parse("test", "{{ x | title }}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from("hello world"))])
+                .await
+                .unwrap(),
+            "Hello World"
+        );
+    }
+
+    // r[verify filter.trim]
+    #[tokio::test]
+    async fn test_trim_filter() {
+        let t = Template::parse("test", "{{ x | trim }}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from("  hello  "))])
+                .await
+                .unwrap(),
+            "hello"
+        );
+    }
+
+    // r[verify filter.default]
+    #[tokio::test]
+    async fn test_default_filter() {
+        let t = Template::parse("test", "{{ x | default(\"fallback\") }}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::NULL)]).await.unwrap(),
+            "fallback"
+        );
+        assert_eq!(
+            t.render_with([("x", Value::from("value"))]).await.unwrap(),
+            "value"
+        );
+    }
+
+    // r[verify filter.path-segments]
+    #[tokio::test]
+    async fn test_path_segments_filter() {
+        let t = Template::parse("test", "{{ path | path_segments | join(\",\") }}").unwrap();
+        assert_eq!(
+            t.render_with([("path", Value::from("/foo/bar/baz"))])
+                .await
+                .unwrap(),
+            "foo,bar,baz"
+        );
+    }
+
+    // r[verify filter.path-first]
+    #[tokio::test]
+    async fn test_path_first_filter() {
+        let t = Template::parse("test", "{{ path | path_first }}").unwrap();
+        assert_eq!(
+            t.render_with([("path", Value::from("/foo/bar"))])
+                .await
+                .unwrap(),
+            "foo"
+        );
+    }
+
+    // r[verify filter.path-parent]
+    #[tokio::test]
+    async fn test_path_parent_filter() {
+        let t = Template::parse("test", "{{ path | path_parent }}").unwrap();
+        assert_eq!(
+            t.render_with([("path", Value::from("/foo/bar"))])
+                .await
+                .unwrap(),
+            "/foo"
+        );
+    }
+
+    // r[verify filter.path-basename]
+    #[tokio::test]
+    async fn test_path_basename_filter() {
+        let t = Template::parse("test", "{{ path | path_basename }}").unwrap();
+        assert_eq!(
+            t.render_with([("path", Value::from("/foo/bar"))])
+                .await
+                .unwrap(),
+            "bar"
+        );
+    }
+
+    // r[verify stmt.for.loop-index0]
+    #[tokio::test]
+    async fn test_loop_index0() {
+        let t =
+            Template::parse("test", "{% for x in items %}{{ loop.index0 }}{% endfor %}").unwrap();
+        let items: Value = VArray::from_iter([Value::from("a"), Value::from("b")]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "01");
+    }
+
+    // r[verify stmt.for.loop-first]
+    // r[verify stmt.for.loop-last]
+    #[tokio::test]
+    async fn test_loop_first_last() {
+        let t = Template::parse(
+            "test",
+            "{% for x in items %}{% if loop.first %}F{% endif %}{% if loop.last %}L{% endif %}{{ x }}{% endfor %}",
+        )
+        .unwrap();
+        let items: Value =
+            VArray::from_iter([Value::from("a"), Value::from("b"), Value::from("c")]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "FabLc");
+    }
+
+    // r[verify stmt.for.loop-length]
+    #[tokio::test]
+    async fn test_loop_length() {
+        let t =
+            Template::parse("test", "{% for x in items %}{{ loop.length }}{% endfor %}").unwrap();
+        let items: Value =
+            VArray::from_iter([Value::from("a"), Value::from("b"), Value::from("c")]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "333");
+    }
+
+    // r[verify stmt.for.else]
+    #[tokio::test]
+    async fn test_for_else() {
+        let t = Template::parse(
+            "test",
+            "{% for x in items %}{{ x }}{% else %}empty{% endfor %}",
+        )
+        .unwrap();
+        let empty: Value = VArray::from_iter(Vec::<Value>::new()).into();
+        assert_eq!(t.render_with([("items", empty)]).await.unwrap(), "empty");
+    }
+
+    // r[verify stmt.if.elif]
+    #[tokio::test]
+    async fn test_if_elif() {
+        let t = Template::parse(
+            "test",
+            "{% if x == 1 %}one{% elif x == 2 %}two{% else %}other{% endif %}",
+        )
+        .unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(1i64))]).await.unwrap(),
+            "one"
+        );
+        assert_eq!(
+            t.render_with([("x", Value::from(2i64))]).await.unwrap(),
+            "two"
+        );
+        assert_eq!(
+            t.render_with([("x", Value::from(3i64))]).await.unwrap(),
+            "other"
+        );
+    }
+
+    // r[verify test.defined]
+    #[tokio::test]
+    async fn test_is_defined() {
+        let t = Template::parse("test", "{% if x is defined %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(42i64))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_whitespace_control_trim() {
+        // `{{- … -}}` trims surrounding whitespace; `{%- … -%}` likewise.
+        let t = Template::parse("t", "a  {{- \"X\" -}}  b").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "aXb");
+        let t2 = Template::parse("t", "x\n  {%- if true -%}  Y  {%- endif -%}  \nz").unwrap();
+        assert_eq!(t2.render(&Context::new()).await.unwrap(), "xYz");
+    }
+
+    // r[verify test.none]
+    #[tokio::test]
+    async fn test_is_none() {
+        let t = Template::parse("test", "{% if x is none %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(t.render_with([("x", Value::NULL)]).await.unwrap(), "yes");
+    }
+
+    // r[verify test.string]
+    #[tokio::test]
+    async fn test_is_string() {
+        let t = Template::parse("test", "{% if x is string %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from("hello"))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify test.number]
+    #[tokio::test]
+    async fn test_is_number() {
+        let t = Template::parse("test", "{% if x is number %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(42i64))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify test.integer]
+    #[tokio::test]
+    async fn test_is_integer() {
+        let t = Template::parse("test", "{% if x is integer %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(42i64))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify test.float]
+    // r[verify literal.float]
+    #[tokio::test]
+    async fn test_is_float() {
+        let t = Template::parse("test", "{% if x is float %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(2.14f64))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify test.mapping]
+    #[tokio::test]
+    async fn test_is_mapping() {
+        let t = Template::parse("test", "{% if x is mapping %}yes{% else %}no{% endif %}").unwrap();
+        let obj: Value = VObject::new().into();
+        assert_eq!(t.render_with([("x", obj)]).await.unwrap(), "yes");
+    }
+
+    // r[verify test.iterable]
+    #[tokio::test]
+    async fn test_is_iterable() {
+        let t =
+            Template::parse("test", "{% if x is iterable %}yes{% else %}no{% endif %}").unwrap();
+        let items: Value = VArray::from_iter([Value::from(1i64)]).into();
+        assert_eq!(t.render_with([("x", items)]).await.unwrap(), "yes");
+    }
+
+    // r[verify test.odd]
+    #[tokio::test]
+    async fn test_is_odd() {
+        let t = Template::parse("test", "{% if x is odd %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(3i64))]).await.unwrap(),
+            "yes"
+        );
+        assert_eq!(
+            t.render_with([("x", Value::from(4i64))]).await.unwrap(),
+            "no"
+        );
+    }
+
+    // r[verify test.even]
+    #[tokio::test]
+    async fn test_is_even() {
+        let t = Template::parse("test", "{% if x is even %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(4i64))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify test.empty]
+    #[tokio::test]
+    async fn test_is_empty() {
+        let t = Template::parse("test", "{% if x is empty %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(""))]).await.unwrap(),
+            "yes"
+        );
+        let empty_arr: Value = VArray::from_iter(Vec::<Value>::new()).into();
+        assert_eq!(t.render_with([("x", empty_arr)]).await.unwrap(), "yes");
+    }
+
+    // r[verify test.ending-with]
+    #[tokio::test]
+    async fn test_is_ending_with() {
+        let t = Template::parse(
+            "test",
+            "{% if path is ending_with(\".html\") %}yes{% else %}no{% endif %}",
+        )
+        .unwrap();
+        assert_eq!(
+            t.render_with([("path", Value::from("index.html"))])
+                .await
+                .unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify test.lt]
+    #[tokio::test]
+    async fn test_is_lt() {
+        let t = Template::parse("test", "{% if x is lt(5) %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(3i64))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify test.ne]
+    #[tokio::test]
+    async fn test_is_ne() {
+        let t = Template::parse("test", "{% if x is ne(5) %}yes{% else %}no{% endif %}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from(3i64))]).await.unwrap(),
+            "yes"
+        );
+    }
+
+    // r[verify delim.statement]
+    #[tokio::test]
+    async fn test_statement_delimiter() {
+        let t = Template::parse("test", "{% set x = 1 %}{{ x }}").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "1");
+    }
+
+    // r[verify delim.comment]
+    #[tokio::test]
+    async fn test_comment_delimiter() {
+        let t = Template::parse("test", "a{# this is a comment #}b").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "ab");
+    }
+
+    // r[verify delim.comment]
+    // A comment containing multibyte UTF-8 (€, em-dash, curly quotes) must be
+    // skipped whole — the lexer's 2-byte delimiter window returns None on a
+    // multibyte boundary, which must not be mistaken for an unclosed comment.
+    #[tokio::test]
+    async fn test_comment_multibyte() {
+        let t = Template::parse("test", "a{# €49 — “quoted” #}b").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "ab");
+        // Nested + multibyte, and content after the close still renders.
+        let t = Template::parse("test", "x{# outer {# inner — 🐝 #} still #}y").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "xy");
+    }
+
+    // r[verify expr.index.bracket]
+    #[tokio::test]
+    async fn test_index_bracket() {
+        let t = Template::parse("test", "{{ items[1] }}").unwrap();
+        let items: Value = VArray::from_iter([Value::from("a"), Value::from("b")]).into();
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "b");
+    }
+
+    // r[verify ident.syntax]
+    // r[verify ident.case-sensitive]
+    #[tokio::test]
+    async fn test_identifier_case_sensitive() {
+        let t = Template::parse("test", "{{ Foo }}{{ foo }}").unwrap();
+        assert_eq!(
+            t.render_with([("Foo", Value::from("A")), ("foo", Value::from("B"))])
+                .await
+                .unwrap(),
+            "AB"
+        );
+    }
+
+    // r[verify whitespace.inside-delimiters]
+    #[tokio::test]
+    async fn test_whitespace_inside_delimiters() {
+        let t = Template::parse("test", "{{   x   }}").unwrap();
+        assert_eq!(
+            t.render_with([("x", Value::from("val"))]).await.unwrap(),
+            "val"
+        );
+    }
+
+    // r[verify scope.lexical]
+    // r[verify scope.block]
+    #[tokio::test]
+    async fn test_lexical_scope() {
+        // Inner set doesn't affect outer scope after for loop ends
+        let t = Template::parse(
+            "test",
+            "{% set x = 1 %}{% for i in items %}{% set x = i %}{% endfor %}{{ x }}",
+        )
+        .unwrap();
+        let items: Value = VArray::from_iter([Value::from(5i64)]).into();
+        // x should still be 1 because the inner set was in a different scope
+        assert_eq!(t.render_with([("items", items)]).await.unwrap(), "1");
+    }
+
+    // r[verify expr.field.missing]
+    #[tokio::test]
+    async fn test_missing_field_error() {
+        // Accessing a missing field produces an error (implementation choice: strict mode)
+        let t = Template::parse("test", "{{ obj.missing }}").unwrap();
+        let mut obj = VObject::new();
+        obj.insert(VString::from("existing"), Value::from("value"));
+        let obj: Value = obj.into();
+        let result = t.render_with([("obj", obj)]).await;
+        assert!(result.is_err());
+    }
+
+    // r[verify expr.index.missing-key]
+    #[tokio::test]
+    async fn test_missing_key_error() {
+        // Accessing a missing key produces an error (implementation choice: strict mode)
+        let t = Template::parse("test", "{{ dict[\"missing\"] }}").unwrap();
+        let mut dict = VObject::new();
+        dict.insert(VString::from("existing"), Value::from("value"));
+        let dict: Value = dict.into();
+        let result = t.render_with([("dict", dict)]).await;
+        assert!(result.is_err());
+    }
+
+    // r[verify expr.index.out-of-bounds]
+    #[tokio::test]
+    async fn test_index_out_of_bounds_error() {
+        // Out of bounds index produces an error (implementation choice)
+        let t = Template::parse("test", "{{ items[99] }}").unwrap();
+        let items: Value = VArray::from_iter([Value::from("a"), Value::from("b")]).into();
+        let result = t.render_with([("items", items)]).await;
+        assert!(result.is_err());
+    }
+
+    // r[verify error.undefined-filter]
+    #[tokio::test]
+    async fn test_undefined_filter_error() {
+        // Unknown filters error at render time, not parse time
+        let t = Template::parse("test", "{{ x | nonexistent_filter }}").unwrap();
+        let result = t.render_with([("x", Value::from("test"))]).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Unknown filter"));
+    }
+
+    // r[verify error.undefined-test]
+    #[tokio::test]
+    async fn test_undefined_test_error() {
+        let t = Template::parse("test", "{% if x is nonexistent_test %}yes{% endif %}").unwrap();
+        let result = t.render_with([("x", Value::from(1i64))]).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Unknown test"));
+    }
+
+    // r[verify error.type-mismatch]
+    #[tokio::test]
+    async fn test_type_mismatch_iteration() {
+        // Iterating over a non-iterable (lenient behavior): returns empty, no error
+        // This verifies type handling in iteration context
+        let t = Template::parse(
+            "test",
+            "{% for x in num %}{{ x }}{% else %}empty{% endfor %}",
+        )
+        .unwrap();
+        let result = t.render_with([("num", Value::from(42i64))]).await.unwrap();
+        // Falls into else because iteration is empty
+        assert_eq!(result, "empty");
+    }
+
+    // r[verify keyword.reserved]
+    #[tokio::test]
+    async fn test_reserved_keywords() {
+        // 'if', 'for', 'true', etc. are keywords, not identifiers
+        // Using them where an identifier is expected should fail or work as keywords
+        let t = Template::parse("test", "{% if true %}yes{% endif %}").unwrap();
+        assert_eq!(t.render(&Context::new()).await.unwrap(), "yes");
+    }
+
+    // r[verify inherit.include.syntax]
+    #[tokio::test]
+    async fn test_include_syntax() {
+        // Include syntax parses correctly - {% include "path" %}
+        let t = Template::parse("test", "{% include \"header.html\" %}");
+        assert!(t.is_ok());
+    }
+
+    // r[verify inherit.include.context]
+    #[tokio::test]
+    async fn test_include_context() {
+        // Include is parsed; verify the parsed node exists
+        // (Full include rendering is not yet implemented)
+        let t = Template::parse("test", "before{% include \"x.html\" %}after").unwrap();
+        // Template parses successfully - include syntax is recognized
+        let result = t.render(&Context::new()).await.unwrap();
+        // Contains placeholder comment for unimplemented include
+        assert!(result.contains("include"));
+    }
+
+    // r[verify filter.default.undefined]
+    #[tokio::test]
+    async fn default_filter_on_undefined_variable_returns_fallback() {
+        let t = Template::parse(
+            "test",
+            "{% set cap = title | default(value=\"\") %}[{{ cap }}]",
+        )
+        .unwrap();
+        let result = t.render(&Context::new()).await.unwrap();
+        assert_eq!(
+            result.trim(),
+            "[]",
+            "undefined var should give empty string via default"
+        );
+    }
+
+    // r[verify inherit.extends.position]
+    #[tokio::test]
+    async fn test_extends_position() {
+        // Extends is processed at Engine level; the extends tag is found regardless of position
+        // but spec says it SHOULD be first (implementation doesn't strictly enforce)
+        let mut loader = InMemoryLoader::new();
+        loader.add("base.html", "BASE{% block content %}default{% endblock %}");
+        loader.add(
+            "child.html",
+            "{% extends \"base.html\" %}{% block content %}child{% endblock %}",
+        );
+        let mut engine = Engine::new(loader);
+        // Valid extends at start - inheritance works
+        let result = engine.render("child.html", &Context::new()).await.unwrap();
+        assert_eq!(result, "BASEchild");
+    }
+}

--- a/gingembre/src/semantic.rs
+++ b/gingembre/src/semantic.rs
@@ -1,0 +1,851 @@
+//! Semantic information for Gingembre templates.
+//!
+//! This module builds a scoped symbol/reference index from the parsed AST. It is
+//! intentionally editor-agnostic: LSP frontends can map spans to protocol ranges,
+//! while Gingembre owns the meaning of bindings and references.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::ast::{
+    BinaryExpr, CallExpr, DictLit, Expr, FilterExpr, Ident, IfNode, ListLit, Literal,
+    MacroCallExpr, MacroNode, Node, SetValue, Span, Target, Template, TernaryExpr, TestExpr,
+    UnaryExpr,
+};
+use facet::Facet;
+
+#[derive(Debug, Clone, Facet)]
+pub struct TemplateSemanticIndex {
+    pub symbols: Vec<TemplateSymbol>,
+    pub references: Vec<TemplateReference>,
+    pub tokens: Vec<TemplateSemanticToken>,
+    scopes: Vec<TemplateScope>,
+}
+
+#[derive(Debug, Clone, Facet)]
+pub struct TemplateSymbol {
+    pub id: usize,
+    pub name: String,
+    pub kind: TemplateSymbolKind,
+    pub span: Option<Span>,
+    pub origin: Option<TemplateSymbolOrigin>,
+    scope: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Facet)]
+#[repr(u8)]
+pub enum TemplateSymbolOrigin {
+    ContextRoot,
+    Function,
+    ExpressionPath(Vec<String>),
+    IterationItem(Vec<String>),
+    MacroParam,
+    ImportAlias,
+    Macro,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Facet)]
+#[repr(u8)]
+pub enum TemplateSymbolKind {
+    ContextRoot,
+    Function,
+    SetBinding,
+    LoopBinding,
+    MacroParam,
+    ImportAlias,
+    Macro,
+}
+
+#[derive(Debug, Clone, Facet)]
+pub struct TemplateReference {
+    pub name: String,
+    pub span: Span,
+    pub kind: TemplateReferenceKind,
+    pub access: TemplateReferenceAccess,
+    pub symbol_id: Option<usize>,
+    pub path: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Facet)]
+#[repr(u8)]
+pub enum TemplateReferenceAccess {
+    Read,
+    Write,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Facet)]
+#[repr(u8)]
+pub enum TemplateReferenceKind {
+    Variable,
+    Function,
+    Field,
+    Filter,
+    Test,
+    MacroNamespace,
+    Macro,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Facet)]
+pub struct TemplateSemanticToken {
+    pub span: Span,
+    pub kind: TemplateSemanticTokenKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Facet)]
+#[repr(u8)]
+pub enum TemplateSemanticTokenKind {
+    Variable,
+    Parameter,
+    Property,
+    Function,
+    Macro,
+    String,
+    Number,
+    Keyword,
+}
+
+#[derive(Debug, Clone, Facet)]
+struct TemplateScope {
+    parent: Option<usize>,
+    span: Span,
+    symbols: HashMap<String, usize>,
+}
+
+impl TemplateSemanticIndex {
+    pub fn build(
+        template: &Template,
+        context_roots: &[&str],
+        functions: &[&str],
+    ) -> TemplateSemanticIndex {
+        let mut builder = SemanticBuilder {
+            index: TemplateSemanticIndex {
+                symbols: Vec::new(),
+                references: Vec::new(),
+                tokens: Vec::new(),
+                scopes: Vec::new(),
+            },
+        };
+        let root_scope = builder.push_scope(None, template.span);
+        for name in context_roots {
+            builder.define(
+                root_scope,
+                *name,
+                TemplateSymbolKind::ContextRoot,
+                None,
+                Some(TemplateSymbolOrigin::ContextRoot),
+            );
+        }
+        for name in functions {
+            builder.define(
+                root_scope,
+                *name,
+                TemplateSymbolKind::Function,
+                None,
+                Some(TemplateSymbolOrigin::Function),
+            );
+        }
+        builder.collect_nodes(&template.body, root_scope);
+        builder.index
+    }
+
+    pub fn symbol_at_offset(&self, offset: usize) -> Option<&TemplateSymbol> {
+        self.symbols.iter().find(|symbol| {
+            symbol
+                .span
+                .is_some_and(|span| span_contains_offset(span, offset))
+        })
+    }
+
+    pub fn reference_at_offset(&self, offset: usize) -> Option<&TemplateReference> {
+        self.references
+            .iter()
+            .find(|reference| span_contains_offset(reference.span, offset))
+    }
+
+    pub fn symbol_for_offset(&self, offset: usize) -> Option<&TemplateSymbol> {
+        if let Some(reference) = self.reference_at_offset(offset) {
+            return reference
+                .symbol_id
+                .and_then(|symbol_id| self.symbols.get(symbol_id));
+        }
+        self.symbol_at_offset(offset)
+    }
+
+    pub fn references_to_symbol(&self, symbol_id: usize) -> Vec<&TemplateReference> {
+        self.references
+            .iter()
+            .filter(|reference| reference.symbol_id == Some(symbol_id))
+            .collect()
+    }
+
+    pub fn references_to_symbol_with_access(
+        &self,
+        symbol_id: usize,
+        access: TemplateReferenceAccess,
+    ) -> Vec<&TemplateReference> {
+        self.references
+            .iter()
+            .filter(|reference| {
+                reference.symbol_id == Some(symbol_id) && reference.access == access
+            })
+            .collect()
+    }
+
+    pub fn read_references_to_symbol(&self, symbol_id: usize) -> Vec<&TemplateReference> {
+        self.references_to_symbol_with_access(symbol_id, TemplateReferenceAccess::Read)
+    }
+
+    pub fn write_references_to_symbol(&self, symbol_id: usize) -> Vec<&TemplateReference> {
+        self.references_to_symbol_with_access(symbol_id, TemplateReferenceAccess::Write)
+    }
+
+    pub fn visible_symbols_at_offset(&self, offset: usize) -> Vec<&TemplateSymbol> {
+        let mut scope_ids = self
+            .scopes
+            .iter()
+            .enumerate()
+            .filter(|(_, scope)| span_contains_offset(scope.span, offset))
+            .map(|(scope_id, _)| scope_id)
+            .collect::<Vec<_>>();
+        scope_ids.sort_by_key(|scope_id| std::cmp::Reverse(self.scope_depth(*scope_id)));
+
+        let mut visible = Vec::new();
+        let mut seen = HashSet::new();
+        for scope_id in scope_ids {
+            let mut current = Some(scope_id);
+            while let Some(id) = current {
+                for (name, symbol_id) in &self.scopes[id].symbols {
+                    if let Some(symbol) = self.symbols.get(*symbol_id)
+                        && symbol_is_visible_at_offset(symbol, offset)
+                        && seen.insert(name.clone())
+                    {
+                        visible.push(symbol);
+                    }
+                }
+                current = self.scopes[id].parent;
+            }
+        }
+        visible
+    }
+
+    pub fn visible_symbol_named_at_offset(
+        &self,
+        name: &str,
+        offset: usize,
+    ) -> Option<&TemplateSymbol> {
+        self.visible_symbols_at_offset(offset)
+            .into_iter()
+            .find(|symbol| symbol.name == name)
+    }
+
+    fn scope_depth(&self, mut scope_id: usize) -> usize {
+        let mut depth = 0;
+        while let Some(parent) = self.scopes[scope_id].parent {
+            depth += 1;
+            scope_id = parent;
+        }
+        depth
+    }
+}
+
+struct SemanticBuilder {
+    index: TemplateSemanticIndex,
+}
+
+impl SemanticBuilder {
+    fn push_scope(&mut self, parent: Option<usize>, span: Span) -> usize {
+        let scope_id = self.index.scopes.len();
+        self.index.scopes.push(TemplateScope {
+            parent,
+            span,
+            symbols: HashMap::new(),
+        });
+        scope_id
+    }
+
+    fn define(
+        &mut self,
+        scope: usize,
+        name: impl Into<String>,
+        kind: TemplateSymbolKind,
+        span: Option<Span>,
+        origin: Option<TemplateSymbolOrigin>,
+    ) -> usize {
+        let name = name.into();
+        let id = self.index.symbols.len();
+        self.index.symbols.push(TemplateSymbol {
+            id,
+            name: name.clone(),
+            kind,
+            span,
+            origin,
+            scope,
+        });
+        self.index.scopes[scope].symbols.insert(name, id);
+        if let Some(span) = span {
+            self.index.tokens.push(TemplateSemanticToken {
+                span,
+                kind: semantic_token_kind_for_symbol(kind),
+            });
+        }
+        id
+    }
+
+    fn resolve(&self, scope: usize, name: &str) -> Option<usize> {
+        let mut current = Some(scope);
+        while let Some(scope_id) = current {
+            if let Some(symbol_id) = self.index.scopes[scope_id].symbols.get(name) {
+                return Some(*symbol_id);
+            }
+            current = self.index.scopes[scope_id].parent;
+        }
+        None
+    }
+
+    fn reference(&mut self, scope: usize, ident: &Ident, kind: TemplateReferenceKind) {
+        self.reference_with_access(scope, ident, kind, TemplateReferenceAccess::Read);
+    }
+
+    fn reference_with_access(
+        &mut self,
+        scope: usize,
+        ident: &Ident,
+        kind: TemplateReferenceKind,
+        access: TemplateReferenceAccess,
+    ) {
+        let symbol_id = self.resolve(scope, &ident.name);
+        self.index.references.push(TemplateReference {
+            name: ident.name.clone(),
+            span: ident.span,
+            kind,
+            access,
+            symbol_id,
+            path: vec![ident.name.clone()],
+        });
+        self.index.tokens.push(TemplateSemanticToken {
+            span: ident.span,
+            kind: semantic_token_kind_for_reference(
+                kind,
+                symbol_id.and_then(|id| self.index.symbols.get(id)),
+            ),
+        });
+    }
+
+    fn collect_nodes(&mut self, nodes: &[Node], scope: usize) {
+        for node in nodes {
+            match node {
+                Node::Text(_) | Node::Comment(_) | Node::Continue(_) | Node::Break(_) => {}
+                Node::Print(node) => self.collect_expr(&node.expr, scope),
+                Node::If(node) => self.collect_if(node, scope),
+                Node::For(node) => {
+                    self.collect_expr(&node.iter, scope);
+                    let body_scope = self.push_scope(Some(scope), node.span);
+                    self.define_target(body_scope, &node.target, expr_path(&node.iter));
+                    self.collect_nodes(&node.body, body_scope);
+                    if let Some(body) = &node.else_body {
+                        self.collect_nodes(body, scope);
+                    }
+                }
+                Node::Include(node) => {
+                    self.index.tokens.push(TemplateSemanticToken {
+                        span: node.path.span,
+                        kind: TemplateSemanticTokenKind::String,
+                    });
+                    if let Some(context) = &node.context {
+                        self.collect_expr(context, scope);
+                    }
+                }
+                Node::Block(node) => self.collect_nodes(&node.body, scope),
+                Node::Extends(node) => self.index.tokens.push(TemplateSemanticToken {
+                    span: node.path.span,
+                    kind: TemplateSemanticTokenKind::String,
+                }),
+                Node::Set(node) => {
+                    let origin = match &node.value {
+                        SetValue::Expr(expr) => {
+                            self.collect_expr(expr, scope);
+                            expr_path(expr).map(TemplateSymbolOrigin::ExpressionPath)
+                        }
+                        SetValue::Body(body) => {
+                            self.collect_nodes(body, scope);
+                            None
+                        }
+                    };
+                    self.define_set_binding(scope, &node.name, origin);
+                }
+                Node::Import(node) => {
+                    self.index.tokens.push(TemplateSemanticToken {
+                        span: node.path.span,
+                        kind: TemplateSemanticTokenKind::String,
+                    });
+                    self.define(
+                        scope,
+                        node.alias.name.clone(),
+                        TemplateSymbolKind::ImportAlias,
+                        Some(node.alias.span),
+                        Some(TemplateSymbolOrigin::ImportAlias),
+                    );
+                }
+                Node::Macro(node) => self.collect_macro(node, scope),
+                Node::CallBlock(node) => {
+                    self.reference(scope, &node.func_name, TemplateReferenceKind::Function);
+                    for (name, expr) in &node.kwargs {
+                        self.index.tokens.push(TemplateSemanticToken {
+                            span: name.span,
+                            kind: TemplateSemanticTokenKind::Property,
+                        });
+                        self.collect_expr(expr, scope);
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_if(&mut self, node: &IfNode, scope: usize) {
+        self.collect_expr(&node.condition, scope);
+        self.collect_nodes(&node.then_body, scope);
+        for branch in &node.elif_branches {
+            self.collect_expr(&branch.condition, scope);
+            self.collect_nodes(&branch.body, scope);
+        }
+        if let Some(body) = &node.else_body {
+            self.collect_nodes(body, scope);
+        }
+    }
+
+    fn define_set_binding(
+        &mut self,
+        scope: usize,
+        ident: &Ident,
+        origin: Option<TemplateSymbolOrigin>,
+    ) {
+        if let Some(symbol_id) = self.index.scopes[scope]
+            .symbols
+            .get(&ident.name)
+            .copied()
+            .filter(|symbol_id| {
+                self.index
+                    .symbols
+                    .get(*symbol_id)
+                    .is_some_and(|symbol| symbol.kind == TemplateSymbolKind::SetBinding)
+            })
+        {
+            self.index.references.push(TemplateReference {
+                name: ident.name.clone(),
+                span: ident.span,
+                kind: TemplateReferenceKind::Variable,
+                access: TemplateReferenceAccess::Write,
+                symbol_id: Some(symbol_id),
+                path: vec![ident.name.clone()],
+            });
+            self.index.tokens.push(TemplateSemanticToken {
+                span: ident.span,
+                kind: TemplateSemanticTokenKind::Variable,
+            });
+            return;
+        }
+
+        self.define(
+            scope,
+            ident.name.clone(),
+            TemplateSymbolKind::SetBinding,
+            Some(ident.span),
+            origin,
+        );
+    }
+
+    fn collect_macro(&mut self, node: &MacroNode, scope: usize) {
+        self.define(
+            scope,
+            node.name.name.clone(),
+            TemplateSymbolKind::Macro,
+            Some(node.name.span),
+            Some(TemplateSymbolOrigin::Macro),
+        );
+        let macro_scope = self.push_scope(Some(scope), node.span);
+        for param in &node.params {
+            self.define(
+                macro_scope,
+                param.name.name.clone(),
+                TemplateSymbolKind::MacroParam,
+                Some(param.name.span),
+                Some(TemplateSymbolOrigin::MacroParam),
+            );
+            if let Some(default) = &param.default {
+                self.collect_expr(default, macro_scope);
+            }
+        }
+        self.collect_nodes(&node.body, macro_scope);
+    }
+
+    fn define_target(&mut self, scope: usize, target: &Target, iter_path: Option<Vec<String>>) {
+        match target {
+            Target::Single { name, span } => {
+                self.define(
+                    scope,
+                    name.clone(),
+                    TemplateSymbolKind::LoopBinding,
+                    Some(*span),
+                    iter_path.map(TemplateSymbolOrigin::IterationItem),
+                );
+            }
+            Target::Tuple { names, .. } => {
+                for (name, span) in names {
+                    self.define(
+                        scope,
+                        name.clone(),
+                        TemplateSymbolKind::LoopBinding,
+                        Some(*span),
+                        iter_path.clone().map(TemplateSymbolOrigin::IterationItem),
+                    );
+                }
+            }
+        }
+    }
+
+    fn collect_expr(&mut self, expr: &Expr, scope: usize) {
+        match expr {
+            Expr::Literal(literal) => self.collect_literal(literal, scope),
+            Expr::Var(ident) => self.reference(scope, ident, TemplateReferenceKind::Variable),
+            Expr::Field(expr) => {
+                self.collect_expr(&expr.base, scope);
+                self.index.references.push(TemplateReference {
+                    name: expr.field.name.clone(),
+                    span: expr.field.span,
+                    kind: TemplateReferenceKind::Field,
+                    access: TemplateReferenceAccess::Read,
+                    symbol_id: None,
+                    path: field_expr_path(expr).unwrap_or_else(|| vec![expr.field.name.clone()]),
+                });
+                self.index.tokens.push(TemplateSemanticToken {
+                    span: expr.field.span,
+                    kind: TemplateSemanticTokenKind::Property,
+                });
+            }
+            Expr::Index(expr) => {
+                self.collect_expr(&expr.base, scope);
+                self.collect_expr(&expr.index, scope);
+            }
+            Expr::Filter(expr) => self.collect_filter(expr, scope),
+            Expr::Binary(expr) => self.collect_binary(expr, scope),
+            Expr::Unary(expr) => self.collect_unary(expr, scope),
+            Expr::Call(expr) => self.collect_call(expr, scope),
+            Expr::Ternary(expr) => self.collect_ternary(expr, scope),
+            Expr::Test(expr) => self.collect_test(expr, scope),
+            Expr::MacroCall(expr) => self.collect_macro_call(expr, scope),
+            Expr::Optional(expr) => self.collect_expr(&expr.expr, scope),
+        }
+    }
+
+    fn collect_filter(&mut self, expr: &FilterExpr, scope: usize) {
+        self.collect_expr(&expr.expr, scope);
+        self.index.references.push(TemplateReference {
+            name: expr.filter.name.clone(),
+            span: expr.filter.span,
+            kind: TemplateReferenceKind::Filter,
+            access: TemplateReferenceAccess::Read,
+            symbol_id: None,
+            path: vec![expr.filter.name.clone()],
+        });
+        self.index.tokens.push(TemplateSemanticToken {
+            span: expr.filter.span,
+            kind: TemplateSemanticTokenKind::Function,
+        });
+        for arg in &expr.args {
+            self.collect_expr(arg, scope);
+        }
+        for (name, expr) in &expr.kwargs {
+            self.index.tokens.push(TemplateSemanticToken {
+                span: name.span,
+                kind: TemplateSemanticTokenKind::Property,
+            });
+            self.collect_expr(expr, scope);
+        }
+    }
+
+    fn collect_binary(&mut self, expr: &BinaryExpr, scope: usize) {
+        self.collect_expr(&expr.left, scope);
+        self.collect_expr(&expr.right, scope);
+    }
+
+    fn collect_unary(&mut self, expr: &UnaryExpr, scope: usize) {
+        self.collect_expr(&expr.expr, scope);
+    }
+
+    fn collect_call(&mut self, expr: &CallExpr, scope: usize) {
+        self.collect_expr(&expr.func, scope);
+        for arg in &expr.args {
+            self.collect_expr(arg, scope);
+        }
+        for (name, expr) in &expr.kwargs {
+            self.index.tokens.push(TemplateSemanticToken {
+                span: name.span,
+                kind: TemplateSemanticTokenKind::Property,
+            });
+            self.collect_expr(expr, scope);
+        }
+    }
+
+    fn collect_ternary(&mut self, expr: &TernaryExpr, scope: usize) {
+        self.collect_expr(&expr.value, scope);
+        self.collect_expr(&expr.condition, scope);
+        self.collect_expr(&expr.otherwise, scope);
+    }
+
+    fn collect_test(&mut self, expr: &TestExpr, scope: usize) {
+        self.collect_expr(&expr.expr, scope);
+        self.index.references.push(TemplateReference {
+            name: expr.test_name.name.clone(),
+            span: expr.test_name.span,
+            kind: TemplateReferenceKind::Test,
+            access: TemplateReferenceAccess::Read,
+            symbol_id: None,
+            path: vec![expr.test_name.name.clone()],
+        });
+        self.index.tokens.push(TemplateSemanticToken {
+            span: expr.test_name.span,
+            kind: TemplateSemanticTokenKind::Function,
+        });
+        for arg in &expr.args {
+            self.collect_expr(arg, scope);
+        }
+    }
+
+    fn collect_macro_call(&mut self, expr: &MacroCallExpr, scope: usize) {
+        self.reference(
+            scope,
+            &expr.namespace,
+            TemplateReferenceKind::MacroNamespace,
+        );
+        self.index.references.push(TemplateReference {
+            name: expr.macro_name.name.clone(),
+            span: expr.macro_name.span,
+            kind: TemplateReferenceKind::Macro,
+            access: TemplateReferenceAccess::Read,
+            symbol_id: None,
+            path: vec![expr.namespace.name.clone(), expr.macro_name.name.clone()],
+        });
+        self.index.tokens.push(TemplateSemanticToken {
+            span: expr.macro_name.span,
+            kind: TemplateSemanticTokenKind::Macro,
+        });
+        for arg in &expr.args {
+            self.collect_expr(arg, scope);
+        }
+        for (name, expr) in &expr.kwargs {
+            self.index.tokens.push(TemplateSemanticToken {
+                span: name.span,
+                kind: TemplateSemanticTokenKind::Property,
+            });
+            self.collect_expr(expr, scope);
+        }
+    }
+
+    fn collect_literal(&mut self, literal: &Literal, scope: usize) {
+        self.token_literal(literal);
+        match literal {
+            Literal::List(ListLit { elements, .. }) => {
+                for expr in elements {
+                    self.collect_expr(expr, scope);
+                }
+            }
+            Literal::Dict(DictLit { entries, .. }) => {
+                for (key, value) in entries {
+                    self.collect_expr(key, scope);
+                    self.collect_expr(value, scope);
+                }
+            }
+            Literal::String(_)
+            | Literal::Int(_)
+            | Literal::Float(_)
+            | Literal::Bool(_)
+            | Literal::None(_) => {}
+        }
+    }
+
+    fn token_literal(&mut self, literal: &Literal) {
+        let kind = match literal {
+            Literal::String(_) => TemplateSemanticTokenKind::String,
+            Literal::Int(_) | Literal::Float(_) => TemplateSemanticTokenKind::Number,
+            Literal::Bool(_) | Literal::None(_) => TemplateSemanticTokenKind::Keyword,
+            Literal::List(_) | Literal::Dict(_) => return,
+        };
+        self.index.tokens.push(TemplateSemanticToken {
+            span: literal.span(),
+            kind,
+        });
+    }
+}
+
+fn semantic_token_kind_for_symbol(kind: TemplateSymbolKind) -> TemplateSemanticTokenKind {
+    match kind {
+        TemplateSymbolKind::ContextRoot | TemplateSymbolKind::SetBinding => {
+            TemplateSemanticTokenKind::Variable
+        }
+        TemplateSymbolKind::Function => TemplateSemanticTokenKind::Function,
+        TemplateSymbolKind::LoopBinding | TemplateSymbolKind::MacroParam => {
+            TemplateSemanticTokenKind::Parameter
+        }
+        TemplateSymbolKind::ImportAlias | TemplateSymbolKind::Macro => {
+            TemplateSemanticTokenKind::Macro
+        }
+    }
+}
+
+fn semantic_token_kind_for_reference(
+    kind: TemplateReferenceKind,
+    symbol: Option<&TemplateSymbol>,
+) -> TemplateSemanticTokenKind {
+    match kind {
+        TemplateReferenceKind::Field => TemplateSemanticTokenKind::Property,
+        TemplateReferenceKind::Filter
+        | TemplateReferenceKind::Test
+        | TemplateReferenceKind::Function => TemplateSemanticTokenKind::Function,
+        TemplateReferenceKind::MacroNamespace | TemplateReferenceKind::Macro => {
+            TemplateSemanticTokenKind::Macro
+        }
+        TemplateReferenceKind::Variable => symbol
+            .map(|symbol| semantic_token_kind_for_symbol(symbol.kind))
+            .unwrap_or(TemplateSemanticTokenKind::Variable),
+    }
+}
+
+fn span_contains_offset(span: Span, offset: usize) -> bool {
+    span.offset() <= offset && offset <= span.offset().saturating_add(span.len())
+}
+
+fn symbol_is_visible_at_offset(symbol: &TemplateSymbol, offset: usize) -> bool {
+    symbol.span.is_none_or(|span| span.offset() <= offset)
+}
+
+fn expr_path(expr: &Expr) -> Option<Vec<String>> {
+    match expr {
+        Expr::Var(ident) => Some(vec![ident.name.clone()]),
+        Expr::Field(field) => field_expr_path(field),
+        _ => None,
+    }
+}
+
+fn field_expr_path(expr: &crate::ast::FieldExpr) -> Option<Vec<String>> {
+    let mut path = expr_path(&expr.base)?;
+    path.push(expr.field.name.clone());
+    Some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn semantic_index(source: &str) -> TemplateSemanticIndex {
+        let template = crate::parse_template("test.html", source).expect("template");
+        TemplateSemanticIndex::build(&template, &["page", "section", "root"], &[])
+    }
+
+    #[test]
+    fn records_set_and_loop_binding_origins() {
+        let source =
+            "{% set current = page %}\n{% for item in section.pages %}{{ item.path }}{% endfor %}";
+        let index = semantic_index(source);
+
+        let current = index
+            .symbols
+            .iter()
+            .find(|symbol| symbol.name == "current")
+            .expect("current symbol");
+        assert_eq!(
+            current.origin,
+            Some(TemplateSymbolOrigin::ExpressionPath(vec![
+                "page".to_string()
+            ]))
+        );
+
+        let item = index
+            .symbols
+            .iter()
+            .find(|symbol| symbol.name == "item")
+            .expect("item symbol");
+        assert_eq!(
+            item.origin,
+            Some(TemplateSymbolOrigin::IterationItem(vec![
+                "section".to_string(),
+                "pages".to_string()
+            ]))
+        );
+    }
+
+    #[test]
+    fn hides_later_bindings_from_visible_symbol_lookup() {
+        let source = "{{ alpha }}\n{% set alpha = page %}\n{{ alpha.path }}";
+        let index = semantic_index(source);
+        let first_alpha = source.find("alpha").expect("first alpha");
+        assert!(
+            index
+                .visible_symbol_named_at_offset("alpha", first_alpha)
+                .is_none(),
+            "set bindings are not visible before their declaration"
+        );
+        let last_alpha = source.rfind("alpha").expect("last alpha");
+        assert!(
+            index
+                .visible_symbol_named_at_offset("alpha", last_alpha)
+                .is_some(),
+            "set bindings are visible after their declaration"
+        );
+    }
+
+    #[test]
+    fn repeated_set_in_same_scope_references_original_binding() {
+        let source = "{% set current_path = \"/\" %}\n{% set current_path = section.path %}\n{% set current_path = page.path %}\n{{ current_path }}";
+        let index = semantic_index(source);
+        let offsets = source
+            .match_indices("current_path")
+            .map(|(offset, _)| offset)
+            .collect::<Vec<_>>();
+        assert_eq!(offsets.len(), 4);
+
+        let symbol = index
+            .symbol_for_offset(offsets[0])
+            .expect("first set binding");
+        assert_eq!(symbol.name, "current_path");
+        assert_eq!(symbol.kind, TemplateSymbolKind::SetBinding);
+        assert_eq!(symbol.span.expect("symbol span").offset(), offsets[0]);
+
+        for offset in offsets.iter().copied().skip(1) {
+            let resolved = index
+                .symbol_for_offset(offset)
+                .expect("later assignment or use resolves");
+            assert_eq!(resolved.id, symbol.id);
+        }
+
+        assert_eq!(index.references_to_symbol(symbol.id).len(), 3);
+    }
+
+    #[test]
+    fn classifies_symbol_references_as_reads_or_writes() {
+        let source = "{% set current_path = \"/\" %}\n{% set current_path = section.path %}\n{{ current_path }}";
+        let index = semantic_index(source);
+        let offsets = source
+            .match_indices("current_path")
+            .map(|(offset, _)| offset)
+            .collect::<Vec<_>>();
+        assert_eq!(offsets.len(), 3);
+
+        let symbol = index
+            .symbol_for_offset(offsets[0])
+            .expect("first set binding");
+        let references = index.references_to_symbol(symbol.id);
+        assert_eq!(index.write_references_to_symbol(symbol.id).len(), 1);
+        assert_eq!(index.read_references_to_symbol(symbol.id).len(), 1);
+        assert_eq!(
+            references
+                .iter()
+                .map(|reference| reference.access)
+                .collect::<Vec<_>>(),
+            vec![
+                TemplateReferenceAccess::Write,
+                TemplateReferenceAccess::Read
+            ]
+        );
+        assert_eq!(references[0].span.offset(), offsets[1]);
+        assert_eq!(references[1].span.offset(), offsets[2]);
+    }
+}


### PR DESCRIPTION
Step 1 of consolidating our custom languages (fable, gingembre, vix) onto a shared
language-infrastructure layer in the facet workspace. See `notes/langs-consolidation.md`
for the full design + migration plan.

## What this does

Mechanically copies `gingembre` and `gingembre-syntax` out of the dodeca repo into the
facet workspace (flat top-level, matching `fable/`, `weavy/`, `picante/`), and wires them
into `members`. **No behavior change.**

- Source is **byte-for-byte identical** to dodeca's: `diff -rq` on both crates reports
  only `Cargo.toml` differing. Every `.rs` is unchanged.
- The only manifest change is dependency reconciliation against facet's
  `[workspace.dependencies]` — notably `facet`/`facet-value` now resolve to facet's
  **local member crates** (the whole point of the move; kills the publish/bump dance),
  and `cstree`/`ariadne`/`camino`/`thiserror`/`tracing`/`futures`/`tokio` switch to
  `workspace = true` (all versions already compatible).
- `cstree` is unchanged — the facet-native CST migration is a **separate later step**.
- No lint-posture changes; pre-existing warnings untouched (also a separate step).

## Explicitly NOT in this PR

- **dodeca is untouched.** It still consumes its local path copy of gingembre and builds
  as before. Repointing dodeca to consume gingembre *from* facet is deferred until that
  tree is free — its gate will be "dodeca builds + renders its site identically."

## Verification

- `cargo nextest run -p gingembre -p gingembre-syntax`: **158/158 passed**
- `cargo build -p gingembre -p gingembre-syntax`: clean