### PR TITLE
vix: build a dependency graph from a lockfile (the resolution→build seam)

### DIFF
--- a/playgrounds/snark/src/bundled/vix/samples/crate.vix
+++ b/playgrounds/snark/src/bundled/vix/samples/crate.vix
@@ -1,4 +1,4 @@
-use vix::{Tree, Target};
+use vix::{Tree, Target, Path};
 use caps::Rustc;
 
 fn doc_string(doc: Doc, key: String) -> String {
@@ -8,6 +8,30 @@ fn doc_string(doc: Doc, key: String) -> String {
 fn package_doc(manifest: Tree) -> Doc {
     let doc = toml(manifest / p"Cargo.toml");
     doc.get("package").unwrap()
+}
+
+fn lock_doc(graph: Tree) -> Doc {
+    toml(graph / p"Cargo.lock")
+}
+
+fn lock_package(lock: Doc, name: String) -> Doc {
+    lock.package(name).unwrap()
+}
+
+fn lock_package_name(lock: Doc, name: String) -> String {
+    let package = lock_package(lock, name);
+    doc_string(package, "name")
+}
+
+fn lock_package_version(lock: Doc, name: String) -> String {
+    let package = lock_package(lock, name);
+    doc_string(package, "version")
+}
+
+pub fn lock_fixture_deps(graph: Tree, name: String) -> String {
+    let lock = lock_doc(graph);
+    let package = lock_package(lock, name);
+    package.get("dependencies").unwrap().join(",")
 }
 
 pub fn crate_lib(target: Target, manifest: Tree) -> Tree {
@@ -102,4 +126,135 @@ pub fn crate_bin(target: Target, graph: Tree) -> Tree {
     let root = graph / p"app";
     let rlib = dep_rlib(target, dep);
     bin_link(target, root, rlib) / p"mini_app"
+}
+
+fn lock_lib_metadata(target: Target, manifest: Tree, package: Doc, rmeta: Path, rlib: Path) -> Tree {
+    let rustc = Rustc::acquire(target);
+    let name = doc_string(package, "name");
+    let edition = doc_string(package_doc(manifest), "edition");
+
+    rustc! {
+        --crate-name {name}
+        --edition {edition}
+        --crate-type lib
+        --emit=metadata={rmeta},link={rlib}
+        {manifest / p"src/lib.rs"}
+    }
+}
+
+fn lock_core_meta(target: Target, graph: Tree, lock: Doc) -> Tree {
+    let package = lock_package(lock, "core_lib");
+    lock_lib_metadata(target, graph / p"crates/core_lib", package, p"libcore_lib.rmeta", p"libcore_lib.rlib") / p"libcore_lib.rmeta"
+}
+
+fn lock_core_rlib(target: Target, graph: Tree, lock: Doc) -> Tree {
+    let package = lock_package(lock, "core_lib");
+    lock_lib_metadata(target, graph / p"crates/core_lib", package, p"libcore_lib.rmeta", p"libcore_lib.rlib") / p"libcore_lib.rlib"
+}
+
+fn lock_formatting_meta(target: Target, graph: Tree, lock: Doc) -> Tree {
+    let package = lock_package(lock, "formatting_lib");
+    lock_lib_metadata(target, graph / p"crates/formatting_lib", package, p"libformatting_lib.rmeta", p"libformatting_lib.rlib") / p"libformatting_lib.rmeta"
+}
+
+fn lock_formatting_rlib(target: Target, graph: Tree, lock: Doc) -> Tree {
+    let package = lock_package(lock, "formatting_lib");
+    lock_lib_metadata(target, graph / p"crates/formatting_lib", package, p"libformatting_lib.rmeta", p"libformatting_lib.rlib") / p"libformatting_lib.rlib"
+}
+
+fn lock_alpha_metadata(target: Target, graph: Tree, lock: Doc, core: Tree) -> Tree {
+    let rustc = Rustc::acquire(target);
+    let manifest = graph / p"crates/alpha_lib";
+    let package = lock_package(lock, "alpha_lib");
+    let name = doc_string(package, "name");
+    let edition = doc_string(package_doc(manifest), "edition");
+
+    rustc! {
+        --crate-name {name}
+        --edition {edition}
+        --crate-type lib
+        --emit=metadata={p"libalpha_lib.rmeta"},link={p"libalpha_lib.rlib"}
+        --extern core_lib={core / p"libcore_lib.rmeta"}
+        -L dependency={core}
+        {manifest / p"src/lib.rs"}
+    } / p"libalpha_lib.rmeta"
+}
+
+fn lock_alpha_rlib(target: Target, graph: Tree, lock: Doc, core: Tree) -> Tree {
+    let rustc = Rustc::acquire(target);
+    let manifest = graph / p"crates/alpha_lib";
+    let package = lock_package(lock, "alpha_lib");
+    let name = doc_string(package, "name");
+    let edition = doc_string(package_doc(manifest), "edition");
+
+    rustc! {
+        --crate-name {name}
+        --edition {edition}
+        --crate-type lib
+        --emit=metadata={p"libalpha_lib.rmeta"},link={p"libalpha_lib.rlib"}
+        --extern core_lib={core / p"libcore_lib.rlib"}
+        -L dependency={core}
+        {manifest / p"src/lib.rs"}
+    } / p"libalpha_lib.rlib"
+}
+
+fn lock_bin_metadata(target: Target, graph: Tree, lock: Doc, alpha: Tree, formatting: Tree, core: Tree) -> Tree {
+    let rustc = Rustc::acquire(target);
+    let manifest = graph / p"app";
+    let name = lock_package_name(lock, "mini_app");
+    let edition = doc_string(package_doc(manifest), "edition");
+
+    rustc! {
+        --crate-name {name}
+        --edition {edition}
+        --crate-type bin
+        --emit=metadata={p"mini_app.rmeta"}
+        --extern alpha_lib={alpha / p"libalpha_lib.rmeta"}
+        --extern formatting_lib={formatting / p"libformatting_lib.rmeta"}
+        -L dependency={alpha}
+        -L dependency={formatting}
+        -L dependency={core}
+        {manifest / p"src/main.rs"}
+    }
+}
+
+fn lock_bin_link(target: Target, graph: Tree, lock: Doc, alpha: Tree, formatting: Tree, core: Tree) -> Tree {
+    let rustc = Rustc::acquire(target);
+    let manifest = graph / p"app";
+    let name = lock_package_name(lock, "mini_app");
+    let edition = doc_string(package_doc(manifest), "edition");
+
+    rustc! {
+        --crate-name {name}
+        --edition {edition}
+        --crate-type bin
+        --emit=link={p"mini_app"}
+        --extern alpha_lib={alpha / p"libalpha_lib.rlib"}
+        --extern formatting_lib={formatting / p"libformatting_lib.rlib"}
+        -L dependency={alpha}
+        -L dependency={formatting}
+        -L dependency={core}
+        {manifest / p"src/main.rs"}
+    }
+}
+
+pub fn crate_lock_bin_check(target: Target, graph: Tree) -> Tree {
+    let lock = lock_doc(graph);
+    let core = lock_core_meta(target, graph, lock);
+    let alpha = lock_alpha_metadata(target, graph, lock, core);
+    let formatting = lock_formatting_meta(target, graph, lock);
+    lock_bin_metadata(target, graph, lock, alpha, formatting, core) / p"mini_app.rmeta"
+}
+
+pub fn crate_lock_bin(target: Target, graph: Tree) -> Tree {
+    let lock = lock_doc(graph);
+    let core = lock_core_rlib(target, graph, lock);
+    let alpha = lock_alpha_rlib(target, graph, lock, core);
+    let formatting = lock_formatting_rlib(target, graph, lock);
+    lock_bin_link(target, graph, lock, alpha, formatting, core) / p"mini_app"
+}
+
+pub fn crate_lock_root_version(graph: Tree) -> String {
+    let lock = lock_doc(graph);
+    lock_package_version(lock, "mini_app")
 }

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/Cargo.lock
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/Cargo.lock
@@ -1,0 +1,25 @@
+# This file is the resolved manifest consumed by crate.vix.
+version = 4
+
+[[package]]
+name = "alpha_lib"
+version = "0.1.0"
+dependencies = [
+ "core_lib",
+]
+
+[[package]]
+name = "core_lib"
+version = "0.1.0"
+
+[[package]]
+name = "formatting_lib"
+version = "0.1.0"
+
+[[package]]
+name = "mini_app"
+version = "0.1.0"
+dependencies = [
+ "alpha_lib",
+ "formatting_lib",
+]

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/app/Cargo.lock
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/app/Cargo.lock
@@ -1,0 +1,24 @@
+version = 4
+
+[[package]]
+name = "alpha_lib"
+version = "0.1.0"
+dependencies = [
+ "core_lib",
+]
+
+[[package]]
+name = "core_lib"
+version = "0.1.0"
+
+[[package]]
+name = "formatting_lib"
+version = "0.1.0"
+
+[[package]]
+name = "mini_app"
+version = "0.1.0"
+dependencies = [
+ "alpha_lib",
+ "formatting_lib",
+]

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/app/Cargo.toml
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/app/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "mini_app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+alpha_lib = { path = "../crates/alpha_lib" }
+formatting_lib = { path = "../crates/formatting_lib" }

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/app/src/main.rs
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/app/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("{} + {}", alpha_lib::phrase(), formatting_lib::suffix());
+}

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/alpha_lib/Cargo.toml
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/alpha_lib/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "alpha_lib"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+core_lib = { path = "../core_lib" }

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/alpha_lib/src/lib.rs
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/alpha_lib/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn phrase() -> String {
+    format!("{} via alpha", core_lib::core_word())
+}

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/core_lib/Cargo.toml
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/core_lib/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "core_lib"
+version = "0.1.0"
+edition = "2021"

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/core_lib/src/lib.rs
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/core_lib/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn core_word() -> &'static str {
+    "core"
+}

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/formatting_lib/Cargo.toml
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/formatting_lib/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "formatting_lib"
+version = "0.1.0"
+edition = "2021"

--- a/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/formatting_lib/src/lib.rs
+++ b/playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/formatting_lib/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn suffix() -> &'static str {
+    "formatted"
+}

