### PR TITLE
figue: add implementation links to help output

### DIFF
--- a/figue/src/builder.rs
+++ b/figue/src/builder.rs
@@ -56,6 +56,7 @@
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use std::string::String;
+use std::sync::Arc;
 
 use camino::Utf8PathBuf;
 use facet::Facet;
@@ -513,6 +514,60 @@ impl HelpConfigBuilder {
     pub fn width(mut self, width: usize) -> Self {
         self.config.width = width;
         self
+    }
+
+    /// Enable or disable implementation source file hints in help output.
+    ///
+    /// When enabled, help text includes an `Implementation:` section that points
+    /// to the source file reported by Facet shape metadata (`Shape::source_file`).
+    /// This is useful for CLIs that want to guide contributors to command handlers.
+    pub fn include_implementation_source_file(mut self, include: bool) -> Self {
+        self.config.include_implementation_source_file = include;
+        self
+    }
+
+    /// Add an implementation URL line in help output.
+    ///
+    /// The callback receives the implementation source file path from Facet shape
+    /// metadata (for example, `src\\cli\\mod.rs`) and returns a URL string.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use figue::builder;
+    /// # use facet::Facet;
+    /// # #[derive(Facet)] struct Args { #[facet(figue::named)] verbose: bool }
+    /// let _config = builder::<Args>()
+    ///     .unwrap()
+    ///     .help(|h| h.include_implementation_url(|path| {
+    ///         format!("https://example.com/src/{}", path.replace('\\', "/"))
+    ///     }))
+    ///     .build();
+    /// ```
+    pub fn include_implementation_url<F>(mut self, render_url: F) -> Self
+    where
+        F: Fn(&str) -> String + Send + Sync + 'static,
+    {
+        self.config.implementation_url = Some(Arc::new(render_url));
+        self
+    }
+
+    /// Add a GitHub implementation URL line in help output.
+    ///
+    /// This is a convenience wrapper over [`Self::include_implementation_url`].
+    /// It creates URLs like:
+    /// `https://github.com/<owner/repo>/blob/<revision>/<path>`
+    pub fn include_implementation_github_url(
+        self,
+        owner_repo: impl Into<String>,
+        revision: impl Into<String>,
+    ) -> Self {
+        let owner_repo = owner_repo.into();
+        let revision = revision.into();
+        self.include_implementation_url(move |source_file| {
+            let normalized = source_file.replace('\\', "/");
+            format!("https://github.com/{owner_repo}/blob/{revision}/{normalized}")
+        })
     }
 
     /// Build the help configuration.

--- a/figue/src/driver.rs
+++ b/figue/src/driver.rs
@@ -1914,6 +1914,7 @@ mod tests {
         match result {
             Err(DriverError::Help { text, .. }) => {
                 let text = strip_ansi_escapes::strip_str(&text);
+                println!("{text}");
                 let source_file = crate::help::implementation_source_for_subcommand_path(
                     ArgsWithImplementationHelp::SHAPE,
                     &[],
@@ -1950,6 +1951,7 @@ mod tests {
         match result {
             Err(DriverError::Help { text, .. }) => {
                 let text = strip_ansi_escapes::strip_str(&text);
+                println!("{text}");
                 let source_file = crate::help::implementation_source_for_subcommand_path(
                     ArgsWithImplementationHelp::SHAPE,
                     &["Serve".to_string()],

--- a/figue/src/driver.rs
+++ b/figue/src/driver.rs
@@ -1791,6 +1791,15 @@ mod tests {
     }
 
     #[derive(Facet, Debug)]
+    struct ArgsWithNestedImplementationHelp {
+        #[facet(figue::subcommand)]
+        command: NestedImplementationHelpCommand,
+
+        #[facet(flatten)]
+        builtins: FigueBuiltins,
+    }
+
+    #[derive(Facet, Debug)]
     #[allow(dead_code)]
     #[repr(u8)]
     enum ImplementationHelpCommand {
@@ -1804,6 +1813,33 @@ mod tests {
         /// Port to listen on.
         #[facet(figue::named)]
         port: Option<u16>,
+    }
+
+    #[derive(Facet, Debug)]
+    #[allow(dead_code)]
+    #[repr(u8)]
+    enum NestedImplementationHelpCommand {
+        /// Repository commands.
+        Repo {
+            #[facet(figue::subcommand)]
+            action: NestedImplementationRepoCommand,
+        },
+    }
+
+    #[derive(Facet, Debug)]
+    #[allow(dead_code)]
+    #[repr(u8)]
+    enum NestedImplementationRepoCommand {
+        /// Clone a repository.
+        Clone(NestedImplementationCloneArgs),
+    }
+
+    #[derive(Facet, Debug)]
+    #[allow(dead_code)]
+    struct NestedImplementationCloneArgs {
+        /// Maximum history depth.
+        #[facet(figue::named)]
+        depth: Option<u16>,
     }
 
     #[derive(Facet, Debug)]
@@ -1914,7 +1950,6 @@ mod tests {
         match result {
             Err(DriverError::Help { text, .. }) => {
                 let text = strip_ansi_escapes::strip_str(&text);
-                println!("{text}");
                 let source_file = crate::help::implementation_source_for_subcommand_path(
                     ArgsWithImplementationHelp::SHAPE,
                     &[],
@@ -1951,7 +1986,6 @@ mod tests {
         match result {
             Err(DriverError::Help { text, .. }) => {
                 let text = strip_ansi_escapes::strip_str(&text);
-                println!("{text}");
                 let source_file = crate::help::implementation_source_for_subcommand_path(
                     ArgsWithImplementationHelp::SHAPE,
                     &["Serve".to_string()],
@@ -1962,6 +1996,43 @@ mod tests {
                     source_file.replace('\\', "/")
                 );
 
+                assert!(text.contains("Implementation:"));
+                assert!(text.contains(source_file));
+                assert!(text.contains(&expected_url));
+            }
+            other => panic!("expected DriverError::Help, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_driver_nested_subcommand_help_includes_implementation_source_and_github_url() {
+        let config = builder::<ArgsWithNestedImplementationHelp>()
+            .unwrap()
+            .cli(|cli| cli.args(["repo", "clone", "--help"]))
+            .help(|h| {
+                h.program_name("test-app")
+                    .include_implementation_source_file(true)
+                    .include_implementation_github_url("example/teamy", "deadbeef")
+            })
+            .build();
+
+        let driver = Driver::new(config);
+        let result = driver.run().into_result();
+
+        match result {
+            Err(DriverError::Help { text, .. }) => {
+                let text = strip_ansi_escapes::strip_str(&text);
+                let source_file = crate::help::implementation_source_for_subcommand_path(
+                    ArgsWithNestedImplementationHelp::SHAPE,
+                    &["Repo".to_string(), "Clone".to_string()],
+                )
+                .expect("nested subcommand help should resolve a source file");
+                let expected_url = format!(
+                    "https://github.com/example/teamy/blob/deadbeef/{}",
+                    source_file.replace('\\', "/")
+                );
+
+                assert!(text.contains("test-app repo clone"));
                 assert!(text.contains("Implementation:"));
                 assert!(text.contains(source_file));
                 assert!(text.contains(&expected_url));

--- a/figue/src/driver.rs
+++ b/figue/src/driver.rs
@@ -32,7 +32,7 @@ use crate::dump::dump_config_with_schema;
 use crate::enum_conflicts::detect_enum_conflicts;
 use crate::env_subst::{EnvSubstError, RealEnv, substitute_env_vars};
 use crate::help::{
-    generate_help_for_subcommand_with_config_formats,
+    generate_help_for_subcommand_with_config_formats_and_shape,
     generate_root_html_help_with_config_formats_and_anchor, html_help_anchor_for_subcommand_path,
     open_html_help_file, write_html_help_to_temp_file,
 };
@@ -251,7 +251,8 @@ impl<T: Facet<'static>> Driver<T> {
                 };
 
                 let config_file_extensions = self.config_file_extensions();
-                let text = generate_help_for_subcommand_with_config_formats(
+                let text = generate_help_for_subcommand_with_config_formats_and_shape(
+                    T::SHAPE,
                     &self.config.schema,
                     &subcommand_path,
                     &help_config,
@@ -572,7 +573,8 @@ impl<T: Facet<'static>> Driver<T> {
                     .unwrap_or_default();
 
                 let config_file_extensions = self.config_file_extensions();
-                let help = generate_help_for_subcommand_with_config_formats(
+                let help = generate_help_for_subcommand_with_config_formats_and_shape(
+                    T::SHAPE,
                     &self.config.schema,
                     &[],
                     &help_config,
@@ -614,7 +616,8 @@ impl<T: Facet<'static>> Driver<T> {
                 };
 
                 let config_file_extensions = self.config_file_extensions();
-                let help = generate_help_for_subcommand_with_config_formats(
+                let help = generate_help_for_subcommand_with_config_formats_and_shape(
+                    T::SHAPE,
                     &self.config.schema,
                     &subcommand_path,
                     &help_config,
@@ -656,7 +659,8 @@ impl<T: Facet<'static>> Driver<T> {
                 };
 
                 let config_file_extensions = self.config_file_extensions();
-                let help = generate_help_for_subcommand_with_config_formats(
+                let help = generate_help_for_subcommand_with_config_formats_and_shape(
+                    T::SHAPE,
                     &self.config.schema,
                     &subcommand_path,
                     &help_config,
@@ -1778,6 +1782,31 @@ mod tests {
     }
 
     #[derive(Facet, Debug)]
+    struct ArgsWithImplementationHelp {
+        #[facet(figue::subcommand)]
+        command: ImplementationHelpCommand,
+
+        #[facet(flatten)]
+        builtins: FigueBuiltins,
+    }
+
+    #[derive(Facet, Debug)]
+    #[allow(dead_code)]
+    #[repr(u8)]
+    enum ImplementationHelpCommand {
+        /// Serve requests.
+        Serve(ImplementationHelpServeArgs),
+    }
+
+    #[derive(Facet, Debug)]
+    #[allow(dead_code)]
+    struct ImplementationHelpServeArgs {
+        /// Port to listen on.
+        #[facet(figue::named)]
+        port: Option<u16>,
+    }
+
+    #[derive(Facet, Debug)]
     struct HelpTestConfig {
         #[facet(default = "localhost")]
         host: String,
@@ -1862,6 +1891,78 @@ mod tests {
                 let text = strip_ansi_escapes::strip_str(&text);
                 assert!(text.contains("--config <FILE>"));
                 assert!(text.contains("Supported file formats: .json, .jsonc."));
+            }
+            other => panic!("expected DriverError::Help, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_driver_help_includes_implementation_source_and_github_url() {
+        let config = builder::<ArgsWithImplementationHelp>()
+            .unwrap()
+            .cli(|cli| cli.args(["--help"]))
+            .help(|h| {
+                h.program_name("test-app")
+                    .include_implementation_source_file(true)
+                    .include_implementation_github_url("example/teamy", "deadbeef")
+            })
+            .build();
+
+        let driver = Driver::new(config);
+        let result = driver.run().into_result();
+
+        match result {
+            Err(DriverError::Help { text, .. }) => {
+                let text = strip_ansi_escapes::strip_str(&text);
+                let source_file = crate::help::implementation_source_for_subcommand_path(
+                    ArgsWithImplementationHelp::SHAPE,
+                    &[],
+                )
+                .expect("root help should resolve a source file");
+                let expected_url = format!(
+                    "https://github.com/example/teamy/blob/deadbeef/{}",
+                    source_file.replace('\\', "/")
+                );
+
+                assert!(text.contains("Implementation:"));
+                assert!(text.contains(source_file));
+                assert!(text.contains(&expected_url));
+            }
+            other => panic!("expected DriverError::Help, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_driver_subcommand_help_includes_implementation_source_and_github_url() {
+        let config = builder::<ArgsWithImplementationHelp>()
+            .unwrap()
+            .cli(|cli| cli.args(["serve", "--help"]))
+            .help(|h| {
+                h.program_name("test-app")
+                    .include_implementation_source_file(true)
+                    .include_implementation_github_url("example/teamy", "deadbeef")
+            })
+            .build();
+
+        let driver = Driver::new(config);
+        let result = driver.run().into_result();
+
+        match result {
+            Err(DriverError::Help { text, .. }) => {
+                let text = strip_ansi_escapes::strip_str(&text);
+                let source_file = crate::help::implementation_source_for_subcommand_path(
+                    ArgsWithImplementationHelp::SHAPE,
+                    &["Serve".to_string()],
+                )
+                .expect("subcommand help should resolve a source file");
+                let expected_url = format!(
+                    "https://github.com/example/teamy/blob/deadbeef/{}",
+                    source_file.replace('\\', "/")
+                );
+
+                assert!(text.contains("Implementation:"));
+                assert!(text.contains(source_file));
+                assert!(text.contains(&expected_url));
             }
             other => panic!("expected DriverError::Help, got {:?}", other),
         }

--- a/figue/src/help.rs
+++ b/figue/src/help.rs
@@ -311,16 +311,19 @@ fn next_subcommand_shape(
     shape: &'static facet_core::Shape,
     target_effective_name: &str,
 ) -> Option<&'static facet_core::Shape> {
-    let fields = match shape.ty {
-        facet_core::Type::User(facet_core::UserType::Struct(s)) => s.fields,
+    let shape = unwrap_option_shape(shape);
+    let enum_shape = match shape.ty {
+        facet_core::Type::User(facet_core::UserType::Struct(s)) => {
+            let subcommand_field = s
+                .fields
+                .iter()
+                .find(|field| field.has_attr(Some("args"), "subcommand"))?;
+            unwrap_option_shape(subcommand_field.shape())
+        }
+        facet_core::Type::User(facet_core::UserType::Enum(_)) => shape,
         _ => return None,
     };
 
-    let subcommand_field = fields
-        .iter()
-        .find(|field| field.has_attr(Some("args"), "subcommand"))?;
-
-    let enum_shape = unwrap_option_shape(subcommand_field.shape());
     let variants = match enum_shape.ty {
         facet_core::Type::User(facet_core::UserType::Enum(e)) => e.variants,
         _ => return None,
@@ -334,14 +337,14 @@ fn next_subcommand_shape(
         return Some(enum_shape);
     }
 
-    let has_direct_subcommand = variant
+    let direct_subcommand_field = variant
         .data
         .fields
         .iter()
-        .any(|field| field.has_attr(Some("args"), "subcommand"));
+        .find(|field| field.has_attr(Some("args"), "subcommand"));
 
-    if has_direct_subcommand {
-        return Some(enum_shape);
+    if let Some(direct_subcommand_field) = direct_subcommand_field {
+        return Some(unwrap_option_shape(direct_subcommand_field.shape()));
     }
 
     if variant.data.fields.len() == 1 {

--- a/figue/src/help.rs
+++ b/figue/src/help.rs
@@ -12,11 +12,13 @@ use facet_core::Facet;
 use heck::ToKebabCase;
 use owo_colors::OwoColorize;
 use owo_colors::Stream::Stdout;
+use std::fmt;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::string::String;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::vec::Vec;
 
@@ -55,7 +57,13 @@ pub fn generate_help_for_shape(shape: &'static facet_core::Shape, config: &HelpC
         }
     };
 
-    generate_help_for_subcommand(&schema, &[], config)
+    generate_help_for_subcommand_with_config_formats_and_shape(
+        shape,
+        &schema,
+        &[],
+        config,
+        DEFAULT_CONFIG_FILE_EXTENSIONS,
+    )
 }
 
 /// Generate HTML help for a Facet type.
@@ -229,7 +237,7 @@ pub fn open_html_help_file(path: impl AsRef<Path>) -> io::Result<()> {
 }
 
 /// Configuration for help text generation.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HelpConfig {
     /// Program name (defaults to executable name)
     pub program_name: Option<String>,
@@ -239,6 +247,29 @@ pub struct HelpConfig {
     pub description: Option<String>,
     /// Width for wrapping text (0 = no wrapping)
     pub width: usize,
+    /// Whether to include implementation source file information in help output.
+    pub include_implementation_source_file: bool,
+    /// Optional callback to render an implementation URL from a source file path.
+    pub implementation_url: Option<Arc<dyn Fn(&str) -> String + Send + Sync>>,
+}
+
+impl fmt::Debug for HelpConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HelpConfig")
+            .field("program_name", &self.program_name)
+            .field("version", &self.version)
+            .field("description", &self.description)
+            .field("width", &self.width)
+            .field(
+                "include_implementation_source_file",
+                &self.include_implementation_source_file,
+            )
+            .field(
+                "implementation_url",
+                &self.implementation_url.as_ref().map(|_| "<fn>"),
+            )
+            .finish()
+    }
 }
 
 impl Default for HelpConfig {
@@ -248,8 +279,83 @@ impl Default for HelpConfig {
             version: None,
             description: None,
             width: 80,
+            include_implementation_source_file: false,
+            implementation_url: None,
         }
     }
+}
+
+/// Resolve implementation source file for a subcommand path from a root shape.
+///
+/// The `subcommand_path` should contain effective subcommand names (as emitted by
+/// `ConfigValue::extract_subcommand_path`). An empty path resolves to the root shape.
+pub(crate) fn implementation_source_for_subcommand_path(
+    root_shape: &'static facet_core::Shape,
+    subcommand_path: &[String],
+) -> Option<&'static str> {
+    let mut current_shape = root_shape;
+
+    if subcommand_path.is_empty() {
+        return current_shape.source_file;
+    }
+
+    for segment in subcommand_path {
+        let next_shape = next_subcommand_shape(current_shape, segment)?;
+        current_shape = next_shape;
+    }
+
+    current_shape.source_file
+}
+
+fn next_subcommand_shape(
+    shape: &'static facet_core::Shape,
+    target_effective_name: &str,
+) -> Option<&'static facet_core::Shape> {
+    let fields = match shape.ty {
+        facet_core::Type::User(facet_core::UserType::Struct(s)) => s.fields,
+        _ => return None,
+    };
+
+    let subcommand_field = fields
+        .iter()
+        .find(|field| field.has_attr(Some("args"), "subcommand"))?;
+
+    let enum_shape = unwrap_option_shape(subcommand_field.shape());
+    let variants = match enum_shape.ty {
+        facet_core::Type::User(facet_core::UserType::Enum(e)) => e.variants,
+        _ => return None,
+    };
+
+    let variant = variants
+        .iter()
+        .find(|variant| variant.effective_name() == target_effective_name)?;
+
+    if variant.data.fields.is_empty() {
+        return Some(enum_shape);
+    }
+
+    let has_direct_subcommand = variant
+        .data
+        .fields
+        .iter()
+        .any(|field| field.has_attr(Some("args"), "subcommand"));
+
+    if has_direct_subcommand {
+        return Some(enum_shape);
+    }
+
+    if variant.data.fields.len() == 1 {
+        return Some(unwrap_option_shape(variant.data.fields[0].shape()));
+    }
+
+    Some(enum_shape)
+}
+
+fn unwrap_option_shape(mut shape: &'static facet_core::Shape) -> &'static facet_core::Shape {
+    while let facet_core::Def::Option(option_def) = shape.def {
+        shape = option_def.t;
+    }
+    shape
 }
 
 /// Generate help text for a specific subcommand path from a Schema.
@@ -331,6 +437,60 @@ pub(crate) fn generate_help_for_subcommand_with_config_formats(
     }
 
     generate_help_for_subcommand_level(current_args, final_sub, &command_path.join(" "), config)
+}
+
+pub(crate) fn generate_help_for_subcommand_with_config_formats_and_shape(
+    shape: &'static facet_core::Shape,
+    schema: &Schema,
+    subcommand_path: &[String],
+    config: &HelpConfig,
+    config_file_extensions: &[&str],
+) -> String {
+    let mut help = generate_help_for_subcommand_with_config_formats(
+        schema,
+        subcommand_path,
+        config,
+        config_file_extensions,
+    );
+    append_implementation_source_for_subcommand_path(&mut help, shape, subcommand_path, config);
+    help
+}
+
+fn append_implementation_source_for_subcommand_path(
+    help_text: &mut String,
+    root_shape: &'static facet_core::Shape,
+    subcommand_path: &[String],
+    config: &HelpConfig,
+) {
+    let Some(source_file) = implementation_source_for_subcommand_path(root_shape, subcommand_path)
+    else {
+        return;
+    };
+
+    let implementation_url = config
+        .implementation_url
+        .as_ref()
+        .map(|render_url| render_url(source_file));
+
+    if !config.include_implementation_source_file && implementation_url.is_none() {
+        return;
+    }
+
+    if !help_text.ends_with('\n') {
+        help_text.push('\n');
+    }
+    help_text.push('\n');
+    help_text.push_str("Implementation:\n");
+    if config.include_implementation_source_file {
+        help_text.push_str("    ");
+        help_text.push_str(source_file);
+        help_text.push('\n');
+    }
+    if let Some(implementation_url) = implementation_url {
+        help_text.push_str("    ");
+        help_text.push_str(&implementation_url);
+        help_text.push('\n');
+    }
 }
 
 /// Generate help from a built Schema.


### PR DESCRIPTION
## Summary

This PR adds opt-in implementation references to figue help output.

When enabled, generated `--help` text can append an `Implementation:` block with:

- a local source file path
- a GitHub URL for the resolved command/subcommand implementation

## What changed

- added help builder support for including implementation source paths
- added help builder support for including GitHub implementation URLs
- moved implementation footer rendering into help generation
- made subcommand help resolve the correct implementation target from Facet shape metadata
- added focused tests for root help and subcommand help

## Motivation

This addresses the gap described in #2425: help output currently explains the command surface, but does not help contributors jump to the command implementation.

## Validation

- `cargo test implementation_source --lib`

Closes #2425