### PR TITLE
CI fixes: vix-wire rustdoc tag + nextest override for coverage-slow fable tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -115,3 +115,10 @@ retries = 0
 fail-fast = true
 # Short timeout to catch infinite loops quickly
 slow-timeout = { period = "3s", terminate-after = 2 }
+
+# Fable's declared-value/type checker tests are legitimately heavy and
+# time out only under CI coverage instrumentation (observed 3x, always
+# passing locally in 10-24s). Longer leash, assertions untouched.
+[[profile.default.overrides]]
+filter = 'test(declared_value_checker_reports_required_errors) | test(declared_type_checker_rejects_duplicate_and_unknown_names)'
+slow-timeout = { period = "120s", terminate-after = 5 }

--- a/vix-wire/src/lib.rs
+++ b/vix-wire/src/lib.rs
@@ -48,7 +48,7 @@ pub struct WireExecRequest {
     pub capability: u64,
     /// Which tool to run (the command grammar's name — toy registry for now).
     pub command: String,
-    /// A shipped machine Pending<T> value evaluated executor-side against the
+    /// A shipped machine `Pending<T>` value evaluated executor-side against the
     /// Run value; its result is the only thing that crosses.
     pub observer: Option<ValueBundle>,
 }


### PR DESCRIPTION
Fixes the two reds that rode onto main: unclosed HTML tag in vix-wire docs (escaped), and the fable checker tests that time out only under CI coverage instrumentation (3rd occurrence; 120s x5 leash, assertions untouched).