### PR TITLE
vix: real module system

### DIFF
--- a/vix/src/binder.rs
+++ b/vix/src/binder.rs
@@ -244,17 +244,18 @@ pub fn bind_module_set(
             };
             let import_specs = import_specs(use_item)?;
             for (target_module, name) in import_specs {
-                if target_module == "vix" || target_module == "caps" {
-                    continue;
-                }
-                let target = files.get(&target_module).ok_or_else(|| {
-                    format!(
-                        "module `{from}` imports `{name}` from missing module `{target_module}`"
-                    )
-                })?;
-                let item = module_item(target, &name).ok_or_else(|| {
-                    format!("module `{target_module}` has no item named `{name}`")
-                })?;
+                let item = if let Some(item) = builtin_module_item(&target_module, &name) {
+                    item
+                } else {
+                    let target = files.get(&target_module).ok_or_else(|| {
+                        format!(
+                            "module `{from}` imports `{name}` from missing module `{target_module}`"
+                        )
+                    })?;
+                    module_item(target, &name).ok_or_else(|| {
+                        format!("module `{target_module}` has no item named `{name}`")
+                    })?
+                };
                 if from != &target_module && !item.public {
                     return Err(format!(
                         "module `{from}` cannot import private item `{target_module}::{name}`"
@@ -331,6 +332,19 @@ fn module_item(file: &SourceFile, name: &str) -> Option<ModuleItem> {
         }),
         _ => None,
     })
+}
+
+fn builtin_module_item(module: &str, name: &str) -> Option<ModuleItem> {
+    let kind = match (module, name) {
+        (
+            "vix",
+            "Int" | "Float" | "String" | "Bool" | "Blob" | "Doc" | "Tree" | "Path" | "Target"
+            | "Map" | "Array" | "Flag" | "Run" | "Os",
+        ) => ImportKind::Type,
+        ("caps", "Cc" | "Ar" | "Rustc") => ImportKind::Type,
+        _ => return None,
+    };
+    Some(ModuleItem { kind, public: true })
 }
 
 struct Binder {

--- a/vix/src/binder.rs
+++ b/vix/src/binder.rs
@@ -21,6 +21,8 @@
 //! Unresolved references are values, not errors: the future type/prelude layers
 //! consume this list.
 
+use std::collections::BTreeMap;
+
 use crate::ast::{
     Arg, ArrayElem, Block, CommandPart, EnumItem, Expr, FieldList, GenericParams, Item, PathRef,
     Pattern, SourceFile, Span, Spanned, Stmt, StructItem, TupleFields, Type,
@@ -42,6 +44,45 @@ pub enum SymbolKind {
     TypeParam,
     /// A name bound by a match pattern (payload/shorthand positions).
     Binding,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportKind {
+    Fn,
+    Type,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedImport {
+    pub module: String,
+    pub name: String,
+    pub kind: ImportKind,
+}
+
+#[derive(Debug)]
+pub struct ModuleBindings {
+    modules: BTreeMap<String, Bindings>,
+    imports: BTreeMap<(String, String), ResolvedImport>,
+}
+
+impl ModuleBindings {
+    pub fn module(&self, path: &str) -> Option<&Bindings> {
+        self.modules.get(path)
+    }
+
+    pub fn modules(&self) -> impl Iterator<Item = (&str, &Bindings)> {
+        self.modules
+            .iter()
+            .map(|(path, bindings)| (path.as_str(), bindings))
+    }
+
+    pub fn import(&self, module: &str, name: &str) -> Option<&ResolvedImport> {
+        self.imports.get(&(module.to_string(), name.to_string()))
+    }
+
+    pub fn imports(&self) -> impl Iterator<Item = (&(String, String), &ResolvedImport)> {
+        self.imports.iter()
+    }
 }
 
 /// Primitive scalar types need no declaration or import; they resolve silently
@@ -181,6 +222,115 @@ pub fn bind(file: &SourceFile) -> Bindings {
     }
 
     b.out
+}
+
+pub fn bind_module_set(
+    root: &str,
+    files: &BTreeMap<String, SourceFile>,
+) -> Result<ModuleBindings, String> {
+    if !files.contains_key(root) {
+        return Err(format!("root module `{root}` is not in the module set"));
+    }
+
+    let modules = files
+        .iter()
+        .map(|(path, file)| (path.clone(), bind(file)))
+        .collect();
+    let mut imports = BTreeMap::new();
+    for (from, file) in files {
+        for item in &file.items {
+            let Item::Use(use_item) = item else {
+                continue;
+            };
+            let import_specs = import_specs(use_item)?;
+            for (target_module, name) in import_specs {
+                if target_module == "vix" || target_module == "caps" {
+                    continue;
+                }
+                let target = files.get(&target_module).ok_or_else(|| {
+                    format!(
+                        "module `{from}` imports `{name}` from missing module `{target_module}`"
+                    )
+                })?;
+                let item = module_item(target, &name).ok_or_else(|| {
+                    format!("module `{target_module}` has no item named `{name}`")
+                })?;
+                if from != &target_module && !item.public {
+                    return Err(format!(
+                        "module `{from}` cannot import private item `{target_module}::{name}`"
+                    ));
+                }
+                imports.insert(
+                    (from.clone(), name.clone()),
+                    ResolvedImport {
+                        module: target_module,
+                        name,
+                        kind: item.kind,
+                    },
+                );
+            }
+        }
+    }
+
+    Ok(ModuleBindings { modules, imports })
+}
+
+struct ModuleItem {
+    kind: ImportKind,
+    public: bool,
+}
+
+fn import_specs(use_item: &crate::ast::UseItem) -> Result<Vec<(String, String)>, String> {
+    let segments = &use_item.tree.segments;
+    if segments.is_empty() {
+        return Err("empty use path".into());
+    }
+    if use_item.tree.leaves.is_empty() {
+        let Some((name, module_segments)) = segments.split_last() else {
+            return Err("empty use path".into());
+        };
+        if module_segments.is_empty() {
+            return Err(format!("use `{}` has no module path", name.value));
+        }
+        return Ok(vec![(
+            module_segments
+                .iter()
+                .map(|segment| segment.value.as_str())
+                .collect::<Vec<_>>()
+                .join("::"),
+            name.value.clone(),
+        )]);
+    }
+
+    let module = segments
+        .iter()
+        .map(|segment| segment.value.as_str())
+        .collect::<Vec<_>>()
+        .join("::");
+    Ok(use_item
+        .tree
+        .leaves
+        .iter()
+        .map(|leaf| (module.clone(), leaf.value.clone()))
+        .collect())
+}
+
+fn module_item(file: &SourceFile, name: &str) -> Option<ModuleItem> {
+    file.items.iter().find_map(|item| match item {
+        Item::Fn(f) if f.name.value == name => Some(ModuleItem {
+            kind: ImportKind::Fn,
+            public: f.vis.is_some(),
+        }),
+        Item::Struct(s) if s.name.value == name => Some(ModuleItem {
+            kind: ImportKind::Type,
+            public: s.vis.is_some(),
+        }),
+        Item::Enum(e) if e.name.value == name => Some(ModuleItem {
+            kind: ImportKind::Type,
+            public: e.vis.is_some(),
+        }),
+        _ => None,
+    })
 }
 
 struct Binder {

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -2749,6 +2749,9 @@ impl<'a> FnLowerer<'a> {
         let segments: Vec<&str> = path.segments.iter().map(|s| s.value.as_str()).collect();
         match segments.as_slice() {
             [kind @ ("Cc" | "Ar" | "Rustc"), "acquire"] => {
+                if self.tables.resolve_type_module(self.current_module, kind) != Some("caps") {
+                    return Ok(None);
+                }
                 let [ast::Arg::Expr(target)] = call.args.args.as_slice() else {
                     return Err(format!("{kind}::acquire takes one target"));
                 };

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -702,7 +702,7 @@ fn module_set_hash(root: &str, modules: &BTreeMap<String, String>) -> Vec<u8> {
     hasher.update(root.as_bytes());
     for (path, source) in modules {
         hasher.update(path.as_bytes());
-        hasher.update(&(source.len() as u64).to_le_bytes());
+        hasher.update((source.len() as u64).to_le_bytes());
         hasher.update(source.as_bytes());
     }
     hasher.finalize().to_vec()

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -39,7 +39,9 @@ use super::driver::{
 };
 use crate::ast;
 use crate::fetch::FetchBackend;
-use crate::module::{ModuleTables, VariantShape, load_module_tables, type_schema_name};
+use crate::module::{
+    ModuleTables, VariantShape, load_module_tables_from_modules, type_schema_name,
+};
 
 /// The machine facade for this slice: load source, demand a function's
 /// value at the edge.
@@ -85,8 +87,22 @@ impl Machine {
     }
 
     pub fn load_with_lane(source: &str, lane: Lane) -> Result<Machine, String> {
-        let module_hash = module_hash(source);
-        let tables = load_module_tables(source)?;
+        let mut modules = BTreeMap::new();
+        modules.insert("root".to_string(), source.to_string());
+        Self::load_modules_with_lane("root", modules, lane)
+    }
+
+    pub fn load_modules(root: &str, modules: BTreeMap<String, String>) -> Result<Machine, String> {
+        Self::load_modules_with_lane(root, modules, Lane::Interp)
+    }
+
+    pub fn load_modules_with_lane(
+        root: &str,
+        modules: BTreeMap<String, String>,
+        lane: Lane,
+    ) -> Result<Machine, String> {
+        let module_hash = module_set_hash(root, &modules);
+        let tables = load_module_tables_from_modules(root, &modules)?;
 
         // Deterministic fn_ref assignment: sorted names.
         let mut names: Vec<&String> = tables.fns.keys().collect();
@@ -176,6 +192,7 @@ impl Machine {
                 FnLowerer::lower(
                     item,
                     &tables,
+                    &tables.fn_modules[*name],
                     &fn_refs,
                     signatures,
                     &schema_refs,
@@ -250,7 +267,7 @@ impl Machine {
             fn_param_names: fn_param_names.into_iter().collect(),
             fn_returns: fn_returns.into_iter().collect(),
             render_names,
-            source: source.to_string(),
+            source: modules.get(root).cloned().unwrap_or_default(),
             module_hash,
         })
     }
@@ -271,9 +288,19 @@ impl Machine {
     }
 
     pub fn reload(&mut self, source: &str) -> Result<ReloadDiff, String> {
+        let mut modules = BTreeMap::new();
+        modules.insert("root".to_string(), source.to_string());
+        self.reload_modules("root", modules)
+    }
+
+    pub fn reload_modules(
+        &mut self,
+        root: &str,
+        modules: BTreeMap<String, String>,
+    ) -> Result<ReloadDiff, String> {
         let before = self.fn_hashes();
-        let module_hash = module_hash(source);
-        let tables = load_module_tables(source)?;
+        let module_hash = module_set_hash(root, &modules);
+        let tables = load_module_tables_from_modules(root, &modules)?;
 
         let mut names: Vec<&String> = tables.fns.keys().collect();
         names.sort();
@@ -353,6 +380,7 @@ impl Machine {
                 FnLowerer::lower(
                     item,
                     &tables,
+                    &tables.fn_modules[*name],
                     &fn_refs,
                     signatures,
                     &schema_refs,
@@ -395,7 +423,7 @@ impl Machine {
         self.fn_param_names = fn_param_names.into_iter().collect();
         self.fn_returns = fn_returns.into_iter().collect();
         self.render_names = render_names;
-        self.source = source.to_string();
+        self.source = modules.get(root).cloned().unwrap_or_default();
         self.module_hash = module_hash;
 
         let after = self.fn_hashes();
@@ -659,6 +687,24 @@ fn module_hash(source: &str) -> Vec<u8> {
     let mut hasher = Sha256::new();
     hasher.update(b"vix-machine-module");
     hasher.update(source.as_bytes());
+    hasher.finalize().to_vec()
+}
+
+fn module_set_hash(root: &str, modules: &BTreeMap<String, String>) -> Vec<u8> {
+    if modules.len() == 1
+        && root == "root"
+        && let Some(source) = modules.get(root)
+    {
+        return module_hash(source);
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(b"vix-machine-module-set");
+    hasher.update(root.as_bytes());
+    for (path, source) in modules {
+        hasher.update(path.as_bytes());
+        hasher.update(&(source.len() as u64).to_le_bytes());
+        hasher.update(source.as_bytes());
+    }
     hasher.finalize().to_vec()
 }
 
@@ -1819,6 +1865,7 @@ fn fork_binding_cell(cell: &BindingCell) -> BindingCell {
 
 struct FnLowerer<'a> {
     tables: &'a ModuleTables,
+    current_module: &'a str,
     fn_refs: &'a HashMap<String, usize>,
     signatures: FnSignatures<'a>,
     schema_refs: &'a HashMap<String, i64>,
@@ -1838,6 +1885,7 @@ impl<'a> FnLowerer<'a> {
     fn lower(
         item: &ast::FnItem,
         tables: &'a ModuleTables,
+        current_module: &'a str,
         fn_refs: &'a HashMap<String, usize>,
         signatures: FnSignatures<'a>,
         schema_refs: &'a HashMap<String, i64>,
@@ -1845,6 +1893,7 @@ impl<'a> FnLowerer<'a> {
     ) -> Result<(TaskFn, LoweredInfo), String> {
         let mut this = FnLowerer {
             tables,
+            current_module,
             fn_refs,
             signatures,
             schema_refs,
@@ -2482,22 +2531,30 @@ impl<'a> FnLowerer<'a> {
             "oci" => return self.oci_call(call),
             _ => {}
         }
-        if let Some(&fn_ref) = self.fn_refs.get(name) {
+        if let Some(resolved_name) = self.resolve_function_name(name).map(str::to_string)
+            && let Some(&fn_ref) = self.fn_refs.get(&resolved_name)
+        {
             let param_names = self
                 .signatures
                 .param_names
-                .get(name)
-                .ok_or_else(|| format!("missing param names for {name}"))?
+                .get(&resolved_name)
+                .ok_or_else(|| format!("missing param names for {resolved_name}"))?
                 .clone();
             let param_schemas = self
                 .signatures
                 .params
-                .get(name)
-                .ok_or_else(|| format!("missing param schemas for {name}"))?
+                .get(&resolved_name)
+                .ok_or_else(|| format!("missing param schemas for {resolved_name}"))?
                 .clone();
-            let bound =
-                self.bind_call_args(name, &param_names, &param_schemas, &call.args, 0, true)?;
-            let return_schema = self.signatures.returns[name].clone();
+            let bound = self.bind_call_args(
+                &resolved_name,
+                &param_names,
+                &param_schemas,
+                &call.args,
+                0,
+                true,
+            )?;
+            let return_schema = self.signatures.returns[&resolved_name].clone();
             if bound.partial {
                 return self.pending_alloc_for_fn(
                     fn_ref,
@@ -2541,6 +2598,10 @@ impl<'a> FnLowerer<'a> {
             .ok_or_else(|| format!("callee {name} is `{}`, not pending", callee.schema))?
             .to_string();
         self.pending_invoke(callee, bound.args, &value_schema)
+    }
+
+    fn resolve_function_name(&self, name: &str) -> Option<&str> {
+        self.tables.resolve_fn(self.current_module, name)
     }
 
     fn invoke_fn(
@@ -4839,6 +4900,23 @@ pub fn poly(n: Int) -> Int {
         })
     }
 
+    fn load_modules_with_lane(
+        root: &str,
+        modules: BTreeMap<String, String>,
+        lane: Lane,
+    ) -> Machine {
+        Machine::load_modules_with_lane(root, modules, lane).unwrap_or_else(|err| {
+            panic!("module set loads on {lane:?}: {err}");
+        })
+    }
+
+    fn modules(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+        entries
+            .iter()
+            .map(|(path, source)| ((*path).to_string(), (*source).to_string()))
+            .collect()
+    }
+
     fn lua_fetch_backend() -> FakeFetchBackend {
         FakeFetchBackend::new().with_archive(
             "https://www.lua.org/ftp/lua-5.4.8.tar.gz",
@@ -5988,6 +6066,204 @@ pub fn src_tree(nonce: Int) -> Tree {{
                 vec![(key.clone(), false), (key, true)],
                 "{lane:?}"
             );
+        }
+    }
+
+    #[test]
+    fn module_set_imported_pub_fn_resolves_and_runs() {
+        let set = modules(&[
+            (
+                "root",
+                r#"
+use a::answer;
+
+pub fn main() -> Int {
+    answer()
+}
+"#,
+            ),
+            (
+                "a",
+                r#"
+pub fn answer() -> Int {
+    42
+}
+"#,
+            ),
+        ]);
+        for lane in lanes() {
+            let mut machine = load_modules_with_lane("root", set.clone(), lane);
+            assert_eq!(machine.demand_i64("main", vec![]).unwrap(), 42, "{lane:?}");
+        }
+    }
+
+    #[test]
+    fn module_set_importing_private_item_errors_loudly() {
+        let set = modules(&[
+            (
+                "root",
+                r#"
+use a::answer;
+
+pub fn main() -> Int {
+    answer()
+}
+"#,
+            ),
+            (
+                "a",
+                r#"
+fn answer() -> Int {
+    42
+}
+"#,
+            ),
+        ]);
+        let err = match Machine::load_modules("root", set) {
+            Ok(_) => panic!("private import loaded"),
+            Err(err) => err,
+        };
+        assert!(
+            err.contains("cannot import private item `a::answer`"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn cross_module_hashes_match_same_content_in_one_file() {
+        let single = r#"
+pub fn answer() -> Int {
+    40 + 2
+}
+
+pub fn main() -> Int {
+    answer()
+}
+"#;
+        let split = modules(&[
+            (
+                "root",
+                r#"
+use a::answer;
+
+pub fn main() -> Int {
+    answer()
+}
+"#,
+            ),
+            (
+                "a",
+                r#"
+pub fn answer() -> Int {
+    40 + 2
+}
+"#,
+            ),
+        ]);
+        for lane in lanes() {
+            let single = load_with_lane(single, lane);
+            let split = load_modules_with_lane("root", split.clone(), lane);
+            assert_eq!(single.fn_hash("main"), split.fn_hash("main"), "{lane:?}");
+            assert_eq!(
+                single.fn_hash("answer"),
+                split.fn_hash("a::answer"),
+                "{lane:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn warm_reload_cross_module_leaf_edit_misses_transitive_users_only() {
+        let initial = modules(&[
+            (
+                "root",
+                r#"
+use a::bridge;
+
+fn independent() -> Int {
+    5
+}
+
+pub fn main() -> Int {
+    bridge() + independent()
+}
+"#,
+            ),
+            (
+                "a",
+                r#"
+fn leaf() -> Int {
+    1
+}
+
+pub fn bridge() -> Int {
+    leaf() + 10
+}
+
+fn unused() -> Int {
+    100
+}
+"#,
+            ),
+        ]);
+        let edited = modules(&[
+            (
+                "root",
+                r#"
+use a::bridge;
+
+fn independent() -> Int {
+    5
+}
+
+pub fn main() -> Int {
+    bridge() + independent()
+}
+"#,
+            ),
+            (
+                "a",
+                r#"
+fn leaf() -> Int {
+    2
+}
+
+pub fn bridge() -> Int {
+    leaf() + 10
+}
+
+fn unused() -> Int {
+    100
+}
+"#,
+            ),
+        ]);
+        for lane in lanes() {
+            let mut machine = load_modules_with_lane("root", initial.clone(), lane);
+            assert_eq!(machine.demand_i64("main", vec![]).unwrap(), 16, "{lane:?}");
+            let diff = machine.reload_modules("root", edited.clone()).unwrap();
+            assert_eq!(
+                diff.changed,
+                BTreeSet::from([
+                    "a::bridge".to_string(),
+                    "a::leaf".to_string(),
+                    "main".to_string(),
+                ]),
+                "{lane:?}"
+            );
+            assert_eq!(machine.demand_i64("main", vec![]).unwrap(), 17, "{lane:?}");
+            assert_eq!(
+                spawned_functions(&machine),
+                BTreeSet::from([
+                    "a::bridge".to_string(),
+                    "a::leaf".to_string(),
+                    "main".to_string(),
+                ]),
+                "{lane:?}"
+            );
+            let hits = memo_hit_functions(&machine);
+            assert!(hits.contains("independent"), "{lane:?}: {hits:?}");
+            assert!(!hits.contains("a::unused"), "{lane:?}: {hits:?}");
         }
     }
 

--- a/vix/src/module.rs
+++ b/vix/src/module.rs
@@ -46,16 +46,27 @@ impl ModuleTables {
         let imported = info.imports.get(name)?;
         (imported.kind == ImportKind::Fn).then_some(imported.name.as_str())
     }
+
+    pub(crate) fn resolve_type_module(&self, module: &str, name: &str) -> Option<&str> {
+        let info = self.modules.get(module)?;
+        if let Some(local_module) = info.types.get(name) {
+            return Some(local_module.as_str());
+        }
+        let imported = info.imports.get(name)?;
+        (imported.kind == ImportKind::Type).then_some(imported.module.as_str())
+    }
 }
 
 #[derive(Clone)]
 struct ModuleInfo {
     fns: BTreeMap<String, String>,
+    types: BTreeMap<String, String>,
     imports: BTreeMap<String, ResolvedModuleItem>,
 }
 
 #[derive(Clone)]
 struct ResolvedModuleItem {
+    module: String,
     name: String,
     kind: ImportKind,
 }
@@ -94,6 +105,7 @@ pub(crate) fn load_module_tables_from_modules(
                 path.clone(),
                 ModuleInfo {
                     fns: BTreeMap::new(),
+                    types: BTreeMap::new(),
                     imports: BTreeMap::new(),
                 },
             )
@@ -120,6 +132,11 @@ pub(crate) fn load_module_tables_from_modules(
                 Item::Enum(e) => {
                     insert_unique_type_hash(&mut type_hashes, &e.name.value, canon_enum_hash(e))?;
                     insert_unique_span(&mut type_spans, &e.name.value, e.span)?;
+                    module_infos
+                        .get_mut(module)
+                        .expect("module info exists")
+                        .types
+                        .insert(e.name.value.clone(), module.clone());
                     let variants = e
                         .variants
                         .iter()
@@ -141,6 +158,11 @@ pub(crate) fn load_module_tables_from_modules(
                 Item::Struct(s) => {
                     insert_unique_type_hash(&mut type_hashes, &s.name.value, canon_struct_hash(s))?;
                     insert_unique_span(&mut type_spans, &s.name.value, s.span)?;
+                    module_infos
+                        .get_mut(module)
+                        .expect("module info exists")
+                        .types
+                        .insert(s.name.value.clone(), module.clone());
                     let fields = s
                         .fields
                         .iter()
@@ -164,15 +186,14 @@ pub(crate) fn load_module_tables_from_modules(
     }
 
     for ((module, imported_name), import) in bindings.imports() {
-        if import.module == "vix" || import.module == "caps" {
-            continue;
-        }
         let resolved = match import.kind {
             ImportKind::Fn => ResolvedModuleItem {
+                module: import.module.clone(),
                 name: canonical_fn_name(root, &import.module, &import.name),
                 kind: import.kind,
             },
             ImportKind::Type => ResolvedModuleItem {
+                module: import.module.clone(),
                 name: import.name.clone(),
                 kind: import.kind,
             },
@@ -413,7 +434,9 @@ fn closure_fn_hashes(
                             .entry(owner.to_string())
                             .or_default()
                             .insert(target);
-                    } else if let Some(owner) = owner_for(span, type_spans) {
+                    } else if type_hashes.contains_key(&target)
+                        && let Some(owner) = owner_for(span, type_spans)
+                    {
                         type_edges
                             .entry(owner.to_string())
                             .or_default()

--- a/vix/src/module.rs
+++ b/vix/src/module.rs
@@ -6,7 +6,7 @@ use weavy::mem::{Access, Descriptor, Layout};
 
 use crate::VixParser;
 use crate::ast::{self, EnumItem, Expr, Item, SourceFile, Span, StructItem};
-use crate::binder::{self, SymbolKind};
+use crate::binder::{self, ImportKind, ModuleBindings, SymbolKind};
 
 #[derive(Clone)]
 pub(crate) struct EnumInfo {
@@ -29,83 +29,180 @@ pub(crate) struct StructInfo {
 
 pub(crate) struct ModuleTables {
     pub(crate) fns: HashMap<String, ast::FnItem>,
+    pub(crate) fn_modules: HashMap<String, String>,
     pub(crate) fn_hashes: HashMap<String, u64>,
     pub(crate) enums: HashMap<String, EnumInfo>,
     pub(crate) structs: HashMap<String, StructInfo>,
     pub(crate) descriptors: HashMap<String, Descriptor<String>>,
+    modules: BTreeMap<String, ModuleInfo>,
 }
 
-pub(crate) fn load_module_tables(source: &str) -> Result<ModuleTables, String> {
+impl ModuleTables {
+    pub(crate) fn resolve_fn(&self, module: &str, name: &str) -> Option<&str> {
+        let info = self.modules.get(module)?;
+        if let Some(local) = info.fns.get(name) {
+            return Some(local.as_str());
+        }
+        let imported = info.imports.get(name)?;
+        (imported.kind == ImportKind::Fn).then_some(imported.name.as_str())
+    }
+}
+
+#[derive(Clone)]
+struct ModuleInfo {
+    fns: BTreeMap<String, String>,
+    imports: BTreeMap<String, ResolvedModuleItem>,
+}
+
+#[derive(Clone)]
+struct ResolvedModuleItem {
+    name: String,
+    kind: ImportKind,
+}
+
+pub(crate) fn load_module_tables_from_modules(
+    root: &str,
+    modules: &BTreeMap<String, String>,
+) -> Result<ModuleTables, String> {
     // Table construction is the expensive part (seconds in dev profile);
     // the parser itself is immutable after build — share one per process.
     static PARSER: std::sync::OnceLock<VixParser> = std::sync::OnceLock::new();
     let parser = PARSER.get_or_init(VixParser::new);
-    let file: SourceFile = parser.parse(source).map_err(|e| e.message)?;
+    let files: BTreeMap<String, SourceFile> = modules
+        .iter()
+        .map(|(path, source)| {
+            parser
+                .parse(source)
+                .map(|file| (path.clone(), file))
+                .map_err(|e| format!("parsing module `{path}`: {}", e.message))
+        })
+        .collect::<Result<_, _>>()?;
+    let bindings = binder::bind_module_set(root, &files)?;
+
     let mut fns = HashMap::new();
+    let mut fn_modules = HashMap::new();
     let mut bare_fn_hashes = BTreeMap::new();
     let mut enums = HashMap::new();
     let mut structs = HashMap::new();
     let mut type_hashes = BTreeMap::new();
-    let mut fn_spans = BTreeMap::new();
-    let mut type_spans = BTreeMap::new();
-    for item in &file.items {
-        match item {
-            Item::Fn(f) => {
-                bare_fn_hashes.insert(f.name.value.clone(), canon_fn_hash(f));
-                fn_spans.insert(f.name.value.clone(), f.span);
-                fns.insert(f.name.value.clone(), (**f).clone());
-            }
-            Item::Enum(e) => {
-                type_hashes.insert(e.name.value.clone(), canon_enum_hash(e));
-                type_spans.insert(e.name.value.clone(), e.span);
-                let variants = e
-                    .variants
-                    .iter()
-                    .map(|v| {
-                        let shape = if let Some(t) = &v.tuple {
-                            VariantShape::Tuple(t.types.len())
-                        } else if let Some(fl) = &v.fields {
-                            VariantShape::Record(
-                                fl.fields.iter().map(|f| f.name.value.clone()).collect(),
-                            )
-                        } else {
-                            VariantShape::Unit
-                        };
-                        (v.name.value.clone(), shape)
-                    })
-                    .collect();
-                enums.insert(e.name.value.clone(), EnumInfo { variants });
-            }
-            Item::Struct(s) => {
-                type_hashes.insert(s.name.value.clone(), canon_struct_hash(s));
-                type_spans.insert(s.name.value.clone(), s.span);
-                let fields = s
-                    .fields
-                    .iter()
-                    .flat_map(|fl| &fl.fields)
-                    .map(|f| (f.name.value.clone(), f.default.clone()))
-                    .collect();
-                structs.insert(
-                    s.name.value.clone(),
-                    StructInfo {
-                        fields,
-                        is_unit: s.fields.is_none() && s.tuple.is_none(),
-                    },
-                );
-            }
-            Item::Use(_) => {}
-        }
-    }
-    let descriptors = declared_descriptors(&file)?;
-    let fn_hashes = closure_fn_hashes(&file, &bare_fn_hashes, &type_hashes, &fn_spans, &type_spans)
-        .into_iter()
+    let mut fn_spans_by_module = BTreeMap::new();
+    let mut type_spans_by_module = BTreeMap::new();
+    let mut module_infos: BTreeMap<String, ModuleInfo> = files
+        .keys()
+        .map(|path| {
+            (
+                path.clone(),
+                ModuleInfo {
+                    fns: BTreeMap::new(),
+                    imports: BTreeMap::new(),
+                },
+            )
+        })
         .collect();
+
+    for (module, file) in &files {
+        let mut fn_spans = BTreeMap::new();
+        let mut type_spans = BTreeMap::new();
+        for item in &file.items {
+            match item {
+                Item::Fn(f) => {
+                    let canonical = canonical_fn_name(root, module, &f.name.value);
+                    bare_fn_hashes.insert(canonical.clone(), canon_fn_hash(f));
+                    fn_spans.insert(canonical.clone(), f.span);
+                    module_infos
+                        .get_mut(module)
+                        .expect("module info exists")
+                        .fns
+                        .insert(f.name.value.clone(), canonical.clone());
+                    fn_modules.insert(canonical.clone(), module.clone());
+                    fns.insert(canonical, (**f).clone());
+                }
+                Item::Enum(e) => {
+                    insert_unique_type_hash(&mut type_hashes, &e.name.value, canon_enum_hash(e))?;
+                    insert_unique_span(&mut type_spans, &e.name.value, e.span)?;
+                    let variants = e
+                        .variants
+                        .iter()
+                        .map(|v| {
+                            let shape = if let Some(t) = &v.tuple {
+                                VariantShape::Tuple(t.types.len())
+                            } else if let Some(fl) = &v.fields {
+                                VariantShape::Record(
+                                    fl.fields.iter().map(|f| f.name.value.clone()).collect(),
+                                )
+                            } else {
+                                VariantShape::Unit
+                            };
+                            (v.name.value.clone(), shape)
+                        })
+                        .collect();
+                    insert_unique(&mut enums, &e.name.value, EnumInfo { variants })?;
+                }
+                Item::Struct(s) => {
+                    insert_unique_type_hash(&mut type_hashes, &s.name.value, canon_struct_hash(s))?;
+                    insert_unique_span(&mut type_spans, &s.name.value, s.span)?;
+                    let fields = s
+                        .fields
+                        .iter()
+                        .flat_map(|fl| &fl.fields)
+                        .map(|f| (f.name.value.clone(), f.default.clone()))
+                        .collect();
+                    insert_unique(
+                        &mut structs,
+                        &s.name.value,
+                        StructInfo {
+                            fields,
+                            is_unit: s.fields.is_none() && s.tuple.is_none(),
+                        },
+                    )?;
+                }
+                Item::Use(_) => {}
+            }
+        }
+        fn_spans_by_module.insert(module.clone(), fn_spans);
+        type_spans_by_module.insert(module.clone(), type_spans);
+    }
+
+    for ((module, imported_name), import) in bindings.imports() {
+        if import.module == "vix" || import.module == "caps" {
+            continue;
+        }
+        let resolved = match import.kind {
+            ImportKind::Fn => ResolvedModuleItem {
+                name: canonical_fn_name(root, &import.module, &import.name),
+                kind: import.kind,
+            },
+            ImportKind::Type => ResolvedModuleItem {
+                name: import.name.clone(),
+                kind: import.kind,
+            },
+        };
+        module_infos
+            .get_mut(module)
+            .expect("module info exists")
+            .imports
+            .insert(imported_name.clone(), resolved);
+    }
+
+    let descriptors = declared_descriptors(&files)?;
+    let fn_hashes = closure_fn_hashes(
+        &bindings,
+        &bare_fn_hashes,
+        &type_hashes,
+        &fn_spans_by_module,
+        &type_spans_by_module,
+        &module_infos,
+    )
+    .into_iter()
+    .collect();
     Ok(ModuleTables {
         fns,
+        fn_modules,
         fn_hashes,
         enums,
         structs,
         descriptors,
+        modules: module_infos,
     })
 }
 
@@ -144,63 +241,110 @@ pub(crate) fn type_path_schema_name(path: &ast::TypePath) -> Result<String, Stri
     }
 }
 
-fn declared_descriptors(file: &SourceFile) -> Result<HashMap<String, Descriptor<String>>, String> {
+fn canonical_fn_name(root: &str, module: &str, name: &str) -> String {
+    if module == root {
+        name.to_string()
+    } else {
+        format!("{module}::{name}")
+    }
+}
+
+fn insert_unique<T>(map: &mut HashMap<String, T>, name: &str, value: T) -> Result<(), String> {
+    if map.insert(name.to_string(), value).is_some() {
+        return Err(format!(
+            "duplicate type name `{name}` across module set is outside vix v1"
+        ));
+    }
+    Ok(())
+}
+
+fn insert_unique_type_hash(
+    map: &mut BTreeMap<String, u64>,
+    name: &str,
+    value: u64,
+) -> Result<(), String> {
+    if map.insert(name.to_string(), value).is_some() {
+        return Err(format!(
+            "duplicate type name `{name}` across module set is outside vix v1"
+        ));
+    }
+    Ok(())
+}
+
+fn insert_unique_span(
+    map: &mut BTreeMap<String, Span>,
+    name: &str,
+    value: Span,
+) -> Result<(), String> {
+    if map.insert(name.to_string(), value).is_some() {
+        return Err(format!(
+            "duplicate type name `{name}` across module set is outside vix v1"
+        ));
+    }
+    Ok(())
+}
+
+fn declared_descriptors(
+    files: &BTreeMap<String, SourceFile>,
+) -> Result<HashMap<String, Descriptor<String>>, String> {
     let mut descriptors = HashMap::new();
     descriptors.insert("Int".into(), declared_mem::i64_("Int".into()));
     descriptors.insert("Float".into(), declared_mem::f64_("Float".into()));
     descriptors.insert("Bool".into(), declared_mem::i64_("Bool".into()));
 
-    for item in &file.items {
-        match item {
-            Item::Struct(s) => {
-                let fields = if let Some(fields) = &s.fields {
-                    fields
-                        .fields
+    for file in files.values() {
+        for item in &file.items {
+            match item {
+                Item::Struct(s) => {
+                    let fields = if let Some(fields) = &s.fields {
+                        fields
+                            .fields
+                            .iter()
+                            .map(|field| descriptor_for_type(&field.ty))
+                            .collect::<Result<Vec<_>, _>>()?
+                    } else if let Some(tuple) = &s.tuple {
+                        tuple
+                            .types
+                            .iter()
+                            .map(descriptor_for_type)
+                            .collect::<Result<Vec<_>, _>>()?
+                    } else {
+                        Vec::new()
+                    };
+                    descriptors.insert(
+                        s.name.value.clone(),
+                        declared_mem::declared_struct(s.name.value.clone(), fields),
+                    );
+                }
+                Item::Enum(e) => {
+                    let variants = e
+                        .variants
                         .iter()
-                        .map(|field| descriptor_for_type(&field.ty))
-                        .collect::<Result<Vec<_>, _>>()?
-                } else if let Some(tuple) = &s.tuple {
-                    tuple
-                        .types
-                        .iter()
-                        .map(descriptor_for_type)
-                        .collect::<Result<Vec<_>, _>>()?
-                } else {
-                    Vec::new()
-                };
-                descriptors.insert(
-                    s.name.value.clone(),
-                    declared_mem::declared_struct(s.name.value.clone(), fields),
-                );
+                        .map(|variant| {
+                            if let Some(tuple) = &variant.tuple {
+                                tuple
+                                    .types
+                                    .iter()
+                                    .map(descriptor_for_type)
+                                    .collect::<Result<Vec<_>, _>>()
+                            } else if let Some(fields) = &variant.fields {
+                                fields
+                                    .fields
+                                    .iter()
+                                    .map(|field| descriptor_for_type(&field.ty))
+                                    .collect::<Result<Vec<_>, _>>()
+                            } else {
+                                Ok(Vec::new())
+                            }
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    descriptors.insert(
+                        e.name.value.clone(),
+                        declared_mem::declared_enum(e.name.value.clone(), variants),
+                    );
+                }
+                Item::Fn(_) | Item::Use(_) => {}
             }
-            Item::Enum(e) => {
-                let variants = e
-                    .variants
-                    .iter()
-                    .map(|variant| {
-                        if let Some(tuple) = &variant.tuple {
-                            tuple
-                                .types
-                                .iter()
-                                .map(descriptor_for_type)
-                                .collect::<Result<Vec<_>, _>>()
-                        } else if let Some(fields) = &variant.fields {
-                            fields
-                                .fields
-                                .iter()
-                                .map(|field| descriptor_for_type(&field.ty))
-                                .collect::<Result<Vec<_>, _>>()
-                        } else {
-                            Ok(Vec::new())
-                        }
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                descriptors.insert(
-                    e.name.value.clone(),
-                    declared_mem::declared_enum(e.name.value.clone(), variants),
-                );
-            }
-            Item::Fn(_) | Item::Use(_) => {}
         }
     }
     Ok(descriptors)
@@ -228,13 +372,13 @@ fn handle_i64(schema: impl Into<String>, target: impl Into<String>) -> Descripto
 }
 
 fn closure_fn_hashes(
-    file: &SourceFile,
+    bindings: &ModuleBindings,
     bare_fn_hashes: &BTreeMap<String, u64>,
     type_hashes: &BTreeMap<String, u64>,
-    fn_spans: &BTreeMap<String, Span>,
-    type_spans: &BTreeMap<String, Span>,
+    fn_spans_by_module: &BTreeMap<String, BTreeMap<String, Span>>,
+    type_spans_by_module: &BTreeMap<String, BTreeMap<String, Span>>,
+    modules: &BTreeMap<String, ModuleInfo>,
 ) -> BTreeMap<String, u64> {
-    let bindings = binder::bind(file);
     let mut fn_edges: BTreeMap<String, BTreeSet<String>> = bare_fn_hashes
         .keys()
         .map(|name| (name.clone(), BTreeSet::new()))
@@ -248,36 +392,36 @@ fn closure_fn_hashes(
         .map(|name| (name.clone(), BTreeSet::new()))
         .collect();
 
-    for (span, id) in bindings.refs() {
-        let symbol = bindings.symbol(id);
-        match symbol.kind {
-            SymbolKind::Fn => {
-                if let Some(owner) = owner_for(span, fn_spans) {
-                    fn_edges
-                        .entry(owner.to_string())
-                        .or_default()
-                        .insert(symbol.name.clone());
+    for (module, module_bindings) in bindings.modules() {
+        let fn_spans = &fn_spans_by_module[module];
+        let type_spans = &type_spans_by_module[module];
+        for (span, id) in module_bindings.refs() {
+            let symbol = module_bindings.symbol(id);
+            let resolved = resolve_symbol_ref(modules, module, symbol.kind, &symbol.name);
+            match resolved {
+                Some(ResolvedSymbolRef::Fn(target)) => {
+                    if let Some(owner) = owner_for(span, fn_spans) {
+                        fn_edges
+                            .entry(owner.to_string())
+                            .or_default()
+                            .insert(target);
+                    }
                 }
-            }
-            SymbolKind::Type => {
-                if let Some(owner) = owner_for(span, fn_spans) {
-                    fn_type_refs
-                        .entry(owner.to_string())
-                        .or_default()
-                        .insert(symbol.name.clone());
-                } else if let Some(owner) = owner_for(span, type_spans) {
-                    type_edges
-                        .entry(owner.to_string())
-                        .or_default()
-                        .insert(symbol.name.clone());
+                Some(ResolvedSymbolRef::Type(target)) => {
+                    if let Some(owner) = owner_for(span, fn_spans) {
+                        fn_type_refs
+                            .entry(owner.to_string())
+                            .or_default()
+                            .insert(target);
+                    } else if let Some(owner) = owner_for(span, type_spans) {
+                        type_edges
+                            .entry(owner.to_string())
+                            .or_default()
+                            .insert(target);
+                    }
                 }
+                None => {}
             }
-            SymbolKind::Param
-            | SymbolKind::Let
-            | SymbolKind::ClosureParam
-            | SymbolKind::Import
-            | SymbolKind::TypeParam
-            | SymbolKind::Binding => {}
         }
     }
 
@@ -293,6 +437,39 @@ fn closure_fn_hashes(
         })
         .collect();
     graph_closure_hashes(bare_fn_hashes, &fn_edges, &fn_type_hashes)
+}
+
+enum ResolvedSymbolRef {
+    Fn(String),
+    Type(String),
+}
+
+fn resolve_symbol_ref(
+    modules: &BTreeMap<String, ModuleInfo>,
+    module: &str,
+    kind: SymbolKind,
+    name: &str,
+) -> Option<ResolvedSymbolRef> {
+    match kind {
+        SymbolKind::Fn => modules[module]
+            .fns
+            .get(name)
+            .cloned()
+            .map(ResolvedSymbolRef::Fn),
+        SymbolKind::Type => Some(ResolvedSymbolRef::Type(name.to_string())),
+        SymbolKind::Import => {
+            let item = modules[module].imports.get(name)?;
+            match item.kind {
+                ImportKind::Fn => Some(ResolvedSymbolRef::Fn(item.name.clone())),
+                ImportKind::Type => Some(ResolvedSymbolRef::Type(item.name.clone())),
+            }
+        }
+        SymbolKind::Param
+        | SymbolKind::Let
+        | SymbolKind::ClosureParam
+        | SymbolKind::TypeParam
+        | SymbolKind::Binding => None,
+    }
 }
 
 fn owner_for(span: Span, owners: &BTreeMap<String, Span>) -> Option<&str> {


### PR DESCRIPTION
## Summary
- Add Machine::load_modules/load_modules_with_lane and reload_modules for in-memory module sets, with existing single-source load/reload preserved as root-only sugar.
- Add binder/module-set import resolution with pub visibility gates, canonical internal names for non-root functions, and cross-module closure-hash dependencies.
- Route vix/caps imports through loader-provided built-in module items; capability acquire lowering now checks that Cc/Ar/Rustc resolve through caps instead of matching text alone.

## Proof
- Cross-module pub fn import resolves and runs; importing a private item errors loudly.
- Same content in one file vs split across root+a yields identical main and helper closure hashes.
- Warm reload editing a::leaf changes only a::leaf, a::bridge, and root main; independent and unused functions stay out of the blast radius.

## File convention proposal for Amos review
- Module path root loads from mod.vix at the package root.
- Module path foo loads from foo.vix first; if absent, foo/mod.vix.
- Module path foo::bar loads from foo/bar.vix first; if absent, foo/bar/mod.vix.
- In-memory module paths use the same logical names (root, foo, foo::bar) so wasm/tests and directory loading agree.

## STOP / not landed in this pass
- Filesystem directory loader is not implemented yet: there is no vix CLI loader hook in this tree, and the wasm-clean map API is the landed path.
- Free primitive calls like fetch/extract/json/toml/elf are still recognized by primitive lowering by name. Capability primitives were moved to resolved module identity; changing free primitives needs a source/import decision because existing samples call them unqualified.
- Type schema names are still bare ABI names; duplicate cross-module type names error loudly instead of inventing content-addressed schema identity in this slice.

## Verification
- cargo nextest run -p vix -p weavy
- cargo clippy --all-features --all-targets --message-format=short -- -D warnings
- cargo build --release --target wasm32-unknown-unknown -p snark-wasm