### PR TITLE
vox: axum websocket transport + first-party ws connect on wasm

### DIFF
--- a/.github/workflows/vox.yml
+++ b/.github/workflows/vox.yml
@@ -340,6 +340,9 @@ jobs:
       - name: Check vox (default features) for wasm32
         run: cargo check --target wasm32-unknown-unknown -p vox
 
+      - name: Check vox facade for wasm32 (websocket transport)
+        run: cargo check --target wasm32-unknown-unknown -p vox --no-default-features --features runtime,transport-websocket
+
       - name: Check vox-websocket for wasm32
         run: cargo check --target wasm32-unknown-unknown -p vox-websocket
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8506,8 +8506,10 @@ dependencies = [
 name = "wasm-browser-tests"
 version = "0.10.0-rc.1"
 dependencies = [
+ "futures-util",
  "spec-proto",
  "vox",
+ "vox-rt",
  "vox-types",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http",
@@ -426,8 +427,10 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_path_to_error",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -4866,6 +4869,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 name = "peer-server"
 version = "0.2.2"
 dependencies = [
+ "axum",
  "spec-proto",
  "subject-rust",
  "tokio",
@@ -8335,6 +8339,7 @@ dependencies = [
 name = "vox-websocket"
 version = "0.10.0-rc.5"
 dependencies = [
+ "axum",
  "futures-channel",
  "futures-util",
  "js-sys",
@@ -8502,9 +8507,8 @@ name = "wasm-browser-tests"
 version = "0.10.0-rc.1"
 dependencies = [
  "spec-proto",
- "vox-core",
+ "vox",
  "vox-types",
- "vox-websocket",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,7 +381,7 @@ arborium-highlight = "^2.4.5"
 arborium-theme = "^2.4.5"
 aho-corasick = "1.1.4"
 autocfg = "^1.5.0"
-axum = { version = "0.8.9", default-features = false, features = ["http1", "tokio", "json"] }
+axum = { version = "0.8.9", default-features = false, features = ["http1", "tokio", "json", "ws"] }
 ariadne = "^0.6"
 blake3 = "^1"
 bolero = "^0.13.4"

--- a/vox/rust/vox-websocket/Cargo.toml
+++ b/vox/rust/vox-websocket/Cargo.toml
@@ -16,6 +16,7 @@ description = "WebSocket transport for vox — message-framed Link over tungsten
 
 [package.metadata."docs.rs"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
+features = ["axum"]
 
 [features]
 # Native-only: bridge an `axum` websocket route to a vox [`Link`].

--- a/vox/rust/vox-websocket/Cargo.toml
+++ b/vox/rust/vox-websocket/Cargo.toml
@@ -17,6 +17,10 @@ description = "WebSocket transport for vox — message-framed Link over tungsten
 [package.metadata."docs.rs"]
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
+[features]
+# Native-only: bridge an `axum` websocket route to a vox [`Link`].
+axum = ["dep:axum"]
+
 [dependencies]
 vox-types.workspace = true
 vox-core.workspace = true
@@ -25,6 +29,7 @@ vox-core.workspace = true
 tokio = { workspace = true, features = ["net", "rt", "sync", "macros"] }
 tokio-tungstenite.workspace = true
 futures-util.workspace = true
+axum = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen.workspace = true
@@ -34,7 +39,6 @@ web-sys = { workspace = true, features = [
   "BinaryType",
   "MessageEvent",
   "CloseEvent",
-  "DomException",
   "ErrorEvent",
 ] }
 futures-channel.workspace = true

--- a/vox/rust/vox-websocket/src/axum.rs
+++ b/vox/rust/vox-websocket/src/axum.rs
@@ -1,0 +1,191 @@
+//! axum integration: bridge an axum websocket route to a vox [`Link`].
+//!
+//! An [`AxumWsLink`] wraps the [`WebSocket`] handed to
+//! [`WebSocketUpgrade::on_upgrade`](axum::extract::ws::WebSocketUpgrade::on_upgrade),
+//! so an existing axum HTTP server can host a vox endpoint alongside its other
+//! routes. Framing is identical to the native [`WsLink`](crate::WsLink): each
+//! vox payload maps 1:1 to a binary WebSocket frame.
+
+use std::io;
+
+use axum::extract::ws::{Message as AxumMessage, WebSocket};
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use vox_types::{Backing, Link, LinkRx, LinkTx};
+
+/// A [`Link`] over an axum [`WebSocket`].
+pub struct AxumWsLink {
+    socket: WebSocket,
+}
+
+impl AxumWsLink {
+    /// Wrap an already-upgraded axum [`WebSocket`].
+    pub fn new(socket: WebSocket) -> Self {
+        Self { socket }
+    }
+}
+
+impl Link for AxumWsLink {
+    type Tx = AxumWsLinkTx;
+    type Rx = AxumWsLinkRx;
+
+    fn split(self) -> (Self::Tx, Self::Rx) {
+        let (tx_out, rx_out) = mpsc::channel::<Vec<u8>>(1);
+        let (tx_in, rx_in) = mpsc::channel::<Result<AxumMessage, io::Error>>(1);
+
+        let io_task = tokio::spawn(io_loop(self.socket, rx_out, tx_in));
+
+        (
+            AxumWsLinkTx {
+                tx: tx_out,
+                io_task,
+            },
+            AxumWsLinkRx { rx: rx_in },
+        )
+    }
+}
+
+/// Background I/O task that owns the axum [`WebSocket`].
+///
+/// Mirrors the native [`WsLink`](crate::WsLink) I/O loop: outbound payloads are
+/// coalesced then flushed as binary frames, and inbound frames are forwarded to
+/// the read channel. When the write channel closes the socket is dropped,
+/// causing the peer to see EOF.
+async fn io_loop(
+    mut ws: WebSocket,
+    mut rx_out: mpsc::Receiver<Vec<u8>>,
+    tx_in: mpsc::Sender<Result<AxumMessage, io::Error>>,
+) {
+    loop {
+        tokio::select! {
+            // Outbound: drain the write channel and send as binary frames.
+            msg = rx_out.recv() => {
+                match msg {
+                    Some(bytes) => {
+                        if let Err(e) = ws.feed(AxumMessage::binary(bytes)).await {
+                            let _ = tx_in.send(Err(io::Error::other(e.to_string()))).await;
+                            return;
+                        }
+                        // Coalesce: drain any already-queued messages before flushing.
+                        while let Ok(bytes) = rx_out.try_recv() {
+                            if let Err(e) = ws.feed(AxumMessage::binary(bytes)).await {
+                                let _ = tx_in.send(Err(io::Error::other(e.to_string()))).await;
+                                return;
+                            }
+                        }
+                        if let Err(e) = ws.flush().await {
+                            let _ = tx_in.send(Err(io::Error::other(e.to_string()))).await;
+                            return;
+                        }
+                    }
+                    None => {
+                        // Write channel closed — drop the socket, EOF for the peer.
+                        return;
+                    }
+                }
+            }
+            // Inbound: read from the socket and forward to the read channel.
+            frame = ws.next() => {
+                match frame {
+                    Some(Ok(msg)) => {
+                        if tx_in.send(Ok(msg)).await.is_err() {
+                            // Reader dropped — shut down.
+                            return;
+                        }
+                    }
+                    Some(Err(e)) => {
+                        let _ = tx_in.send(Err(io::Error::other(e.to_string()))).await;
+                        return;
+                    }
+                    None => {
+                        // WebSocket stream ended.
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tx
+// ---------------------------------------------------------------------------
+
+/// Sending half of an [`AxumWsLink`].
+pub struct AxumWsLinkTx {
+    tx: mpsc::Sender<Vec<u8>>,
+    io_task: JoinHandle<()>,
+}
+
+impl LinkTx for AxumWsLinkTx {
+    async fn send(&self, bytes: Vec<u8>) -> io::Result<()> {
+        let permit = self.tx.clone().reserve_owned().await.map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "websocket writer task stopped",
+            )
+        })?;
+        drop(permit.send(bytes));
+        Ok(())
+    }
+
+    async fn close(self) -> io::Result<()> {
+        drop(self.tx);
+        self.io_task.await.map_err(io::Error::other)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rx
+// ---------------------------------------------------------------------------
+
+/// Receiving half of an [`AxumWsLink`].
+pub struct AxumWsLinkRx {
+    rx: mpsc::Receiver<Result<AxumMessage, io::Error>>,
+}
+
+/// Error type for [`AxumWsLinkRx`].
+#[derive(Debug)]
+pub struct AxumWsLinkRxError(io::Error);
+
+impl std::fmt::Display for AxumWsLinkRxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "axum websocket rx: {}", self.0)
+    }
+}
+
+impl std::error::Error for AxumWsLinkRxError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl LinkRx for AxumWsLinkRx {
+    type Error = AxumWsLinkRxError;
+
+    async fn recv(&mut self) -> Result<Option<Backing>, Self::Error> {
+        loop {
+            match self.rx.recv().await {
+                Some(Ok(AxumMessage::Binary(data))) => {
+                    return Ok(Some(Backing::Boxed(data.to_vec().into_boxed_slice())));
+                }
+                Some(Ok(AxumMessage::Close(_))) | None => {
+                    return Ok(None);
+                }
+                Some(Ok(AxumMessage::Ping(_) | AxumMessage::Pong(_))) => {
+                    continue;
+                }
+                Some(Ok(AxumMessage::Text(_))) => {
+                    return Err(AxumWsLinkRxError(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "text frames not allowed on vox websocket link",
+                    )));
+                }
+                Some(Err(e)) => {
+                    return Err(AxumWsLinkRxError(e));
+                }
+            }
+        }
+    }
+}

--- a/vox/rust/vox-websocket/src/lib.rs
+++ b/vox/rust/vox-websocket/src/lib.rs
@@ -5,6 +5,8 @@
 //!
 //! - **Native**: uses `tokio-tungstenite`
 //! - **WASM**: uses `web_sys::WebSocket`
+//! - **axum** (feature `axum`, native): bridges an axum websocket route to a
+//!   vox [`Link`](vox_types::Link) via [`AxumWsLink`].
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native;
@@ -15,3 +17,8 @@ pub use native::*;
 mod wasm;
 #[cfg(target_arch = "wasm32")]
 pub use wasm::*;
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "axum"))]
+mod axum;
+#[cfg(all(not(target_arch = "wasm32"), feature = "axum"))]
+pub use axum::{AxumWsLink, AxumWsLinkRx, AxumWsLinkRxError, AxumWsLinkTx};

--- a/vox/rust/vox-websocket/src/lib.rs
+++ b/vox/rust/vox-websocket/src/lib.rs
@@ -6,7 +6,7 @@
 //! - **Native**: uses `tokio-tungstenite`
 //! - **WASM**: uses `web_sys::WebSocket`
 //! - **axum** (feature `axum`, native): bridges an axum websocket route to a
-//!   vox [`Link`](vox_types::Link) via [`AxumWsLink`].
+//!   vox `Link` via `AxumWsLink`.
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native;

--- a/vox/rust/vox-websocket/src/wasm.rs
+++ b/vox/rust/vox-websocket/src/wasm.rs
@@ -259,18 +259,10 @@ impl LinkRx for WsLinkRx {
     type Error = WsLinkRxError;
 
     async fn recv(&mut self) -> Result<Option<Backing>, WsLinkRxError> {
-        loop {
-            match self.rx.next().await {
-                Some(WsEvent::Message(data)) => {
-                    return Ok(Some(Backing::Boxed(data.into_boxed_slice())));
-                }
-                Some(WsEvent::Close) | None => {
-                    return Ok(None);
-                }
-                Some(WsEvent::Error(e)) => {
-                    return Err(WsLinkRxError(format!("WebSocket error: {e}")));
-                }
-            }
+        match self.rx.next().await {
+            Some(WsEvent::Message(data)) => Ok(Some(Backing::Boxed(data.into_boxed_slice()))),
+            Some(WsEvent::Close) | None => Ok(None),
+            Some(WsEvent::Error(e)) => Err(WsLinkRxError(format!("WebSocket error: {e}"))),
         }
     }
 }

--- a/vox/rust/vox-websocket/src/wasm.rs
+++ b/vox/rust/vox-websocket/src/wasm.rs
@@ -1,15 +1,15 @@
 //! WASM (web_sys) WebSocket transport implementing [`Link`].
 
 use std::cell::RefCell;
-use std::io::{self, ErrorKind};
+use std::io;
 
 use futures_channel::mpsc;
 use futures_util::{StreamExt, lock::Mutex};
 use js_sys::ArrayBuffer;
 use vox_types::{Backing, Link, LinkRx, LinkTx};
+use wasm_bindgen::JsCast;
 use wasm_bindgen::closure::Closure;
-use wasm_bindgen::{JsCast, JsValue};
-use web_sys::{BinaryType, CloseEvent, DomException, ErrorEvent, MessageEvent, WebSocket};
+use web_sys::{BinaryType, CloseEvent, ErrorEvent, MessageEvent, WebSocket};
 
 enum WsEvent {
     Message(Vec<u8>),
@@ -77,34 +77,11 @@ pub fn ws_link_source(url: impl Into<String>) -> WsLinkSource {
 impl vox_core::LinkSource for WsLinkSource {
     type Link = WsLink;
     async fn next_link(&mut self) -> io::Result<vox_core::Attachment<Self::Link>> {
-        let websocket = WebSocket::new(&self.url).map_err(convert_js_err)?;
-        Ok(vox_core::Attachment::initiator(WsLink::new(websocket)))
-    }
-}
-
-#[derive(Debug)]
-struct JsError(DomException);
-
-impl core::error::Error for JsError {}
-
-impl core::fmt::Display for JsError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} ({}): {}",
-            self.0.name(),
-            self.0.code(),
-            self.0.message()
-        )
-    }
-}
-// see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket#exceptions
-fn convert_js_err(val: JsValue) -> io::Error {
-    match val.dyn_into::<DomException>() {
-        Ok(e) => io::Error::new(ErrorKind::InvalidInput, JsError(e)),
-        Err(_) => {
-            io::Error::other("exception during websocket creation but cannot cast to DomException")
-        }
+        // Wait for the socket to reach OPEN before handing it to the initiator.
+        // Otherwise the initiator's first `send` races the connection and fails
+        // with "WebSocket is still in CONNECTING state".
+        let link = WsLink::connect(&self.url).await?;
+        Ok(vox_core::Attachment::initiator(link))
     }
 }
 

--- a/vox/rust/wasm-browser-tests/Cargo.toml
+++ b/vox/rust/wasm-browser-tests/Cargo.toml
@@ -16,7 +16,9 @@ vox = { path = "../vox", default-features = false, features = [
   "transport-websocket",
 ] }
 vox-types.workspace = true
+vox-rt.workspace = true
 spec-proto.workspace = true
 
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
+futures-util.workspace = true

--- a/vox/rust/wasm-browser-tests/Cargo.toml
+++ b/vox/rust/wasm-browser-tests/Cargo.toml
@@ -9,8 +9,12 @@ crate-type = ["cdylib"]
 
 # All dependencies are wasm32-only since the entire crate is cfg-gated
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-vox-websocket.workspace = true
-vox-core.workspace = true
+# Exercise the first-party high-level connect path (`vox::connect_lane`) on
+# wasm, rather than reaching for the low-level link + initiator directly.
+vox = { path = "../vox", default-features = false, features = [
+  "runtime",
+  "transport-websocket",
+] }
 vox-types.workspace = true
 spec-proto.workspace = true
 

--- a/vox/rust/wasm-browser-tests/src/lib.rs
+++ b/vox/rust/wasm-browser-tests/src/lib.rs
@@ -8,8 +8,6 @@
 #![cfg(target_arch = "wasm32")]
 
 use spec_proto::{Color, LookupError, MathError, Message, Point, Rectangle, Shape, TestbedClient};
-use vox_core::initiator_on;
-use vox_websocket::WsLink;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -71,12 +69,14 @@ impl TestResults {
 pub async fn run_tests(ws_url: &str) -> TestResults {
     let mut results = Vec::new();
 
-    console_log!("Connecting to {ws_url}...");
+    console_log!("Connecting to {ws_url} via vox::connect_lane...");
 
-    let link = match WsLink::connect(ws_url).await {
-        Ok(l) => l,
+    // First-party high-level connect: parses the `ws://`/`wss://` scheme, opens
+    // a browser WebSocket, performs the vox handshake, and opens a typed lane.
+    let client: TestbedClient = match vox::connect_lane(ws_url).await {
+        Ok(client) => client,
         Err(e) => {
-            console_error!("Failed to connect: {e:?}");
+            console_error!("connect_lane failed: {e:?}");
             results.push(TestResult {
                 name: "connect".into(),
                 passed: false,
@@ -86,22 +86,7 @@ pub async fn run_tests(ws_url: &str) -> TestResults {
         }
     };
 
-    console_log!("Connected! Performing handshake...");
-
-    let client = match initiator_on(link).establish::<TestbedClient>().await {
-        Ok(result) => result,
-        Err(e) => {
-            console_error!("Handshake failed: {e:?}");
-            results.push(TestResult {
-                name: "handshake".into(),
-                passed: false,
-                error: Some(format!("{e:?}")),
-            });
-            return TestResults { results };
-        }
-    };
-
-    console_log!("Handshake complete.");
+    console_log!("Connected and lane opened.");
 
     // Run echo tests
     run_echo_tests(&client, &mut results).await;

--- a/vox/rust/wasm-browser-tests/src/lib.rs
+++ b/vox/rust/wasm-browser-tests/src/lib.rs
@@ -258,7 +258,7 @@ async fn run_complex_tests(client: &TestbedClient, results: &mut Vec<TestResult>
     // Test: parse_color
     console_log!("Testing parse_color...");
     match client.parse_color("red".into()).await {
-        Ok(result) if matches!(result, Some(Color::Red)) => {
+        Ok(Some(Color::Red)) => {
             results.push(TestResult {
                 name: "parse_color".into(),
                 passed: true,
@@ -460,7 +460,7 @@ async fn run_fallible_tests(client: &TestbedClient, results: &mut Vec<TestResult
     // Test: divide (success)
     console_log!("Testing divide (success)...");
     match client.divide(10, 2).await {
-        Ok(result) if result == 5 => {
+        Ok(5) => {
             results.push(TestResult {
                 name: "divide_success".into(),
                 passed: true,
@@ -566,5 +566,273 @@ async fn run_fallible_tests(client: &TestbedClient, results: &mut Vec<TestResult
                 error: Some(format!("expected NotFound, got {e:?}")),
             });
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stress / soak test
+// ---------------------------------------------------------------------------
+//
+// Opens many concurrent WebSocket connections to the *same* server, and on
+// each one hammers a rotating mix of request/response calls, error paths, and
+// both stream directions until a deadline. Every call is wrapped in a
+// per-call timeout so a wedged connection is reported as "stuck" rather than
+// hanging the whole run.
+
+use std::time::Duration;
+
+use futures_util::future::{FutureExt, LocalBoxFuture, join, join_all};
+use vox_rt::time::{Instant, timeout};
+
+/// How long a single RPC may take before we consider the connection stuck.
+const PER_CALL_TIMEOUT: Duration = Duration::from_secs(5);
+/// Number of distinct operations the workers rotate through.
+const OP_COUNT: u64 = 10;
+
+/// Aggregated result of a stress run, surfaced to JS.
+#[wasm_bindgen]
+pub struct StressSummary {
+    connections: u32,
+    connected: u32,
+    total_requests: u64,
+    total_errors: u64,
+    stuck: u64,
+    elapsed_ms: f64,
+    first_error: Option<String>,
+}
+
+#[wasm_bindgen]
+impl StressSummary {
+    #[wasm_bindgen(getter)]
+    pub fn connections(&self) -> u32 {
+        self.connections
+    }
+
+    /// Number of workers that successfully established a connection + lane.
+    #[wasm_bindgen(getter)]
+    pub fn connected(&self) -> u32 {
+        self.connected
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn total_requests(&self) -> f64 {
+        self.total_requests as f64
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn total_errors(&self) -> f64 {
+        self.total_errors as f64
+    }
+
+    /// Number of calls that exceeded [`PER_CALL_TIMEOUT`] (i.e. got stuck).
+    #[wasm_bindgen(getter)]
+    pub fn stuck(&self) -> f64 {
+        self.stuck as f64
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn elapsed_ms(&self) -> f64 {
+        self.elapsed_ms
+    }
+
+    pub fn get_first_error(&self) -> Option<String> {
+        self.first_error.clone()
+    }
+
+    /// Everything connected, and no errors or stuck calls occurred.
+    pub fn all_ok(&self) -> bool {
+        self.connected == self.connections
+            && self.total_errors == 0
+            && self.stuck == 0
+            && self.total_requests > 0
+    }
+}
+
+#[derive(Default)]
+struct WorkerStats {
+    connected: bool,
+    requests: u64,
+    errors: u64,
+    stuck: u64,
+    first_error: Option<String>,
+}
+
+impl WorkerStats {
+    fn note_error(&mut self, msg: String) {
+        self.errors += 1;
+        if self.first_error.is_none() {
+            self.first_error = Some(msg);
+        }
+    }
+}
+
+/// Run the soak test: `connections` concurrent clients against `ws_url`, each
+/// looping for `duration_ms`.
+#[wasm_bindgen]
+pub async fn run_stress(ws_url: &str, connections: u32, duration_ms: f64) -> StressSummary {
+    let duration = Duration::from_millis(duration_ms as u64);
+    console_log!(
+        "Stress: {connections} connections against {ws_url} for {duration_ms}ms via vox::connect_lane"
+    );
+
+    let started = Instant::now();
+    let workers: Vec<LocalBoxFuture<'_, WorkerStats>> = (0..connections)
+        .map(|id| stress_worker(ws_url.to_string(), id, duration).boxed_local())
+        .collect();
+    let stats = join_all(workers).await;
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+
+    let mut summary = StressSummary {
+        connections,
+        connected: 0,
+        total_requests: 0,
+        total_errors: 0,
+        stuck: 0,
+        elapsed_ms,
+        first_error: None,
+    };
+    for st in stats {
+        if st.connected {
+            summary.connected += 1;
+        }
+        summary.total_requests += st.requests;
+        summary.total_errors += st.errors;
+        summary.stuck += st.stuck;
+        if summary.first_error.is_none() {
+            summary.first_error = st.first_error;
+        }
+    }
+
+    console_log!(
+        "Stress done: connected={}/{}, requests={}, errors={}, stuck={}, elapsed={:.0}ms",
+        summary.connected,
+        summary.connections,
+        summary.total_requests,
+        summary.total_errors,
+        summary.stuck,
+        summary.elapsed_ms
+    );
+    summary
+}
+
+async fn stress_worker(ws_url: String, id: u32, duration: Duration) -> WorkerStats {
+    let mut stats = WorkerStats::default();
+
+    let client: TestbedClient = match vox::connect_lane(&ws_url).await {
+        Ok(client) => client,
+        Err(e) => {
+            stats.note_error(format!("worker {id} connect: {e:?}"));
+            return stats;
+        }
+    };
+    stats.connected = true;
+
+    let deadline = Instant::now() + duration;
+    let mut i: u64 = 0;
+    while Instant::now() < deadline {
+        match timeout(PER_CALL_TIMEOUT, run_one_op(&client, i)).await {
+            Ok(Ok(())) => stats.requests += 1,
+            Ok(Err(msg)) => stats.note_error(format!("worker {id} {msg}")),
+            Err(_) => {
+                stats.stuck += 1;
+                if stats.first_error.is_none() {
+                    stats.first_error = Some(format!(
+                        "worker {id} op {} stuck > {PER_CALL_TIMEOUT:?}",
+                        i % OP_COUNT
+                    ));
+                }
+                // A stuck connection won't recover; stop hammering it.
+                break;
+            }
+        }
+        i += 1;
+    }
+
+    stats
+}
+
+/// Execute one operation from the rotating mix and validate its result.
+async fn run_one_op(client: &TestbedClient, i: u64) -> Result<(), String> {
+    match i % OP_COUNT {
+        0 => match client.echo("stress".into()).await {
+            Ok(s) if s == "stress" => Ok(()),
+            Ok(s) => Err(format!("echo got {s:?}")),
+            Err(e) => Err(format!("echo: {e:?}")),
+        },
+        1 => match client.reverse("abcdef".into()).await {
+            Ok(s) if s == "fedcba" => Ok(()),
+            Ok(s) => Err(format!("reverse got {s:?}")),
+            Err(e) => Err(format!("reverse: {e:?}")),
+        },
+        2 => match client.divide(84, 2).await {
+            Ok(42) => Ok(()),
+            Ok(v) => Err(format!("divide got {v}")),
+            Err(e) => Err(format!("divide: {e:?}")),
+        },
+        3 => match client.divide(1, 0).await {
+            Err(vox_types::VoxError::User(e)) if matches!(*e, MathError::DivisionByZero) => Ok(()),
+            other => Err(format!("divide-by-zero expected error, got {other:?}")),
+        },
+        4 => match client.lookup(1).await {
+            Ok(p) if p.name == "Alice" => Ok(()),
+            Ok(p) => Err(format!("lookup got {p:?}")),
+            Err(e) => Err(format!("lookup: {e:?}")),
+        },
+        5 => match client.lookup(999).await {
+            Err(vox_types::VoxError::User(e)) if matches!(*e, LookupError::NotFound) => Ok(()),
+            other => Err(format!("lookup-missing expected NotFound, got {other:?}")),
+        },
+        6 => {
+            let point = Point { x: 3, y: -4 };
+            match client.echo_point(point.clone()).await {
+                Ok(p) if p == point => Ok(()),
+                Ok(p) => Err(format!("echo_point got {p:?}")),
+                Err(e) => Err(format!("echo_point: {e:?}")),
+            }
+        }
+        7 => match client.get_points(3).await {
+            Ok(pts) if pts.len() == 3 && pts[2] == (Point { x: 2, y: 4 }) => Ok(()),
+            Ok(pts) => Err(format!("get_points got {pts:?}")),
+            Err(e) => Err(format!("get_points: {e:?}")),
+        },
+        8 => stress_sum(client).await,
+        _ => stress_generate(client).await,
+    }
+}
+
+/// Client-to-server stream: send 0..10 and expect the server to sum them (45).
+async fn stress_sum(client: &TestbedClient) -> Result<(), String> {
+    let (tx, rx) = vox::channel::<i32>();
+    let produce = async move {
+        for n in 0..10 {
+            let _ = tx.send(n).await;
+        }
+        let _ = tx.close(Default::default()).await;
+    };
+    let (_, resp) = join(produce, client.sum(rx)).await;
+    match resp {
+        Ok(45) => Ok(()),
+        Ok(v) => Err(format!("sum got {v}")),
+        Err(e) => Err(format!("sum: {e:?}")),
+    }
+}
+
+/// Server-to-client stream: ask for 8 values and expect 0..8.
+async fn stress_generate(client: &TestbedClient) -> Result<(), String> {
+    let (tx, mut rx) = vox::channel::<i32>();
+    let drain = async move {
+        let mut received = Vec::new();
+        while let Ok(Some(n)) = rx.recv().await {
+            received.push(*n.get());
+        }
+        received
+    };
+    let (call, received) = join(client.generate(8, tx), drain).await;
+    call.map_err(|e| format!("generate: {e:?}"))?;
+    let expected: Vec<i32> = (0..8).collect();
+    if received == expected {
+        Ok(())
+    } else {
+        Err(format!("generate got {received:?}"))
     }
 }

--- a/vox/typescript/peer-server/Cargo.toml
+++ b/vox/typescript/peer-server/Cargo.toml
@@ -15,9 +15,14 @@ rustdoc-args = ["--html-in-header", "arborium-header.html"]
 name = "ws-peer-server"
 path = "src/main.rs"
 
+[[bin]]
+name = "axum-peer-server"
+path = "src/bin/axum-peer-server.rs"
+
 [dependencies]
 vox-core.workspace = true
-vox-websocket.workspace = true
+vox-websocket = { workspace = true, features = ["axum"] }
 spec-proto.workspace = true
 subject-rust.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "macros"] }
+axum.workspace = true

--- a/vox/typescript/peer-server/src/bin/axum-peer-server.rs
+++ b/vox/typescript/peer-server/src/bin/axum-peer-server.rs
@@ -1,11 +1,9 @@
 //! axum HTTP peer server hosting a vox endpoint on a websocket route.
 //!
 //! Unlike `ws-peer-server` (a bare `tokio-tungstenite` accept loop), this is a
-//! real [`axum`] HTTP application: it serves a plain route at `/` and upgrades
-//! `/ws` into a vox [`Link`](vox_types::Link) via
-//! [`AxumWsLink`](vox_websocket::AxumWsLink), running the shared
-//! [`TestbedService`](subject_rust::TestbedService). Clients connect to
-//! `ws://host:port/ws`.
+//! real `axum` HTTP application: it serves a plain route at `/` and upgrades
+//! `/ws` into a vox `Link` via [`AxumWsLink`], running the shared
+//! [`TestbedService`]. Clients connect to `ws://host:port/ws`.
 
 use std::env;
 

--- a/vox/typescript/peer-server/src/bin/axum-peer-server.rs
+++ b/vox/typescript/peer-server/src/bin/axum-peer-server.rs
@@ -1,0 +1,74 @@
+//! axum HTTP peer server hosting a vox endpoint on a websocket route.
+//!
+//! Unlike `ws-peer-server` (a bare `tokio-tungstenite` accept loop), this is a
+//! real [`axum`] HTTP application: it serves a plain route at `/` and upgrades
+//! `/ws` into a vox [`Link`](vox_types::Link) via
+//! [`AxumWsLink`](vox_websocket::AxumWsLink), running the shared
+//! [`TestbedService`](subject_rust::TestbedService). Clients connect to
+//! `ws://host:port/ws`.
+
+use std::env;
+
+use axum::Router;
+use axum::extract::ws::WebSocketUpgrade;
+use axum::response::Response;
+use axum::routing::get;
+use spec_proto::TestbedDispatcher;
+use subject_rust::TestbedService;
+use vox_core::acceptor_transport;
+use vox_websocket::AxumWsLink;
+
+const PEER_SERVER_RUNTIME_STACK_BYTES: usize = 32 * 1024 * 1024;
+
+fn main() -> Result<(), String> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .thread_stack_size(PEER_SERVER_RUNTIME_STACK_BYTES)
+        .enable_all()
+        .build()
+        .map_err(|e| format!("failed to create tokio runtime: {e}"))?;
+    rt.block_on(run())
+}
+
+async fn run() -> Result<(), String> {
+    let port = env::var("WS_PORT").unwrap_or_else(|_| "9000".to_string());
+    let addr = format!("127.0.0.1:{port}");
+
+    let app = Router::new()
+        .route("/", get(|| async { "vox axum peer server" }))
+        .route("/ws", get(ws_handler));
+
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .map_err(|e| format!("bind {addr}: {e}"))?;
+    eprintln!("axum peer server listening on http://{addr} (vox ws at /ws)");
+
+    // Print port on stdout for Playwright to parse.
+    println!("{port}");
+
+    axum::serve(listener, app)
+        .await
+        .map_err(|e| format!("serve: {e}"))
+}
+
+/// Upgrade an incoming HTTP request to a websocket and drive a vox connection
+/// over it, using the shared [`TestbedService`].
+async fn ws_handler(ws: WebSocketUpgrade) -> Response {
+    ws.on_upgrade(|socket| async move {
+        let link = AxumWsLink::new(socket);
+
+        let connection = match acceptor_transport(link)
+            .on_lane(TestbedDispatcher::new(TestbedService))
+            .establish_connection()
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Connection establishment failed: {e:?}");
+                return;
+            }
+        };
+
+        eprintln!("Connection established (axum)");
+        connection.closed().await;
+    })
+}

--- a/vox/typescript/tests/shared/ws-server.ts
+++ b/vox/typescript/tests/shared/ws-server.ts
@@ -7,7 +7,13 @@ const execFileAsync = promisify(execFile);
 const wsServerBuildTimeoutMs = 120_000;
 const wsServerStartupTimeoutMs = 5_000;
 
-let wsServerBuildPromise: Promise<void> | null = null;
+// Default vox peer-server binary: a bare tokio-tungstenite accept loop. The
+// axum variant (`axum-peer-server`) is selected by passing `binaryName`.
+const defaultBinaryName = "ws-peer-server";
+
+// Build promises are cached per binary name so requesting a different peer
+// server (e.g. the axum variant) doesn't return a stale build.
+const wsServerBuildPromises = new Map<string, Promise<void>>();
 let cargoTargetDirPromise: Promise<string> | null = null;
 
 // `projectRoot` (vox/) may be a standalone Cargo workspace or a subdirectory
@@ -26,14 +32,18 @@ function getCargoTargetDir(projectRoot: string): Promise<string> {
   return cargoTargetDirPromise;
 }
 
-export async function startWsServer(projectRoot: string, wsPort: number): Promise<ChildProcess> {
+export async function startWsServer(
+  projectRoot: string,
+  wsPort: number,
+  binaryName: string = defaultBinaryName,
+): Promise<ChildProcess> {
   const [, targetDir] = await Promise.all([
-    buildWsServerBinary(projectRoot),
+    buildWsServerBinary(projectRoot, binaryName),
     getCargoTargetDir(projectRoot),
   ]);
 
-  const binaryName = process.platform === "win32" ? "ws-peer-server.exe" : "ws-peer-server";
-  const binaryPath = join(targetDir, "debug", binaryName);
+  const executableName = process.platform === "win32" ? `${binaryName}.exe` : binaryName;
+  const binaryPath = join(targetDir, "debug", executableName);
   const wsServer = spawn(binaryPath, [], {
     cwd: projectRoot,
     env: { ...process.env, WS_PORT: String(wsPort) },
@@ -44,13 +54,14 @@ export async function startWsServer(projectRoot: string, wsPort: number): Promis
   return wsServer;
 }
 
-function buildWsServerBinary(projectRoot: string): Promise<void> {
-  if (wsServerBuildPromise) {
-    return wsServerBuildPromise;
+function buildWsServerBinary(projectRoot: string, binaryName: string): Promise<void> {
+  const cached = wsServerBuildPromises.get(binaryName);
+  if (cached) {
+    return cached;
   }
 
-  wsServerBuildPromise = new Promise<void>((resolve, reject) => {
-    const cargoBuild = spawn("cargo", ["build", "-p", "peer-server", "--bin", "ws-peer-server"], {
+  const buildPromise = new Promise<void>((resolve, reject) => {
+    const cargoBuild = spawn("cargo", ["build", "-p", "peer-server", "--bin", binaryName], {
       cwd: projectRoot,
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -83,11 +94,12 @@ function buildWsServerBinary(projectRoot: string): Promise<void> {
       reject(new Error(`WS server build failed (code=${code}, signal=${signal})`));
     });
   }).catch((err) => {
-    wsServerBuildPromise = null;
+    wsServerBuildPromises.delete(binaryName);
     throw err;
   });
 
-  return wsServerBuildPromise;
+  wsServerBuildPromises.set(binaryName, buildPromise);
+  return buildPromise;
 }
 
 function waitForWsServerReady(wsServer: ChildProcess, wsPort: number): Promise<void> {

--- a/vox/wasm/tests/browser-wasm/src/main.ts
+++ b/vox/wasm/tests/browser-wasm/src/main.ts
@@ -4,18 +4,32 @@
 // a Rust WebSocket server to verify cross-platform compatibility.
 
 // The wasm module is built by wasm-pack and placed in pkg/
-import init, { run_tests, TestResults } from '../pkg/wasm_browser_tests.js';
+import init, { run_stress, run_tests, TestResults } from '../pkg/wasm_browser_tests.js';
+
+interface StressReport {
+  connections: number;
+  connected: number;
+  totalRequests: number;
+  totalErrors: number;
+  stuck: number;
+  elapsedMs: number;
+  firstError?: string;
+  allOk: boolean;
+}
 
 // Make test results available to Playwright
 declare global {
   interface Window {
     testResults: { name: string; passed: boolean; error?: string }[];
+    stressSummary: StressReport | null;
     runTests: (wsUrl: string) => Promise<void>;
+    runStress: (wsUrl: string, connections: number, durationMs: number) => Promise<void>;
     testsComplete: boolean;
   }
 }
 
 window.testResults = [];
+window.stressSummary = null;
 window.testsComplete = false;
 
 function log(message: string) {
@@ -69,11 +83,62 @@ async function runWasmTests(wsUrl: string): Promise<void> {
   window.testsComplete = true;
 }
 
-window.runTests = runWasmTests;
+async function runWasmStress(wsUrl: string, connections: number, durationMs: number): Promise<void> {
+  log("Initializing Wasm module...");
 
-// Auto-run if ws= is in the URL params
+  try {
+    await init();
+    log(`Stress: ${connections} connections against ${wsUrl} for ${durationMs}ms...`);
+
+    const summary = await run_stress(wsUrl, connections, durationMs);
+    window.stressSummary = {
+      connections: summary.connections,
+      connected: summary.connected,
+      totalRequests: summary.total_requests,
+      totalErrors: summary.total_errors,
+      stuck: summary.stuck,
+      elapsedMs: summary.elapsed_ms,
+      firstError: summary.get_first_error() ?? undefined,
+      allOk: summary.all_ok(),
+    };
+    summary.free();
+
+    log(
+      `Stress done: connected=${window.stressSummary.connected}/${window.stressSummary.connections}, ` +
+        `requests=${window.stressSummary.totalRequests}, errors=${window.stressSummary.totalErrors}, ` +
+        `stuck=${window.stressSummary.stuck}`,
+    );
+  } catch (e) {
+    const error = e instanceof Error ? e.message : String(e);
+    log(`Error: ${error}`);
+    window.stressSummary = {
+      connections,
+      connected: 0,
+      totalRequests: 0,
+      totalErrors: 1,
+      stuck: 0,
+      elapsedMs: 0,
+      firstError: error,
+      allOk: false,
+    };
+  }
+
+  window.testsComplete = true;
+}
+
+window.runTests = runWasmTests;
+window.runStress = runWasmStress;
+
+// Auto-run based on URL params: `?stress=1` runs the soak test, otherwise the
+// one-shot conformance run.
 const urlParams = new URLSearchParams(window.location.search);
 const wsUrl = urlParams.get("ws");
 if (wsUrl) {
-  runWasmTests(wsUrl);
+  if (urlParams.get("stress")) {
+    const connections = Number(urlParams.get("connections") ?? "8");
+    const durationMs = Number(urlParams.get("durationMs") ?? "30000");
+    runWasmStress(wsUrl, connections, durationMs);
+  } else {
+    runWasmTests(wsUrl);
+  }
 }

--- a/vox/wasm/tests/playwright/ws-wasm-axum-stress.spec.ts
+++ b/vox/wasm/tests/playwright/ws-wasm-axum-stress.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect } from "@playwright/test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import { startWsServer } from "../../../typescript/tests/shared/ws-server";
+
+// Root of the vox project
+const projectRoot = new URL("../../../", import.meta.url).pathname;
+
+// Soak parameters: many concurrent connections to the same axum server,
+// hammered for a fixed wall-clock duration.
+const CONNECTIONS = 8;
+const DURATION_MS = 30_000;
+
+let wsServer: ChildProcess | null = null;
+let viteServer: ChildProcess | null = null;
+let wsPort = 0;
+let vitePort = 0;
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, () => {
+      const port = (srv.address() as { port: number }).port;
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+test.beforeAll(async () => {
+  wsPort = await getFreePort();
+  vitePort = await getFreePort();
+
+  // Start the axum HTTP peer server (vox endpoint on the /ws route).
+  console.log(`Starting axum peer server on port ${wsPort}...`);
+  wsServer = await startWsServer(projectRoot, wsPort, "axum-peer-server");
+  console.log(`axum peer server started on port ${wsPort}`);
+
+  // Start Vite dev server for wasm browser test app
+  console.log(`Starting Vite dev server for Wasm tests on port ${vitePort}...`);
+  viteServer = spawn("pnpm", ["exec", "vite", "--port", String(vitePort), "--host", "127.0.0.1"], {
+    cwd: `${projectRoot}wasm/tests/browser-wasm`,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = globalThis.setTimeout(
+      () => reject(new Error("Timeout starting Vite server")),
+      10000,
+    );
+
+    viteServer!.stdout!.on("data", (data: Buffer) => {
+      // eslint-disable-next-line no-control-regex
+      const text = data.toString().replace(/\x1b\[[0-9;]*m/g, "");
+      console.log(`[vite stdout] ${text.trim()}`);
+      if (text.includes(`127.0.0.1:${vitePort}`)) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+
+    viteServer!.stderr!.on("data", (data: Buffer) => {
+      console.log(`[vite stderr] ${data.toString().trim()}`);
+    });
+
+    viteServer!.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    viteServer!.on("exit", (code, signal) => {
+      clearTimeout(timeout);
+      reject(new Error(`Vite exited unexpectedly (code=${code}, signal=${signal})`));
+    });
+  });
+
+  console.log(`Vite dev server started on port ${vitePort}`);
+});
+
+test.afterAll(async () => {
+  if (viteServer) {
+    viteServer.kill("SIGTERM");
+    viteServer = null;
+  }
+  if (wsServer) {
+    wsServer.kill("SIGTERM");
+    wsServer = null;
+  }
+});
+
+test("stress: many concurrent wasm connections hammer the axum vox server", async ({ page }) => {
+  // Soak duration + module init + margin.
+  test.setTimeout(DURATION_MS + 60_000);
+
+  page.on("console", (msg) => {
+    console.log(`[browser ${msg.type()}] ${msg.text()}`);
+  });
+  page.on("pageerror", (err) => {
+    console.log(`[browser pageerror] ${err.message}`);
+  });
+  page.on("requestfailed", (req) => {
+    console.log(`[browser requestfailed] ${req.url()} - ${req.failure()?.errorText}`);
+  });
+
+  const wsUrl = `ws://127.0.0.1:${wsPort}/ws`;
+  const target = `http://127.0.0.1:${vitePort}/?ws=${encodeURIComponent(wsUrl)}&stress=1&connections=${CONNECTIONS}&durationMs=${DURATION_MS}`;
+  console.log(`Navigating to stress page (${target})...`);
+  await page.goto(target, { waitUntil: "networkidle" });
+
+  // Wait for the whole soak to finish (duration + generous margin).
+  await page.waitForFunction(() => (window as any).testsComplete === true, {
+    timeout: DURATION_MS + 30_000,
+  });
+
+  const summary = await page.evaluate(() => (window as any).stressSummary);
+  console.log("Stress summary:", summary);
+
+  expect(summary, "stress summary should be present").toBeTruthy();
+  // Every worker connected, nothing errored, nothing got stuck.
+  expect(summary.connected, "all connections should establish").toBe(CONNECTIONS);
+  expect(summary.stuck, `stuck calls (first error: ${summary.firstError})`).toBe(0);
+  expect(summary.totalErrors, `errors (first error: ${summary.firstError})`).toBe(0);
+  expect(summary.allOk).toBe(true);
+  // A real soak should push a lot of traffic through; guard against a no-op.
+  expect(summary.totalRequests).toBeGreaterThan(CONNECTIONS * 10);
+});

--- a/vox/wasm/tests/playwright/ws-wasm-axum-stress.spec.ts
+++ b/vox/wasm/tests/playwright/ws-wasm-axum-stress.spec.ts
@@ -9,7 +9,7 @@ const projectRoot = new URL("../../../", import.meta.url).pathname;
 // Soak parameters: many concurrent connections to the same axum server,
 // hammered for a fixed wall-clock duration.
 const CONNECTIONS = 8;
-const DURATION_MS = 30_000;
+const DURATION_MS = 10_000;
 
 let wsServer: ChildProcess | null = null;
 let viteServer: ChildProcess | null = null;

--- a/vox/wasm/tests/playwright/ws-wasm-axum.spec.ts
+++ b/vox/wasm/tests/playwright/ws-wasm-axum.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from "@playwright/test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import { startWsServer } from "../../../typescript/tests/shared/ws-server";
+
+// Root of the vox project
+const projectRoot = new URL("../../../", import.meta.url).pathname;
+
+let wsServer: ChildProcess | null = null;
+let viteServer: ChildProcess | null = null;
+let wsPort = 0;
+let vitePort = 0;
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, () => {
+      const port = (srv.address() as { port: number }).port;
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+test.beforeAll(async () => {
+  wsPort = await getFreePort();
+  vitePort = await getFreePort();
+
+  // Start the axum HTTP peer server (vox endpoint on the /ws route).
+  console.log(`Starting axum peer server on port ${wsPort}...`);
+  wsServer = await startWsServer(projectRoot, wsPort, "axum-peer-server");
+
+  console.log(`axum peer server started on port ${wsPort}`);
+
+  // Start Vite dev server for wasm browser test app
+  console.log(`Starting Vite dev server for Wasm tests on port ${vitePort}...`);
+  viteServer = spawn("pnpm", ["exec", "vite", "--port", String(vitePort), "--host", "127.0.0.1"], {
+    cwd: `${projectRoot}wasm/tests/browser-wasm`,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = globalThis.setTimeout(
+      () => reject(new Error("Timeout starting Vite server")),
+      10000,
+    );
+
+    viteServer!.stdout!.on("data", (data: Buffer) => {
+      // eslint-disable-next-line no-control-regex
+      const text = data.toString().replace(/\x1b\[[0-9;]*m/g, "");
+      console.log(`[vite stdout] ${text.trim()}`);
+      if (text.includes(`127.0.0.1:${vitePort}`)) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+
+    viteServer!.stderr!.on("data", (data: Buffer) => {
+      console.log(`[vite stderr] ${data.toString().trim()}`);
+    });
+
+    viteServer!.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    viteServer!.on("exit", (code, signal) => {
+      clearTimeout(timeout);
+      reject(new Error(`Vite exited unexpectedly (code=${code}, signal=${signal})`));
+    });
+  });
+
+  console.log(`Vite dev server started on port ${vitePort}`);
+});
+
+test.afterAll(async () => {
+  if (viteServer) {
+    viteServer.kill("SIGTERM");
+    viteServer = null;
+  }
+  if (wsServer) {
+    wsServer.kill("SIGTERM");
+    wsServer = null;
+  }
+});
+
+test("Rust/Wasm client (vox::connect_lane) can talk to an axum vox server", async ({ page }) => {
+  page.on("console", (msg) => {
+    console.log(`[browser ${msg.type()}] ${msg.text()}`);
+  });
+
+  page.on("pageerror", (err) => {
+    console.log(`[browser pageerror] ${err.message}`);
+  });
+
+  page.on("requestfailed", (req) => {
+    console.log(`[browser requestfailed] ${req.url()} - ${req.failure()?.errorText}`);
+  });
+
+  // The vox endpoint lives on the /ws route of the axum server.
+  const wsUrl = `ws://127.0.0.1:${wsPort}/ws`;
+  console.log(`Navigating to test page (vite=${vitePort}, ws=${wsUrl})...`);
+  await page.goto(`http://127.0.0.1:${vitePort}/?ws=${encodeURIComponent(wsUrl)}`, {
+    waitUntil: "networkidle",
+  });
+  console.log("Navigation complete, waiting for testsComplete...");
+
+  await page.waitForFunction(() => (window as any).testsComplete === true, { timeout: 10000 });
+  console.log("testsComplete is true");
+
+  const results = await page.evaluate(() => (window as any).testResults);
+  console.log("Wasm test results:", results);
+
+  expect(results).toBeInstanceOf(Array);
+  expect(results.length).toBeGreaterThan(0);
+
+  for (const result of results) {
+    expect(result.passed, `Test "${result.name}" failed: ${result.error}`).toBe(true);
+  }
+});


### PR DESCRIPTION
## What

Make `ws`/`wss` a first-party transport for `vox` even in a Rust→wasm build, and show (and test in CI) a wasm websocket vox client talking to a Rust HTTP server powered by **axum**.

### `AxumWsLink` — new
`vox-websocket` gains an optional, native-only `axum` feature exposing `AxumWsLink`, which implements `Link`/`LinkTx`/`LinkRx` over `axum::extract::ws::WebSocket`. An existing axum HTTP app can now host a vox endpoint on a route alongside everything else. Framing is identical to the native tungstenite `WsLink` (one vox payload per binary frame); text frames are rejected, close/EOF map to `None`.

### Proven end to end
- New `axum-peer-server` binary: a real axum app (plain `GET /` + vox `GET /ws` upgrade) reusing `subject_rust::TestbedService`.
- New `ws-wasm-axum.spec.ts` Playwright test drives the existing Rust/Wasm client against it — 16/16 testbed methods over `ws://…/ws`.
- The wasm client now uses the **first-party** `vox::connect_lane("ws://…")` instead of the low-level link + initiator, so the test actually exercises the public path.

### Bug fix: `vox::connect("ws://…")` never worked on wasm
The wasm `WsLinkSource::next_link` handed the initiator a socket that was still in `CONNECTING` state (`WsLink::new(WebSocket::new(url))`), so the initiator's first `send` failed with `InvalidStateError: still in CONNECTING state`. The prior wasm test only passed because it used `WsLink::connect` (which awaits open) directly. `next_link` now awaits open via `WsLink::connect`; removed the dead `JsError`/`convert_js_err`/`DomException` path.

### CI
Added a wasm32 check of the `vox` facade with `--no-default-features --features runtime,transport-websocket`. The new Playwright spec runs in the existing `wasm-browser-tests` job.

## Testing
- `ws-wasm-axum.spec.ts`: 16/16 green (wasm `vox::connect_lane` → `AxumWsLink` → axum server).
- `ws-wasm.spec.ts` (bare `ws-peer-server`, shared client): green, no regression.
- `cargo clippy -p vox-websocket --features axum -p peer-server`: clean.
- `cargo check --target wasm32-unknown-unknown` for `vox` (+ws feature), `vox-websocket`, `wasm-browser-tests`: clean.
- `cd typescript && pnpm check`: pass. Native `vox-websocket` tests: 4/4.