### PR TITLE
vix: crate builds with dependencies (--extern, rmeta) + real rustc oracle

### DIFF
--- a/playgrounds/snark/src/bundled/vix/samples/crate.vix
+++ b/playgrounds/snark/src/bundled/vix/samples/crate.vix
@@ -5,10 +5,14 @@ fn doc_string(doc: Doc, key: String) -> String {
     doc.get(key).unwrap()
 }
 
+fn package_doc(manifest: Tree) -> Doc {
+    let doc = toml(manifest / p"Cargo.toml");
+    doc.get("package").unwrap()
+}
+
 pub fn crate_lib(target: Target, manifest: Tree) -> Tree {
     let rustc = Rustc::acquire(target);
-    let doc = toml(manifest / p"Cargo.toml");
-    let package = doc.get("package").unwrap();
+    let package = package_doc(manifest);
     let name = doc_string(package, "name");
     let edition = doc_string(package, "edition");
 
@@ -16,8 +20,86 @@ pub fn crate_lib(target: Target, manifest: Tree) -> Tree {
         --crate-name {name}
         --edition {edition}
         --crate-type lib
-        -L {manifest}
+        --emit=metadata={p"libmini_vendored.rmeta"},link={p"libmini_vendored.rlib"}
+        -L dependency={manifest}
         {manifest / p"src/lib.rs"}
-        -o {p"libmini_vendored.rlib"}
     }
+}
+
+fn dep_metadata(target: Target, dep: Tree) -> Tree {
+    let rustc = Rustc::acquire(target);
+    let package = package_doc(dep);
+    let name = doc_string(package, "name");
+    let edition = doc_string(package, "edition");
+
+    rustc! {
+        --crate-name {name}
+        --edition {edition}
+        --crate-type lib
+        --emit=metadata={p"libhelper.rmeta"},link={p"libhelper.rlib"}
+        {dep / p"src/lib.rs"}
+    } / p"libhelper.rmeta"
+}
+
+fn dep_rlib(target: Target, dep: Tree) -> Tree {
+    let rustc = Rustc::acquire(target);
+    let package = package_doc(dep);
+    let name = doc_string(package, "name");
+    let edition = doc_string(package, "edition");
+
+    rustc! {
+        --crate-name {name}
+        --edition {edition}
+        --crate-type lib
+        --emit=metadata={p"libhelper.rmeta"},link={p"libhelper.rlib"}
+        {dep / p"src/lib.rs"}
+    } / p"libhelper.rlib"
+}
+
+fn bin_check(target: Target, manifest: Tree, dep_meta: Tree) -> Tree {
+    let rustc = Rustc::acquire(target);
+    let package = package_doc(manifest);
+    let name = doc_string(package, "name");
+    let edition = doc_string(package, "edition");
+
+    rustc! {
+        --crate-name {name}
+        --edition {edition}
+        --crate-type bin
+        --emit=metadata={p"mini_app.rmeta"}
+        --extern helper={dep_meta / p"libhelper.rmeta"}
+        -L dependency={dep_meta}
+        {manifest / p"src/main.rs"}
+    }
+}
+
+fn bin_link(target: Target, manifest: Tree, dep_rlib: Tree) -> Tree {
+    let rustc = Rustc::acquire(target);
+    let package = package_doc(manifest);
+    let name = doc_string(package, "name");
+    let edition = doc_string(package, "edition");
+
+    rustc! {
+        --crate-name {name}
+        --edition {edition}
+        --crate-type bin
+        --emit=link={p"mini_app"}
+        --extern helper={dep_rlib / p"libhelper.rlib"}
+        -L dependency={dep_rlib}
+        {manifest / p"src/main.rs"}
+    }
+}
+
+pub fn crate_bin_check(target: Target, graph: Tree) -> Tree {
+    let dep = graph / p"crates/helper";
+    let root = graph / p"app";
+    let meta = dep_metadata(target, dep);
+    bin_check(target, root, meta) / p"mini_app.rmeta"
+}
+
+pub fn crate_bin(target: Target, graph: Tree) -> Tree {
+    let dep = graph / p"crates/helper";
+    let root = graph / p"app";
+    let rlib = dep_rlib(target, dep);
+    bin_link(target, root, rlib) / p"mini_app"
 }

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/app/Cargo.toml
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/app/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "mini_app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+helper = { path = "../crates/helper" }

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/app/src/main.rs
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/app/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("{}", helper::message());
+}

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/crates/helper/Cargo.toml
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/crates/helper/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "helper"
+version = "0.1.0"
+edition = "2021"

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/crates/helper/src/lib.rs
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/crates/helper/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn message() -> &'static str {
+    "vix dependency fixture"
+}

