### PR TITLE
flatten a transparent type does not work

### DIFF
--- a/facet-json/tests/integration/issue_2264.rs
+++ b/facet-json/tests/integration/issue_2264.rs
@@ -1,0 +1,57 @@
+//! Regression test for https://github.com/facet-rs/facet/issues/2264
+//!
+//! `#[facet(flatten)]` on a field whose type is a `#[facet(transparent)]`
+//! newtype wrapper should look through the wrapper and flatten the inner
+//! type's fields as if the wrapper were not there.
+
+use facet::Facet;
+use facet_testhelpers::test;
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+struct Fields {
+    data: [String; 2],
+}
+
+#[derive(Facet, Clone, PartialEq, Debug)]
+#[facet(transparent)]
+struct Transparent<T>(T);
+
+/// Without the wrapper — must keep working.
+#[derive(Facet, Clone, PartialEq, Debug)]
+struct Flatten {
+    kind: String,
+    #[facet(flatten)]
+    fields: Fields,
+}
+
+/// With the transparent wrapper — this was the bug.
+#[derive(Facet, Clone, PartialEq, Debug)]
+struct WrappedFlatten {
+    kind: String,
+    #[facet(flatten)]
+    fields: Transparent<Fields>,
+}
+
+const JSON: &str = r#"{"kind":"foo","data":["lorem","ipsum"]}"#;
+
+#[test]
+fn test_issue_2264_flatten_without_wrapper() {
+    let v: Flatten = facet_json::from_str(JSON).unwrap();
+    assert_eq!(v.kind, "foo");
+    assert_eq!(v.fields.data, ["lorem", "ipsum"]);
+
+    let roundtrip = facet_json::to_string(&v).unwrap();
+    let back: Flatten = facet_json::from_str(&roundtrip).unwrap();
+    assert_eq!(v, back);
+}
+
+#[test]
+fn test_issue_2264_flatten_with_transparent_wrapper() {
+    let v: WrappedFlatten = facet_json::from_str(JSON).unwrap();
+    assert_eq!(v.kind, "foo");
+    assert_eq!(v.fields.0.data, ["lorem", "ipsum"]);
+
+    let roundtrip = facet_json::to_string(&v).unwrap();
+    let back: WrappedFlatten = facet_json::from_str(&roundtrip).unwrap();
+    assert_eq!(v, back);
+}

--- a/facet-json/tests/integration/mod.rs
+++ b/facet-json/tests/integration/mod.rs
@@ -23,6 +23,7 @@ mod issue_2004;
 mod issue_2007;
 mod issue_2010;
 mod issue_2059;
+mod issue_2264;
 mod issue_2341_newtype_as_json_object_key;
 mod issue_2342_json_facet_other_deep;
 mod issue_2363_bool_string_number_field_proxy;

--- a/facet-reflect/src/peek/fields.rs
+++ b/facet-reflect/src/peek/fields.rs
@@ -484,7 +484,7 @@ impl<'mem, 'facet> Iterator for FieldsForSerializeIter<'mem, 'facet> {
                             }
                             // None - skip this field entirely
                             continue;
-                        } else if let Ok(struct_peek) = peek.into_struct() {
+                        } else if let Ok(struct_peek) = peek.innermost_peek().into_struct() {
                             self.stack.push(FieldsForSerializeIterState::Fields(
                                 FieldIter::new_struct(struct_peek),
                             ))

--- a/facet-solver/src/lib.rs
+++ b/facet-solver/src/lib.rs
@@ -2788,6 +2788,8 @@ impl SchemaBuilder {
             None => (original_shape, false),
         };
 
+        let (shape, field_path) = unwrap_transparent_with_path(shape, field_path);
+
         match shape.ty {
             Type::User(UserType::Struct(struct_type)) => {
                 // Flatten a struct: get its resolutions and merge into each of ours
@@ -3207,4 +3209,17 @@ fn unwrap_transparent(shape: &'static Shape) -> &'static Shape {
     } else {
         shape
     }
+}
+
+/// Like `unwrap_transparent`, but also extends `path` with a `"0"` segment for each
+/// transparent layer unwrapped, so the reflect navigator can follow the same descent.
+fn unwrap_transparent_with_path(
+    mut shape: &'static Shape,
+    mut path: FieldPath,
+) -> (&'static Shape, FieldPath) {
+    while let Some(inner) = shape.inner {
+        path = path.push_field("0");
+        shape = inner;
+    }
+    (shape, path)
 }


### PR DESCRIPTION
Fixes #2264

# Issue : 
Deserialization: the solver analyzed the wrapper struct (field "0") instead of the inner type, so it expected a JSON key "0" and rejected the actual fields.
Serialization: FieldsForSerializeIter called into_struct() on the wrapper, yielding field "0" instead of the inner type's fields, so it wrote "0": {...} instead of flattening inline.

# Fix: 
in the solver, unwrap shape.inner before analyzing a flattened field (extending the path with "0" per layer so the reflect navigator can follow). In the serializer iterator, call innermost_peek() before into_struct() so transparent wrappers are seen through before field iteration.

The test has been picked up from the issue repro. 