### PR TITLE
For urlencoded add support for char, i8, i16, i32, u8, u16, u32, f32, f64

### DIFF
--- a/facet-urlencoded/src/lib.rs
+++ b/facet-urlencoded/src/lib.rs
@@ -10,7 +10,8 @@
 //!
 #![doc = include_str!("../readme-footer.md")]
 
-use facet_core::{Def, Facet, Type, UserType};
+use facet::{NumericType, PrimitiveType};
+use facet_core::{Def, Facet, Shape, Type, UserType};
 use facet_reflect::{AllocError, Partial, ReflectError, ShapeMismatchError, TypePlan};
 use log::*;
 
@@ -326,55 +327,51 @@ fn deserialize_scalar_field<'facet, const BORROW: bool>(
     value: &str,
     mut wip: Partial<'facet, BORROW>,
 ) -> Result<Partial<'facet, BORROW>, UrlEncodedError> {
+    let shape = wip.shape();
+
     // Transparently descend through `Option<T>`. Mirrors how
     // facet-format's path_navigator handles it.
-    let is_option = matches!(wip.shape().def, Def::Option(_));
+    let is_option = matches!(shape.def, Def::Option(_));
     if is_option {
         wip = wip.begin_some()?;
     }
-    match wip.shape().def {
+    match shape.def {
         Def::Scalar => {
-            if wip.shape().is_type::<String>() {
+            if shape.is_type::<String>() {
                 let s = value.to_string();
                 wip = wip.set(s)?;
-            } else if wip.shape().is_type::<u64>() {
-                match value.parse::<u64>() {
-                    Ok(num) => wip = wip.set(num)?,
-                    Err(_) => {
-                        return Err(UrlEncodedError::InvalidNumber(
-                            key.to_string(),
-                            value.to_string(),
-                        ));
-                    }
-                };
-            } else if wip.shape().is_type::<i64>() {
-                match value.parse::<i64>() {
-                    Ok(num) => wip = wip.set(num)?,
-                    Err(_) => {
-                        return Err(UrlEncodedError::InvalidNumber(
-                            key.to_string(),
-                            value.to_string(),
-                        ));
-                    }
-                };
-            } else if wip.shape().is_type::<bool>() {
+            } else if shape.is_type::<bool>() {
                 let parsed = match value {
                     "true" | "1" | "on" | "yes" => true,
                     "false" | "0" | "off" | "no" | "" => false,
                     _ => {
                         return Err(UrlEncodedError::UnsupportedType(format!(
-                            "{}: unparseable bool literal {value:?}",
-                            wip.shape()
+                            "{shape}: unparseable bool literal {value:?}",
                         )));
                     }
                 };
                 wip = wip.set(parsed)?;
+            } else if let Some(value) = try_deserialize_number::<u64>(shape, key, value) {
+                wip = wip.set(value?)?;
+            } else if let Some(value) = try_deserialize_number::<i64>(shape, key, value) {
+                wip = wip.set(value?)?;
+            } else if let Some(value) = try_deserialize_number::<u32>(shape, key, value) {
+                wip = wip.set(value?)?;
+            } else if let Some(value) = try_deserialize_number::<i32>(shape, key, value) {
+                wip = wip.set(value?)?;
+            } else if let Some(value) = try_deserialize_number::<u8>(shape, key, value) {
+                wip = wip.set(value?)?;
+            } else if let Some(value) = try_deserialize_number::<f64>(shape, key, value) {
+                wip = wip.set(value?)?;
+            } else if let Some(value) = try_deserialize_number::<f32>(shape, key, value) {
+                wip = wip.set(value?)?;
             } else {
-                warn!("facet-urlencoded: unsupported scalar type: {}", wip.shape());
-                return Err(UrlEncodedError::UnsupportedType(format!("{}", wip.shape())));
+                warn!("facet-urlencoded: unsupported scalar type: {shape}");
+                return Err(UrlEncodedError::UnsupportedType(format!("{shape}")));
             }
         }
-        Def::Undefined if matches!(wip.shape().ty, Type::User(UserType::Enum(_))) => {
+
+        Def::Undefined if matches!(shape.ty, Type::User(UserType::Enum(_))) => {
             wip = wip.select_variant_named(value)?;
         }
         _ => {
@@ -392,6 +389,19 @@ fn deserialize_scalar_field<'facet, const BORROW: bool>(
     }
 
     Ok(wip)
+}
+
+/// If the shape matches the number type try to parse the value.
+fn try_deserialize_number<T: Facet<'static> + core::str::FromStr>(
+    shape: &'static Shape,
+    key: &str,
+    value: &str,
+) -> Option<Result<T, UrlEncodedError>> {
+    shape.is_type::<T>().then(|| {
+        value
+            .parse()
+            .map_err(|_| UrlEncodedError::InvalidNumber(key.to_string(), value.to_string()))
+    })
 }
 
 /// Errors that can occur during URL encoded form data deserialization.

--- a/facet-urlencoded/src/lib.rs
+++ b/facet-urlencoded/src/lib.rs
@@ -10,8 +10,7 @@
 //!
 #![doc = include_str!("../readme-footer.md")]
 
-use facet::{NumericType, PrimitiveType};
-use facet_core::{Def, Facet, Shape, Type, UserType};
+use facet_core::{Def, Facet, NumericType, PrimitiveType, TextualType, Type, UserType};
 use facet_reflect::{AllocError, Partial, ReflectError, ShapeMismatchError, TypePlan};
 use log::*;
 
@@ -327,60 +326,79 @@ fn deserialize_scalar_field<'facet, const BORROW: bool>(
     value: &str,
     mut wip: Partial<'facet, BORROW>,
 ) -> Result<Partial<'facet, BORROW>, UrlEncodedError> {
-    let shape = wip.shape();
+    let mut shape = wip.shape();
 
     // Transparently descend through `Option<T>`. Mirrors how
     // facet-format's path_navigator handles it.
     let is_option = matches!(shape.def, Def::Option(_));
     if is_option {
         wip = wip.begin_some()?;
+        shape = wip.shape();
     }
-    match shape.def {
-        Def::Scalar => {
-            if shape.is_type::<String>() {
-                let s = value.to_string();
-                wip = wip.set(s)?;
-            } else if shape.is_type::<bool>() {
+
+    let result = match shape.ty {
+        Type::Primitive(primitive) => match primitive {
+            PrimitiveType::Boolean => {
                 let parsed = match value {
                     "true" | "1" | "on" | "yes" => true,
                     "false" | "0" | "off" | "no" | "" => false,
-                    _ => {
-                        return Err(UrlEncodedError::UnsupportedType(format!(
-                            "{shape}: unparseable bool literal {value:?}",
-                        )));
-                    }
+                    _ => Err(UrlEncodedError::InvalidBool(
+                        key.to_string(),
+                        value.to_string(),
+                    ))?,
                 };
-                wip = wip.set(parsed)?;
-            } else if let Some(value) = try_deserialize_number::<u64>(shape, key, value) {
-                wip = wip.set(value?)?;
-            } else if let Some(value) = try_deserialize_number::<i64>(shape, key, value) {
-                wip = wip.set(value?)?;
-            } else if let Some(value) = try_deserialize_number::<u32>(shape, key, value) {
-                wip = wip.set(value?)?;
-            } else if let Some(value) = try_deserialize_number::<i32>(shape, key, value) {
-                wip = wip.set(value?)?;
-            } else if let Some(value) = try_deserialize_number::<u8>(shape, key, value) {
-                wip = wip.set(value?)?;
-            } else if let Some(value) = try_deserialize_number::<f64>(shape, key, value) {
-                wip = wip.set(value?)?;
-            } else if let Some(value) = try_deserialize_number::<f32>(shape, key, value) {
-                wip = wip.set(value?)?;
-            } else {
-                warn!("facet-urlencoded: unsupported scalar type: {shape}");
-                return Err(UrlEncodedError::UnsupportedType(format!("{shape}")));
+                wip.set(parsed).map_err(UrlEncodedError::ReflectError)
             }
-        }
-
-        Def::Undefined if matches!(shape.ty, Type::User(UserType::Enum(_))) => {
-            wip = wip.select_variant_named(value)?;
-        }
-        _ => {
-            error!("Expected scalar or enum field");
-            return Err(UrlEncodedError::UnsupportedShape(format!(
-                "Expected scalar or enum for field '{key}'"
-            )));
-        }
-    }
+            PrimitiveType::Numeric(numeric) => {
+                let size = shape
+                    .layout
+                    .sized_layout()
+                    .map(|layout| layout.size())
+                    .unwrap_or_default();
+                match numeric {
+                    NumericType::Integer { signed: false } => match size {
+                        1 => deserialize_number::<_, u8>(wip, key, value),
+                        2 => deserialize_number::<_, u16>(wip, key, value),
+                        4 => deserialize_number::<_, u32>(wip, key, value),
+                        8 => deserialize_number::<_, u64>(wip, key, value),
+                        _ => Err(UrlEncodedError::UnsupportedShape(wip.shape().to_string())),
+                    },
+                    NumericType::Integer { signed: true } => match size {
+                        1 => deserialize_number::<_, i8>(wip, key, value),
+                        2 => deserialize_number::<_, i16>(wip, key, value),
+                        4 => deserialize_number::<_, i32>(wip, key, value),
+                        8 => deserialize_number::<_, i64>(wip, key, value),
+                        _ => Err(UrlEncodedError::UnsupportedShape(wip.shape().to_string())),
+                    },
+                    NumericType::Float => match size {
+                        4 => deserialize_number::<_, f32>(wip, key, value),
+                        8 => deserialize_number::<_, f64>(wip, key, value),
+                        _ => Err(UrlEncodedError::UnsupportedShape(wip.shape().to_string())),
+                    },
+                    _ => Err(UrlEncodedError::UnsupportedShape(wip.shape().to_string())),
+                }
+            }
+            PrimitiveType::Textual(TextualType::Char) => {
+                let mut chars = value.chars();
+                let (Some(char), None) = (chars.next(), chars.next()) else {
+                    return Err(UrlEncodedError::InvalidChar(
+                        key.to_string(),
+                        value.to_string(),
+                    ));
+                };
+                wip.set(char).map_err(UrlEncodedError::ReflectError)
+            }
+            _ => Err(UrlEncodedError::UnsupportedShape(wip.shape().to_string())),
+        },
+        Type::User(UserType::Enum(_)) => wip
+            .select_variant_named(value)
+            .map_err(UrlEncodedError::ReflectError),
+        Type::User(UserType::Opaque) if shape.is_type::<String>() => wip
+            .set(value.to_string())
+            .map_err(UrlEncodedError::ReflectError),
+        _ => Err(UrlEncodedError::UnsupportedShape(wip.shape().to_string())),
+    };
+    wip = result?;
 
     // Pop the `begin_some` frame opened above so the caller's
     // `.end()` can pop the field cleanly.
@@ -392,16 +410,16 @@ fn deserialize_scalar_field<'facet, const BORROW: bool>(
 }
 
 /// If the shape matches the number type try to parse the value.
-fn try_deserialize_number<T: Facet<'static> + core::str::FromStr>(
-    shape: &'static Shape,
+fn deserialize_number<'facet, const BORROW: bool, T: Facet<'facet> + core::str::FromStr>(
+    wip: Partial<'facet, BORROW>,
     key: &str,
     value: &str,
-) -> Option<Result<T, UrlEncodedError>> {
-    shape.is_type::<T>().then(|| {
-        value
-            .parse()
-            .map_err(|_| UrlEncodedError::InvalidNumber(key.to_string(), value.to_string()))
-    })
+) -> Result<Partial<'facet, BORROW>, UrlEncodedError> {
+    let value = value
+        .parse::<T>()
+        .map_err(|_| UrlEncodedError::InvalidNumber(key.to_string(), value.to_string()))?;
+    let wip = wip.set(value)?;
+    Ok(wip)
 }
 
 /// Errors that can occur during URL encoded form data deserialization.
