### PR TITLE
vix: minimal real-process exec lane (feature-gated, trusts the host)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8222,6 +8222,7 @@ dependencies = [
  "sha2 0.10.9",
  "snark",
  "snark-dsl",
+ "tempfile",
  "tokio",
  "weavy",
 ]

--- a/vix/Cargo.toml
+++ b/vix/Cargo.toml
@@ -28,9 +28,13 @@ weavy = { path = "../weavy" }
 [features]
 default = []
 jit = ["weavy/jit"]
+real-process = ["dep:tempfile"]
 
 [build-dependencies]
 snark-dsl = { path = "../snark-dsl", features = ["typed-ast"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tempfile = { workspace = true, optional = true }
 
 # The graph demand engine's driver uses only core::future (vix stays
 # wasm-clean); tokio is DEV-only, an executor + timers for the demand tests.

--- a/vix/docs/cargo-manifest-build.md
+++ b/vix/docs/cargo-manifest-build.md
@@ -120,16 +120,36 @@ Slice 1 is deliberately narrower than Cargo:
 - fake-VFS exec tests proving cold run, warm memo hit, and tier-2 cutoff after an
   unread file edit.
 
-The current exec substrate is fake-VFS-only: command tools are in-process
-implementations behind `Tool`, and no real-process runner exists. Slice 1 can
-therefore prove the lowering and cache behavior with a fake `rustc` tool, but
-the end-to-end real `cargo build` artifact comparison waits for a real-process
-exec backend.
+The default exec substrate is fake-VFS-only: command tools are in-process
+implementations behind `Tool`, and this remains the CI/default lane. The
+`real-process` Cargo feature adds an opt-in native backend that runs the same
+command-role plans as host processes. It is deliberately unsandboxed and trusts
+the host: vix stages role-declared inputs into a temporary work directory,
+scrubs the environment to an explicit allowlist, runs the host command, and
+harvests declared outputs back into vix trees.
+
+That open backend is not Vixen's sound runtime lane. It has no VFS
+interception, no syscall mediation, and no sandbox ceiling beyond what staging
+happens to provide. Tier 2 verifies only what command roles declare: input-role
+content bytes and search-dir membership. Header contents discovered by a real
+compiler through the host filesystem are not observed unless the command grammar
+declares them as inputs. This is enough for local artifact smoke tests and for
+the cache behavior that open vix can honestly own; proprietary VFS mediation is
+the sound lane.
+
+Slice 1 can prove lowering and cache behavior with the fake `rustc` tool, and
+with `--features real-process` it can additionally compile trivial host
+artifacts through `cc!`. The end-to-end real `cargo build` artifact comparison
+still waits for slice 2's real `rustc` plan graph.
 
 ## Later Slices
 
-Slice 2 should add path dependencies and `--extern`/`-L dependency` wiring, then
-split rmeta and final artifact units so dependents can start from metadata
-where rustc permits it. After that, add build-script compile/run units and feed
-their declared outputs into parent rustc invocations. Proc-macro host units can
-share most dependency wiring but need host/target separation in the plan keys.
+Slice 2 should add a real `rustc` oracle on top of the same real-process
+staging: path dependencies and `--extern`/`-L dependency` wiring, then split
+rmeta and final artifact units so dependents can start from metadata where
+rustc permits it. It will need command grammars that declare every rustc source,
+extern artifact, search path, response file, and emitted artifact explicitly;
+otherwise open tier-2 verification can only prove the subset the roles name.
+After that, add build-script compile/run units and feed their declared outputs
+into parent rustc invocations. Proc-macro host units can share most dependency
+wiring but need host/target separation in the plan keys.

--- a/vix/src/data.rs
+++ b/vix/src/data.rs
@@ -22,16 +22,23 @@ pub(crate) fn parse_json(input: Value) -> Result<Value, String> {
 fn input_text(input: Value) -> Result<String, String> {
     match input {
         Value::Str(text) => Ok(text),
-        Value::Tree(Tree { entries }) => {
-            let len = entries.len();
-            let [(path, contents)] =
-                entries
-                    .into_iter()
-                    .collect::<Vec<_>>()
-                    .try_into()
-                    .map_err(|_| {
-                        format!("parser input tree must contain exactly one blob, got {len}")
-                    })?;
+        Value::Tree(Tree { entries, blobs }) => {
+            let len = entries.len() + blobs.len();
+            if len != 1 {
+                return Err(format!(
+                    "parser input tree must contain exactly one blob, got {len}"
+                ));
+            }
+            let (path, contents) = entries
+                .into_iter()
+                .map(|(path, contents)| Ok((path, contents)))
+                .chain(blobs.into_iter().map(|(path, contents)| {
+                    String::from_utf8(contents)
+                        .map(|contents| (path, contents))
+                        .map_err(|err| err.to_string())
+                }))
+                .next()
+                .expect("one parser input")?;
             if contents.is_empty() {
                 Err(format!("parser input blob `{path}` is empty"))
             } else {

--- a/vix/src/exec.rs
+++ b/vix/src/exec.rs
@@ -31,7 +31,7 @@
 //! here is the grammar's output shape; the toy role extraction in the oracle
 //! stands in for the real snark command grammars.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 // ---------------------------------------------------------------------------
@@ -39,10 +39,12 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 // ---------------------------------------------------------------------------
 
 /// A content-addressed tree: path -> contents. (The oracle's stand-in for the
-/// CAS; contents are strings because the design doesn't care about bytes.)
+/// CAS. Text entries keep the fake lane readable; blob entries carry real
+/// process artifacts without lossy UTF-8 conversion.
 #[derive(facet::Facet, Debug, Clone, Default, PartialEq, Eq)]
 pub struct Tree {
     pub entries: BTreeMap<String, String>,
+    pub blobs: BTreeMap<String, Vec<u8>>,
 }
 
 impl Tree {
@@ -52,7 +54,52 @@ impl Tree {
                 .iter()
                 .map(|(p, c)| (p.to_string(), c.to_string()))
                 .collect(),
+            blobs: BTreeMap::new(),
         }
+    }
+
+    pub fn of_blobs(entries: &[(&str, &[u8])]) -> Tree {
+        Tree {
+            entries: BTreeMap::new(),
+            blobs: entries
+                .iter()
+                .map(|(p, c)| (p.to_string(), c.to_vec()))
+                .collect(),
+        }
+    }
+
+    pub fn insert_bytes(&mut self, path: impl Into<String>, contents: Vec<u8>) {
+        let path = path.into();
+        match String::from_utf8(contents) {
+            Ok(text) => {
+                self.entries.insert(path, text);
+            }
+            Err(err) => {
+                self.blobs.insert(path, err.into_bytes());
+            }
+        }
+    }
+
+    pub fn bytes(&self, path: &str) -> Option<Vec<u8>> {
+        self.entries
+            .get(path)
+            .map(|contents| contents.as_bytes().to_vec())
+            .or_else(|| self.blobs.get(path).cloned())
+    }
+
+    pub fn display_entries(&self) -> Vec<(String, String)> {
+        let mut out: Vec<(String, String)> = self
+            .entries
+            .iter()
+            .map(|(path, contents)| (path.clone(), contents.clone()))
+            .collect();
+        out.extend(
+            self.blobs
+                .iter()
+                .map(|(path, contents)| (path.clone(), format!("<blob:{} bytes>", contents.len()))),
+        );
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
     }
 
     /// The TIER-1 fingerprint: everything, coarsely. Any change anywhere in
@@ -61,6 +108,12 @@ impl Tree {
     pub fn fingerprint(&self) -> u64 {
         let mut h = DefaultHasher::new();
         for (path, contents) in &self.entries {
+            0u8.hash(&mut h);
+            path.hash(&mut h);
+            contents.hash(&mut h);
+        }
+        for (path, contents) in &self.blobs {
+            1u8.hash(&mut h);
             path.hash(&mut h);
             contents.hash(&mut h);
         }
@@ -279,6 +332,9 @@ pub struct Outcome {
 /// never sees a filesystem; it sees this.
 pub trait Snapshot {
     fn read(&self, path: &str) -> Option<String>;
+    fn read_bytes(&self, path: &str) -> Option<Vec<u8>> {
+        self.read(path).map(String::into_bytes)
+    }
     fn list(&self, dir: &str) -> Option<Vec<String>>;
 }
 
@@ -291,8 +347,12 @@ pub trait Tool {
 }
 
 fn content_hash(s: &str) -> u64 {
+    content_hash_bytes(s.as_bytes())
+}
+
+fn content_hash_bytes(bytes: &[u8]) -> u64 {
     let mut h = DefaultHasher::new();
-    s.hash(&mut h);
+    bytes.hash(&mut h);
     h.finish()
 }
 
@@ -329,14 +389,30 @@ impl Snapshot for MountedWorld<'_> {
         None
     }
 
+    fn read_bytes(&self, path: &str) -> Option<Vec<u8>> {
+        for m in self.mounts {
+            if let Some(rest) = path.strip_prefix(&m.at) {
+                let key = rest.trim_start_matches('/');
+                if let Some(contents) = m.tree.entries.get(key) {
+                    return Some(contents.as_bytes().to_vec());
+                }
+                if let Some(contents) = m.tree.blobs.get(key) {
+                    return Some(contents.clone());
+                }
+            }
+        }
+        None
+    }
+
     fn list(&self, dir: &str) -> Option<Vec<String>> {
         for m in self.mounts {
             if let Some(rest) = dir.strip_prefix(&m.at) {
                 let prefix = rest.trim_start_matches('/');
-                let names: Vec<String> = m
+                let names: BTreeSet<String> = m
                     .tree
                     .entries
                     .keys()
+                    .chain(m.tree.blobs.keys())
                     .filter(|k| {
                         prefix.is_empty()
                             || k.strip_prefix(prefix).is_some_and(|r| r.starts_with('/'))
@@ -344,7 +420,7 @@ impl Snapshot for MountedWorld<'_> {
                     .cloned()
                     .collect();
                 if !names.is_empty() || prefix.is_empty() {
-                    return Some(names);
+                    return Some(names.into_iter().collect());
                 }
             }
         }
@@ -378,6 +454,24 @@ impl<'a> ObservedWorld<'a> {
         got
     }
 
+    pub fn read_bytes(&mut self, path: &str) -> Option<Vec<u8>> {
+        let got = self.world.read_bytes(path);
+        let obs = match &got {
+            Some(contents) => ReadObservation::Content(content_hash_bytes(contents)),
+            None => ReadObservation::Absent,
+        };
+        self.read_set.entries.insert(path.to_string(), obs);
+        got
+    }
+
+    pub fn peek_bytes(&self, path: &str) -> Option<Vec<u8>> {
+        self.world.read_bytes(path)
+    }
+
+    pub fn peek_list(&self, dir: &str) -> Option<Vec<String>> {
+        self.world.list(dir)
+    }
+
     pub fn list(&mut self, dir: &str) -> Option<Vec<String>> {
         let got = self.world.list(dir);
         let obs = match &got {
@@ -399,9 +493,9 @@ impl<'a> ObservedWorld<'a> {
 /// never a false positive.
 pub fn verify(read_set: &ReadSet, world: &dyn Snapshot) -> bool {
     read_set.entries.iter().all(|(path, obs)| match obs {
-        ReadObservation::Content(hash) => {
-            world.read(path).is_some_and(|c| content_hash(&c) == *hash)
-        }
+        ReadObservation::Content(hash) => world
+            .read_bytes(path)
+            .is_some_and(|c| content_hash_bytes(&c) == *hash),
         ReadObservation::Absent => {
             if let Some(dir) = path.strip_suffix('/') {
                 world.list(dir).is_none()

--- a/vix/src/lib.rs
+++ b/vix/src/lib.rs
@@ -25,6 +25,8 @@ pub mod fetch;
 pub mod ide;
 pub mod machine;
 pub(crate) mod module;
+#[cfg(all(feature = "real-process", not(target_arch = "wasm32")))]
+pub mod real_process;
 pub mod value;
 
 /// The tree-sitter grammar.json emitted from grammar.js at build time, embedded so
@@ -298,16 +300,25 @@ pub mod support {
             let base = path.rsplit_once('/').map(|(_, b)| b).unwrap_or(path);
             return Ok(crate::exec::Tree::of(&[(base, contents.as_str())]));
         }
+        if let Some(contents) = tree.blobs.get(path) {
+            let base = path.rsplit_once('/').map(|(_, b)| b).unwrap_or(path);
+            return Ok(crate::exec::Tree::of_blobs(&[(base, contents.as_slice())]));
+        }
         let prefix = format!("{path}/");
         let entries: BTreeMap<String, String> = tree
             .entries
             .iter()
             .filter_map(|(k, v)| k.strip_prefix(&prefix).map(|r| (r.to_string(), v.clone())))
             .collect();
-        if entries.is_empty() {
+        let blobs: BTreeMap<String, Vec<u8>> = tree
+            .blobs
+            .iter()
+            .filter_map(|(k, v)| k.strip_prefix(&prefix).map(|r| (r.to_string(), v.clone())))
+            .collect();
+        if entries.is_empty() && blobs.is_empty() {
             return Err(format!("no `{path}` in tree"));
         }
-        Ok(crate::exec::Tree { entries })
+        Ok(crate::exec::Tree { entries, blobs })
     }
 
     pub(crate) fn assign_roles(

--- a/vix/src/machine/driver.rs
+++ b/vix/src/machine/driver.rs
@@ -1408,6 +1408,14 @@ impl Driver {
         }
     }
 
+    pub fn tree_blob_entries(&mut self, handle: i64) -> Result<BTreeMap<String, Vec<u8>>, String> {
+        let handle = self.force_tree_handle(handle)?;
+        match self.store.borrow().tree_entry(handle)? {
+            TreeEntry::Concrete(tree) => Ok(tree.blobs),
+            TreeEntry::Merge(_) | TreeEntry::Exec(_) => Err("tree force returned pending".into()),
+        }
+    }
+
     pub fn intern_tree_concrete(&self, tree: crate::exec::Tree) -> i64 {
         self.store.borrow_mut().alloc_tree_concrete(tree).0
     }
@@ -2586,6 +2594,9 @@ impl Driver {
                     for (path, contents) in tree.entries {
                         merged.entries.insert(path, contents);
                     }
+                    for (path, contents) in tree.blobs {
+                        merged.blobs.insert(path, contents);
+                    }
                 }
                 Ok(self.store.borrow_mut().alloc_tree_concrete(merged).0)
             }
@@ -2938,12 +2949,7 @@ impl Driver {
                     run.command.clone(),
                     run.output.clone(),
                     event.clone(),
-                    outcome
-                        .outputs
-                        .entries
-                        .iter()
-                        .map(|(path, contents)| (path.clone(), contents.clone()))
-                        .collect::<Vec<_>>(),
+                    outcome.outputs.display_entries(),
                 )
             };
             let timestamp_us = self.next_timestamp();
@@ -2992,8 +2998,15 @@ impl Driver {
                     return Err("forced command tree stayed pending".into());
                 };
                 let root = format!("/m/{}", mounts.len());
-                let text = if tree.entries.len() == 1 {
-                    format!("{root}/{}", tree.entries.keys().next().expect("one entry"))
+                let entry_count = tree.entries.len() + tree.blobs.len();
+                let text = if entry_count == 1 {
+                    let key = tree
+                        .entries
+                        .keys()
+                        .next()
+                        .or_else(|| tree.blobs.keys().next())
+                        .expect("one entry");
+                    format!("{root}/{key}")
                 } else {
                     root.clone()
                 };
@@ -3136,18 +3149,23 @@ impl Driver {
                 let TreeEntry::Concrete(tree) = self.store.borrow().tree_entry(forced)? else {
                     return Err("elf input tree stayed pending".into());
                 };
-                let [(path, contents)] =
-                    <[(String, String); 1]>::try_from(tree.entries.into_iter().collect::<Vec<_>>())
-                        .map_err(|entries| {
-                            format!(
-                                "elf input tree must contain exactly one blob, got {}",
-                                entries.len()
-                            )
-                        })?;
+                let count = tree.entries.len() + tree.blobs.len();
+                if count != 1 {
+                    return Err(format!(
+                        "elf input tree must contain exactly one blob, got {count}"
+                    ));
+                }
+                let (path, contents) = tree
+                    .entries
+                    .into_iter()
+                    .map(|(path, contents)| (path, contents.into_bytes()))
+                    .chain(tree.blobs)
+                    .next()
+                    .expect("one tree entry");
                 if contents.is_empty() {
                     return Err(format!("elf input blob `{path}` is empty"));
                 }
-                Ok(contents.into_bytes())
+                Ok(contents)
             }
             other => Err(format!(
                 "elf input must be Blob, String, or Tree, got {other}"
@@ -3862,7 +3880,7 @@ fn render_tree(store: &ValueStore, handle: i64) -> Result<RenderedValue, String>
     match store.tree_entry(handle)? {
         TreeEntry::Concrete(tree) => Ok(RenderedValue::Tree {
             entries: tree
-                .entries
+                .display_entries()
                 .into_iter()
                 .map(|(path, contents)| RenderedTreeEntry { path, contents })
                 .collect(),
@@ -4710,6 +4728,15 @@ fn encode_concrete_tree(tree: &crate::exec::Tree) -> Vec<u8> {
         encode_string(path, &mut bytes);
         encode_string(contents, &mut bytes);
     }
+    bytes.extend_from_slice(
+        &i64::try_from(tree.blobs.len())
+            .expect("tree blob count fits i64")
+            .to_le_bytes(),
+    );
+    for (path, contents) in &tree.blobs {
+        encode_string(path, &mut bytes);
+        encode_bytes(contents, &mut bytes);
+    }
     bytes
 }
 
@@ -4725,19 +4752,31 @@ fn decode_concrete_tree(bytes: &[u8]) -> Result<crate::exec::Tree, String> {
         let contents = decode_string(bytes, &mut at)?;
         entries.insert(path, contents);
     }
+    let mut blobs = BTreeMap::new();
+    if at < bytes.len() {
+        let blob_count =
+            usize::try_from(read_frame_word(bytes, at)).map_err(|_| "tree blob count")?;
+        at += 8;
+        for _ in 0..blob_count {
+            let path = decode_string(bytes, &mut at)?;
+            let contents = decode_bytes(bytes, &mut at)?;
+            blobs.insert(path, contents);
+        }
+    }
     if at != bytes.len() {
         return Err(format!(
             "tree entry has {} trailing bytes",
             bytes.len() - at
         ));
     }
-    Ok(crate::exec::Tree { entries })
+    Ok(crate::exec::Tree { entries, blobs })
 }
 
 fn hash_concrete_tree(tree: &crate::exec::Tree) -> ContentHash {
     let mut hasher = Sha256::new();
     hasher.update(b"vix-tree-concrete");
     for (path, contents) in &tree.entries {
+        hasher.update([0]);
         hasher.update(
             i64::try_from(path.len())
                 .expect("path length fits i64")
@@ -4751,19 +4790,43 @@ fn hash_concrete_tree(tree: &crate::exec::Tree) -> ContentHash {
         );
         hasher.update(contents.as_bytes());
     }
+    for (path, contents) in &tree.blobs {
+        hasher.update([1]);
+        hasher.update(
+            i64::try_from(path.len())
+                .expect("path length fits i64")
+                .to_le_bytes(),
+        );
+        hasher.update(path.as_bytes());
+        hasher.update(
+            i64::try_from(contents.len())
+                .expect("contents length fits i64")
+                .to_le_bytes(),
+        );
+        hasher.update(contents);
+    }
     hasher.finalize().into()
 }
 
 fn encode_string(value: &str, bytes: &mut Vec<u8>) {
+    encode_bytes(value.as_bytes(), bytes);
+}
+
+fn encode_bytes(value: &[u8], bytes: &mut Vec<u8>) {
     bytes.extend_from_slice(
         &i64::try_from(value.len())
             .expect("string length fits i64")
             .to_le_bytes(),
     );
-    bytes.extend_from_slice(value.as_bytes());
+    bytes.extend_from_slice(value);
 }
 
 fn decode_string(bytes: &[u8], at: &mut usize) -> Result<String, String> {
+    let value = decode_bytes(bytes, at)?;
+    String::from_utf8(value).map_err(|err| err.to_string())
+}
+
+fn decode_bytes(bytes: &[u8], at: &mut usize) -> Result<Vec<u8>, String> {
     if bytes.len() < *at + 8 {
         return Err("string length truncated".into());
     }
@@ -4772,7 +4835,7 @@ fn decode_string(bytes: &[u8], at: &mut usize) -> Result<String, String> {
     if bytes.len() < *at + len {
         return Err("string data truncated".into());
     }
-    let value = String::from_utf8(bytes[*at..*at + len].to_vec()).map_err(|err| err.to_string())?;
+    let value = bytes[*at..*at + len].to_vec();
     *at += len;
     Ok(value)
 }

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -621,6 +621,13 @@ impl Machine {
         self.driver.tree_entries(handle)
     }
 
+    pub fn tree_blob_entries(
+        &mut self,
+        handle: i64,
+    ) -> Result<std::collections::BTreeMap<String, Vec<u8>>, String> {
+        self.driver.tree_blob_entries(handle)
+    }
+
     #[cfg(test)]
     fn intern_tree_concrete(&self, tree: crate::exec::Tree) -> i64 {
         self.driver.intern_tree_concrete(tree)

--- a/vix/src/real_process.rs
+++ b/vix/src/real_process.rs
@@ -1,0 +1,298 @@
+//! Native real-process exec backend for open vix.
+//!
+//! This backend deliberately trusts the host. It does not sandbox, interpose a
+//! VFS, or observe arbitrary process reads. Declared command roles define the
+//! staged input ceiling and the tier-2 read-set: input roles pin content bytes;
+//! search-dir roles pin directory membership only.
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+
+use sha2::{Digest, Sha256};
+
+use crate::exec::{ExecCache, ExecEvent, ExecPlan, ObservedWorld, Outcome, Role, Tool, Tree};
+use crate::machine::{
+    MachineExecBackend, MachineExecRequest, MachinePathDemand, MachinePendingRun,
+};
+
+const ENV_ALLOWLIST: &[&str] = &["PATH", "HOME", "TMPDIR", "TEMP", "TMP", "SystemRoot"];
+
+pub struct RealProcessBackend {
+    cache: Mutex<ExecCache>,
+}
+
+impl RealProcessBackend {
+    pub fn new() -> Self {
+        Self {
+            cache: Mutex::new(ExecCache::new()),
+        }
+    }
+}
+
+impl Default for RealProcessBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MachineExecBackend for RealProcessBackend {
+    fn spawn(&self, request: MachineExecRequest) -> Result<Arc<dyn MachinePendingRun>, String> {
+        let tool = RealProcessTool {
+            command: request.command.clone(),
+            output: request.output.clone(),
+        };
+        let mut cache = self
+            .cache
+            .lock()
+            .map_err(|_| "real-process exec cache poisoned".to_string())?;
+        let outcome = cache.exec(&request.plan, request.capability, &request.mounts, &tool)?;
+        let event = cache
+            .events
+            .last()
+            .cloned()
+            .ok_or_else(|| "real-process cache did not record an event".to_string())?;
+        Ok(Arc::new(RealProcessRun { outcome, event }))
+    }
+}
+
+struct RealProcessRun {
+    outcome: Outcome,
+    event: ExecEvent,
+}
+
+impl MachinePendingRun for RealProcessRun {
+    fn demand_path(&self, path: &str) -> Result<MachinePathDemand, String> {
+        if self.outcome.outputs.entries.contains_key(path) {
+            let contents = self
+                .outcome
+                .outputs
+                .entries
+                .get(path)
+                .expect("entry checked")
+                .clone();
+            return Ok(MachinePathDemand::File(contents));
+        }
+        if self.outcome.outputs.blobs.contains_key(path)
+            || has_child(&self.outcome.outputs.entries, path)
+            || has_child(&self.outcome.outputs.blobs, path)
+        {
+            return Ok(MachinePathDemand::FinishRequired {
+                path: path.to_string(),
+            });
+        }
+        Ok(MachinePathDemand::Missing {
+            path: path.to_string(),
+        })
+    }
+
+    fn flush(&self) -> Result<(Tree, ExecEvent), String> {
+        Ok((self.outcome.outputs.clone(), self.event.clone()))
+    }
+}
+
+fn has_child<T>(entries: &BTreeMap<String, T>, path: &str) -> bool {
+    let prefix = format!("{path}/");
+    entries.keys().any(|entry| entry.starts_with(&prefix))
+}
+
+struct RealProcessTool {
+    command: String,
+    output: String,
+}
+
+impl Tool for RealProcessTool {
+    fn run(&self, plan: &ExecPlan, world: &mut ObservedWorld<'_>) -> Result<Tree, String> {
+        let plan = plan.normalized();
+        let temp = tempfile::Builder::new()
+            .prefix("vix-real-process-")
+            .tempdir()
+            .map_err(|err| format!("real-process tempdir: {err}"))?;
+        let root = temp.path();
+        fs::create_dir_all(root.join(".vix-cas"))
+            .map_err(|err| format!("real-process cas dir: {err}"))?;
+
+        stage_declared_inputs(&plan, world, root)?;
+        prepare_output_dirs(&plan, root)?;
+
+        let argv = plan
+            .argv
+            .iter()
+            .map(|(arg, role)| map_arg(arg, *role, root))
+            .collect::<Result<Vec<_>, _>>()?;
+        let output = Command::new(&self.command)
+            .args(argv)
+            .current_dir(root)
+            .env_clear()
+            .envs(scrubbed_env(root))
+            .output()
+            .map_err(|err| format!("real-process {} spawn failed: {err}", self.command))?;
+        if !output.status.success() {
+            return Err(format!(
+                "real-process {} exited with {}: {}",
+                self.command,
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        harvest_outputs(&plan, root).or_else(|err| {
+            if self.output.is_empty() {
+                Err(err)
+            } else {
+                let mut tree = Tree::default();
+                let physical = physical_path(&self.output, root)?;
+                let bytes = fs::read(&physical).map_err(|read_err| {
+                    format!("{err}; fallback output read failed: {read_err}")
+                })?;
+                tree.insert_bytes(self.output.clone(), bytes);
+                Ok(tree)
+            }
+        })
+    }
+}
+
+fn stage_declared_inputs(
+    plan: &ExecPlan,
+    world: &mut ObservedWorld<'_>,
+    root: &Path,
+) -> Result<(), String> {
+    for (arg, role) in &plan.argv {
+        match role {
+            Role::Input => {
+                let bytes = world.read_bytes(arg).ok_or_else(|| {
+                    format!("real-process input `{arg}` is outside mounted trees")
+                })?;
+                stage_file(root, arg, &bytes)?;
+            }
+            Role::SearchDir => {
+                let physical = physical_path(arg, root)?;
+                fs::create_dir_all(&physical)
+                    .map_err(|err| format!("real-process create search dir `{arg}`: {err}"))?;
+                if let Some(names) = world.list(arg) {
+                    for name in names {
+                        let logical = listed_logical_path(arg, &name, world);
+                        if let Some(bytes) = world.peek_bytes(&logical) {
+                            stage_file(root, &logical, &bytes)?;
+                        }
+                    }
+                }
+            }
+            Role::Output | Role::Flag => {}
+        }
+    }
+    Ok(())
+}
+
+fn listed_logical_path(dir: &str, name: &str, world: &ObservedWorld<'_>) -> String {
+    let direct = format!("{}/{}", dir.trim_end_matches('/'), name);
+    if world.peek_bytes(&direct).is_some() {
+        return direct;
+    }
+    if let Some(root) = mount_root(dir) {
+        let rooted = format!("{root}/{name}");
+        if world.peek_bytes(&rooted).is_some() {
+            return rooted;
+        }
+    }
+    direct
+}
+
+fn mount_root(path: &str) -> Option<String> {
+    let mut parts = path.trim_start_matches('/').split('/');
+    let first = parts.next()?;
+    let second = parts.next()?;
+    if first == "m" {
+        Some(format!("/{first}/{second}"))
+    } else {
+        None
+    }
+}
+
+fn prepare_output_dirs(plan: &ExecPlan, root: &Path) -> Result<(), String> {
+    for (arg, role) in &plan.argv {
+        if *role == Role::Output {
+            let path = physical_path(arg, root)?;
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|err| format!("real-process create output dir `{arg}`: {err}"))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn harvest_outputs(plan: &ExecPlan, root: &Path) -> Result<Tree, String> {
+    let mut tree = Tree::default();
+    for (arg, role) in &plan.argv {
+        if *role == Role::Output {
+            let path = physical_path(arg, root)?;
+            let bytes = fs::read(&path)
+                .map_err(|err| format!("real-process output `{arg}` was not produced: {err}"))?;
+            tree.insert_bytes(arg.clone(), bytes);
+        }
+    }
+    if tree.entries.is_empty() && tree.blobs.is_empty() {
+        return Err("real-process plan declared no outputs".to_string());
+    }
+    Ok(tree)
+}
+
+fn stage_file(root: &Path, logical: &str, bytes: &[u8]) -> Result<(), String> {
+    let physical = physical_path(logical, root)?;
+    if let Some(parent) = physical.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("real-process create staged parent `{logical}`: {err}"))?;
+    }
+
+    let hash = Sha256::digest(bytes);
+    let cas_path = root.join(".vix-cas").join(hex::encode(hash));
+    if !cas_path.exists() {
+        fs::write(&cas_path, bytes)
+            .map_err(|err| format!("real-process write cas `{logical}`: {err}"))?;
+    }
+    fs::hard_link(&cas_path, &physical)
+        .or_else(|_| fs::copy(&cas_path, &physical).map(|_| ()))
+        .map_err(|err| format!("real-process stage `{logical}`: {err}"))
+}
+
+fn map_arg(arg: &str, role: Role, root: &Path) -> Result<OsString, String> {
+    match role {
+        Role::Input | Role::Output | Role::SearchDir => {
+            Ok(physical_path(arg, root)?.into_os_string())
+        }
+        Role::Flag => Ok(OsString::from(arg)),
+    }
+}
+
+fn physical_path(logical: &str, root: &Path) -> Result<PathBuf, String> {
+    let relative = logical.trim_start_matches('/');
+    let path = Path::new(relative);
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir | Component::RootDir))
+    {
+        return Err(format!(
+            "real-process refuses non-relative staged path `{logical}`"
+        ));
+    }
+    Ok(root.join(path))
+}
+
+fn scrubbed_env(root: &Path) -> Vec<(OsString, OsString)> {
+    let mut env: Vec<(OsString, OsString)> = ENV_ALLOWLIST
+        .iter()
+        .filter_map(|key| std::env::var_os(key).map(|value| (OsString::from(key), value)))
+        .collect();
+    let tmp = root.join("tmp");
+    let _ = fs::create_dir_all(&tmp);
+    let tmp = tmp.into_os_string();
+    env.retain(|(key, _)| !matches!(key.to_str(), Some("TMPDIR" | "TEMP" | "TMP")));
+    env.push((OsString::from("TMPDIR"), tmp.clone()));
+    env.push((OsString::from("TEMP"), tmp.clone()));
+    env.push((OsString::from("TMP"), tmp));
+    env
+}

--- a/vix/src/value.rs
+++ b/vix/src/value.rs
@@ -105,7 +105,11 @@ impl Value {
             Value::Tree(t) => {
                 let mut h = DefaultHasher::new();
                 self.hash_into(&mut h);
-                format!("tree({:08x}, {} paths)", h.finish() as u32, t.entries.len())
+                format!(
+                    "tree({:08x}, {} paths)",
+                    h.finish() as u32,
+                    t.entries.len() + t.blobs.len()
+                )
             }
         }
     }
@@ -265,7 +269,9 @@ impl Ord for Value {
             (Value::Tree(_), Value::Tree(_)) => {
                 let a = self.forced_tree().expect("tree rank");
                 let b = other.forced_tree().expect("tree rank");
-                a.entries.cmp(&b.entries)
+                a.entries
+                    .cmp(&b.entries)
+                    .then_with(|| a.blobs.cmp(&b.blobs))
             }
             _ => self.rank().cmp(&other.rank()),
         }

--- a/vix/tests/real_process.rs
+++ b/vix/tests/real_process.rs
@@ -1,0 +1,157 @@
+#![cfg(all(feature = "real-process", not(target_arch = "wasm32")))]
+
+use std::sync::Arc;
+
+use vix::exec::{ExecEvent, Tree};
+use vix::machine::{DriveEvent, Machine, MachineArg};
+use vix::real_process::RealProcessBackend;
+
+const SOURCE: &str = r#"
+use vix::{Tree, Path, Target};
+use caps::Cc;
+
+fn get_cc(target: Target) -> Cc {
+    Cc::acquire(target)
+}
+
+fn build_a(cc: Cc, src: Tree, unit: Path) -> Tree {
+    cc! { -O2 -Wall -I {src} -c {src / unit} -o {unit.with_ext("o")} }
+}
+
+fn build_b(cc: Cc, src: Tree, unit: Path) -> Tree {
+    cc! { -Wall -O2 -I {src} -c {src / unit} -o {unit.with_ext("o")} }
+}
+
+pub fn object_kind(cc: Cc, src: Tree, unit: Path) -> String {
+    elf(build_a(cc, src, unit)).kind
+}
+"#;
+
+#[test]
+fn real_process_cc_runs_through_machine_exec_cache() -> Result<(), String> {
+    if !host_cc_available() {
+        return Ok(());
+    }
+
+    let backend = Arc::new(RealProcessBackend::new());
+    let mut machine = Machine::load(SOURCE)?.with_exec_backend(backend);
+    let target = machine.linux_target_handle();
+    let cc = machine.demand_i64("get_cc", vec![target])?;
+    let unit = machine
+        .intern_arg("Path", MachineArg::Path("hello.c".to_string()))?
+        .0;
+    let source_v1 = source_tree("original README");
+    let source_v2 = source_tree("edited README that is not a declared input");
+    let tree_v1 = machine.intern_arg("Tree", MachineArg::Tree(source_v1))?.0;
+    let tree_v2 = machine.intern_arg("Tree", MachineArg::Tree(source_v2))?.0;
+
+    machine.clear_trace();
+    let first = machine.demand_i64("build_a", vec![cc, tree_v1, unit])?;
+    let first_object = tree_bytes(&mut machine, first, "hello.o")?;
+    assert_run_serving(&machine, |event| matches!(event, ExecEvent::Ran));
+    assert_object_magic(&first_object)?;
+
+    machine.clear_trace();
+    let warm = machine.demand_i64("build_b", vec![cc, tree_v1, unit])?;
+    assert_eq!(tree_bytes(&mut machine, warm, "hello.o")?, first_object);
+    assert_run_serving(&machine, |event| matches!(event, ExecEvent::Tier1Hit));
+
+    machine.clear_trace();
+    let cutoff = machine.demand_i64("build_a", vec![cc, tree_v2, unit])?;
+    assert_eq!(tree_bytes(&mut machine, cutoff, "hello.o")?, first_object);
+    assert_run_serving(&machine, |event| {
+        matches!(event, ExecEvent::Tier2Cutoff { verified: 2 })
+    });
+
+    #[cfg(target_os = "linux")]
+    {
+        let kind = machine.call(
+            "object_kind",
+            &[
+                vix::machine::NamedArg {
+                    name: "cc".to_string(),
+                    value: MachineArg::Word(cc),
+                },
+                vix::machine::NamedArg {
+                    name: "src".to_string(),
+                    value: MachineArg::Word(tree_v1),
+                },
+                vix::machine::NamedArg {
+                    name: "unit".to_string(),
+                    value: MachineArg::Word(unit),
+                },
+            ],
+        )?;
+        let rendered = machine.render_value("String", kind.0)?;
+        assert!(matches!(
+            rendered,
+            vix::machine::RenderedValue::String { value } if value == "rel"
+        ));
+    }
+
+    Ok(())
+}
+
+fn host_cc_available() -> bool {
+    std::process::Command::new("cc")
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+fn source_tree(readme: &str) -> Tree {
+    Tree::of(&[
+        (
+            "hello.c",
+            "int vix_real_process_probe(void) { return 42; }\n",
+        ),
+        ("README", readme),
+    ])
+}
+
+fn assert_run_serving(machine: &Machine, matches_event: impl Fn(&ExecEvent) -> bool) {
+    assert!(
+        machine.trace().iter().any(|event| matches!(
+            event,
+            DriveEvent::RunCompleted {
+                command_name,
+                serving,
+                ..
+            } if command_name == "cc" && matches_event(serving)
+        )),
+        "{:?}",
+        machine.trace()
+    );
+}
+
+fn tree_bytes(machine: &mut Machine, handle: i64, path: &str) -> Result<Vec<u8>, String> {
+    if let Some(bytes) = machine.tree_blob_entries(handle)?.remove(path) {
+        return Ok(bytes);
+    }
+    machine
+        .tree_entries(handle)?
+        .remove(path)
+        .map(String::into_bytes)
+        .ok_or_else(|| format!("missing `{path}` in real-process output tree"))
+}
+
+fn assert_object_magic(bytes: &[u8]) -> Result<(), String> {
+    if bytes.len() < 4 {
+        return Err(format!("object file too short: {} bytes", bytes.len()));
+    }
+    #[cfg(target_os = "linux")]
+    if bytes.starts_with(b"\x7fELF") {
+        return Ok(());
+    }
+    #[cfg(target_os = "macos")]
+    if matches!(
+        &bytes[..4],
+        [0xcf, 0xfa, 0xed, 0xfe]
+            | [0xfe, 0xed, 0xfa, 0xcf]
+            | [0xce, 0xfa, 0xed, 0xfe]
+            | [0xfe, 0xed, 0xfa, 0xce]
+    ) {
+        return Ok(());
+    }
+    Err(format!("unrecognized object magic: {:02x?}", &bytes[..4]))
+}


### PR DESCRIPTION
Summary:
- Add a native-only real-process MachineExecBackend behind the real-process feature.
- Stage role-declared inputs into hermetic-ish temp dirs, run host commands with a scrubbed environment, and harvest declared outputs including binary blobs.
- Document that open vix trusts the host and that tier-2 verification covers only role-declared reads; VFS mediation/sandboxing remains outside this lane.

Testing:
- cargo check -p vix --features real-process
- cargo nextest run -p vix -p weavy
- cargo nextest run -p vix --features real-process (87 passed, 1 leaky marker on warm_demand_spawns_nothing; focused rerun passed cleanly)
- cargo nextest run -p vix --features real-process -E 'binary(real_process)'
- cargo clippy -p vix -p weavy --all-targets --message-format=short -- -D warnings
- cargo clippy -p vix --features real-process --all-targets --message-format=short -- -D warnings
- cargo check -p snark-wasm --target wasm32-unknown-unknown
- cargo check -p vix --target wasm32-unknown-unknown --features real-process