--- a/vix/src/exec.rs
+++ b/vix/src/exec.rs
@@ -135,13 +135,73 @@ pub struct Mount {
 pub enum Role {
     /// A path the tool will read.
     Input,
+    /// An argv element that contains a path the tool will read.
+    InputFlag,
     /// A path the tool will write.
     Output,
+    /// An argv element that contains one or more paths the tool will write.
+    OutputFlag,
     /// A directory the tool will PROBE (search paths — the negative-lookup
     /// factory).
     SearchDir,
+    /// An argv element that contains a directory the tool will probe.
+    SearchDirFlag,
     /// Behavior-changing but not path-shaped.
     Flag,
+}
+
+pub fn role_input_paths(arg: &str, role: Role) -> Vec<String> {
+    match role {
+        Role::Input => vec![arg.to_string()],
+        Role::InputFlag => embedded_path_after_equals(arg).into_iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
+pub fn role_output_paths(arg: &str, role: Role) -> Vec<String> {
+    match role {
+        Role::Output => vec![arg.to_string()],
+        Role::OutputFlag => rustc_emit_output_paths(arg),
+        _ => Vec::new(),
+    }
+}
+
+pub fn role_search_dir_paths(arg: &str, role: Role) -> Vec<String> {
+    match role {
+        Role::SearchDir => vec![arg.to_string()],
+        Role::SearchDirFlag => embedded_path_after_equals(arg).into_iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
+pub fn role_embedded_paths(arg: &str, role: Role) -> Vec<String> {
+    let mut paths = role_input_paths(arg, role);
+    paths.extend(role_output_paths(arg, role));
+    paths.extend(role_search_dir_paths(arg, role));
+    paths
+}
+
+fn embedded_path_after_equals(arg: &str) -> Option<String> {
+    arg.rsplit_once('=')
+        .map(|(_, path)| path)
+        .filter(|path| !path.is_empty())
+        .map(str::to_string)
+}
+
+fn rustc_emit_output_paths(arg: &str) -> Vec<String> {
+    let Some(spec) = arg.strip_prefix("--emit=") else {
+        return Vec::new();
+    };
+    spec.split(',')
+        .filter_map(|entry| {
+            let mut parts = entry.splitn(2, '=');
+            let _kind = parts.next()?;
+            parts
+                .next()
+                .filter(|path| !path.is_empty())
+                .map(str::to_string)
+        })
+        .collect()
 }
 
 /// A resolved command: argv with roles. This is what a `cc! { … }` block
@@ -213,16 +273,17 @@ impl ExecPlan {
 /// derive this from salience queries over the parsed invocation.
 pub fn describe(command: &str, plan: &ExecPlan) -> Vec<String> {
     let base = |p: &str| p.rsplit('/').next().unwrap_or(p).to_string();
-    let output = plan
-        .argv
-        .iter()
-        .find(|(_, r)| *r == Role::Output)
-        .map(|(a, _)| base(a));
+    let output = plan.argv.iter().find_map(|(a, r)| {
+        role_output_paths(a, *r)
+            .into_iter()
+            .next()
+            .map(|path| base(&path))
+    });
     let inputs: Vec<String> = plan
         .argv
         .iter()
-        .filter(|(_, r)| *r == Role::Input)
-        .map(|(a, _)| base(a))
+        .flat_map(|(a, r)| role_input_paths(a, *r))
+        .map(|path| base(&path))
         .collect();
     let flags: Vec<&str> = plan
         .argv
@@ -233,8 +294,7 @@ pub fn describe(command: &str, plan: &ExecPlan) -> Vec<String> {
     let search: Vec<String> = plan
         .argv
         .iter()
-        .filter(|(_, r)| *r == Role::SearchDir)
-        .map(|(a, _)| a.clone())
+        .flat_map(|(a, r)| role_search_dir_paths(a, *r))
         .collect();
 
     let level0 = match command {
@@ -627,17 +687,15 @@ pub struct FakeCc;
 
 impl Tool for FakeCc {
     fn run(&self, plan: &ExecPlan, world: &mut ObservedWorld<'_>) -> Result<Tree, String> {
-        let search_dirs: Vec<&str> = plan
+        let search_dirs: Vec<String> = plan
             .argv
             .iter()
-            .filter(|(_, r)| *r == Role::SearchDir)
-            .map(|(a, _)| a.as_str())
+            .flat_map(|(a, r)| role_search_dir_paths(a, *r))
             .collect();
         let output = plan
             .argv
             .iter()
-            .find(|(_, r)| *r == Role::Output)
-            .map(|(a, _)| a.clone())
+            .find_map(|(a, r)| role_output_paths(a, *r).into_iter().next())
             .ok_or("cc: no output")?;
 
         let mut digest = DefaultHasher::new();
@@ -646,9 +704,13 @@ impl Tool for FakeCc {
                 arg.hash(&mut digest);
             }
         }
-        for (input, _) in plan.argv.iter().filter(|(_, r)| *r == Role::Input) {
+        for input in plan
+            .argv
+            .iter()
+            .flat_map(|(arg, role)| role_input_paths(arg, *role))
+        {
             let source = world
-                .read(input)
+                .read(&input)
                 .ok_or_else(|| format!("cc: cannot read `{input}` (outside the mounts?)"))?;
             source.hash(&mut digest);
             // Quoted includes probe the including file's own directory FIRST
@@ -693,12 +755,14 @@ pub struct FakeRustc;
 
 impl Tool for FakeRustc {
     fn run(&self, plan: &ExecPlan, world: &mut ObservedWorld<'_>) -> Result<Tree, String> {
-        let output = plan
+        let outputs: Vec<String> = plan
             .argv
             .iter()
-            .find(|(_, role)| *role == Role::Output)
-            .map(|(arg, _)| arg.clone())
-            .ok_or("rustc: no output")?;
+            .flat_map(|(arg, role)| role_output_paths(arg, *role))
+            .collect();
+        if outputs.is_empty() {
+            return Err("rustc: no output".into());
+        }
         let mut digest = DefaultHasher::new();
         let mut crate_type = "lib";
         for (index, (arg, role)) in plan.argv.iter().enumerate() {
@@ -709,24 +773,35 @@ impl Tool for FakeRustc {
                         crate_type = arg;
                     }
                 }
-                Role::SearchDir => {
+                Role::SearchDir | Role::SearchDirFlag => {
                     arg.hash(&mut digest);
                 }
-                Role::Output => {}
-                Role::Input => {
-                    let source = world.read(arg).ok_or_else(|| {
-                        format!("rustc: cannot read `{arg}` (outside the mounts?)")
-                    })?;
-                    source.hash(&mut digest);
+                Role::Output | Role::OutputFlag => {}
+                Role::Input | Role::InputFlag => {
+                    for input in role_input_paths(arg, *role) {
+                        let source = world.read(&input).ok_or_else(|| {
+                            format!("rustc: cannot read `{input}` (outside the mounts?)")
+                        })?;
+                        source.hash(&mut digest);
+                    }
                 }
             }
         }
 
-        let kind = if crate_type == "bin" { "bin" } else { "rlib" };
-        Ok(Tree::of(&[(
-            output.as_str(),
-            &format!("{kind}({:016x})", digest.finish()),
-        )]))
+        let digest = digest.finish();
+        let mut tree = Tree::default();
+        for output in outputs {
+            let kind = if output.ends_with(".rmeta") {
+                "rmeta"
+            } else if crate_type == "bin" {
+                "bin"
+            } else {
+                "rlib"
+            };
+            tree.entries
+                .insert(output, format!("{kind}({digest:016x})"));
+        }
+        Ok(tree)
     }
 }
 
@@ -739,8 +814,7 @@ impl Tool for FakeAr {
         let output = plan
             .argv
             .iter()
-            .find(|(_, r)| *r == Role::Output)
-            .map(|(a, _)| a.clone())
+            .find_map(|(a, r)| role_output_paths(a, *r).into_iter().next())
             .ok_or("ar: no output")?;
         let mut digest = DefaultHasher::new();
         for (arg, role) in &plan.argv {
@@ -748,15 +822,19 @@ impl Tool for FakeAr {
                 arg.hash(&mut digest);
             }
         }
-        for (input, _) in plan.argv.iter().filter(|(_, r)| *r == Role::Input) {
-            if let Some(contents) = world.read(input) {
+        for input in plan
+            .argv
+            .iter()
+            .flat_map(|(arg, role)| role_input_paths(arg, *role))
+        {
+            if let Some(contents) = world.read(&input) {
                 contents.hash(&mut digest);
                 continue;
             }
             // A directory input: enumerate it (a LISTING observation — new
             // members will diverge the pin) and archive every file.
             let names = world
-                .list(input)
+                .list(&input)
                 .ok_or_else(|| format!("ar: cannot read `{input}` (outside the mounts?)"))?;
             for name in names {
                 let contents = world

--- a/vix/src/lib.rs
+++ b/vix/src/lib.rs
@@ -358,9 +358,14 @@ pub mod support {
                 for arg in argv {
                     let role = match prev {
                         Some("-o") => Role::Output,
-                        Some("-L") => Role::SearchDir,
+                        Some("-L") if arg.contains("/m/") => Role::SearchDirFlag,
+                        Some("-L") => Role::Flag,
+                        Some("--extern") if arg.contains("/m/") => Role::InputFlag,
+                        Some("--extern") => Role::Flag,
                         _ if arg.starts_with("/m/") => Role::Input,
-                        _ if arg.starts_with("-L") && arg.contains("/m/") => Role::SearchDir,
+                        _ if arg.starts_with("--emit=") && arg.contains('=') => Role::OutputFlag,
+                        _ if arg.starts_with("-L") && arg.contains("/m/") => Role::SearchDirFlag,
+                        _ if arg.starts_with("--extern") && arg.contains("/m/") => Role::InputFlag,
                         _ => Role::Flag,
                     };
                     out.push((arg.clone(), role));

--- a/vix/src/machine/driver.rs
+++ b/vix/src/machine/driver.rs
@@ -2883,10 +2883,15 @@ impl Driver {
         for part in req.parts {
             match part {
                 CommandRequestPart::Token(handle) => {
-                    argv.push(self.store.borrow().string_value(handle, "String")?);
+                    let token = self.store.borrow().string_value(handle, "String")?;
+                    append_command_token(token, &mut argv)?;
                 }
                 CommandRequestPart::Splice(word) => {
-                    self.splice_word_into_command(word, &mut argv, &mut mounts)?;
+                    let prefer_tree_root =
+                        argv.last().is_some_and(|arg| arg.ends_with("dependency="));
+                    let args =
+                        self.splice_word_to_command_args(word, &mut mounts, prefer_tree_root)?;
+                    append_spliced_command_args(args, &mut argv)?;
                 }
             }
         }
@@ -3112,12 +3117,12 @@ impl Driver {
         Ok(outcome.outputs)
     }
 
-    fn splice_word_into_command(
+    fn splice_word_to_command_args(
         &mut self,
         word: i64,
-        argv: &mut Vec<String>,
         mounts: &mut Vec<crate::exec::Mount>,
-    ) -> Result<(), String> {
+        prefer_tree_root: bool,
+    ) -> Result<Vec<String>, String> {
         let entry = self
             .store
             .borrow()
@@ -3125,17 +3130,19 @@ impl Driver {
             .cloned()
             .ok_or_else(|| format!("cannot splice scalar word {word} into a command"))?;
         match entry.schema.as_str() {
-            "Path" | "String" | "Flag" => {
-                argv.push(String::from_utf8(entry.bytes).map_err(|err| err.to_string())?);
-            }
+            "Path" | "String" | "Flag" => Ok(vec![
+                String::from_utf8(entry.bytes).map_err(|err| err.to_string())?,
+            ]),
             "Array" => match { self.store.borrow().array_entry(word, &self.schema_refs)? } {
                 ArrayEntry::Words { words, .. } => {
+                    let mut args = Vec::new();
                     for word in words {
-                        self.splice_word_into_command(word, argv, mounts)?;
+                        args.extend(self.splice_word_to_command_args(word, mounts, false)?);
                     }
+                    Ok(args)
                 }
                 ArrayEntry::Pending(_) => {
-                    return Err("pending arrays cannot be spliced into commands".into());
+                    Err("pending arrays cannot be spliced into commands".into())
                 }
             },
             "Tree" => {
@@ -3145,7 +3152,7 @@ impl Driver {
                 };
                 let root = format!("/m/{}", mounts.len());
                 let entry_count = tree.entries.len() + tree.blobs.len();
-                let text = if entry_count == 1 {
+                let text = if entry_count == 1 && !prefer_tree_root {
                     let key = tree
                         .entries
                         .keys()
@@ -3157,11 +3164,10 @@ impl Driver {
                     root.clone()
                 };
                 mounts.push(crate::exec::Mount { at: root, tree });
-                argv.push(text);
+                Ok(vec![text])
             }
-            other => return Err(format!("cannot splice {other} into a command")),
+            other => Err(format!("cannot splice {other} into a command")),
         }
-        Ok(())
     }
 
     fn fetch_request(&mut self, req: FetchRequest) -> Result<(usize, i64), String> {
@@ -5656,6 +5662,31 @@ fn cap_schema(command: &str) -> String {
         _ => "Cc",
     }
     .to_string()
+}
+
+fn append_command_token(token: String, argv: &mut Vec<String>) -> Result<(), String> {
+    if token.starts_with(',') {
+        let previous = argv
+            .last_mut()
+            .ok_or_else(|| format!("command affix `{token}` has no previous argument"))?;
+        previous.push_str(&token);
+        return Ok(());
+    }
+    argv.push(token);
+    Ok(())
+}
+
+fn append_spliced_command_args(args: Vec<String>, argv: &mut Vec<String>) -> Result<(), String> {
+    if argv.last().is_some_and(|arg| arg.ends_with('=')) {
+        if args.len() != 1 {
+            return Err("command affix splice must produce exactly one argument".into());
+        }
+        let previous = argv.last_mut().expect("checked");
+        previous.push_str(&args[0]);
+        return Ok(());
+    }
+    argv.extend(args);
+    Ok(())
 }
 
 fn capability_hash(command: &str, fingerprint: &str) -> u64 {

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -5057,6 +5057,35 @@ pub fn poly(n: Int) -> Int {
         tar(&entries)
     }
 
+    fn two_crate_graph_tree() -> Tree {
+        Tree::of(&[
+            (
+                "app/Cargo.toml",
+                include_str!(
+                    "../../../playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/app/Cargo.toml"
+                ),
+            ),
+            (
+                "app/src/main.rs",
+                include_str!(
+                    "../../../playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/app/src/main.rs"
+                ),
+            ),
+            (
+                "crates/helper/Cargo.toml",
+                include_str!(
+                    "../../../playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/crates/helper/Cargo.toml"
+                ),
+            ),
+            (
+                "crates/helper/src/lib.rs",
+                include_str!(
+                    "../../../playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/crates/helper/src/lib.rs"
+                ),
+            ),
+        ])
+    }
+
     #[test]
     fn the_scalar_corpus_runs_on_the_machine() {
         for lane in lanes() {
@@ -7015,11 +7044,18 @@ pub fn moved(n: Int) -> Map<String, Float> {
             let entries = machine.tree_entries(built).unwrap();
             assert_eq!(
                 entries.keys().collect::<Vec<_>>(),
-                vec![&"libmini_vendored.rlib".to_string()],
+                vec![
+                    &"libmini_vendored.rlib".to_string(),
+                    &"libmini_vendored.rmeta".to_string()
+                ],
                 "{lane:?}: {entries:?}"
             );
             assert!(
                 entries["libmini_vendored.rlib"].starts_with("rlib("),
+                "{lane:?}: {entries:?}"
+            );
+            assert!(
+                entries["libmini_vendored.rmeta"].starts_with("rmeta("),
                 "{lane:?}: {entries:?}"
             );
 
@@ -7044,11 +7080,11 @@ pub fn moved(n: Int) -> Map<String, Float> {
                         "2021".to_string(),
                         "--crate-type".to_string(),
                         "lib".to_string(),
+                        "--emit=metadata=libmini_vendored.rmeta,link=libmini_vendored.rlib"
+                            .to_string(),
                         "-L".to_string(),
-                        "/m/0".to_string(),
+                        "dependency=/m/0".to_string(),
                         "/m/1/lib.rs".to_string(),
-                        "-o".to_string(),
-                        "libmini_vendored.rlib".to_string(),
                     ][..],
                 )],
                 "{lane:?}: {requested:?}"
@@ -7071,6 +7107,7 @@ pub fn moved(n: Int) -> Map<String, Float> {
                 completed.as_slice(),
                 [("rustc", ExecEvent::Ran, outputs)]
                     if outputs.iter().any(|(path, _)| path == "libmini_vendored.rlib")
+                        && outputs.iter().any(|(path, _)| path == "libmini_vendored.rmeta")
             ));
 
             let crate_hash = machine.fn_hash("crate_lib").expect("crate_lib hash");
@@ -7129,6 +7166,111 @@ pub fn moved(n: Int) -> Map<String, Float> {
                 "{lane:?}: {:?}",
                 machine.trace()
             );
+        }
+    }
+
+    #[test]
+    fn crate_vix_fake_rustc_builds_bin_with_dependency_metadata_and_rlib() {
+        let src = include_str!("../../../playgrounds/snark/src/bundled/vix/samples/crate.vix");
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            let target = machine.linux_target_handle();
+            let graph = machine.intern_tree_concrete(two_crate_graph_tree());
+
+            let checked = machine
+                .demand_i64("crate_bin_check", vec![target, graph])
+                .unwrap();
+            let check_entries = machine.tree_entries(checked).unwrap();
+            assert_eq!(
+                check_entries.keys().collect::<Vec<_>>(),
+                vec![&"mini_app.rmeta".to_string()],
+                "{lane:?}: {check_entries:?}"
+            );
+            assert!(
+                check_entries["mini_app.rmeta"].starts_with("rmeta("),
+                "{lane:?}: {check_entries:?}"
+            );
+
+            let built = machine
+                .demand_i64("crate_bin", vec![target, graph])
+                .unwrap();
+            let entries = machine.tree_entries(built).unwrap();
+            assert_eq!(
+                entries.keys().collect::<Vec<_>>(),
+                vec![&"mini_app".to_string()],
+                "{lane:?}: {entries:?}"
+            );
+            assert!(
+                entries["mini_app"].starts_with("bin("),
+                "{lane:?}: {entries:?}"
+            );
+
+            let requested = machine
+                .trace()
+                .iter()
+                .filter_map(|event| match event {
+                    DriveEvent::RunRequested {
+                        command_name, argv, ..
+                    } if command_name == "rustc" => Some(argv.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(requested.len(), 4, "{lane:?}: {requested:#?}");
+            assert!(
+                requested[0]
+                    .iter()
+                    .any(|arg| arg == "--emit=metadata=libhelper.rmeta,link=libhelper.rlib"),
+                "{lane:?}: {requested:#?}"
+            );
+            assert!(
+                requested[1]
+                    .iter()
+                    .any(|arg| arg == "--emit=metadata=mini_app.rmeta"),
+                "{lane:?}: {requested:#?}"
+            );
+            assert!(
+                requested[1]
+                    .iter()
+                    .any(|arg| arg.starts_with("helper=/m/") && arg.ends_with("/libhelper.rmeta")),
+                "{lane:?}: {requested:#?}"
+            );
+            assert!(
+                requested[1]
+                    .iter()
+                    .any(|arg| arg.starts_with("dependency=/m/")),
+                "{lane:?}: {requested:#?}"
+            );
+            assert!(
+                requested[2]
+                    .iter()
+                    .any(|arg| arg == "--emit=metadata=libhelper.rmeta,link=libhelper.rlib"),
+                "{lane:?}: {requested:#?}"
+            );
+            assert!(
+                requested[3].iter().any(|arg| arg == "--emit=link=mini_app"),
+                "{lane:?}: {requested:#?}"
+            );
+            assert!(
+                requested[3]
+                    .iter()
+                    .any(|arg| arg.starts_with("helper=/m/") && arg.ends_with("/libhelper.rlib")),
+                "{lane:?}: {requested:#?}"
+            );
+
+            let started = machine
+                .trace()
+                .iter()
+                .filter(|event| {
+                    matches!(
+                        event,
+                        DriveEvent::RunStarted {
+                            command_name,
+                            ..
+                        } if command_name == "rustc"
+                    )
+                })
+                .count();
+            assert_eq!(started, 4, "{lane:?}: {:?}", machine.trace());
         }
     }
 

--- a/vix/src/real_process.rs
+++ b/vix/src/real_process.rs
@@ -14,7 +14,10 @@ use std::sync::{Arc, Mutex};
 
 use sha2::{Digest, Sha256};
 
-use crate::exec::{ExecCache, ExecEvent, ExecPlan, ObservedWorld, Outcome, Role, Tool, Tree};
+use crate::exec::{
+    ExecCache, ExecEvent, ExecPlan, ObservedWorld, Outcome, Role, Tool, Tree, role_embedded_paths,
+    role_input_paths, role_output_paths, role_search_dir_paths,
+};
 use crate::machine::{
     MachineExecBackend, MachineExecRequest, MachinePathDemand, MachinePendingRun,
 };
@@ -162,26 +165,30 @@ fn stage_declared_inputs(
 ) -> Result<(), String> {
     for (arg, role) in &plan.argv {
         match role {
-            Role::Input => {
-                let bytes = world.read_bytes(arg).ok_or_else(|| {
-                    format!("real-process input `{arg}` is outside mounted trees")
-                })?;
-                stage_file(root, arg, &bytes)?;
+            Role::Input | Role::InputFlag => {
+                for input in role_input_paths(arg, *role) {
+                    let bytes = world.read_bytes(&input).ok_or_else(|| {
+                        format!("real-process input `{input}` is outside mounted trees")
+                    })?;
+                    stage_file(root, &input, &bytes)?;
+                }
             }
-            Role::SearchDir => {
-                let physical = physical_path(arg, root)?;
-                fs::create_dir_all(&physical)
-                    .map_err(|err| format!("real-process create search dir `{arg}`: {err}"))?;
-                if let Some(names) = world.list(arg) {
-                    for name in names {
-                        let logical = listed_logical_path(arg, &name, world);
-                        if let Some(bytes) = world.peek_bytes(&logical) {
-                            stage_file(root, &logical, &bytes)?;
+            Role::SearchDir | Role::SearchDirFlag => {
+                for dir in role_search_dir_paths(arg, *role) {
+                    let physical = physical_path(&dir, root)?;
+                    fs::create_dir_all(&physical)
+                        .map_err(|err| format!("real-process create search dir `{dir}`: {err}"))?;
+                    if let Some(names) = world.list(&dir) {
+                        for name in names {
+                            let logical = listed_logical_path(&dir, &name, world);
+                            if let Some(bytes) = world.peek_bytes(&logical) {
+                                stage_file(root, &logical, &bytes)?;
+                            }
                         }
                     }
                 }
             }
-            Role::Output | Role::Flag => {}
+            Role::Output | Role::OutputFlag | Role::Flag => {}
         }
     }
     Ok(())
@@ -214,11 +221,11 @@ fn mount_root(path: &str) -> Option<String> {
 
 fn prepare_output_dirs(plan: &ExecPlan, root: &Path) -> Result<(), String> {
     for (arg, role) in &plan.argv {
-        if *role == Role::Output {
-            let path = physical_path(arg, root)?;
+        for output in role_output_paths(arg, *role) {
+            let path = physical_path(&output, root)?;
             if let Some(parent) = path.parent() {
                 fs::create_dir_all(parent)
-                    .map_err(|err| format!("real-process create output dir `{arg}`: {err}"))?;
+                    .map_err(|err| format!("real-process create output dir `{output}`: {err}"))?;
             }
         }
     }
@@ -228,11 +235,11 @@ fn prepare_output_dirs(plan: &ExecPlan, root: &Path) -> Result<(), String> {
 fn harvest_outputs(plan: &ExecPlan, root: &Path) -> Result<Tree, String> {
     let mut tree = Tree::default();
     for (arg, role) in &plan.argv {
-        if *role == Role::Output {
-            let path = physical_path(arg, root)?;
+        for output in role_output_paths(arg, *role) {
+            let path = physical_path(&output, root)?;
             let bytes = fs::read(&path)
-                .map_err(|err| format!("real-process output `{arg}` was not produced: {err}"))?;
-            tree.insert_bytes(arg.clone(), bytes);
+                .map_err(|err| format!("real-process output `{output}` was not produced: {err}"))?;
+            tree.insert_bytes(output, bytes);
         }
     }
     if tree.entries.is_empty() && tree.blobs.is_empty() {
@@ -263,6 +270,16 @@ fn map_arg(arg: &str, role: Role, root: &Path) -> Result<OsString, String> {
     match role {
         Role::Input | Role::Output | Role::SearchDir => {
             Ok(physical_path(arg, root)?.into_os_string())
+        }
+        Role::InputFlag | Role::OutputFlag | Role::SearchDirFlag => {
+            let mut mapped = arg.to_string();
+            let mut paths = role_embedded_paths(arg, role);
+            paths.sort_by_key(|path| std::cmp::Reverse(path.len()));
+            for path in paths {
+                let physical = physical_path(&path, root)?;
+                mapped = mapped.replace(&path, physical.to_string_lossy().as_ref());
+            }
+            Ok(OsString::from(mapped))
         }
         Role::Flag => Ok(OsString::from(arg)),
     }

--- a/vix/tests/crate_real_process.rs
+++ b/vix/tests/crate_real_process.rs
@@ -1,0 +1,304 @@
+#![cfg(all(feature = "real-process", not(target_arch = "wasm32")))]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use facet::Facet;
+use vix::exec::Tree;
+use vix::machine::{DriveEvent, Machine, MachineArg};
+use vix::real_process::RealProcessBackend;
+
+const SOURCE: &str = include_str!("../../playgrounds/snark/src/bundled/vix/samples/crate.vix");
+const APP_MANIFEST: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/app/Cargo.toml"
+);
+const APP_MAIN: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/app/src/main.rs"
+);
+const HELPER_MANIFEST: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/crates/helper/Cargo.toml"
+);
+const HELPER_LIB: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/crates/helper/src/lib.rs"
+);
+const EXPECTED_STDOUT: &[u8] = b"vix dependency fixture\n";
+
+#[test]
+fn real_process_rustc_builds_two_crate_fixture_and_matches_cargo_unit_graph_oracle()
+-> Result<(), String> {
+    if !host_rustc_available() {
+        return Ok(());
+    }
+
+    let backend = Arc::new(RealProcessBackend::new());
+    let mut machine = Machine::load(SOURCE)?.with_exec_backend(backend);
+    let target = machine.linux_target_handle();
+    let graph = machine
+        .intern_arg("Tree", MachineArg::Tree(two_crate_graph_tree()))?
+        .0;
+
+    let checked = machine.demand_i64("crate_bin_check", vec![target, graph])?;
+    let _rmeta = tree_file_bytes(&mut machine, checked, "mini_app.rmeta")?;
+
+    let built = machine.demand_i64("crate_bin", vec![target, graph])?;
+    let bin = tree_file_bytes(&mut machine, built, "mini_app")?;
+    let stdout = run_binary_bytes(&bin)?;
+    if stdout != EXPECTED_STDOUT {
+        return Err(format!(
+            "unexpected binary stdout: {:?}",
+            String::from_utf8_lossy(&stdout)
+        ));
+    }
+
+    let machine_graph = machine_rustc_unit_graph(&machine)?;
+    let cargo_graph = cargo_unit_graph_oracle()?;
+    if machine_graph != cargo_graph {
+        return Err(format!(
+            "machine unit graph did not match cargo oracle\nmachine: {machine_graph:#?}\ncargo: {cargo_graph:#?}"
+        ));
+    }
+
+    Ok(())
+}
+
+fn host_rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+fn two_crate_graph_tree() -> Tree {
+    Tree::of(&[
+        ("app/Cargo.toml", APP_MANIFEST),
+        ("app/src/main.rs", APP_MAIN),
+        ("crates/helper/Cargo.toml", HELPER_MANIFEST),
+        ("crates/helper/src/lib.rs", HELPER_LIB),
+    ])
+}
+
+fn run_binary_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let temp = tempfile::Builder::new()
+        .prefix("vix-real-rustc-bin-")
+        .tempdir()
+        .map_err(|err| err.to_string())?;
+    let bin = temp.path().join("mini_app");
+    fs::write(&bin, bytes).map_err(|err| err.to_string())?;
+    make_executable(&bin)?;
+    let output = Command::new(&bin).output().map_err(|err| err.to_string())?;
+    if !output.status.success() {
+        return Err(format!(
+            "built binary exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(output.stdout)
+}
+
+fn tree_file_bytes(machine: &mut Machine, handle: i64, path: &str) -> Result<Vec<u8>, String> {
+    let blobs = machine.tree_blob_entries(handle)?;
+    if let Some(bytes) = blobs.get(path) {
+        return Ok(bytes.clone());
+    }
+    let entries = machine.tree_entries(handle)?;
+    if let Some(contents) = entries.get(path) {
+        return Ok(contents.as_bytes().to_vec());
+    }
+    Err(format!(
+        "missing `{path}` in text entries {entries:?} and blob entries {blobs:?}"
+    ))
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path)
+        .map_err(|err| err.to_string())?
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).map_err(|err| err.to_string())
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct UnitShape {
+    name: String,
+    crate_type: String,
+    edition: String,
+    source_suffix: String,
+    dependencies: Vec<String>,
+}
+
+fn machine_rustc_unit_graph(machine: &Machine) -> Result<Vec<UnitShape>, String> {
+    let mut shapes = machine
+        .trace()
+        .iter()
+        .filter_map(|event| match event {
+            DriveEvent::RunRequested {
+                command_name, argv, ..
+            } if command_name == "rustc" => Some(argv.as_slice()),
+            _ => None,
+        })
+        .map(machine_unit_shape)
+        .collect::<Result<Vec<_>, _>>()?;
+    shapes.sort();
+    shapes.dedup();
+    Ok(shapes)
+}
+
+fn machine_unit_shape(argv: &[String]) -> Result<UnitShape, String> {
+    let arg_after = |flag: &str| {
+        argv.windows(2)
+            .find_map(|pair| (pair[0] == flag).then(|| pair[1].clone()))
+            .ok_or_else(|| format!("missing {flag} in {argv:?}"))
+    };
+    let source = argv
+        .iter()
+        .find(|arg| arg.ends_with(".rs"))
+        .ok_or_else(|| format!("missing source in {argv:?}"))?;
+    let dependencies = argv
+        .windows(2)
+        .filter_map(|pair| {
+            if pair[0] == "--extern" {
+                pair[1].split_once('=').map(|(name, _)| name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    Ok(UnitShape {
+        name: arg_after("--crate-name")?,
+        crate_type: arg_after("--crate-type")?,
+        edition: arg_after("--edition")?,
+        source_suffix: source_suffix(source)?,
+        dependencies,
+    })
+}
+
+fn source_suffix(source: &str) -> Result<String, String> {
+    if source.ends_with("/src/lib.rs") || source.ends_with("/lib.rs") {
+        Ok("src/lib.rs".to_string())
+    } else if source.ends_with("/src/main.rs") || source.ends_with("/main.rs") {
+        Ok("src/main.rs".to_string())
+    } else {
+        Err(format!("unexpected source path `{source}`"))
+    }
+}
+
+fn cargo_unit_graph_oracle() -> Result<Vec<UnitShape>, String> {
+    if !Command::new("cargo")
+        .arg("+nightly")
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success())
+    {
+        return Ok(Vec::new());
+    }
+
+    let temp = tempfile::Builder::new()
+        .prefix("vix-cargo-unit-graph-oracle-")
+        .tempdir()
+        .map_err(|err| err.to_string())?;
+    write_fixture(temp.path())?;
+    let manifest = temp.path().join("app/Cargo.toml");
+    let output = Command::new("cargo")
+        .arg("+nightly")
+        .arg("build")
+        .arg("--unit-graph")
+        .arg("-Z")
+        .arg("unstable-options")
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .env("CARGO_NET_OFFLINE", "true")
+        .output()
+        .map_err(|err| err.to_string())?;
+    if !output.status.success() {
+        return Err(format!(
+            "cargo unit graph oracle exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let stdout = String::from_utf8(output.stdout).map_err(|err| err.to_string())?;
+    let graph: CargoUnitGraph = facet_json::from_str(&stdout).map_err(|err| err.to_string())?;
+    let mut shapes = graph
+        .units
+        .iter()
+        .map(|unit| {
+            let dependencies = unit
+                .dependencies
+                .iter()
+                .map(|dep| dep.extern_crate_name.clone())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            Ok(UnitShape {
+                name: unit.target.name.clone(),
+                crate_type: unit
+                    .target
+                    .crate_types
+                    .first()
+                    .cloned()
+                    .ok_or_else(|| format!("missing crate type for {:?}", unit.target))?,
+                edition: unit.target.edition.clone(),
+                source_suffix: source_suffix(&unit.target.src_path)?,
+                dependencies,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    shapes.sort();
+    Ok(shapes)
+}
+
+fn write_fixture(root: &Path) -> Result<(), String> {
+    let files: [(PathBuf, &str); 4] = [
+        (PathBuf::from("app/Cargo.toml"), APP_MANIFEST),
+        (PathBuf::from("app/src/main.rs"), APP_MAIN),
+        (PathBuf::from("crates/helper/Cargo.toml"), HELPER_MANIFEST),
+        (PathBuf::from("crates/helper/src/lib.rs"), HELPER_LIB),
+    ];
+    for (relative, contents) in files {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+        }
+        fs::write(path, contents).map_err(|err| err.to_string())?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Facet)]
+struct CargoUnitGraph {
+    units: Vec<CargoUnit>,
+}
+
+#[derive(Debug, Facet)]
+struct CargoUnit {
+    target: CargoTarget,
+    dependencies: Vec<CargoDependency>,
+}
+
+#[derive(Debug, Facet)]
+struct CargoTarget {
+    name: String,
+    src_path: String,
+    edition: String,
+    crate_types: Vec<String>,
+}
+
+#[derive(Debug, Facet)]
+struct CargoDependency {
+    extern_crate_name: String,
+}


### PR DESCRIPTION
Summary:
- Extends the vix rustc command vocabulary with embedded input/output/search-dir roles for --extern, -L dependency, and explicit --emit metadata/link paths.
- Expands crate.vix to build a two-crate offline fixture through dependency metadata, dependency rlib, bin check, and bin link phases without Cargo in the production path.
- Adds fake-rustc machine coverage plus a gated real-process rustc oracle that runs the produced binary and compares unit shape against cargo +nightly --unit-graph in a test-only oracle helper.

Pipelining:
- crate_bin_check demands libhelper.rmeta before crate_bin demands libhelper.rlib.
- The current real-process backend still executes and harvests all declared outputs at spawn/finish time, so true multi-output early availability is not implemented there yet; the test records the static two-output model and the pending-tree demand boundary.

Testing:
- cargo nextest run -p vix -p weavy: 204 passed (1 leaky), 0 skipped
- cargo nextest run -p vix --features real-process: 89 passed, 0 skipped
- cargo clippy -p vix -p weavy --all-targets --message-format=short -- -D warnings
- cargo clippy -p vix -p weavy --all-features --all-targets --message-format=short -- -D warnings
- cargo check -p vix --features real-process --tests
- git diff --check