### PR TITLE
vix: restore nothing-forces on the real-process demand path

### DIFF
--- a/picante/src/facet_eq.rs
+++ b/picante/src/facet_eq.rs
@@ -96,28 +96,16 @@ where
         !matches!(self.backend, PlannedEqualityBackend::None)
     }
 
-    #[cfg(test)]
+    #[cfg(all(
+        test,
+        feature = "jit",
+        any(
+            all(target_os = "macos", target_arch = "aarch64"),
+            all(target_os = "linux", target_arch = "x86_64")
+        )
+    ))]
     pub(crate) fn has_native_plan(&self) -> bool {
-        #[cfg(all(
-            feature = "jit",
-            any(
-                all(target_os = "macos", target_arch = "aarch64"),
-                all(target_os = "linux", target_arch = "x86_64")
-            )
-        ))]
-        {
-            matches!(self.backend, PlannedEqualityBackend::Native(_))
-        }
-        #[cfg(not(all(
-            feature = "jit",
-            any(
-                all(target_os = "macos", target_arch = "aarch64"),
-                all(target_os = "linux", target_arch = "x86_64")
-            )
-        )))]
-        {
-            false
-        }
+        matches!(self.backend, PlannedEqualityBackend::Native(_))
     }
 }
 

--- a/vix-wire/src/lib.rs
+++ b/vix-wire/src/lib.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use facet::Facet;
 use tokio::sync::Mutex;
