### PR TITLE
Add aliases for named args and subcommands

### DIFF
--- a/figue-attrs/src/lib.rs
+++ b/figue-attrs/src/lib.rs
@@ -43,6 +43,18 @@ facet::define_attr_grammar! {
         ///
         /// Usage: `#[facet(args::short = 'v')]` or just `#[facet(args::short)]`
         Short(Option<char>),
+        /// Adds an additional accepted CLI alias.
+        ///
+        /// For named fields, this adds an extra long-form flag spelling such as
+        /// `--scopes` alongside the canonical `--scope`.
+        ///
+        /// For subcommand variants, this adds an extra subcommand spelling such as
+        /// `profiles` alongside the canonical `profile`.
+        ///
+        /// Multiple aliases can be specified by repeating the attribute.
+        ///
+        /// Usage: `#[facet(args::alias = "scopes")]`
+        Alias(&'static str),
         /// Marks a field as a subcommand.
         ///
         /// The field type must be an enum where each variant represents a subcommand.

--- a/figue/src/completions.rs
+++ b/figue/src/completions.rs
@@ -333,21 +333,41 @@ fn generate_zsh_function(
             ""
         };
 
-        for long_name in std::iter::once(&flag.long).chain(flag.aliases.iter()) {
-            if let Some(short) = flag.short {
-                // Short and long are mutually exclusive in completion
+        let long_names: Vec<&str> = std::iter::once(flag.long.as_str())
+            .chain(flag.aliases.iter().map(|alias| alias.as_str()))
+            .collect();
+        let synonymous = flag
+            .short
+            .into_iter()
+            .map(|short| format!("-{short}"))
+            .chain(long_names.iter().map(|long_name| format!("--{long_name}")))
+            .collect::<Vec<_>>();
+        let exclusion_group = if synonymous.len() > 1 {
+            Some(format!("'({})'", synonymous.join(" ")))
+        } else {
+            None
+        };
+
+        if let Some(short) = flag.short {
+            if let Some(exclusion_group) = exclusion_group.as_deref() {
                 out.push_str(&format!(
-                    "        '(-{short} --{long})'-{short}'[{escaped_desc}]{value_spec}'\n",
-                    long = long_name,
-                ));
-                out.push_str(&format!(
-                    "        '(-{short} --{long})'--{long}'[{escaped_desc}]{value_spec}'\n",
-                    long = long_name,
+                    "        {exclusion_group}-{short}'[{escaped_desc}]{value_spec}'\n",
                 ));
             } else {
                 out.push_str(&format!(
-                    "        '--{long}[{escaped_desc}]{value_spec}'\n",
-                    long = long_name,
+                    "        '-{short}[{escaped_desc}]{value_spec}'\n",
+                ));
+            }
+        }
+
+        for long_name in long_names {
+            if let Some(exclusion_group) = exclusion_group.as_deref() {
+                out.push_str(&format!(
+                    "        {exclusion_group}--{long_name}'[{escaped_desc}]{value_spec}'\n",
+                ));
+            } else {
+                out.push_str(&format!(
+                    "        '--{long_name}[{escaped_desc}]{value_spec}'\n",
                 ));
             }
         }
@@ -978,6 +998,12 @@ mod tests {
     }
 
     #[derive(Facet)]
+    struct ArgsWithShortAlias {
+        #[facet(args::named, args::short = 'c', args::alias = "colour")]
+        color: bool,
+    }
+
+    #[derive(Facet)]
     #[repr(u8)]
     enum CommandWithAlias {
         #[facet(args::alias = "profiles")]
@@ -1005,6 +1031,26 @@ mod tests {
     }
 
     #[test]
+    fn test_aliases_share_one_zsh_exclusion_group() {
+        let schema = Schema::from_shape(ArgsWithShortAlias::SHAPE).unwrap();
+        let completions = generate_completions_for_schema(&schema, Shell::Zsh, "myapp");
+        let group = "'(-c --color --colour)'";
+
+        assert!(
+            completions.contains(&format!("{group}-c")),
+            "expected short flag to use shared exclusion group: {completions}"
+        );
+        assert!(
+            completions.contains(&format!("{group}--color")),
+            "expected canonical long flag to use shared exclusion group: {completions}"
+        );
+        assert!(
+            completions.contains(&format!("{group}--colour")),
+            "expected alias long flag to use shared exclusion group: {completions}"
+        );
+    }
+
+    #[test]
     fn test_subcommand_aliases_appear_in_completions() {
         let schema = Schema::from_shape(ArgsWithAliasedSubcommand::SHAPE).unwrap();
         let bash = generate_completions_for_schema(&schema, Shell::Bash, "myapp");
@@ -1013,4 +1059,9 @@ mod tests {
         assert!(fish.contains("profiles"), "expected subcommand alias in fish completions: {fish}");
     }
 }
+
+
+
+
+
 

--- a/figue/src/completions.rs
+++ b/figue/src/completions.rs
@@ -113,13 +113,21 @@ fn generate_bash_function(
     // Build flags string
     if !flags.is_empty() {
         out.push_str("    local flags=\"");
-        for (i, flag) in flags.iter().enumerate() {
-            if i > 0 {
-                out.push(' ');
+        let mut first = true;
+        for flag in &flags {
+            for long_name in std::iter::once(&flag.long).chain(flag.aliases.iter()) {
+                if !first {
+                    out.push(' ');
+                }
+                first = false;
+                out.push_str(&format!("--{long_name}"));
             }
-            out.push_str(&format!("--{}", flag.long));
             if let Some(short) = flag.short {
-                out.push_str(&format!(" -{short}"));
+                if !first {
+                    out.push(' ');
+                }
+                first = false;
+                out.push_str(&format!("-{short}"));
             }
         }
         out.push_str("\"\n");
@@ -130,11 +138,12 @@ fn generate_bash_function(
     // Build commands string
     if !subcommands.is_empty() {
         out.push_str("    local commands=\"");
-        for (i, cmd) in subcommands.iter().enumerate() {
+        let command_names: Vec<&str> = subcommands.iter().flat_map(|cmd| cmd.all_names()).collect();
+        for (i, cmd) in command_names.iter().enumerate() {
             if i > 0 {
                 out.push(' ');
             }
-            out.push_str(&cmd.name);
+            out.push_str(cmd);
         }
         out.push_str("\"\n");
     } else {
@@ -146,7 +155,10 @@ fn generate_bash_function(
     if !value_flags.is_empty() {
         out.push_str("\n    case \"$prev\" in\n");
         for flag in &value_flags {
-            let mut cases = vec![format!("--{}", flag.long)];
+            let mut cases = std::iter::once(&flag.long)
+                .chain(flag.aliases.iter())
+                .map(|long_name| format!("--{long_name}"))
+                .collect::<Vec<_>>();
             if let Some(short) = flag.short {
                 cases.push(format!("-{short}"));
             }
@@ -177,7 +189,10 @@ fn generate_bash_function(
         if !value_flags.is_empty() {
             out.push_str("                case \"${words[i]}\" in\n");
             for flag in &value_flags {
-                let mut cases = vec![format!("--{}", flag.long)];
+                let mut cases = std::iter::once(&flag.long)
+                    .chain(flag.aliases.iter())
+                    .map(|long_name| format!("--{long_name}"))
+                    .collect::<Vec<_>>();
                 if let Some(short) = flag.short {
                     cases.push(format!("-{short}"));
                 }
@@ -211,9 +226,10 @@ fn generate_bash_function(
             } else {
                 format!("{}_{}", func_name, cmd.name.replace('-', "_"))
             };
+            let case_patterns = cmd.all_names().collect::<Vec<_>>().join("|");
             out.push_str(&format!(
                 "            {})\n                _{sub_func}\n                return\n                ;;\n",
-                cmd.name
+                case_patterns
             ));
         }
 
@@ -317,21 +333,23 @@ fn generate_zsh_function(
             ""
         };
 
-        if let Some(short) = flag.short {
-            // Short and long are mutually exclusive in completion
-            out.push_str(&format!(
-                "        '(-{short} --{long})'-{short}'[{escaped_desc}]{value_spec}'\n",
-                long = flag.long,
-            ));
-            out.push_str(&format!(
-                "        '(-{short} --{long})'--{long}'[{escaped_desc}]{value_spec}'\n",
-                long = flag.long,
-            ));
-        } else {
-            out.push_str(&format!(
-                "        '--{long}[{escaped_desc}]{value_spec}'\n",
-                long = flag.long,
-            ));
+        for long_name in std::iter::once(&flag.long).chain(flag.aliases.iter()) {
+            if let Some(short) = flag.short {
+                // Short and long are mutually exclusive in completion
+                out.push_str(&format!(
+                    "        '(-{short} --{long})'-{short}'[{escaped_desc}]{value_spec}'\n",
+                    long = long_name,
+                ));
+                out.push_str(&format!(
+                    "        '(-{short} --{long})'--{long}'[{escaped_desc}]{value_spec}'\n",
+                    long = long_name,
+                ));
+            } else {
+                out.push_str(&format!(
+                    "        '--{long}[{escaped_desc}]{value_spec}'\n",
+                    long = long_name,
+                ));
+            }
         }
     }
     out.push_str("    )\n\n");
@@ -342,10 +360,12 @@ fn generate_zsh_function(
         for cmd in &subcommands {
             let desc = cmd.doc.as_deref().unwrap_or("");
             let escaped_desc = escape_zsh_description(desc);
-            out.push_str(&format!(
-                "        '{name}:{escaped_desc}'\n",
-                name = cmd.name
-            ));
+            for name in cmd.all_names() {
+                out.push_str(&format!(
+                    "        '{name}:{escaped_desc}'\n",
+                    name = name
+                ));
+            }
         }
         out.push_str("    )\n\n");
 
@@ -369,9 +389,10 @@ fn generate_zsh_function(
         // Add case for each subcommand
         for cmd in &subcommands {
             let sub_func = format!("{}_{}", func_name, cmd.name.replace('-', "_"));
+            let case_patterns = cmd.all_names().collect::<Vec<_>>().join("|");
             out.push_str(&format!(
                 "                {name})\n                    _{sub_func} && ret=0\n                    ;;\n",
-                name = cmd.name,
+                name = case_patterns,
             ));
         }
 
@@ -462,7 +483,9 @@ fn generate_fish_level(out: &mut String, args: &ArgLevelSchema, program_name: &s
         if let Some(short) = flag.short {
             out.push_str(&format!(" -s {short}"));
         }
-        out.push_str(&format!(" -l {}", flag.long));
+        for long_name in std::iter::once(&flag.long).chain(flag.aliases.iter()) {
+            out.push_str(&format!(" -l {long_name}"));
+        }
 
         // If flag takes a value, require an argument
         if flag.takes_value {
@@ -484,7 +507,7 @@ fn generate_fish_level(out: &mut String, args: &ArgLevelSchema, program_name: &s
         ));
 
         // Build condition that no subcommand of THIS level has been seen yet
-        let sub_names: Vec<&str> = subcommands.iter().map(|s| s.name.as_str()).collect();
+        let sub_names: Vec<&str> = subcommands.iter().flat_map(|s| s.all_names()).collect();
         let no_sub_condition = if path.is_empty() {
             "__fish_use_subcommand".to_string()
         } else {
@@ -497,15 +520,22 @@ fn generate_fish_level(out: &mut String, args: &ArgLevelSchema, program_name: &s
 
         for cmd in &subcommands {
             let desc = cmd.doc.as_deref().unwrap_or("");
-            out.push_str(&format!(
-                "complete -c {program_name} -n '{no_sub_condition}' -f -a {name}",
-                name = cmd.name
-            ));
-            if !desc.is_empty() {
-                let escaped_desc = desc.replace('\'', "'\\''");
-                out.push_str(&format!(" -d '{escaped_desc}'"));
+            let names = cmd.all_names().collect::<Vec<_>>();
+            for name in names {
+                out.push_str(&format!(
+                    "complete -c {program_name} -n '{no_sub_condition}' -f -a {name}"
+                ));
+                let display_desc = if name == cmd.name {
+                    desc.to_string()
+                } else {
+                    format!("Alias for {}", cmd.name)
+                };
+                if !display_desc.is_empty() {
+                    let escaped_desc = display_desc.replace('\'', "'\\''");
+                    out.push_str(&format!(" -d '{escaped_desc}'"));
+                }
+                out.push('\n');
             }
-            out.push('\n');
         }
     }
 }
@@ -528,14 +558,23 @@ fn generate_fish_subcommands(
 
 struct FlagInfo {
     long: String,
+    aliases: Vec<String>,
     short: Option<char>,
     doc: Option<String>,
     takes_value: bool,
 }
 
+#[derive(Clone)]
 struct SubcommandInfo {
     name: String,
+    aliases: Vec<String>,
     doc: Option<String>,
+}
+
+impl SubcommandInfo {
+    fn all_names(&self) -> impl Iterator<Item = &str> {
+        std::iter::once(self.name.as_str()).chain(self.aliases.iter().map(|alias| alias.as_str()))
+    }
 }
 
 /// Collect flags and subcommands from an ArgLevelSchema.
@@ -570,6 +609,7 @@ fn arg_to_flag(name: &str, arg: &ArgSchema) -> FlagInfo {
     FlagInfo {
         // Use kebab-case for the CLI flag name
         long: name.to_kebab_case(),
+        aliases: arg.aliases().to_vec(),
         short: arg.kind().short(),
         doc: arg.docs().summary().map(|s| s.trim().to_string()),
         takes_value,
@@ -581,6 +621,7 @@ fn subcommand_to_info(sub: &Subcommand) -> SubcommandInfo {
     SubcommandInfo {
         // cli_name is already kebab-case and respects renames
         name: sub.cli_name().to_string(),
+        aliases: sub.aliases().to_vec(),
         doc: sub.docs().summary().map(|s| s.trim().to_string()),
     }
 }
@@ -930,4 +971,46 @@ mod tests {
             "string flag should require value"
         );
     }
+    #[derive(Facet)]
+    struct ArgsWithAlias {
+        #[facet(args::named, args::alias = "colour")]
+        color: bool,
+    }
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    enum CommandWithAlias {
+        #[facet(args::alias = "profiles")]
+        Profile,
+    }
+
+    #[derive(Facet)]
+    struct ArgsWithAliasedSubcommand {
+        #[facet(args::subcommand)]
+        command: Option<CommandWithAlias>,
+    }
+
+    #[test]
+    fn test_aliases_appear_in_bash_completions() {
+        let schema = Schema::from_shape(ArgsWithAlias::SHAPE).unwrap();
+        let completions = generate_completions_for_schema(&schema, Shell::Bash, "myapp");
+        assert!(completions.contains("--colour"), "expected alias in bash completions: {completions}");
+    }
+
+    #[test]
+    fn test_aliases_appear_in_fish_completions() {
+        let schema = Schema::from_shape(ArgsWithAlias::SHAPE).unwrap();
+        let completions = generate_completions_for_schema(&schema, Shell::Fish, "myapp");
+        assert!(completions.contains(" -l colour"), "expected alias in fish completions: {completions}");
+    }
+
+    #[test]
+    fn test_subcommand_aliases_appear_in_completions() {
+        let schema = Schema::from_shape(ArgsWithAliasedSubcommand::SHAPE).unwrap();
+        let bash = generate_completions_for_schema(&schema, Shell::Bash, "myapp");
+        let fish = generate_completions_for_schema(&schema, Shell::Fish, "myapp");
+        assert!(bash.contains("profiles"), "expected subcommand alias in bash completions: {bash}");
+        assert!(fish.contains("profiles"), "expected subcommand alias in fish completions: {fish}");
+    }
 }
+

--- a/figue/src/help.rs
+++ b/figue/src/help.rs
@@ -2464,6 +2464,12 @@ fn write_arg_help(out: &mut String, arg: &ArgSchema, config: &HelpConfig) {
         out.push_str(&wrap_text("[can be repeated]", DOC_INDENT, config.width));
     }
 
+    if !arg.aliases().is_empty() {
+        out.push('\n');
+        out.push_str(DOC_INDENT);
+        out.push_str(&format!("aliases: {}", arg.aliases().join(", ")));
+    }
+
     out.push('\n');
 }
 
@@ -2481,6 +2487,11 @@ fn write_subcommand_help(out: &mut String, sub: &Subcommand, config: &HelpConfig
     if let Some(summary) = sub.docs().summary() {
         out.push('\n');
         out.push_str(&wrap_text(summary.trim(), "            ", config.width));
+    }
+
+    if !sub.aliases().is_empty() {
+        out.push_str("\n            ");
+        out.push_str(&format!("aliases: {}", sub.aliases().join(", ")));
     }
 
     out.push('\n');
@@ -3042,4 +3053,39 @@ mod tests {
             );
         }
     }
+    #[derive(Facet)]
+    struct ArgsWithAlias {
+        #[facet(args::named, args::alias = "colour")]
+        color: bool,
+    }
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    enum CommandWithAlias {
+        #[facet(args::alias = "profiles")]
+        Profile,
+    }
+
+    #[derive(Facet)]
+    struct ArgsWithAliasedSubcommand {
+        #[facet(args::subcommand)]
+        command: Option<CommandWithAlias>,
+    }
+
+    #[test]
+    fn test_help_shows_aliases_after_canonical_name() {
+        let schema = Schema::from_shape(ArgsWithAlias::SHAPE).unwrap();
+        let help = generate_help_for_subcommand(&schema, &[], &HelpConfig::default());
+        assert!(help.contains("--[no-]color"), "help should show canonical flag: {help}");
+        assert!(help.contains("aliases: colour"), "help should show aliases: {help}");
+    }
+
+    #[test]
+    fn test_help_shows_subcommand_aliases_with_canonical_name() {
+        let schema = Schema::from_shape(ArgsWithAliasedSubcommand::SHAPE).unwrap();
+        let help = generate_help_for_subcommand(&schema, &[], &HelpConfig::default());
+        assert!(help.contains("profile"), "help should show canonical subcommand: {help}");
+        assert!(help.contains("aliases: profiles"), "help should surface compatibility aliases: {help}");
+    }
 }
+

--- a/figue/src/layers/cli.rs
+++ b/figue/src/layers/cli.rs
@@ -449,36 +449,21 @@ impl<'a> ParseContext<'a> {
                 );
                 self.index += 1;
             } else {
-                let all_flags: Vec<&str> = level
-                    .args()
-                    .iter()
-                    .filter_map(|(name, schema)| {
-                        if matches!(schema.kind(), ArgKind::Named { .. }) {
-                            Some(name.as_str())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                let suggestion = crate::suggest::suggest_flag(flag_name, all_flags);
+                let all_flags = self.visible_long_flag_names(level);
+                let suggestion = crate::suggest::suggest_flag(
+                    flag_name,
+                    all_flags.iter().map(|flag| flag.as_str()),
+                );
                 self.emit_error(format!("unknown flag: --{}{}", flag_name, suggestion));
                 self.index += 1;
             }
         } else {
             // Collect all available flag names for suggestion
-            let all_flags: Vec<&str> = level
-                .args()
-                .iter()
-                .filter_map(|(name, schema)| {
-                    // Only suggest named flags
-                    if matches!(schema.kind(), ArgKind::Named { .. }) {
-                        Some(name.as_str())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            let suggestion = crate::suggest::suggest_flag(flag_name, all_flags);
+            let all_flags = self.visible_long_flag_names(level);
+            let suggestion = crate::suggest::suggest_flag(
+                flag_name,
+                all_flags.iter().map(|flag| flag.as_str()),
+            );
             self.emit_error(format!("unknown flag: --{}{}", flag_name, suggestion));
             self.index += 1;
         }
@@ -1034,15 +1019,7 @@ impl<'a> ParseContext<'a> {
 
         let arg = self.args[self.index];
 
-        // Find subcommand by long name (kebab-case) or short alias token ("d").
-        let subcommand = level.subcommands().iter().find(|(name, sub)| {
-            name.to_kebab_case() == arg
-                || sub
-                    .short()
-                    .is_some_and(|short| arg.chars().eq(core::iter::once(short)))
-        });
-
-        let Some((_, subcommand)) = subcommand else {
+        let Some(subcommand) = level.find_subcommand(arg) else {
             return false;
         };
 
@@ -1178,6 +1155,42 @@ impl<'a> ParseContext<'a> {
         None
     }
 
+    /// Collect all visible long-form flag names at the current parse point.
+    ///
+    /// This includes both canonical names and aliases from the current level
+    /// plus any parent levels that can accept bubbled-up flags.
+    fn visible_long_flag_names(&self, level: &ArgLevelSchema) -> Vec<String> {
+        let mut flags = Vec::new();
+
+        let mut push_unique = |name: String| {
+            if !flags.iter().any(|existing| existing == &name) {
+                flags.push(name);
+            }
+        };
+
+        for (_effective_name, schema) in level.args().iter() {
+            if !matches!(schema.kind(), ArgKind::Named { .. }) {
+                continue;
+            }
+            for long_name in schema.long_flag_names() {
+                push_unique(long_name);
+            }
+        }
+
+        for parent in self.parent_stack.iter().rev() {
+            for (_effective_name, schema) in parent.args.args().iter() {
+                if !matches!(schema.kind(), ArgKind::Named { .. }) {
+                    continue;
+                }
+                for long_name in schema.long_flag_names() {
+                    push_unique(long_name);
+                }
+            }
+        }
+
+        flags
+    }
+
     /// If the level expects subcommands, try to suggest a similar subcommand name.
     fn suggest_subcommand_if_expected(&self, arg: &str, level: &ArgLevelSchema) -> String {
         // Only suggest if this level has subcommands defined
@@ -1185,14 +1198,15 @@ impl<'a> ParseContext<'a> {
             return String::new();
         }
 
-        // Get all subcommand names in kebab-case
-        let subcommand_names: Vec<String> = level
-            .subcommands()
-            .iter()
-            .map(|(name, _)| name.to_kebab_case())
-            .collect();
+        let mut spellings_to_canonical: Vec<(&str, &str)> = Vec::new();
+        for subcommand in level.subcommands().values() {
+            spellings_to_canonical.push((subcommand.cli_name(), subcommand.cli_name()));
+            for alias in subcommand.aliases() {
+                spellings_to_canonical.push((alias.as_str(), subcommand.cli_name()));
+            }
+        }
 
-        crate::suggest::suggest_subcommand(arg, subcommand_names.iter().map(|s| s.as_str()))
+        crate::suggest::suggest_subcommand(arg, spellings_to_canonical)
     }
 
     fn try_parse_positional(&mut self, level: &ArgLevelSchema) -> bool {
@@ -3296,4 +3310,44 @@ mod tests {
             ]),
         );
     }
+    #[derive(Facet)]
+    struct AliasedLongFlags {
+        #[facet(args::named, args::alias = "colour")]
+        color: bool,
+        #[facet(args::named, args::alias = "drive-letter-pattern")]
+        drive: String,
+    }
+
+    #[test]
+    fn test_cv_alias_bool_uses_canonical_field() {
+        assert_parses_to::<AliasedLongFlags>(
+            &["--colour"],
+            cv::object([("color", cv::bool(true, "--colour"))]),
+        );
+    }
+
+    #[test]
+    fn test_cv_alias_value_uses_canonical_field() {
+        assert_parses_to::<AliasedLongFlags>(
+            &["--drive-letter-pattern", "C"],
+            cv::object([("drive", cv::string("C", "C"))]),
+        );
+    }
+
+    #[test]
+    fn test_alias_unknown_flag_suggestion_uses_aliases() {
+        assert_diagnostic_contains::<AliasedLongFlags>(
+            &["--colur"],
+            "Did you mean '--colour'?",
+        );
+    }
+
+    #[test]
+    fn test_no_prefix_alias_negates_bool() {
+        assert_parses_to::<AliasedLongFlags>(
+            &["--no-colour"],
+            cv::object([("color", cv::bool(false, "--no-colour"))]),
+        );
+    }
 }
+

--- a/figue/src/layers/cli.rs
+++ b/figue/src/layers/cli.rs
@@ -1161,9 +1161,10 @@ impl<'a> ParseContext<'a> {
     /// plus any parent levels that can accept bubbled-up flags.
     fn visible_long_flag_names(&self, level: &ArgLevelSchema) -> Vec<String> {
         let mut flags = Vec::new();
+        let mut seen = std::collections::HashSet::new();
 
         let mut push_unique = |name: String| {
-            if !flags.iter().any(|existing| existing == &name) {
+            if seen.insert(name.clone()) {
                 flags.push(name);
             }
         };
@@ -3350,4 +3351,5 @@ mod tests {
         );
     }
 }
+
 

--- a/figue/src/schema.rs
+++ b/figue/src/schema.rs
@@ -12,11 +12,11 @@ use indexmap::IndexMap;
 
 use crate::path::Path;
 
-/// Wrapper around args IndexMap that provides kebab-case lookup.
+/// Wrapper around args IndexMap that provides CLI-aware lookup.
 ///
 /// Schema stores field names as effective names (snake_case or renamed).
-/// CLI flags come in as kebab-case. This wrapper converts schema keys to
-/// kebab-case during lookup so `--deep-flag` matches `deep_flag` in schema.
+/// CLI flags come in as kebab-case and may also match configured long-form
+/// aliases so `--deep-flag` or `--deep` can resolve to the same schema entry.
 pub struct Args<'a> {
     inner: &'a IndexMap<String, ArgSchema, RandomState>,
 }
@@ -27,7 +27,7 @@ impl<'a> Args<'a> {
     pub fn get(&self, flag_name: &str) -> Option<(&'a String, &'a ArgSchema)> {
         self.inner
             .iter()
-            .find(|(key, _)| key.to_kebab_case() == flag_name)
+            .find(|(_, schema)| schema.matches_long_flag(flag_name))
     }
 
     /// Iterate over all args with their effective names.
@@ -282,6 +282,9 @@ pub struct Subcommand {
     /// Derived from effective_name converted to kebab-case.
     name: String,
 
+    /// Additional accepted CLI aliases for this subcommand.
+    aliases: Vec<String>,
+
     /// Effective name (respects `#[facet(rename = "...")]`).
     /// Used for deserialization with facet-format.
     effective_name: String,
@@ -310,6 +313,9 @@ pub struct Subcommand {
 pub struct ArgSchema {
     /// Argument name / effective name (rename or field name).
     name: String,
+
+    /// Additional accepted long-form CLI flag aliases for this argument.
+    aliases: Vec<String>,
 
     /// Path where this argument writes in ConfigValue.
     ///
@@ -618,6 +624,13 @@ impl ArgLevelSchema {
     pub fn has_subcommands(&self) -> bool {
         !self.subcommands.is_empty()
     }
+
+    /// Find a subcommand by any accepted CLI spelling.
+    pub fn find_subcommand(&self, name: &str) -> Option<&Subcommand> {
+        self.subcommands
+            .values()
+            .find(|subcommand| subcommand.matches_cli_name(name))
+    }
 }
 
 impl Docs {
@@ -668,6 +681,32 @@ impl ArgSchema {
         &self.kind
     }
 
+    /// Get the canonical long-form CLI flag name for this argument.
+    ///
+    /// Returns `None` for positional arguments.
+    pub fn long_name(&self) -> Option<String> {
+        match self.kind() {
+            ArgKind::Named { .. } => Some(self.name.to_kebab_case()),
+            ArgKind::Positional => None,
+        }
+    }
+
+    /// Get the additional accepted long-form CLI flag aliases for this argument.
+    pub fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
+    /// Iterate over all accepted long-form CLI flag names for this argument.
+    pub fn long_flag_names(&self) -> impl Iterator<Item = String> + '_ {
+        self.long_name().into_iter().chain(self.aliases.iter().cloned())
+    }
+
+    /// Check whether this argument accepts the given long-form CLI flag name.
+    pub fn matches_long_flag(&self, flag_name: &str) -> bool {
+        self.long_name().as_deref() == Some(flag_name)
+            || self.aliases.iter().any(|alias| alias == flag_name)
+    }
+
     /// Get the value schema.
     pub fn value(&self) -> &ValueSchema {
         &self.value
@@ -708,6 +747,11 @@ impl Subcommand {
         &self.name
     }
 
+    /// Get additional accepted CLI aliases for this subcommand.
+    pub fn aliases(&self) -> &[String] {
+        &self.aliases
+    }
+
     /// Get the effective name (respects `#[facet(rename = "...")]`).
     /// This is what facet-format expects for deserialization.
     pub fn effective_name(&self) -> &str {
@@ -733,6 +777,15 @@ impl Subcommand {
     /// Get the documentation for this subcommand.
     pub fn docs(&self) -> &Docs {
         &self.docs
+    }
+
+    /// Check whether the provided CLI token selects this subcommand.
+    pub fn matches_cli_name(&self, name: &str) -> bool {
+        self.cli_name() == name
+            || self.aliases.iter().any(|alias| alias == name)
+            || self
+                .short
+                .is_some_and(|short| name.chars().eq(core::iter::once(short)))
     }
 }
 
@@ -992,3 +1045,4 @@ impl ValueSchema {
 #[cfg(test)]
 #[allow(dead_code)]
 mod tests;
+

--- a/figue/src/schema/from_schema.rs
+++ b/figue/src/schema/from_schema.rs
@@ -181,6 +181,27 @@ fn extract_env_aliases(field: &Field) -> Vec<String> {
     aliases
 }
 
+/// Extract all alias values from a named field's `#[facet(args::alias = "...")]`
+/// attributes, normalized to kebab-case CLI flag names.
+fn extract_field_aliases(field: &Field) -> Vec<String> {
+    let mut aliases = Vec::new();
+    for field_attr in field.attributes {
+        if field_attr.ns == Some("args") && field_attr.key == "alias" {
+            if let Some(parsed) = field_attr.get_as::<Attr>()
+                && let Attr::Alias(alias) = parsed
+            {
+                aliases.push(alias.to_kebab_case());
+                continue;
+            }
+
+            if let Some(s) = field_attr.get_as::<&str>() {
+                aliases.push(s.to_kebab_case());
+            }
+        }
+    }
+    aliases
+}
+
 /// Check if a field has `#[facet(args::env_subst)]` attribute.
 fn has_env_subst(field: &Field) -> bool {
     field.has_attr(Some("args"), "env_subst")
@@ -330,6 +351,29 @@ fn enum_variants(enum_type: EnumType) -> Vec<String> {
 
 fn variant_cli_name(variant: &Variant) -> String {
     variant.effective_name().to_kebab_case()
+}
+
+/// Extract all long-form aliases from a subcommand enum variant's
+/// `#[facet(args::alias = "...")]` attributes.
+fn extract_variant_aliases(variant: &Variant) -> Vec<String> {
+    let mut aliases = Vec::new();
+
+    for variant_attr in variant.attributes {
+        if variant_attr.ns == Some("args") && variant_attr.key == "alias" {
+            if let Some(parsed) = variant_attr.get_as::<Attr>()
+                && let Attr::Alias(alias) = parsed
+            {
+                aliases.push(alias.to_string());
+                continue;
+            }
+
+            if let Some(alias) = variant_attr.get_as::<&str>() {
+                aliases.push(alias.to_string());
+            }
+        }
+    }
+
+    aliases
 }
 
 fn leaf_schema_from_shape(
@@ -741,6 +785,40 @@ fn short_from_variant(variant: &Variant) -> Option<char> {
         })
 }
 
+fn check_flag_alias_conflicts(
+    seen_long: &mut HashMap<String, SchemaErrorContext>,
+    aliases: &[String],
+    field_ctx: &SchemaErrorContext,
+    field_name: &str,
+) -> Result<(), SchemaError> {
+    let mut seen_local: HashMap<&str, ()> = HashMap::new();
+
+    for alias in aliases {
+        if seen_local.insert(alias.as_str(), ()).is_some() {
+            return Err(SchemaError::new(
+                field_ctx.clone(),
+                format!("duplicate alias `--{alias}` on `{field_name}`"),
+            )
+            .with_primary_label("alias repeated here"));
+        }
+
+        if let Some(existing_ctx) = seen_long.get(alias) {
+            return Err(SchemaError::new(
+                existing_ctx.clone(),
+                format!("duplicate flag `--{alias}`"),
+            )
+            .with_primary_label(format!("`--{alias}` first defined here"))
+            .with_label(field_ctx.clone(), "alias defined again here"));
+        }
+    }
+
+    for alias in aliases {
+        seen_long.insert(alias.clone(), field_ctx.clone());
+    }
+
+    Ok(())
+}
+
 fn variant_fields_for_schema(variant: &Variant) -> &'static [Field] {
     let fields = variant.data.fields;
     if is_flattened_tuple_variant(variant) {
@@ -841,6 +919,7 @@ fn arg_level_from_fields_with_prefix(
                     let value = value_schema_from_config_value_schema(config_field_schema.value());
                     let arg = ArgSchema {
                         name: name.clone(),
+                        aliases: Vec::new(),
                         insertion_path: vec![config_field_name.clone(), name.clone()],
                         docs: config_field_schema.docs().clone(),
                         kind: ArgKind::Named {
@@ -1039,6 +1118,7 @@ fn arg_level_from_fields_with_prefix(
 
             for variant in enum_type.variants {
                 let cli_name = variant_cli_name(variant);
+                let aliases = extract_variant_aliases(variant);
                 // effective_name respects #[facet(rename = "...")], used for deserialization
                 let effective_name = variant.effective_name().to_string();
                 let docs = docs_from_lines(variant.doc);
@@ -1071,8 +1151,25 @@ fn arg_level_from_fields_with_prefix(
                     seen_subcommand_short.insert(short, variant_ctx.clone());
                 }
 
+                let mut seen_variant_spellings = std::collections::HashSet::new();
+                seen_variant_spellings.insert(cli_name.clone());
+                if let Some(short) = short {
+                    seen_variant_spellings.insert(short.to_string());
+                }
+                for alias in &aliases {
+                    if !seen_variant_spellings.insert(alias.clone()) {
+                        return Err(SchemaError::new(
+                            variant_ctx.clone(),
+                            format!(
+                                "duplicate subcommand alias `{alias}` for subcommand `{cli_name}`"
+                            ),
+                        ));
+                    }
+                }
+
                 let sub = Subcommand {
                     name: cli_name.clone(),
+                    aliases: aliases.clone(),
                     effective_name: effective_name.clone(),
                     docs,
                     short,
@@ -1090,6 +1187,22 @@ fn arg_level_from_fields_with_prefix(
                     .with_label(variant_ctx, "defined again here"));
                 }
                 seen_subcommands.insert(cli_name.clone(), variant_ctx.clone());
+
+                for alias in &aliases {
+                    if let Some(existing_ctx) = seen_subcommands.get(alias) {
+                        return Err(SchemaError::new(
+                            existing_ctx.clone(),
+                            format!("duplicate subcommand name `{alias}`"),
+                        )
+                        .with_primary_label("first defined here")
+                        .with_label(
+                            variant_ctx.clone(),
+                            format!("alias `{alias}` defined again here"),
+                        ));
+                    }
+                    seen_subcommands.insert(alias.clone(), variant_ctx.clone());
+                }
+
                 subcommands.insert(effective_name, sub);
             }
 
@@ -1102,6 +1215,17 @@ fn arg_level_from_fields_with_prefix(
             None
         };
         let counted = field.has_attr(Some("args"), "counted");
+        let aliases = extract_field_aliases(field);
+
+        if !aliases.is_empty() && (is_positional || is_subcommand || is_config_field(field)) {
+            return Err(SchemaError::new(
+                field_ctx,
+                format!(
+                    "field `{}` uses args::alias on a non-named argument",
+                    field.name
+                ),
+            ));
+        }
 
         let kind = if is_positional {
             ArgKind::Positional
@@ -1146,6 +1270,7 @@ fn arg_level_from_fields_with_prefix(
                 .with_label(field_ctx.clone(), "defined again here"));
             }
             seen_long.insert(long.clone(), field_ctx.clone());
+            check_flag_alias_conflicts(&mut seen_long, &aliases, &field_ctx, field.name)?;
 
             if let Some(c) = short {
                 if let Some(existing_ctx) = seen_short.get(&c) {
@@ -1190,6 +1315,7 @@ fn arg_level_from_fields_with_prefix(
 
         let arg = ArgSchema {
             name: effective_name.clone(),
+            aliases,
             insertion_path: vec![effective_name.clone()],
             docs,
             kind,
@@ -1240,3 +1366,4 @@ const fn is_supported_counted_type(shape: &'static facet_core::Shape) -> bool {
 fn is_config_field(field: &facet_core::Field) -> bool {
     field.has_attr(Some("args"), "config")
 }
+

--- a/figue/src/schema/from_schema.rs
+++ b/figue/src/schema/from_schema.rs
@@ -363,12 +363,12 @@ fn extract_variant_aliases(variant: &Variant) -> Vec<String> {
             if let Some(parsed) = variant_attr.get_as::<Attr>()
                 && let Attr::Alias(alias) = parsed
             {
-                aliases.push(alias.to_string());
+                aliases.push(alias.to_kebab_case());
                 continue;
             }
 
             if let Some(alias) = variant_attr.get_as::<&str>() {
-                aliases.push(alias.to_string());
+                aliases.push(alias.to_kebab_case());
             }
         }
     }
@@ -1366,4 +1366,5 @@ const fn is_supported_counted_type(shape: &'static facet_core::Shape) -> bool {
 fn is_config_field(field: &facet_core::Field) -> bool {
     field.has_attr(Some("args"), "config")
 }
+
 

--- a/figue/src/schema/tests.rs
+++ b/figue/src/schema/tests.rs
@@ -657,6 +657,33 @@ struct ArgsWithSubcommandAliasAliasConflict {
     command: SubcommandAliasAliasConflict,
 }
 
+#[derive(Facet)]
+#[repr(u8)]
+enum SubcommandWithCasedAlias {
+    #[facet(args::alias = "Profiles")]
+    UserProfiles,
+}
+
+#[derive(Facet)]
+struct ArgsWithCasedSubcommandAlias {
+    #[facet(args::subcommand)]
+    command: SubcommandWithCasedAlias,
+}
+
+#[derive(Facet)]
+#[repr(u8)]
+enum SubcommandAliasCaseConflict {
+    Profiles,
+    #[facet(args::alias = "Profiles")]
+    User,
+}
+
+#[derive(Facet)]
+struct ArgsWithSubcommandAliasCaseConflict {
+    #[facet(args::subcommand)]
+    command: SubcommandAliasCaseConflict,
+}
+
 #[test]
 fn test_schema_aliases_are_stored() {
     let schema = Schema::from_shape(ArgsWithAlias::SHAPE).expect("schema should build");
@@ -721,3 +748,32 @@ fn test_subcommand_alias_conflict_with_other_alias_detected() {
     let err = result.unwrap_err().to_string();
     assert!(err.contains("duplicate subcommand name `profiles`"), "unexpected error: {err}");
 }
+
+#[test]
+fn test_subcommand_aliases_are_normalized_to_kebab_case() {
+    let schema = Schema::from_shape(ArgsWithCasedSubcommandAlias::SHAPE)
+        .expect("schema should build");
+    let subcommand = schema
+        .args()
+        .subcommands()
+        .values()
+        .next()
+        .expect("subcommand should be present");
+
+    assert_eq!(subcommand.aliases(), &["profiles".to_string()]);
+}
+
+#[test]
+fn test_subcommand_alias_conflict_after_case_normalization_detected() {
+    let result = Schema::from_shape(ArgsWithSubcommandAliasCaseConflict::SHAPE);
+    assert!(
+        result.is_err(),
+        "should detect alias/canonical conflict after kebab-case normalization"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("duplicate subcommand name `profiles`"),
+        "unexpected error: {err}"
+    );
+}
+

--- a/figue/src/schema/tests.rs
+++ b/figue/src/schema/tests.rs
@@ -578,3 +578,146 @@ fn test_env_alias_conflict_detected() {
         err
     );
 }
+
+// ============================================================================
+// Alias support
+// ============================================================================
+
+#[derive(Facet)]
+struct ArgsWithAlias {
+    #[facet(args::named, rename = "drive", args::alias = "drive-letter-pattern")]
+    drive_letter_pattern: String,
+}
+
+#[derive(Facet)]
+struct ConflictingAliasAndCanonical {
+    #[facet(args::named, args::alias = "port")]
+    host: String,
+    #[facet(args::named)]
+    port: String,
+}
+
+#[derive(Facet)]
+struct DuplicateAliasOnField {
+    #[facet(
+        args::named,
+        args::alias = "drive-letter-pattern",
+        args::alias = "drive-letter-pattern"
+    )]
+    drive: String,
+}
+
+#[derive(Facet)]
+struct ConflictingAliases {
+    #[facet(args::named, args::alias = "drive-letter-pattern")]
+    drive: String,
+    #[facet(args::named, args::alias = "drive-letter-pattern")]
+    path: String,
+}
+
+#[derive(Facet)]
+#[repr(u8)]
+enum SubcommandWithDuplicateAlias {
+    #[facet(args::alias = "profiles", args::alias = "profiles")]
+    Profile,
+}
+
+#[derive(Facet)]
+struct ArgsWithDuplicateSubcommandAlias {
+    #[facet(args::subcommand)]
+    command: SubcommandWithDuplicateAlias,
+}
+
+#[derive(Facet)]
+#[repr(u8)]
+enum SubcommandAliasCanonicalConflict {
+    Profile,
+    #[facet(args::alias = "profile")]
+    Profiles,
+}
+
+#[derive(Facet)]
+struct ArgsWithSubcommandAliasCanonicalConflict {
+    #[facet(args::subcommand)]
+    command: SubcommandAliasCanonicalConflict,
+}
+
+#[derive(Facet)]
+#[repr(u8)]
+enum SubcommandAliasAliasConflict {
+    #[facet(args::alias = "profiles")]
+    Profile,
+    #[facet(args::alias = "profiles")]
+    User,
+}
+
+#[derive(Facet)]
+struct ArgsWithSubcommandAliasAliasConflict {
+    #[facet(args::subcommand)]
+    command: SubcommandAliasAliasConflict,
+}
+
+#[test]
+fn test_schema_aliases_are_stored() {
+    let schema = Schema::from_shape(ArgsWithAlias::SHAPE).expect("schema should build");
+    let (_, arg) = schema
+        .args()
+        .args()
+        .get("drive")
+        .expect("drive arg should be present");
+    assert_eq!(arg.aliases(), &["drive-letter-pattern".to_string()]);
+}
+
+#[test]
+fn test_schema_alias_conflicts_with_canonical_flag() {
+    let result = Schema::from_shape(ConflictingAliasAndCanonical::SHAPE);
+    assert!(result.is_err(), "should detect alias/canonical conflict");
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("duplicate flag `--port`"), "unexpected error: {err}");
+}
+
+#[test]
+fn test_schema_duplicate_alias_on_same_field_is_rejected() {
+    let result = Schema::from_shape(DuplicateAliasOnField::SHAPE);
+    assert!(result.is_err(), "should detect duplicate alias on one field");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("duplicate alias `--drive-letter-pattern`"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_schema_duplicate_alias_across_fields_is_rejected() {
+    let result = Schema::from_shape(ConflictingAliases::SHAPE);
+    assert!(result.is_err(), "should detect duplicate alias across fields");
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("duplicate flag `--drive-letter-pattern`"), "unexpected error: {err}");
+}
+
+#[test]
+fn test_subcommand_duplicate_alias_on_same_variant_detected() {
+    let result = Schema::from_shape(ArgsWithDuplicateSubcommandAlias::SHAPE);
+    assert!(result.is_err(), "should detect duplicate alias on one variant");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("duplicate subcommand alias") && err.contains("profiles"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_subcommand_alias_conflict_with_canonical_name_detected() {
+    let result = Schema::from_shape(ArgsWithSubcommandAliasCanonicalConflict::SHAPE);
+    assert!(result.is_err(), "should detect alias/canonical conflict");
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("duplicate subcommand name `profile`"), "unexpected error: {err}");
+}
+
+#[test]
+fn test_subcommand_alias_conflict_with_other_alias_detected() {
+    let result = Schema::from_shape(ArgsWithSubcommandAliasAliasConflict::SHAPE);
+    assert!(result.is_err(), "should detect alias/alias conflict");
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("duplicate subcommand name `profiles`"), "unexpected error: {err}");
+}

--- a/figue/src/suggest.rs
+++ b/figue/src/suggest.rs
@@ -170,13 +170,23 @@ pub fn suggest_flag<'a>(query: &str, flag_names: impl IntoIterator<Item = &'a st
     }
 }
 
-/// Suggest a similar subcommand name.
+/// Suggest a similar subcommand name, considering aliases but returning the
+/// canonical subcommand spelling.
 pub fn suggest_subcommand<'a>(
     query: &str,
-    subcommand_names: impl IntoIterator<Item = &'a str>,
+    subcommand_spellings: impl IntoIterator<Item = (&'a str, &'a str)>,
 ) -> String {
-    match find_best_match(query, subcommand_names) {
-        Some(suggestion) => format!(". Did you mean '{suggestion}'?"),
+    let spellings: Vec<(&str, &str)> = subcommand_spellings.into_iter().collect();
+
+    match find_best_match(query, spellings.iter().map(|(spelling, _)| *spelling)) {
+        Some(suggestion) => {
+            let canonical = spellings
+                .iter()
+                .find(|(spelling, _)| *spelling == suggestion)
+                .map(|(_, canonical)| *canonical)
+                .unwrap_or(suggestion);
+            format!(". Did you mean '{canonical}'?")
+        }
         None => String::new(),
     }
 }
@@ -229,3 +239,4 @@ mod tests {
         assert_eq!(format_suggestion("completely_different", candidates), "");
     }
 }
+

--- a/figue/tests/integration/help.rs
+++ b/figue/tests/integration/help.rs
@@ -459,3 +459,32 @@ fn test_help_short_flag_h_works_in_subcommand() {
         err
     );
 }
+
+#[test]
+fn test_help_shows_subcommand_aliases_with_canonical_name() {
+    #[derive(Facet, Debug)]
+    struct Cli {
+        #[facet(args::subcommand)]
+        command: Command,
+
+        #[facet(flatten)]
+        builtins: args::FigueBuiltins,
+    }
+
+    #[derive(Facet, Debug)]
+    #[repr(u8)]
+    #[allow(dead_code)]
+    enum Command {
+        #[facet(args::alias = "profiles")]
+        Profile,
+    }
+
+    let result = figue::from_slice::<Cli>(&["--help"]);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.is_help(), "expected help error, got: {:?}", err);
+
+    let help = err.help_text().expect("should have help text");
+    assert!(help.contains("profile"), "help should show canonical subcommand: {help}");
+    assert!(help.contains("aliases: profiles"), "help should surface compatibility aliases: {help}");
+}

--- a/figue/tests/integration/subcommand.rs
+++ b/figue/tests/integration/subcommand.rs
@@ -663,3 +663,27 @@ fn test_nested_subcommands_in_struct() {
         }
     }
 }
+
+/// Test long-form subcommand aliases resolve to the canonical variant.
+#[test]
+fn test_subcommand_alias() {
+    #[derive(Facet, Debug, PartialEq)]
+    #[repr(u8)]
+    enum Command {
+        #[facet(args::alias = "profiles")]
+        Profile {
+            #[facet(args::named)]
+            verbose: bool,
+        },
+    }
+
+    #[derive(Facet, Debug, PartialEq)]
+    struct Args {
+        #[facet(args::subcommand)]
+        command: Command,
+    }
+
+    let canonical: Args = figue::from_slice(&["profile", "--verbose"]).unwrap();
+    let alias: Args = figue::from_slice(&["profiles", "--verbose"]).unwrap();
+    assert_eq!(alias.command, canonical.command);
+}

--- a/figue/tests/integration/subcommand_errors.rs
+++ b/figue/tests/integration/subcommand_errors.rs
@@ -525,3 +525,32 @@ fn test_nested_subcommand_not_provided_with_builtins() {
     let err = figue::from_slice::<Cli>(&["repo"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
+
+#[test]
+fn test_unknown_subcommand_suggestion_considers_aliases() {
+    #[derive(Facet, Debug)]
+    struct Cli {
+        #[facet(args::subcommand)]
+        command: Command,
+
+        #[facet(flatten)]
+        builtins: args::FigueBuiltins,
+    }
+
+    #[derive(Facet, Debug)]
+    #[repr(u8)]
+    #[allow(dead_code)]
+    enum Command {
+        #[facet(args::alias = "profiles")]
+        Profile,
+    }
+
+    let err = figue::from_slice::<Cli>(&["profilse"]).unwrap_err();
+    let rendered = err.to_string();
+    let stripped = strip_ansi_escapes::strip(rendered.as_bytes());
+    let stripped = String::from_utf8_lossy(&stripped);
+    assert!(
+        stripped.contains("Did you mean 'profile'?"),
+        "unexpected diagnostic: {stripped}"
+    );
+}


### PR DESCRIPTION
## Summary
- add repeated `#[facet(args::alias = "...")]` support for named args and subcommand variants
- teach schema building, CLI parsing, suggestions, help, and shell completions about aliases
- add regression coverage for collisions, negated bool aliases, and subcommand alias behavior

## Testing
- cargo test -p figue

Closes #2408
Closes #2409
