### PR TITLE
vix: checker v0 (resolve + type_of) written in vix

### DIFF
--- a/playgrounds/snark/tests/wasmFlow.test.ts
+++ b/playgrounds/snark/tests/wasmFlow.test.ts
@@ -1791,7 +1791,7 @@ test("runs every vendored grammar sample through generated grammar.json and Snar
       { id: "nginx", sample: "samples/basic.conf", ok: true, language: "nginx", errorCount: 0, missingCount: 0 },
       { id: "proto", sample: "samples/addressbook.proto", ok: true, language: "proto", errorCount: 0, missingCount: 0 },
       { id: "thrift", sample: "samples/tutorial.thrift", ok: true, language: "thrift", errorCount: 0, missingCount: 0 },
-      { id: "vix", sample: "samples/cargo.vix", ok: true, language: "vix", errorCount: 0, missingCount: 0 },
+      { id: "vix", sample: "samples/ast-query.vix", ok: true, language: "vix", errorCount: 0, missingCount: 0 },
       { id: "yuri", sample: "samples/example.yuri", ok: true, language: "yuri", errorCount: 0, missingCount: 0 },
     ],
   );

--- a/vix/checker/checker.vix
+++ b/vix/checker/checker.vix
@@ -1,0 +1,76 @@
+// The bootstrap checker v0. This is deliberately Vix source: Rust only loads it
+// and asserts the corpus facts it returns.
+
+pub fn resolve_ref(source: String, name: String) -> String {
+    let f = ast(source).fn(name);
+    f.name
+}
+
+pub fn type_of(source: String, function: String) -> String {
+    let kind: String = ast(source).fn(function).tail.kind;
+    match kind {
+        "number" => "Int",
+        "string" => "String",
+        "path" => "Path",
+        "bool" => "Bool",
+        _ => "Error",
+    }
+}
+
+pub fn function_signature(source: String, name: String) -> String {
+    let f = ast(source).fn(name);
+    let params: String = f.param_types.join(",");
+    let ret: String = f.return_type_text;
+    visibility_prefix(f)
+        + "fn"
+        + generic_params(f)
+        + "("
+        + params
+        + ")->"
+        + ret
+        + " abi="
+        + abi_class(ret)
+}
+
+pub fn diagnostic_kind(source: String, function: String) -> String {
+    let status: String = ast(source).fn(function).return_type_status;
+    match status {
+        "some" => "None",
+        "none" => "OmittedReturnType",
+        _ => "Error",
+    }
+}
+
+pub fn diagnostic_span_start(source: String, function: String) -> Int {
+    ast(source).fn(function).name_span.start
+}
+
+pub fn diagnostic_span_end(source: String, function: String) -> Int {
+    ast(source).fn(function).name_span.end
+}
+
+pub fn diagnostic_suggestion(source: String, function: String) -> String {
+    type_of(source, function)
+}
+
+fn visibility_prefix(f: Doc) -> String {
+    let prefix: String = f.visibility_prefix;
+    prefix
+}
+
+fn generic_params(f: Doc) -> String {
+    let params = f.generic_params.join(",");
+    match params {
+        "" => "",
+        _ => "<" + params + ">",
+    }
+}
+
+fn abi_class(ty: String) -> String {
+    match ty {
+        "Int" => "BitsWord",
+        "Float" => "BitsWord",
+        "Bool" => "BitsWord",
+        _ => "Handle<" + ty + ">",
+    }
+}

--- a/vix/src/machine/ast_probe.rs
+++ b/vix/src/machine/ast_probe.rs
@@ -80,7 +80,7 @@ pub(super) fn fn_item<'a>(file: &'a SourceFile, name: &str) -> Result<&'a FnItem
 pub(super) fn fn_body_children(item: &FnItem) -> Value {
     let mut children = item.body.stmts.iter().map(stmt_summary).collect::<Vec<_>>();
     if let Some(tail) = &item.body.tail {
-        children.push(node_summary("tail", None, expr_span(tail)));
+        children.push(expr_summary("tail", tail));
     }
     Value::Array(children)
 }
