### PR TITLE
vix: oci() artifact probe (images as merged trees)

### DIFF
--- a/playgrounds/snark/src/bundled/vix/samples/oci-glibc-preflight.vix
+++ b/playgrounds/snark/src/bundled/vix/samples/oci-glibc-preflight.vix
@@ -1,0 +1,12 @@
+// OCI preflight shape: image bytes are never executed.
+// The current comparison surface supports string equality/inequality;
+// semantic GLIBC floor ordering is the next policy primitive.
+
+pub fn shipped_glibc(image: Tree) -> String {
+    let libc = oci(image).files.get("usr/lib/libc.so.6").unwrap().contents;
+    elf(libc).needs_glibc
+}
+
+pub fn matches_floor(image: Tree) -> Bool {
+    shipped_glibc(image) == "GLIBC_2.35"
+}

--- a/vix-wire/src/lib.rs
+++ b/vix-wire/src/lib.rs
@@ -48,7 +48,7 @@ pub struct WireExecRequest {
     pub capability: u64,
     /// Which tool to run (the command grammar's name — toy registry for now).
     pub command: String,
-    /// A shipped machine Pending<T> value evaluated executor-side against the
+    /// A shipped machine `Pending<T>` value evaluated executor-side against the
     /// Run value; its result is the only thing that crosses.
     pub observer: Option<ValueBundle>,
 }

--- a/vix/src/machine/driver.rs
+++ b/vix/src/machine/driver.rs
@@ -136,6 +136,7 @@ pub const ELF_DOC_HOST: u32 = 24;
 pub const AST_DOC_HOST: u32 = 25;
 pub const AST_FN_HOST: u32 = 26;
 pub const ARRAY_LEN_HOST: u32 = 27;
