### PR TITLE
Support optional-value named CLI args in figue

### DIFF
--- a/facet-format/src/deserializer/eenum.rs
+++ b/facet-format/src/deserializer/eenum.rs
@@ -2155,7 +2155,9 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                             arity += 1;
                         }
                     }
-                    ParseEventKind::FieldKey(_) | ParseEventKind::OrderedField => {}
+                    ParseEventKind::FieldKey(_)
+                    | ParseEventKind::OrderedField
+                    | ParseEventKind::OptionSome => {}
                 }
             }
 

--- a/facet-format/src/deserializer/entry.rs
+++ b/facet-format/src/deserializer/entry.rs
@@ -575,6 +575,12 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
             ) {
                 let _ = self.expect_event("null or unit")?;
                 wip = wip.set_default()?;
+            } else if matches!(event.kind, ParseEventKind::OptionSome) {
+                let _ = self.expect_event("option some")?;
+                wip = wip
+                    .begin_some()?
+                    .with(|w| self.deserialize_value_recursive(w, opt_def.t))?
+                    .end()?;
             } else {
                 wip = self.deserialize_value_recursive(wip, opt_def.t)?;
             }
@@ -651,6 +657,12 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
             let _ = self.expect_event("null or unit")?;
             // Set to None (default)
             wip = wip.set_default()?;
+        } else if matches!(event.kind, ParseEventKind::OptionSome) {
+            let _ = self.expect_event("option some")?;
+            wip = wip
+                .begin_some()?
+                .with(|w| self.deserialize_into_inner(w, MetaSource::FromEvents))?
+                .end()?;
         } else {
             // Some(value)
             wip = wip
@@ -863,7 +875,9 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                         });
                     }
                 }
-                ParseEventKind::OrderedField | ParseEventKind::VariantTag(_) => {}
+                ParseEventKind::OrderedField
+                | ParseEventKind::OptionSome
+                | ParseEventKind::VariantTag(_) => {}
             }
         }
 

--- a/facet-format/src/deserializer/mod.rs
+++ b/facet-format/src/deserializer/mod.rs
@@ -762,6 +762,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                         expecting_value = false;
                     }
                 }
+                crate::ParseEventKind::OptionSome => {}
             }
         };
 

--- a/facet-format/src/event.rs
+++ b/facet-format/src/event.rs
@@ -517,6 +517,12 @@ pub enum ParseEventKind<'de> {
     SequenceEnd,
     /// Scalar literal.
     Scalar(ScalarValue<'de>),
+    /// Explicit marker that an option layer is present.
+    ///
+    /// The following event represents the value inside `Some(...)`. This lets
+    /// formats distinguish an outer `Some(None)` from a plain `None` when
+    /// deserializing nested options.
+    OptionSome,
     /// Tagged value from a self-describing format with native tagged union syntax.
     ///
     /// This is used by formats like Styx that have explicit tag syntax (e.g., `@tag(value)`).
@@ -546,6 +552,7 @@ impl<'de> fmt::Debug for ParseEventKind<'de> {
             }
             ParseEventKind::SequenceEnd => f.write_str("SequenceEnd"),
             ParseEventKind::Scalar(value) => f.debug_tuple("Scalar").field(value).finish(),
+            ParseEventKind::OptionSome => f.write_str("OptionSome"),
             ParseEventKind::VariantTag(tag) => f.debug_tuple("VariantTag").field(tag).finish(),
         }
     }
@@ -571,6 +578,7 @@ impl ParseEventKind<'_> {
             ParseEventKind::SequenceStart(_) => "sequence start",
             ParseEventKind::SequenceEnd => "sequence end",
             ParseEventKind::Scalar(_) => "scalar",
+            ParseEventKind::OptionSome => "option some",
             ParseEventKind::VariantTag(_) => "variant tag",
         }
     }

--- a/facet-format/src/solver.rs
+++ b/facet-format/src/solver.rs
@@ -118,6 +118,7 @@ pub fn solve_variant<'de>(
                     expecting_value = false;
                 }
             }
+            ParseEventKind::OptionSome => {}
         }
     };
 

--- a/figue/src/completions.rs
+++ b/figue/src/completions.rs
@@ -7,7 +7,7 @@ use heck::ToKebabCase;
 use std::string::String;
 use std::vec::Vec;
 
-use crate::schema::{ArgLevelSchema, ArgSchema, Schema, Subcommand};
+use crate::schema::{ArgLevelSchema, ArgSchema, NamedValueMode, Schema, Subcommand};
 
 /// Supported shells for completion generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, facet::Facet)]
@@ -142,7 +142,10 @@ fn generate_bash_function(
     }
 
     // Handle flags that take values
-    let value_flags: Vec<_> = flags.iter().filter(|f| f.takes_value).collect();
+    let value_flags: Vec<_> = flags
+        .iter()
+        .filter(|f| matches!(f.value_mode, NamedValueMode::RequiredValue))
+        .collect();
     if !value_flags.is_empty() {
         out.push_str("\n    case \"$prev\" in\n");
         for flag in &value_flags {
@@ -310,11 +313,10 @@ fn generate_zsh_function(
         let desc = flag.doc.as_deref().unwrap_or("");
         let escaped_desc = escape_zsh_description(desc);
 
-        // For flags that take values, add the value placeholder
-        let value_spec = if flag.takes_value {
-            ":value:_default"
-        } else {
-            ""
+        let value_spec = match flag.value_mode {
+            NamedValueMode::RequiredValue => ":value:_default",
+            NamedValueMode::OptionalValue => "::value:_default",
+            NamedValueMode::BoolFlag | NamedValueMode::CountedFlag => "",
         };
 
         if let Some(short) = flag.short {
@@ -465,7 +467,7 @@ fn generate_fish_level(out: &mut String, args: &ArgLevelSchema, program_name: &s
         out.push_str(&format!(" -l {}", flag.long));
 
         // If flag takes a value, require an argument
-        if flag.takes_value {
+        if matches!(flag.value_mode, NamedValueMode::RequiredValue | NamedValueMode::OptionalValue) {
             out.push_str(" -r");
         }
 
@@ -530,7 +532,7 @@ struct FlagInfo {
     long: String,
     short: Option<char>,
     doc: Option<String>,
-    takes_value: bool,
+    value_mode: NamedValueMode,
 }
 
 struct SubcommandInfo {
@@ -564,15 +566,15 @@ fn collect_options(args: &ArgLevelSchema) -> (Vec<FlagInfo>, Vec<SubcommandInfo>
 
 /// Convert an ArgSchema to FlagInfo.
 fn arg_to_flag(name: &str, arg: &ArgSchema) -> FlagInfo {
-    // Determine if this flag takes a value (not a boolean flag)
-    let takes_value = !arg.value().inner_if_option().is_bool();
+    let value_mode = arg
+        .named_value_mode()
+        .expect("arg_to_flag called on a non-named argument");
 
     FlagInfo {
-        // Use kebab-case for the CLI flag name
         long: name.to_kebab_case(),
         short: arg.kind().short(),
         doc: arg.docs().summary().map(|s| s.trim().to_string()),
-        takes_value,
+        value_mode,
     }
 }
 

--- a/figue/src/config_value.rs
+++ b/figue/src/config_value.rs
@@ -96,6 +96,8 @@ pub enum ConfigValue {
     Object(Sourced<ObjectMap>),
     /// An enum value (subcommand or enum field in config).
     Enum(Sourced<EnumValue>),
+    /// An explicit outer `Some(...)` marker for nested option deserialization.
+    ExplicitSome(Sourced<Box<ConfigValue>>),
 }
 
 pub trait ConfigValueVisitor {
@@ -129,6 +131,9 @@ impl ConfigValue {
                     path.pop();
                 }
             }
+            ConfigValue::ExplicitSome(sourced) => {
+                sourced.value.visit(visitor, path);
+            }
             _ => {}
         }
         visitor.exit_value(path, self);
@@ -159,6 +164,9 @@ impl ConfigValue {
                     path.pop();
                 }
             }
+            ConfigValue::ExplicitSome(sourced) => {
+                sourced.value.visit_mut(visitor, path);
+            }
             _ => {}
         }
     }
@@ -174,6 +182,7 @@ impl ConfigValue {
             ConfigValue::Array(s) => s.span,
             ConfigValue::Object(s) => s.span,
             ConfigValue::Enum(s) => s.span,
+            ConfigValue::ExplicitSome(s) => s.span,
         }
     }
 
@@ -188,6 +197,7 @@ impl ConfigValue {
             ConfigValue::Array(s) => &mut s.span,
             ConfigValue::Object(s) => &mut s.span,
             ConfigValue::Enum(s) => &mut s.span,
+            ConfigValue::ExplicitSome(s) => &mut s.span,
         }
     }
 
@@ -202,6 +212,7 @@ impl ConfigValue {
             ConfigValue::Array(s) => s.provenance.as_ref(),
             ConfigValue::Object(s) => s.provenance.as_ref(),
             ConfigValue::Enum(s) => s.provenance.as_ref(),
+            ConfigValue::ExplicitSome(s) => s.provenance.as_ref(),
         }
     }
 
@@ -284,6 +295,10 @@ impl ConfigValue {
                     };
                     value.set_file_provenance_recursive(file, &key_path);
                 }
+            }
+            ConfigValue::ExplicitSome(s) => {
+                s.set_file_provenance(file.clone(), path);
+                s.value.set_file_provenance_recursive(file, path);
             }
         }
     }