--- a/vix/docs/cargo-manifest-build.md
+++ b/vix/docs/cargo-manifest-build.md
@@ -153,3 +153,47 @@ otherwise open tier-2 verification can only prove the subset the roles name.
 After that, add build-script compile/run units and feed their declared outputs
 into parent rustc invocations. Proc-macro host units can share most dependency
 wiring but need host/target separation in the plan keys.
+
+## Lockfile Consumer Seam
+
+The resolution-to-build interface is a Cargo.lock-shaped resolved manifest.
+Open `crate.vix` consumes it as data with `toml()`. It does not invoke Cargo to
+resolve, inspect metadata, or build.
+
+The current open consumer accepts this Cargo.lock subset:
+
+- top-level `version` is allowed and ignored by the builder;
+- `[[package]]` tables are the resolved package set;
+- each package must provide `name` and `version`;
+- `dependencies = ["dep_name", ...]` is the resolved direct dependency list by
+  package name;
+- `source` is accepted when present, with Cargo's normal string shape, but path
+  packages may omit it exactly as Cargo.lock does.
+
+For the vendored offline fixture, package source trees live beside the lockfile:
+`app/` for the root binary and `crates/<package-name>/` for libraries. That
+layout convention is the open fixture's source locator; the lockfile remains the
+resolved package/edge contract.
+
+The build graph is demand-shaped rather than Cargo-shaped. A package's metadata
+or link artifact demands its direct dependencies' rmeta/rlib trees, and rustc
+receives those artifacts through `--extern` plus `-L dependency` search paths.
+The current fixture proves a transitive graph:
+
+```text
+mini_app -> alpha_lib -> core_lib
+mini_app -> formatting_lib
+```
+
+The default fake lane proves the command graph and extern wiring. With
+`real-process`, the same vix entry points run real `rustc`, execute the produced
+binary, and compare the derived unit shapes with
+`cargo +nightly build --unit-graph -Z unstable-options --locked` as the oracle.
+
+## Rodin Emit-Lock Follow-Up
+
+Rodin stays a separate proprietary resolver lane. The remaining bridge is small:
+convert Rodin's `SolveResult` into the Cargo.lock-shaped document above, including
+the selected package rows and direct dependency names. Once Rodin emits that
+lock-shaped tree, the open `crate.vix` consumer can build it without calling
+Cargo, closing the resolve -> emit-lock -> build round trip.

