### PR TITLE
figue: add help pseudo-subcommands

### DIFF
--- a/figue/src/driver.rs
+++ b/figue/src/driver.rs
@@ -32,7 +32,8 @@ use crate::dump::dump_config_with_schema;
 use crate::enum_conflicts::detect_enum_conflicts;
 use crate::env_subst::{EnvSubstError, RealEnv, substitute_env_vars};
 use crate::help::{
-    generate_help_for_subcommand_with_config_formats, generate_help_list_for_subcommand,
+    generate_help_for_subcommand_with_config_formats,
+    generate_help_list_for_subcommand_with_config_formats,
     generate_root_html_help_with_config_formats_and_anchor, html_help_anchor_for_subcommand_path,
     open_html_help_file, write_html_help_to_temp_file,
 };
@@ -263,11 +264,12 @@ impl<T: Facet<'static>> Driver<T> {
 
                 let config_file_extensions = self.config_file_extensions();
                 let text = if let Some(mode) = layers.cli.help_list_mode {
-                    generate_help_list_for_subcommand(
+                    generate_help_list_for_subcommand_with_config_formats(
                         &self.config.schema,
                         &subcommand_path,
                         &help_config,
                         mode,
+                        &config_file_extensions,
                     )
                 } else {
                     generate_help_for_subcommand_with_config_formats(

--- a/figue/src/driver.rs
+++ b/figue/src/driver.rs
@@ -32,7 +32,7 @@ use crate::dump::dump_config_with_schema;
 use crate::enum_conflicts::detect_enum_conflicts;
 use crate::env_subst::{EnvSubstError, RealEnv, substitute_env_vars};
 use crate::help::{
-    generate_help_for_subcommand_with_config_formats,
+    generate_help_for_subcommand_with_config_formats, generate_help_list_for_subcommand,
     generate_root_html_help_with_config_formats_and_anchor, html_help_anchor_for_subcommand_path,
     open_html_help_file, write_html_help_to_temp_file,
 };
@@ -68,6 +68,17 @@ pub struct LayerOutput {
     /// example, `--cfg cfg.json` should load `cfg.json` as the `cfg` block, not
     /// as a top-level file containing every config root.
     pub config_file_paths: indexmap::IndexMap<String, camino::Utf8PathBuf>,
+    /// Requested pseudo-help list mode (from `help list` shorthand), if any.
+    pub help_list_mode: Option<HelpListMode>,
+}
+
+/// Mode for pseudo-help listing (`help list`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelpListMode {
+    /// Show full help text for each reachable leaf subcommand.
+    Full,
+    /// Show only full command paths for reachable leaf subcommands.
+    Short,
 }
 
 /// A key that was unused by the schema, with provenance.
@@ -251,12 +262,21 @@ impl<T: Facet<'static>> Driver<T> {
                 };
 
                 let config_file_extensions = self.config_file_extensions();
-                let text = generate_help_for_subcommand_with_config_formats(
-                    &self.config.schema,
-                    &subcommand_path,
-                    &help_config,
-                    &config_file_extensions,
-                );
+                let text = if let Some(mode) = layers.cli.help_list_mode {
+                    generate_help_list_for_subcommand(
+                        &self.config.schema,
+                        &subcommand_path,
+                        &help_config,
+                        mode,
+                    )
+                } else {
+                    generate_help_for_subcommand_with_config_formats(
+                        &self.config.schema,
+                        &subcommand_path,
+                        &help_config,
+                        &config_file_extensions,
+                    )
+                };
                 return DriverOutcome::err(DriverError::Help {
                     text,
                     suggestion: None,
@@ -1803,6 +1823,22 @@ mod tests {
         port: u16,
     }
 
+    #[derive(Facet, Debug)]
+    struct ArgsWithExplicitHelpSubcommand {
+        #[facet(figue::subcommand)]
+        command: TestCommandWithExplicitHelp,
+
+        #[facet(flatten)]
+        builtins: FigueBuiltins,
+    }
+
+    #[derive(Facet, Debug, PartialEq)]
+    #[repr(u8)]
+    enum TestCommandWithExplicitHelp {
+        Help,
+        Build,
+    }
+
     #[test]
     fn test_driver_help_flag() {
         let config = builder::<ArgsWithBuiltins>()
@@ -1844,6 +1880,62 @@ mod tests {
             matches!(result, Err(DriverError::Help { .. })),
             "expected DriverError::Help"
         );
+    }
+
+    #[test]
+    fn test_driver_help_word_alias_triggers_help_without_help_subcommand() {
+        let config = builder::<ArgsWithSubcommandAndBuiltins>()
+            .expect("failed to build args schema")
+            .cli(|cli| cli.args(["help"]))
+            .help(|h| h.program_name("test-app"))
+            .build();
+
+        let result = Driver::new(config).run().into_result();
+
+        match result {
+            Err(DriverError::Help { text, .. }) => {
+                assert!(text.contains("test-app"));
+                assert!(text.contains("--[no-]help"));
+            }
+            other => panic!("expected DriverError::Help, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_driver_help_word_prefers_explicit_help_subcommand() {
+        let config = builder::<ArgsWithExplicitHelpSubcommand>()
+            .expect("failed to build args schema")
+            .cli(|cli| cli.args(["help"]))
+            .build();
+
+        let result = Driver::new(config).run().into_result();
+
+        match result {
+            Ok(output) => {
+                assert_eq!(output.value.command, TestCommandWithExplicitHelp::Help);
+                assert!(!output.value.builtins.help);
+            }
+            Err(e) => panic!("expected success, got error: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn test_driver_help_list_short_prints_leaf_commands() {
+        let config = builder::<ArgsWithNestedSubcommands>()
+            .expect("failed to build schema")
+            .cli(|cli| cli.args(["db", "help", "list", "--short"]))
+            .help(|h| h.program_name("test-app"))
+            .build();
+
+        let result = Driver::new(config).run().into_result();
+
+        match result {
+            Err(DriverError::Help { text, .. }) => {
+                let text = strip_ansi_escapes::strip_str(&text);
+                assert_eq!(text, "test-app db create\ntest-app db run\ntest-app db rollback");
+            }
+            other => panic!("expected DriverError::Help, got {:?}", other),
+        }
     }
 
     #[test]

--- a/figue/src/help.rs
+++ b/figue/src/help.rs
@@ -346,6 +346,22 @@ pub(crate) fn generate_help_list_for_subcommand(
     config: &HelpConfig,
     mode: HelpListMode,
 ) -> String {
+    generate_help_list_for_subcommand_with_config_formats(
+        schema,
+        subcommand_path,
+        config,
+        mode,
+        DEFAULT_CONFIG_FILE_EXTENSIONS,
+    )
+}
+
+pub(crate) fn generate_help_list_for_subcommand_with_config_formats(
+    schema: &Schema,
+    subcommand_path: &[String],
+    config: &HelpConfig,
+    mode: HelpListMode,
+    config_file_extensions: &[&str],
+) -> String {
     let program_name = config
         .program_name
         .clone()
@@ -406,11 +422,19 @@ pub(crate) fn generate_help_list_for_subcommand(
         HelpListMode::Full => {
             let mut sections = Vec::new();
             let mut leaf_paths = Vec::new();
+            if current_args.subcommand_optional() {
+                leaf_paths.push(resolved_path.clone());
+            }
             let mut working_path = resolved_path.clone();
             collect_leaf_subcommand_paths(&mut leaf_paths, &mut working_path, current_args);
 
             for child_path in leaf_paths {
-                sections.push(generate_help_for_subcommand(schema, &child_path, config));
+                sections.push(generate_help_for_subcommand_with_config_formats(
+                    schema,
+                    &child_path,
+                    config,
+                    config_file_extensions,
+                ));
             }
             sections.join("\n\n")
         }
@@ -3237,6 +3261,49 @@ mod tests {
         assert!(output.contains("myapp cache show"));
         assert!(!output.contains("myapp home\n\n"));
         assert!(!output.contains("myapp cache\n\n"));
+    }
+
+    #[test]
+    fn test_help_list_full_includes_optional_current_command_and_custom_formats() {
+        #[derive(Facet)]
+        struct Args {
+            #[facet(args::config)]
+            config: Config,
+
+            #[facet(args::subcommand)]
+            command: Option<Command>,
+        }
+
+        #[derive(Facet)]
+        struct Config {
+            #[facet(default = "localhost")]
+            host: String,
+        }
+
+        #[derive(Facet)]
+        #[repr(u8)]
+        #[allow(dead_code)]
+        enum Command {
+            Serve,
+            Status,
+        }
+
+        let schema = Schema::from_shape(Args::SHAPE).unwrap();
+        let output = generate_help_list_for_subcommand_with_config_formats(
+            &schema,
+            &[],
+            &HelpConfig {
+                program_name: Some("tool".to_string()),
+                ..HelpConfig::default()
+            },
+            HelpListMode::Full,
+            &["json", "jsonc"],
+        );
+
+        assert!(output.contains("tool\n"));
+        assert!(output.contains("Supported file formats: .json, .jsonc."));
+        assert!(output.contains("tool serve"));
+        assert!(output.contains("tool status"));
     }
 
     #[test]

--- a/figue/src/help.rs
+++ b/figue/src/help.rs
@@ -3,6 +3,7 @@
 //! This module provides utilities to generate help text from Schema,
 //! including doc comments, field names, and attribute information.
 
+use crate::driver::HelpListMode;
 use crate::missing::normalize_program_name;
 use crate::schema::{
     ArgLevelSchema, ArgSchema, ConfigFieldGroupSchema, ConfigFieldSchema, ConfigStructSchema,
@@ -331,6 +332,155 @@ pub(crate) fn generate_help_for_subcommand_with_config_formats(
     }
 
     generate_help_for_subcommand_level(current_args, final_sub, &command_path.join(" "), config)
+}
+
+/// Generate help-list output for subcommands at the current command level.
+///
+/// In [`HelpListMode::Short`], this returns one full CLI command path per line,
+/// recursively listing all reachable leaf commands.
+/// In [`HelpListMode::Full`], this returns concatenated help output for each
+/// reachable leaf subcommand under the current command path.
+pub(crate) fn generate_help_list_for_subcommand(
+    schema: &Schema,
+    subcommand_path: &[String],
+    config: &HelpConfig,
+    mode: HelpListMode,
+) -> String {
+    let program_name = config
+        .program_name
+        .clone()
+        .or_else(|| {
+            std::env::args()
+                .next()
+                .map(|path| normalize_program_name(&path))
+        })
+        .unwrap_or_else(|| "program".to_string());
+
+    let mut current_args = schema.args();
+    let mut resolved_path = Vec::new();
+
+    for name in subcommand_path {
+        let sub = current_args
+            .subcommands()
+            .values()
+            .find(|s| s.effective_name() == name);
+
+        let Some(sub) = sub else {
+            return generate_help_for_subcommand(schema, &[], config);
+        };
+
+        resolved_path.push(sub.effective_name().to_string());
+        current_args = sub.args();
+    }
+
+    if !current_args.has_subcommands() {
+        let command_display = if resolved_path.is_empty() {
+            program_name
+        } else {
+            let cli_chain = resolve_cli_chain(schema, &resolved_path);
+            if cli_chain.is_empty() {
+                program_name
+            } else {
+                format!("{} {}", program_name, cli_chain.join(" "))
+            }
+        };
+        return format!("No subcommands available for {command_display}.");
+    }
+
+    match mode {
+        HelpListMode::Short => {
+            let mut cli_chain = if resolved_path.is_empty() {
+                Vec::new()
+            } else {
+                resolve_cli_chain(schema, &resolved_path)
+            };
+            let mut commands = Vec::new();
+            collect_short_help_commands(
+                &mut commands,
+                program_name.as_str(),
+                &mut cli_chain,
+                current_args,
+            );
+            commands.join("\n")
+        }
+        HelpListMode::Full => {
+            let mut sections = Vec::new();
+            let mut leaf_paths = Vec::new();
+            let mut working_path = resolved_path.clone();
+            collect_leaf_subcommand_paths(&mut leaf_paths, &mut working_path, current_args);
+
+            for child_path in leaf_paths {
+                sections.push(generate_help_for_subcommand(schema, &child_path, config));
+            }
+            sections.join("\n\n")
+        }
+    }
+}
+
+fn collect_leaf_subcommand_paths(
+    leaf_paths: &mut Vec<Vec<String>>,
+    current_path: &mut Vec<String>,
+    args: &ArgLevelSchema,
+) {
+    if !args.has_subcommands() {
+        if !current_path.is_empty() {
+            leaf_paths.push(current_path.clone());
+        }
+        return;
+    }
+
+    for sub in args.subcommands().values() {
+        current_path.push(sub.effective_name().to_string());
+        collect_leaf_subcommand_paths(leaf_paths, current_path, sub.args());
+        current_path.pop();
+    }
+}
+
+fn collect_short_help_commands(
+    commands: &mut Vec<String>,
+    program_name: &str,
+    cli_chain: &mut Vec<String>,
+    args: &ArgLevelSchema,
+) {
+    if args.subcommand_optional() {
+        if cli_chain.is_empty() {
+            commands.push(program_name.to_string());
+        } else {
+            commands.push(format!("{} {}", program_name, cli_chain.join(" ")));
+        }
+    }
+
+    if !args.has_subcommands() {
+        if !cli_chain.is_empty() {
+            commands.push(format!("{} {}", program_name, cli_chain.join(" ")));
+        }
+        return;
+    }
+
+    for sub in args.subcommands().values() {
+        cli_chain.push(sub.cli_name().to_string());
+        collect_short_help_commands(commands, program_name, cli_chain, sub.args());
+        cli_chain.pop();
+    }
+}
+
+fn resolve_cli_chain(schema: &Schema, subcommand_path: &[String]) -> Vec<String> {
+    let mut current_args = schema.args();
+    let mut cli_path = Vec::new();
+
+    for name in subcommand_path {
+        let sub = current_args
+            .subcommands()
+            .values()
+            .find(|s| s.effective_name() == name);
+        let Some(sub) = sub else {
+            break;
+        };
+        cli_path.push(sub.cli_name().to_string());
+        current_args = sub.args();
+    }
+
+    cli_path
 }
 
 /// Generate help from a built Schema.
@@ -2999,6 +3149,94 @@ mod tests {
             std::fs::read_to_string(path).expect("HTML help should be readable"),
             "<!doctype html><title>help</title>"
         );
+    }
+
+    #[derive(Facet)]
+    struct NestedRootArgs {
+        #[facet(args::subcommand)]
+        command: NestedRootCommand,
+    }
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    #[allow(dead_code)]
+    enum NestedRootCommand {
+        Home(NestedHomeArgs),
+        Cache(NestedCacheArgs),
+    }
+
+    #[derive(Facet)]
+    struct NestedHomeArgs {
+        #[facet(args::subcommand)]
+        command: NestedHomeCommand,
+    }
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    #[allow(dead_code)]
+    enum NestedHomeCommand {
+        Open,
+        Show,
+    }
+
+    #[derive(Facet)]
+    struct NestedCacheArgs {
+        #[facet(args::subcommand)]
+        command: NestedCacheCommand,
+    }
+
+    #[derive(Facet)]
+    #[repr(u8)]
+    #[allow(dead_code)]
+    enum NestedCacheCommand {
+        Open,
+        Show,
+    }
+
+    #[test]
+    fn test_help_list_short_is_recursive_with_full_command_paths() {
+        let schema = Schema::from_shape(NestedRootArgs::SHAPE).unwrap();
+        let output = generate_help_list_for_subcommand(
+            &schema,
+            &[],
+            &HelpConfig {
+                program_name: Some("myapp".to_string()),
+                ..HelpConfig::default()
+            },
+            HelpListMode::Short,
+        );
+
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(
+            lines,
+            vec![
+                "myapp home open",
+                "myapp home show",
+                "myapp cache open",
+                "myapp cache show"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_help_list_full_is_recursive_for_leaf_subcommands() {
+        let schema = Schema::from_shape(NestedRootArgs::SHAPE).unwrap();
+        let output = generate_help_list_for_subcommand(
+            &schema,
+            &[],
+            &HelpConfig {
+                program_name: Some("myapp".to_string()),
+                ..HelpConfig::default()
+            },
+            HelpListMode::Full,
+        );
+
+        assert!(output.contains("myapp home open"));
+        assert!(output.contains("myapp home show"));
+        assert!(output.contains("myapp cache open"));
+        assert!(output.contains("myapp cache show"));
+        assert!(!output.contains("myapp home\n\n"));
+        assert!(!output.contains("myapp cache\n\n"));
     }
 
     #[test]

--- a/figue/src/help.rs
+++ b/figue/src/help.rs
@@ -340,21 +340,6 @@ pub(crate) fn generate_help_for_subcommand_with_config_formats(
 /// recursively listing all reachable leaf commands.
 /// In [`HelpListMode::Full`], this returns concatenated help output for each
 /// reachable leaf subcommand under the current command path.
-pub(crate) fn generate_help_list_for_subcommand(
-    schema: &Schema,
-    subcommand_path: &[String],
-    config: &HelpConfig,
-    mode: HelpListMode,
-) -> String {
-    generate_help_list_for_subcommand_with_config_formats(
-        schema,
-        subcommand_path,
-        config,
-        mode,
-        DEFAULT_CONFIG_FILE_EXTENSIONS,
-    )
-}
-
 pub(crate) fn generate_help_list_for_subcommand_with_config_formats(
     schema: &Schema,
     subcommand_path: &[String],
@@ -3220,7 +3205,7 @@ mod tests {
     #[test]
     fn test_help_list_short_is_recursive_with_full_command_paths() {
         let schema = Schema::from_shape(NestedRootArgs::SHAPE).unwrap();
-        let output = generate_help_list_for_subcommand(
+        let output = generate_help_list_for_subcommand_with_config_formats(
             &schema,
             &[],
             &HelpConfig {
@@ -3228,6 +3213,7 @@ mod tests {
                 ..HelpConfig::default()
             },
             HelpListMode::Short,
+            DEFAULT_CONFIG_FILE_EXTENSIONS,
         );
 
         let lines: Vec<&str> = output.lines().collect();
@@ -3245,7 +3231,7 @@ mod tests {
     #[test]
     fn test_help_list_full_is_recursive_for_leaf_subcommands() {
         let schema = Schema::from_shape(NestedRootArgs::SHAPE).unwrap();
-        let output = generate_help_list_for_subcommand(
+        let output = generate_help_list_for_subcommand_with_config_formats(
             &schema,
             &[],
             &HelpConfig {
@@ -3253,6 +3239,7 @@ mod tests {
                 ..HelpConfig::default()
             },
             HelpListMode::Full,
+            DEFAULT_CONFIG_FILE_EXTENSIONS,
         );
 
         assert!(output.contains("myapp home open"));

--- a/figue/src/layers/cli.rs
+++ b/figue/src/layers/cli.rs
@@ -36,7 +36,7 @@ use heck::ToKebabCase;
 use indexmap::IndexMap;
 
 use crate::config_value::{ConfigValue, EnumValue, Sourced};
-use crate::driver::{Diagnostic, LayerOutput, Severity};
+use crate::driver::{Diagnostic, HelpListMode, LayerOutput, Severity};
 use crate::provenance::Provenance;
 use crate::schema::{
     ArgKind, ArgLevelSchema, ArgSchema, ConfigStructSchema, ConfigValueSchema, Schema, Subcommand,
@@ -228,6 +228,8 @@ struct ParseContext<'a> {
     config_builders: IndexMap<String, ValueBuilder<'a>, RandomState>,
     /// Config file paths captured by config root.
     config_file_paths: IndexMap<String, camino::Utf8PathBuf, RandomState>,
+    /// Requested pseudo-help list mode (`help list`), if any.
+    help_list_mode: Option<HelpListMode>,
 }
 
 impl<'a> ParseContext<'a> {
@@ -267,6 +269,7 @@ impl<'a> ParseContext<'a> {
             parent_stack: Vec::new(),
             config_builders,
             config_file_paths: IndexMap::default(),
+            help_list_mode: None,
         }
     }
 
@@ -1029,7 +1032,7 @@ impl<'a> ParseContext<'a> {
 
     fn try_parse_subcommand(&mut self, level: &'a ArgLevelSchema) -> bool {
         let Some(field_name) = level.subcommand_field_name() else {
-            return false;
+            return self.try_parse_help_pseudo_subcommand(level);
         };
 
         let arg = self.args[self.index];
@@ -1043,11 +1046,87 @@ impl<'a> ParseContext<'a> {
         });
 
         let Some((_, subcommand)) = subcommand else {
-            return false;
+            return self.try_parse_help_pseudo_subcommand(level);
         };
 
         self.consume_subcommand(level, field_name, subcommand, arg);
         true
+    }
+
+    fn try_parse_help_pseudo_subcommand(&mut self, level: &ArgLevelSchema) -> bool {
+        let arg = self.args[self.index];
+        if arg != "help" {
+            return false;
+        }
+
+        if level.subcommands().values().any(|sub| sub.cli_name() == "help") {
+            return false;
+        }
+
+        let list_mode = self.parse_help_list_mode();
+
+        if let Some((_effective_name, arg_schema)) = level.args().get("help")
+            && matches!(arg_schema.kind(), ArgKind::Named { .. })
+            && arg_schema.value().inner_if_option().is_bool()
+        {
+            if let Some(mode) = list_mode {
+                self.help_list_mode = Some(mode);
+            }
+            self.parse_flag_value_simple(
+                arg,
+                InsertTarget::Current,
+                arg_schema.insertion_path(),
+                true,
+                None,
+                None,
+            );
+            if list_mode.is_some() {
+                self.index += if list_mode == Some(HelpListMode::Short) {
+                    2
+                } else {
+                    1
+                };
+            }
+            return true;
+        }
+
+        if let Some(lookup) = self.find_long_flag_in_parents("help")
+            && lookup.is_bool
+        {
+            if let Some(mode) = list_mode {
+                self.help_list_mode = Some(mode);
+            }
+            self.parse_flag_value_simple(
+                arg,
+                InsertTarget::Parent(lookup.parent_idx),
+                &lookup.insertion_path,
+                true,
+                None,
+                None,
+            );
+            if list_mode.is_some() {
+                self.index += if list_mode == Some(HelpListMode::Short) {
+                    2
+                } else {
+                    1
+                };
+            }
+            return true;
+        }
+
+        false
+    }
+
+    fn parse_help_list_mode(&self) -> Option<HelpListMode> {
+        let next = self.args.get(self.index + 1)?;
+        if *next != "list" {
+            return None;
+        }
+
+        match self.args.get(self.index + 2) {
+            Some(flag) if *flag == "--short" => Some(HelpListMode::Short),
+            _ => Some(HelpListMode::Full),
+        }
     }
 
     fn consume_subcommand(
@@ -1412,6 +1491,7 @@ impl<'a> ParseContext<'a> {
             diagnostics,
             source_text: None,
             config_file_paths: self.config_file_paths,
+            help_list_mode: self.help_list_mode,
         }
     }
 }

--- a/figue/src/layers/env.rs
+++ b/figue/src/layers/env.rs
@@ -241,6 +241,7 @@ pub fn parse_env(schema: &Schema, env_config: &EnvConfig, source: &dyn EnvSource
         diagnostics,
         source_text: None,
         config_file_paths: IndexMap::default(),
+        help_list_mode: None,
     };
 
     // Assign spans to env-sourced values and build the virtual source document
@@ -403,6 +404,7 @@ fn parse_env_no_config(env_config: &EnvConfig, source: &dyn EnvSource) -> LayerO
         diagnostics: Vec::new(),
         source_text: None,
         config_file_paths: IndexMap::default(),
+        help_list_mode: None,
     }
 }
 

--- a/figue/src/layers/file.rs
+++ b/figue/src/layers/file.rs
@@ -398,6 +398,7 @@ impl<'a> FileParseContext<'a> {
                     diagnostics: self.early_diagnostics,
                     source_text: None,
                     config_file_paths: IndexMap::default(),
+                    help_list_mode: None,
                 }
             }
         } else {
@@ -408,6 +409,7 @@ impl<'a> FileParseContext<'a> {
                 diagnostics: self.early_diagnostics,
                 source_text: None,
                 config_file_paths: IndexMap::default(),
+                help_list_mode: None,
             }
         };
 
@@ -441,6 +443,7 @@ impl<'a> FileParseContext<'a> {
                 diagnostics,
                 source_text: None,
                 config_file_paths: IndexMap::default(),
+                help_list_mode: None,
             };
         };
 
@@ -501,6 +504,7 @@ impl<'a> FileParseContext<'a> {
             diagnostics,
             source_text: None,
             config_file_paths: IndexMap::default(),
+            help_list_mode: None,
         }
     }
 
@@ -550,6 +554,7 @@ impl<'a> FileParseContext<'a> {
             diagnostics,
             source_text: None,
             config_file_paths: IndexMap::default(),
+            help_list_mode: None,
         }
     }
 }

--- a/figue/src/value_builder.rs
+++ b/figue/src/value_builder.rs
@@ -312,6 +312,7 @@ impl<'a> ValueBuilder<'a> {
             diagnostics: self.diagnostics,
             source_text: None,
             config_file_paths: IndexMap::default(),
+            help_list_mode: None,
         }
     }
 
@@ -408,6 +409,7 @@ impl<'a> ValueBuilder<'a> {
             diagnostics: self.diagnostics,
             source_text: None,
             config_file_paths: IndexMap::default(),
+            help_list_mode: None,
         }
     }
 


### PR DESCRIPTION
## Summary

This PR adds pseudo-help subcommand support to figue when no real `help` subcommand exists at the current command level.

It also adds recursive subcommand listing support via:

- `help list`
- `help list --short`

## What changed

- treat `help` as shorthand for `--help` when no explicit `help` subcommand exists
- preserve precedence for schema-defined real `help` subcommands
- add `help list` to render help for all reachable leaf subcommands from the current command level
- add `help list --short` to print only the full leaf command paths
- plumb the pseudo-help list mode through CLI parsing into the driver help short-circuit
- add focused tests for renderer behavior, shorthand help behavior, and explicit-help precedence

## Motivation

This addresses #2427 by making it much easier to inspect and enumerate a CLI's subcommand tree without manually invoking `--help` on each subcommand.

## Validation

- `cargo test help_list --lib`
- `cargo test help_word --lib`

Closes #2427