@@ -410,10 +428,12 @@ fn try_deserialize_number<T: Facet<'static> + core::str::FromStr>(
 pub enum UrlEncodedError {
     /// The field value couldn't be parsed as a number.
     InvalidNumber(String, String),
+    /// The field value couldn't be parsed as a char.
+    InvalidChar(String, String),
+    /// The field value couldn't be parsed as a bool.
+    InvalidBool(String, String),
     /// The shape is not supported for deserialization.
     UnsupportedShape(String),
-    /// The type is not supported for deserialization.
-    UnsupportedType(String),
     /// Reflection error
     ReflectError(ReflectError),
 }
@@ -448,11 +468,14 @@ impl core::fmt::Display for UrlEncodedError {
             UrlEncodedError::InvalidNumber(field, value) => {
                 write!(f, "Invalid number for field '{field}': '{value}'")
             }
+            UrlEncodedError::InvalidChar(field, value) => {
+                write!(f, "Invalid char for field '{field}': '{value}'")
+            }
+            UrlEncodedError::InvalidBool(field, value) => {
+                write!(f, "Invalid bool for field '{field}': '{value}'")
+            }
             UrlEncodedError::UnsupportedShape(shape) => {
                 write!(f, "Unsupported shape: {shape}")
-            }
-            UrlEncodedError::UnsupportedType(ty) => {
-                write!(f, "Unsupported type: {ty}")
             }
             UrlEncodedError::ReflectError(err) => {
                 write!(f, "Reflection error: {err}")

--- a/facet-urlencoded/src/tests.rs
+++ b/facet-urlencoded/src/tests.rs
@@ -315,3 +315,80 @@ fn test_flattened() {
         }
     );
 }