+pub const OCI_DOC_HOST: u32 = 28;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Lane {
@@ -587,13 +588,36 @@ struct PendingInvocation {
 }
 
 #[derive(Clone, Debug)]
-enum PendingPrimitive {
-    Elf {
-        projection: super::elf::Projection,
-    },
-    Ast {
-        projection: super::ast_probe::Projection,
-    },
+struct PendingPrimitive {
+    kind: PendingPrimitiveKind,
+}
+
+#[derive(Clone, Debug)]
+enum PendingPrimitiveKind {
+    Elf(super::elf::Projection),
+    Ast(super::ast_probe::Projection),
+    Oci(super::oci::Projection),
+}
+
+impl PendingPrimitive {
+    fn to_word(&self) -> i64 {
+        match self.kind {
+            PendingPrimitiveKind::Elf(projection) => projection.to_word(),
+            PendingPrimitiveKind::Ast(projection) => projection.to_word(),
+            PendingPrimitiveKind::Oci(projection) => 2_000 + projection.to_word(),
+        }
+    }
+
+    fn from_word(word: i64) -> Result<Self, String> {
+        let kind = if word >= 2_000 {
+            PendingPrimitiveKind::Oci(super::oci::Projection::from_word(word - 2_000)?)
+        } else if word >= 1_000 {
+            PendingPrimitiveKind::Ast(super::ast_probe::Projection::from_word(word)?)
+        } else {
+            PendingPrimitiveKind::Elf(super::elf::Projection::from_word(word)?)
+        };
+        Ok(Self { kind })
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1150,6 +1174,8 @@ pub struct Driver {
     ast_roots: HashMap<i64, i64>,
     ast_parse_memo: HashMap<ContentHash, Arc<ast::SourceFile>>,
     ast_projection_memo: HashMap<(ContentHash, super::ast_probe::Projection, String), i64>,
+    oci_projection_memo: HashMap<(ContentHash, super::oci::Projection), i64>,
+    oci_file_memo: HashMap<(ContentHash, String), Option<i64>>,
     runs: BTreeMap<u64, PendingExecRun>,
     next_run_id: u64,
     trace_clock: u64,
@@ -1196,6 +1222,8 @@ impl Driver {
             ast_roots: HashMap::new(),
             ast_parse_memo: HashMap::new(),
             ast_projection_memo: HashMap::new(),
+            oci_projection_memo: HashMap::new(),
+            oci_file_memo: HashMap::new(),
             runs: BTreeMap::new(),
             next_run_id: 0,
             trace_clock: 0,
@@ -1793,6 +1821,7 @@ impl Driver {
             let schema_refs = &self.schema_refs;
             let store_cell = &self.store;
             let ast_roots_cell = RefCell::new(&mut self.ast_roots);
+            let oci_file_memo_cell = RefCell::new(&mut self.oci_file_memo);
             let journal_cell = RefCell::new(&mut self.journal);
             let clock_cell = RefCell::new(&mut self.trace_clock);
             let lowered_fns = &self.fns;
@@ -2267,7 +2296,18 @@ impl Driver {
                     let doc = read_frame_word(frame, primitive_region + 8);
                     let key = read_frame_word(frame, primitive_region + 16);
                     let key = store_cell.borrow().string_value(key, "String")?;
-                    let (handle, _) = doc_get(store_cell, descriptors, schema_refs, doc, &key)?;
+                    let (handle, _) = doc_get_with_virtual(
+                        &VirtualDocGetCtx {
+                            store: store_cell,
+                            descriptors,
+                            schema_refs,
+                            oci_file_memo: &oci_file_memo_cell,
+                            store_events: &store_events,
+                            clock_cell: &clock_cell,
+                        },
+                        doc,
+                        &key,
+                    )?;
                     write_frame_word(frame, dst_slot, handle);
                     Ok(())
                 })();
@@ -2312,6 +2352,19 @@ impl Driver {
                     let input = read_frame_word(frame, primitive_region + 8);
                     let handle = alloc_ast_doc(store_cell, descriptors, schema_refs, input)?;
                     ast_roots_cell.borrow_mut().insert(handle, input);
+                    write_frame_word(frame, dst_slot, handle);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
+            let mut oci_doc_host = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let input = read_frame_word(frame, primitive_region + 8);
+                    let handle = alloc_oci_doc(store_cell, descriptors, schema_refs, input)?;
                     write_frame_word(frame, dst_slot, handle);
                     Ok(())
                 })();
@@ -2520,7 +2573,7 @@ impl Driver {
                 });
             };
 
-            let mut hosts: [HostFn<'_>; 28] = [
+            let mut hosts: [HostFn<'_>; 29] = [
                 &mut invoke,
                 &mut store_alloc,
                 &mut store_read,
@@ -2549,6 +2602,7 @@ impl Driver {
                 &mut ast_doc_host,
                 &mut ast_fn_host,
                 &mut array_len_host,
+                &mut oci_doc_host,
             ];
             let step = exec
                 .task
@@ -2714,12 +2768,15 @@ impl Driver {
             ));
         }
         if let Some(primitive) = invocation.primitive {
-            let value = match primitive {
-                PendingPrimitive::Elf { projection } => {
+            let value = match primitive.kind {
+                PendingPrimitiveKind::Elf(projection) => {
                     self.force_elf_projection(projection, &invocation.args)?
                 }
-                PendingPrimitive::Ast { projection } => {
+                PendingPrimitiveKind::Ast(projection) => {
                     self.force_ast_projection(projection, &invocation.args)?
+                }
+                PendingPrimitiveKind::Oci(projection) => {
+                    self.force_oci_projection(projection, &invocation.args)?
                 }
             };
             return Ok(PendingForce::Ready {
@@ -3363,6 +3420,51 @@ impl Driver {
         Ok(handle)
     }
 
+    fn force_oci_projection(
+        &mut self,
+        projection: super::oci::Projection,
+        args: &[i64],
+    ) -> Result<i64, String> {
+        let [input] = args else {
+            return Err(format!(
+                "OCI projection {} expected one input, got {}",
+                projection.name(),
+                args.len()
+            ));
+        };
+        let tree = self.oci_input_tree(*input)?;
+        let input_hash = super::oci::input_hash(&tree);
+        if let Some(&handle) = self.oci_projection_memo.get(&(input_hash, projection)) {
+            let timestamp_us = self.next_timestamp();
+            self.emit(DriveEvent::ArtifactProbe {
+                format: "oci".to_string(),
+                projection: projection.name().to_string(),
+                input: hash_u64(input_hash),
+                cache_hit: true,
+                timestamp_us,
+            });
+            return Ok(handle);
+        }
+        let handle = if projection == super::oci::Projection::Files {
+            alloc_oci_files_doc(&self.store, &self.descriptors, input_hash, *input)?
+        } else {
+            let layout = super::oci::parse_layout(tree)?;
+            let value = super::oci::project(&layout, projection)?;
+            alloc_doc_from_value(&self.store, &self.descriptors, &self.schema_refs, value)?
+        };
+        self.oci_projection_memo
+            .insert((input_hash, projection), handle);
+        let timestamp_us = self.next_timestamp();
+        self.emit(DriveEvent::ArtifactProbe {
+            format: "oci".to_string(),
+            projection: projection.name().to_string(),
+            input: hash_u64(input_hash),
+            cache_hit: false,
+            timestamp_us,
+        });
+        Ok(handle)
+    }
+
     fn ast_input_source(&mut self, handle: i64) -> Result<(String, ContentHash), String> {
         let entry = self
             .store
@@ -3394,6 +3496,25 @@ impl Driver {
         hasher.update(b"vix-ast-input");
         hasher.update(source.as_bytes());
         Ok((source, hasher.finalize().into()))
+    }
+
+    fn oci_input_tree(&mut self, handle: i64) -> Result<crate::exec::Tree, String> {
+        let store = self.store.borrow();
+        let entry = store
+            .entry(handle)
+            .ok_or_else(|| format!("store handle {handle}"))?;
+        if entry.schema == "Tree" {
+            drop(store);
+            {
+                let forced = self.force_tree_handle(handle)?;
+                let TreeEntry::Concrete(tree) = self.store.borrow().tree_entry(forced)? else {
+                    return Err("OCI input tree stayed pending".into());
+                };
+                Ok(tree)
+            }
+        } else {
+            oci_tree_from_entry(entry)
+        }
     }
 }
 
@@ -3433,6 +3554,7 @@ enum DocPayload {
     String(i64),
     Array(i64),
     Map(i64),
+    Virtual(i64),
 }
 
 fn alloc_doc_from_value(
@@ -3557,6 +3679,10 @@ fn doc_payload(
             &entry.bytes,
             field_offset(descriptor, &entry.bytes, 0),
         )),
+        7 => DocPayload::Virtual(read_frame_word(
+            &entry.bytes,
+            field_offset(descriptor, &entry.bytes, 0),
+        )),
         other => return Err(format!("unknown Doc tag {other}")),
     })
 }
@@ -3586,6 +3712,132 @@ fn doc_get(
     )
 }
 
+struct VirtualDocGetCtx<'a> {
+    store: &'a RefCell<ValueStore>,
+    descriptors: &'a HashMap<String, Descriptor<String>>,
+    schema_refs: &'a [String],
+    oci_file_memo: &'a RefCell<&'a mut HashMap<(ContentHash, String), Option<i64>>>,
+    store_events: &'a RefCell<Vec<DriveEvent>>,
+    clock_cell: &'a RefCell<&'a mut u64>,
+}
+
+fn doc_get_with_virtual(
+    ctx: &VirtualDocGetCtx<'_>,
+    doc: i64,
+    key: &str,
+) -> Result<(i64, bool), String> {
+    let virtual_input = {
+        let store = ctx.store.borrow();
+        oci_virtual_files_input(&store, ctx.descriptors, doc)?
+    };
+    if let Some(input) = virtual_input {
+        return oci_virtual_file_get(ctx, input, key);
+    }
+    doc_get(ctx.store, ctx.descriptors, ctx.schema_refs, doc, key)
+}
+
+fn oci_virtual_file_get(
+    ctx: &VirtualDocGetCtx<'_>,
+    input: i64,
+    path: &str,
+) -> Result<(i64, bool), String> {
+    let tree = {
+        let store = ctx.store.borrow();
+        oci_tree_from_store(&store, input)?
+    };
+    let input_hash = super::oci::input_hash(&tree);
+    let key = (input_hash, path.to_string());
+    if let Some(cached) = ctx.oci_file_memo.borrow().get(&key).cloned() {
+        emit_artifact_probe(
+            ctx.store_events,
+            ctx.clock_cell,
+            "oci",
+            &format!("files/{path}"),
+            input_hash,
+            true,
+        );
+        return match cached {
+            Some(handle) => ctx.store.borrow_mut().alloc_option_some(
+                "Realized<Doc>",
+                handle,
+                Some(Realization::Ready),
+                ctx.schema_refs,
+            ),
+            None => ctx
+                .store
+                .borrow_mut()
+                .alloc_option_none("Realized<Doc>", ctx.schema_refs),
+        };
+    }
+    let layout = super::oci::parse_layout(tree)?;
+    let projected = super::oci::project_file(&layout, path)?;
+    let handle = projected
+        .map(|file| {
+            alloc_doc_from_value(
+                ctx.store,
+                ctx.descriptors,
+                ctx.schema_refs,
+                Value::Map(BTreeMap::from([
+                    (Value::Str("path".to_string()), Value::Str(path.to_string())),
+                    (
+                        Value::Str("contents".to_string()),
+                        Value::Str(file.contents),
+                    ),
+                    (
+                        Value::Str("layer_digest".to_string()),
+                        Value::Str(file.layer_digest),
+                    ),
+                    (Value::Str("size".to_string()), Value::Int(file.size)),
+                ])),
+            )
+        })
+        .transpose()?;
+    ctx.oci_file_memo.borrow_mut().insert(key, handle);
+    emit_artifact_probe(
+        ctx.store_events,
+        ctx.clock_cell,
+        "oci",
+        &format!("files/{path}"),
+        input_hash,
+        false,
+    );
+    match handle {
+        Some(handle) => ctx.store.borrow_mut().alloc_option_some(
+            "Realized<Doc>",
+            handle,
+            Some(Realization::Ready),
+            ctx.schema_refs,
+        ),
+        None => ctx
+            .store
+            .borrow_mut()
+            .alloc_option_none("Realized<Doc>", ctx.schema_refs),
+    }
+}
+
+fn emit_artifact_probe(
+    store_events: &RefCell<Vec<DriveEvent>>,
+    clock_cell: &RefCell<&mut u64>,
+    format: &str,
+    projection: &str,
+    input_hash: ContentHash,
+    cache_hit: bool,
+) {
+    let timestamp_us = {
+        let mut clock = clock_cell.borrow_mut();
+        let timestamp_us = **clock;
+        **clock = timestamp_us.saturating_add(1);
+        timestamp_us
+    };
+    store_events.borrow_mut().push(DriveEvent::ArtifactProbe {
+        format: format.to_string(),
+        projection: projection.to_string(),
+        input: hash_u64(input_hash),
+        cache_hit,
+        timestamp_us,
+    });
+}
+
 fn doc_coerce(
     store: &RefCell<ValueStore>,
     descriptors: &HashMap<String, Descriptor<String>>,
@@ -3602,6 +3854,7 @@ fn doc_coerce(
         (DocPayload::String(value), "String") => Ok(value),
         (DocPayload::Array(value), "Array") => Ok(value),
         (DocPayload::Map(value), "Map<String,Doc>") => Ok(value),
+        (DocPayload::Virtual(_), schema) => Err(format!("cannot coerce Doc::Virtual to {schema}")),
         (payload, schema) => Err(format!("cannot coerce Doc::{payload:?} to {schema}")),
     }
 }
@@ -3655,6 +3908,54 @@ fn alloc_elf_doc(
     alloc_doc_variant(store, descriptors, 6, &[map])
 }
 
+fn alloc_oci_doc(
+    store: &RefCell<ValueStore>,
+    descriptors: &HashMap<String, Descriptor<String>>,
+    schema_refs: &[String],
+    input: i64,
+) -> Result<i64, String> {
+    let input_hash = {
+        let store = store.borrow();
+        let tree = oci_tree_from_store(&store, input)?;
+        super::oci::input_hash(&tree)
+    };
+    let mut pairs = Vec::new();
+    for projection in super::oci::Projection::ALL {
+        let key = store
+            .borrow_mut()
+            .alloc_raw("String", projection.name().as_bytes().to_vec())
+            .0;
+        let pending = oci_projection_pending(input, input_hash, projection);
+        let pending = store.borrow_mut().alloc_pending("Doc", pending).0;
+        pairs.push(MapPair {
+            key_schema: "String".to_string(),
+            key_word: key,
+            value_schema: pending_schema("Doc"),
+            value_word: pending,
+            value_realization: None,
+        });
+    }
+    let map = store
+        .borrow_mut()
+        .alloc_map("Map<String,Doc>", pairs, schema_refs, descriptors)?
+        .0;
+    alloc_doc_variant(store, descriptors, 6, &[map])
+}
+
+fn alloc_oci_files_doc(
+    store: &RefCell<ValueStore>,
+    descriptors: &HashMap<String, Descriptor<String>>,
+    input_hash: ContentHash,
+    input: i64,
+) -> Result<i64, String> {
+    let marker = format!("oci-files:{}:{input}", hex_content_hash(&input_hash));
+    let marker = store
+        .borrow_mut()
+        .alloc_raw("String", marker.into_bytes())
+        .0;
+    alloc_doc_variant(store, descriptors, 7, &[marker])
+}
+
 fn elf_projection_pending(
     input: i64,
     input_hash: ContentHash,
@@ -3667,7 +3968,9 @@ fn elf_projection_pending(
     let identity_hash = hasher.finalize().into();
     PendingInvocation {
         closure_hash: hash_u64(("elf", projection.name())),
-        primitive: Some(PendingPrimitive::Elf { projection }),
+        primitive: Some(PendingPrimitive {
+            kind: PendingPrimitiveKind::Elf(projection),
+        }),
         args: vec![input],
         remaining_arity: 0,
         identity_hash,
@@ -3788,7 +4091,9 @@ fn ast_projection_pending(
     args.extend(extra_args);
     PendingInvocation {
         closure_hash: hash_u64(("ast", projection.name())),
-        primitive: Some(PendingPrimitive::Ast { projection }),
+        primitive: Some(PendingPrimitive {
+            kind: PendingPrimitiveKind::Ast(projection),
+        }),
         args,
         remaining_arity: 0,
         identity_hash: hasher.finalize().into(),
@@ -3817,6 +4122,71 @@ fn alloc_doc_object(
         .alloc_map("Map<String,Doc>", pairs, schema_refs, descriptors)?
         .0;
     alloc_doc_variant(store, descriptors, 6, &[map])
+}
+
+fn oci_projection_pending(
+    input: i64,
+    input_hash: ContentHash,
+    projection: super::oci::Projection,
+) -> PendingInvocation {
+    let mut hasher = Sha256::new();
+    hasher.update(b"vix-oci-projection");
+    hasher.update(projection.name().as_bytes());
+    hasher.update(input_hash);
+    let identity_hash = hasher.finalize().into();
+    PendingInvocation {
+        closure_hash: hash_u64(("oci", projection.name())),
+        primitive: Some(PendingPrimitive {
+            kind: PendingPrimitiveKind::Oci(projection),
+        }),
+        args: vec![input],
+        remaining_arity: 0,
+        identity_hash,
+    }
+}
+
+fn oci_virtual_files_input(
+    store: &ValueStore,
+    descriptors: &HashMap<String, Descriptor<String>>,
+    doc: i64,
+) -> Result<Option<i64>, String> {
+    let DocPayload::Virtual(marker) = doc_payload(store, descriptors, doc)? else {
+        return Ok(None);
+    };
+    let marker = store.string_value(marker, "String")?;
+    let Some(rest) = marker.strip_prefix("oci-files:") else {
+        return Ok(None);
+    };
+    let Some((_, input)) = rest.rsplit_once(':') else {
+        return Err(format!("bad OCI files marker `{marker}`"));
+    };
+    input
+        .parse::<i64>()
+        .map(Some)
+        .map_err(|err| format!("bad OCI files marker `{marker}`: {err}"))
+}
+
+fn oci_tree_from_store(store: &ValueStore, input: i64) -> Result<crate::exec::Tree, String> {
+    let entry = store
+        .entry(input)
+        .ok_or_else(|| format!("store handle {input}"))?;
+    if entry.schema == "Tree" {
+        let TreeEntry::Concrete(tree) = store.tree_entry(input)? else {
+            return Err("OCI input tree must be concrete".into());
+        };
+        Ok(tree)
+    } else {
+        oci_tree_from_entry(entry)
+    }
+}
+
+fn oci_tree_from_entry(entry: &StoreEntry) -> Result<crate::exec::Tree, String> {
+    match entry.schema.as_str() {
+        "Blob" | "String" => super::oci::archive_to_tree(&entry.bytes),
+        other => Err(format!(
+            "OCI input must be Blob, String, or Tree, got {other}"
+        )),
+    }
 }
 
 fn compare_words(
@@ -3952,6 +4322,7 @@ fn compare_docs(
         DocPayload::String(_) => 4,
         DocPayload::Array(_) => 5,
         DocPayload::Map(_) => 6,
+        DocPayload::Virtual(_) => 7,
     };
     let tag_order = tag(&a_payload).cmp(&tag(&b_payload));
     if tag_order != Ordering::Equal {
@@ -3972,6 +4343,9 @@ fn compare_docs(
         }
         (DocPayload::Map(a), DocPayload::Map(b)) => {
             compare_words(store, descriptors, schema_refs, "Map<String,Doc>", a, b)
+        }
+        (DocPayload::Virtual(a), DocPayload::Virtual(b)) => {
+            compare_words(store, descriptors, schema_refs, "String", a, b)
         }
         _ => Ok(Ordering::Equal),
     }
@@ -4424,6 +4798,17 @@ fn render_doc(
                 schema_refs,
                 names,
                 "Map<String,Doc>",
+                word,
+            )?)),
+        ),
+        DocPayload::Virtual(word) => (
+            "Virtual".to_string(),
+            Some(Box::new(render_word(
+                store,
+                descriptors,
+                schema_refs,
+                names,
+                "String",
                 word,
             )?)),
         ),
@@ -4972,25 +5357,6 @@ fn map_schemas(schema: &str) -> Option<(&str, &str)> {
     Some((key, value))
 }
 
-fn pending_primitive_to_word(primitive: &PendingPrimitive) -> i64 {
-    match primitive {
-        PendingPrimitive::Elf { projection } => projection.to_word(),
-        PendingPrimitive::Ast { projection } => projection.to_word(),
-    }
-}
-
-fn pending_primitive_from_word(word: i64) -> Result<PendingPrimitive, String> {
-    if word >= 1000 {
-        Ok(PendingPrimitive::Ast {
-            projection: super::ast_probe::Projection::from_word(word)?,
-        })
-    } else {
-        Ok(PendingPrimitive::Elf {
-            projection: super::elf::Projection::from_word(word)?,
-        })
-    }
-}
-
 fn encode_pending_invocation(invocation: &PendingInvocation) -> Vec<u8> {
     let mut bytes = Vec::new();
     bytes.extend_from_slice(&invocation.closure_hash.to_le_bytes());
@@ -5007,7 +5373,7 @@ fn encode_pending_invocation(invocation: &PendingInvocation) -> Vec<u8> {
     let primitive = invocation
         .primitive
         .as_ref()
-        .map(pending_primitive_to_word)
+        .map(PendingPrimitive::to_word)
         .unwrap_or(-1);
     bytes.extend_from_slice(&primitive.to_le_bytes());
     bytes.extend_from_slice(&invocation.identity_hash);
@@ -5028,7 +5394,7 @@ fn decode_pending_invocation(bytes: &[u8]) -> Result<PendingInvocation, String> 
         usize::try_from(read_frame_word(bytes, 16)).map_err(|_| "remaining arity")?;
     let primitive = match read_frame_word(bytes, 24) {
         -1 => None,
-        word => Some(pending_primitive_from_word(word)?),
+        word => Some(PendingPrimitive::from_word(word)?),
     };
     let identity_hash: ContentHash = bytes[32..64]
         .try_into()

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -32,7 +32,7 @@ use super::driver::{
     ARRAY_MAP_PENDING_HOST, AST_DOC_HOST, AST_FN_HOST, CodeBundle, DOC_COERCE_HOST, DOC_GET_HOST,
     DOC_PARSE_HOST, DriveEvent, DriveEventSink, Driver, ELF_DOC_HOST, EXEC_HOST, FETCH_HOST,
     GLOB_HOST, INVOKE_HOST, Lane, LoweredFn, MAP_EMPTY_HOST, MAP_GET_HOST, MAP_INSERT_HOST,
-    MachineExecBackend, OPTION_UNWRAP_HOST, PATH_WITH_EXT_HOST, PENDING_ALLOC_HOST,
+    MachineExecBackend, OCI_DOC_HOST, OPTION_UNWRAP_HOST, PATH_WITH_EXT_HOST, PENDING_ALLOC_HOST,
     PENDING_COERCE_HOST, PENDING_INVOKE_HOST, RenderNames, RenderVariant, RenderedValue,
     STORE_ALLOC_HOST, STORE_READ_HOST, STORE_TAG_HOST, StepMode, StoreHandle, TREE_PROJECT_HOST,
     ValueBundle,
@@ -1607,6 +1607,7 @@ fn add_builtin_descriptors(descriptors: &mut HashMap<String, Descriptor<String>>
                     "DocMap".into(),
                     "Map<String,Doc>".into(),
                 )],
+                vec![declared_mem::handle("DocVirtual".into(), "String".into())],
             ],
         )
     });
@@ -2478,6 +2479,7 @@ impl<'a> FnLowerer<'a> {
             "json" => return self.doc_parse_call(call, 1),
             "elf" => return self.elf_call(call),
             "ast" => return self.ast_call(call),
+            "oci" => return self.oci_call(call),
             _ => {}
         }
         if let Some(&fn_ref) = self.fn_refs.get(name) {
@@ -4414,6 +4416,33 @@ impl<'a> FnLowerer<'a> {
         })
     }
 
+    fn oci_call(&mut self, call: &ast::Call) -> Result<ValueSlot, String> {
+        let [ast::Arg::Expr(arg)] = call.args.args.as_slice() else {
+            return Err("oci takes one OCI layout Blob, String, or Tree".into());
+        };
+        let input = self.expr(arg)?;
+        if !matches!(input.schema.as_str(), "Blob" | "String" | "Tree") {
+            return Err(format!("oci called on {}", input.schema));
+        }
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: input.slot,
+        });
+        self.code.push(Op::HostCall { host: OCI_DOC_HOST });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: "Doc".into(),
+            realization: None,
+            pending: None,
+        })
+    }
+
     fn ast_fn(&mut self, receiver: &ValueSlot, name: &ValueSlot) -> Result<ValueSlot, String> {
         self.expect_schema(receiver, "Doc")?;
         self.expect_schema(name, "String")?;
@@ -4780,6 +4809,7 @@ mod tests {
     use super::*;
     use crate::exec::{ExecEvent, Tree};
     use crate::fetch::FakeFetchBackend;
+    use sha2::{Digest, Sha256};
     use std::cell::RefCell;
     use std::collections::BTreeMap;
     use std::hash::{DefaultHasher, Hash, Hasher};
@@ -4845,6 +4875,105 @@ pub fn poly(n: Int) -> Int {
             ),
             ("README.md", readme),
         ])