@@ -89,16 +89,72 @@ pub(super) fn fn_fields(item: &FnItem) -> BTreeMap<Value, Value> {
     BTreeMap::from([
         (string_key("kind"), Value::Str("fn".to_string())),
         (string_key("name"), Value::Str(item.name.value.clone())),
+        (string_key("name_span"), span_value(item.name.span)),
+        (string_key("public"), Value::Bool(item.vis.is_some())),
+        (
+            string_key("visibility_prefix"),
+            Value::Str(if item.vis.is_some() { "pub " } else { "" }.to_string()),
+        ),
         (string_key("span"), span_value(item.span)),
         (
             string_key("params"),
             Value::Array(item.params.params.iter().map(param_value).collect()),
         ),
         (
+            string_key("param_types"),
+            Value::Array(
+                item.params
+                    .params
+                    .iter()
+                    .map(|param| Value::Str(type_text(&param.ty)))
+                    .collect(),
+            ),
+        ),
+        (
+            string_key("generic_params"),
+            Value::Array(
+                item.generics
+                    .iter()
+                    .flat_map(|generics| &generics.params)
+                    .map(|param| Value::Str(param.value.clone()))
+                    .collect(),
+            ),
+        ),
+        (
             string_key("return_type"),
             item.return_type
                 .as_ref()
                 .map(type_value)
+                .unwrap_or_else(option_none),
+        ),
+        (
+            string_key("has_return_type"),
+            Value::Bool(item.return_type.is_some()),
+        ),
+        (
+            string_key("return_type_status"),
+            Value::Str(
+                if item.return_type.is_some() {
+                    "some"
+                } else {
+                    "none"
+                }
+                .to_string(),
+            ),
+        ),
+        (
+            string_key("return_type_text"),
+            item.return_type
+                .as_ref()
+                .map(|ty| Value::Str(type_text(ty)))
+                .unwrap_or_else(option_none),
+        ),
+        (
+            string_key("tail"),
+            item.body
+                .tail
+                .as_ref()
+                .map(|tail| expr_summary("tail", tail))
                 .unwrap_or_else(option_none),
         ),
     ])
@@ -128,6 +184,53 @@ fn stmt_summary(stmt: &ast::Stmt) -> Value {
     match stmt {
         ast::Stmt::Let(stmt) => node_summary("let", Some(&stmt.name.value), stmt.span),
         ast::Stmt::Expr(stmt) => node_summary("expr", None, stmt.span),
+    }
+}
+
+fn expr_summary(role: &str, expr: &ast::Expr) -> Value {
+    let mut fields = BTreeMap::from([
+        (string_key("role"), Value::Str(role.to_string())),
+        (string_key("kind"), Value::Str(expr_kind(expr).to_string())),
+        (string_key("span"), span_value(expr_span(expr))),
+    ]);
+    if let Some(text) = expr_leaf_text(expr) {
+        fields.insert(string_key("text"), Value::Str(text));
+    }
+    Value::Map(fields)
+}
+
+fn expr_kind(expr: &ast::Expr) -> &'static str {
+    match expr {
+        ast::Expr::Binary(_) => "binary",
+        ast::Expr::Unary(_) => "unary",
+        ast::Expr::Call(_) => "call",
+        ast::Expr::MethodCall(_) => "method_call",
+        ast::Expr::Field(_) => "field",
+        ast::Expr::Match(_) => "match",
+        ast::Expr::Closure(_) => "closure",
+        ast::Expr::Command(_) => "command",
+        ast::Expr::StructLit(_) => "struct_lit",
+        ast::Expr::Map(_) => "map",
+        ast::Expr::Tuple(_) => "tuple",
+        ast::Expr::Array(_) => "array",
+        ast::Expr::Paren(_) => "paren",
+        ast::Expr::Scoped(_) => "scoped",
+        ast::Expr::Identifier(_) => "identifier",
+        ast::Expr::Str(_) => "string",
+        ast::Expr::Path(_) => "path",
+        ast::Expr::Number(_) => "number",
+        ast::Expr::Bool(_) => "bool",
+    }
+}
+
+fn expr_leaf_text(expr: &ast::Expr) -> Option<String> {
+    match expr {
+        ast::Expr::Identifier(expr)
+        | ast::Expr::Str(expr)
+        | ast::Expr::Path(expr)
+        | ast::Expr::Number(expr) => Some(expr.value.clone()),
+        ast::Expr::Bool(expr) => Some(expr.value.to_string()),
+        _ => None,
     }
 }
 