--- a/vix/src/machine/driver.rs
+++ b/vix/src/machine/driver.rs
@@ -139,6 +139,7 @@ pub const ARRAY_LEN_HOST: u32 = 27;
 pub const OCI_DOC_HOST: u32 = 28;
 pub const STRING_CONCAT_HOST: u32 = 29;
 pub const ARRAY_JOIN_HOST: u32 = 30;
+pub const DOC_PACKAGE_HOST: u32 = 31;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Lane {
@@ -2629,6 +2630,21 @@ impl Driver {
                 }
             };
 
+            let mut doc_package_host = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let doc = read_frame_word(frame, primitive_region + 8);
+                    let name = read_frame_word(frame, primitive_region + 16);
+                    let name = store_cell.borrow().string_value(name, "String")?;
+                    let handle = doc_package(store_cell, descriptors, schema_refs, doc, &name)?;
+                    write_frame_word(frame, dst_slot, handle);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
             let mut doc_coerce_host = |frame: &mut [u8]| {
                 let result = (|| {
                     let dst_slot = read_frame_word(frame, primitive_region) as usize;
@@ -2995,7 +3011,7 @@ impl Driver {
                 });
             };
 
-            let mut hosts: [HostFn<'_>; 31] = [
+            let mut hosts: [HostFn<'_>; 32] = [
                 &mut invoke,
                 &mut store_alloc,
                 &mut store_read,
@@ -3027,6 +3043,7 @@ impl Driver {
                 &mut oci_doc_host,
                 &mut string_concat_host,
                 &mut array_join_host,
+                &mut doc_package_host,
             ];
             let step = exec
                 .task
@@ -4393,6 +4410,72 @@ fn doc_get_with_virtual(
         return oci_virtual_file_get(ctx, input, key);
     }
     doc_get(ctx.store, ctx.descriptors, ctx.schema_refs, doc, key)
+}
+
+fn doc_package(
+    store: &RefCell<ValueStore>,
+    descriptors: &HashMap<String, Descriptor<String>>,
+    schema_refs: &[String],
+    lock_doc: i64,
+    wanted_name: &str,
+) -> Result<i64, String> {
+    let (package_option, _) = doc_get(store, descriptors, schema_refs, lock_doc, "package")?;
+    let packages = match store.borrow().option_payload(package_option, schema_refs)? {
+        OptionPayload::Some { word, .. } => {
+            match doc_payload(&store.borrow(), descriptors, word)? {
+                DocPayload::Array(array) => array,
+                other => {
+                    return Err(format!(
+                        "Cargo.lock `package` expected array, got {other:?}"
+                    ));
+                }
+            }
+        }
+        OptionPayload::None => {
+            return Ok(store
+                .borrow_mut()
+                .alloc_option_none("Realized<Doc>", schema_refs)?
+                .0);
+        }
+    };
+    let package_words = match store.borrow().array_entry(packages, schema_refs)? {
+        ArrayEntry::Words { elem_schema, words } if elem_schema == "Doc" => words,
+        ArrayEntry::Words { elem_schema, .. } => {
+            return Err(format!("Cargo.lock `package` array contains {elem_schema}"));
+        }
+        ArrayEntry::Pending(_) => return Err("Cargo.lock `package` array is pending".into()),
+    };
+    for package in package_words {
+        let (name_option, _) = doc_get(store, descriptors, schema_refs, package, "name")?;
+        let name = match store.borrow().option_payload(name_option, schema_refs)? {
+            OptionPayload::Some { word, .. } => {
+                match doc_payload(&store.borrow(), descriptors, word)? {
+                    DocPayload::String(handle) => store.borrow().string_value(handle, "String")?,
+                    other => {
+                        return Err(format!(
+                            "Cargo.lock package `name` expected string, got {other:?}"
+                        ));
+                    }
+                }
+            }
+            OptionPayload::None => continue,
+        };
+        if name == wanted_name {
+            return Ok(store
+                .borrow_mut()
+                .alloc_option_some(
+                    "Realized<Doc>",
+                    package,
+                    Some(Realization::Ready),
+                    schema_refs,
+                )?
+                .0);
+        }
+    }
+    Ok(store
+        .borrow_mut()
+        .alloc_option_none("Realized<Doc>", schema_refs)?
+        .0)
 }
 
 fn oci_virtual_file_get(

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -30,12 +30,12 @@ use super::TotalF64;
 use super::driver::{
     ACQUIRE_HOST, ARRAY_ALLOC_HOST, ARRAY_COLLECT_HOST, ARRAY_FILTER_EXCLUDE_HOST, ARRAY_JOIN_HOST,
     ARRAY_LEN_HOST, ARRAY_MAP_PENDING_HOST, AST_DOC_HOST, AST_FN_HOST, CodeBundle, DOC_COERCE_HOST,
-    DOC_GET_HOST, DOC_PARSE_HOST, DriveEvent, DriveEventSink, Driver, ELF_DOC_HOST, EXEC_HOST,
-    FETCH_HOST, GLOB_HOST, INVOKE_HOST, Lane, LoweredFn, MAP_EMPTY_HOST, MAP_GET_HOST,
-    MAP_INSERT_HOST, MachineExecBackend, OCI_DOC_HOST, OPTION_UNWRAP_HOST, PATH_WITH_EXT_HOST,
-    PENDING_ALLOC_HOST, PENDING_COERCE_HOST, PENDING_INVOKE_HOST, RenderNames, RenderVariant,
-    RenderedValue, STORE_ALLOC_HOST, STORE_READ_HOST, STORE_TAG_HOST, STRING_CONCAT_HOST, StepMode,
-    StoreHandle, TREE_PROJECT_HOST, ValueBundle,
+    DOC_GET_HOST, DOC_PACKAGE_HOST, DOC_PARSE_HOST, DriveEvent, DriveEventSink, Driver,
+    ELF_DOC_HOST, EXEC_HOST, FETCH_HOST, GLOB_HOST, INVOKE_HOST, Lane, LoweredFn, MAP_EMPTY_HOST,
+    MAP_GET_HOST, MAP_INSERT_HOST, MachineExecBackend, OCI_DOC_HOST, OPTION_UNWRAP_HOST,
+    PATH_WITH_EXT_HOST, PENDING_ALLOC_HOST, PENDING_COERCE_HOST, PENDING_INVOKE_HOST, RenderNames,
+    RenderVariant, RenderedValue, STORE_ALLOC_HOST, STORE_READ_HOST, STORE_TAG_HOST,
+    STRING_CONCAT_HOST, StepMode, StoreHandle, TREE_PROJECT_HOST, ValueBundle,
 };
 use crate::ast;
 use crate::fetch::FetchBackend;
@@ -1480,6 +1480,9 @@ fn collect_expr_schemas(
                 ("get", Some("Doc")) | ("get", Some("Realized<Doc>")) => {
                     Ok(Some(option_schema("Realized<Doc>")))
                 }
+                ("package", Some("Doc")) | ("package", Some("Realized<Doc>")) => {
+                    Ok(Some(option_schema("Realized<Doc>")))
+                }
                 ("get", Some(schema)) => Ok(map_value_schema(schema).map(option_schema)),
                 ("unwrap", Some(schema)) => Ok(option_value_schema(schema).map(str::to_string)),
                 ("join", Some("Array" | "Doc" | "Realized<Doc>")) => Ok(Some("String".into())),
@@ -2865,6 +2868,14 @@ impl<'a> FnLowerer<'a> {
                 }
                 let key = self.method_arg(&call.args.args[0], Some(key_schema))?;
                 self.map_get(&receiver, key, key_schema, &result_value_schema)
+            }
+            "package" => {
+                if call.args.args.len() != 1 {
+                    return Err("Doc.package takes one package name".into());
+                }
+                let receiver = self.coerce_to_schema(receiver, "Doc")?;
+                let name = self.method_arg(&call.args.args[0], Some("String"))?;
+                self.doc_package(&receiver, &name)
             }
             "fn" => {
                 if call.args.args.len() != 1 {
@@ -4283,6 +4294,34 @@ impl<'a> FnLowerer<'a> {
             src: key.slot,
         });
         self.code.push(Op::HostCall { host: DOC_GET_HOST });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: option_schema("Realized<Doc>"),
+            realization: None,
+            pending: None,
+        })
+    }
+
+    fn doc_package(&mut self, doc: &ValueSlot, name: &ValueSlot) -> Result<ValueSlot, String> {
+        self.expect_schema(doc, "Doc")?;
+        self.expect_schema(name, "String")?;
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: doc.slot,
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 16,
+            src: name.slot,
+        });
+        self.code.push(Op::HostCall {
+            host: DOC_PACKAGE_HOST,
+        });
         Ok(ValueSlot {
             slot: dst,
             schema: option_schema("Realized<Doc>"),

--- a/vix/tests/crate_lock.rs
+++ b/vix/tests/crate_lock.rs
@@ -1,0 +1,137 @@
+use std::collections::BTreeSet;
+
+use vix::exec::Tree;
+use vix::machine::{DriveEvent, Machine, MachineArg, RenderedValue};
+
+const SOURCE: &str = include_str!("../../playgrounds/snark/src/bundled/vix/samples/crate.vix");
+const LOCK: &str =
+    include_str!("../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/Cargo.lock");
+const APP_LOCK: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/app/Cargo.lock"
+);
+const APP_MANIFEST: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/app/Cargo.toml"
+);
+const APP_MAIN: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/app/src/main.rs"
+);
+const ALPHA_MANIFEST: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/alpha_lib/Cargo.toml"
+);
+const ALPHA_LIB: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/alpha_lib/src/lib.rs"
+);
+const CORE_MANIFEST: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/core_lib/Cargo.toml"
+);
+const CORE_LIB: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/core_lib/src/lib.rs"
+);
+const FORMATTING_MANIFEST: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/formatting_lib/Cargo.toml"
+);
+const FORMATTING_LIB: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/formatting_lib/src/lib.rs"
+);
+
+#[test]
+fn crate_vix_consumes_lockfile_and_builds_transitive_graph_with_fake_rustc() -> Result<(), String> {
+    let mut machine = Machine::load(SOURCE)?;
+    let target = machine.linux_target_handle();
+    let graph = machine
+        .intern_arg("Tree", MachineArg::Tree(lock_graph_tree()))?
+        .0;
+
+    let root_version = machine.demand_i64("crate_lock_root_version", vec![graph])?;
+    if rendered_string(&machine, "crate_lock_root_version", root_version)? != "0.1.0" {
+        return Err("lock root version did not come from Cargo.lock".into());
+    }
+
+    let alpha = machine
+        .intern_arg("String", MachineArg::String("alpha_lib".to_string()))?
+        .0;
+    let alpha_deps = machine.demand_i64("lock_fixture_deps", vec![graph, alpha])?;
+    if rendered_string(&machine, "lock_fixture_deps", alpha_deps)? != "core_lib" {
+        return Err("alpha_lib dependencies did not come from Cargo.lock".into());
+    }
+
+    let checked = machine.demand_i64("crate_lock_bin_check", vec![target, graph])?;
+    if !machine
+        .tree_entries(checked)?
+        .contains_key("mini_app.rmeta")
+    {
+        return Err("metadata build did not produce mini_app.rmeta".into());
+    }
+
+    let built = machine.demand_i64("crate_lock_bin", vec![target, graph])?;
+    if !machine.tree_entries(built)?.contains_key("mini_app") {
+        return Err("link build did not produce mini_app".into());
+    }
+
+    let extern_edges = rustc_extern_edges(&machine);
+    for edge in [
+        ("alpha_lib", "core_lib"),
+        ("mini_app", "alpha_lib"),
+        ("mini_app", "formatting_lib"),
+    ] {
+        if !extern_edges.contains(&edge) {
+            return Err(format!(
+                "missing rustc extern edge {edge:?}: {extern_edges:?}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn rendered_string(machine: &Machine, name: &str, word: i64) -> Result<String, String> {
+    match machine.render_result(name, word)? {
+        RenderedValue::String { value } => Ok(value),
+        other => Err(format!("{name} rendered as {other:?}, not String")),
+    }
+}
+
+fn rustc_extern_edges(machine: &Machine) -> BTreeSet<(&str, &str)> {
+    machine
+        .trace()
+        .iter()
+        .filter_map(|event| match event {
+            DriveEvent::RunRequested {
+                command_name, argv, ..
+            } if command_name == "rustc" => Some(argv.as_slice()),
+            _ => None,
+        })
+        .filter_map(|argv| {
+            let from = arg_after(argv, "--crate-name")?;
+            Some(
+                argv.windows(2)
+                    .filter_map(move |pair| {
+                        (pair[0] == "--extern")
+                            .then(|| pair[1].split_once('=').map(|(name, _)| (from, name)))
+                            .flatten()
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .flatten()
+        .collect()
+}
+
+fn arg_after<'a>(argv: &'a [String], flag: &str) -> Option<&'a str> {
+    argv.windows(2)
+        .find_map(|pair| (pair[0] == flag).then_some(pair[1].as_str()))
+}
+
+fn lock_graph_tree() -> Tree {
+    Tree::of(&[
+        ("Cargo.lock", LOCK),
+        ("app/Cargo.lock", APP_LOCK),
+        ("app/Cargo.toml", APP_MANIFEST),
+        ("app/src/main.rs", APP_MAIN),
+        ("crates/alpha_lib/Cargo.toml", ALPHA_MANIFEST),
+        ("crates/alpha_lib/src/lib.rs", ALPHA_LIB),
+        ("crates/core_lib/Cargo.toml", CORE_MANIFEST),
+        ("crates/core_lib/src/lib.rs", CORE_LIB),
+        ("crates/formatting_lib/Cargo.toml", FORMATTING_MANIFEST),
+        ("crates/formatting_lib/src/lib.rs", FORMATTING_LIB),
+    ])
+}

--- a/vix/tests/crate_real_process.rs
+++ b/vix/tests/crate_real_process.rs
@@ -25,6 +25,36 @@ const HELPER_LIB: &str = include_str!(
     "../../playgrounds/snark/src/bundled/vix/samples/fixtures/two_crate_graph/crates/helper/src/lib.rs"
 );
 const EXPECTED_STDOUT: &[u8] = b"vix dependency fixture\n";
+const LOCK_GRAPH_LOCK: &str =
+    include_str!("../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/Cargo.lock");
+const LOCK_GRAPH_APP_LOCK: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/app/Cargo.lock"
+);
+const LOCK_GRAPH_APP_MANIFEST: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/app/Cargo.toml"
+);
+const LOCK_GRAPH_APP_MAIN: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/app/src/main.rs"
+);
+const LOCK_GRAPH_ALPHA_MANIFEST: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/alpha_lib/Cargo.toml"
+);
+const LOCK_GRAPH_ALPHA_LIB: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/alpha_lib/src/lib.rs"
+);
+const LOCK_GRAPH_CORE_MANIFEST: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/core_lib/Cargo.toml"
+);
+const LOCK_GRAPH_CORE_LIB: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/core_lib/src/lib.rs"
+);
+const LOCK_GRAPH_FORMATTING_MANIFEST: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/formatting_lib/Cargo.toml"
+);
+const LOCK_GRAPH_FORMATTING_LIB: &str = include_str!(
+    "../../playgrounds/snark/src/bundled/vix/samples/fixtures/lock_graph/crates/formatting_lib/src/lib.rs"
+);
+const LOCK_GRAPH_EXPECTED_STDOUT: &[u8] = b"core via alpha + formatted\n";
 
 #[test]
 fn real_process_rustc_builds_two_crate_fixture_and_matches_cargo_unit_graph_oracle()