+    }
+
+    fn tiny_oci_layout() -> (Tree, String) {
+        let config =
+            r#"{"config":{"Env":["A=base","B=top"],"Entrypoint":["/bin/app"],"Cmd":["--serve"]}}"#;
+        let config_digest = digest(config.as_bytes());
+        let config_path = blob_path(&config_digest);
+
+        let base = tar(&[
+            ("etc/message", b"base\n".as_slice()),
+            ("etc/remove", b"remove me\n".as_slice()),
+            ("bin/app", b"not-an-elf\n".as_slice()),
+        ]);
+        let overlay = tar(&[("etc/message", b"overlay\n".as_slice())]);
+        let whiteout = tar(&[("etc/.wh.remove", b"".as_slice())]);
+        let base_digest = digest(base.as_bytes());
+        let overlay_digest = digest(overlay.as_bytes());
+        let whiteout_digest = digest(whiteout.as_bytes());
+
+        let manifest = format!(
+            r#"{{"schemaVersion":2,"config":{{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"{config_digest}","size":{config_size}}},"layers":[{{"mediaType":"application/vnd.oci.image.layer.v1.tar","digest":"{base_digest}","size":{base_size}}},{{"mediaType":"application/vnd.oci.image.layer.v1.tar","digest":"{overlay_digest}","size":{overlay_size}}},{{"mediaType":"application/vnd.oci.image.layer.v1.tar","digest":"{whiteout_digest}","size":{whiteout_size}}}]}}"#,
+            config_size = config.len(),
+            base_size = base.len(),
+            overlay_size = overlay.len(),
+            whiteout_size = whiteout.len(),
+        );
+        let manifest_digest = digest(manifest.as_bytes());
+        let manifest_path = blob_path(&manifest_digest);
+        let index = format!(
+            r#"{{"schemaVersion":2,"manifests":[{{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"{manifest_digest}","size":{manifest_size}}}]}}"#,
+            manifest_size = manifest.len(),
+        );
+        (
+            Tree::of(&[
+                ("oci-layout", r#"{"imageLayoutVersion":"1.0.0"}"#),
+                ("index.json", index.as_str()),
+                (manifest_path.as_str(), manifest.as_str()),
+                (config_path.as_str(), config),
+                (blob_path(&base_digest).as_str(), base.as_str()),
+                (blob_path(&overlay_digest).as_str(), overlay.as_str()),
+                (blob_path(&whiteout_digest).as_str(), whiteout.as_str()),
+            ]),
+            overlay_digest,
+        )
+    }
+
+    fn digest(bytes: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        format!("sha256:{}", hex::encode(hasher.finalize()))
+    }
+
+    fn blob_path(digest: &str) -> String {
+        let (algorithm, hex) = digest.split_once(':').expect("digest algorithm");
+        format!("blobs/{algorithm}/{hex}")
+    }
+
+    fn tar(entries: &[(&str, &[u8])]) -> String {
+        let mut out = Vec::new();
+        for (path, contents) in entries {
+            let mut header = [0u8; 512];
+            assert!(path.len() <= 100, "test tar path too long: {path}");
+            header[..path.len()].copy_from_slice(path.as_bytes());
+            header[100..108].copy_from_slice(b"0000644\0");
+            header[108..116].copy_from_slice(b"0000000\0");
+            header[116..124].copy_from_slice(b"0000000\0");
+            write_octal(&mut header[124..136], contents.len() as u64);
+            header[136..148].copy_from_slice(b"00000000000\0");
+            header[148..156].fill(b' ');
+            header[156] = b'0';
+            header[257..263].copy_from_slice(b"ustar\0");
+            header[263..265].copy_from_slice(b"00");
+            let checksum: u32 = header.iter().map(|byte| u32::from(*byte)).sum();
+            write_checksum(&mut header[148..156], checksum);
+            out.extend_from_slice(&header);
+            out.extend_from_slice(contents);
+            out.resize(out.len().div_ceil(512) * 512, 0);
+        }
+        out.resize(out.len() + 1024, 0);
+        String::from_utf8(out).expect("test tar is valid UTF-8")
+    }
+
+    fn write_octal(dst: &mut [u8], value: u64) {
+        let text = format!("{value:011o}\0");
+        dst.copy_from_slice(text.as_bytes());
+    }
+
+    fn write_checksum(dst: &mut [u8], value: u32) {
+        let text = format!("{value:06o}\0 ");
+        dst.copy_from_slice(text.as_bytes());
+    }
+
+    fn tree_archive(tree: &Tree) -> String {
+        let entries = tree
+            .entries
+            .iter()
+            .map(|(path, contents)| (path.as_str(), contents.as_bytes()))
+            .collect::<Vec<_>>();
+        tar(&entries)
     }
 
     #[test]
@@ -7047,6 +7176,149 @@ pub fn body_twice(source: String) -> (Int, Int) {
     }
 
     #[test]
+    fn oci_structural_projection_contracts_are_pinned() {
+        let src = r#"
+pub fn layers(input: Tree) -> [Doc] { oci(input).layers }
+pub fn env(input: Tree) -> [String] { oci(input).env }
+pub fn entrypoint(input: Tree) -> [String] { oci(input).entrypoint }
+pub fn cmd(input: Tree) -> [String] { oci(input).cmd }
+pub fn shadow(input: Tree) -> String { oci(input).files.get("etc/message").unwrap().contents }
+pub fn shadow_layer(input: Tree) -> String { oci(input).files.get("etc/message").unwrap().layer_digest }
+"#;
+        let (layout, overlay_digest) = tiny_oci_layout();
+        let parsed = super::super::oci::parse_layout(layout.clone()).unwrap();
+        assert_eq!(
+            super::super::oci::project_file(&parsed, "etc/remove").unwrap(),
+            None
+        );
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            let input = machine.intern_tree_concrete(layout.clone());
+
+            let layers = machine.demand_i64("layers", vec![input]).unwrap();
+            let layers = rendered_doc_maps(&machine, "layers", layers);
+            assert_eq!(layers.len(), 3, "{lane:?}");
+
+            let env = machine.demand_i64("env", vec![input]).unwrap();
+            assert_eq!(
+                rendered_doc_strings(&machine, "env", env),
+                vec!["A=base".to_string(), "B=top".to_string()],
+                "{lane:?}"
+            );
+            let entrypoint = machine.demand_i64("entrypoint", vec![input]).unwrap();
+            assert_eq!(
+                rendered_doc_strings(&machine, "entrypoint", entrypoint),
+                vec!["/bin/app".to_string()],
+                "{lane:?}"
+            );
+            let cmd = machine.demand_i64("cmd", vec![input]).unwrap();
+            assert_eq!(
+                rendered_doc_strings(&machine, "cmd", cmd),
+                vec!["--serve".to_string()],
+                "{lane:?}"
+            );
+
+            let shadow = machine.demand_i64("shadow", vec![input]).unwrap();
+            assert_eq!(
+                machine.driver.raw_string(shadow, "String").unwrap(),
+                "overlay\n",
+                "{lane:?}"
+            );
+            let layer = machine.demand_i64("shadow_layer", vec![input]).unwrap();
+            assert_eq!(
+                machine.driver.raw_string(layer, "String").unwrap(),
+                overlay_digest,
+                "{lane:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn oci_config_projection_does_not_parse_layers() {
+        let src = r#"
+pub fn env(input: Tree) -> [String] { oci(input).config.config.Env }
+"#;
+        let (layout, _) = tiny_oci_layout();
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            let input = machine.intern_tree_concrete(layout.clone());
+            let env = machine.demand_i64("env", vec![input]).unwrap();
+            assert_eq!(
+                rendered_doc_strings(&machine, "env", env),
+                vec!["A=base".to_string(), "B=top".to_string()],
+                "{lane:?}"
+            );
+            assert_eq!(
+                artifact_probes_for(&machine, "oci"),
+                vec![("config".to_string(), false)],
+                "{lane:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn oci_accepts_layout_blob_archives() {
+        let src = r#"
+pub fn env(input: Blob) -> [String] { oci(input).env }
+"#;
+        let (layout, _) = tiny_oci_layout();
+        let archive = tree_archive(&layout);
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            let input = machine
+                .driver
+                .intern_raw_value("Blob", archive.as_bytes().to_vec())
+                .0;
+            let env = machine.demand_i64("env", vec![input]).unwrap();
+            assert_eq!(
+                rendered_doc_strings(&machine, "env", env),
+                vec!["A=base".to_string(), "B=top".to_string()],
+                "{lane:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn oci_file_projection_is_path_local_and_memoized() {
+        let src = r#"
+pub fn shadow_twice(input: Tree) -> (String, String) {
+    let files = oci(input).files;
+    (
+        files.get("etc/message").unwrap().contents,
+        files.get("etc/message").unwrap().contents,
+    )
+}
+"#;
+        let (layout, _) = tiny_oci_layout();
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            let input = machine.intern_tree_concrete(layout.clone());
+            let tuple = machine.demand_i64("shadow_twice", vec![input]).unwrap();
+            let left = machine.driver.store_field(tuple, 0).unwrap();
+            let right = machine.driver.store_field(tuple, 1).unwrap();
+            assert_eq!(
+                machine.driver.raw_string(left, "String").unwrap(),
+                "overlay\n",
+                "{lane:?}"
+            );
+            assert_eq!(
+                machine.driver.raw_string(right, "String").unwrap(),
+                "overlay\n",
+                "{lane:?}"
+            );
+            assert_eq!(
+                artifact_probes_for(&machine, "oci"),
+                vec![
+                    ("files".to_string(), false),
+                    ("files/etc/message".to_string(), false),
+                    ("files/etc/message".to_string(), true),
+                ],
+                "{lane:?}"
+            );
+        }
+    }
+
+    #[test]
     fn scalar_array_collect_sorts_and_rejects_arguments() {
         let bad = r#"
 pub fn bad() -> [Int] {
@@ -7440,6 +7712,10 @@ pub fn lazy(n: Int) -> Map<String, Float> {
     }
 
     fn artifact_probes(machine: &Machine) -> Vec<(String, bool)> {
+        artifact_probes_for(machine, "elf")
+    }
+
+    fn artifact_probes_for(machine: &Machine, wanted: &str) -> Vec<(String, bool)> {
         machine
             .trace()
             .iter()
@@ -7449,7 +7725,7 @@ pub fn lazy(n: Int) -> Map<String, Float> {
                     projection,
                     cache_hit,
                     ..
-                } if format == "elf" => Some((projection.clone(), *cache_hit)),
+                } if format == wanted => Some((projection.clone(), *cache_hit)),
                 _ => None,
             })
             .collect()

--- a/vix/src/machine/mod.rs
+++ b/vix/src/machine/mod.rs
@@ -64,6 +64,7 @@ mod ast_probe;
 pub mod driver;
 mod elf;
 pub mod lower;
+mod oci;
 pub mod value;
 
 pub use driver::{

--- a/vix/src/machine/oci.rs
+++ b/vix/src/machine/oci.rs
@@ -1,0 +1,389 @@
+use std::collections::BTreeMap;
+
+use sha2::{Digest, Sha256};
+
+use crate::exec::Tree;
+use crate::value::Value;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(super) enum Projection {
+    Layers,
+    Config,
+    Env,
+    Entrypoint,
+    Cmd,
+    Files,
+}
+
+impl Projection {
+    pub(super) const ALL: [Projection; 6] = [
+        Projection::Layers,
+        Projection::Config,
+        Projection::Env,
+        Projection::Entrypoint,
+        Projection::Cmd,
+        Projection::Files,
+    ];
+
+    pub(super) fn name(self) -> &'static str {
+        match self {
+            Projection::Layers => "layers",
+            Projection::Config => "config",
+            Projection::Env => "env",
+            Projection::Entrypoint => "entrypoint",
+            Projection::Cmd => "cmd",
+            Projection::Files => "files",
+        }
+    }
+
+    pub(super) fn to_word(self) -> i64 {
+        match self {
+            Projection::Layers => 0,
+            Projection::Config => 1,
+            Projection::Env => 2,
+            Projection::Entrypoint => 3,
+            Projection::Cmd => 4,
+            Projection::Files => 5,
+        }
+    }
+
+    pub(super) fn from_word(word: i64) -> Result<Self, String> {
+        Ok(match word {
+            0 => Projection::Layers,
+            1 => Projection::Config,
+            2 => Projection::Env,
+            3 => Projection::Entrypoint,
+            4 => Projection::Cmd,
+            5 => Projection::Files,
+            other => return Err(format!("unknown OCI projection {other}")),
+        })
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct Layout {
+    tree: Tree,
+    config: Value,
+    layers: Vec<LayerDescriptor>,
+}
+
+#[derive(Clone)]
+struct LayerDescriptor {
+    digest: String,
+    size: i64,
+    media_type: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct FileProjection {
+    pub layer_digest: String,
+    pub contents: String,
+    pub size: i64,
+}
+
+pub(super) fn parse_layout(tree: Tree) -> Result<Layout, String> {
+    let index = parse_json_blob(&tree, "index.json")?;
+    let manifest_digest = first_manifest_digest(&index)?;
+    let manifest = parse_json_blob(&tree, &blob_path(manifest_digest)?)?;
+    let config_digest = string_field(object_field(&manifest, "config")?, "digest")?;
+    let config = parse_json_blob(&tree, &blob_path(config_digest)?)?;
+    let layers = array_field(&manifest, "layers")?
+        .iter()
+        .map(|layer| {
+            Ok(LayerDescriptor {
+                digest: string_field(layer, "digest")?.to_string(),
+                size: int_field(layer, "size")?,
+                media_type: string_field(layer, "mediaType").unwrap_or("").to_string(),
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok(Layout {
+        tree,
+        config,
+        layers,
+    })
+}
+
+pub(super) fn archive_to_tree(bytes: &[u8]) -> Result<Tree, String> {
+    let mut entries = BTreeMap::new();
+    let mut offset = 0usize;
+    while offset + 512 <= bytes.len() {
+        let header = &bytes[offset..offset + 512];
+        if header.iter().all(|byte| *byte == 0) {
+            return Ok(Tree {
+                entries,
+                blobs: BTreeMap::new(),
+            });
+        }
+        let name = normalize_path(&tar_name(header)?);
+        let size = tar_size(header)?;
+        let typeflag = header[156];
+        let data_offset = offset + 512;
+        let data_end = data_offset
+            .checked_add(size)
+            .ok_or_else(|| "tar entry size overflow".to_string())?;
+        if data_end > bytes.len() {
+            return Err(format!("tar entry `{name}` extends past archive"));
+        }
+        if matches!(typeflag, 0 | b'0') && !name.is_empty() {
+            let contents = String::from_utf8(bytes[data_offset..data_end].to_vec())
+                .map_err(|err| format!("OCI archive entry `{name}` is not UTF-8: {err}"))?;
+            entries.insert(name, contents);
+        }
+        offset = data_offset
+            .checked_add(padded_len(size))
+            .ok_or_else(|| "tar offset overflow".to_string())?;
+    }
+    Ok(Tree {
+        entries,
+        blobs: BTreeMap::new(),
+    })
+}
+
+pub(super) fn project(layout: &Layout, projection: Projection) -> Result<Value, String> {
+    match projection {
+        Projection::Layers => Ok(Value::Array(
+            layout
+                .layers
+                .iter()
+                .map(|layer| {
+                    Value::Map(BTreeMap::from([
+                        (
+                            Value::Str("digest".to_string()),
+                            Value::Str(layer.digest.clone()),
+                        ),
+                        (Value::Str("size".to_string()), Value::Int(layer.size)),
+                        (
+                            Value::Str("mediaType".to_string()),
+                            Value::Str(layer.media_type.clone()),
+                        ),
+                    ]))
+                })
+                .collect(),
+        )),
+        Projection::Config => Ok(layout.config.clone()),
+        Projection::Env => config_array(layout, "Env"),
+        Projection::Entrypoint => config_array(layout, "Entrypoint"),
+        Projection::Cmd => config_array(layout, "Cmd"),
+        Projection::Files => Err("OCI files projection is a virtual Doc".to_string()),
+    }
+}
+
+pub(super) fn project_file(layout: &Layout, path: &str) -> Result<Option<FileProjection>, String> {
+    let path = normalize_path(path);
+    for layer in layout.layers.iter().rev() {
+        let tar = layer_bytes(layout, &layer.digest)?;
+        match find_in_layer(tar, &path)? {
+            LayerHit::Found(contents) => {
+                return Ok(Some(FileProjection {
+                    layer_digest: layer.digest.clone(),
+                    size: i64::try_from(contents.len()).unwrap_or(i64::MAX),
+                    contents: String::from_utf8(contents)
+                        .map_err(|err| format!("OCI file `{path}` is not UTF-8: {err}"))?,
+                }));
+            }
+            LayerHit::Whiteout => return Ok(None),
+            LayerHit::Miss => {}
+        }
+    }
+    Ok(None)
+}
+
+pub(super) fn input_hash(tree: &Tree) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"vix-oci-layout-tree");
+    for (path, contents) in &tree.entries {
+        hasher.update(
+            i64::try_from(path.len())
+                .expect("path length fits i64")
+                .to_le_bytes(),
+        );
+        hasher.update(path.as_bytes());
+        hasher.update(
+            i64::try_from(contents.len())
+                .expect("contents length fits i64")
+                .to_le_bytes(),
+        );
+        hasher.update(contents.as_bytes());
+    }
+    hasher.finalize().into()
+}
+
+fn parse_json_blob(tree: &Tree, path: &str) -> Result<Value, String> {
+    let text = tree
+        .entries
+        .get(path)
+        .ok_or_else(|| format!("OCI layout is missing `{path}`"))?;
+    crate::data::parse_json(Value::Str(text.clone()))
+}
+
+fn first_manifest_digest(index: &Value) -> Result<&str, String> {
+    let manifests = array_field(index, "manifests")?;
+    let manifest = manifests
+        .first()
+        .ok_or_else(|| "OCI index has no manifests".to_string())?;
+    string_field(manifest, "digest")
+}
+
+fn config_array(layout: &Layout, key: &str) -> Result<Value, String> {
+    let config = object_field(&layout.config, "config")?;
+    Ok(match map_get(config, key) {
+        Some(Value::Array(values)) => Value::Array(values.clone()),
+        Some(Value::Variant { .. }) | None => Value::Array(Vec::new()),
+        Some(other) => {
+            return Err(format!(
+                "OCI config `{key}` must be an array or null, got {other:?}"
+            ));
+        }
+    })
+}
+
+fn object_field<'a>(value: &'a Value, key: &str) -> Result<&'a Value, String> {
+    map_get(value, key).ok_or_else(|| format!("JSON object is missing `{key}`"))
+}
+
+fn array_field<'a>(value: &'a Value, key: &str) -> Result<&'a [Value], String> {
+    match object_field(value, key)? {
+        Value::Array(values) => Ok(values),
+        other => Err(format!(
+            "JSON field `{key}` must be an array, got {other:?}"
+        )),
+    }
+}
+
+fn string_field<'a>(value: &'a Value, key: &str) -> Result<&'a str, String> {
+    match object_field(value, key)? {
+        Value::Str(value) => Ok(value),
+        other => Err(format!(
+            "JSON field `{key}` must be a string, got {other:?}"
+        )),
+    }
+}
+
+fn int_field(value: &Value, key: &str) -> Result<i64, String> {
+    match object_field(value, key)? {
+        Value::Int(value) => Ok(*value),
+        other => Err(format!("JSON field `{key}` must be an int, got {other:?}")),
+    }
+}
+
+fn map_get<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
+    let Value::Map(map) = value else {
+        return None;
+    };
+    map.get(&Value::Str(key.to_string()))
+}
+
+fn blob_path(digest: &str) -> Result<String, String> {
+    let (algorithm, hex) = digest
+        .split_once(':')
+        .ok_or_else(|| format!("OCI digest `{digest}` has no algorithm"))?;
+    Ok(format!("blobs/{algorithm}/{hex}"))
+}
+
+fn layer_bytes<'a>(layout: &'a Layout, digest: &str) -> Result<&'a [u8], String> {
+    let path = blob_path(digest)?;
+    let contents = layout
+        .tree
+        .entries
+        .get(&path)
+        .ok_or_else(|| format!("OCI layout is missing layer blob `{path}`"))?;
+    Ok(contents.as_bytes())
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum LayerHit {
+    Found(Vec<u8>),
+    Whiteout,
+    Miss,
+}
+
+fn find_in_layer(bytes: &[u8], path: &str) -> Result<LayerHit, String> {
+    let mut offset = 0usize;
+    while offset + 512 <= bytes.len() {
+        let header = &bytes[offset..offset + 512];
+        if header.iter().all(|byte| *byte == 0) {
+            return Ok(LayerHit::Miss);
+        }
+        let name = tar_name(header)?;
+        let size = tar_size(header)?;
+        let typeflag = header[156];
+        let data_offset = offset + 512;
+        let data_end = data_offset
+            .checked_add(size)
+            .ok_or_else(|| "tar entry size overflow".to_string())?;
+        if data_end > bytes.len() {
+            return Err(format!("tar entry `{name}` extends past layer"));
+        }
+        if whiteout_covers(&name, path) {
+            return Ok(LayerHit::Whiteout);
+        }
+        if normalize_path(&name) == path && matches!(typeflag, 0 | b'0') {
+            return Ok(LayerHit::Found(bytes[data_offset..data_end].to_vec()));
+        }
+        offset = data_offset
+            .checked_add(padded_len(size))
+            .ok_or_else(|| "tar offset overflow".to_string())?;
+    }
+    Ok(LayerHit::Miss)
+}
+
+fn tar_name(header: &[u8]) -> Result<String, String> {
+    let name = header_string(&header[0..100])?;
+    let prefix = header_string(&header[345..500])?;
+    if prefix.is_empty() {
+        Ok(name)
+    } else if name.is_empty() {
+        Ok(prefix)
+    } else {
+        Ok(format!("{prefix}/{name}"))
+    }
+}
+
+fn header_string(bytes: &[u8]) -> Result<String, String> {
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(bytes.len());
+    std::str::from_utf8(&bytes[..end])
+        .map(str::to_string)
+        .map_err(|err| err.to_string())
+}
+
+fn tar_size(header: &[u8]) -> Result<usize, String> {
+    let raw = header_string(&header[124..136])?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(0);
+    }
+    usize::from_str_radix(trimmed, 8).map_err(|err| format!("tar size `{trimmed}`: {err}"))
+}
+
+fn padded_len(size: usize) -> usize {
+    size.div_ceil(512) * 512
+}
+
+fn normalize_path(path: &str) -> String {
+    path.trim_start_matches('/').to_string()
+}
+
+fn whiteout_covers(entry: &str, path: &str) -> bool {
+    let entry = normalize_path(entry);
+    let (dir, name) = split_parent(&entry);
+    if name == ".wh..wh..opq" {
+        let (path_dir, _) = split_parent(path);
+        return path_dir == dir;
+    }
+    let Some(removed) = name.strip_prefix(".wh.") else {
+        return false;
+    };
+    let (path_dir, path_name) = split_parent(path);
+    path_dir == dir && path_name == removed
+}
+
+fn split_parent(path: &str) -> (&str, &str) {
+    match path.rsplit_once('/') {
+        Some((dir, name)) => (dir, name),
+        None => ("", path),
+    }
+}

