### PR TITLE
vix: ast() probe — source as a structural value

### DIFF
--- a/playgrounds/snark/src/bundled/vix/samples/ast-query.vix
+++ b/playgrounds/snark/src/bundled/vix/samples/ast-query.vix
@@ -1,0 +1,15 @@
+// ast-query.vix — first rung: vix querying vix.
+
+use vix::Tree;
+
+pub fn fn_count(source: Tree) -> Int {
+    ast(source).fns.len()
+}
+
+pub fn declaration_start(source: Tree) -> Int {
+    ast(source).fn("toolchain").span.start
+}
+
+pub fn declaration_end(source: Tree) -> Int {
+    ast(source).fn("toolchain").span.end
+}

--- a/vix/src/machine/ast_probe.rs
+++ b/vix/src/machine/ast_probe.rs
@@ -1,0 +1,262 @@
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+use crate::VixParser;
+use crate::ast::{self, FnItem, Item, SourceFile, Span, Type};
+use crate::value::{Payload, Value};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(super) enum Projection {
+    Items,
+    Fns,
+    Fn,
+    FnBodyChildren,
+}
+
+impl Projection {
+    pub(super) fn name(self) -> &'static str {
+        match self {
+            Projection::Items => "items",
+            Projection::Fns => "fns",
+            Projection::Fn => "fn",
+            Projection::FnBodyChildren => "fn.body.children",
+        }
+    }
+
+    pub(super) fn to_word(self) -> i64 {
+        match self {
+            Projection::Items => 1000,
+            Projection::Fns => 1001,
+            Projection::Fn => 1002,
+            Projection::FnBodyChildren => 1003,
+        }
+    }
+
+    pub(super) fn from_word(word: i64) -> Result<Self, String> {
+        Ok(match word {
+            1000 => Projection::Items,
+            1001 => Projection::Fns,
+            1002 => Projection::Fn,
+            1003 => Projection::FnBodyChildren,
+            other => return Err(format!("unknown ast projection {other}")),
+        })
+    }
+}
+
+pub(super) fn parse(source: &str) -> Result<SourceFile, String> {
+    static PARSER: OnceLock<VixParser> = OnceLock::new();
+    PARSER
+        .get_or_init(VixParser::new)
+        .parse(source)
+        .map_err(|err| err.message)
+}
+
+pub(super) fn items(file: &SourceFile) -> Value {
+    Value::Array(file.items.iter().map(item_summary).collect())
+}
+
+pub(super) fn fns(file: &SourceFile) -> Value {
+    Value::Array(
+        file.items
+            .iter()
+            .filter_map(|item| match item {
+                Item::Fn(item) => Some(fn_summary(item)),
+                _ => None,
+            })
+            .collect(),
+    )
+}
+
+pub(super) fn fn_item<'a>(file: &'a SourceFile, name: &str) -> Result<&'a FnItem, String> {
+    file.items
+        .iter()
+        .find_map(|item| match item {
+            Item::Fn(item) if item.name.value == name => Some(item.as_ref()),
+            _ => None,
+        })
+        .ok_or_else(|| format!("no fn named {name}"))
+}
+
+pub(super) fn fn_body_children(item: &FnItem) -> Value {
+    let mut children = item.body.stmts.iter().map(stmt_summary).collect::<Vec<_>>();
+    if let Some(tail) = &item.body.tail {
+        children.push(node_summary("tail", None, expr_span(tail)));
+    }
+    Value::Array(children)
+}
+
+pub(super) fn fn_fields(item: &FnItem) -> BTreeMap<Value, Value> {
+    BTreeMap::from([
+        (string_key("kind"), Value::Str("fn".to_string())),
+        (string_key("name"), Value::Str(item.name.value.clone())),
+        (string_key("span"), span_value(item.span)),
+        (
+            string_key("params"),
+            Value::Array(item.params.params.iter().map(param_value).collect()),
+        ),
+        (
+            string_key("return_type"),
+            item.return_type
+                .as_ref()
+                .map(type_value)
+                .unwrap_or_else(option_none),
+        ),
+    ])
+}
+
+pub(super) fn span_value(span: Span) -> Value {
+    Value::Map(BTreeMap::from([
+        (string_key("start"), Value::Int(i64::from(span.start))),
+        (string_key("end"), Value::Int(i64::from(span.end))),
+    ]))
+}
+
+fn item_summary(item: &Item) -> Value {
+    match item {
+        Item::Use(item) => node_summary("use", None, item.span),
+        Item::Fn(item) => fn_summary(item),
+        Item::Struct(item) => node_summary("struct", Some(&item.name.value), item.span),
+        Item::Enum(item) => node_summary("enum", Some(&item.name.value), item.span),
+    }
+}
+
+fn fn_summary(item: &FnItem) -> Value {
+    node_summary("fn", Some(&item.name.value), item.span)
+}
+
+fn stmt_summary(stmt: &ast::Stmt) -> Value {
+    match stmt {
+        ast::Stmt::Let(stmt) => node_summary("let", Some(&stmt.name.value), stmt.span),
+        ast::Stmt::Expr(stmt) => node_summary("expr", None, stmt.span),
+    }
+}
+
+fn node_summary(kind: &str, name: Option<&str>, span: Span) -> Value {
+    let mut fields = BTreeMap::from([
+        (string_key("kind"), Value::Str(kind.to_string())),
+        (string_key("span"), span_value(span)),
+    ]);
+    if let Some(name) = name {
+        fields.insert(string_key("name"), Value::Str(name.to_string()));
+    }
+    Value::Map(fields)
+}
+
+fn param_value(param: &ast::Param) -> Value {
+    Value::Map(BTreeMap::from([
+        (string_key("name"), Value::Str(param.name.value.clone())),
+        (string_key("type"), type_value(&param.ty)),
+        (string_key("span"), span_value(param.span)),
+    ]))
+}
+
+fn type_value(ty: &Type) -> Value {
+    Value::Map(BTreeMap::from([
+        (string_key("kind"), Value::Str(type_kind(ty).to_string())),
+        (string_key("text"), Value::Str(type_text(ty))),
+        (string_key("span"), span_value(type_span(ty))),
+    ]))
+}
+
+fn type_kind(ty: &Type) -> &'static str {
+    match ty {
+        Type::Array(_) => "array",
+        Type::Fn(_) => "fn",
+        Type::Tuple(_) => "tuple",
+        Type::Generic(_) => "generic",
+        Type::Path(_) => "path",
+    }
+}
+
+fn type_span(ty: &Type) -> Span {
+    match ty {
+        Type::Array(ty) => ty.span,
+        Type::Fn(ty) => ty.span,
+        Type::Tuple(ty) => ty.span,
+        Type::Generic(ty) => ty.span,
+        Type::Path(ty) => ty.span,
+    }
+}
+
+fn type_text(ty: &Type) -> String {
+    match ty {
+        Type::Array(array) => format!("[{}]", type_text(&array.elem)),
+        Type::Fn(func) => {
+            let params = func
+                .params
+                .iter()
+                .map(type_text)
+                .collect::<Vec<_>>()
+                .join(", ");
+            match &func.return_type {
+                Some(ret) => format!("fn({params}) -> {}", type_text(ret)),
+                None => format!("fn({params})"),
+            }
+        }
+        Type::Tuple(tuple) => format!(
+            "({})",
+            tuple
+                .elems
+                .iter()
+                .map(type_text)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Type::Generic(generic) => format!(
+            "{}<{}>",
+            type_path_text(&generic.base),
+            generic
+                .args
+                .iter()
+                .map(type_text)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Type::Path(path) => type_path_text(path),
+    }
+}
+
+fn type_path_text(path: &ast::TypePath) -> String {
+    path.segments
+        .iter()
+        .map(|segment| segment.value.as_str())
+        .collect::<Vec<_>>()
+        .join("::")
+}
+
+fn expr_span(expr: &ast::Expr) -> Span {
+    match expr {
+        ast::Expr::Binary(expr) => expr.span,
+        ast::Expr::Unary(expr) => expr.span,
+        ast::Expr::Call(expr) => expr.span,
+        ast::Expr::MethodCall(expr) => expr.span,
+        ast::Expr::Field(expr) => expr.span,
+        ast::Expr::Match(expr) => expr.span,
+        ast::Expr::Closure(expr) => expr.span,
+        ast::Expr::Command(expr) => expr.span,
+        ast::Expr::StructLit(expr) => expr.span,
+        ast::Expr::Map(expr) => expr.span,
+        ast::Expr::Tuple(expr) => expr.span,
+        ast::Expr::Array(expr) => expr.span,
+        ast::Expr::Paren(expr) => expr.span,
+        ast::Expr::Scoped(expr) => expr.span,
+        ast::Expr::Identifier(expr)
+        | ast::Expr::Str(expr)
+        | ast::Expr::Path(expr)
+        | ast::Expr::Number(expr) => expr.span,
+        ast::Expr::Bool(expr) => expr.span,
+    }
+}
+
+fn option_none() -> Value {
+    Value::Variant {
+        enum_name: "Option".to_string(),
+        index: 1,
+        name: "None".to_string(),
+        payload: Payload::Unit,
+    }
+}
+
+fn string_key(key: &str) -> Value {
+    Value::Str(key.to_string())
+}

--- a/vix/src/machine/driver.rs
+++ b/vix/src/machine/driver.rs
@@ -41,6 +41,7 @@ use weavy::mem::{Access, Descriptor, Tag};
 use weavy::task::Op;
 use weavy::task::{FnId, HostFn, Program, Task, TaskStep};
 
+use crate::ast;
 use crate::fetch::{FetchBackend, NoFetchBackend};
 use crate::support::{PathMissing, assign_roles, subtree, tool_for};
 use crate::value::{Payload, Value};
@@ -132,6 +133,9 @@ pub const DOC_PARSE_HOST: u32 = 21;
 pub const DOC_GET_HOST: u32 = 22;
 pub const DOC_COERCE_HOST: u32 = 23;
 pub const ELF_DOC_HOST: u32 = 24;
+pub const AST_DOC_HOST: u32 = 25;
+pub const AST_FN_HOST: u32 = 26;
+pub const ARRAY_LEN_HOST: u32 = 27;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Lane {
@@ -583,8 +587,13 @@ struct PendingInvocation {
 }
 
 #[derive(Clone, Debug)]
-struct PendingPrimitive {
-    projection: super::elf::Projection,
+enum PendingPrimitive {
+    Elf {
+        projection: super::elf::Projection,
+    },
+    Ast {
+        projection: super::ast_probe::Projection,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -1138,6 +1147,9 @@ pub struct Driver {
     fetch_backend: Arc<dyn FetchBackend>,
     exec_backend: Option<Arc<dyn MachineExecBackend>>,
     elf_projection_memo: HashMap<(ContentHash, super::elf::Projection), i64>,
+    ast_roots: HashMap<i64, i64>,
+    ast_parse_memo: HashMap<ContentHash, Arc<ast::SourceFile>>,
+    ast_projection_memo: HashMap<(ContentHash, super::ast_probe::Projection, String), i64>,
     runs: BTreeMap<u64, PendingExecRun>,
     next_run_id: u64,
     trace_clock: u64,
@@ -1181,6 +1193,9 @@ impl Driver {
             fetch_backend: Arc::new(NoFetchBackend),
             exec_backend: None,
             elf_projection_memo: HashMap::new(),
+            ast_roots: HashMap::new(),
+            ast_parse_memo: HashMap::new(),
+            ast_projection_memo: HashMap::new(),
             runs: BTreeMap::new(),
             next_run_id: 0,
             trace_clock: 0,
@@ -1769,6 +1784,7 @@ impl Driver {
             let descriptors = &self.descriptors;
             let schema_refs = &self.schema_refs;
             let store_cell = &self.store;
+            let ast_roots_cell = RefCell::new(&mut self.ast_roots);
             let journal_cell = RefCell::new(&mut self.journal);
             let clock_cell = RefCell::new(&mut self.trace_clock);
             let lowered_fns = &self.fns;
@@ -2282,6 +2298,69 @@ impl Driver {
                 }
             };
 
+            let mut ast_doc_host = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let input = read_frame_word(frame, primitive_region + 8);
+                    let handle = alloc_ast_doc(store_cell, descriptors, schema_refs, input)?;
+                    ast_roots_cell.borrow_mut().insert(handle, input);
+                    write_frame_word(frame, dst_slot, handle);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
+            let mut ast_fn_host = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let root = read_frame_word(frame, primitive_region + 8);
+                    let name = read_frame_word(frame, primitive_region + 16);
+                    let input = *ast_roots_cell
+                        .borrow()
+                        .get(&root)
+                        .ok_or_else(|| format!("handle {root} is not an ast() root"))?;
+                    let input_hash = store_cell
+                        .borrow()
+                        .entry(input)
+                        .ok_or_else(|| format!("store handle {input}"))?
+                        .content_hash;
+                    let pending = ast_projection_pending(
+                        input,
+                        input_hash,
+                        super::ast_probe::Projection::Fn,
+                        vec![name],
+                    );
+                    let pending = store_cell.borrow_mut().alloc_pending("Doc", pending).0;
+                    write_frame_word(frame, dst_slot, pending);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
+            let mut array_len_host = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let array = read_frame_word(frame, primitive_region + 8);
+                    let len = match store_cell.borrow().array_entry(array, schema_refs)? {
+                        ArrayEntry::Words { words, .. } => words.len(),
+                        ArrayEntry::Pending(pending) => pending.len(),
+                    };
+                    write_frame_word(
+                        frame,
+                        dst_slot,
+                        i64::try_from(len).expect("array length fits i64"),
+                    );
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
             let mut array_filter_exclude = |frame: &mut [u8]| {
                 let result = (|| {
                     let dst_slot = read_frame_word(frame, primitive_region) as usize;
@@ -2433,7 +2512,7 @@ impl Driver {
                 });
             };
 
-            let mut hosts: [HostFn<'_>; 25] = [
+            let mut hosts: [HostFn<'_>; 28] = [
                 &mut invoke,
                 &mut store_alloc,
                 &mut store_read,
@@ -2459,6 +2538,9 @@ impl Driver {
                 &mut doc_get_host,
                 &mut doc_coerce_host,
                 &mut elf_doc_host,
+                &mut ast_doc_host,
+                &mut ast_fn_host,
+                &mut array_len_host,
             ];
             let step = exec
                 .task
@@ -2621,7 +2703,14 @@ impl Driver {
             ));
         }
         if let Some(primitive) = invocation.primitive {
-            let value = self.force_elf_projection(primitive.projection, &invocation.args)?;
+            let value = match primitive {
+                PendingPrimitive::Elf { projection } => {
+                    self.force_elf_projection(projection, &invocation.args)?
+                }
+                PendingPrimitive::Ast { projection } => {
+                    self.force_ast_projection(projection, &invocation.args)?
+                }
+            };
             return Ok(PendingForce::Ready {
                 input_slot: req.input_slot,
                 value,
@@ -3154,6 +3243,140 @@ impl Driver {
             )),
         }
     }
+
+    fn force_ast_projection(
+        &mut self,
+        projection: super::ast_probe::Projection,
+        args: &[i64],
+    ) -> Result<i64, String> {
+        let input = *args.first().ok_or_else(|| {
+            format!(
+                "ast projection {} expected an input argument",
+                projection.name()
+            )
+        })?;
+        let name = match projection {
+            super::ast_probe::Projection::Items | super::ast_probe::Projection::Fns => {
+                if args.len() != 1 {
+                    return Err(format!(
+                        "ast projection {} expected one input, got {}",
+                        projection.name(),
+                        args.len()
+                    ));
+                }
+                String::new()
+            }
+            super::ast_probe::Projection::Fn | super::ast_probe::Projection::FnBodyChildren => {
+                let [_, name] = args else {
+                    return Err(format!(
+                        "ast projection {} expected input and name, got {} args",
+                        projection.name(),
+                        args.len()
+                    ));
+                };
+                self.store.borrow().string_value(*name, "String")?
+            }
+        };
+        let (source, input_hash) = self.ast_input_source(input)?;
+        let memo_key = (input_hash, projection, name.clone());
+        if let Some(&handle) = self.ast_projection_memo.get(&memo_key) {
+            let timestamp_us = self.next_timestamp();
+            self.emit(DriveEvent::ArtifactProbe {
+                format: "ast".to_string(),
+                projection: projection.name().to_string(),
+                input: hash_u64((input_hash, &name)),
+                cache_hit: true,
+                timestamp_us,
+            });
+            return Ok(handle);
+        }
+
+        let file = if let Some(file) = self.ast_parse_memo.get(&input_hash) {
+            Arc::clone(file)
+        } else {
+            let file = Arc::new(super::ast_probe::parse(&source)?);
+            self.ast_parse_memo.insert(input_hash, Arc::clone(&file));
+            file
+        };
+
+        let handle = match projection {
+            super::ast_probe::Projection::Items => alloc_doc_from_value(
+                &self.store,
+                &self.descriptors,
+                &self.schema_refs,
+                super::ast_probe::items(&file),
+            )?,
+            super::ast_probe::Projection::Fns => alloc_doc_from_value(
+                &self.store,
+                &self.descriptors,
+                &self.schema_refs,
+                super::ast_probe::fns(&file),
+            )?,
+            super::ast_probe::Projection::Fn => {
+                let item = super::ast_probe::fn_item(&file, &name)?;
+                alloc_ast_fn_doc(
+                    &self.store,
+                    &self.descriptors,
+                    &self.schema_refs,
+                    input,
+                    input_hash,
+                    item,
+                )?
+            }
+            super::ast_probe::Projection::FnBodyChildren => {
+                let item = super::ast_probe::fn_item(&file, &name)?;
+                alloc_doc_from_value(
+                    &self.store,
+                    &self.descriptors,
+                    &self.schema_refs,
+                    super::ast_probe::fn_body_children(item),
+                )?
+            }
+        };
+        self.ast_projection_memo.insert(memo_key, handle);
+        let timestamp_us = self.next_timestamp();
+        self.emit(DriveEvent::ArtifactProbe {
+            format: "ast".to_string(),
+            projection: projection.name().to_string(),
+            input: hash_u64((input_hash, &name)),
+            cache_hit: false,
+            timestamp_us,
+        });
+        Ok(handle)
+    }
+
+    fn ast_input_source(&mut self, handle: i64) -> Result<(String, ContentHash), String> {
+        let entry = self
+            .store
+            .borrow()
+            .entry(handle)
+            .cloned()
+            .ok_or_else(|| format!("store handle {handle}"))?;
+        let source = match entry.schema.as_str() {
+            "String" => String::from_utf8(entry.bytes).map_err(|err| err.to_string())?,
+            "Tree" => {
+                let forced = self.force_tree_handle(handle)?;
+                let TreeEntry::Concrete(tree) = self.store.borrow().tree_entry(forced)? else {
+                    return Err("ast input tree stayed pending".into());
+                };
+                let len = tree.entries.len();
+                let [(path, contents)] =
+                    <[(String, String); 1]>::try_from(tree.entries.into_iter().collect::<Vec<_>>())
+                        .map_err(|_| {
+                            format!("ast input tree must contain exactly one source, got {len}")
+                        })?;
+                if contents.is_empty() {
+                    return Err(format!("ast input source `{path}` is empty"));
+                }
+                contents
+            }
+            other => return Err(format!("ast input must be String or Tree, got {other}")),
+        };
+        let mut hasher = Sha256::new();
+        hasher.update(b"vix-ast-input");
+        hasher.update(source.as_bytes());
+        Ok((source, hasher.finalize().into()))
+    }
 }
 
 enum Burst {
@@ -3426,11 +3649,156 @@ fn elf_projection_pending(
     let identity_hash = hasher.finalize().into();
     PendingInvocation {
         closure_hash: hash_u64(("elf", projection.name())),
-        primitive: Some(PendingPrimitive { projection }),
+        primitive: Some(PendingPrimitive::Elf { projection }),
         args: vec![input],
         remaining_arity: 0,
         identity_hash,
     }
+}
+
+fn alloc_ast_doc(
+    store: &RefCell<ValueStore>,
+    descriptors: &HashMap<String, Descriptor<String>>,
+    schema_refs: &[String],
+    input: i64,
+) -> Result<i64, String> {
+    let input_hash = {
+        let store = store.borrow();
+        let entry = store
+            .entry(input)
+            .ok_or_else(|| format!("store handle {input}"))?;
+        match entry.schema.as_str() {
+            "String" | "Tree" => entry.content_hash,
+            other => return Err(format!("ast input must be String or Tree, got {other}")),
+        }
+    };
+    let rows = [
+        (
+            "items",
+            ast_projection_pending(
+                input,
+                input_hash,
+                super::ast_probe::Projection::Items,
+                Vec::new(),
+            ),
+        ),
+        (
+            "fns",
+            ast_projection_pending(
+                input,
+                input_hash,
+                super::ast_probe::Projection::Fns,
+                Vec::new(),
+            ),
+        ),
+    ]
+    .into_iter()
+    .map(|(key, pending)| {
+        let pending = store.borrow_mut().alloc_pending("Doc", pending).0;
+        (key.to_string(), pending_schema("Doc"), pending)
+    })
+    .collect::<Vec<_>>();
+    alloc_doc_object(store, descriptors, schema_refs, rows)
+}
+
+fn alloc_ast_fn_doc(
+    store: &RefCell<ValueStore>,
+    descriptors: &HashMap<String, Descriptor<String>>,
+    schema_refs: &[String],
+    input: i64,
+    input_hash: ContentHash,
+    item: &ast::FnItem,
+) -> Result<i64, String> {
+    let name_handle = store
+        .borrow_mut()
+        .alloc_raw("String", item.name.value.as_bytes().to_vec())
+        .0;
+    let children = ast_projection_pending(
+        input,
+        input_hash,
+        super::ast_probe::Projection::FnBodyChildren,
+        vec![name_handle],
+    );
+    let children = store.borrow_mut().alloc_pending("Doc", children).0;
+    let body = alloc_doc_object(
+        store,
+        descriptors,
+        schema_refs,
+        vec![
+            (
+                "span".to_string(),
+                "Doc".to_string(),
+                alloc_doc_from_value(
+                    store,
+                    descriptors,
+                    schema_refs,
+                    super::ast_probe::span_value(item.body.span),
+                )?,
+            ),
+            ("children".to_string(), pending_schema("Doc"), children),
+        ],
+    )?;
+    let mut rows = super::ast_probe::fn_fields(item)
+        .into_iter()
+        .map(|(key, value)| {
+            let Value::Str(key) = key else {
+                return Err(format!("ast fn key must be string, got {key:?}"));
+            };
+            let handle = alloc_doc_from_value(store, descriptors, schema_refs, value)?;
+            Ok((key, "Doc".to_string(), handle))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    rows.push(("body".to_string(), "Doc".to_string(), body));
+    alloc_doc_object(store, descriptors, schema_refs, rows)
+}
+
+fn ast_projection_pending(
+    input: i64,
+    input_hash: ContentHash,
+    projection: super::ast_probe::Projection,
+    extra_args: Vec<i64>,
+) -> PendingInvocation {
+    let mut hasher = Sha256::new();
+    hasher.update(b"vix-ast-projection");
+    hasher.update(projection.name().as_bytes());
+    hasher.update(input_hash);
+    for arg in &extra_args {
+        hasher.update(arg.to_le_bytes());
+    }
+    let mut args = Vec::with_capacity(1 + extra_args.len());
+    args.push(input);
+    args.extend(extra_args);
+    PendingInvocation {
+        closure_hash: hash_u64(("ast", projection.name())),
+        primitive: Some(PendingPrimitive::Ast { projection }),
+        args,
+        remaining_arity: 0,
+        identity_hash: hasher.finalize().into(),
+    }
+}
+
+fn alloc_doc_object(
+    store: &RefCell<ValueStore>,
+    descriptors: &HashMap<String, Descriptor<String>>,
+    schema_refs: &[String],
+    rows: Vec<(String, String, i64)>,
+) -> Result<i64, String> {
+    let mut pairs = Vec::with_capacity(rows.len());
+    for (key, value_schema, value_word) in rows {
+        let key_word = store.borrow_mut().alloc_raw("String", key.into_bytes()).0;
+        pairs.push(MapPair {
+            key_schema: "String".to_string(),
+            key_word,
+            value_schema,
+            value_word,
+            value_realization: None,
+        });
+    }
+    let map = store
+        .borrow_mut()
+        .alloc_map("Map<String,Doc>", pairs, schema_refs, descriptors)?
+        .0;
+    alloc_doc_variant(store, descriptors, 6, &[map])
 }
 
 fn compare_words(
@@ -4586,6 +4954,25 @@ fn map_schemas(schema: &str) -> Option<(&str, &str)> {
     Some((key, value))
 }
 
+fn pending_primitive_to_word(primitive: &PendingPrimitive) -> i64 {
+    match primitive {
+        PendingPrimitive::Elf { projection } => projection.to_word(),
+        PendingPrimitive::Ast { projection } => projection.to_word(),
+    }
+}
+
+fn pending_primitive_from_word(word: i64) -> Result<PendingPrimitive, String> {
+    if word >= 1000 {
+        Ok(PendingPrimitive::Ast {
+            projection: super::ast_probe::Projection::from_word(word)?,
+        })
+    } else {
+        Ok(PendingPrimitive::Elf {
+            projection: super::elf::Projection::from_word(word)?,
+        })
+    }
+}
+
 fn encode_pending_invocation(invocation: &PendingInvocation) -> Vec<u8> {
     let mut bytes = Vec::new();
     bytes.extend_from_slice(&invocation.closure_hash.to_le_bytes());
@@ -4602,7 +4989,7 @@ fn encode_pending_invocation(invocation: &PendingInvocation) -> Vec<u8> {
     let primitive = invocation
         .primitive
         .as_ref()
-        .map(|primitive| primitive.projection.to_word())
+        .map(pending_primitive_to_word)
         .unwrap_or(-1);
     bytes.extend_from_slice(&primitive.to_le_bytes());
     bytes.extend_from_slice(&invocation.identity_hash);
@@ -4623,9 +5010,7 @@ fn decode_pending_invocation(bytes: &[u8]) -> Result<PendingInvocation, String> 
         usize::try_from(read_frame_word(bytes, 16)).map_err(|_| "remaining arity")?;
     let primitive = match read_frame_word(bytes, 24) {
         -1 => None,
-        word => Some(PendingPrimitive {
-            projection: super::elf::Projection::from_word(word)?,
-        }),
+        word => Some(pending_primitive_from_word(word)?),
     };
     let identity_hash: ContentHash = bytes[32..64]
         .try_into()

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -28,13 +28,14 @@ use weavy::task::{Fn as TaskFn, FnId, Op, Program};
 
 use super::TotalF64;
 use super::driver::{
-    ACQUIRE_HOST, ARRAY_ALLOC_HOST, ARRAY_COLLECT_HOST, ARRAY_FILTER_EXCLUDE_HOST,
-    ARRAY_MAP_PENDING_HOST, CodeBundle, DOC_COERCE_HOST, DOC_GET_HOST, DOC_PARSE_HOST, DriveEvent,
-    DriveEventSink, Driver, ELF_DOC_HOST, EXEC_HOST, FETCH_HOST, GLOB_HOST, INVOKE_HOST, Lane,
-    LoweredFn, MAP_EMPTY_HOST, MAP_GET_HOST, MAP_INSERT_HOST, MachineExecBackend,
-    OPTION_UNWRAP_HOST, PATH_WITH_EXT_HOST, PENDING_ALLOC_HOST, PENDING_COERCE_HOST,
-    PENDING_INVOKE_HOST, RenderNames, RenderVariant, RenderedValue, STORE_ALLOC_HOST,
-    STORE_READ_HOST, STORE_TAG_HOST, StepMode, StoreHandle, TREE_PROJECT_HOST, ValueBundle,
+    ACQUIRE_HOST, ARRAY_ALLOC_HOST, ARRAY_COLLECT_HOST, ARRAY_FILTER_EXCLUDE_HOST, ARRAY_LEN_HOST,
+    ARRAY_MAP_PENDING_HOST, AST_DOC_HOST, AST_FN_HOST, CodeBundle, DOC_COERCE_HOST, DOC_GET_HOST,
+    DOC_PARSE_HOST, DriveEvent, DriveEventSink, Driver, ELF_DOC_HOST, EXEC_HOST, FETCH_HOST,
+    GLOB_HOST, INVOKE_HOST, Lane, LoweredFn, MAP_EMPTY_HOST, MAP_GET_HOST, MAP_INSERT_HOST,
+    MachineExecBackend, OPTION_UNWRAP_HOST, PATH_WITH_EXT_HOST, PENDING_ALLOC_HOST,
+    PENDING_COERCE_HOST, PENDING_INVOKE_HOST, RenderNames, RenderVariant, RenderedValue,
+    STORE_ALLOC_HOST, STORE_READ_HOST, STORE_TAG_HOST, StepMode, StoreHandle, TREE_PROJECT_HOST,
+    ValueBundle,
 };
 use crate::ast;
 use crate::fetch::FetchBackend;
@@ -2469,6 +2470,7 @@ impl<'a> FnLowerer<'a> {
             "toml" => return self.doc_parse_call(call, 0),
             "json" => return self.doc_parse_call(call, 1),
             "elf" => return self.elf_call(call),
+            "ast" => return self.ast_call(call),
             _ => {}
         }
         if let Some(&fn_ref) = self.fn_refs.get(name) {
@@ -2707,6 +2709,21 @@ impl<'a> FnLowerer<'a> {
                 let ext = self.method_arg(arg, Some("String"))?;
                 self.path_with_ext(&receiver, &ext)
             }
+            "len" => {
+                if !call.args.args.is_empty() {
+                    return Err("len takes no arguments".into());
+                }
+                let receiver = match receiver.schema.as_str() {
+                    "Array" => receiver,
+                    "Doc" => self.coerce_doc_to_schema(receiver, "Array")?,
+                    "Realized<Doc>" => {
+                        let doc = self.coerce_to_schema(receiver, "Doc")?;
+                        self.coerce_doc_to_schema(doc, "Array")?
+                    }
+                    _ => return Err(format!("len called on {}", receiver.schema)),
+                };
+                self.array_len(&receiver)
+            }
             "glob" => self.tree_glob(&receiver, call),
             "filter" => self.array_filter_exclude(&receiver, call),
             "map" => self.array_map_pending(&receiver, call),
@@ -2748,6 +2765,14 @@ impl<'a> FnLowerer<'a> {
                 }
                 let key = self.method_arg(&call.args.args[0], Some(key_schema))?;
                 self.map_get(&receiver, key, key_schema, &result_value_schema)
+            }
+            "fn" => {
+                if call.args.args.len() != 1 {
+                    return Err("Doc.fn takes one name".into());
+                }
+                let receiver = self.coerce_to_schema(receiver, "Doc")?;
+                let name = self.method_arg(&call.args.args[0], Some("String"))?;
+                self.ast_fn(&receiver, &name)
             }
             "unwrap" => {
                 if !call.args.args.is_empty() {
@@ -4057,6 +4082,29 @@ impl<'a> FnLowerer<'a> {
         })
     }
 
+    fn array_len(&mut self, receiver: &ValueSlot) -> Result<ValueSlot, String> {
+        self.expect_schema(receiver, "Array")?;
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: receiver.slot,
+        });
+        self.code.push(Op::HostCall {
+            host: ARRAY_LEN_HOST,
+        });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: "Int".into(),
+            realization: None,
+            pending: None,
+        })
+    }
+
     fn doc_get(&mut self, doc: &ValueSlot, key: &ValueSlot) -> Result<ValueSlot, String> {
         self.expect_schema(doc, "Doc")?;
         self.expect_schema(key, "String")?;
@@ -4330,6 +4378,60 @@ impl<'a> FnLowerer<'a> {
             realization: None,
             pending: None,
         })
+    }
+
+    fn ast_call(&mut self, call: &ast::Call) -> Result<ValueSlot, String> {
+        let [ast::Arg::Expr(arg)] = call.args.args.as_slice() else {
+            return Err("ast takes one source String or single-source Tree".into());
+        };
+        let input = self.expr(arg)?;
+        if !matches!(input.schema.as_str(), "String" | "Tree") {
+            return Err(format!("ast called on {}", input.schema));
+        }
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: input.slot,
+        });
+        self.code.push(Op::HostCall { host: AST_DOC_HOST });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: "Doc".into(),
+            realization: None,
+            pending: None,
+        })
+    }
+
+    fn ast_fn(&mut self, receiver: &ValueSlot, name: &ValueSlot) -> Result<ValueSlot, String> {
+        self.expect_schema(receiver, "Doc")?;
+        self.expect_schema(name, "String")?;
+        let pending_slot = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: pending_slot.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: receiver.slot,
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 16,
+            src: name.slot,
+        });
+        self.code.push(Op::HostCall { host: AST_FN_HOST });
+        let pending = ValueSlot {
+            slot: pending_slot,
+            schema: pending_schema("Doc"),
+            realization: None,
+            pending: None,
+        };
+        self.coerce_pending_to_schema(pending, "Doc")
     }
 
     fn path_with_ext(&mut self, path: &ValueSlot, ext: &ValueSlot) -> Result<ValueSlot, String> {
@@ -6802,6 +6904,142 @@ pub fn arch_twice(input: Blob) -> (String, String) {
     }
 
     #[test]
+    fn ast_structural_projection_contracts_are_pinned() {
+        let src = r#"
+pub fn item_count(source: String) -> Int { ast(source).items.len() }
+pub fn fn_count(source: String) -> Int { ast(source).fns.len() }
+pub fn toolchain_start(source: String) -> Int { ast(source).fn("toolchain").span.start }
+pub fn toolchain_param_count(source: String) -> Int { ast(source).fn("toolchain").params.len() }
+pub fn toolchain_body_children(source: String) -> Int {
+    ast(source).fn("toolchain").body.children.len()
+}
+"#;
+        let types = include_str!("../../../playgrounds/snark/src/bundled/vix/samples/types.vix");
+        let parsed = crate::VixParser::new().parse(types).unwrap();
+        let expected_items = i64::try_from(parsed.items.len()).unwrap();
+        let expected_fns = i64::try_from(
+            parsed
+                .items
+                .iter()
+                .filter(|item| matches!(item, ast::Item::Fn(_)))
+                .count(),
+        )
+        .unwrap();
+        let toolchain = parsed
+            .items
+            .iter()
+            .find_map(|item| match item {
+                ast::Item::Fn(item) if item.name.value == "toolchain" => Some(item),
+                _ => None,
+            })
+            .unwrap();
+        let expected_body_children =
+            i64::try_from(toolchain.body.stmts.len() + usize::from(toolchain.body.tail.is_some()))
+                .unwrap();
+
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            let source = machine
+                .driver
+                .intern_raw_value("String", types.as_bytes().to_vec())
+                .0;
+
+            assert_eq!(
+                machine.demand_i64("item_count", vec![source]).unwrap(),
+                expected_items,
+                "{lane:?}"
+            );
+            assert_eq!(
+                machine.demand_i64("fn_count", vec![source]).unwrap(),
+                expected_fns,
+                "{lane:?}"
+            );
+            assert_eq!(
+                machine.demand_i64("toolchain_start", vec![source]).unwrap(),
+                i64::from(toolchain.span.start),
+                "{lane:?}"
+            );
+            assert_eq!(
+                machine
+                    .demand_i64("toolchain_param_count", vec![source])
+                    .unwrap(),
+                i64::try_from(toolchain.params.params.len()).unwrap(),
+                "{lane:?}"
+            );
+            assert_eq!(
+                machine
+                    .demand_i64("toolchain_body_children", vec![source])
+                    .unwrap(),
+                expected_body_children,
+                "{lane:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ast_items_projection_does_not_force_fn_or_body_children() {
+        let src = r#"
+pub fn item_count(source: String) -> Int { ast(source).items.len() }
+"#;
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            let source = machine
+                .driver
+                .intern_raw_value(
+                    "String",
+                    include_str!("../../../playgrounds/snark/src/bundled/vix/samples/types.vix")
+                        .as_bytes()
+                        .to_vec(),
+                )
+                .0;
+            assert!(machine.demand_i64("item_count", vec![source]).unwrap() > 0);
+            assert_eq!(
+                ast_artifact_probes(&machine),
+                vec![("items".to_string(), false)],
+                "{lane:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ast_fn_body_children_projection_is_lazy_and_memoized() {
+        let src = r#"
+pub fn body_twice(source: String) -> (Int, Int) {
+    (
+        ast(source).fn("toolchain").body.children.len(),
+        ast(source).fn("toolchain").body.children.len(),
+    )
+}
+"#;
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            let source = machine
+                .driver
+                .intern_raw_value(
+                    "String",
+                    include_str!("../../../playgrounds/snark/src/bundled/vix/samples/types.vix")
+                        .as_bytes()
+                        .to_vec(),
+                )
+                .0;
+            let tuple = machine.demand_i64("body_twice", vec![source]).unwrap();
+            let left = machine.driver.store_field(tuple, 0).unwrap();
+            let right = machine.driver.store_field(tuple, 1).unwrap();
+            assert_eq!(left, right, "{lane:?}");
+            assert_eq!(
+                ast_artifact_probes(&machine),
+                vec![
+                    ("fn".to_string(), false),
+                    ("fn.body.children".to_string(), false),
+                    ("fn".to_string(), true),
+                    ("fn.body.children".to_string(), true),
+                ],
+                "{lane:?}"
+            );
+        }
+    }
+
+    #[test]
     fn scalar_array_collect_sorts_and_rejects_arguments() {
         let bad = r#"
 pub fn bad() -> [Int] {
@@ -7205,6 +7443,22 @@ pub fn lazy(n: Int) -> Map<String, Float> {
                     cache_hit,
                     ..
                 } if format == "elf" => Some((projection.clone(), *cache_hit)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn ast_artifact_probes(machine: &Machine) -> Vec<(String, bool)> {
+        machine
+            .trace()
+            .iter()
+            .filter_map(|event| match event {
+                DriveEvent::ArtifactProbe {
+                    format,
+                    projection,
+                    cache_hit,
+                    ..
+                } if format == "ast" => Some((projection.clone(), *cache_hit)),
                 _ => None,
             })
             .collect()

--- a/vix/src/machine/mod.rs
+++ b/vix/src/machine/mod.rs
@@ -60,6 +60,7 @@
 //! several producers, one path selected, unselected producers provably
 //! never executing (trace absence), through the VM and JIT.
 
+mod ast_probe;
 pub mod driver;
 mod elf;
 pub mod lower;


### PR DESCRIPTION
## Summary
- add ast(source) as a lazy structural Doc probe over vix's generated typed AST
- expose root .items and .fns lists, .fn(name) lookup, spans, params, return_type, body.span, and lazy body.children
- add Array.len() so vix can run real AST queries and include ast-query.vix as the first vix-queries-vix sample

## Laziness proofs
- ast(source).items.len() emits only ArtifactProbe { format: ast, projection: items }
- ast(source).fn("toolchain").body.children.len() emits fn and fn.body.children only when body.children is touched
- repeated body child projection emits cache_hit=true on the second projection

## Testing
- cargo nextest run -p vix -p weavy
- cargo clippy -p vix -p weavy --all-features --all-targets --message-format=short -- -D warnings
- pnpm --filter @bearcove/snark-wasm run build