@@ -187,9 +290,9 @@ fn type_text(ty: &Type) -> String {
                 .iter()
                 .map(type_text)
                 .collect::<Vec<_>>()
-                .join(", ");
+                .join(",");
             match &func.return_type {
-                Some(ret) => format!("fn({params}) -> {}", type_text(ret)),
+                Some(ret) => format!("fn({params})->{}", type_text(ret)),
                 None => format!("fn({params})"),
             }
         }
@@ -200,7 +303,7 @@ fn type_text(ty: &Type) -> String {
                 .iter()
                 .map(type_text)
                 .collect::<Vec<_>>()
-                .join(", ")
+                .join(",")
         ),
         Type::Generic(generic) => format!(
             "{}<{}>",
@@ -210,7 +313,7 @@ fn type_text(ty: &Type) -> String {
                 .iter()
                 .map(type_text)
                 .collect::<Vec<_>>()
-                .join(", ")
+                .join(",")
         ),
         Type::Path(path) => type_path_text(path),
     }

--- a/vix/src/machine/driver.rs
+++ b/vix/src/machine/driver.rs
@@ -137,6 +137,8 @@ pub const AST_DOC_HOST: u32 = 25;
 pub const AST_FN_HOST: u32 = 26;
 pub const ARRAY_LEN_HOST: u32 = 27;
 pub const OCI_DOC_HOST: u32 = 28;
+pub const STRING_CONCAT_HOST: u32 = 29;
+pub const ARRAY_JOIN_HOST: u32 = 30;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Lane {
@@ -2422,6 +2424,75 @@ impl Driver {
                 }
             };
 