--- a/figue/src/config_value.rs
+++ b/figue/src/config_value.rs
@@ -131,6 +131,13 @@ impl ConfigValue {
                     path.pop();
                 }
             }
+            ConfigValue::Enum(e) => {
+                for (key, value) in &e.value.fields {
+                    path.push(key.clone());
+                    value.visit(visitor, path);
+                    path.pop();
+                }
+            }
             ConfigValue::ExplicitSome(sourced) => {
                 sourced.value.visit(visitor, path);
             }
@@ -355,6 +362,31 @@ impl ConfigValue {
 mod tests {
     use super::*;
     use facet_core::Facet;
+
+    #[derive(Default)]
+    struct RecordingVisitor {
+        paths: Vec<String>,
+    }
+
+    impl ConfigValueVisitor for RecordingVisitor {
+        fn enter_value(&mut self, path: &Path, _value: &ConfigValue) {
+            self.paths.push(path.join("."));
+        }
+    }
+
+    #[test]
+    fn test_visit_recurses_into_enum_fields() {
+        let value = cv_object([(
+            "command",
+            cv_enum("Run", [("dry_run", cv_bool(true))]),
+        )]);
+
+        let mut visitor = RecordingVisitor::default();
+        let mut path = Path::default();
+        value.visit(&mut visitor, &mut path);
+
+        assert_eq!(visitor.paths, vec!["", "command", "command.dry_run"]);
+    }
 
     #[test]
     fn test_unit_is_scalar() {

--- a/figue/src/config_value_parser.rs
+++ b/figue/src/config_value_parser.rs
@@ -1424,6 +1424,11 @@ impl<'input> ConfigValueParser<'input> {
                 // Emit the outer struct start (the enum wrapper)
                 self.event(ParseEventKind::StructStart(ContainerKind::Object))
             }
+            ConfigValue::ExplicitSome(sourced) => {
+                self.update_span(sourced);
+                self.stack.push(StackFrame::Value(sourced.value.as_ref()));
+                self.event(ParseEventKind::OptionSome)
+            }
         }
     }
 }
@@ -1449,6 +1454,7 @@ enum BuildFrame {
     Array {
         items: Vec<ConfigValue>,
     },
+    OptionSome,
     PendingField {
         map: IndexMap<String, ConfigValue, std::hash::RandomState>,
         key: String,
@@ -1494,6 +1500,15 @@ impl ConfigValueSerializer {
                 items.push(value);
                 self.stack.push(BuildFrame::Array { items });
                 Ok(())
+            }
+            BuildFrame::OptionSome => {
+                let span = value.span();
+                let provenance = value.provenance().cloned();
+                self.attach_value(ConfigValue::ExplicitSome(Sourced {
+                    value: Box::new(value),
+                    span,
+                    provenance,
+                }))
             }
             BuildFrame::Object { .. } => {
                 Err("Cannot attach value directly to Object without field_key")?
@@ -1559,6 +1574,11 @@ impl facet_format::FormatSerializer for ConfigValueSerializer {
             }
             _ => Err("end_seq called without matching begin_seq")?,
         }
+    }
+
+    fn begin_option_some(&mut self) -> Result<(), Self::Error> {
+        self.stack.push(BuildFrame::OptionSome);
+        Ok(())
     }
 
     fn scalar(&mut self, value: facet_format::ScalarValue) -> Result<(), Self::Error> {

--- a/figue/src/dump.rs
+++ b/figue/src/dump.rs
@@ -653,6 +653,9 @@ fn build_leaf_entry(
                 children,
             }
         }
+        ConfigValue::ExplicitSome(sourced) => {
+            build_leaf_entry(key, &sourced.value, is_sensitive, opts)
+        }
     }
 }
 

--- a/figue/src/enum_conflicts.rs
+++ b/figue/src/enum_conflicts.rs
@@ -248,6 +248,7 @@ fn get_provenance(value: &ConfigValue) -> Option<Provenance> {
         ConfigValue::Array(s) => s.provenance.clone(),
         ConfigValue::Object(s) => s.provenance.clone(),
         ConfigValue::Enum(s) => s.provenance.clone(),
+        ConfigValue::ExplicitSome(s) => s.provenance.clone().or_else(|| get_provenance(&s.value)),
     }
 }
 

--- a/figue/src/env_subst.rs
+++ b/figue/src/env_subst.rs
@@ -276,6 +276,10 @@ fn get_provenance_cloned(value: &ConfigValue) -> Option<Provenance> {
         ConfigValue::Array(s) => s.provenance.clone(),
         ConfigValue::Object(s) => s.provenance.clone(),
         ConfigValue::Enum(s) => s.provenance.clone(),
+        ConfigValue::ExplicitSome(s) => s
+            .provenance
+            .clone()
+            .or_else(|| get_provenance_cloned(&s.value)),
     }
 }
 
@@ -293,7 +297,28 @@ fn substitute_in_config_value(
         ..
     } = schema
     {
+        if let ConfigValue::ExplicitSome(sourced) = value {
+            return substitute_in_config_value(
+                &mut sourced.value,
+                inner_schema,
+                env_subst,
+                env,
+                path,
+                provenance,
+            );
+        }
         return substitute_in_config_value(value, inner_schema, env_subst, env, path, provenance);
+    }
+
+    if let ConfigValue::ExplicitSome(sourced) = value {
+        return substitute_in_config_value(
+            &mut sourced.value,
+            schema,
+            env_subst,
+            env,
+            path,
+            provenance,
+        );
     }
 
     // String value - perform substitution if enabled

--- a/figue/src/help.rs
+++ b/figue/src/help.rs
@@ -6,7 +6,7 @@
 use crate::missing::normalize_program_name;
 use crate::schema::{
     ArgLevelSchema, ArgSchema, ConfigFieldGroupSchema, ConfigFieldSchema, ConfigStructSchema,
-    ConfigValueSchema, Docs, Schema, Subcommand,
+    ConfigValueSchema, Docs, NamedValueMode, Schema, Subcommand,
 };
 use facet_core::Facet;
 use heck::ToKebabCase;