-use vix::exec::{ExecPlan, MountedWorld, ObservedWorld, ReadSet, Role, Tree};
+use vix::exec::{ExecPlan, MountedWorld, ObservedWorld, Outcome, ReadSet, Role, Tree};
 use vix::machine::{
     Machine, MachineExecBackend, MachineExecRequest, MachinePathDemand, MachinePendingRun,
     ValueBundle,
@@ -87,7 +87,7 @@ pub enum WireExecEvent {
     Finished {
         ok: bool,
         tree: u64,
-        read_set_len: u64,
+        read_set: ReadSet,
     },
     Failed {
         error: String,
@@ -555,7 +555,7 @@ impl ExecutorService {
             .send(WireExecEvent::Finished {
                 ok: true,
                 tree: done.tree,
-                read_set_len: done.read_set.entries.len() as u64,
+                read_set: done.read_set.clone(),
             })
             .await;
     }
@@ -658,7 +658,7 @@ impl ExecutorService {
         let _ = feed.send(WireExecEvent::Finished {
             ok: true,
             tree: done.tree,
-            read_set_len: done.read_set.entries.len() as u64,
+            read_set: done.read_set.clone(),
         });
 
         self.finish_with_observer(request, identity, &done, events)
@@ -811,8 +811,8 @@ struct FleetRun {
 struct FleetRunState {
     ready_paths: std::collections::HashSet<String>,
     source: Option<vix::exec::ExecEvent>,
-    finished: Option<Result<u64, String>>,
-    flushed: Option<Tree>,
+    finished: Option<Result<(u64, ReadSet), String>>,
+    flushed: Option<Outcome>,
 }
 
 impl FleetRun {
@@ -832,9 +832,9 @@ impl FleetRun {
             WireExecEvent::PathReady { path, .. } => {
                 state.ready_paths.insert(path);
             }
-            WireExecEvent::Finished { ok, tree, .. } => {
+            WireExecEvent::Finished { ok, tree, read_set } => {
                 state.finished = Some(if ok {
-                    Ok(tree)
+                    Ok((tree, read_set))
                 } else {
                     Err("run failed".to_string())
                 });
@@ -860,9 +860,14 @@ impl MachinePendingRun for FleetRun {
                 if let Some(finished) = &state.finished {
                     finished.clone()?;
                     drop(state);
-                    let (tree, _) = self.flush()?;
+                    let (outcome, _) = self.flush()?;
                     let prefix = format!("{path}/");
-                    return if tree.entries.keys().any(|entry| entry.starts_with(&prefix)) {
+                    return if outcome
+                        .outputs
+                        .entries
+                        .keys()
+                        .any(|entry| entry.starts_with(&prefix))
+                    {
                         Ok(MachinePathDemand::FinishRequired {
                             path: path.to_string(),
                         })
@@ -887,20 +892,21 @@ impl MachinePendingRun for FleetRun {
         Ok(MachinePathDemand::File(contents))
     }
 
-    fn flush(&self) -> Result<(Tree, vix::exec::ExecEvent), String> {
-        let (tree_hash, source) = {
+    fn flush(&self) -> Result<(Outcome, vix::exec::ExecEvent), String> {
+        let (tree_hash, read_set, source) = {
             let mut state = self.state.lock().unwrap();
             loop {
                 if let Some(finished) = &state.finished {
-                    let hash = finished.clone()?;
-                    if let Some(tree) = &state.flushed {
+                    let (hash, read_set) = finished.clone()?;
+                    if let Some(outcome) = &state.flushed {
                         return Ok((
-                            tree.clone(),
+                            outcome.clone(),
                             state.source.clone().unwrap_or(vix::exec::ExecEvent::Ran),
                         ));
                     }
                     break (
                         hash,
+                        read_set,
                         state.source.clone().unwrap_or(vix::exec::ExecEvent::Ran),
                     );
                 }
@@ -920,8 +926,12 @@ impl MachinePendingRun for FleetRun {
                 tree_from_bytes(&bytes)
             })
         })?;
-        self.state.lock().unwrap().flushed = Some(tree.clone());
-        Ok((tree, source))
+        let outcome = Outcome {
+            outputs: tree,
+            read_set,
+        };
+        self.state.lock().unwrap().flushed = Some(outcome.clone());
+        Ok((outcome, source))
     }
 }
 

--- a/vix/src/exec.rs
+++ b/vix/src/exec.rs
@@ -640,11 +640,32 @@ impl ExecCache {
         mounts: &[Mount],
         tool: &dyn Tool,
     ) -> Result<Outcome, String> {
+        if let Some(hit) = self.lookup(plan, capability, mounts) {
+            return Ok(hit);
+        }
+
+        let world = MountedWorld::new(mounts);
+        let mut observed = ObservedWorld::new(&world);
+        let outputs = tool.run(plan, &mut observed)?;
+        let outcome = Outcome {
+            outputs,
+            read_set: observed.into_read_set(),
+        };
+        self.record_ran(plan, capability, mounts, outcome.clone());
+        Ok(outcome)
+    }
+
+    pub fn lookup(
+        &mut self,
+        plan: &ExecPlan,
+        capability: u64,
+        mounts: &[Mount],
+    ) -> Option<Outcome> {
         let (identity, coarse) = self.keys(plan, capability, mounts);
 
         if let Some(hit) = self.tier1.get(&coarse) {
             self.events.push(ExecEvent::Tier1Hit);
-            return Ok(hit.clone());
+            return Some(hit.clone());
         }
 
         let world = MountedWorld::new(mounts);
@@ -656,24 +677,24 @@ impl ExecCache {
                     });
                     // Re-pin under the new coarse key: next time is tier-1.
                     self.tier1.insert(coarse, outcome.clone());
-                    return Ok(outcome.clone());
+                    return Some(outcome.clone());
                 }
             }
         }
+        None
+    }
 
-        let mut observed = ObservedWorld::new(&world);
-        let outputs = tool.run(plan, &mut observed)?;
-        let outcome = Outcome {
-            outputs,
-            read_set: observed.into_read_set(),
-        };
+    pub fn record_ran(
+        &mut self,
+        plan: &ExecPlan,
+        capability: u64,
+        mounts: &[Mount],
+        outcome: Outcome,
+    ) {
+        let (identity, coarse) = self.keys(plan, capability, mounts);
         self.events.push(ExecEvent::Ran);
         self.tier1.insert(coarse, outcome.clone());
-        self.candidates
-            .entry(identity)
-            .or_default()
-            .push(outcome.clone());
-        Ok(outcome)
+        self.candidates.entry(identity).or_default().push(outcome);
     }
 }
 

--- a/vix/src/machine/driver.rs
+++ b/vix/src/machine/driver.rs
@@ -96,7 +96,7 @@ pub enum MachinePathDemand {
 
 pub trait MachinePendingRun: Send + Sync {
     fn demand_path(&self, path: &str) -> Result<MachinePathDemand, String>;
-    fn flush(&self) -> Result<(crate::exec::Tree, crate::exec::ExecEvent), String>;
+    fn flush(&self) -> Result<(crate::exec::Outcome, crate::exec::ExecEvent), String>;
 }
 
 pub trait MachineExecBackend: Send + Sync {
@@ -738,7 +738,6 @@ enum TreeEntry {
     Exec(u64),
 }
 
-#[derive(Clone)]
 struct PendingExecRun {
     command: String,
     plan: crate::exec::ExecPlan,
@@ -3485,13 +3484,19 @@ impl Driver {
             TreeEntry::Concrete(_) => Ok(tree_handle),
             TreeEntry::Merge(pending) => {
                 let mut merged = crate::exec::Tree::default();
+                let mut values = Vec::with_capacity(pending.len());
                 for handle in pending {
                     let invocation = self.store.borrow().pending_invocation(handle)?;
                     if invocation.primitive.is_some() {
                         return Err("primitive pending value cannot produce a tree".into());
                     }
                     let fn_ref = self.fn_ref_for_hash(invocation.closure_hash)?;
-                    let value = self.demand(fn_ref, invocation.args)?;
+                    values.push(self.demand(fn_ref, invocation.args)?);
+                }
+                for &value in &values {
+                    self.start_tree_runs(value)?;
+                }
+                for value in values {
                     let value = self.force_tree_handle(value)?;
                     let TreeEntry::Concrete(tree) = self.store.borrow().tree_entry(value)? else {
                         return Err("forced merge branch stayed pending".into());
@@ -3508,6 +3513,29 @@ impl Driver {
             TreeEntry::Exec(run_id) => {
                 let tree = self.finish_run(run_id)?;
                 Ok(self.store.borrow_mut().alloc_tree_concrete(tree).0)
+            }
+        }
+    }
+
+    fn start_tree_runs(&mut self, tree_handle: i64) -> Result<(), String> {
+        let tree = self.store.borrow().tree_entry(tree_handle)?;
+        match tree {
+            TreeEntry::Concrete(_) => Ok(()),
+            TreeEntry::Exec(run_id) => self.ensure_run_started(run_id),
+            TreeEntry::Merge(pending) => {
+                let mut values = Vec::with_capacity(pending.len());
+                for handle in pending {
+                    let invocation = self.store.borrow().pending_invocation(handle)?;
+                    if invocation.primitive.is_some() {
+                        return Err("primitive pending value cannot produce a tree".into());
+                    }
+                    let fn_ref = self.fn_ref_for_hash(invocation.closure_hash)?;
+                    values.push(self.demand(fn_ref, invocation.args)?);
+                }
+                for value in values {
+                    self.start_tree_runs(value)?;
+                }
+                Ok(())
             }
         }
     }
@@ -3750,18 +3778,13 @@ impl Driver {
     }
 
     fn ensure_run_started(&mut self, run_id: u64) -> Result<(), String> {
-        let needs_start = self
-            .runs
-            .get(&run_id)
-            .ok_or_else(|| format!("run {run_id}"))?
-            .completed
-            .is_none()
-            && self
+        let needs_start = {
+            let run = self
                 .runs
                 .get(&run_id)
-                .ok_or_else(|| format!("run {run_id}"))?
-                .remote
-                .is_none();
+                .ok_or_else(|| format!("run {run_id}"))?;
+            run.completed.is_none() && run.remote.is_none()
+        };
         if !self
             .runs
             .get(&run_id)
@@ -3782,7 +3805,7 @@ impl Driver {
                 timestamp_us,
             });
         }
-        if needs_start {
+        if needs_start && let Some(backend) = self.exec_backend.clone() {
             let (command, plan, capability, mounts) = {
                 let run = self.runs.get(&run_id).expect("run checked");
                 (
@@ -3792,34 +3815,21 @@ impl Driver {
                     run.mounts.clone(),
                 )
             };
-            if let Some(backend) = &self.exec_backend {
-                let request = {
-                    let run = self.runs.get(&run_id).expect("run checked");
-                    MachineExecRequest {
-                        command,
-                        plan,
-                        capability,
-                        mounts,
-                        output: run.output.clone(),
-                        span: run.span,
-                        observer: None,
-                    }
-                };
-                let remote = backend.spawn(request)?;
-                let run = self.runs.get_mut(&run_id).expect("run checked");
-                run.remote = Some(remote);
-            } else {
-                let tool = tool_for(&command)?;
-                let outcome = self.exec_cache.exec(&plan, capability, &mounts, tool)?;
-                let event = self
-                    .exec_cache
-                    .events
-                    .last()
-                    .cloned()
-                    .expect("exec pushed an event");
-                let run = self.runs.get_mut(&run_id).expect("run checked");
-                run.completed = Some((outcome, event));
-            }
+            let request = {
+                let run = self.runs.get(&run_id).expect("run checked");
+                MachineExecRequest {
+                    command,
+                    plan,
+                    capability,
+                    mounts,
+                    output: run.output.clone(),
+                    span: run.span,
+                    observer: None,
+                }
+            };
+            let remote = backend.spawn(request)?;
+            let run = self.runs.get_mut(&run_id).expect("run checked");
+            run.remote = Some(remote);
         }
         Ok(())
     }
@@ -3884,18 +3894,31 @@ impl Driver {
             return Ok(outcome);
         }
         if let Some(remote) = self.runs.get(&run_id).and_then(|run| run.remote.clone()) {
-            let (tree, event) = remote.flush()?;
-            let outcome = crate::exec::Outcome {
-                outputs: tree,
-                read_set: crate::exec::ReadSet::default(),
-            };
+            let (outcome, event) = remote.flush()?;
             let run = self.runs.get_mut(&run_id).expect("run checked");
             run.completed = Some((outcome.clone(), event));
             return Ok(outcome);
         }
-        Err(format!(
-            "scheduled run {run_id} has no local or remote completion"
-        ))
+        let (command, plan, capability, mounts) = {
+            let run = self.runs.get(&run_id).expect("run checked");
+            (
+                run.command.clone(),
+                run.plan.clone(),
+                run.capability,
+                run.mounts.clone(),
+            )
+        };
+        let tool = tool_for(&command)?;
+        let outcome = self.exec_cache.exec(&plan, capability, &mounts, tool)?;
+        let event = self
+            .exec_cache
+            .events
+            .last()
+            .cloned()
+            .expect("exec pushed an event");
+        let run = self.runs.get_mut(&run_id).expect("run checked");
+        run.completed = Some((outcome.clone(), event));
+        Ok(outcome)
     }
 
     fn finish_run(&mut self, run_id: u64) -> Result<crate::exec::Tree, String> {

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -5741,15 +5741,18 @@ fn max_store_field_count(block: &ast::Block) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::super::driver::StepCommand;
+    use super::super::driver::{
+        MachineExecBackend, MachineExecRequest, MachinePathDemand, MachinePendingRun, StepCommand,
+    };
     use super::*;
-    use crate::exec::{ExecEvent, Tree};
+    use crate::exec::{ExecEvent, Outcome, ReadSet, Tree};
     use crate::fetch::FakeFetchBackend;
     use sha2::{Digest, Sha256};
     use std::cell::RefCell;
     use std::collections::BTreeMap;
     use std::hash::{DefaultHasher, Hash, Hasher};
     use std::rc::Rc;
+    use std::sync::Arc;
 
     const CORPUS: &str = r#"
 fn square(x: Int) -> Int { x * x }
@@ -5773,6 +5776,44 @@ pub fn poly(n: Int) -> Int {
         Machine::load_with_lane(source, lane).unwrap_or_else(|err| {
             panic!("loads on {lane:?}: {err}");
         })
+    }
+
+    #[derive(Default)]
+    struct DeferredExecBackend;
+
+    impl MachineExecBackend for DeferredExecBackend {
+        fn spawn(&self, request: MachineExecRequest) -> Result<Arc<dyn MachinePendingRun>, String> {
+            Ok(Arc::new(DeferredRun { request }))
+        }
+    }
+
+    struct DeferredRun {
+        request: MachineExecRequest,
+    }
+
+    impl MachinePendingRun for DeferredRun {
+        fn demand_path(&self, path: &str) -> Result<MachinePathDemand, String> {
+            Ok(MachinePathDemand::FinishRequired {
+                path: path.to_string(),
+            })
+        }
+
+        fn flush(&self) -> Result<(Outcome, ExecEvent), String> {
+            let mut tree = Tree::default();
+            tree.entries.insert(
+                self.request.output.clone(),
+                format!("deferred({})", self.request.output),
+            );
+            Ok((
+                Outcome {
+                    outputs: tree,
+                    read_set: ReadSet {
+                        entries: BTreeMap::new(),
+                    },
+                },
+                ExecEvent::Ran,
+            ))
+        }
     }
 
     fn load_modules_with_lane(
@@ -9796,6 +9837,23 @@ pub fn lazy(n: Int) -> Map<String, Float> {
         })
     }
 
+    fn has_two_starts_before_any_completion(machine: &Machine) -> bool {
+        let mut starts = 0usize;
+        for event in machine.trace() {
+            match event {
+                DriveEvent::RunStarted { .. } => {
+                    starts += 1;
+                    if starts >= 2 {
+                        return true;
+                    }
+                }
+                DriveEvent::RunCompleted { .. } => return false,
+                _ => {}
+            }
+        }
+        false
+    }
+
     fn output_set(paths: &[&str]) -> Vec<u64> {
         let mut values: Vec<u64> = paths.iter().map(|path| trace_hash(path)).collect();
         values.sort();
@@ -9807,6 +9865,43 @@ pub fn lazy(n: Int) -> Map<String, Float> {
             include_str!("../../../playgrounds/snark/src/bundled/vix/samples/merge-demand.vix"),
             lane,
         )
+    }
+
+    #[test]
+    fn async_backend_merge_starts_sibling_runs_before_joining_any() {
+        let src = r#"
+use vix::{Tree, Path, Target};
+use caps::Cc;
+
+fn object(cc: Cc, unit: Path) -> Tree {
+    cc! { -o {unit.with_ext("o")} }
+}
+
+pub fn both(target: Target) -> Tree {
+    let cc = Cc::acquire(target);
+    let units = [p"a.c", p"b.c"];
+    units.map(|u| object(cc, u)).collect()
+}
+"#;
+        for lane in lanes() {
+            let backend = Arc::new(DeferredExecBackend);
+            let mut machine = Machine::load_with_lane(src, lane)
+                .unwrap_or_else(|err| panic!("loads on {lane:?}: {err}"))
+                .with_exec_backend(backend);
+            let target = machine.linux_target_handle();
+            let handle = machine.demand_i64("both", vec![target]).unwrap();
+            let entries = machine.tree_entries(handle).unwrap();
+            assert_eq!(
+                entries.keys().cloned().collect::<Vec<_>>(),
+                vec!["a.o".to_string(), "b.o".to_string()],
+                "{lane:?}: {entries:?}"
+            );
+            assert!(
+                has_two_starts_before_any_completion(&machine),
+                "{lane:?}: {:?}",
+                machine.trace()
+            );
+        }
     }
 
     #[test]

--- a/vix/src/real_process.rs
+++ b/vix/src/real_process.rs
@@ -11,12 +11,13 @@ use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
 
 use sha2::{Digest, Sha256};
 
 use crate::exec::{
-    ExecCache, ExecEvent, ExecPlan, ObservedWorld, Outcome, Role, Tool, Tree, role_embedded_paths,
-    role_input_paths, role_output_paths, role_search_dir_paths,
+    ExecCache, ExecEvent, ExecPlan, MountedWorld, ObservedWorld, Outcome, Role, Tool, Tree,
+    role_embedded_paths, role_input_paths, role_output_paths, role_search_dir_paths,
 };
 use crate::machine::{
     MachineExecBackend, MachineExecRequest, MachinePathDemand, MachinePendingRun,
@@ -25,13 +26,13 @@ use crate::machine::{
 const ENV_ALLOWLIST: &[&str] = &["PATH", "HOME", "TMPDIR", "TEMP", "TMP", "SystemRoot"];
 
 pub struct RealProcessBackend {
-    cache: Mutex<ExecCache>,
+    cache: Arc<Mutex<ExecCache>>,
 }
 
 impl RealProcessBackend {
     pub fn new() -> Self {
         Self {
-            cache: Mutex::new(ExecCache::new()),
+            cache: Arc::new(Mutex::new(ExecCache::new())),
         }
     }
 }
@@ -44,57 +45,128 @@ impl Default for RealProcessBackend {
 
 impl MachineExecBackend for RealProcessBackend {
     fn spawn(&self, request: MachineExecRequest) -> Result<Arc<dyn MachinePendingRun>, String> {
-        let tool = RealProcessTool {
-            command: request.command.clone(),
-            output: request.output.clone(),
-        };
-        let mut cache = self
-            .cache
-            .lock()
-            .map_err(|_| "real-process exec cache poisoned".to_string())?;
-        let outcome = cache.exec(&request.plan, request.capability, &request.mounts, &tool)?;
-        let event = cache
-            .events
-            .last()
-            .cloned()
-            .ok_or_else(|| "real-process cache did not record an event".to_string())?;
-        Ok(Arc::new(RealProcessRun { outcome, event }))
+        let cache = Arc::clone(&self.cache);
+        let handle = std::thread::spawn(move || run_real_process_request(cache, request));
+        Ok(Arc::new(RealProcessRun {
+            state: Mutex::new(Some(RealProcessRunState::Starting(handle))),
+        }))
     }
 }
 
 struct RealProcessRun {
-    outcome: Outcome,
-    event: ExecEvent,
+    state: Mutex<Option<RealProcessRunState>>,
+}
+
+enum RealProcessRunState {
+    Starting(JoinHandle<Result<(Outcome, ExecEvent), String>>),
+    Done(Outcome, ExecEvent),
 }
 
 impl MachinePendingRun for RealProcessRun {
     fn demand_path(&self, path: &str) -> Result<MachinePathDemand, String> {
-        if self.outcome.outputs.entries.contains_key(path) {
-            let contents = self
-                .outcome
-                .outputs
-                .entries
-                .get(path)
-                .expect("entry checked")
-                .clone();
-            return Ok(MachinePathDemand::File(contents));
-        }
-        if self.outcome.outputs.blobs.contains_key(path)
-            || has_child(&self.outcome.outputs.entries, path)
-            || has_child(&self.outcome.outputs.blobs, path)
-        {
-            return Ok(MachinePathDemand::FinishRequired {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| "real-process run state poisoned".to_string())?;
+        if let Some(RealProcessRunState::Done(outcome, _)) = &*state {
+            if outcome.outputs.entries.contains_key(path) {
+                let contents = outcome
+                    .outputs
+                    .entries
+                    .get(path)
+                    .expect("entry checked")
+                    .clone();
+                return Ok(MachinePathDemand::File(contents));
+            }
+            if outcome.outputs.blobs.contains_key(path)
+                || has_child(&outcome.outputs.entries, path)
+                || has_child(&outcome.outputs.blobs, path)
+            {
+                return Ok(MachinePathDemand::FinishRequired {
+                    path: path.to_string(),
+                });
+            }
+            return Ok(MachinePathDemand::Missing {
                 path: path.to_string(),
             });
         }
-        Ok(MachinePathDemand::Missing {
+        Ok(MachinePathDemand::FinishRequired {
             path: path.to_string(),
         })
     }
 
-    fn flush(&self) -> Result<(Tree, ExecEvent), String> {
-        Ok((self.outcome.outputs.clone(), self.event.clone()))
+    fn flush(&self) -> Result<(Outcome, ExecEvent), String> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "real-process run state poisoned".to_string())?;
+        match state
+            .take()
+            .ok_or_else(|| "real-process run state missing".to_string())?
+        {
+            RealProcessRunState::Done(outcome, event) => {
+                *state = Some(RealProcessRunState::Done(outcome.clone(), event.clone()));
+                Ok((outcome, event))
+            }
+            RealProcessRunState::Starting(handle) => {
+                let (outcome, event) = handle
+                    .join()
+                    .map_err(|_| "real-process runner thread panicked".to_string())??;
+                *state = Some(RealProcessRunState::Done(outcome.clone(), event.clone()));
+                Ok((outcome, event))
+            }
+        }
     }
+}
+
+fn run_real_process_request(
+    cache: Arc<Mutex<ExecCache>>,
+    request: MachineExecRequest,
+) -> Result<(Outcome, ExecEvent), String> {
+    if let Some((outcome, event)) = {
+        let mut cache = cache
+            .lock()
+            .map_err(|_| "real-process exec cache poisoned".to_string())?;
+        cache
+            .lookup(&request.plan, request.capability, &request.mounts)
+            .map(|outcome| {
+                let event = cache
+                    .events
+                    .last()
+                    .cloned()
+                    .expect("lookup pushed an event");
+                (outcome, event)
+            })
+    } {
+        return Ok((outcome, event));
+    }
+
+    let tool = RealProcessTool {
+        command: request.command,
+        output: request.output,
+    };
+    let world = MountedWorld::new(&request.mounts);
+    let mut observed = ObservedWorld::new(&world);
+    let outputs = tool.run(&request.plan, &mut observed)?;
+    let outcome = Outcome {
+        outputs,
+        read_set: observed.into_read_set(),
+    };
+    let mut cache = cache
+        .lock()
+        .map_err(|_| "real-process exec cache poisoned".to_string())?;
+    cache.record_ran(
+        &request.plan,
+        request.capability,
+        &request.mounts,
+        outcome.clone(),
+    );
+    let event = cache
+        .events
+        .last()
+        .cloned()
+        .ok_or_else(|| "real-process cache did not record an event".to_string())?;
+    Ok((outcome, event))
 }
 
 fn has_child<T>(entries: &BTreeMap<String, T>, path: &str) -> bool {

--- a/vix/tests/crate_real_process.rs
+++ b/vix/tests/crate_real_process.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
+use std::time::Instant;
 
 use facet::Facet;
 use vix::exec::Tree;
@@ -108,6 +109,7 @@ fn real_process_rustc_builds_lockfile_graph_and_matches_cargo_unit_graph_oracle(
         .intern_arg("Tree", MachineArg::Tree(lock_graph_tree()))?
         .0;
 
+    let cold_start = Instant::now();
     let checked = machine.demand_i64("crate_lock_bin_check", vec![target, graph])?;
     let _rmeta = tree_file_bytes(&mut machine, checked, "mini_app.rmeta")?;
 
@@ -120,6 +122,8 @@ fn real_process_rustc_builds_lockfile_graph_and_matches_cargo_unit_graph_oracle(
             String::from_utf8_lossy(&stdout)
         ));
     }
+    let cold_elapsed = cold_start.elapsed();
+    let built_tree = tree_snapshot(&mut machine, built)?;
 
     let machine_graph = machine_rustc_unit_graph(&machine)?;
     let cargo_graph = cargo_lock_graph_unit_graph_oracle()?;
@@ -128,6 +132,29 @@ fn real_process_rustc_builds_lockfile_graph_and_matches_cargo_unit_graph_oracle(
             "lock graph machine unit graph did not match cargo oracle\nmachine: {machine_graph:#?}\ncargo: {cargo_graph:#?}"
         ));
     }
+
+    machine.clear_trace();
+    let warm_start = Instant::now();
+    let warm = machine.demand_i64("crate_lock_bin", vec![target, graph])?;
+    let warm_tree = tree_snapshot(&mut machine, warm)?;
+    let warm_elapsed = warm_start.elapsed();
+    if warm_tree != built_tree {
+        return Err(format!(
+            "warm crate_lock_bin tree differed from cold tree\ncold: {built_tree:?}\nwarm: {warm_tree:?}"
+        ));
+    }
+    let warm_requested = machine
+        .trace()
+        .iter()
+        .filter(|event| matches!(event, DriveEvent::RunRequested { .. }))
+        .count();
+    if warm_requested != 0 {
+        return Err(format!(
+            "warm crate_lock_bin emitted {warm_requested} RunRequested events: {:?}",
+            machine.trace()
+        ));
+    }
+    eprintln!("crate_lock_bin machine wall: cold={cold_elapsed:?} warm={warm_elapsed:?}");
 
     Ok(())
 }
@@ -200,6 +227,13 @@ fn tree_file_bytes(machine: &mut Machine, handle: i64, path: &str) -> Result<Vec
     Err(format!(
         "missing `{path}` in text entries {entries:?} and blob entries {blobs:?}"
     ))
+}
+
+fn tree_snapshot(machine: &mut Machine, handle: i64) -> Result<Tree, String> {
+    Ok(Tree {
+        entries: machine.tree_entries(handle)?,
+        blobs: machine.tree_blob_entries(handle)?,
+    })
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
Summary:
- Restore pending-run behavior through the driver demand path: merge branches are all demanded/started before any branch is joined, and local fake completion moves out of ensure_run_started.
- Make RealProcessBackend::spawn return a real pending handle backed by a spawned runner, with flush returning the full Outcome so observed read sets are preserved.
- Pin the law with deterministic async Pin B and extend the real-process lockfile test with a same-machine warm re-demand memo row.

Testing:
- cargo nextest run -p vix -p weavy
- cargo nextest run -p vix -p weavy --features real-process
- cargo clippy -p vix -p weavy --all-targets --message-format=short -- -D warnings
- cargo clippy -p vix -p weavy --all-targets --features real-process --message-format=short -- -D warnings
- cargo check -p snark-wasm --target wasm32-unknown-unknown
- focused real-process lockfile: cold=648.36175ms warm=109.125us
- stax record run 3: total active 0.548s, off-CPU 10.465s