@@ -64,6 +94,44 @@ fn real_process_rustc_builds_two_crate_fixture_and_matches_cargo_unit_graph_orac
     Ok(())
 }
 
+#[test]
+fn real_process_rustc_builds_lockfile_graph_and_matches_cargo_unit_graph_oracle()
+-> Result<(), String> {
+    if !host_rustc_available() {
+        return Ok(());
+    }
+
+    let backend = Arc::new(RealProcessBackend::new());
+    let mut machine = Machine::load(SOURCE)?.with_exec_backend(backend);
+    let target = machine.linux_target_handle();
+    let graph = machine
+        .intern_arg("Tree", MachineArg::Tree(lock_graph_tree()))?
+        .0;
+
+    let checked = machine.demand_i64("crate_lock_bin_check", vec![target, graph])?;
+    let _rmeta = tree_file_bytes(&mut machine, checked, "mini_app.rmeta")?;
+
+    let built = machine.demand_i64("crate_lock_bin", vec![target, graph])?;
+    let bin = tree_file_bytes(&mut machine, built, "mini_app")?;
+    let stdout = run_binary_bytes(&bin)?;
+    if stdout != LOCK_GRAPH_EXPECTED_STDOUT {
+        return Err(format!(
+            "unexpected lock graph binary stdout: {:?}",
+            String::from_utf8_lossy(&stdout)
+        ));
+    }
+
+    let machine_graph = machine_rustc_unit_graph(&machine)?;
+    let cargo_graph = cargo_lock_graph_unit_graph_oracle()?;
+    if machine_graph != cargo_graph {
+        return Err(format!(
+            "lock graph machine unit graph did not match cargo oracle\nmachine: {machine_graph:#?}\ncargo: {cargo_graph:#?}"
+        ));
+    }
+
+    Ok(())
+}
+
 fn host_rustc_available() -> bool {
     Command::new("rustc")
         .arg("--version")
@@ -77,6 +145,27 @@ fn two_crate_graph_tree() -> Tree {
         ("app/src/main.rs", APP_MAIN),
         ("crates/helper/Cargo.toml", HELPER_MANIFEST),
         ("crates/helper/src/lib.rs", HELPER_LIB),
+    ])
+}
+
+fn lock_graph_tree() -> Tree {
+    Tree::of(&[
+        ("Cargo.lock", LOCK_GRAPH_LOCK),
+        ("app/Cargo.lock", LOCK_GRAPH_APP_LOCK),
+        ("app/Cargo.toml", LOCK_GRAPH_APP_MANIFEST),
+        ("app/src/main.rs", LOCK_GRAPH_APP_MAIN),
+        ("crates/alpha_lib/Cargo.toml", LOCK_GRAPH_ALPHA_MANIFEST),
+        ("crates/alpha_lib/src/lib.rs", LOCK_GRAPH_ALPHA_LIB),
+        ("crates/core_lib/Cargo.toml", LOCK_GRAPH_CORE_MANIFEST),
+        ("crates/core_lib/src/lib.rs", LOCK_GRAPH_CORE_LIB),
+        (
+            "crates/formatting_lib/Cargo.toml",
+            LOCK_GRAPH_FORMATTING_MANIFEST,
+        ),
+        (
+            "crates/formatting_lib/src/lib.rs",
+            LOCK_GRAPH_FORMATTING_LIB,
+        ),
     ])
 }
 