+
+#[test]
+fn test_char() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct Struct {
+        char: char,
+    }
+
+    assert_eq!(from_str::<Struct>("char=a").unwrap(), Struct { char: 'a' });
+    assert_eq!(from_str::<Struct>("char=0").unwrap(), Struct { char: '0' });
+    assert_eq!(from_str::<Struct>("char=à").unwrap(), Struct { char: 'à' });
+
+    assert!(from_str::<Struct>("char=hello").is_err());
+}
+
+#[test]
+fn test_numeric_signed() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct Singed {
+        i8: i8,
+        i16: i16,
+        i32: i32,
+        i64: i64,
+    }
+    let value: Singed = from_str("i8=0&i16=1&i32=2&i64=3").unwrap();
+    assert_eq!(
+        value,
+        Singed {
+            i8: 0,
+            i16: 1,
+            i32: 2,
+            i64: 3,
+        }
+    )
+}
+
+#[test]
+fn test_numeric_unsigned() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct Unsigned {
+        u8: u8,
+        u16: u16,
+        u32: u32,
+        u64: u64,
+    }
+    let value: Unsigned = from_str("u8=0&u16=1&u32=2&u64=3").unwrap();
+    assert_eq!(
+        value,
+        Unsigned {
+            u8: 0,
+            u16: 1,
+            u32: 2,
+            u64: 3,
+        }
+    )
+}
+
+#[test]
+fn test_numeric_float() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct Float {
+        f32: f32,
+        f64: f64,
+        f32_dot: f32,
+        f64_dot: f32,
+    }
+    let value: Float = from_str("f32=0&f64=1&f32_dot=2.5&f64_dot=3.5").unwrap();
+    assert_eq!(
+        value,
+        Float {
+            f32: 0.0,
+            f64: 1.0,
+            f32_dot: 2.5,
+            f64_dot: 3.5,
+        }
+    )
+}


### PR DESCRIPTION
Me again, needed support urlencoded support for other numeric types.

The first commit just adds the types to the existing checks and the second commit changes the check from `shape.def` to `shape.ty` to avoid iteration all types.
If the first commit is preferred I can change it back (but just the first commit is buggy at the moment ^^)

This also adds error cases for `bool` and `char` and removes the `UnsupportedType` error used for scalar type check and bools if the value was wrong.

Only `String` continues to use the `shape.is_type` check.