### PR TITLE
figue: improve tuple subcommand schema diagnostics

### DIFF
--- a/figue/src/schema/from_schema.rs
+++ b/figue/src/schema/from_schema.rs
@@ -153,8 +153,7 @@ fn discover_config_fields(
             };
 
             for variant in enum_type.variants {
-                let variant_ctx =
-                    SchemaErrorContext::root(enum_shape).with_variant(variant_cli_name(variant));
+                let variant_ctx = variant_payload_context(enum_shape, variant);
                 let variant_fields = variant_fields_for_schema(variant);
                 discover_config_fields(variant_fields, &variant_ctx, true)?;
             }
@@ -764,6 +763,14 @@ fn is_flattened_tuple_variant(variant: &Variant) -> bool {
     }
 }
 
+fn variant_payload_context(enum_shape: &'static Shape, variant: &Variant) -> SchemaErrorContext {
+    if is_flattened_tuple_variant(variant) {
+        SchemaErrorContext::root(variant.data.fields[0].shape())
+    } else {
+        SchemaErrorContext::root(enum_shape).with_variant(variant_cli_name(variant))
+    }
+}
+
 fn arg_level_from_fields(
     fields: &'static [Field],
     ctx: &SchemaErrorContext,
@@ -1046,7 +1053,8 @@ fn arg_level_from_fields_with_prefix(
                 let variant_fields = variant_fields_for_schema(variant);
                 let variant_ctx =
                     SchemaErrorContext::root(enum_shape).with_variant(cli_name.clone());
-                let args_schema = arg_level_from_fields(variant_fields, &variant_ctx)?;
+                let payload_ctx = variant_payload_context(enum_shape, variant);
+                let args_schema = arg_level_from_fields(variant_fields, &payload_ctx)?;
                 let is_flattened_tuple = is_flattened_tuple_variant(variant);
 
                 if let Some(short) = short {

--- a/figue/src/schema/snapshots/figue__schema__tests__snapshot_schema_missing_args_annotation_in_tuple_subcommand_payload.snap
+++ b/figue/src/schema/snapshots/figue__schema__tests__snapshot_schema_missing_args_annotation_in_tuple_subcommand_payload.snap
@@ -1,0 +1,18 @@
+---
+source: figue/src/schema/tests.rs
+assertion_line: 220
+expression: stripped
+---
+Error: field `dir` is missing a #[facet(args::...)] annotation
+   ╭─[ <unknown>:3:5 ]
+   │
+ 2 │ struct NestedMissingArgsPayload {
+   │        ────────────┬───────────  
+   │                    ╰───────────── defined at figue/src/schema/tests.rs:70
+ 3 │     dir: String,
+   │     ─────┬─────  
+   │          ╰─────── field `dir` is missing a #[facet(args::...)] annotation
+ 4 │ }
+   │ ┬  
+   │ ╰── end of definition
+───╯

--- a/figue/src/schema/tests.rs
+++ b/figue/src/schema/tests.rs
@@ -68,6 +68,23 @@ struct MissingArgsAnnotation {
 }
 
 #[derive(Facet)]
+struct NestedMissingArgsPayload {
+    dir: String,
+}
+
+#[derive(Facet)]
+#[repr(u8)]
+enum NestedMissingArgsCommand {
+    Add(NestedMissingArgsPayload),
+}
+
+#[derive(Facet)]
+struct NestedMissingArgsRoot {
+    #[facet(args::subcommand)]
+    command: NestedMissingArgsCommand,
+}
+
+#[derive(Facet)]
 #[repr(u8)]
 enum SubA {
     A,
@@ -198,6 +215,10 @@ fn snapshot_schema_missing_args_annotation() {
     assert_schema_snapshot!(Schema::from_shape(MissingArgsAnnotation::SHAPE));
 }
 
+#[test]
+fn snapshot_schema_missing_args_annotation_in_tuple_subcommand_payload() {
+    assert_schema_snapshot!(Schema::from_shape(NestedMissingArgsRoot::SHAPE));
+}
 #[test]
 fn snapshot_schema_multiple_subcommands() {
     assert_schema_snapshot!(Schema::from_shape(MultipleSubcommands::SHAPE));


### PR DESCRIPTION
## Summary
Improve `figue` schema diagnostics for tuple-variant subcommand payloads.

## What changed
- use the tuple payload struct as the diagnostic source context when validating flattened tuple-variant subcommand args
- keep the outer enum context for variant-level bookkeeping and conflict checks
- add a regression test and snapshot covering an unannotated field inside a tuple subcommand payload

## Why
Before this change, an error like a missing `#[facet(args::...)]` annotation inside `Enum::Variant(Args)` could be reported against the outer command enum instead of the real payload field. That made the panic output misleading in downstream CLIs.

Closes #2429.

## Validation
- `cargo test missing_args_annotation -- --nocapture`