@@ -262,6 +351,46 @@ fn cargo_unit_graph_oracle() -> Result<Vec<UnitShape>, String> {
     Ok(shapes)
 }
 
+fn cargo_lock_graph_unit_graph_oracle() -> Result<Vec<UnitShape>, String> {
+    if !Command::new("cargo")
+        .arg("+nightly")
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success())
+    {
+        return Ok(Vec::new());
+    }
+
+    let temp = tempfile::Builder::new()
+        .prefix("vix-cargo-lock-graph-unit-graph-oracle-")
+        .tempdir()
+        .map_err(|err| err.to_string())?;
+    write_lock_graph_fixture(temp.path())?;
+    let manifest = temp.path().join("app/Cargo.toml");
+    let output = Command::new("cargo")
+        .arg("+nightly")
+        .arg("build")
+        .arg("--unit-graph")
+        .arg("-Z")
+        .arg("unstable-options")
+        .arg("--locked")
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .env("CARGO_NET_OFFLINE", "true")
+        .output()
+        .map_err(|err| err.to_string())?;
+    if !output.status.success() {
+        return Err(format!(
+            "cargo lock graph unit graph oracle exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let stdout = String::from_utf8(output.stdout).map_err(|err| err.to_string())?;
+    cargo_unit_shapes_from_json(&stdout)
+}
+
 fn write_fixture(root: &Path) -> Result<(), String> {
     let files: [(PathBuf, &str); 4] = [
         (PathBuf::from("app/Cargo.toml"), APP_MANIFEST),
@@ -277,6 +406,78 @@ fn write_fixture(root: &Path) -> Result<(), String> {
         fs::write(path, contents).map_err(|err| err.to_string())?;
     }
     Ok(())
+}
+
+fn write_lock_graph_fixture(root: &Path) -> Result<(), String> {
+    let files: [(PathBuf, &str); 10] = [
+        (PathBuf::from("Cargo.lock"), LOCK_GRAPH_LOCK),
+        (PathBuf::from("app/Cargo.lock"), LOCK_GRAPH_APP_LOCK),
+        (PathBuf::from("app/Cargo.toml"), LOCK_GRAPH_APP_MANIFEST),
+        (PathBuf::from("app/src/main.rs"), LOCK_GRAPH_APP_MAIN),
+        (
+            PathBuf::from("crates/alpha_lib/Cargo.toml"),
+            LOCK_GRAPH_ALPHA_MANIFEST,
+        ),
+        (
+            PathBuf::from("crates/alpha_lib/src/lib.rs"),
+            LOCK_GRAPH_ALPHA_LIB,
+        ),
+        (
+            PathBuf::from("crates/core_lib/Cargo.toml"),
+            LOCK_GRAPH_CORE_MANIFEST,
+        ),
+        (
+            PathBuf::from("crates/core_lib/src/lib.rs"),
+            LOCK_GRAPH_CORE_LIB,
+        ),
+        (
+            PathBuf::from("crates/formatting_lib/Cargo.toml"),
+            LOCK_GRAPH_FORMATTING_MANIFEST,
+        ),
+        (
+            PathBuf::from("crates/formatting_lib/src/lib.rs"),
+            LOCK_GRAPH_FORMATTING_LIB,
+        ),
+    ];
+    for (relative, contents) in files {
+        let path = root.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+        }
+        fs::write(path, contents).map_err(|err| err.to_string())?;
+    }
+    Ok(())
+}
+
+fn cargo_unit_shapes_from_json(stdout: &str) -> Result<Vec<UnitShape>, String> {
+    let graph: CargoUnitGraph = facet_json::from_str(stdout).map_err(|err| err.to_string())?;
+    let mut shapes = graph
+        .units
+        .iter()
+        .map(|unit| {
+            let dependencies = unit
+                .dependencies
+                .iter()
+                .map(|dep| dep.extern_crate_name.clone())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            Ok(UnitShape {
+                name: unit.target.name.clone(),
+                crate_type: unit
+                    .target
+                    .crate_types
+                    .first()
+                    .cloned()
+                    .ok_or_else(|| format!("missing crate type for {:?}", unit.target))?,
+                edition: unit.target.edition.clone(),
+                source_suffix: source_suffix(&unit.target.src_path)?,
+                dependencies,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    shapes.sort();
+    Ok(shapes)
 }
 
 #[derive(Debug, Facet)]


### PR DESCRIPTION
## Summary

This adds the open consumer half of the resolution to build seam: `crate.vix` reads a Cargo.lock-shaped resolved manifest as TOML data and uses it to wire a transitive rustc dependency graph. Cargo remains oracle-only in tests; production vix never invokes Cargo for resolution, metadata, or building.

## Lock schema consumed

- top-level `version` is accepted and ignored by the builder
- `[[package]]` rows define the resolved package set
- each row consumes `name` and `version`
- `dependencies = ["dep_name", ...]` is consumed as direct dependency names
- `source` may be present with Cargo.lock's normal string shape; path packages may omit it as Cargo.lock does
- the vendored fixture locates sources beside the lockfile at `app/` and `crates/<package-name>/`

## Topological build shape

The demand graph drives ordering: package artifacts demand dependency rmeta/rlib trees first, then pass them to rustc via `--extern` and `-L dependency`. The fixture proves `mini_app -> alpha_lib -> core_lib` plus `mini_app -> formatting_lib`.

## Demo and oracles

- default fake-rustc test parses the lock, checks dependency names, builds metadata/link artifacts, and asserts rustc extern edges
- real-process test runs real rustc, executes the produced `mini_app` binary, and compares unit shapes against `cargo +nightly build --unit-graph -Z unstable-options --locked`
- docs now name the lockfile schema and keep Cargo as test oracle only

## Remaining Rodin work

Rodin stays in the proprietary resolver lane. The remaining bridge is Rodin `SolveResult` -> this Cargo.lock-shaped document: selected package rows plus direct dependency names. Once emitted, open `crate.vix` can consume it directly for resolve to emit-lock to build.

## Verification

- `cargo check -p vix --all-targets --message-format=short`
- `cargo nextest run -p vix -p weavy`
- `cargo nextest run -p vix -p weavy --features real-process`
- `cargo clippy -p vix -p weavy --all-targets --message-format=short -- -D warnings`
- `cargo clippy -p vix -p weavy --features real-process --all-targets --message-format=short -- -D warnings`
- wasm read-only pass: confirmed existing wasm `runVixMachine` tests cover merge-demand/eval/lua and no new wasm-facing API was touched
