### PR TITLE
vix: law pins — exec-substrate differential + machine-seam ceiling

### DIFF
--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -7368,6 +7368,38 @@ pub fn main(target: Target) -> Tree {
     }
 
     #[test]
+    fn machine_exec_mount_ceiling_errors_outside_declared_mounts() {
+        let src = r#"
+use vix::Target;
+use caps::Cc;
+
+pub fn bad(target: Target) -> Tree {
+    let cc = Cc::acquire(target);
+    cc! { -c {p"/m/unmounted/ghost.c"} -o {p"ghost.o"} }
+}
+"#;
+        let mut traces = Vec::new();
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            let target = machine.linux_target_handle();
+            let handle = machine.demand_i64("bad", vec![target]).unwrap();
+            let err = machine
+                .tree_entries(handle)
+                .expect_err("undeclared input path is outside the mount ceiling");
+            assert!(err.contains("outside the mounts"), "{lane:?}: {err}");
+            assert_eq!(run_requested_count(&machine), 1, "{lane:?}");
+            assert_eq!(
+                started_outputs(&machine),
+                output_set(&["ghost.o"]),
+                "{lane:?}"
+            );
+            assert_eq!(completed_outputs(&machine), Vec::<u64>::new(), "{lane:?}");
+            traces.push((lane, machine.trace().to_vec()));
+        }
+        assert_lane_traces_equal(&traces);
+    }
+
+    #[test]
     fn unused_command_binding_emits_no_exec_ops_or_runs() {
         let src = r#"
 use vix::Target;

--- a/vix/src/real_process.rs
+++ b/vix/src/real_process.rs
@@ -193,11 +193,7 @@ impl Tool for RealProcessTool {
         stage_declared_inputs(&plan, world, root)?;
         prepare_output_dirs(&plan, root)?;
 
-        let argv = plan
-            .argv
-            .iter()
-            .map(|(arg, role)| map_arg(arg, *role, root))
-            .collect::<Result<Vec<_>, _>>()?;
+        let argv = map_argv(&self.command, &plan, world, root)?;
         let output = Command::new(&self.command)
             .args(argv)
             .current_dir(root)
@@ -239,10 +235,7 @@ fn stage_declared_inputs(
         match role {
             Role::Input | Role::InputFlag => {
                 for input in role_input_paths(arg, *role) {
-                    let bytes = world.read_bytes(&input).ok_or_else(|| {
-                        format!("real-process input `{input}` is outside mounted trees")
-                    })?;
-                    stage_file(root, &input, &bytes)?;
+                    stage_declared_input(&input, world, root)?;
                 }
             }
             Role::SearchDir | Role::SearchDirFlag => {
@@ -264,6 +257,29 @@ fn stage_declared_inputs(
         }
     }
     Ok(())
+}
+
+fn stage_declared_input(
+    input: &str,
+    world: &mut ObservedWorld<'_>,
+    root: &Path,
+) -> Result<(), String> {
+    if let Some(bytes) = world.read_bytes(input) {
+        return stage_file(root, input, &bytes);
+    }
+    if let Some(names) = world.list(input) {
+        for name in names {
+            let logical = format!("{}/{}", input.trim_end_matches('/'), name);
+            let bytes = world.read_bytes(&logical).ok_or_else(|| {
+                format!("real-process input `{logical}` vanished while staging `{input}`")
+            })?;
+            stage_file(root, &logical, &bytes)?;
+        }
+        return Ok(());
+    }
+    Err(format!(
+        "real-process input `{input}` is outside mounted trees"
+    ))
 }
 
 fn listed_logical_path(dir: &str, name: &str, world: &ObservedWorld<'_>) -> String {
@@ -369,6 +385,30 @@ fn physical_path(logical: &str, root: &Path) -> Result<PathBuf, String> {
         ));
     }
     Ok(root.join(path))
+}
+
+fn map_argv(
+    command: &str,
+    plan: &ExecPlan,
+    world: &ObservedWorld<'_>,
+    root: &Path,
+) -> Result<Vec<OsString>, String> {
+    let mut argv = Vec::new();
+    for (arg, role) in &plan.argv {
+        if command == "ar"
+            && *role == Role::Input
+            && world.peek_bytes(arg).is_none()
+            && let Some(names) = world.peek_list(arg)
+        {
+            for name in names {
+                let logical = format!("{}/{}", arg.trim_end_matches('/'), name);
+                argv.push(physical_path(&logical, root)?.into_os_string());
+            }
+            continue;
+        }
+        argv.push(map_arg(arg, *role, root)?);
+    }
+    Ok(argv)
 }
 
 fn scrubbed_env(root: &Path) -> Vec<(OsString, OsString)> {

--- a/vix/tests/real_process.rs
+++ b/vix/tests/real_process.rs
@@ -1,10 +1,17 @@
 #![cfg(all(feature = "real-process", not(target_arch = "wasm32")))]
 
+use std::collections::{BTreeMap, BTreeSet};
+use std::process::Command;
 use std::sync::Arc;
 
 use vix::exec::{ExecEvent, Tree};
+use vix::fetch::FakeFetchBackend;
 use vix::machine::{DriveEvent, Machine, MachineArg};
 use vix::real_process::RealProcessBackend;
+
+const LUA_SOURCE: &str = include_str!("../../playgrounds/snark/src/bundled/vix/samples/lua.vix");
+const LUA_URL: &str = "https://www.lua.org/ftp/lua-5.4.8.tar.gz";
+const LUA_ARCHIVE_BYTES: &[u8] = b"lua-5.4.8 fixture archive";
 
 const SOURCE: &str = r#"
 use vix::{Tree, Path, Target};
@@ -92,11 +99,76 @@ fn real_process_cc_runs_through_machine_exec_cache() -> Result<(), String> {
     Ok(())
 }
 
+#[test]
+fn fake_and_real_lua_exec_substrates_emit_same_normalized_trace() -> Result<(), String> {
+    if !host_cc_available() || !host_command_available("ar") {
+        return Ok(());
+    }
+
+    let mut fake = Machine::load(LUA_SOURCE)?.with_fetch_backend(lua_build_fetch_backend());
+    let fake_target = fake.linux_target_handle();
+    let fake_lua = fake.demand_i64("lua", vec![fake_target])?;
+    let fake_lua_bytes = tree_bytes(&mut fake, fake_lua, "lua")?;
+    if !fake_lua_bytes.starts_with(b"obj(") {
+        return Err(format!(
+            "fake lua fixture produced unexpected bytes: {:?}",
+            String::from_utf8_lossy(&fake_lua_bytes)
+        ));
+    }
+    let fake_trace = normalize_exec_substrate_trace(fake.trace());
+
+    let backend = Arc::new(RealProcessBackend::new());
+    let mut real = Machine::load(LUA_SOURCE)?
+        .with_fetch_backend(lua_build_fetch_backend())
+        .with_exec_backend(backend);
+    let real_target = real.linux_target_handle();
+    let real_lua = real.demand_i64("lua", vec![real_target])?;
+    let real_lua_bytes = tree_bytes(&mut real, real_lua, "lua")?;
+    if real_lua_bytes.is_empty() {
+        return Err("real lua fixture produced an empty executable".to_string());
+    }
+    let real_trace = normalize_exec_substrate_trace(real.trace());
+
+    assert_eq!(fake_trace, real_trace);
+
+    Ok(())
+}
+
 fn host_cc_available() -> bool {
-    std::process::Command::new("cc")
+    Command::new("cc")
         .arg("--version")
         .output()
         .is_ok_and(|output| output.status.success())
+}
+
+fn host_command_available(name: &str) -> bool {
+    Command::new(name).output().is_ok()
+}
+
+fn lua_build_fetch_backend() -> FakeFetchBackend {
+    FakeFetchBackend::new().with_archive(
+        LUA_URL,
+        LUA_ARCHIVE_BYTES,
+        Tree::of(&[
+            ("lua-5.4.8/src/lua.h", "int lua_api(void);\n"),
+            (
+                "lua-5.4.8/src/lapi.c",
+                "#include \"lua.h\"\nint lua_api(void) { return 7; }\n",
+            ),
+            (
+                "lua-5.4.8/src/lauxlib.c",
+                "#include \"lua.h\"\nint lua_aux(void) { return lua_api(); }\n",
+            ),
+            (
+                "lua-5.4.8/src/lua.c",
+                "#include \"lua.h\"\nint main(void) { return lua_api() == 7 ? 0 : 1; }\n",
+            ),
+            (
+                "lua-5.4.8/src/luac.c",
+                "#include \"lua.h\"\nint luac_main(void) { return lua_api(); }\n",
+            ),
+        ]),
+    )
 }
 
 fn source_tree(readme: &str) -> Tree {
@@ -154,4 +226,305 @@ fn assert_object_magic(bytes: &[u8]) -> Result<(), String> {
         return Ok(());
     }
     Err(format!("unrecognized object magic: {:02x?}", &bytes[..4]))
+}
+
+// Normalization rules for the fake-real exec-substrate differential:
+// - drop all timestamps;
+// - collect RunRequested/RunStarted/RunCompleted by run id, preserving each
+//   run's own event sequence;
+// - sort the run records by their canonical request shape, so sibling overlap
+//   and cross-run interleaving differences do not affect equality;
+// - remove run ids after grouping;
+// - compare completed output path sets, not bytes, because fake cc/ar emit
+//   modeled strings while real cc/ar emit host object/archive/executable bytes;
+// - compare serving as a class, so tier variants remain semantic while payload
+//   counters can differ across substrate read-set granularity;
+// - trim a trailing completion for runs whose output is later consumed as an
+//   explicit single-file mounted input: the fake backend has computed that file
+//   but does not log completion for file projection, while real-process must
+//   flush to materialize host bytes for the consumer process.
+fn normalize_exec_substrate_trace(trace: &[DriveEvent]) -> NormalizedTrace {
+    let mut events = Vec::new();
+    let mut runs: BTreeMap<u64, Vec<NormalizedRunEvent>> = BTreeMap::new();
+
+    for event in trace {
+        match event {
+            DriveEvent::Demanded { fn_hash } => {
+                events.push(NormalizedEvent::Demanded { fn_hash: *fn_hash });
+            }
+            DriveEvent::MemoHit { fn_hash } => {
+                events.push(NormalizedEvent::MemoHit { fn_hash: *fn_hash });
+            }
+            DriveEvent::MemoProjectionHit { fn_hash, verified } => {
+                events.push(NormalizedEvent::MemoProjectionHit {
+                    fn_hash: *fn_hash,
+                    verified: *verified,
+                });
+            }
+            DriveEvent::Spawned { fn_hash } => {
+                events.push(NormalizedEvent::Spawned { fn_hash: *fn_hash });
+            }
+            DriveEvent::ParkedOn { fn_hash } => {
+                events.push(NormalizedEvent::ParkedOn { fn_hash: *fn_hash });
+            }
+            DriveEvent::Completed { fn_hash } => {
+                events.push(NormalizedEvent::Completed { fn_hash: *fn_hash });
+            }
+            DriveEvent::SpawnedInvocation { fn_hash, key_hash } => {
+                events.push(NormalizedEvent::SpawnedInvocation {
+                    fn_hash: *fn_hash,
+                    key_hash: *key_hash,
+                });
+            }
+            DriveEvent::StoreAlloc {
+                schema_ref,
+                deduped,
+            } => {
+                events.push(NormalizedEvent::StoreAlloc {
+                    schema_ref: *schema_ref,
+                    deduped: *deduped,
+                });
+            }
+            DriveEvent::RunRequested {
+                command,
+                output,
+                run_id,
+                command_name,
+                argv,
+                describe,
+                span,
+                ..
+            } => runs
+                .entry(*run_id)
+                .or_default()
+                .push(NormalizedRunEvent::Requested {
+                    command: *command,
+                    output: *output,
+                    command_name: command_name.clone(),
+                    argv: argv.clone(),
+                    describe: describe.clone(),
+                    span: *span,
+                }),
+            DriveEvent::RunStarted {
+                command,
+                output,
+                run_id,
+                command_name,
+                ..
+            } => runs
+                .entry(*run_id)
+                .or_default()
+                .push(NormalizedRunEvent::Started {
+                    command: *command,
+                    output: *output,
+                    command_name: command_name.clone(),
+                }),
+            DriveEvent::RunCompleted {
+                command,
+                output,
+                run_id,
+                command_name,
+                serving,
+                outputs,
+                ..
+            } => {
+                let mut output_paths = outputs
+                    .iter()
+                    .map(|(path, _)| path.clone())
+                    .collect::<Vec<_>>();
+                output_paths.sort();
+                runs.entry(*run_id)
+                    .or_default()
+                    .push(NormalizedRunEvent::Completed {
+                        command: *command,
+                        output: *output,
+                        command_name: command_name.clone(),
+                        serving: ServingClass::from(serving),
+                        output_paths,
+                    });
+            }
+            DriveEvent::Observation {
+                key,
+                replayed,
+                key_text,
+                ..
+            } => events.push(NormalizedEvent::Observation {
+                key: *key,
+                replayed: *replayed,
+                key_text: key_text.clone(),
+            }),
+            DriveEvent::ArtifactProbe {
+                format,
+                projection,
+                input,
+                cache_hit,
+                ..
+            } => events.push(NormalizedEvent::ArtifactProbe {
+                format: format.clone(),
+                projection: projection.clone(),
+                input: *input,
+                cache_hit: *cache_hit,
+            }),
+        }
+    }
+
+    let mut runs = runs
+        .into_values()
+        .map(|events| NormalizedRun { events })
+        .collect::<Vec<_>>();
+    trim_single_file_materialization_completions(&mut runs);
+    runs.sort();
+    NormalizedTrace { events, runs }
+}
+
+fn trim_single_file_materialization_completions(runs: &mut [NormalizedRun]) {
+    let consumed_files = runs
+        .iter()
+        .flat_map(|run| run.events.iter())
+        .filter_map(|event| match event {
+            NormalizedRunEvent::Requested { argv, .. } => Some(argv),
+            _ => None,
+        })
+        .flat_map(|argv| argv.iter().filter_map(|arg| mounted_file_basename(arg)))
+        .collect::<BTreeSet<_>>();
+
+    for run in runs {
+        let should_trim = run
+            .events
+            .iter()
+            .find_map(|event| match event {
+                NormalizedRunEvent::Requested {
+                    command_name, argv, ..
+                } => requested_output_path(command_name, argv),
+                _ => None,
+            })
+            .and_then(|path| path.rsplit('/').next().map(str::to_string))
+            .is_some_and(|basename| consumed_files.contains(&basename));
+        if should_trim
+            && matches!(
+                run.events.last(),
+                Some(NormalizedRunEvent::Completed {
+                    serving: ServingClass::Ran,
+                    ..
+                })
+            )
+        {
+            run.events.pop();
+        }
+    }
+}
+
+fn mounted_file_basename(arg: &str) -> Option<String> {
+    let rest = arg.strip_prefix("/m/")?;
+    let (_, path) = rest.split_once('/')?;
+    path.rsplit('/').next().map(str::to_string)
+}
+
+fn requested_output_path(command_name: &str, argv: &[String]) -> Option<String> {
+    match command_name {
+        "cc" => argv
+            .windows(2)
+            .find_map(|pair| (pair[0] == "-o").then(|| pair[1].clone())),
+        "ar" => argv
+            .iter()
+            .find(|arg| arg.as_str() != "rcs" && !arg.starts_with("/m/"))
+            .cloned(),
+        _ => None,
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct NormalizedTrace {
+    events: Vec<NormalizedEvent>,
+    runs: Vec<NormalizedRun>,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct NormalizedRun {
+    events: Vec<NormalizedRunEvent>,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum NormalizedRunEvent {
+    Requested {
+        command: u64,
+        output: u64,
+        command_name: String,
+        argv: Vec<String>,
+        describe: Vec<String>,
+        span: Option<(u32, u32)>,
+    },
+    Started {
+        command: u64,
+        output: u64,
+        command_name: String,
+    },
+    Completed {
+        command: u64,
+        output: u64,
+        command_name: String,
+        serving: ServingClass,
+        output_paths: Vec<String>,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum NormalizedEvent {
+    Demanded {
+        fn_hash: u64,
+    },
+    MemoHit {
+        fn_hash: u64,
+    },
+    MemoProjectionHit {
+        fn_hash: u64,
+        verified: usize,
+    },
+    Spawned {
+        fn_hash: u64,
+    },
+    ParkedOn {
+        fn_hash: u64,
+    },
+    Completed {
+        fn_hash: u64,
+    },
+    SpawnedInvocation {
+        fn_hash: u64,
+        key_hash: u64,
+    },
+    StoreAlloc {
+        schema_ref: u64,
+        deduped: bool,
+    },
+    Observation {
+        key: u64,
+        replayed: bool,
+        key_text: String,
+    },
+    ArtifactProbe {
+        format: String,
+        projection: String,
+        input: u64,
+        cache_hit: bool,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum ServingClass {
+    Ran,
+    Tier1Hit,
+    Tier2Cutoff,
+    Joined,
+}
+
+impl From<&ExecEvent> for ServingClass {
+    fn from(event: &ExecEvent) -> Self {
+        match event {
+            ExecEvent::Ran => ServingClass::Ran,
+            ExecEvent::Tier1Hit => ServingClass::Tier1Hit,
+            ExecEvent::Tier2Cutoff { .. } => ServingClass::Tier2Cutoff,
+            ExecEvent::Joined => ServingClass::Joined,
+        }
+    }
 }


### PR DESCRIPTION
Summary:
- Adds the fake-vs-real exec-substrate trace oracle over the lua.vix build fixture, host-gated under real-process.
- Pins machine-seam propagation of the mount ceiling error through the full demand path.
- Fixes real-process directory inputs for ar so mounted Tree inputs are staged and expanded like the fake substrate.

Normalization rules:
- Drop timestamps and run ids.
- Group run events by run id, preserve each run sequence, sort run records by canonical request shape.
- Compare output path sets rather than fake/real artifact bytes.
- Compare serving as a tier class.
- Canonicalize the single-file materialization logging split surfaced by the differential: fake computes projected files without logging completion, while real must flush host bytes before the consumer process can run.

Testing:
- cargo nextest run -p vix -p weavy
- cargo nextest run -p vix -p weavy --features real-process
- cargo clippy -p vix -p weavy --all-targets --message-format=short -- -D warnings
- cargo clippy -p vix -p weavy --all-targets --features real-process --message-format=short -- -D warnings
- pnpm --filter @bearcove/snark-playground run test:flow