### PR TITLE
vix: Version value kind + real glibc preflight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8219,6 +8219,7 @@ dependencies = [
  "facet-value",
  "hex",
  "phon",
+ "semver 1.0.28",
  "sha2 0.10.9",
  "snark",
  "snark-dsl",

--- a/playgrounds/snark/src/bundled/vix/samples/oci-glibc-preflight.vix
+++ b/playgrounds/snark/src/bundled/vix/samples/oci-glibc-preflight.vix
@@ -1,12 +1,8 @@
-// OCI preflight shape: image bytes are never executed.
-// The current comparison surface supports string equality/inequality;
-// semantic GLIBC floor ordering is the next policy primitive.
-
-pub fn shipped_glibc(image: Tree) -> String {
-    let libc = oci(image).files.get("usr/lib/libc.so.6").unwrap().contents;
-    elf(libc).needs_glibc
+pub fn shipped_glibc(image: Tree) -> Version {
+    let libc: Blob = oci(image).files.get("usr/lib/libc.so.6").unwrap().contents;
+    version(elf(libc).needs_glibc)
 }
 
 pub fn matches_floor(image: Tree) -> Bool {
-    shipped_glibc(image) == "GLIBC_2.35"
+    version("2.34.0") <= shipped_glibc(image)
 }

--- a/vix/Cargo.toml
+++ b/vix/Cargo.toml
@@ -19,6 +19,7 @@ facet-toml = { path = "../facet-toml" }
 facet-value = { path = "../facet-value", default-features = false, features = ["alloc"] }
 hex.workspace = true
 phon = { path = "../phon/rust/phon", default-features = false }
+semver = "1.0.28"
 sha2.workspace = true
 # vix lowers to weavy (portability is weavy's concern — constitution
 # A6); the dependency activates when the typed instruction vocabulary

--- a/vix/src/binder.rs
+++ b/vix/src/binder.rs
@@ -87,7 +87,9 @@ impl ModuleBindings {
 
 /// Primitive scalar types need no declaration or import; they resolve silently
 /// (no ref recorded — there is no def site to jump to).
-const BUILTIN_TYPES: &[&str] = &["Int", "Float", "String", "Bool", "Blob", "Doc", "Tree"];
+const BUILTIN_TYPES: &[&str] = &[
+    "Int", "Float", "String", "Bool", "Blob", "Doc", "Tree", "Version",
+];
 
 #[derive(Debug, Clone)]
 pub struct Symbol {
@@ -339,7 +341,7 @@ fn builtin_module_item(module: &str, name: &str) -> Option<ModuleItem> {
         (
             "vix",
             "Int" | "Float" | "String" | "Bool" | "Blob" | "Doc" | "Tree" | "Path" | "Target"
-            | "Map" | "Array" | "Flag" | "Run" | "Os" | "Arch",
+            | "Map" | "Array" | "Flag" | "Run" | "Os" | "Arch" | "Version",
         ) => ImportKind::Type,
         ("caps", "Cc" | "Ar" | "Rustc") => ImportKind::Type,
         _ => return None,

--- a/vix/src/machine/driver.rs
+++ b/vix/src/machine/driver.rs
@@ -141,6 +141,8 @@ pub const STRING_CONCAT_HOST: u32 = 29;
 pub const ARRAY_JOIN_HOST: u32 = 30;
 pub const DOC_PACKAGE_HOST: u32 = 31;
 pub const TARGET_HOST: u32 = 32;
+pub const VERSION_PARSE_HOST: u32 = 33;
+pub const VALUE_COMPARE_HOST: u32 = 34;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Lane {
@@ -323,6 +325,9 @@ pub enum RenderedValue {
         value: String,
     },
     Flag {
+        value: String,
+    },
+    Version {
         value: String,
     },
     Raw {
@@ -1626,6 +1631,14 @@ impl Driver {
         self.store.borrow_mut().alloc_raw(schema, bytes)
     }
 
+    pub fn intern_version_value(&self, text: &str) -> Result<(i64, bool), String> {
+        let version = super::version::parse(text)?;
+        Ok(self
+            .store
+            .borrow_mut()
+            .alloc_raw("Version", super::version::canonical_bytes(&version)))
+    }
+
     pub fn intern_linux_target(&self) -> (i64, bool) {
         self.intern_structured_target(OS_LINUX, host_arch_index())
             .unwrap_or_else(|_| {
@@ -2711,6 +2724,57 @@ impl Driver {
                 }
             };
 
+            let mut version_parse_host = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let input = read_frame_word(frame, primitive_region + 8);
+                    let text = store_cell.borrow().string_value(input, "String")?;
+                    let version = super::version::parse(&text)?;
+                    let (handle, _) = store_cell
+                        .borrow_mut()
+                        .alloc_raw("Version", super::version::canonical_bytes(&version));
+                    write_frame_word(frame, dst_slot, handle);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
+            let mut value_compare_host = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let schema =
+                        schema_name_for(read_frame_word(frame, primitive_region + 8), schema_refs)?;
+                    let op = read_frame_word(frame, primitive_region + 16);
+                    let left = read_frame_word(frame, primitive_region + 24);
+                    let right = read_frame_word(frame, primitive_region + 32);
+                    let store = store_cell.borrow();
+                    let ordering = compare_expression_words(
+                        &store,
+                        descriptors,
+                        schema_refs,
+                        &schema,
+                        left,
+                        right,
+                    )?;
+                    let value = match op {
+                        0 => ordering == Ordering::Equal,
+                        1 => ordering != Ordering::Equal,
+                        2 => ordering == Ordering::Less,
+                        3 => ordering != Ordering::Greater,
+                        4 => ordering == Ordering::Greater,
+                        5 => ordering != Ordering::Less,
+                        other => return Err(format!("unknown compare op {other}")),
+                    };
+                    write_frame_word(frame, dst_slot, i64::from(value));
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
             let mut ast_fn_host = |frame: &mut [u8]| {
                 let result = (|| {
                     let dst_slot = read_frame_word(frame, primitive_region) as usize;
@@ -3021,7 +3085,7 @@ impl Driver {
                 }
             };
 
-            let mut hosts: [HostFn<'_>; 33] = [
+            let mut hosts: [HostFn<'_>; 35] = [
                 &mut invoke,
                 &mut store_alloc,
                 &mut store_read,
@@ -3055,6 +3119,8 @@ impl Driver {
                 &mut array_join_host,
                 &mut doc_package_host,
                 &mut target_host,
+                &mut version_parse_host,
+                &mut value_compare_host,
             ];
             let step = exec
                 .task
@@ -4239,6 +4305,7 @@ enum DocPayload {
     Int(i64),
     Float(i64),
     String(i64),
+    Blob(i64),
     Array(i64),
     Map(i64),
     Virtual(i64),
@@ -4262,6 +4329,10 @@ fn alloc_doc_from_value(
         Value::Str(value) => {
             let handle = store.borrow_mut().alloc_raw("String", value.into_bytes()).0;
             alloc_doc_variant(store, descriptors, 4, &[handle])
+        }
+        Value::Blob(value) => {
+            let handle = store.borrow_mut().alloc_raw("Blob", value).0;
+            alloc_doc_variant(store, descriptors, 8, &[handle])
         }
         Value::Array(values) => {
             let words = values
@@ -4355,6 +4426,10 @@ fn doc_payload(
             field_offset(descriptor, &entry.bytes, 0),
         )),
         4 => DocPayload::String(read_frame_word(
+            &entry.bytes,
+            field_offset(descriptor, &entry.bytes, 0),
+        )),
+        8 => DocPayload::Blob(read_frame_word(
             &entry.bytes,
             field_offset(descriptor, &entry.bytes, 0),
         )),
@@ -4534,7 +4609,10 @@ fn oci_virtual_file_get(
                     (Value::Str("path".to_string()), Value::Str(path.to_string())),
                     (
                         Value::Str("contents".to_string()),
-                        Value::Str(file.contents),
+                        match file.contents {
+                            super::oci::FileContents::Text(contents) => Value::Str(contents),
+                            super::oci::FileContents::Blob(contents) => Value::Blob(contents),
+                        },
                     ),
                     (
                         Value::Str("layer_digest".to_string()),
@@ -4605,6 +4683,7 @@ fn doc_coerce(
         (DocPayload::Int(value), "Int") => Ok(value),
         (DocPayload::Float(value), "Float") => Ok(value),
         (DocPayload::String(value), "String") => Ok(value),
+        (DocPayload::Blob(value), "Blob") => Ok(value),
         (DocPayload::Array(value), "Array") => Ok(value),
         (DocPayload::Map(value), "Map<String,Doc>") => Ok(value),
         (DocPayload::Virtual(_), schema) => Err(format!("cannot coerce Doc::Virtual to {schema}")),
@@ -4974,11 +5053,44 @@ fn compare_words(
             let b = store.string_value(b, schema)?;
             Ok(a.cmp(&b))
         }
+        "Version" => {
+            let a = store.entry(a).ok_or_else(|| format!("store handle {a}"))?;
+            let b = store.entry(b).ok_or_else(|| format!("store handle {b}"))?;
+            if a.schema != "Version" || b.schema != "Version" {
+                return Err(format!(
+                    "compare expected Version, got {} and {}",
+                    a.schema, b.schema
+                ));
+            }
+            super::version::cmp_total(&a.bytes, &b.bytes)
+        }
         "Array" => compare_arrays(store, descriptors, schema_refs, a, b),
         schema if schema.starts_with("Map<") => compare_maps(store, descriptors, schema_refs, a, b),
         "Doc" => compare_docs(store, descriptors, schema_refs, a, b),
         schema => compare_declared_value(store, descriptors, schema_refs, schema, a, b),
     }
+}
+
+fn compare_expression_words(
+    store: &ValueStore,
+    descriptors: &HashMap<String, Descriptor<String>>,
+    schema_refs: &[String],
+    schema: &str,
+    a: i64,
+    b: i64,
+) -> Result<Ordering, String> {
+    if schema == "Version" {
+        let a = store.entry(a).ok_or_else(|| format!("store handle {a}"))?;
+        let b = store.entry(b).ok_or_else(|| format!("store handle {b}"))?;
+        if a.schema != "Version" || b.schema != "Version" {
+            return Err(format!(
+                "compare expected Version, got {} and {}",
+                a.schema, b.schema
+            ));
+        }
+        return super::version::cmp_precedence(&a.bytes, &b.bytes);
+    }
+    compare_words(store, descriptors, schema_refs, schema, a, b)
 }
 
 fn compare_arrays(
@@ -5076,6 +5188,7 @@ fn compare_docs(
         DocPayload::Array(_) => 5,
         DocPayload::Map(_) => 6,
         DocPayload::Virtual(_) => 7,
+        DocPayload::Blob(_) => 8,
     };
     let tag_order = tag(&a_payload).cmp(&tag(&b_payload));
     if tag_order != Ordering::Equal {
@@ -5090,6 +5203,9 @@ fn compare_docs(
         }
         (DocPayload::String(a), DocPayload::String(b)) => {
             compare_words(store, descriptors, schema_refs, "String", a, b)
+        }
+        (DocPayload::Blob(a), DocPayload::Blob(b)) => {
+            compare_words(store, descriptors, schema_refs, "Blob", a, b)
         }
         (DocPayload::Array(a), DocPayload::Array(b)) => {
             compare_words(store, descriptors, schema_refs, "Array", a, b)
@@ -5285,6 +5401,9 @@ fn render_word(
         }),
         "Path" => Ok(RenderedValue::Path {
             value: store.string_value(word, "Path")?,
+        }),
+        "Version" => Ok(RenderedValue::Version {
+            value: store.string_value(word, "Version")?,
         }),
         "Flag" => Ok(RenderedValue::Flag {
             value: store.string_value(word, "Flag")?,
@@ -5531,6 +5650,15 @@ fn render_doc(
                 "String",
                 word,
             )?)),
+        ),
+        DocPayload::Blob(word) => (
+            "Blob".to_string(),
+            Some(Box::new(RenderedValue::Raw {
+                schema: "Blob".to_string(),
+                bytes_utf8: store
+                    .entry(word)
+                    .and_then(|entry| String::from_utf8(entry.bytes.clone()).ok()),
+            })),
         ),
         DocPayload::Array(word) => (
             "Array".to_string(),
@@ -6235,7 +6363,10 @@ fn doc_get_observation_hash(
                     (Value::Str("path".to_string()), Value::Str(key.to_string())),
                     (
                         Value::Str("contents".to_string()),
-                        Value::Str(file.contents),
+                        match file.contents {
+                            super::oci::FileContents::Text(contents) => Value::Str(contents),
+                            super::oci::FileContents::Blob(contents) => Value::Blob(contents),
+                        },
                     ),
                     (
                         Value::Str("layer_digest".to_string()),

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -35,7 +35,7 @@ use super::driver::{
     MAP_GET_HOST, MAP_INSERT_HOST, MachineExecBackend, OCI_DOC_HOST, OPTION_UNWRAP_HOST,
     PATH_WITH_EXT_HOST, PENDING_ALLOC_HOST, PENDING_COERCE_HOST, PENDING_INVOKE_HOST, RenderNames,
     RenderVariant, RenderedValue, STORE_ALLOC_HOST, STORE_READ_HOST, STORE_TAG_HOST,
-    STRING_CONCAT_HOST, StepMode, StoreHandle, TARGET_HOST, TREE_PROJECT_HOST, ValueBundle,
+    STRING_CONCAT_HOST, StepMode, StoreHandle, TARGET_HOST, VALUE_COMPARE_HOST, VERSION_PARSE_HOST, TREE_PROJECT_HOST, ValueBundle,
 
 };
 use crate::ast;
@@ -496,6 +496,9 @@ impl Machine {
             ("Int", MachineArg::Int(value)) => Ok(StoreHandle(value)),
             ("Float", MachineArg::Float(value)) => Ok(StoreHandle(value.to_bits() as i64)),
             ("Bool", MachineArg::Bool(value)) => Ok(StoreHandle(value as i64)),
+            ("Version", MachineArg::String(value)) => {
+                Ok(StoreHandle(self.driver.intern_version_value(&value)?.0))
+            }
             ("String", MachineArg::String(value)) => Ok(StoreHandle(
                 self.driver.intern_raw_value("String", value.into_bytes()).0,
             )),
@@ -732,6 +735,7 @@ fn schema_names_for(
         "Array".to_string(),
         "Map".to_string(),
         "Doc".to_string(),
+        "Version".to_string(),
         "Option<Doc>".to_string(),
         "Pending<Doc>".to_string(),
         "Realized<Doc>".to_string(),
@@ -1480,6 +1484,12 @@ fn collect_expr_schemas(
             {
                 return Ok(Some(schema.clone()));
             }
+            if let ast::PathRef::Identifier(name) = &call.callee
+                && name.value == "version"
+            {
+                out.push("Version".to_string());
+                return Ok(Some("Version".to_string()));
+            }
             if let Ok((enum_name, _, _)) = resolve_path_variant_for_collect(tables, &call.callee) {
                 return Ok(Some(enum_name));
             }
@@ -1697,6 +1707,7 @@ fn add_builtin_descriptors(descriptors: &mut HashMap<String, Descriptor<String>>
                     "Map<String,Doc>".into(),
                 )],
                 vec![declared_mem::handle("DocVirtual".into(), "String".into())],
+                vec![declared_mem::handle("DocBlob".into(), "Blob".into())],
             ],
         )
     });
@@ -2174,6 +2185,12 @@ impl<'a> FnLowerer<'a> {
                 if b.op == "+" && a.schema == "String" && r.schema == "String" {
                     return self.string_concat(&a, &r);
                 }
+                if a.schema == "Version"
+                    && r.schema == "Version"
+                    && matches!(b.op.as_str(), "==" | "!=" | "<" | "<=" | ">" | ">=")
+                {
+                    return self.compare_value(b.op.as_str(), &a, &r, "Version");
+                }
                 let dst = self.alloc();
                 let (op, schema) = match (b.op.as_str(), a.schema.as_str(), r.schema.as_str()) {
                     ("+", "Int", "Int") => (
@@ -2248,6 +2265,38 @@ impl<'a> FnLowerer<'a> {
                             "Bool",
                         )
                     }
+                    ("<", "Int", "Int") => (
+                        Op::LtI64 {
+                            dst,
+                            a: a.slot,
+                            b: r.slot,
+                        },
+                        "Bool",
+                    ),
+                    ("<=", "Int", "Int") => (
+                        Op::LeI64 {
+                            dst,
+                            a: a.slot,
+                            b: r.slot,
+                        },
+                        "Bool",
+                    ),
+                    (">", "Int", "Int") => (
+                        Op::GtI64 {
+                            dst,
+                            a: a.slot,
+                            b: r.slot,
+                        },
+                        "Bool",
+                    ),
+                    (">=", "Int", "Int") => (
+                        Op::GeI64 {
+                            dst,
+                            a: a.slot,
+                            b: r.slot,
+                        },
+                        "Bool",
+                    ),
                     ("&&", "Bool", "Bool") => (
                         Op::MulI64 {
                             dst,
@@ -2572,6 +2621,7 @@ impl<'a> FnLowerer<'a> {
             "extract" => return self.extract_call(call),
             "toml" => return self.doc_parse_call(call, 0),
             "json" => return self.doc_parse_call(call, 1),
+            "version" => return self.version_call(call),
             "elf" => return self.elf_call(call),
             "ast" => return self.ast_call(call),
             "oci" => return self.oci_call(call),
@@ -3404,7 +3454,7 @@ impl<'a> FnLowerer<'a> {
         if value.schema == "Doc"
             && matches!(
                 expected,
-                "String" | "Int" | "Bool" | "Float" | "Array" | "Map<String,Doc>"
+                "String" | "Int" | "Bool" | "Float" | "Blob" | "Array" | "Map<String,Doc>"
             )
         {
             return self.coerce_doc_to_schema(value, expected);
@@ -4673,7 +4723,13 @@ impl<'a> FnLowerer<'a> {
         let [ast::Arg::Expr(arg)] = call.args.args.as_slice() else {
             return Err("elf takes one Blob, String, or single-blob Tree".into());
         };
-        let input = self.expr(arg)?;
+        let mut input = self.expr(arg)?;
+        if input.schema == "Realized<Doc>" {
+            input = self.coerce_to_schema(input, "Doc")?;
+        }
+        if input.schema == "Doc" {
+            input = self.coerce_to_schema(input, "Blob")?;
+        }
         if !matches!(input.schema.as_str(), "Blob" | "String" | "Tree") {
             return Err(format!("elf called on {}", input.schema));
         }
@@ -4745,6 +4801,88 @@ impl<'a> FnLowerer<'a> {
         Ok(ValueSlot {
             slot: dst,
             schema: "Doc".into(),
+            realization: None,
+            pending: None,
+        })
+    }
+
+    fn version_call(&mut self, call: &ast::Call) -> Result<ValueSlot, String> {
+        let [ast::Arg::Expr(arg)] = call.args.args.as_slice() else {
+            return Err("version takes one String".into());
+        };
+        let input = self.expr_expected(arg, Some("String"))?;
+        if input.schema != "String" {
+            return Err(format!("version called on {}", input.schema));
+        }
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: input.slot,
+        });
+        self.code.push(Op::HostCall {
+            host: VERSION_PARSE_HOST,
+        });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: "Version".into(),
+            realization: None,
+            pending: None,
+        })
+    }
+
+    fn compare_value(
+        &mut self,
+        op: &str,
+        left: &ValueSlot,
+        right: &ValueSlot,
+        schema: &str,
+    ) -> Result<ValueSlot, String> {
+        let dst = self.alloc();
+        let schema_ref = *self
+            .schema_refs
+            .get(schema)
+            .ok_or_else(|| format!("no schema ref for {schema}"))?;
+        let op_code = match op {
+            "==" => 0,
+            "!=" => 1,
+            "<" => 2,
+            "<=" => 3,
+            ">" => 4,
+            ">=" => 5,
+            other => return Err(format!("unknown comparison operator {other:?}")),
+        };
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::ConstI64 {
+            dst: region + 8,
+            value: schema_ref,
+        });
+        self.code.push(Op::ConstI64 {
+            dst: region + 16,
+            value: op_code,
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 24,
+            src: left.slot,
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 32,
+            src: right.slot,
+        });
+        self.code.push(Op::HostCall {
+            host: VALUE_COMPARE_HOST,
+        });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: "Bool".into(),
             realization: None,
             pending: None,
         })
@@ -4890,7 +5028,8 @@ fn strict_binary_operand_schema<'a>(op: &str, left: &'a str, right: &'a str) -> 
         ("+" | "-" | "*", "Int")
         | ("+" | "*", "Float")
         | ("+", "String")
-        | ("==" | "!=", "Int" | "Float" | "String" | "Path" | "Bool")
+        | ("==" | "!=", "Int" | "Float" | "String" | "Path" | "Bool" | "Version")
+        | ("<" | "<=" | ">" | ">=", "Int" | "Version")
         | ("&&", "Bool") => Some(left),
         _ => None,
     }
@@ -5263,6 +5402,37 @@ pub fn poly(n: Int) -> Int {
         )
     }
 
+    fn oci_layout_with_libc(libc: &[u8]) -> Tree {
+        let config = r#"{"config":{"Env":[],"Entrypoint":[],"Cmd":[]}}"#;
+        let config_digest = digest(config.as_bytes());
+        let config_path = blob_path(&config_digest);
+        let layer = tar_blob(&[("usr/lib/libc.so.6", libc)]);
+        let layer_digest = digest(&layer);
+        let manifest = format!(
+            r#"{{"schemaVersion":2,"config":{{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"{config_digest}","size":{config_size}}},"layers":[{{"mediaType":"application/vnd.oci.image.layer.v1.tar","digest":"{layer_digest}","size":{layer_size}}}]}}"#,
+            config_size = config.len(),
+            layer_size = layer.len(),
+        );
+        let manifest_digest = digest(manifest.as_bytes());
+        let manifest_path = blob_path(&manifest_digest);
+        let index = format!(
+            r#"{{"schemaVersion":2,"manifests":[{{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"{manifest_digest}","size":{manifest_size}}}]}}"#,
+            manifest_size = manifest.len(),
+        );
+        Tree {
+            entries: BTreeMap::from([
+                (
+                    "oci-layout".to_string(),
+                    r#"{"imageLayoutVersion":"1.0.0"}"#.to_string(),
+                ),
+                ("index.json".to_string(), index),
+                (manifest_path, manifest),
+                (config_path, config.to_string()),
+            ]),
+            blobs: BTreeMap::from([(blob_path(&layer_digest), layer)]),
+        }
+    }
+
     fn digest(bytes: &[u8]) -> String {
         let mut hasher = Sha256::new();
         hasher.update(bytes);
@@ -5275,6 +5445,10 @@ pub fn poly(n: Int) -> Int {
     }
 
     fn tar(entries: &[(&str, &[u8])]) -> String {
+        String::from_utf8(tar_blob(entries)).expect("test tar is valid UTF-8")
+    }
+
+    fn tar_blob(entries: &[(&str, &[u8])]) -> Vec<u8> {
         let mut out = Vec::new();
         for (path, contents) in entries {
             let mut header = [0u8; 512];
@@ -5296,7 +5470,7 @@ pub fn poly(n: Int) -> Int {
             out.resize(out.len().div_ceil(512) * 512, 0);
         }
         out.resize(out.len() + 1024, 0);
-        String::from_utf8(out).expect("test tar is valid UTF-8")
+        out
     }
 
     fn write_octal(dst: &mut [u8], value: u64) {
@@ -8439,6 +8613,30 @@ pub fn env(input: Blob) -> [String] { oci(input).env }
     }
 
     #[test]
+    fn oci_glibc_preflight_uses_version_ordering_without_execution() {
+        let src = include_str!(
+            "../../../playgrounds/snark/src/bundled/vix/samples/oci-glibc-preflight.vix"
+        );
+        let meets = oci_layout_with_libc(include_bytes!("../../tests/fixtures/elf/hello-x86_64"));
+        let below =
+            oci_layout_with_libc(include_bytes!("../../tests/fixtures/elf/libtiny-x86_64.so"));
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            let meets = machine.intern_tree_concrete(meets.clone());
+            let below = machine.intern_tree_concrete(below.clone());
+            assert_eq!(machine.demand_i64("matches_floor", vec![meets]).unwrap(), 1);
+            assert_eq!(machine.demand_i64("matches_floor", vec![below]).unwrap(), 0);
+            assert!(
+                machine
+                    .trace()
+                    .iter()
+                    .all(|event| !matches!(event, DriveEvent::RunRequested { .. })),
+                "{lane:?}: preflight must not execute"
+            );
+        }
+    }
+
+    #[test]
     fn oci_file_projection_is_path_local_and_memoized() {
         let src = r#"
 pub fn shadow_twice(input: Tree) -> (String, String) {
@@ -8596,6 +8794,60 @@ pub fn az() -> Map<String, Int> {
                     .unwrap(),
                 std::cmp::Ordering::Equal,
                 "{lane:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn version_values_parse_and_compare_by_semver_precedence() {
+        let src = r#"
+pub fn release_after_pre() -> Bool { version("1.0.0") > version("1.0.0-rc.1") }
+pub fn numeric_pre_before_alpha() -> Bool { version("1.0.0-1") < version("1.0.0-alpha") }
+pub fn prerelease_chain() -> Bool {
+    version("1.0.0-alpha") < version("1.0.0-alpha.1")
+        && version("1.0.0-alpha.1") < version("1.0.0-alpha.beta")
+        && version("1.0.0-beta.2") < version("1.0.0-beta.11")
+}
+pub fn build_metadata_ignored_by_language_equality() -> Bool {
+    version("1.2.3+abc") == version("1.2.3+xyz")
+}
+pub fn glibc_name_normalizes() -> Bool { version("GLIBC_2.35") == version("2.35.0") }
+"#;
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            for name in [
+                "release_after_pre",
+                "numeric_pre_before_alpha",
+                "prerelease_chain",
+                "build_metadata_ignored_by_language_equality",
+                "glibc_name_normalizes",
+            ] {
+                assert_eq!(
+                    machine.demand_i64(name, vec![]).unwrap(),
+                    1,
+                    "{lane:?}: {name}"
+                );
+            }
+
+            let a = machine.driver.intern_version_value("1.2.3+abc").unwrap().0;
+            let b = machine.driver.intern_version_value("1.2.3+xyz").unwrap().0;
+            assert_eq!(
+                machine.driver.compare_store_words("Version", a, b).unwrap(),
+                std::cmp::Ordering::Less,
+                "store ordering remains total on {lane:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_version_parse_is_a_loud_machine_error() {
+        let src = r#"pub fn bad() -> Version { version("1.x") }"#;
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            let err = machine.demand_i64("bad", vec![]).unwrap_err();
+            assert!(
+                err.contains("version(\"1.x\") parse error"),
+                "{lane:?}: {err}"
             );
         }
     }

--- a/vix/src/machine/mod.rs
+++ b/vix/src/machine/mod.rs
@@ -66,6 +66,7 @@ mod elf;
 pub mod lower;
 mod oci;
 pub mod value;
+mod version;
 
 pub use driver::{
     CodeBundle, CodeRef, DriveEvent, MachineExecBackend, MachineExecRequest, MachinePathDemand,

--- a/vix/src/machine/oci.rs
+++ b/vix/src/machine/oci.rs
@@ -77,8 +77,14 @@ struct LayerDescriptor {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct FileProjection {
     pub layer_digest: String,
-    pub contents: String,
+    pub contents: FileContents,
     pub size: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum FileContents {
+    Text(String),
+    Blob(Vec<u8>),
 }
 
 pub(super) fn parse_layout(tree: Tree) -> Result<Layout, String> {
@@ -178,8 +184,10 @@ pub(super) fn project_file(layout: &Layout, path: &str) -> Result<Option<FilePro
                 return Ok(Some(FileProjection {
                     layer_digest: layer.digest.clone(),
                     size: i64::try_from(contents.len()).unwrap_or(i64::MAX),
-                    contents: String::from_utf8(contents)
-                        .map_err(|err| format!("OCI file `{path}` is not UTF-8: {err}"))?,
+                    contents: match String::from_utf8(contents) {
+                        Ok(text) => FileContents::Text(text),
+                        Err(err) => FileContents::Blob(err.into_bytes()),
+                    },
                 }));
             }
             LayerHit::Whiteout => return Ok(None),
@@ -193,6 +201,7 @@ pub(super) fn input_hash(tree: &Tree) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(b"vix-oci-layout-tree");
     for (path, contents) in &tree.entries {
+        hasher.update([0]);
         hasher.update(
             i64::try_from(path.len())
                 .expect("path length fits i64")
@@ -205,6 +214,21 @@ pub(super) fn input_hash(tree: &Tree) -> [u8; 32] {
                 .to_le_bytes(),
         );
         hasher.update(contents.as_bytes());
+    }
+    for (path, contents) in &tree.blobs {
+        hasher.update([1]);
+        hasher.update(
+            i64::try_from(path.len())
+                .expect("path length fits i64")
+                .to_le_bytes(),
+        );
+        hasher.update(path.as_bytes());
+        hasher.update(
+            i64::try_from(contents.len())
+                .expect("contents length fits i64")
+                .to_le_bytes(),
+        );
+        hasher.update(contents);
     }
     hasher.finalize().into()
 }
@@ -283,12 +307,13 @@ fn blob_path(digest: &str) -> Result<String, String> {
 
 fn layer_bytes<'a>(layout: &'a Layout, digest: &str) -> Result<&'a [u8], String> {
     let path = blob_path(digest)?;
-    let contents = layout
-        .tree
-        .entries
-        .get(&path)
-        .ok_or_else(|| format!("OCI layout is missing layer blob `{path}`"))?;
-    Ok(contents.as_bytes())
+    if let Some(contents) = layout.tree.entries.get(&path) {
+        return Ok(contents.as_bytes());
+    }
+    if let Some(contents) = layout.tree.blobs.get(&path) {
+        return Ok(contents);
+    }
+    Err(format!("OCI layout is missing layer blob `{path}`"))
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/vix/src/machine/version.rs
+++ b/vix/src/machine/version.rs
@@ -1,0 +1,60 @@
+use std::cmp::Ordering;
+
+use semver::Version;
+
+pub(super) fn parse(text: &str) -> Result<Version, String> {
+    let normalized = normalize_input(text);
+    Version::parse(&normalized).map_err(|err| format!("version({text:?}) parse error: {err}"))
+}
+
+pub(super) fn parse_bytes(bytes: &[u8]) -> Result<Version, String> {
+    let text = std::str::from_utf8(bytes).map_err(|err| err.to_string())?;
+    Version::parse(text).map_err(|err| format!("stored Version {text:?} parse error: {err}"))
+}
+
+pub(super) fn canonical_bytes(version: &Version) -> Vec<u8> {
+    version.to_string().into_bytes()
+}
+
+pub(super) fn cmp_total(a: &[u8], b: &[u8]) -> Result<Ordering, String> {
+    Ok(parse_bytes(a)?.cmp(&parse_bytes(b)?))
+}
+
+pub(super) fn cmp_precedence(a: &[u8], b: &[u8]) -> Result<Ordering, String> {
+    Ok(parse_bytes(a)?.cmp_precedence(&parse_bytes(b)?))
+}
+
+fn normalize_input(text: &str) -> String {
+    let text = text.strip_prefix("GLIBC_").unwrap_or(text);
+    let (core_and_pre, build) = text
+        .split_once('+')
+        .map_or((text, None), |(core, build)| (core, Some(build)));
+    let (core, pre) = core_and_pre
+        .split_once('-')
+        .map_or((core_and_pre, None), |(core, pre)| (core, Some(pre)));
+    let dot_count = core.bytes().filter(|byte| *byte == b'.').count();
+    let mut normalized = core.to_string();
+    if dot_count == 1 {
+        normalized.push_str(".0");
+    }
+    if let Some(pre) = pre {
+        normalized.push('-');
+        normalized.push_str(pre);
+    }
+    if let Some(build) = build {
+        normalized.push('+');
+        normalized.push_str(build);
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glibc_names_normalize_to_semver() {
+        assert_eq!(parse("GLIBC_2.35").unwrap().to_string(), "2.35.0");
+        assert!(parse("GLIBC_").is_err());
+    }
+}

--- a/vix/src/value.rs
+++ b/vix/src/value.rs
@@ -9,6 +9,7 @@ pub enum Value {
     Int(i64),
     Float(f64),
     Bool(bool),
+    Blob(Vec<u8>),
     Str(String),
     Path(String),
     Flag(String),
@@ -68,6 +69,7 @@ impl Value {
             Value::Closure { .. } => 12,
             Value::Partial { .. } => 13,
             Value::Tree(_) => 14,
+            Value::Blob(_) => 15,
         }
     }
 
@@ -83,6 +85,7 @@ impl Value {
             Value::Int(v) => v.to_string(),
             Value::Float(v) => v.to_string(),
             Value::Bool(v) => v.to_string(),
+            Value::Blob(v) => format!("blob({} bytes)", v.len()),
             Value::Str(v) => format!("{v:?}"),
             Value::Path(v) => v.clone(),
             Value::Flag(v) => v.clone(),
@@ -120,6 +123,7 @@ impl Value {
             Value::Int(v) => v.hash(h),
             Value::Float(v) => normalize_float(*v).to_bits().hash(h),
             Value::Bool(v) => v.hash(h),
+            Value::Blob(v) => v.hash(h),
             Value::Str(v) | Value::Path(v) | Value::Flag(v) => v.hash(h),
             Value::Tuple(vs) | Value::Array(vs) => {
                 vs.len().hash(h);
@@ -224,6 +228,7 @@ impl Ord for Value {
             (Value::Int(a), Value::Int(b)) => a.cmp(b),
             (Value::Float(a), Value::Float(b)) => float_cmp(*a, *b),
             (Value::Bool(a), Value::Bool(b)) => a.cmp(b),
+            (Value::Blob(a), Value::Blob(b)) => a.cmp(b),
             (Value::Str(a), Value::Str(b))
             | (Value::Path(a), Value::Path(b))
             | (Value::Flag(a), Value::Flag(b)) => a.cmp(b),


### PR DESCRIPTION
## Summary
- add a handle-backed Version value kind parsed by version(...) with semver precedence comparisons
- wire Version into vix builtin types, machine comparison/rendering, and canonical store ordering
- make OCI file projection preserve binary contents as Blob so elf(...).needs_glibc can inspect libc from an image layer
- rewrite oci-glibc-preflight.vix to compare parsed glibc Version against a floor without execution

## Verification
- cargo nextest run -p vix -p weavy
- cargo clippy -p vix -p weavy --all-features --all-targets --message-format=short -- -D warnings
- cargo check -p vix --target wasm32-unknown-unknown