### PR TITLE
vix: Target grows arch + host()

### DIFF
--- a/vix/src/binder.rs
+++ b/vix/src/binder.rs
@@ -339,7 +339,7 @@ fn builtin_module_item(module: &str, name: &str) -> Option<ModuleItem> {
         (
             "vix",
             "Int" | "Float" | "String" | "Bool" | "Blob" | "Doc" | "Tree" | "Path" | "Target"
-            | "Map" | "Array" | "Flag" | "Run" | "Os",
+            | "Map" | "Array" | "Flag" | "Run" | "Os" | "Arch",
         ) => ImportKind::Type,
         ("caps", "Cc" | "Ar" | "Rustc") => ImportKind::Type,
         _ => return None,

--- a/vix/src/machine/driver.rs
+++ b/vix/src/machine/driver.rs
@@ -140,6 +140,7 @@ pub const OCI_DOC_HOST: u32 = 28;
 pub const STRING_CONCAT_HOST: u32 = 29;
 pub const ARRAY_JOIN_HOST: u32 = 30;
 pub const DOC_PACKAGE_HOST: u32 = 31;
+pub const TARGET_HOST: u32 = 32;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Lane {
@@ -1626,42 +1627,34 @@ impl Driver {
     }
 
     pub fn intern_linux_target(&self) -> (i64, bool) {
-        self.intern_structured_target(0).unwrap_or_else(|_| {
-            self.store
-                .borrow_mut()
-                .alloc_raw("Target", 0x391c555cf0975f9cu64.to_le_bytes().to_vec())
-        })
+        self.intern_structured_target(OS_LINUX, host_arch_index())
+            .unwrap_or_else(|_| {
+                self.store
+                    .borrow_mut()
+                    .alloc_raw("Target", 0x391c555cf0975f9cu64.to_le_bytes().to_vec())
+            })
     }
 
     #[cfg(test)]
     pub fn intern_windows_target(&self) -> Result<(i64, bool), String> {
-        self.intern_structured_target(2)
+        self.intern_structured_target(OS_WINDOWS, host_arch_index())
     }
 
-    fn intern_structured_target(&self, os_index: u64) -> Result<(i64, bool), String> {
-        let os_descriptor = self
-            .descriptors
-            .get("Os")
-            .ok_or_else(|| "missing Os descriptor".to_string())?;
-        let mut os_bytes = vec![0u8; os_descriptor.layout.size];
-        write_variant_tag(&mut os_bytes, os_descriptor, os_index);
-        let os = self
-            .store
-            .borrow_mut()
-            .alloc("Os", os_bytes, &self.descriptors)
-            .0;
+    pub fn intern_host_target(&self) -> Result<(i64, bool), String> {
+        self.intern_structured_target(host_os_index(), host_arch_index())
+    }
 
-        let target_descriptor = self
-            .descriptors
-            .get("Target")
-            .ok_or_else(|| "missing Target descriptor".to_string())?;
-        let mut target_bytes = vec![0u8; target_descriptor.layout.size];
-        let offset = field_offset(target_descriptor, &target_bytes, 0);
-        target_bytes[offset..offset + 8].copy_from_slice(&os.to_le_bytes());
-        Ok(self
-            .store
-            .borrow_mut()
-            .alloc("Target", target_bytes, &self.descriptors))
+    #[cfg(test)]
+    pub fn intern_target(&self, os_index: u64, arch_index: u64) -> Result<(i64, bool), String> {
+        self.intern_structured_target(os_index, arch_index)
+    }
+
+    fn intern_structured_target(
+        &self,
+        os_index: u64,
+        arch_index: u64,
+    ) -> Result<(i64, bool), String> {
+        intern_structured_target(&self.store, &self.descriptors, os_index, arch_index)
     }
 
     /// Demand one invocation's identity: the edge of the machine.
@@ -3011,7 +3004,24 @@ impl Driver {
                 });
             };
 
-            let mut hosts: [HostFn<'_>; 32] = [
+            let mut target_host = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let (handle, _) = intern_structured_target(
+                        store_cell,
+                        descriptors,
+                        host_os_index(),
+                        host_arch_index(),
+                    )?;
+                    write_frame_word(frame, dst_slot, handle);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
+            let mut hosts: [HostFn<'_>; 33] = [
                 &mut invoke,
                 &mut store_alloc,
                 &mut store_read,
@@ -3044,6 +3054,7 @@ impl Driver {
                 &mut string_concat_host,
                 &mut array_join_host,
                 &mut doc_package_host,
+                &mut target_host,
             ];
             let step = exec
                 .task
@@ -6830,6 +6841,98 @@ fn decode_bytes(bytes: &[u8], at: &mut usize) -> Result<Vec<u8>, String> {
     Ok(value)
 }
 
+const OS_LINUX: u64 = 0;
+const OS_MACOS: u64 = 1;
+const OS_WINDOWS: u64 = 2;
+
+const ARCH_X86_64: u64 = 0;
+const ARCH_AARCH64: u64 = 1;
+const ARCH_ARM: u64 = 2;
+const ARCH_RISCV64: u64 = 3;
+const ARCH_WASM32: u64 = 4;
+const ARCH_UNKNOWN: u64 = 5;
+
+fn host_os_index() -> u64 {
+    if cfg!(target_os = "linux") {
+        OS_LINUX
+    } else if cfg!(target_os = "macos") {
+        OS_MACOS
+    } else if cfg!(target_os = "windows") {
+        OS_WINDOWS
+    } else {
+        OS_LINUX
+    }
+}
+
+fn host_arch_index() -> u64 {
+    if cfg!(target_arch = "x86_64") {
+        ARCH_X86_64
+    } else if cfg!(target_arch = "aarch64") {
+        ARCH_AARCH64
+    } else if cfg!(target_arch = "arm") {
+        ARCH_ARM
+    } else if cfg!(target_arch = "riscv64") {
+        ARCH_RISCV64
+    } else if cfg!(target_arch = "wasm32") {
+        ARCH_WASM32
+    } else {
+        ARCH_UNKNOWN
+    }
+}
+
+fn os_variant_name(index: usize) -> &'static str {
+    match index {
+        0 => "Linux",
+        1 => "Macos",
+        2 => "Windows",
+        _ => "Unknown",
+    }
+}
+
+fn arch_variant_name(index: usize) -> &'static str {
+    match index {
+        0 => "X86_64",
+        1 => "Aarch64",
+        2 => "Arm",
+        3 => "Riscv64",
+        4 => "Wasm32",
+        _ => "Unknown",
+    }
+}
+
+fn intern_structured_target(
+    store: &RefCell<ValueStore>,
+    descriptors: &HashMap<String, Descriptor<String>>,
+    os_index: u64,
+    arch_index: u64,
+) -> Result<(i64, bool), String> {
+    let os_descriptor = descriptors
+        .get("Os")
+        .ok_or_else(|| "missing Os descriptor".to_string())?;
+    let mut os_bytes = vec![0u8; os_descriptor.layout.size];
+    write_variant_tag(&mut os_bytes, os_descriptor, os_index);
+    let os = store.borrow_mut().alloc("Os", os_bytes, descriptors).0;
+
+    let arch_descriptor = descriptors
+        .get("Arch")
+        .ok_or_else(|| "missing Arch descriptor".to_string())?;
+    let mut arch_bytes = vec![0u8; arch_descriptor.layout.size];
+    write_variant_tag(&mut arch_bytes, arch_descriptor, arch_index);
+    let arch = store.borrow_mut().alloc("Arch", arch_bytes, descriptors).0;
+
+    let target_descriptor = descriptors
+        .get("Target")
+        .ok_or_else(|| "missing Target descriptor".to_string())?;
+    let mut target_bytes = vec![0u8; target_descriptor.layout.size];
+    let os_offset = field_offset(target_descriptor, &target_bytes, 0);
+    target_bytes[os_offset..os_offset + 8].copy_from_slice(&os.to_le_bytes());
+    let arch_offset = field_offset(target_descriptor, &target_bytes, 1);
+    target_bytes[arch_offset..arch_offset + 8].copy_from_slice(&arch.to_le_bytes());
+    Ok(store
+        .borrow_mut()
+        .alloc("Target", target_bytes, descriptors))
+}
+
 fn target_hash(store: &RefCell<ValueStore>, handle: i64) -> Result<u64, String> {
     let store = store.borrow();
     let entry = store
@@ -6838,31 +6941,48 @@ fn target_hash(store: &RefCell<ValueStore>, handle: i64) -> Result<u64, String> 
     if entry.schema != "Target" {
         return Err(format!("handle {handle} is `{}`, not Target", entry.schema));
     }
-    if entry.bytes.len() != 8 {
+    if entry.bytes.len() != 8 && entry.bytes.len() != 16 {
         return Err(format!("Target entry has {} bytes", entry.bytes.len()));
     }
-    let word = i64::from_le_bytes(entry.bytes[..8].try_into().expect("target hash bytes"));
-    if let Some(os) = store.entry(word)
+    let os_word = i64::from_le_bytes(entry.bytes[..8].try_into().expect("target os bytes"));
+    if let Some(os) = store.entry(os_word)
         && os.schema == "Os"
     {
         let index = usize::from(*os.bytes.first().ok_or("empty Os entry")?);
+        let arch = if entry.bytes.len() >= 16 {
+            let arch_word =
+                i64::from_le_bytes(entry.bytes[8..16].try_into().expect("target arch bytes"));
+            match store.entry(arch_word) {
+                Some(arch) if arch.schema == "Arch" => {
+                    usize::from(*arch.bytes.first().ok_or("empty Arch entry")?)
+                }
+                _ => usize::try_from(host_arch_index()).expect("host arch index fits usize"),
+            }
+        } else {
+            usize::try_from(host_arch_index()).expect("host arch index fits usize")
+        };
         let value = Value::Struct {
             name: "Target".into(),
-            fields: vec![(
-                "os".into(),
-                Value::Variant {
-                    enum_name: "Os".into(),
-                    index,
-                    name: match index {
-                        0 => "Linux",
-                        1 => "Macos",
-                        2 => "Windows",
-                        _ => "Unknown",
-                    }
-                    .into(),
-                    payload: Payload::Unit,
-                },
-            )],
+            fields: vec![
+                (
+                    "os".into(),
+                    Value::Variant {
+                        enum_name: "Os".into(),
+                        index,
+                        name: os_variant_name(index).into(),
+                        payload: Payload::Unit,
+                    },
+                ),
+                (
+                    "arch".into(),
+                    Value::Variant {
+                        enum_name: "Arch".into(),
+                        index: arch,
+                        name: arch_variant_name(arch).into(),
+                        payload: Payload::Unit,
+                    },
+                ),
+            ],
         };
         return Ok(value.canon_hash());
     }

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -35,7 +35,8 @@ use super::driver::{
     MAP_GET_HOST, MAP_INSERT_HOST, MachineExecBackend, OCI_DOC_HOST, OPTION_UNWRAP_HOST,
     PATH_WITH_EXT_HOST, PENDING_ALLOC_HOST, PENDING_COERCE_HOST, PENDING_INVOKE_HOST, RenderNames,
     RenderVariant, RenderedValue, STORE_ALLOC_HOST, STORE_READ_HOST, STORE_TAG_HOST,
-    STRING_CONCAT_HOST, StepMode, StoreHandle, TREE_PROJECT_HOST, ValueBundle,
+    STRING_CONCAT_HOST, StepMode, StoreHandle, TARGET_HOST, TREE_PROJECT_HOST, ValueBundle,
+
 };
 use crate::ast;
 use crate::fetch::FetchBackend;
@@ -720,6 +721,7 @@ fn schema_names_for(
         "Blob".to_string(),
         "Bool".to_string(),
         "Target".to_string(),
+        "Arch".to_string(),
         "Os".to_string(),
         "Cc".to_string(),
         "Ar".to_string(),
@@ -756,7 +758,7 @@ fn schema_names_for(
 }
 
 fn render_names_for(tables: &ModuleTables) -> RenderNames {
-    let structs = tables
+    let mut structs: BTreeMap<String, Vec<String>> = tables
         .structs
         .iter()
         .map(|(name, info)| {
@@ -769,7 +771,10 @@ fn render_names_for(tables: &ModuleTables) -> RenderNames {
             )
         })
         .collect();
-    let enums = tables
+    structs
+        .entry("Target".into())
+        .or_insert_with(|| vec!["os".into(), "arch".into()]);
+    let mut enums: BTreeMap<String, Vec<RenderVariant>> = tables
         .enums
         .iter()
         .map(|(name, info)| {
@@ -791,6 +796,24 @@ fn render_names_for(tables: &ModuleTables) -> RenderNames {
             )
         })
         .collect();
+    enums.entry("Os".into()).or_insert_with(|| {
+        ["Linux", "Macos", "Windows"]
+            .into_iter()
+            .map(|name| RenderVariant {
+                name: name.into(),
+                fields: Vec::new(),
+            })
+            .collect()
+    });
+    enums.entry("Arch".into()).or_insert_with(|| {
+        ["X86_64", "Aarch64", "Arm", "Riscv64", "Wasm32", "Unknown"]
+            .into_iter()
+            .map(|name| RenderVariant {
+                name: name.into(),
+                fields: Vec::new(),
+            })
+            .collect()
+    });
     RenderNames { structs, enums }
 }
 
@@ -1635,12 +1658,21 @@ fn add_builtin_descriptors(descriptors: &mut HashMap<String, Descriptor<String>>
     descriptors.entry("Target".into()).or_insert_with(|| {
         declared_mem::declared_struct(
             "Target".into(),
-            vec![declared_mem::handle("OsRef".into(), "Os".into())],
+            vec![
+                declared_mem::handle("OsRef".into(), "Os".into()),
+                declared_mem::handle("ArchRef".into(), "Arch".into()),
+            ],
         )
     });
     descriptors
         .entry("Os".into())
         .or_insert_with(|| declared_mem::declared_enum("Os".into(), vec![vec![], vec![], vec![]]));
+    descriptors.entry("Arch".into()).or_insert_with(|| {
+        declared_mem::declared_enum(
+            "Arch".into(),
+            vec![vec![], vec![], vec![], vec![], vec![], vec![]],
+        )
+    });
     descriptors.entry("Run".into()).or_insert_with(|| {
         declared_mem::declared_struct(
             "Run".into(),
@@ -2772,6 +2804,19 @@ impl<'a> FnLowerer<'a> {
                 let target = self.expr_expected(target, Some("Target"))?;
                 Ok(Some(self.acquire(kind, &target)?))
             }
+            ["Target", "host"] => {
+                if self
+                    .tables
+                    .resolve_type_module(self.current_module, "Target")
+                    != Some("vix")
+                {
+                    return Ok(None);
+                }
+                if !call.args.args.is_empty() {
+                    return Err("Target::host takes no arguments".into());
+                }
+                Ok(Some(self.target_host()))
+            }
             _ => Ok(None),
         }
     }
@@ -3007,6 +3052,9 @@ impl<'a> FnLowerer<'a> {
                 if receiver.schema == "Target" && name.value == "os" {
                     return Ok(self.store_read(&receiver, 0, "Os".into()));
                 }
+                if receiver.schema == "Target" && name.value == "arch" {
+                    return Ok(self.store_read(&receiver, 1, "Arch".into()));
+                }
                 let info = self
                     .tables
                     .structs
@@ -3063,6 +3111,9 @@ impl<'a> FnLowerer<'a> {
         let path = path_ref_segments(&lit.path)?;
         if path.len() == 1 {
             let name = &path[0];
+            if name == "Target" {
+                return self.target_literal(lit);
+            }
             let info = self
                 .tables
                 .structs
@@ -3127,6 +3178,61 @@ impl<'a> FnLowerer<'a> {
             fields.push(self.expr(&init.value)?);
         }
         self.store_alloc(&enum_name, variant_index, &fields)
+    }
+
+    fn target_literal(&mut self, lit: &ast::StructLiteral) -> Result<ValueSlot, String> {
+        if lit.spreads.len() > 1 {
+            return Err("multiple Target record update spreads are outside the B3 subset".into());
+        }
+        let mut os = None;
+        let mut arch = None;
+        for field in &lit.fields {
+            match field.name.value.as_str() {
+                "os" => {
+                    if os
+                        .replace(self.expr_expected(&field.value, Some("Os"))?)
+                        .is_some()
+                    {
+                        return Err("duplicate field `os` in struct literal `Target`".into());
+                    }
+                }
+                "arch" => {
+                    if arch
+                        .replace(self.expr_expected(&field.value, Some("Arch"))?)
+                        .is_some()
+                    {
+                        return Err("duplicate field `arch` in struct literal `Target`".into());
+                    }
+                }
+                other => return Err(format!("unknown field {other} on Target")),
+            }
+        }
+        let base = match lit.spreads.as_slice() {
+            [] => None,
+            [spread] => {
+                let Some(base) = &spread.base else {
+                    return Err("Target record update spread requires a base expression".into());
+                };
+                Some(self.expr_expected(base, Some("Target"))?)
+            }
+            _ => unreachable!("length checked above"),
+        };
+        let os = if let Some(os) = os {
+            os
+        } else if let Some(base) = &base {
+            self.store_read(base, 0, "Os".into())
+        } else {
+            return Err("missing field os for struct Target".into());
+        };
+        let arch = if let Some(arch) = arch {
+            arch
+        } else if let Some(base) = &base {
+            self.store_read(base, 1, "Arch".into())
+        } else {
+            let host = self.target_host();
+            self.store_read(&host, 1, "Arch".into())
+        };
+        self.store_alloc("Target", 0, &[os, arch])
     }
 
     fn struct_field_schema(&self, struct_name: &str, field_index: usize) -> Result<String, String> {
@@ -3216,12 +3322,7 @@ impl<'a> FnLowerer<'a> {
                 name == variant_name && matches!(shape, VariantShape::Unit)
             });
         }
-        match (enum_name, variant_name) {
-            ("Os", "Linux") => Some(0),
-            ("Os", "Macos") => Some(1),
-            ("Os", "Windows") => Some(2),
-            _ => None,
-        }
+        builtin_unit_variant_index(enum_name, variant_name)
     }
 
     fn bind_payload_pattern(
@@ -3941,6 +4042,22 @@ impl<'a> FnLowerer<'a> {
             realization: None,
             pending: None,
         })
+    }
+
+    fn target_host(&mut self) -> ValueSlot {
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::HostCall { host: TARGET_HOST });
+        ValueSlot {
+            slot: dst,
+            schema: "Target".to_string(),
+            realization: None,
+            pending: None,
+        }
     }
 
     fn array_literal(&mut self, array: &ast::Array) -> Result<ValueSlot, String> {
@@ -4867,10 +4984,12 @@ fn resolve_variant_segments(
     let [enum_name, variant_name] = segments else {
         return Err(format!("path {segments:?} is not a declared variant path"));
     };
-    let info = tables
-        .enums
-        .get(enum_name)
-        .ok_or_else(|| format!("unknown enum {enum_name}"))?;
+    let Some(info) = tables.enums.get(enum_name) else {
+        let Some(index) = builtin_unit_variant_index(enum_name, variant_name) else {
+            return Err(format!("unknown enum {enum_name}"));
+        };
+        return Ok((enum_name.clone(), index, VariantShape::Unit));
+    };
     let (index, (_, shape)) = info
         .variants
         .iter()
@@ -4878,6 +4997,21 @@ fn resolve_variant_segments(
         .find(|(_, (name, _))| name == variant_name)
         .ok_or_else(|| format!("unknown variant {enum_name}::{variant_name}"))?;
     Ok((enum_name.clone(), index, shape.clone()))
+}
+
+fn builtin_unit_variant_index(enum_name: &str, variant_name: &str) -> Option<usize> {
+    match (enum_name, variant_name) {
+        ("Os", "Linux") => Some(0),
+        ("Os", "Macos") => Some(1),
+        ("Os", "Windows") => Some(2),
+        ("Arch", "X86_64") => Some(0),
+        ("Arch", "Aarch64") => Some(1),
+        ("Arch", "Arm") => Some(2),
+        ("Arch", "Riscv64") => Some(3),
+        ("Arch", "Wasm32") => Some(4),
+        ("Arch", "Unknown") => Some(5),
+        _ => None,
+    }
 }
 
 fn max_call_argc(block: &ast::Block) -> usize {
@@ -6362,8 +6496,8 @@ pub fn main() -> String {
 
     #[test]
     fn types_vix_toolchain_acquires_capabilities_and_updates_records() {
-        const CC_PIN: &str = "acquire:Cc:1c17ad644df20b15";
-        const AR_PIN: &str = "acquire:Ar:1c17ad644df20b15";
+        const CC_PIN: &str = "acquire:Cc:a67daa6cb12f954f";
+        const AR_PIN: &str = "acquire:Ar:a67daa6cb12f954f";
 
         let src = include_str!("../../../playgrounds/snark/src/bundled/vix/samples/types.vix");
         let mut traces = Vec::new();
@@ -6428,6 +6562,103 @@ pub fn main() -> String {
             traces.push((lane, machine.trace().to_vec()));
         }
         assert_lane_traces_equal(&traces);
+    }
+
+    #[test]
+    fn capability_identity_includes_target_arch() {
+        let src = r#"
+use vix::{Target, Arch};
+use caps::Cc;
+
+pub fn cc_for(target: Target) -> Cc {
+    Cc::acquire(target)
+}
+
+pub fn classify_arch(target: Target) -> Int {
+    match target.arch {
+        Arch::Aarch64 => 64,
+        Arch::X86_64 => 86,
+        _ => 0,
+    }
+}
+"#;
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            let (linux_x86, _) = machine.driver.intern_target(0, 0).unwrap();
+            let (linux_arm64, _) = machine.driver.intern_target(0, 1).unwrap();
+
+            let x86_cc = machine.demand_i64("cc_for", vec![linux_x86]).unwrap();
+            let arm64_cc = machine.demand_i64("cc_for", vec![linux_arm64]).unwrap();
+
+            let x86_fingerprint = machine.driver.raw_string(x86_cc, "Cc").unwrap();
+            let arm64_fingerprint = machine.driver.raw_string(arm64_cc, "Cc").unwrap();
+            assert_ne!(x86_fingerprint, arm64_fingerprint, "{lane:?}");
+            assert!(x86_fingerprint.starts_with("acquire:Cc:"), "{lane:?}");
+            assert!(arm64_fingerprint.starts_with("acquire:Cc:"), "{lane:?}");
+            assert_eq!(
+                machine
+                    .demand_i64("classify_arch", vec![linux_arm64])
+                    .unwrap(),
+                64,
+                "{lane:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn target_host_and_cross_target_are_distinct_capabilities() {
+        let src = r#"
+use vix::{Target, Os, Arch};
+use caps::{Cc, Rustc};
+
+pub fn host_cc() -> Cc {
+    Cc::acquire(Target::host())
+}
+
+pub fn cross_cc() -> Cc {
+    Cc::acquire(Target { os: Os::Linux, arch: Arch::Aarch64 })
+}
+
+pub fn cross_x86_cc() -> Cc {
+    Cc::acquire(Target { os: Os::Linux, arch: Arch::X86_64 })
+}
+
+pub fn os_only_cc() -> Cc {
+    Cc::acquire(Target { os: Os::Linux })
+}
+
+pub fn cross_rustc() -> Rustc {
+    Rustc::acquire(Target { os: Os::Linux, arch: Arch::Aarch64 })
+}
+"#;
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+
+            let host_cc = machine.demand_i64("host_cc", vec![]).unwrap();
+            let cross_cc = machine.demand_i64("cross_cc", vec![]).unwrap();
+            let cross_x86_cc = machine.demand_i64("cross_x86_cc", vec![]).unwrap();
+            let os_only_cc = machine.demand_i64("os_only_cc", vec![]).unwrap();
+            let cross_rustc = machine.demand_i64("cross_rustc", vec![]).unwrap();
+
+            let host_cc = machine.driver.raw_string(host_cc, "Cc").unwrap();
+            let cross_cc = machine.driver.raw_string(cross_cc, "Cc").unwrap();
+            let cross_x86_cc = machine.driver.raw_string(cross_x86_cc, "Cc").unwrap();
+            let os_only_cc = machine.driver.raw_string(os_only_cc, "Cc").unwrap();
+            let cross_rustc = machine.driver.raw_string(cross_rustc, "Rustc").unwrap();
+
+            // This is the crate.vix slice-3b split: proc-macro producers acquire
+            // host tools, target units acquire target tools, and artifact probes
+            // can key ELF/OCI facts by architecture.
+            assert!(
+                host_cc != cross_cc || host_cc != cross_x86_cc,
+                "{lane:?}: host={host_cc} cross_aarch64={cross_cc} cross_x86_64={cross_x86_cc}"
+            );
+            assert_ne!(cross_cc, cross_rustc, "{lane:?}");
+            assert!(cross_cc.starts_with("acquire:Cc:"), "{lane:?}");
+            assert!(cross_x86_cc.starts_with("acquire:Cc:"), "{lane:?}");
+            assert!(os_only_cc.starts_with("acquire:Cc:"), "{lane:?}");
+            assert!(cross_rustc.starts_with("acquire:Rustc:"), "{lane:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- grow builtin Target from { os } to declared { os, arch } and add a declared Arch enum
- add Target::host(), Target.arch access, and Target literals with os-only compatibility via host arch defaulting
- include arch in capability target hashing so same-kind acquires split by target arch
- refresh the snark wasm flow expected preferred vix sample now that ast-query.vix sorts first

## Proof
- cargo fmt --check
- cargo nextest run -p vix -p weavy
- cargo clippy -p vix -p weavy --all-features --all-targets --message-format=short -- -D warnings
- pnpm --filter @bearcove/snark-playground test:flow

## Notes
- Arch representation is a builtin declared enum: X86_64, Aarch64, Arm, Riscv64, Wasm32, Unknown.
- Existing os-only Target construction defaults arch from Target::host(), preserving native-target behavior while making cross targets explicit.
- Distinct-capability proof is in vix machine tests: two Linux targets differing only by arch acquire distinct Cc capabilities; Target::host() and explicit cross targets acquire distinct tool identities.