+            let mut string_concat_host = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let left = read_frame_word(frame, primitive_region + 8);
+                    let right = read_frame_word(frame, primitive_region + 16);
+                    let left = store_cell.borrow().string_value(left, "String")?;
+                    let right = store_cell.borrow().string_value(right, "String")?;
+                    let handle = store_cell
+                        .borrow_mut()
+                        .alloc_raw(
+                            "String",
+                            [left.as_str(), right.as_str()].concat().into_bytes(),
+                        )
+                        .0;
+                    write_frame_word(frame, dst_slot, handle);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
+            let mut array_join_host = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let array = read_frame_word(frame, primitive_region + 8);
+                    let separator = read_frame_word(frame, primitive_region + 16);
+                    let separator = store_cell.borrow().string_value(separator, "String")?;
+                    let joined = match store_cell.borrow().array_entry(array, schema_refs)? {
+                        ArrayEntry::Words { elem_schema, words } => {
+                            if elem_schema != "String" && elem_schema != "Doc" {
+                                return Err(format!("join called on Array<{elem_schema}>"));
+                            }
+                            words
+                                .into_iter()
+                                .map(|word| {
+                                    if elem_schema == "String" {
+                                        store_cell.borrow().string_value(word, "String")
+                                    } else {
+                                        let DocPayload::String(handle) =
+                                            doc_payload(&store_cell.borrow(), descriptors, word)?
+                                        else {
+                                            return Err(
+                                                "join called on non-string Doc array element"
+                                                    .to_string(),
+                                            );
+                                        };
+                                        store_cell.borrow().string_value(handle, "String")
+                                    }
+                                })
+                                .collect::<Result<Vec<_>, _>>()?
+                                .join(&separator)
+                        }
+                        ArrayEntry::Pending(_) => {
+                            return Err("join called on pending array".to_string());
+                        }
+                    };
+                    let handle = store_cell
+                        .borrow_mut()
+                        .alloc_raw("String", joined.into_bytes())
+                        .0;
+                    write_frame_word(frame, dst_slot, handle);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
             let mut array_filter_exclude = |frame: &mut [u8]| {
                 let result = (|| {
                     let dst_slot = read_frame_word(frame, primitive_region) as usize;
@@ -2573,7 +2644,7 @@ impl Driver {
                 });
             };
 
-            let mut hosts: [HostFn<'_>; 29] = [
+            let mut hosts: [HostFn<'_>; 31] = [
                 &mut invoke,
                 &mut store_alloc,
                 &mut store_read,
@@ -2603,6 +2674,8 @@ impl Driver {
                 &mut ast_fn_host,
                 &mut array_len_host,
                 &mut oci_doc_host,
+                &mut string_concat_host,
+                &mut array_join_host,
             ];
             let step = exec
                 .task

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -28,14 +28,14 @@ use weavy::task::{Fn as TaskFn, FnId, Op, Program};
 
 use super::TotalF64;
 use super::driver::{
-    ACQUIRE_HOST, ARRAY_ALLOC_HOST, ARRAY_COLLECT_HOST, ARRAY_FILTER_EXCLUDE_HOST, ARRAY_LEN_HOST,
-    ARRAY_MAP_PENDING_HOST, AST_DOC_HOST, AST_FN_HOST, CodeBundle, DOC_COERCE_HOST, DOC_GET_HOST,
-    DOC_PARSE_HOST, DriveEvent, DriveEventSink, Driver, ELF_DOC_HOST, EXEC_HOST, FETCH_HOST,
-    GLOB_HOST, INVOKE_HOST, Lane, LoweredFn, MAP_EMPTY_HOST, MAP_GET_HOST, MAP_INSERT_HOST,
-    MachineExecBackend, OCI_DOC_HOST, OPTION_UNWRAP_HOST, PATH_WITH_EXT_HOST, PENDING_ALLOC_HOST,
-    PENDING_COERCE_HOST, PENDING_INVOKE_HOST, RenderNames, RenderVariant, RenderedValue,
-    STORE_ALLOC_HOST, STORE_READ_HOST, STORE_TAG_HOST, StepMode, StoreHandle, TREE_PROJECT_HOST,
-    ValueBundle,
+    ACQUIRE_HOST, ARRAY_ALLOC_HOST, ARRAY_COLLECT_HOST, ARRAY_FILTER_EXCLUDE_HOST, ARRAY_JOIN_HOST,
+    ARRAY_LEN_HOST, ARRAY_MAP_PENDING_HOST, AST_DOC_HOST, AST_FN_HOST, CodeBundle, DOC_COERCE_HOST,
+    DOC_GET_HOST, DOC_PARSE_HOST, DriveEvent, DriveEventSink, Driver, ELF_DOC_HOST, EXEC_HOST,
+    FETCH_HOST, GLOB_HOST, INVOKE_HOST, Lane, LoweredFn, MAP_EMPTY_HOST, MAP_GET_HOST,
+    MAP_INSERT_HOST, MachineExecBackend, OCI_DOC_HOST, OPTION_UNWRAP_HOST, PATH_WITH_EXT_HOST,
+    PENDING_ALLOC_HOST, PENDING_COERCE_HOST, PENDING_INVOKE_HOST, RenderNames, RenderVariant,
+    RenderedValue, STORE_ALLOC_HOST, STORE_READ_HOST, STORE_TAG_HOST, STRING_CONCAT_HOST, StepMode,
+    StoreHandle, TREE_PROJECT_HOST, ValueBundle,
 };
 use crate::ast;
 use crate::fetch::FetchBackend;
@@ -1430,9 +1430,16 @@ fn collect_expr_schemas(
             Ok(Some(schema))
         }
         ast::Expr::Binary(binary) => {
-            let _ = collect_expr_schemas(&binary.left, out, tables, fn_returns, env)?;
-            let _ = collect_expr_schemas(&binary.right, out, tables, fn_returns, env)?;
-            Ok(None)
+            let left = collect_expr_schemas(&binary.left, out, tables, fn_returns, env)?;
+            let right = collect_expr_schemas(&binary.right, out, tables, fn_returns, env)?;
+            if binary.op == "+"
+                && left.as_deref() == Some("String")
+                && right.as_deref() == Some("String")
+            {
+                Ok(Some("String".into()))
+            } else {
+                Ok(None)
+            }
         }
         ast::Expr::Unary(unary) => {
             collect_expr_schemas(&unary.operand, out, tables, fn_returns, env)
@@ -1475,6 +1482,7 @@ fn collect_expr_schemas(
                 }
                 ("get", Some(schema)) => Ok(map_value_schema(schema).map(option_schema)),
                 ("unwrap", Some(schema)) => Ok(option_value_schema(schema).map(str::to_string)),
+                ("join", Some("Array" | "Doc" | "Realized<Doc>")) => Ok(Some("String".into())),
                 _ => Ok(None),
             }
         }
@@ -2127,6 +2135,9 @@ impl<'a> FnLowerer<'a> {
                 {
                     a = self.coerce_to_schema(a, &schema)?;
                     r = self.coerce_to_schema(r, &schema)?;
+                }
+                if b.op == "+" && a.schema == "String" && r.schema == "String" {
+                    return self.string_concat(&a, &r);
                 }
                 let dst = self.alloc();
                 let (op, schema) = match (b.op.as_str(), a.schema.as_str(), r.schema.as_str()) {
@@ -2805,6 +2816,22 @@ impl<'a> FnLowerer<'a> {
                     return Err("collect takes no arguments".into());
                 }
                 self.array_collect(&receiver, expected)
+            }
+            "join" => {
+                let receiver = match receiver.schema.as_str() {
+                    "Array" => receiver,
+                    "Doc" => self.coerce_doc_to_schema(receiver, "Array")?,
+                    "Realized<Doc>" => {
+                        let doc = self.coerce_to_schema(receiver, "Doc")?;
+                        self.coerce_doc_to_schema(doc, "Array")?
+                    }
+                    _ => return Err(format!("join called on {}", receiver.schema)),
+                };
+                let [arg] = call.args.args.as_slice() else {
+                    return Err("Array.join takes one separator".into());
+                };
+                let separator = self.method_arg(arg, Some("String"))?;
+                self.array_join(&receiver, &separator)
             }
             "insert" => {
                 let Some((key_schema, value_schema)) = map_schemas(&receiver.schema) else {
@@ -4178,6 +4205,66 @@ impl<'a> FnLowerer<'a> {
         })
     }
 
+    fn array_join(
+        &mut self,
+        receiver: &ValueSlot,
+        separator: &ValueSlot,
+    ) -> Result<ValueSlot, String> {
+        self.expect_schema(receiver, "Array")?;
+        self.expect_schema(separator, "String")?;
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: receiver.slot,
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 16,
+            src: separator.slot,
+        });
+        self.code.push(Op::HostCall {
+            host: ARRAY_JOIN_HOST,
+        });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: "String".into(),
+            realization: None,
+            pending: None,
+        })
+    }
+
+    fn string_concat(&mut self, left: &ValueSlot, right: &ValueSlot) -> Result<ValueSlot, String> {
+        self.expect_schema(left, "String")?;
+        self.expect_schema(right, "String")?;
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: left.slot,
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 16,
+            src: right.slot,
+        });
+        self.code.push(Op::HostCall {
+            host: STRING_CONCAT_HOST,
+        });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: "String".into(),
+            realization: None,
+            pending: None,
+        })
+    }
+
     fn doc_get(&mut self, doc: &ValueSlot, key: &ValueSlot) -> Result<ValueSlot, String> {
         self.expect_schema(doc, "Doc")?;
         self.expect_schema(key, "String")?;
@@ -4646,6 +4733,7 @@ fn strict_binary_operand_schema<'a>(op: &str, left: &'a str, right: &'a str) -> 
     match (op, left) {
         ("+" | "-" | "*", "Int")
         | ("+" | "*", "Float")
+        | ("+", "String")
         | ("==" | "!=", "Int" | "Float" | "String" | "Path" | "Bool")
         | ("&&", "Bool") => Some(left),
         _ => None,

--- a/vix/tests/checker_corpus.rs
+++ b/vix/tests/checker_corpus.rs
@@ -1,6 +1,7 @@
 use facet::Facet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use vix::machine::{Machine, MachineArg, NamedArg, RenderedValue};
 
 #[derive(Facet, Debug)]
 struct CorpusEntry {
@@ -95,11 +96,221 @@ fn checker_corpus_entries_are_real_facet_json() {
 }
 
 #[test]
-#[ignore = "pending vix-written checker binary"]
 fn checker_corpus_matches_vix_checker() {
     let files = corpus_json_files();
-    panic!(
-        "wire {} checker corpus entries to the Vix checker once it exists",
-        files.len()
+    let mut covered = Vec::new();
+    let mut pending = Vec::new();
+
+    for file in files {
+        let entry = load_entry(&file);
+        for assertion in &entry.assertions {
+            let key = format!("{}:{}:{}", entry.id, assertion.query, assertion.subject);
+            if run_covered_assertion(&entry, assertion)
+                .unwrap_or_else(|err| panic!("{file:?} {key}: {err}"))
+            {
+                covered.push(key);
+            } else {
+                pending.push(key);
+            }
+        }
+    }
+    covered.sort();
+    pending.sort();
+
+    assert_eq!(
+        covered,
+        vec![
+            "accept.cargo-manifest:function_signature:cargo_manifest",
+            "accept.crate-build:function_signature:crate_lib",
+            "accept.crate-build:function_signature:doc_string",
+            "accept.elf-policy:function_signature:glibc_policy",
+            "accept.eval-self-hosting:function_signature:demo",
+            "accept.eval-self-hosting:function_signature:eval",
+            "accept.lua-build:function_signature:lua",
+            "accept.lua-build:function_signature:object",
+            "accept.lua-build:function_signature:sources",
+            "accept.merge-demand:function_signature:fallback",
+            "accept.merge-demand:function_signature:object",
+            "accept.merge-demand:function_signature:selected",
+            "accept.merge-demand:function_signature:subtree_chain",
+            "accept.types-tour:function_signature:classify",
+            "accept.types-tour:function_signature:scaled",
+            "accept.types-tour:function_signature:toolchain",
+            "reject.omitted-return-type:diagnostics:OmittedReturnType",
+        ],
+        "covered checker v0 assertions stay explicit"
     );
+
+    assert_eq!(
+        pending,
+        vec![
+            "accept.cargo-manifest:type_of:toml(manifest/p\"Cargo.toml\")",
+            "accept.crate-build:abi_class:rustc! block",
+            "accept.elf-policy:type_of:elf(input).needs_glibc",
+            "accept.eval-self-hosting:abi_class:Expr",
+            "accept.eval-self-hosting:decls:crate",
+            "accept.eval-self-hosting:exhaustive:eval.match",
+            "accept.lua-build:abi_class:cc! blocks",
+            "accept.lua-build:exhaustive:lua.target.os.match",
+            "accept.lua-build:module_graph:crate.imports",
+            "accept.lua-build:type_of:lua.units",
+            "accept.merge-demand:type_of:units.map(|u| object(cc,u)).collect()/p\"wanted.o\"",
+            "accept.types-tour:abi_class:Toolchain",
+            "accept.types-tour:decls:crate",
+            "accept.types-tour:exhaustive:classify.match",
+            "accept.types-tour:exhaustive:toolchain.target.os.match",
+            "accept.types-tour:function_signature:apply",
+            "accept.types-tour:function_signature:depths",
+            "accept.types-tour:function_signature:partials",
+            "accept.types-tour:function_signature:swap",
+            "reject.duplicate-argument:diagnostics:DuplicateArgument",
+            "reject.duplicate-field:diagnostics:DuplicateField",
+            "reject.duplicate-item:diagnostics:DuplicateItem",
+            "reject.duplicate-partial-marker:diagnostics:DuplicatePartialMarker",
+            "reject.duplicate-pattern-field:diagnostics:DuplicatePatternField",
+            "reject.duplicate-struct-field:diagnostics:DuplicateStructField",
+            "reject.duplicate-type-param:diagnostics:DuplicateTypeParam",
+            "reject.duplicate-type:diagnostics:DuplicateType",
+            "reject.duplicate-variant:diagnostics:DuplicateVariant",
+            "reject.generic-lowering-unsupported:lowering_plan:GenericLoweringUnsupported",
+            "reject.guarded-arm-does-not-cover:diagnostics:GuardedArmDoesNotCover",
+            "reject.irrefutable-arm-not-last:diagnostics:IrrefutableArmNotLast",
+            "reject.missing-argument:diagnostics:MissingArgument",
+            "reject.missing-struct-field:diagnostics:MissingStructField",
+            "reject.non-bool-guard:diagnostics:NonBoolGuard",
+            "reject.non-exhaustive-match:diagnostics:NonExhaustiveMatch",
+            "reject.partial-call-non-prefix:diagnostics:PartialCallNonPrefix",
+            "reject.pattern-payload-mismatch:diagnostics:PatternPayloadMismatch",
+            "reject.string-is-not-path:diagnostics:StringIsNotPath",
+            "reject.too-many-arguments:diagnostics:TooManyArguments",
+            "reject.type-mismatch:diagnostics:TypeMismatch",
+            "reject.unknown-argument:diagnostics:UnknownArgument",
+            "reject.unknown-struct-field:diagnostics:UnknownStructField",
+            "reject.unresolved-module:diagnostics:UnresolvedModule",
+            "reject.unresolved-type:diagnostics:UnresolvedType",
+            "reject.unresolved-value:diagnostics:UnresolvedValue",
+        ],
+        "checker v0 pending assertions stay explicit"
+    );
+}
+
+fn run_covered_assertion(entry: &CorpusEntry, assertion: &CorpusAssertion) -> Result<bool, String> {
+    match (entry.outcome.as_str(), assertion.query.as_str()) {
+        ("accept", "function_signature") if plain_signature_assertion(assertion) => {
+            let source = entry_source(entry)?;
+            let actual = checker_string(
+                "function_signature",
+                &[
+                    ("source", MachineArg::String(source)),
+                    ("name", MachineArg::String(assertion.subject.clone())),
+                ],
+            )?;
+            if actual != assertion.expect {
+                return Err(format!(
+                    "function_signature({}) = {actual:?}, expected {:?}",
+                    assertion.subject, assertion.expect
+                ));
+            }
+            Ok(true)
+        }
+        ("reject", "diagnostics") if assertion.subject == "OmittedReturnType" => {
+            let source = entry_source(entry)?;
+            let function = "main".to_string();
+            let kind = checker_string(
+                "diagnostic_kind",
+                &[
+                    ("source", MachineArg::String(source.clone())),
+                    ("function", MachineArg::String(function.clone())),
+                ],
+            )?;
+            let suggestion = checker_string(
+                "diagnostic_suggestion",
+                &[
+                    ("source", MachineArg::String(source.clone())),
+                    ("function", MachineArg::String(function.clone())),
+                ],
+            )?;
+            let span_start = checker_int(
+                "diagnostic_span_start",
+                &[
+                    ("source", MachineArg::String(source.clone())),
+                    ("function", MachineArg::String(function.clone())),
+                ],
+            )?;
+            let span_end = checker_int(
+                "diagnostic_span_end",
+                &[
+                    ("source", MachineArg::String(source)),
+                    ("function", MachineArg::String(function)),
+                ],
+            )?;
+            if kind != assertion.subject {
+                return Err(format!("diagnostic kind = {kind:?}"));
+            }
+            if suggestion != "Int" {
+                return Err(format!("diagnostic suggestion = {suggestion:?}"));
+            }
+            if (span_start, span_end)
+                != (
+                    i64::from(assertion.span_start),
+                    i64::from(assertion.span_end),
+                )
+            {
+                return Err(format!(
+                    "diagnostic span = {span_start}..{span_end}, expected {}..{}",
+                    assertion.span_start, assertion.span_end
+                ));
+            }
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn plain_signature_assertion(assertion: &CorpusAssertion) -> bool {
+    assertion.expect.contains(" abi=")
+        && !assertion.expect.contains(" checked ")
+        && !assertion.expect.contains(" callable_param=")
+        && !assertion.expect.contains(" partial=")
+        && !assertion.expect.contains(" tuple_index=")
+}
+
+fn entry_source(entry: &CorpusEntry) -> Result<String, String> {
+    let [source] = entry.sources.as_slice() else {
+        return Err(format!(
+            "checker v0 expects one source, got {}",
+            entry.sources.len()
+        ));
+    };
+    let path = corpus_root().join(&source.path);
+    fs::read_to_string(&path).map_err(|err| format!("read {path:?}: {err}"))
+}
+
+fn checker_string(function: &str, args: &[(&str, MachineArg)]) -> Result<String, String> {
+    let rendered = checker_rendered(function, args)?;
+    let RenderedValue::String { value } = rendered else {
+        return Err(format!("{function} returned {rendered:?}, not String"));
+    };
+    Ok(value)
+}
+
+fn checker_int(function: &str, args: &[(&str, MachineArg)]) -> Result<i64, String> {
+    let rendered = checker_rendered(function, args)?;
+    let RenderedValue::Int { value } = rendered else {
+        return Err(format!("{function} returned {rendered:?}, not Int"));
+    };
+    Ok(value)
+}
+
+fn checker_rendered(function: &str, args: &[(&str, MachineArg)]) -> Result<RenderedValue, String> {
+    let mut machine = Machine::load(include_str!("../checker/checker.vix"))?;
+    let args = args
+        .iter()
+        .map(|(name, value)| NamedArg {
+            name: (*name).to_string(),
+            value: value.clone(),
+        })
+        .collect::<Vec<_>>();
+    let handle = machine.call(function, &args)?;
+    machine.render_result(function, handle.0)
 }


### PR DESCRIPTION
## Summary
- add vix/checker/checker.vix, a bootstrap Vix checker module for the v0 declaration/signature and omitted-return slice
- extend ast() with structural function fields and tail expression summaries, plus String concat and Array.join so the checker can normalize facts in Vix
- activate vix/tests/checker_corpus.rs for covered assertions while keeping every uncovered corpus assertion in an explicit pending list

## Corpus coverage
Covered: 16 accept function_signature assertions and reject.omitted-return-type diagnostic kind/span/suggestion.
Pending: non-signature accept facts (decls, module_graph, expression type_of, ABI, exhaustiveness) plus the remaining reject diagnostic kinds.

## Gaps found
- Vix boolean literals are expressions but not patterns, so the checker cannot currently branch on Bool with match true/false; v0 branches on string status projected from ast().
- Current ast() still lacks full expression/pattern traversal for the rest of type_of, call checking, and diagnostics.

## Warm re-check
The checker is an ordinary Vix module loaded by Machine; per-definition warm re-check lands on the existing closure-hash/memo path for function_signature, type_of, and diagnostic helper functions. Structural ast() projections remain lazy and content-hashed below those checker calls.

## Verification
- cargo check -p vix --tests
- cargo nextest run -p vix -E binary(checker_corpus)
- cargo nextest run -p vix -p weavy (216 passed, 1 leaky)
- cargo clippy -p vix -p weavy --all-features --all-targets --message-format=short -- -D warnings
- cargo build --release --target wasm32-unknown-unknown -p snark-wasm
- pnpm --filter @bearcove/snark-playground test:flow