@@ -949,9 +949,11 @@ fn render_html_arg_row(out: &mut String, arg: &ArgSchema) {
 }
 
 fn render_arg_name_meta(out: &mut String, arg: &ArgSchema) {
-    let hide_false_bool_default = arg.value().inner_if_option().is_bool()
+    let value_mode = arg.named_value_mode();
+    let is_bool_flag = matches!(value_mode, Some(NamedValueMode::BoolFlag));
+    let hide_false_bool_default = is_bool_flag
         && arg.default().map(config_value_summary).as_deref() == Some("false");
-    let has_enum_values = arg.value().inner_if_option().enum_variants().is_some();
+    let has_enum_values = arg.cli_value_schema().enum_variants().is_some();
 
     if hide_false_bool_default && !has_enum_values {
         return;
@@ -965,12 +967,15 @@ fn render_arg_name_meta(out: &mut String, arg: &ArgSchema) {
         out.push_str("</code>");
     } else if arg.required() {
         out.push_str("Required");
-    } else if !arg.kind().is_positional() && !arg.kind().is_counted() && !arg.value().is_bool() {
+    } else if matches!(
+        value_mode,
+        Some(NamedValueMode::RequiredValue | NamedValueMode::OptionalValue)
+    ) {
         out.push_str("Optional value");
     } else {
         out.push_str("Optional");
     }
-    if let Some(variants) = arg.value().inner_if_option().enum_variants() {
+    if let Some(variants) = arg.cli_value_schema().enum_variants() {
         out.push_str("<br>Values ");
         for variant in variants {
             out.push_str("<code class=\"value-token\">");
@@ -991,8 +996,8 @@ fn arg_help_names(arg: &ArgSchema) -> Vec<String> {
         names.push(format!("-{c},"));
     }
 
-    let is_bool = arg.value().inner_if_option().is_bool();
-    let is_counted = arg.kind().is_counted();
+    let value_mode = arg.named_value_mode();
+    let is_bool = matches!(value_mode, Some(NamedValueMode::BoolFlag));
     let mut long = if is_bool {
         if arg.default().map(config_value_summary).as_deref() == Some("false") {
             format!("--{}", arg.name().to_kebab_case())
@@ -1003,16 +1008,23 @@ fn arg_help_names(arg: &ArgSchema) -> Vec<String> {
         format!("--{}", arg.name().to_kebab_case())
     };
 
-    if !is_counted && !arg.value().is_bool() {
+    if matches!(
+        value_mode,
+        Some(NamedValueMode::RequiredValue | NamedValueMode::OptionalValue)
+    ) {
         let placeholder = if let Some(label) = arg.label() {
             Some(label.to_uppercase())
-        } else if arg.value().inner_if_option().enum_variants().is_some() {
+        } else if arg.cli_value_schema().enum_variants().is_some() {
             None
         } else {
-            Some(arg.value().type_identifier().to_uppercase())
+            Some(arg.cli_value_schema().type_identifier().to_uppercase())
         };
         if let Some(placeholder) = placeholder {
-            long.push_str(&format!(" <{placeholder}>"));
+            if matches!(value_mode, Some(NamedValueMode::OptionalValue)) {
+                long.push_str(&format!("[=<{placeholder}>]"));
+            } else {
+                long.push_str(&format!(" <{placeholder}>"));
+            }
         }
     }
     names.push(long);
@@ -1589,6 +1601,7 @@ fn config_value_summary(value: &crate::config_value::ConfigValue) -> String {
             format!("object{{{} fields}}", s.value.len())
         }
         crate::config_value::ConfigValue::Enum(s) => s.value.variant.clone(),
+        crate::config_value::ConfigValue::ExplicitSome(s) => config_value_summary(&s.value),
     }
 }
 
@@ -2421,8 +2434,8 @@ fn write_arg_help(out: &mut String, arg: &ArgSchema, config: &HelpConfig) {
             format!("<{}>", name.to_uppercase()).if_supports_color(Stdout, |text| text.green())
         ));
     } else {
-        let is_bool = arg.value().inner_if_option().is_bool();
-        let flag_str = if is_bool {
+        let value_mode = arg.named_value_mode();
+        let flag_str = if matches!(value_mode, Some(NamedValueMode::BoolFlag)) {
             format!("--[no-]{}", name.to_kebab_case())
         } else {
             format!("--{}", name.to_kebab_case())
@@ -2432,18 +2445,23 @@ fn write_arg_help(out: &mut String, arg: &ArgSchema, config: &HelpConfig) {
             flag_str.if_supports_color(Stdout, |text| text.green())
         ));
 
-        // Show value placeholder for non-bool, non-counted types
-        if !is_counted && !arg.value().is_bool() {
+        if matches!(
+            value_mode,
+            Some(NamedValueMode::RequiredValue | NamedValueMode::OptionalValue)
+        ) {
             let placeholder = if let Some(desc) = arg.label() {
                 desc.to_uppercase()
-            } else if let Some(variants) = arg.value().inner_if_option().enum_variants() {
+            } else if let Some(variants) = arg.cli_value_schema().enum_variants() {
                 variants.join(",")
             } else {
-                arg.value().type_identifier().to_uppercase()
+                arg.cli_value_schema().type_identifier().to_uppercase()
             };
-            out.push_str(&format!(" <{}>", placeholder));
+            if matches!(value_mode, Some(NamedValueMode::OptionalValue)) {
+                out.push_str(&format!("[=<{}>]", placeholder));
+            } else {
+                out.push_str(&format!(" <{}>", placeholder));
+            }
 
-            // Append the default value or required text
             if let Some(default) = arg.default() {
                 out.push_str(&format!(" [Default: `{}`]", config_value_summary(default)));
             } else if arg.required() {

--- a/figue/src/json_schema.rs
+++ b/figue/src/json_schema.rs
@@ -381,6 +381,7 @@ fn config_value_to_json(value: &ConfigValue) -> Option<Json> {
                     .collect(),
             ),
         )])),
+        ConfigValue::ExplicitSome(value) => config_value_to_json(&value.value),
     }
 }
 

--- a/figue/src/layers/cli.rs
+++ b/figue/src/layers/cli.rs
@@ -664,14 +664,29 @@ impl<'a> ParseContext<'a> {
                 let prov_arg = format!("-{}", ch);
                 if is_last {
                     let flag_span = self.current_span();
-                    let value = self.optional_none_value(&prov_arg, flag_span);
-                    self.insert_value_path_to_with_span(
-                        target,
-                        &insertion_path,
-                        value,
-                        is_multiple,
-                        Some(flag_span),
-                    );
+                    if self.index + 1 < self.args.len() && !self.args[self.index + 1].starts_with('-') {
+                        self.index += 1;
+                        let value_span = self.current_span();
+                        let value_str = self.args[self.index];
+                        let value = self.parse_value_string(value_str, &prov_arg, value_span);
+                        let duplicate_span = Self::union_span(flag_span, value_span);
+                        self.insert_value_path_to_with_span(
+                            target,
+                            &insertion_path,
+                            Self::explicit_some(value),
+                            is_multiple,
+                            Some(duplicate_span),
+                        );
+                    } else {
+                        let value = self.optional_none_value(&prov_arg, flag_span);
+                        self.insert_value_path_to_with_span(
+                            target,
+                            &insertion_path,
+                            value,
+                            is_multiple,
+                            Some(flag_span),
+                        );
+                    }
                 } else {
                     let rest: String = chars[i + 1..].iter().collect();
                     let value_span = self.span_within_current(i + 1, rest.len());

--- a/figue/src/layers/cli.rs
+++ b/figue/src/layers/cli.rs
@@ -39,7 +39,8 @@ use crate::config_value::{ConfigValue, EnumValue, Sourced};
 use crate::driver::{Diagnostic, LayerOutput, Severity};
 use crate::provenance::Provenance;
 use crate::schema::{
-    ArgKind, ArgLevelSchema, ArgSchema, ConfigStructSchema, ConfigValueSchema, Schema, Subcommand,
+    ArgKind, ArgLevelSchema, ArgSchema, ConfigStructSchema, ConfigValueSchema, NamedValueMode,
+    Schema, Subcommand,
 };
 use crate::value_builder::{LeafValue, ValueBuilder};
 
@@ -181,10 +182,10 @@ struct ParentFlagLookup {
     effective_name: String,
     /// ConfigValue path to insert into at that parent level.
     insertion_path: Vec<String>,
-    /// Whether this is a bool flag
-    is_bool: bool,
-    /// Whether this is a counted flag
-    is_counted: bool,
+    /// How this named flag accepts values.
+    value_mode: NamedValueMode,
+    /// Whether this flag accepts multiple values
+    is_multiple: bool,
 }
 
 /// Parsed metadata for a dotted config override flag.
@@ -289,6 +290,12 @@ impl<'a> ParseContext<'a> {
         facet_reflect::Span::new(base + sub_offset, sub_len)
     }
 
+    fn union_span(a: facet_reflect::Span, b: facet_reflect::Span) -> facet_reflect::Span {
+        let start = (a.offset as usize).min(b.offset as usize);
+        let end = ((a.offset + a.len) as usize).max((b.offset + b.len) as usize);
+        facet_reflect::Span::new(start, end - start)
+    }
+
     fn parse(&mut self) {
         self.parse_level(self.schema.args());
         self.apply_counted_fields();
@@ -347,7 +354,7 @@ impl<'a> ParseContext<'a> {
             return;
         }
 
-        // Check for `--flag=value` syntax
+        // Check for --flag=value syntax
         let (flag_name, inline_value) = if let Some(eq_pos) = flag.find('=') {
             (&flag[..eq_pos], Some(&flag[eq_pos + 1..]))
         } else {
@@ -389,21 +396,19 @@ impl<'a> ParseContext<'a> {
             }
         }
 
-        // Look up in schema - Args::get converts schema keys to kebab-case for comparison
-        // and returns the original effective_name for storage in ConfigValue
         if let Some((effective_name, arg_schema)) = level.args().get(flag_name) {
-            if let ArgKind::Named { counted, .. } = arg_schema.kind()
-                && *counted
-            {
+            let value_mode = arg_schema
+                .named_value_mode()
+                .expect("long flag lookup returned a non-named argument");
+            if matches!(value_mode, NamedValueMode::CountedFlag) {
                 self.increment_counted(effective_name);
                 self.index += 1;
                 return;
             }
             self.parse_flag_value(arg, arg_schema, inline_value);
         } else if let Some(lookup) = self.find_long_flag_in_parents(flag_name) {
-            // Adoption agency: flag found in parent level, bubble up
             let target = InsertTarget::Parent(lookup.parent_idx);
-            if lookup.is_counted {
+            if matches!(lookup.value_mode, NamedValueMode::CountedFlag) {
                 self.increment_counted_to(target, &lookup.effective_name);
                 self.index += 1;
                 return;
@@ -412,14 +417,14 @@ impl<'a> ParseContext<'a> {
                 arg,
                 target,
                 &lookup.insertion_path,
-                lookup.is_bool,
-                None, // enum_variants not available for parent lookup
+                lookup.value_mode,
+                lookup.is_multiple,
+                None,
                 inline_value,
             );
         } else if let Some(negated_name) = flag_name.strip_prefix("no-") {
-            // --no-<flag> syntax: negate a boolean flag
             if let Some((_effective_name, arg_schema)) = level.args().get(negated_name)
-                && arg_schema.value().inner_if_option().is_bool()
+                && matches!(arg_schema.named_value_mode(), Some(NamedValueMode::BoolFlag))
             {
                 let prov = Provenance::cli(arg, "false".to_string());
                 self.insert_value_path_to(
@@ -430,12 +435,12 @@ impl<'a> ParseContext<'a> {
                         span: None,
                         provenance: Some(prov),
                     }),
+                    arg_schema.multiple(),
                 );
                 self.index += 1;
             } else if let Some(lookup) = self.find_long_flag_in_parents(negated_name)
-                && lookup.is_bool
+                && matches!(lookup.value_mode, NamedValueMode::BoolFlag)
             {
-                // Adoption agency: boolean flag found in parent, negate it
                 let target = InsertTarget::Parent(lookup.parent_idx);
                 let prov = Provenance::cli(arg, "false".to_string());
                 self.insert_value_path_to(
@@ -446,6 +451,7 @@ impl<'a> ParseContext<'a> {
                         span: None,
                         provenance: Some(prov),
                     }),
+                    lookup.is_multiple,
                 );
                 self.index += 1;
             } else {
@@ -465,12 +471,10 @@ impl<'a> ParseContext<'a> {
                 self.index += 1;
             }
         } else {
-            // Collect all available flag names for suggestion
             let all_flags: Vec<&str> = level
                 .args()
                 .iter()
                 .filter_map(|(name, schema)| {
-                    // Only suggest named flags
                     if matches!(schema.kind(), ArgKind::Named { .. }) {
                         Some(name.as_str())
                     } else {
@@ -582,7 +586,7 @@ impl<'a> ParseContext<'a> {
     fn parse_short_flag(&mut self, arg: &str, level: &'a ArgLevelSchema) {
         let flag_part = &arg[1..]; // strip "-"
 
-        // Check for `-k=value` syntax (single short flag with equals)
+        // Check for -k=value syntax (single short flag with equals)
         if let Some(eq_pos) = flag_part.find('=') {
             let flag_char = flag_part[..eq_pos].chars().next();
             if eq_pos == 1 {
@@ -600,7 +604,6 @@ impl<'a> ParseContext<'a> {
         let chars: Vec<char> = flag_part.chars().collect();
 
         for (i, ch) in chars.iter().enumerate() {
-            // Find argument with this short flag at current level
             let found = level.args().iter().find(|(_, schema)| {
                 if let ArgKind::Named { short: Some(s), .. } = schema.kind() {
                     *s == *ch
@@ -609,45 +612,43 @@ impl<'a> ParseContext<'a> {
                 }
             });
 
-            // Determine target and flag info
-            let (target, name, insertion_path, is_bool, is_counted) =
+            let (target, name, insertion_path, value_mode, is_multiple) =
                 if let Some((name, arg_schema)) = found {
-                    let is_counted =
-                        matches!(arg_schema.kind(), ArgKind::Named { counted: true, .. });
-                    let is_bool = arg_schema
-                        .value()
-                        .inner_if_option()
-                        .is_bool_or_vec_of_bool();
+                    let value_mode = if arg_schema.value().is_bool_or_vec_of_bool() {
+                        NamedValueMode::BoolFlag
+                    } else {
+                        arg_schema
+                            .named_value_mode()
+                            .expect("short flag lookup returned a non-named argument")
+                    };
                     (
                         InsertTarget::Current,
                         name.to_string(),
                         arg_schema.insertion_path().to_vec(),
-                        is_bool,
-                        is_counted,
+                        value_mode,
+                        arg_schema.multiple(),
                     )
                 } else if let Some(lookup) = self.find_short_flag_in_parents(*ch) {
-                    // Adoption agency: flag found in parent level
                     (
                         InsertTarget::Parent(lookup.parent_idx),
                         lookup.effective_name,
                         lookup.insertion_path,
-                        lookup.is_bool,
-                        lookup.is_counted,
+                        lookup.value_mode,
+                        lookup.is_multiple,
                     )
                 } else {
                     self.emit_error(format!("unknown flag: -{}", ch));
                     continue;
                 };
 
-            if is_counted {
+            if matches!(value_mode, NamedValueMode::CountedFlag) {
                 self.increment_counted_to(target, &name);
                 continue;
             }
 
             let is_last = i == chars.len() - 1;
 
-            if is_bool {
-                // Bool flag: set to true
+            if matches!(value_mode, NamedValueMode::BoolFlag) {
                 let prov = Provenance::cli(format!("-{}", ch), "true");
                 self.insert_value_path_to(
                     target,
@@ -657,31 +658,53 @@ impl<'a> ParseContext<'a> {
                         span: None,
                         provenance: Some(prov),
                     }),
+                    is_multiple,
                 );
+            } else if matches!(value_mode, NamedValueMode::OptionalValue) {
+                let prov_arg = format!("-{}", ch);
+                if is_last {
+                    let flag_span = self.current_span();
+                    let value = self.optional_none_value(&prov_arg, flag_span);
+                    self.insert_value_path_to_with_span(
+                        target,
+                        &insertion_path,
+                        value,
+                        is_multiple,
+                        Some(flag_span),
+                    );
+                } else {
+                    let rest: String = chars[i + 1..].iter().collect();
+                    let value_span = self.span_within_current(i + 1, rest.len());
+                    let value = self.parse_value_string(&rest, &prov_arg, value_span);
+                    let duplicate_span = Self::union_span(self.current_span(), value_span);
+                    self.insert_value_path_to_with_span(
+                        target,
+                        &insertion_path,
+                        Self::explicit_some(value),
+                        is_multiple,
+                        Some(duplicate_span),
+                    );
+                    break;
+                }
             } else if is_last {
-                // Non-bool flag at end: look for value
-                let flag_span = self.current_span(); // Save span before incrementing
+                let flag_span = self.current_span();
                 self.index += 1;
                 if self.index < self.args.len() {
                     let value_span = self.current_span();
                     let value_str = self.args[self.index];
                     let prov_arg = format!("-{}", ch);
                     let value = self.parse_value_string(value_str, &prov_arg, value_span);
-                    self.insert_value_path_to(target, &insertion_path, value);
+                    self.insert_value_path_to(target, &insertion_path, value, is_multiple);
                 } else {
-                    // For short flags, we don't have easy access to enum variants
-                    // Could be improved in the future
                     self.emit_error_at(format!("flag -{} requires a value", ch), flag_span);
                 }
             } else {
-                // Non-bool flag with attached value: -p8080
-                // Span for attached value is within the current arg
                 let rest: String = chars[i + 1..].iter().collect();
                 let value_span = self.span_within_current(i + 1, rest.len());
                 let prov_arg = format!("-{}", ch);
                 let value = self.parse_value_string(&rest, &prov_arg, value_span);
-                self.insert_value_path_to(target, &insertion_path, value);
-                break; // Consumed rest of chars
+                self.insert_value_path_to(target, &insertion_path, value, is_multiple);
+                break;
             }
         }
         self.index += 1;
@@ -702,41 +725,39 @@ impl<'a> ParseContext<'a> {
             }
         });
 
-        // Determine target and flag info
-        let (target, name, insertion_path, is_bool, is_counted) =
+        let (target, name, insertion_path, value_mode, is_multiple) =
             if let Some((name, arg_schema)) = found {
-                let is_counted = matches!(arg_schema.kind(), ArgKind::Named { counted: true, .. });
-                let is_bool = arg_schema.value().inner_if_option().is_bool();
+                let value_mode = arg_schema
+                    .named_value_mode()
+                    .expect("short flag lookup returned a non-named argument");
                 (
                     InsertTarget::Current,
                     name.to_string(),
                     arg_schema.insertion_path().to_vec(),
-                    is_bool,
-                    is_counted,
+                    value_mode,
+                    arg_schema.multiple(),
                 )
             } else if let Some(lookup) = self.find_short_flag_in_parents(ch) {
-                // Adoption agency: flag found in parent level
                 (
                     InsertTarget::Parent(lookup.parent_idx),
                     lookup.effective_name,
                     lookup.insertion_path,
-                    lookup.is_bool,
-                    lookup.is_counted,
+                    lookup.value_mode,
+                    lookup.is_multiple,
                 )
             } else {
                 self.emit_error(format!("unknown flag: -{}", ch));
                 return;
             };
 
-        if is_counted {
+        if matches!(value_mode, NamedValueMode::CountedFlag) {
             self.increment_counted_to(target, &name);
             return;
         }
 
         let prov_arg = format!("-{}", ch);
 
-        if is_bool {
-            // -k=true or -k=false
+        if matches!(value_mode, NamedValueMode::BoolFlag) {
             let value = matches!(
                 value_str.to_lowercase().as_str(),
                 "true" | "yes" | "1" | "on" | ""
@@ -750,119 +771,198 @@ impl<'a> ParseContext<'a> {
                     span: None,
                     provenance: Some(prov),
                 }),
+                is_multiple,
             );
-        } else {
-            // Value starts after the '=' which is at position 2 (after -k)
+        } else if matches!(value_mode, NamedValueMode::OptionalValue) {
             let value_span = self.span_within_current(3, value_str.len());
             let value = self.parse_value_string(value_str, &prov_arg, value_span);
-            self.insert_value_path_to(target, &insertion_path, value);
+            self.insert_value_path_to(
+                target,
+                &insertion_path,
+                Self::explicit_some(value),
+                is_multiple,
+            );
+        } else {
+            let value_span = self.span_within_current(3, value_str.len());
+            let value = self.parse_value_string(value_str, &prov_arg, value_span);
+            self.insert_value_path_to(target, &insertion_path, value, is_multiple);
         }
     }
 
     fn parse_flag_value(&mut self, arg: &str, schema: &ArgSchema, inline_value: Option<&str>) {
-        let is_bool = schema.value().inner_if_option().is_bool();
-        let enum_variants = schema.value().inner_if_option().enum_variants();
+        let value_mode = schema
+            .named_value_mode()
+            .expect("parse_flag_value called with a non-named argument");
+        let is_multiple = schema.multiple();
+        let enum_variants = schema.cli_value_schema().enum_variants();
         self.parse_flag_value_simple(
             arg,
             InsertTarget::Current,
             schema.insertion_path(),
-            is_bool,
+            value_mode,
+            is_multiple,
             enum_variants,
             inline_value,
         );
     }
 
-    /// Parse a flag value with explicit is_bool (avoids borrow issues with schema).
     fn parse_flag_value_simple(
         &mut self,
         arg: &str,
         target: InsertTarget,
         insertion_path: &[String],
-        is_bool: bool,
+        value_mode: NamedValueMode,
+        is_multiple: bool,
         enum_variants: Option<&[String]>,
         inline_value: Option<&str>,
     ) {
-        if is_bool {
-            // Bool flag: presence means true
-            let value = if let Some(v) = inline_value {
-                // --flag=true or --flag=false
-                matches!(v.to_lowercase().as_str(), "true" | "yes" | "1" | "on" | "")
-            } else {
-                true
-            };
-            let prov = Provenance::cli(arg, value.to_string());
-            self.insert_value_path_to(
+        match value_mode {
+            NamedValueMode::BoolFlag => {
+                let flag_span = self.current_span();
+                let value = if let Some(v) = inline_value {
+                    matches!(v.to_lowercase().as_str(), "true" | "yes" | "1" | "on" | "")
+                } else {
+                    true
+                };
+                let prov = Provenance::cli(arg, value.to_string());
+                self.insert_value_path_to_with_span(
+                    target,
+                    insertion_path,
+                    ConfigValue::Bool(Sourced {
+                        value,
+                        span: None,
+                        provenance: Some(prov),
+                    }),
+                    is_multiple,
+                    Some(flag_span),
+                );
+                self.index += 1;
+            }
+            NamedValueMode::OptionalValue => {
+                self.parse_optional_flag_value(arg, target, insertion_path, is_multiple, inline_value);
+            }
+            NamedValueMode::RequiredValue => {
+                let flag_span = self.current_span();
+                let name = insertion_path.last().map(String::as_str).unwrap_or("");
+                let is_completions_field = self
+                    .schema
+                    .special()
+                    .completions
+                    .as_ref()
+                    .and_then(|p| p.last())
+                    .map(|s| s.as_str() == name)
+                    .unwrap_or(false);
+
+                let (value_str, value_span) = if let Some(v) = inline_value {
+                    let eq_pos = arg.find('=').unwrap_or(0) + 1;
+                    let span = self.span_within_current(eq_pos, v.len());
+                    self.index += 1;
+                    (v, span)
+                } else {
+                    self.index += 1;
+                    let at_end = self.index >= self.args.len();
+                    let next_looks_like_flag = !at_end && self.args[self.index].starts_with('-');
+
+                    if is_completions_field && (at_end || next_looks_like_flag) {
+                        let prov = Provenance::cli(arg, "auto");
+                        self.insert_value_path_to(
+                            target,
+                            insertion_path,
+                            ConfigValue::String(Sourced {
+                                value: "auto".to_string(),
+                                span: None,
+                                provenance: Some(prov),
+                            }),
+                            is_multiple,
+                        );
+                        return;
+                    }
+
+                    if at_end {
+                        let error_msg = if let Some(variants) = enum_variants {
+                            let variant_list = variants.join(", ");
+                            format!("flag {} requires one of: {}", arg, variant_list)
+                        } else {
+                            format!("flag {} requires a value", arg)
+                        };
+                        self.emit_error_at(error_msg, flag_span);
+                        return;
+                    }
+
+                    let span = self.current_span();
+                    let v = self.args[self.index];
+                    self.index += 1;
+                    (v, span)
+                };
+
+                let prov_arg = arg.split('=').next().unwrap_or(arg);
+                let value = self.parse_value_string(value_str, prov_arg, value_span);
+                let duplicate_span = Self::union_span(flag_span, value_span);
+                self.insert_value_path_to_with_span(
+                    target,
+                    insertion_path,
+                    value,
+                    is_multiple,
+                    Some(duplicate_span),
+                );
+            }
+            NamedValueMode::CountedFlag => {
+                self.index += 1;
+            }
+        }
+    }
+
+    fn parse_optional_flag_value(
+        &mut self,
+        arg: &str,
+        target: InsertTarget,
+        insertion_path: &[String],
+        is_multiple: bool,
+        inline_value: Option<&str>,
+    ) {
+        let flag_span = self.current_span();
+
+        if let Some(v) = inline_value {
+            let eq_pos = arg.find('=').unwrap_or(0) + 1;
+            let value_span = self.span_within_current(eq_pos, v.len());
+            let prov_arg = arg.split('=').next().unwrap_or(arg);
+            let value = self.parse_value_string(v, prov_arg, value_span);
+            let duplicate_span = Self::union_span(flag_span, value_span);
+            self.insert_value_path_to_with_span(
                 target,
                 insertion_path,
-                ConfigValue::Bool(Sourced {
-                    value,
-                    span: None,
-                    provenance: Some(prov),
-                }),
+                Self::explicit_some(value),
+                is_multiple,
+                Some(duplicate_span),
+            );
+            self.index += 1;
+            return;
+        }
+
+        self.index += 1;
+
+        if self.index < self.args.len() && !self.args[self.index].starts_with('-') {
+            let value_span = self.current_span();
+            let value_str = self.args[self.index];
+            let value = self.parse_value_string(value_str, arg, value_span);
+            let duplicate_span = Self::union_span(flag_span, value_span);
+            self.insert_value_path_to_with_span(
+                target,
+                insertion_path,
+                Self::explicit_some(value),
+                is_multiple,
+                Some(duplicate_span),
             );
             self.index += 1;
         } else {
-            // Non-bool: need a value
-            let flag_span = self.current_span();
-            let name = insertion_path.last().map(String::as_str).unwrap_or("");
-
-            // Check up-front whether this is the special completions field,
-            // which is allowed to omit its value (triggering auto-detection).
-            let is_completions_field = self
-                .schema
-                .special()
-                .completions
-                .as_ref()
-                .and_then(|p| p.last())
-                .map(|s| s.as_str() == name)
-                .unwrap_or(false);
-
-            let (value_str, value_span) = if let Some(v) = inline_value {
-                // --flag=value: value starts after the '='
-                let eq_pos = arg.find('=').unwrap_or(0) + 1;
-                let span = self.span_within_current(eq_pos, v.len());
-                self.index += 1;
-                (v, span)
-            } else {
-                self.index += 1;
-                let at_end = self.index >= self.args.len();
-                let next_looks_like_flag = !at_end && self.args[self.index].starts_with('-');
-
-                if is_completions_field && (at_end || next_looks_like_flag) {
-                    // No shell specified — store sentinel for auto-detection.
-                    let prov = Provenance::cli(arg, "auto");
-                    self.insert_value_path_to(
-                        target,
-                        insertion_path,
-                        ConfigValue::String(Sourced {
-                            value: "auto".to_string(),
-                            span: None,
-                            provenance: Some(prov),
-                        }),
-                    );
-                    return;
-                }
-
-                if at_end {
-                    let error_msg = if let Some(variants) = enum_variants {
-                        let variant_list = variants.join(", ");
-                        format!("flag {} requires one of: {}", arg, variant_list)
-                    } else {
-                        format!("flag {} requires a value", arg)
-                    };
-                    self.emit_error_at(error_msg, flag_span);
-                    return;
-                }
-
-                let span = self.current_span();
-                let v = self.args[self.index];
-                self.index += 1;
-                (v, span)
-            };
-
-            let prov_arg = arg.split('=').next().unwrap_or(arg);
-            let value = self.parse_value_string(value_str, prov_arg, value_span);
-            self.insert_value_path_to(target, insertion_path, value);
+            let value = self.optional_none_value(arg, flag_span);
+            self.insert_value_path_to_with_span(
+                target,
+                insertion_path,
+                value,
+                is_multiple,
+                Some(flag_span),
+            );
         }
     }
 
@@ -1137,17 +1237,18 @@ impl<'a> ParseContext<'a> {
     /// Look up a long flag in parent levels (adoption agency algorithm).
     /// Returns owned data to avoid borrow conflicts during mutation.
     fn find_long_flag_in_parents(&self, flag_name: &str) -> Option<ParentFlagLookup> {
-        // Search parent stack from innermost (most recent) to outermost
         for (idx, parent) in self.parent_stack.iter().enumerate().rev() {
             if let Some((effective_name, arg_schema)) = parent.args.args().get(flag_name) {
-                let is_counted = matches!(arg_schema.kind(), ArgKind::Named { counted: true, .. });
-                let is_bool = arg_schema.value().inner_if_option().is_bool();
+                let value_mode = arg_schema
+                    .named_value_mode()
+                    .expect("long flag lookup returned a non-named argument");
+                let is_multiple = arg_schema.multiple();
                 return Some(ParentFlagLookup {
                     parent_idx: idx,
                     effective_name: effective_name.to_string(),
                     insertion_path: arg_schema.insertion_path().to_vec(),
-                    is_bool,
-                    is_counted,
+                    value_mode,
+                    is_multiple,
                 });
             }
         }
@@ -1157,20 +1258,25 @@ impl<'a> ParseContext<'a> {
     /// Look up a short flag in parent levels (adoption agency algorithm).
     /// Returns owned data to avoid borrow conflicts during mutation.
     fn find_short_flag_in_parents(&self, ch: char) -> Option<ParentFlagLookup> {
-        // Search parent stack from innermost (most recent) to outermost
         for (idx, parent) in self.parent_stack.iter().enumerate().rev() {
             for (name, schema) in parent.args.args().iter() {
                 if let ArgKind::Named { short: Some(s), .. } = schema.kind()
                     && *s == ch
                 {
-                    let is_counted = matches!(schema.kind(), ArgKind::Named { counted: true, .. });
-                    let is_bool = schema.value().inner_if_option().is_bool();
+                    let value_mode = if schema.value().is_bool_or_vec_of_bool() {
+                        NamedValueMode::BoolFlag
+                    } else {
+                        schema
+                            .named_value_mode()
+                            .expect("short flag lookup returned a non-named argument")
+                    };
+                    let is_multiple = schema.multiple();
                     return Some(ParentFlagLookup {
                         parent_idx: idx,
                         effective_name: name.to_string(),
                         insertion_path: schema.insertion_path().to_vec(),
-                        is_bool,
-                        is_counted,
+                        value_mode,
+                        is_multiple,
                     });
                 }
             }
@@ -1211,7 +1317,7 @@ impl<'a> ParseContext<'a> {
 
             let value_span = self.current_span();
             let value = self.parse_value_string(arg, arg, value_span);
-            self.insert_value_path_to(InsertTarget::Current, schema.insertion_path(), value);
+            self.insert_value_path_to(InsertTarget::Current, schema.insertion_path(), value, schema.multiple());
             self.index += 1;
             return true;
         }
@@ -1236,23 +1342,79 @@ impl<'a> ParseContext<'a> {
         })
     }
 
+    fn optional_none_value(&self, arg_name: &str, span: facet_reflect::Span) -> ConfigValue {
+        let provenance = Some(Provenance::cli(arg_name, ""));
+        let inner = ConfigValue::Null(Sourced {
+            value: (),
+            span: Some(span),
+            provenance: provenance.clone(),
+        });
+        ConfigValue::ExplicitSome(Sourced {
+            value: Box::new(inner),
+            span: Some(span),
+            provenance,
+        })
+    }
+
+    fn explicit_some(value: ConfigValue) -> ConfigValue {
+        let span = value.span();
+        let provenance = value.provenance().cloned();
+        ConfigValue::ExplicitSome(Sourced {
+            value: Box::new(value),
+            span,
+            provenance,
+        })
+    }
+
     /// Insert a value to a specific target and ConfigValue path.
-    fn insert_value_path_to(&mut self, target: InsertTarget, path: &[String], value: ConfigValue) {
+    fn insert_value_path_to(
+        &mut self,
+        target: InsertTarget,
+        path: &[String],
+        value: ConfigValue,
+        is_multiple: bool,
+    ) {
+        self.insert_value_path_to_with_span(target, path, value, is_multiple, None);
+    }
+
+    fn insert_value_path_to_with_span(
+        &mut self,
+        target: InsertTarget,
+        path: &[String],
+        value: ConfigValue,
+        is_multiple: bool,
+        duplicate_span: Option<facet_reflect::Span>,
+    ) {
         let result_map = match target {
             InsertTarget::Current => &mut self.result,
             InsertTarget::Parent(idx) => &mut self.parent_stack[idx].result,
         };
 
-        Self::insert_value_at_path(result_map, path, value);
+        let duplicate_non_multiple =
+            Self::insert_value_at_path(result_map, path, value, is_multiple);
+
+        if duplicate_non_multiple {
+            let name = path.last().map(String::as_str).unwrap_or("");
+            let message = format!(
+                "argument --{} was provided multiple times, but only one value is allowed",
+                name.to_kebab_case()
+            );
+            if let Some(span) = duplicate_span {
+                self.emit_error_at(message, span);
+            } else {
+                self.emit_error(message);
+            }
+        }
     }
 
     fn insert_value_at_path(
         result_map: &mut IndexMap<String, ConfigValue, RandomState>,
         path: &[String],
         value: ConfigValue,
-    ) {
+        is_multiple: bool,
+    ) -> bool {
         let Some((head, tail)) = path.split_first() else {
-            return;
+            return false;
         };
 
         if !tail.is_empty() {
@@ -1261,42 +1423,69 @@ impl<'a> ParseContext<'a> {
                 .or_insert_with(|| ConfigValue::Object(Sourced::new(IndexMap::default())));
             match entry {
                 ConfigValue::Object(sourced) => {
-                    Self::insert_value_at_path(&mut sourced.value, tail, value);
+                    return Self::insert_value_at_path(&mut sourced.value, tail, value, is_multiple);
                 }
                 existing => {
                     let mut nested = IndexMap::default();
-                    Self::insert_value_at_path(&mut nested, tail, value);
+                    let duplicate = Self::insert_value_at_path(&mut nested, tail, value, is_multiple);
                     *existing = ConfigValue::Object(Sourced::new(nested));
+                    return duplicate;
                 }
             }
-            return;
         }
+
+        let mut duplicate_non_multiple = false;
 
         match result_map.entry(head.clone()) {
             indexmap::map::Entry::Vacant(entry) => {
-                entry.insert(value);
+                if is_multiple {
+                    let wrapper_span = value.span();
+                    let wrapper_provenance = value.provenance().cloned();
+                    entry.insert(ConfigValue::Array(Sourced {
+                        value: vec![value],
+                        span: wrapper_span,
+                        provenance: wrapper_provenance,
+                    }));
+                } else {
+                    entry.insert(value);
+                }
             }
             indexmap::map::Entry::Occupied(mut entry) => {
-                // Accumulate into array for repeated flags
-                let existing = entry.get_mut();
-                if let ConfigValue::Array(arr) = existing {
-                    arr.value.push(value);
+                if is_multiple {
+                    let existing = entry.get_mut();
+                    if let ConfigValue::Array(arr) = existing {
+                        if arr.span.is_none() {
+                            arr.span = value.span();
+                        }
+                        if arr.provenance.is_none() {
+                            arr.provenance = value.provenance().cloned();
+                        }
+                        arr.value.push(value);
+                    } else {
+                        let placeholder = ConfigValue::Null(Sourced {
+                            value: (),
+                            span: None,
+                            provenance: None,
+                        });
+                        let old = core::mem::replace(existing, placeholder);
+                        let wrapper_span = old.span().or(value.span());
+                        let wrapper_provenance = old
+                            .provenance()
+                            .cloned()
+                            .or_else(|| value.provenance().cloned());
+                        *existing = ConfigValue::Array(Sourced {
+                            value: vec![old, value],
+                            span: wrapper_span,
+                            provenance: wrapper_provenance,
+                        });
+                    }
                 } else {
-                    // Convert to array with both values
-                    let placeholder = ConfigValue::Null(Sourced {
-                        value: (),
-                        span: None,
-                        provenance: None,
-                    });
-                    let old = core::mem::replace(existing, placeholder);
-                    *existing = ConfigValue::Array(Sourced {
-                        value: vec![old, value],
-                        span: None,
-                        provenance: None,
-                    });
+                    duplicate_non_multiple = true;
                 }
             }
         }
+
+        duplicate_non_multiple
     }
 
     /// Check if a value exists at the given insertion path.

--- a/figue/src/layers/file.rs
+++ b/figue/src/layers/file.rs
@@ -564,6 +564,7 @@ fn get_provenance(value: &ConfigValue) -> Option<&Provenance> {
         ConfigValue::Array(s) => s.provenance.as_ref(),
         ConfigValue::Object(s) => s.provenance.as_ref(),
         ConfigValue::Enum(s) => s.provenance.as_ref(),
+        ConfigValue::ExplicitSome(s) => s.provenance.as_ref().or_else(|| get_provenance(&s.value)),
     }
 }
 
@@ -587,6 +588,7 @@ mod tests {
             ConfigValue::Array(s) => s.provenance.as_ref(),
             ConfigValue::Object(s) => s.provenance.as_ref(),
             ConfigValue::Enum(s) => s.provenance.as_ref(),
+        ConfigValue::ExplicitSome(s) => s.provenance.as_ref().or_else(|| get_provenance(&s.value)),
         }
     }
 

--- a/figue/src/merge.rs
+++ b/figue/src/merge.rs
@@ -158,6 +158,7 @@ fn get_provenance(value: &ConfigValue) -> Option<&Provenance> {
         ConfigValue::Array(s) => s.provenance.as_ref(),
         ConfigValue::Object(s) => s.provenance.as_ref(),
         ConfigValue::Enum(s) => s.provenance.as_ref(),
+        ConfigValue::ExplicitSome(s) => s.provenance.as_ref().or_else(|| get_provenance(&s.value)),
     }
 }
 

--- a/figue/src/schema.rs
+++ b/figue/src/schema.rs
@@ -359,6 +359,14 @@ pub enum ArgKind {
     Named { short: Option<char>, counted: bool },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NamedValueMode {
+    BoolFlag,
+    CountedFlag,
+    RequiredValue,
+    OptionalValue,
+}
+
 /// Schema for the 'config' field of the top-level args struct
 #[derive(Facet, Debug, Clone)]
 #[facet(skip_all_unless_truthy)]
@@ -700,6 +708,28 @@ impl ArgSchema {
     pub fn default(&self) -> Option<&crate::config_value::ConfigValue> {
         self.default.as_ref()
     }
+
+    pub(crate) fn named_value_mode(&self) -> Option<NamedValueMode> {
+        match self.kind() {
+            ArgKind::Positional => None,
+            ArgKind::Named { counted: true, .. } => Some(NamedValueMode::CountedFlag),
+            ArgKind::Named { counted: false, .. } if self.value().is_bool_flag_value() => {
+                Some(NamedValueMode::BoolFlag)
+            }
+            ArgKind::Named { counted: false, .. }
+                if self.value().optional_value_inner().is_some() =>
+            {
+                Some(NamedValueMode::OptionalValue)
+            }
+            ArgKind::Named { counted: false, .. } => Some(NamedValueMode::RequiredValue),
+        }
+    }
+
+    pub(crate) fn cli_value_schema(&self) -> &ValueSchema {
+        self.value()
+            .optional_value_inner()
+            .unwrap_or_else(|| self.value().inner_if_option())
+    }
 }
 
 impl Subcommand {
@@ -840,6 +870,7 @@ impl ConfigFieldSchema {
     pub fn default(&self) -> Option<&crate::config_value::ConfigValue> {
         self.default.as_ref()
     }
+
 }
 
 impl ConfigVecSchema {
@@ -985,6 +1016,43 @@ impl ValueSchema {
                 ..
             }) => Some(variants.as_slice()),
             _ => None,
+        }
+    }
+
+    pub(crate) fn is_bool_flag_value(&self) -> bool {
+        match self {
+            ValueSchema::Option { value, .. } => value.is_bool_flag_value(),
+            ValueSchema::Leaf(LeafSchema {
+                kind: LeafKind::Scalar(ScalarType::Bool),
+                ..
+            }) => true,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn optional_value_inner(&self) -> Option<&ValueSchema> {
+        let ValueSchema::Option { value: outer, .. } = self else {
+            return None;
+        };
+        let ValueSchema::Option { value: inner, .. } = outer.as_ref() else {
+            return None;
+        };
+        inner
+            .as_ref()
+            .is_single_non_bool_value()
+            .then_some(inner.as_ref())
+    }
+
+    fn is_single_non_bool_value(&self) -> bool {
+        match self {
+            ValueSchema::Leaf(LeafSchema {
+                kind: LeafKind::Scalar(ScalarType::Bool),
+                ..
+            }) => false,
+            ValueSchema::Leaf(_) => true,
+            ValueSchema::Option { .. } | ValueSchema::Vec { .. } | ValueSchema::Struct { .. } => {
+                false
+            }
         }
     }
 }

--- a/figue/src/value_builder.rs
+++ b/figue/src/value_builder.rs
@@ -380,6 +380,9 @@ impl<'a> ValueBuilder<'a> {
                     prov,
                 );
             }
+            ConfigValue::ExplicitSome(s) => {
+                self.import_tree_recursive(&s.value, path);
+            }
         }
     }
 

--- a/figue/tests/integration/mod.rs
+++ b/figue/tests/integration/mod.rs
@@ -14,3 +14,4 @@ mod subcommand;
 mod subcommand_errors;
 mod subspans;
 mod unknown_keys;
+mod optional_value;

--- a/figue/tests/integration/optional_value.rs
+++ b/figue/tests/integration/optional_value.rs
@@ -1,0 +1,185 @@
+use facet::Facet;
+use figue::{self as args};
+
+#[derive(Facet, Debug, PartialEq)]
+struct OptionalArgs {
+    #[facet(args::named, args::short = 'p')]
+    parallel: Option<Option<usize>>,
+
+    #[facet(args::named)]
+    dry_run: bool,
+}
+
+#[test]
+fn optional_value_long_forms() {
+    let args: OptionalArgs = figue::from_slice::<OptionalArgs>(&[]).unwrap();
+    assert_eq!(args.parallel, None);
+    assert!(!args.dry_run);
+
+    let args: OptionalArgs = figue::from_slice(&["--parallel"]).unwrap();
+    assert_eq!(args.parallel, Some(None));
+
+    let args: OptionalArgs = figue::from_slice(&["--parallel", "12"]).unwrap();
+    assert_eq!(args.parallel, Some(Some(12)));
+
+    let args: OptionalArgs = figue::from_slice(&["--parallel=12"]).unwrap();
+    assert_eq!(args.parallel, Some(Some(12)));
+
+    let args: OptionalArgs = figue::from_slice(&["--parallel", "--dry-run"]).unwrap();
+    assert_eq!(args.parallel, Some(None));
+    assert!(args.dry_run);
+}
+
+#[test]
+fn optional_value_duplicate_non_multiple_errors() {
+    let err = figue::from_slice::<OptionalArgs>(&["--parallel", "--parallel=2"]).unwrap_err();
+    assert!(
+        err.to_string().contains("provided multiple times"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn optional_value_short_forms() {
+    let args: OptionalArgs = figue::from_slice(&["-p"]).unwrap();
+    assert_eq!(args.parallel, Some(None));
+
+    let args: OptionalArgs = figue::from_slice(&["-p12"]).unwrap();
+    assert_eq!(args.parallel, Some(Some(12)));
+
+    let args: OptionalArgs = figue::from_slice(&["-p=12"]).unwrap();
+    assert_eq!(args.parallel, Some(Some(12)));
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct OptionalShortCluster {
+    #[facet(args::named, args::short = 'p')]
+    parallel: Option<Option<String>>,
+
+    #[facet(args::named, args::short = 'v')]
+    verbose: bool,
+}
+
+#[test]
+fn optional_value_short_cluster_trailing_chars_are_value() {
+    let args: OptionalShortCluster = figue::from_slice(&["-vp12"]).unwrap();
+    assert!(args.verbose);
+    assert_eq!(args.parallel, Some(Some("12".to_string())));
+
+    let args: OptionalShortCluster = figue::from_slice(&["-pv"]).unwrap();
+    assert!(!args.verbose);
+    assert_eq!(args.parallel, Some(Some("v".to_string())));
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct OptionalNegative {
+    #[facet(args::named)]
+    limit: Option<Option<isize>>,
+}
+
+#[test]
+fn optional_value_dash_prefixed_values_use_equals() {
+    let args: OptionalNegative = figue::from_slice(&["--limit=-3"]).unwrap();
+    assert_eq!(args.limit, Some(Some(-3)));
+
+    let err = figue::from_slice::<OptionalNegative>(&["--limit", "-3"]).unwrap_err();
+    assert!(
+        err.to_string().contains("unknown flag: -3"),
+        "unexpected error: {err}"
+    );
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct App {
+    #[facet(args::named)]
+    parallel: Option<Option<usize>>,
+
+    #[facet(args::subcommand)]
+    command: Command,
+}
+
+#[derive(Facet, Debug, PartialEq)]
+#[repr(u8)]
+enum Command {
+    Run {
+        #[facet(args::named)]
+        dry_run: bool,
+    },
+}
+
+#[test]
+fn optional_value_global_adoption_after_subcommand() {
+    let app: App = figue::from_slice(&["run", "--parallel", "--dry-run"]).unwrap();
+    assert_eq!(app.parallel, Some(None));
+    assert_eq!(app.command, Command::Run { dry_run: true });
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct RequiredValueArgs {
+    #[facet(args::named, args::short = 'j')]
+    concurrency: usize,
+}
+
+#[test]
+fn required_value_flags_still_error_when_bare() {
+    let err = figue::from_slice::<RequiredValueArgs>(&["--concurrency"]).unwrap_err();
+    assert!(err.to_string().contains("requires a value"));
+
+    let err = figue::from_slice::<RequiredValueArgs>(&["-j"]).unwrap_err();
+    assert!(err.to_string().contains("requires a value"));
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct OptionalBoolArgs {
+    #[facet(args::named)]
+    flag: Option<Option<bool>>,
+}
+
+#[test]
+fn nested_optional_bool_stays_bool_flag() {
+    let args: OptionalBoolArgs = figue::from_slice::<OptionalBoolArgs>(&[]).unwrap();
+    assert_eq!(args.flag, None);
+
+    let args: OptionalBoolArgs = figue::from_slice(&["--flag"]).unwrap();
+    assert_eq!(args.flag, Some(Some(true)));
+
+    let args: OptionalBoolArgs = figue::from_slice(&["--no-flag"]).unwrap();
+    assert_eq!(args.flag, Some(Some(false)));
+}
+
+#[derive(Facet, Debug, PartialEq)]
+struct SurfaceArgs {
+    /// Set parallelism
+    #[facet(args::named)]
+    parallel: Option<Option<usize>>,
+
+    /// Set jobs
+    #[facet(args::named)]
+    jobs: Option<usize>,
+}
+
+#[test]
+fn optional_value_help_and_completions_render_optional_placeholder() {
+    let help = figue::generate_help::<SurfaceArgs>(&figue::HelpConfig {
+        program_name: Some("app".to_string()),
+        ..Default::default()
+    });
+    assert!(
+        help.contains("--parallel[=<USIZE>]"),
+        "help should show optional value placeholder:\n{help}"
+    );
+    assert!(
+        help.contains("--jobs <USIZE>"),
+        "ordinary option should keep required value placeholder:\n{help}"
+    );
+
+    let zsh = figue::generate_completions_for_shape(SurfaceArgs::SHAPE, figue::Shell::Zsh, "app");
+    assert!(zsh.contains("--parallel[Set parallelism]::value:_default"));
+    assert!(zsh.contains("--jobs[Set jobs]:value:_default"));
+
+    let bash = figue::generate_completions_for_shape(SurfaceArgs::SHAPE, figue::Shell::Bash, "app");
+    assert!(bash.contains("--parallel"));
+    assert!(!bash.contains("--parallel)\n            # Value expected"));
+}
+
+


### PR DESCRIPTION
Closes #2414.

## What changed

This adds support for optional-value named CLI arguments in `figue`, so `Option<Option<T>>` can represent three distinct states for a named flag:

- omitted
- explicitly present without a value
- present with a value

The implementation ports the Teamy behavior into the monorepo by introducing an explicit nested-option representation in `ConfigValue`, teaching CLI parsing and `facet-format` about that state, and updating help/completions plus downstream config-value handling to preserve and consume it correctly.

## Why

Before this change, `figue` could not distinguish between:

- a flag being absent entirely
- a flag being provided bare to mean explicit presence

That made `Option<Option<T>>` unusable for named args even though it is a useful CLI shape for things like `--parallel` versus `--parallel=12`.

## Impact

Users can now model optional-value named flags directly as `Option<Option<T>>` and get:

- correct parsing for long and short forms
- correct help and completion rendering
- correct roundtripping through the config-value pipeline for future `to_args` support

## Root cause

The CLI/config pipeline needed an explicit representation for `Some(...)` at an outer option layer. Without that, nested optional values collapsed during parsing and deserialization, so the bare-flag state could not survive end-to-end.

## Validation

- `cargo test -p figue optional_value --tests`
- `cargo test -p figue --test main`
- `cargo test -p figue --lib`