--- a/weavy/src/async.rs
+++ b/weavy/src/async.rs
@@ -502,8 +502,12 @@ mod tests {
         ];
         for ops in programs {
             let n = await_count(ops);
-            let inners_i: Vec<_> = (0..n).map(|k| later(2 + k as i64, 20)).collect();
-            let inners_j: Vec<_> = (0..n).map(|k| later(2 + k as i64, 20)).collect();
+            let inners_i: Vec<_> = (0..n)
+                .map(|k| later(2 + k as i64, 20 + k as u64 * 20))
+                .collect();
+            let inners_j: Vec<_> = (0..n)
+                .map(|k| later(2 + k as i64, 20 + k as u64 * 20))
+                .collect();
 
             let (ri, _, ti) = drive(AsyncExec::interpret(ops, inners_i)).await;
             let exec_j = AsyncExec::new(ops, inners_j);


### PR DESCRIPTION
## Summary
- add lazy vix `oci()` structural Doc projections for OCI layout trees and layout tar blobs
- expose `layers`, `config`, `env`, `entrypoint`, `cmd`, and a virtual merged `files` view
- implement whiteout-aware file projection with winning layer attribution and OCI ArtifactProbe cache-hit traces
- add hand-built 3-layer OCI fixture coverage plus a glibc preflight sample shape

## Proofs
- shadow: `etc/message` resolves to the overlay layer digest and contents
- whiteout: `etc/remove` is absent after `.wh.remove`
- laziness: `oci(input).config.config.Env` emits only `oci/config`; file projection emits `oci/files` and `oci/files/etc/message`, with a cache hit on the second path read

## Verification
- `cargo check -p vix -p weavy --all-targets --message-format=short`
- `cargo nextest run -p vix -p weavy` (258/258)
- `cargo clippy -p vix -p weavy --all-targets --message-format=short -- -D warnings`
- `pnpm --filter @bearcove/snark-playground test:flow` (27/27)

Note: vix currently has string equality/inequality but not semantic GLIBC version-floor ordering, so the preflight sample stops at the current comparison surface.