### PR TITLE
vix: VersionSet + semantic cutoff (equivalence-predicate memo tier)

### DIFF
--- a/playgrounds/snark/src/App.tsx
+++ b/playgrounds/snark/src/App.tsx
@@ -338,6 +338,8 @@ type VixExecServing =
 type VixDriveEvent =
   | { type: "Demanded"; fn_hash: string }
   | { type: "MemoHit"; fn_hash: string }
+  | { type: "MemoProjectionHit"; fn_hash: string; verified: number }
+  | { type: "MemoSemanticHit"; fn_hash: string; verified: number }
   | { type: "Spawned"; fn_hash: string }
   | { type: "ParkedOn"; fn_hash: string }
   | { type: "Completed"; fn_hash: string }
@@ -370,6 +372,14 @@ type VixDriveEvent =
       command_name: string;
       serving: VixExecServing;
       outputs: RunOutput[];
+      timestamp_us: number;
+    }
+  | {
+      type: "ArtifactProbe";
+      format: string;
+      projection: string;
+      input: string;
+      cache_hit: boolean;
       timestamp_us: number;
     }
   | {
@@ -2053,6 +2063,8 @@ function formatDriveEvent(
   switch (event.type) {
     case "Demanded":
     case "MemoHit":
+    case "MemoProjectionHit":
+    case "MemoSemanticHit":
     case "Spawned":
     case "ParkedOn":
     case "Completed":
@@ -2071,6 +2083,8 @@ function formatDriveEvent(
       }`;
     case "Observation":
       return `Observation ${event.replayed ? "replayed" : "cold"} ${event.key_text || shortHash(event.key)}`;
+    case "ArtifactProbe":
+      return `ArtifactProbe ${event.cache_hit ? "replayed" : "cold"} ${event.format}:${event.projection}`;
   }
 }
 

--- a/snark-wasm/src/lib.rs
+++ b/snark-wasm/src/lib.rs
@@ -98,6 +98,10 @@ pub enum VixDriveEvent {
         fn_hash: String,
         verified: u64,
     },
+    MemoSemanticHit {
+        fn_hash: String,
+        verified: u64,
+    },
     Spawned {
         fn_hash: String,
     },
@@ -285,6 +289,12 @@ fn trace_events(events: &[vix::machine::driver::DriveEvent]) -> Vec<VixDriveEven
             },
             vix::machine::driver::DriveEvent::MemoProjectionHit { fn_hash, verified } => {
                 VixDriveEvent::MemoProjectionHit {
+                    fn_hash: hex_hash(*fn_hash),
+                    verified: u64::try_from(*verified).expect("verified count fits u64"),
+                }
+            }
+            vix::machine::driver::DriveEvent::MemoSemanticHit { fn_hash, verified } => {
+                VixDriveEvent::MemoSemanticHit {
                     fn_hash: hex_hash(*fn_hash),
                     verified: u64::try_from(*verified).expect("verified count fits u64"),
                 }

--- a/vix-daemon/src/lib.rs
+++ b/vix-daemon/src/lib.rs
@@ -388,7 +388,9 @@ impl MachineEventAdapter {
 
     fn convert(&mut self, event: &DriveEvent) -> Option<DemandEvent> {
         match event {
-            DriveEvent::MemoHit { fn_hash } | DriveEvent::MemoProjectionHit { fn_hash, .. } => {
+            DriveEvent::MemoHit { fn_hash }
+            | DriveEvent::MemoProjectionHit { fn_hash, .. }
+            | DriveEvent::MemoSemanticHit { fn_hash, .. } => {
                 let func = self.func_name(*fn_hash);
                 Some(DemandEvent::Hit {
                     generation: self.generation,

--- a/vix/src/binder.rs
+++ b/vix/src/binder.rs
@@ -88,7 +88,16 @@ impl ModuleBindings {
 /// Primitive scalar types need no declaration or import; they resolve silently
 /// (no ref recorded — there is no def site to jump to).
 const BUILTIN_TYPES: &[&str] = &[
-    "Int", "Float", "String", "Bool", "Blob", "Doc", "Tree", "Version", "Sealed",
+    "Int",
+    "Float",
+    "String",
+    "Bool",
+    "Blob",
+    "Doc",
+    "Tree",
+    "Version",
+    "VersionSet",
+    "Sealed",
 ];
 
 #[derive(Debug, Clone)]
@@ -341,7 +350,8 @@ fn builtin_module_item(module: &str, name: &str) -> Option<ModuleItem> {
         (
             "vix",
             "Int" | "Float" | "String" | "Bool" | "Blob" | "Doc" | "Tree" | "Path" | "Target"
-            | "Map" | "Array" | "Flag" | "Run" | "Os" | "Arch" | "Version" | "Sealed",
+            | "Map" | "Array" | "Flag" | "Run" | "Os" | "Arch" | "Version" | "VersionSet"
+            | "Sealed",
         ) => ImportKind::Type,
         ("caps", "Cc" | "Ar" | "Rustc") => ImportKind::Type,
         _ => return None,

--- a/vix/src/machine/driver.rs
+++ b/vix/src/machine/driver.rs
@@ -28,7 +28,7 @@
 
 use std::cell::RefCell;
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::hash::Hash;
 use std::sync::Arc;
 
@@ -150,6 +150,8 @@ pub const STRING_DEFAULT_HOST: u32 = 37;
 pub const SEALED_SEAL_HOST: u32 = 38;
 pub const SEALED_DECLASSIFY_HOST: u32 = 39;
 pub const SEALED_TO_STRING_HOST: u32 = 40;
+pub const VERSION_SET_PARSE_HOST: u32 = 41;
+pub const VERSION_SET_OP_HOST: u32 = 42;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Lane {
@@ -194,6 +196,8 @@ pub struct LoweredFn {
     /// Schema ref for the returned word. Float returns canonicalize at
     /// the memo boundary.
     pub return_schema: String,
+    /// Semantic memo comparators, one per declared argument verifier.
+    pub semantic_comparators: Vec<SemanticComparator>,
     /// Byte offset of this function's INVOKE region.
     pub invoke_region: u32,
     /// Byte offset of this function's STORE_ALLOC region:
@@ -208,6 +212,12 @@ pub struct LoweredFn {
     pub primitive_region: u32,
 }
 
+#[derive(Clone, Debug)]
+pub struct SemanticComparator {
+    pub arg_index: usize,
+    pub fn_ref: usize,
+}
+
 /// Driver-level events (join the unified trace via lowering-emitted
 /// marks later; recorded directly in this slice).
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -219,6 +229,9 @@ pub enum DriveEvent {
     /// Coarse memo key missed, but all observed projections from a
     /// prior run verified against the new composite arguments.
     MemoProjectionHit { fn_hash: u64, verified: usize },
+    /// Coarse memo key missed, but declared semantic comparators
+    /// accepted the changed arguments.
+    MemoSemanticHit { fn_hash: u64, verified: usize },
     /// Spawned a task (memo miss).
     Spawned { fn_hash: u64 },
     /// A task parked awaiting another invocation's result.
@@ -335,6 +348,9 @@ pub enum RenderedValue {
         value: String,
     },
     Version {
+        value: String,
+    },
+    VersionSet {
         value: String,
     },
     Raw {
@@ -580,6 +596,7 @@ pub type MapWordRow = (String, i64, String, i64, Option<i64>);
 #[derive(Clone, Debug)]
 struct MemoEntry {
     value: i64,
+    args: Vec<i64>,
     read_set: ProjectionReadSet,
 }
 
@@ -587,6 +604,13 @@ struct MemoEntry {
 enum ProjectionArgKey {
     Exact(ContentHash),
     Projectable(String),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MemoHitKind {
+    Exact,
+    Projection,
+    Semantic,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -615,6 +639,10 @@ impl ProjectionReadSet {
 
     fn len(&self) -> usize {
         self.entries.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
     }
 }
 
@@ -1648,6 +1676,11 @@ impl Driver {
         self.fns[fn_ref].hash
     }
 
+    #[cfg(test)]
+    pub fn semantic_comparator_len(&self, fn_ref: usize) -> usize {
+        self.fns[fn_ref].semantic_comparators.len()
+    }
+
     pub fn pending_for_fn(&self, fn_ref: usize, args: Vec<i64>) -> Result<(i64, String), String> {
         let lowered = self
             .fns
@@ -1701,6 +1734,14 @@ impl Driver {
             .alloc_raw("Version", super::version::canonical_bytes(&version)))
     }
 
+    pub fn intern_version_set_req_value(&self, text: &str) -> Result<(i64, bool), String> {
+        let set = super::version_set::VersionSet::from_req(text)?;
+        Ok(self
+            .store
+            .borrow_mut()
+            .alloc_raw("VersionSet", set.canonical_bytes()))
+    }
+
     pub fn intern_linux_target(&self) -> (i64, bool) {
         self.intern_structured_target(OS_LINUX, host_arch_index())
             .unwrap_or_else(|_| {
@@ -1751,6 +1792,16 @@ impl Driver {
             });
             return Ok(entry.value);
         }
+        if let Some(entry) = self.semantic_memo_hit(fn_ref, &args, &key)? {
+            let verified = self.fns[fn_ref].semantic_comparators.len();
+            self.memo.insert(key.clone(), entry.clone());
+            self.index_memo_candidate(fn_ref, &args, &key);
+            self.emit(DriveEvent::MemoSemanticHit {
+                fn_hash: key.0,
+                verified,
+            });
+            return Ok(entry.value);
+        }
 
         // Waiters: invocation key → executions parked on it (by index
         // into `executions`) with the slot to fill.
@@ -1776,6 +1827,7 @@ impl Driver {
                     );
                     let done_entry = MemoEntry {
                         value,
+                        args: exec.args.clone(),
                         read_set: exec.read_set,
                     };
                     self.memo.insert(done_key.clone(), done_entry.clone());
@@ -1941,24 +1993,40 @@ impl Driver {
                             exec.awaited.resize(req.input_slot + 1, 0);
                         }
                         let hit = if let Some(entry) = self.memo.get(&req_key).cloned() {
-                            Some((entry, false))
-                        } else {
+                            Some((entry, MemoHitKind::Exact))
+                        } else if let Some(entry) =
                             self.projection_memo_hit(req.fn_ref, &req.args, &req_key)?
-                                .map(|entry| (entry, true))
+                        {
+                            Some((entry, MemoHitKind::Projection))
+                        } else {
+                            self.semantic_memo_hit(req.fn_ref, &req.args, &req_key)?
+                                .map(|entry| (entry, MemoHitKind::Semantic))
                         };
-                        if let Some((entry, projection_hit)) = hit {
+                        if let Some((entry, hit_kind)) = hit {
                             // Mechanism 1: memo hit — the slot fills
                             // synchronously, no task exists.
-                            if projection_hit {
-                                let verified = entry.read_set.len();
-                                self.memo.insert(req_key.clone(), entry.clone());
-                                self.index_memo_candidate(req.fn_ref, &req.args, &req_key);
-                                self.emit(DriveEvent::MemoProjectionHit {
-                                    fn_hash: req_key.0,
-                                    verified,
-                                });
-                            } else {
-                                self.emit(DriveEvent::MemoHit { fn_hash: req_key.0 });
+                            match hit_kind {
+                                MemoHitKind::Exact => {
+                                    self.emit(DriveEvent::MemoHit { fn_hash: req_key.0 });
+                                }
+                                MemoHitKind::Projection => {
+                                    let verified = entry.read_set.len();
+                                    self.memo.insert(req_key.clone(), entry.clone());
+                                    self.index_memo_candidate(req.fn_ref, &req.args, &req_key);
+                                    self.emit(DriveEvent::MemoProjectionHit {
+                                        fn_hash: req_key.0,
+                                        verified,
+                                    });
+                                }
+                                MemoHitKind::Semantic => {
+                                    let verified = self.fns[req.fn_ref].semantic_comparators.len();
+                                    self.memo.insert(req_key.clone(), entry.clone());
+                                    self.index_memo_candidate(req.fn_ref, &req.args, &req_key);
+                                    self.emit(DriveEvent::MemoSemanticHit {
+                                        fn_hash: req_key.0,
+                                        verified,
+                                    });
+                                }
                             }
                             exec.ready[req.input_slot] = true;
                             exec.awaited[req.input_slot] = entry.value;
@@ -2837,6 +2905,116 @@ impl Driver {
                 }
             };
 
+            let mut version_set_parse_host = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let input = read_frame_word(frame, primitive_region + 8);
+                    let text = store_cell.borrow().string_value(input, "String")?;
+                    let set = super::version_set::VersionSet::from_req(&text)?;
+                    let (handle, _) = store_cell
+                        .borrow_mut()
+                        .alloc_raw("VersionSet", set.canonical_bytes());
+                    write_frame_word(frame, dst_slot, handle);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
+            let mut version_set_op_host = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let op = read_frame_word(frame, primitive_region + 8);
+                    let left = read_frame_word(frame, primitive_region + 16);
+                    let right = read_frame_word(frame, primitive_region + 24);
+                    let store = store_cell.borrow();
+                    let left_entry = store
+                        .entry(left)
+                        .ok_or_else(|| format!("store handle {left}"))?;
+                    if left_entry.schema != "VersionSet" {
+                        return Err(format!(
+                            "VersionSet op expected VersionSet, got {}",
+                            left_entry.schema
+                        ));
+                    }
+                    let left_set = super::version_set::VersionSet::parse_bytes(&left_entry.bytes)?;
+                    match op {
+                        0 | 1 | 3 => {
+                            let right_entry = store
+                                .entry(right)
+                                .ok_or_else(|| format!("store handle {right}"))?;
+                            if right_entry.schema != "VersionSet" {
+                                return Err(format!(
+                                    "VersionSet op expected VersionSet, got {}",
+                                    right_entry.schema
+                                ));
+                            }
+                            let right_set =
+                                super::version_set::VersionSet::parse_bytes(&right_entry.bytes)?;
+                            drop(store);
+                            match op {
+                                0 => {
+                                    let set = left_set.union(&right_set);
+                                    let handle = store_cell
+                                        .borrow_mut()
+                                        .alloc_raw("VersionSet", set.canonical_bytes())
+                                        .0;
+                                    write_frame_word(frame, dst_slot, handle);
+                                }
+                                1 => {
+                                    let set = left_set.intersect(&right_set);
+                                    let handle = store_cell
+                                        .borrow_mut()
+                                        .alloc_raw("VersionSet", set.canonical_bytes())
+                                        .0;
+                                    write_frame_word(frame, dst_slot, handle);
+                                }
+                                3 => {
+                                    write_frame_word(
+                                        frame,
+                                        dst_slot,
+                                        i64::from(left_set.is_subset_of(&right_set)),
+                                    );
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        2 => {
+                            drop(store);
+                            let set = left_set.complement();
+                            let handle = store_cell
+                                .borrow_mut()
+                                .alloc_raw("VersionSet", set.canonical_bytes())
+                                .0;
+                            write_frame_word(frame, dst_slot, handle);
+                        }
+                        4 => {
+                            let right_entry = store
+                                .entry(right)
+                                .ok_or_else(|| format!("store handle {right}"))?;
+                            if right_entry.schema != "Version" {
+                                return Err(format!(
+                                    "VersionSet.contains expected Version, got {}",
+                                    right_entry.schema
+                                ));
+                            }
+                            let version = super::version::parse_bytes(&right_entry.bytes)?;
+                            write_frame_word(
+                                frame,
+                                dst_slot,
+                                i64::from(left_set.contains(&version)),
+                            );
+                        }
+                        other => return Err(format!("unknown VersionSet op {other}")),
+                    }
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
             let mut ast_fn_host = |frame: &mut [u8]| {
                 let result = (|| {
                     let dst_slot = read_frame_word(frame, primitive_region) as usize;
@@ -3338,7 +3516,7 @@ impl Driver {
                 }
             };
 
-            let mut hosts: [HostFn<'_>; 41] = [
+            let mut hosts: [HostFn<'_>; 43] = [
                 &mut invoke,
                 &mut store_alloc,
                 &mut store_read,
@@ -3380,6 +3558,8 @@ impl Driver {
                 &mut sealed_seal,
                 &mut sealed_declassify,
                 &mut sealed_to_string,
+                &mut version_set_parse_host,
+                &mut version_set_op_host,
             ];
             let step = exec
                 .task
@@ -3442,12 +3622,18 @@ impl Driver {
         args: &[i64],
     ) -> Option<ProjectionCandidateKey> {
         let lowered = &self.fns[fn_ref];
+        let semantic_args: BTreeSet<usize> = lowered
+            .semantic_comparators
+            .iter()
+            .map(|comparator| comparator.arg_index)
+            .collect();
         let mut saw_projectable = false;
         let args = args
             .iter()
             .zip(&lowered.arg_schemas)
-            .map(|(&word, schema)| {
-                if self.is_projectable_arg(schema, word) {
+            .enumerate()
+            .map(|(arg_index, (&word, schema))| {
+                if semantic_args.contains(&arg_index) || self.is_projectable_arg(schema, word) {
                     saw_projectable = true;
                     ProjectionArgKey::Projectable(schema.clone())
                 } else {
@@ -3486,11 +3672,68 @@ impl Driver {
             let Some(entry) = self.memo.get(candidate) else {
                 continue;
             };
+            if entry.read_set.is_empty() {
+                continue;
+            }
             if self.verify_projection_read_set(args, &entry.read_set)? {
                 return Ok(Some(entry.clone()));
             }
         }
         Ok(None)
+    }
+
+    fn semantic_memo_hit(
+        &mut self,
+        fn_ref: usize,
+        args: &[i64],
+        key: &CanonMemoKey,
+    ) -> Result<Option<MemoEntry>, String> {
+        if self.fns[fn_ref].semantic_comparators.is_empty() {
+            return Ok(None);
+        }
+        let Some(candidate_key) = self.projection_candidate_key(fn_ref, args) else {
+            return Ok(None);
+        };
+        let Some(candidates) = self.memo_candidates.get(&candidate_key).cloned() else {
+            return Ok(None);
+        };
+        for candidate in candidates {
+            if &candidate == key {
+                continue;
+            }
+            let Some(entry) = self.memo.get(&candidate).cloned() else {
+                continue;
+            };
+            if self.verify_semantic_comparators(fn_ref, &entry.args, args)? {
+                return Ok(Some(entry));
+            }
+        }
+        Ok(None)
+    }
+
+    fn verify_semantic_comparators(
+        &mut self,
+        fn_ref: usize,
+        old_args: &[i64],
+        new_args: &[i64],
+    ) -> Result<bool, String> {
+        let comparators = self.fns[fn_ref].semantic_comparators.clone();
+        for comparator in comparators {
+            let Some(&old_value) = old_args.get(comparator.arg_index) else {
+                return Ok(false);
+            };
+            let Some(&new_value) = new_args.get(comparator.arg_index) else {
+                return Ok(false);
+            };
+            if old_value == new_value {
+                continue;
+            }
+            let accepted = self.demand(comparator.fn_ref, vec![old_value, new_value])?;
+            if accepted == 0 {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 
     fn verify_projection_read_set(
@@ -5347,6 +5590,17 @@ fn compare_words(
             }
             super::version::cmp_total(&a.bytes, &b.bytes)
         }
+        "VersionSet" => {
+            let a = store.entry(a).ok_or_else(|| format!("store handle {a}"))?;
+            let b = store.entry(b).ok_or_else(|| format!("store handle {b}"))?;
+            if a.schema != "VersionSet" || b.schema != "VersionSet" {
+                return Err(format!(
+                    "compare expected VersionSet, got {} and {}",
+                    a.schema, b.schema
+                ));
+            }
+            Ok(a.bytes.cmp(&b.bytes))
+        }
         "Array" => compare_arrays(store, descriptors, schema_refs, a, b),
         schema if schema.starts_with("Map<") => compare_maps(store, descriptors, schema_refs, a, b),
         "Doc" => compare_docs(store, descriptors, schema_refs, a, b),
@@ -5701,6 +5955,20 @@ fn render_word(
         "Version" => Ok(RenderedValue::Version {
             value: store.string_value(word, "Version")?,
         }),
+        "VersionSet" => {
+            let entry = store
+                .entry(word)
+                .ok_or_else(|| format!("store handle {word}"))?;
+            if entry.schema != "VersionSet" {
+                return Err(format!(
+                    "handle {word} is `{}`, not VersionSet",
+                    entry.schema
+                ));
+            }
+            Ok(RenderedValue::VersionSet {
+                value: super::version_set::VersionSet::parse_bytes(&entry.bytes)?.render(),
+            })
+        }
         "Flag" => Ok(RenderedValue::Flag {
             value: store.string_value(word, "Flag")?,
         }),
@@ -7922,10 +8190,12 @@ mod tests {
     use weavy::task::{ArgCopy, Fn as TaskFn, Op};
 
     fn seed_memo(driver: &mut Driver, key: CanonMemoKey, value: i64) {
+        let args = key.1.iter().map(|_| 0).collect();
         driver.memo.insert(
             key,
             MemoEntry {
                 value,
+                args,
                 read_set: ProjectionReadSet::default(),
             },
         );
@@ -7988,6 +8258,7 @@ mod tests {
             arg_offsets: vec![0],
             arg_schemas: vec!["Int".into()],
             return_schema: "Int".into(),
+            semantic_comparators: Vec::new(),
             invoke_region: 8,
             store_alloc_region: 0,
             store_read_region: 0,
@@ -8082,6 +8353,7 @@ mod tests {
             arg_offsets: vec![],
             arg_schemas: vec![],
             return_schema: "Int".into(),
+            semantic_comparators: Vec::new(),
             invoke_region: 8,
             store_alloc_region: 0,
             store_read_region: 0,
@@ -8150,6 +8422,7 @@ mod tests {
             arg_offsets: vec![0],
             arg_schemas: vec!["Int".into()],
             return_schema: "Int".into(),
+            semantic_comparators: Vec::new(),
             invoke_region: 24,
             store_alloc_region: 0,
             store_read_region: 0,
@@ -8198,6 +8471,7 @@ mod tests {
                 arg_offsets,
                 arg_schemas,
                 return_schema: "Int".into(),
+                semantic_comparators: Vec::new(),
                 invoke_region: 128,
                 store_alloc_region: 0,
                 store_read_region: 48,

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -17,6 +17,7 @@
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -36,8 +37,9 @@ use super::driver::{
     PATH_WITH_EXT_HOST, PENDING_ALLOC_HOST, PENDING_COERCE_HOST, PENDING_INVOKE_HOST, RenderNames,
     RenderVariant, RenderedValue, SEALED_DECLASSIFY_HOST, SEALED_SEAL_HOST, SEALED_TO_STRING_HOST,
     STORE_ALLOC_HOST, STORE_READ_HOST, STORE_TAG_HOST, STRING_CONCAT_HOST, STRING_DEFAULT_HOST,
-    STRING_LOWER_HOST, STRING_UPPER_HOST, StepMode, StoreHandle, TARGET_HOST, TREE_PROJECT_HOST,
-    VALUE_COMPARE_HOST, VERSION_PARSE_HOST, ValueBundle,
+    STRING_LOWER_HOST, STRING_UPPER_HOST, SemanticComparator, StepMode, StoreHandle, TARGET_HOST,
+    TREE_PROJECT_HOST, VALUE_COMPARE_HOST, VERSION_PARSE_HOST, VERSION_SET_OP_HOST,
+    VERSION_SET_PARSE_HOST, ValueBundle,
 };
 use crate::ast;
 use crate::fetch::FetchBackend;
@@ -208,18 +210,35 @@ impl Machine {
                 .map_err(|e| format!("lowering {name}: {e}"))?
             };
             task_fns.push(task_fn);
+            let arg_schemas = item
+                .params
+                .params
+                .iter()
+                .map(|param| type_schema_name(&param.ty))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| format!("lowering {name}: {e}"))?;
+            let param_names = item
+                .params
+                .params
+                .iter()
+                .map(|param| param.name.value.clone())
+                .collect::<Vec<_>>();
+            let semantic_comparators = semantic_comparators_for(
+                name,
+                &arg_schemas,
+                &param_names,
+                &fn_refs,
+                &fn_params,
+                &fn_returns,
+            )?;
+            let hash = hash_with_semantic_comparators(hash, &semantic_comparators, &names, &tables);
             lowered.push(LoweredFn {
                 hash,
                 task_fn: FnId(u32::try_from(ix).expect("fn count fits u32")),
                 arg_offsets: info.arg_offsets,
-                arg_schemas: item
-                    .params
-                    .params
-                    .iter()
-                    .map(|param| type_schema_name(&param.ty))
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(|e| format!("lowering {name}: {e}"))?,
+                arg_schemas,
                 return_schema: fn_returns[*name].clone(),
+                semantic_comparators,
                 invoke_region: info.invoke_region,
                 store_alloc_region: info.store_alloc_region,
                 store_read_region: info.store_read_region,
@@ -407,18 +426,35 @@ impl Machine {
                 .map_err(|e| format!("lowering {name}: {e}"))?
             };
             task_fns.push(task_fn);
+            let arg_schemas = item
+                .params
+                .params
+                .iter()
+                .map(|param| type_schema_name(&param.ty))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| format!("lowering {name}: {e}"))?;
+            let param_names = item
+                .params
+                .params
+                .iter()
+                .map(|param| param.name.value.clone())
+                .collect::<Vec<_>>();
+            let semantic_comparators = semantic_comparators_for(
+                name,
+                &arg_schemas,
+                &param_names,
+                &fn_refs,
+                &fn_params,
+                &fn_returns,
+            )?;
+            let hash = hash_with_semantic_comparators(hash, &semantic_comparators, &names, &tables);
             lowered.push(LoweredFn {
                 hash,
                 task_fn: FnId(u32::try_from(ix).expect("fn count fits u32")),
                 arg_offsets: info.arg_offsets,
-                arg_schemas: item
-                    .params
-                    .params
-                    .iter()
-                    .map(|param| type_schema_name(&param.ty))
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(|e| format!("lowering {name}: {e}"))?,
+                arg_schemas,
                 return_schema: fn_returns[*name].clone(),
+                semantic_comparators,
                 invoke_region: info.invoke_region,
                 store_alloc_region: info.store_alloc_region,
                 store_read_region: info.store_read_region,
@@ -516,6 +552,9 @@ impl Machine {
             ("Version", MachineArg::String(value)) => {
                 Ok(StoreHandle(self.driver.intern_version_value(&value)?.0))
             }
+            ("VersionSet", MachineArg::String(value)) => Ok(StoreHandle(
+                self.driver.intern_version_set_req_value(&value)?.0,
+            )),
             ("String", MachineArg::String(value)) => Ok(StoreHandle(
                 self.driver.intern_raw_value("String", value.into_bytes()).0,
             )),
@@ -702,6 +741,13 @@ impl Machine {
             .get(name)
             .map(|&fn_ref| self.driver.fn_ops(fn_ref))
     }
+
+    #[cfg(test)]
+    fn semantic_comparator_len(&self, name: &str) -> Option<usize> {
+        self.fn_refs
+            .get(name)
+            .map(|&fn_ref| self.driver.semantic_comparator_len(fn_ref))
+    }
 }
 
 fn module_hash(source: &str) -> Vec<u8> {
@@ -755,6 +801,7 @@ fn schema_names_for(
         "Map".to_string(),
         "Doc".to_string(),
         "Version".to_string(),
+        "VersionSet".to_string(),
         "Option<Doc>".to_string(),
         "Pending<Doc>".to_string(),
         "Realized<Doc>".to_string(),
@@ -1665,6 +1712,13 @@ fn collect_expr_schemas(
                 out.push("Version".to_string());
                 return Ok(Some("Version".to_string()));
             }
+            if let ast::PathRef::Scoped(path) = &call.callee {
+                let segments: Vec<&str> = path.segments.iter().map(|s| s.value.as_str()).collect();
+                if segments.as_slice() == ["VersionSet", "from_req"] {
+                    out.push("VersionSet".to_string());
+                    return Ok(Some("VersionSet".to_string()));
+                }
+            }
             if let ast::PathRef::Identifier(name) = &call.callee
                 && name.value == "render"
             {
@@ -1699,6 +1753,10 @@ fn collect_expr_schemas(
                 ("get", Some(schema)) => Ok(map_value_schema(schema).map(option_schema)),
                 ("unwrap", Some(schema)) => Ok(option_value_schema(schema).map(str::to_string)),
                 ("join", Some("Array" | "Doc" | "Realized<Doc>")) => Ok(Some("String".into())),
+                ("union" | "intersect" | "complement", Some("VersionSet")) => {
+                    Ok(Some("VersionSet".into()))
+                }
+                ("subset" | "contains", Some("VersionSet")) => Ok(Some("Bool".into())),
                 _ => Ok(None),
             }
         }
@@ -2008,6 +2066,62 @@ fn parked_stub(item: &ast::FnItem) -> Result<(TaskFn, LoweredInfo), String> {
             primitive_region: result,
         },
     ))
+}
+
+fn semantic_comparators_for(
+    fn_name: &str,
+    arg_schemas: &[String],
+    param_names: &[String],
+    fn_refs: &HashMap<String, usize>,
+    fn_params: &HashMap<String, Vec<String>>,
+    fn_returns: &HashMap<String, String>,
+) -> Result<Vec<SemanticComparator>, String> {
+    let mut comparators = Vec::new();
+    for (arg_index, (arg_name, arg_schema)) in param_names.iter().zip(arg_schemas).enumerate() {
+        let comparator_name = format!("{fn_name}__memo_verify_{arg_name}");
+        let Some(&fn_ref) = fn_refs.get(&comparator_name) else {
+            continue;
+        };
+        let params = fn_params
+            .get(&comparator_name)
+            .ok_or_else(|| format!("missing comparator params for {comparator_name}"))?;
+        if params != &[arg_schema.clone(), arg_schema.clone()] {
+            return Err(format!(
+                "semantic comparator `{comparator_name}` must take ({arg_schema}, {arg_schema}), got {params:?}"
+            ));
+        }
+        let return_schema = fn_returns
+            .get(&comparator_name)
+            .ok_or_else(|| format!("missing comparator return for {comparator_name}"))?;
+        if return_schema != "Bool" {
+            return Err(format!(
+                "semantic comparator `{comparator_name}` must return Bool, got {return_schema}"
+            ));
+        }
+        comparators.push(SemanticComparator { arg_index, fn_ref });
+    }
+    Ok(comparators)
+}
+
+fn hash_with_semantic_comparators(
+    base: u64,
+    comparators: &[SemanticComparator],
+    fn_names: &[&String],
+    tables: &ModuleTables,
+) -> u64 {
+    if comparators.is_empty() {
+        return base;
+    }
+    let mut hasher = DefaultHasher::new();
+    "vix-semantic-comparator-hash".hash(&mut hasher);
+    base.hash(&mut hasher);
+    for comparator in comparators {
+        comparator.arg_index.hash(&mut hasher);
+        if let Some(name) = fn_names.get(comparator.fn_ref) {
+            tables.fn_hashes[*name].hash(&mut hasher);
+        }
+    }
+    hasher.finish()
 }
 
 struct LoweredInfo {
@@ -3230,6 +3344,20 @@ impl<'a> FnLowerer<'a> {
                 }
                 Ok(Some(self.target_host()))
             }
+            ["VersionSet", "from_req"] => {
+                if self
+                    .tables
+                    .resolve_type_module(self.current_module, "VersionSet")
+                    != Some("vix")
+                {
+                    return Ok(None);
+                }
+                let [arg] = call.args.args.as_slice() else {
+                    return Err("VersionSet::from_req takes one String".into());
+                };
+                let input = self.method_arg(arg, Some("String"))?;
+                Ok(Some(self.version_set_from_req(&input)?))
+            }
             ["Sealed", "seal"] => {
                 if self
                     .tables
@@ -3385,6 +3513,49 @@ impl<'a> FnLowerer<'a> {
                 let receiver = self.coerce_to_schema(receiver, "Doc")?;
                 let name = self.method_arg(&call.args.args[0], Some("String"))?;
                 self.ast_fn(&receiver, &name)
+            }
+            "union" | "intersect" => {
+                if receiver.schema != "VersionSet" {
+                    return Err(format!("{} called on {}", call.name.value, receiver.schema));
+                }
+                let [arg] = call.args.args.as_slice() else {
+                    return Err(format!(
+                        "VersionSet.{} takes one VersionSet",
+                        call.name.value
+                    ));
+                };
+                let right = self.method_arg(arg, Some("VersionSet"))?;
+                let op = if call.name.value == "union" { 0 } else { 1 };
+                self.version_set_op(op, &receiver, Some(&right), "VersionSet")
+            }
+            "complement" => {
+                if receiver.schema != "VersionSet" {
+                    return Err(format!("complement called on {}", receiver.schema));
+                }
+                if !call.args.args.is_empty() {
+                    return Err("VersionSet.complement takes no arguments".into());
+                }
+                self.version_set_op(2, &receiver, None, "VersionSet")
+            }
+            "subset" => {
+                if receiver.schema != "VersionSet" {
+                    return Err(format!("subset called on {}", receiver.schema));
+                }
+                let [arg] = call.args.args.as_slice() else {
+                    return Err("VersionSet.subset takes one VersionSet".into());
+                };
+                let right = self.method_arg(arg, Some("VersionSet"))?;
+                self.version_set_op(3, &receiver, Some(&right), "Bool")
+            }
+            "contains" => {
+                if receiver.schema != "VersionSet" {
+                    return Err(format!("contains called on {}", receiver.schema));
+                }
+                let [arg] = call.args.args.as_slice() else {
+                    return Err("VersionSet.contains takes one Version".into());
+                };
+                let right = self.method_arg(arg, Some("Version"))?;
+                self.version_set_op(4, &receiver, Some(&right), "Bool")
             }
             "unwrap" => {
                 if !call.args.args.is_empty() {
@@ -5512,6 +5683,73 @@ impl<'a> FnLowerer<'a> {
         })
     }
 
+    fn version_set_from_req(&mut self, input: &ValueSlot) -> Result<ValueSlot, String> {
+        self.expect_schema(input, "String")?;
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: input.slot,
+        });
+        self.code.push(Op::HostCall {
+            host: VERSION_SET_PARSE_HOST,
+        });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: "VersionSet".into(),
+            realization: None,
+            pending: None,
+        })
+    }
+
+    fn version_set_op(
+        &mut self,
+        op: i64,
+        left: &ValueSlot,
+        right: Option<&ValueSlot>,
+        result_schema: &str,
+    ) -> Result<ValueSlot, String> {
+        self.expect_schema(left, "VersionSet")?;
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::ConstI64 {
+            dst: region + 8,
+            value: op,
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 16,
+            src: left.slot,
+        });
+        if let Some(right) = right {
+            self.code.push(Op::CopyI64 {
+                dst: region + 24,
+                src: right.slot,
+            });
+        } else {
+            self.code.push(Op::ConstI64 {
+                dst: region + 24,
+                value: 0,
+            });
+        }
+        self.code.push(Op::HostCall {
+            host: VERSION_SET_OP_HOST,
+        });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: result_schema.into(),
+            realization: None,
+            pending: None,
+        })
+    }
+
     fn compare_value(
         &mut self,
         op: &str,
@@ -5705,7 +5943,7 @@ fn strict_binary_operand_schema<'a>(op: &str, left: &'a str, right: &'a str) -> 
         ("+" | "-" | "*", "Int")
         | ("+" | "*", "Float")
         | ("+", "String")
-        | ("==" | "!=", "Int" | "Float" | "String" | "Path" | "Bool" | "Version")
+        | ("==" | "!=", "Int" | "Float" | "String" | "Path" | "Bool" | "Version" | "VersionSet")
         | ("<" | "<=" | ">" | ">=", "Int" | "Version")
         | ("&&", "Bool") => Some(left),
         _ => None,
@@ -9758,6 +9996,134 @@ pub fn glibc_name_normalizes() -> Bool { version("GLIBC_2.35") == version("2.35.
     }
 
     #[test]
+    fn version_set_values_parse_and_obey_cargo_prerelease_rules() {
+        let src = r#"
+use vix::{Version, VersionSet};
+
+pub fn ops() -> Bool {
+    let pre = VersionSet::from_req("^1.2.3-alpha.1");
+    let narrow = VersionSet::from_req("^1.2.3");
+    let broad = VersionSet::from_req("^1.0.0");
+    let union = narrow.union(broad);
+    let intersection = narrow.intersect(broad);
+    pre.contains(version("1.2.3-alpha.1"))
+        && pre.contains(version("1.2.3"))
+        && (pre.contains(version("1.2.4-alpha.1")) == false)
+        && narrow.subset(broad)
+        && union.contains(version("1.1.0"))
+        && intersection.contains(version("1.2.9"))
+        && broad.complement().contains(version("2.0.0"))
+}
+"#;
+        for lane in lanes() {
+            let mut machine = load_with_lane(src, lane);
+            assert_eq!(machine.demand_i64("ops", vec![]).unwrap(), 1, "{lane:?}");
+        }
+    }
+
+    fn semantic_cutoff_demo_source(comparator_name: &str) -> String {
+        format!(
+            r#"
+use vix::{{Version, VersionSet}};
+
+fn expensive(req: VersionSet) -> Int {{
+    match req.contains(version("1.2.3")) {{
+        true => 42,
+        false => 0,
+    }}
+}}
+
+pub fn derived(req: VersionSet) -> Int {{
+    expensive(req)
+}}
+
+fn {comparator_name}(old: VersionSet, new: VersionSet) -> Bool {{
+    new.subset(old)
+}}
+"#
+        )
+    }
+
+    fn call_derived(machine: &mut Machine, req: &str) -> i64 {
+        machine
+            .call(
+                "derived",
+                &[NamedArg {
+                    name: "req".into(),
+                    value: MachineArg::String(req.into()),
+                }],
+            )
+            .unwrap()
+            .0
+    }
+
+    #[test]
+    fn semantic_cutoff_hits_on_narrowing_and_misses_on_widening() {
+        let src = semantic_cutoff_demo_source("derived__memo_verify_req");
+        for lane in lanes() {
+            let mut narrowed = load_with_lane(&src, lane);
+            assert_eq!(
+                narrowed.semantic_comparator_len("derived"),
+                Some(1),
+                "{lane:?}"
+            );
+            assert_eq!(call_derived(&mut narrowed, "^1.0.0"), 42, "{lane:?}");
+            narrowed.clear_trace();
+            assert_eq!(call_derived(&mut narrowed, "^1.2.0"), 42, "{lane:?}");
+            assert_eq!(
+                memo_semantic_hit_count(&narrowed, "derived"),
+                1,
+                "{lane:?}: {:?}",
+                narrowed.trace()
+            );
+            assert_eq!(spawned_count(&narrowed, "derived"), 0, "{lane:?}");
+            assert_eq!(spawned_count(&narrowed, "expensive"), 0, "{lane:?}");
+            assert_eq!(
+                semantic_verified_count(&narrowed, "derived"),
+                vec![1],
+                "{lane:?}"
+            );
+
+            let mut widened = load_with_lane(&src, lane);
+            assert_eq!(call_derived(&mut widened, "^1.2.0"), 42, "{lane:?}");
+            widened.clear_trace();
+            assert_eq!(call_derived(&mut widened, "^1.0.0"), 42, "{lane:?}");
+            assert_eq!(memo_semantic_hit_count(&widened, "derived"), 0, "{lane:?}");
+            assert_eq!(spawned_count(&widened, "derived"), 1, "{lane:?}");
+            assert_eq!(spawned_count(&widened, "expensive"), 1, "{lane:?}");
+        }
+    }
+
+    #[test]
+    fn semantic_cutoff_soundness_differential_matches_without_comparator() {
+        let enabled_src = semantic_cutoff_demo_source("derived__memo_verify_req");
+        let disabled_src = semantic_cutoff_demo_source("derived__not_a_memo_verify_req");
+        for lane in lanes() {
+            let mut enabled = load_with_lane(&enabled_src, lane);
+            let mut disabled = load_with_lane(&disabled_src, lane);
+            let mut enabled_values = Vec::new();
+            let mut disabled_values = Vec::new();
+            let mut enabled_observable = Vec::new();
+            let mut disabled_observable = Vec::new();
+            for req in ["^1.0.0", "^1.2.0", "^1.0.0"] {
+                enabled.clear_trace();
+                disabled.clear_trace();
+                enabled_values.push(call_derived(&mut enabled, req));
+                disabled_values.push(call_derived(&mut disabled, req));
+                enabled_observable.push(semantic_observable_trace(&enabled));
+                disabled_observable.push(semantic_observable_trace(&disabled));
+            }
+            assert_eq!(enabled_values, disabled_values, "{lane:?}");
+            assert_eq!(enabled_observable, disabled_observable, "{lane:?}");
+            assert_eq!(
+                memo_semantic_hit_count(&enabled, "derived"),
+                0,
+                "last widened run recomputes on {lane:?}"
+            );
+        }
+    }
+
+    #[test]
     fn live_event_sink_streams_the_accumulated_trace() {
         for lane in lanes() {
             for mode in [StepMode::Run, StepMode::Step] {
@@ -10133,6 +10499,17 @@ pub fn lazy(n: Int) -> Map<String, Float> {
             .count()
     }
 
+    fn memo_semantic_hit_count(machine: &Machine, name: &str) -> usize {
+        let hash = machine.fn_hash(name).expect("function hash");
+        machine
+            .trace()
+            .iter()
+            .filter(|event| {
+                matches!(event, DriveEvent::MemoSemanticHit { fn_hash, .. } if *fn_hash == hash)
+            })
+            .count()
+    }
+
     fn projection_verified_count(machine: &Machine, name: &str) -> Vec<usize> {
         let hash = machine.fn_hash(name).expect("function hash");
         machine
@@ -10144,6 +10521,49 @@ pub fn lazy(n: Int) -> Map<String, Float> {
                 }
                 _ => None,
             })
+            .collect()
+    }
+
+    fn semantic_verified_count(machine: &Machine, name: &str) -> Vec<usize> {
+        let hash = machine.fn_hash(name).expect("function hash");
+        machine
+            .trace()
+            .iter()
+            .filter_map(|event| match event {
+                DriveEvent::MemoSemanticHit { fn_hash, verified } if *fn_hash == hash => {
+                    Some(*verified)
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn semantic_observable_trace(machine: &Machine) -> Vec<DriveEvent> {
+        let recompute_hashes = [
+            machine.fn_hash("derived").expect("derived hash"),
+            machine.fn_hash("expensive").expect("expensive hash"),
+            machine
+                .fn_hash("derived__memo_verify_req")
+                .or_else(|| machine.fn_hash("derived__not_a_memo_verify_req"))
+                .expect("comparator hash"),
+        ];
+        machine
+            .trace()
+            .iter()
+            .filter(|event| match event {
+                DriveEvent::Demanded { fn_hash }
+                | DriveEvent::MemoHit { fn_hash }
+                | DriveEvent::MemoProjectionHit { fn_hash, .. }
+                | DriveEvent::MemoSemanticHit { fn_hash, .. }
+                | DriveEvent::Spawned { fn_hash }
+                | DriveEvent::ParkedOn { fn_hash }
+                | DriveEvent::Completed { fn_hash }
+                | DriveEvent::SpawnedInvocation { fn_hash, .. } => {
+                    !recompute_hashes.contains(fn_hash)
+                }
+                _ => true,
+            })
+            .cloned()
             .collect()
     }
 

--- a/vix/src/machine/mod.rs
+++ b/vix/src/machine/mod.rs
@@ -67,6 +67,7 @@ pub mod lower;
 mod oci;
 pub mod value;
 mod version;
+mod version_set;
 
 pub use driver::{
     CodeBundle, CodeRef, DriveEvent, MachineExecBackend, MachineExecRequest, MachinePathDemand,

--- a/vix/src/machine/version_set.rs
+++ b/vix/src/machine/version_set.rs
@@ -1,0 +1,562 @@
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+
+use semver::{BuildMetadata, Comparator, Op, Prerelease, Version, VersionReq};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct VersionSet {
+    releases: IntervalSet,
+    prereleases: IntervalSet,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct IntervalSet {
+    intervals: Vec<Interval>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Interval {
+    start: Option<Version>,
+    end: Option<Version>,
+}
+
+impl VersionSet {
+    pub(super) fn universe() -> Self {
+        Self {
+            releases: IntervalSet::universe(),
+            prereleases: IntervalSet::universe(),
+        }
+    }
+
+    pub(super) fn from_req(text: &str) -> Result<Self, String> {
+        let req = VersionReq::parse(text)
+            .map_err(|err| format!("VersionSet::from_req({text:?}) parse error: {err}"))?;
+        let mut set = Self::universe();
+        let mut prerelease_bases = BTreeSet::new();
+        for cmp in &req.comparators {
+            set = set.intersect(&Self::from_comparator(cmp)?);
+            if !cmp.pre.is_empty()
+                && let (Some(minor), Some(patch)) = (cmp.minor, cmp.patch)
+            {
+                prerelease_bases.insert((cmp.major, minor, patch));
+            }
+        }
+        if prerelease_bases.is_empty() {
+            set.prereleases = IntervalSet::empty();
+        } else {
+            let admitted = prerelease_bases
+                .into_iter()
+                .map(|(major, minor, patch)| IntervalSet::prerelease_base(major, minor, patch))
+                .fold(IntervalSet::empty(), |acc, next| acc.union(&next));
+            set.prereleases = set.prereleases.intersect(&admitted);
+        }
+        Ok(set)
+    }
+
+    pub(super) fn parse_bytes(bytes: &[u8]) -> Result<Self, String> {
+        let text = std::str::from_utf8(bytes).map_err(|err| err.to_string())?;
+        let mut releases = IntervalSet::empty();
+        let mut prereleases = IntervalSet::empty();
+        for line in text.lines() {
+            let Some((kind, rest)) = line.split_once(' ') else {
+                return Err(format!("bad VersionSet line {line:?}"));
+            };
+            let Some((start, end)) = rest.split_once(' ') else {
+                return Err(format!("bad VersionSet line {line:?}"));
+            };
+            let interval = Interval {
+                start: decode_bound(start)?,
+                end: decode_bound(end)?,
+            };
+            match kind {
+                "R" => releases.intervals.push(interval),
+                "P" => prereleases.intervals.push(interval),
+                _ => return Err(format!("bad VersionSet interval kind {kind:?}")),
+            }
+        }
+        releases.normalize();
+        prereleases.normalize();
+        Ok(Self {
+            releases,
+            prereleases,
+        })
+    }
+
+    pub(super) fn canonical_bytes(&self) -> Vec<u8> {
+        let mut out = String::new();
+        for interval in &self.releases.intervals {
+            out.push_str("R ");
+            out.push_str(&encode_bound(&interval.start));
+            out.push(' ');
+            out.push_str(&encode_bound(&interval.end));
+            out.push('\n');
+        }
+        for interval in &self.prereleases.intervals {
+            out.push_str("P ");
+            out.push_str(&encode_bound(&interval.start));
+            out.push(' ');
+            out.push_str(&encode_bound(&interval.end));
+            out.push('\n');
+        }
+        out.into_bytes()
+    }
+
+    pub(super) fn contains(&self, version: &Version) -> bool {
+        if version.pre.is_empty() {
+            self.releases.contains(version)
+        } else {
+            self.prereleases.contains(version)
+        }
+    }
+
+    pub(super) fn union(&self, other: &Self) -> Self {
+        Self {
+            releases: self.releases.union(&other.releases),
+            prereleases: self.prereleases.union(&other.prereleases),
+        }
+    }
+
+    pub(super) fn intersect(&self, other: &Self) -> Self {
+        Self {
+            releases: self.releases.intersect(&other.releases),
+            prereleases: self.prereleases.intersect(&other.prereleases),
+        }
+    }
+
+    pub(super) fn complement(&self) -> Self {
+        Self {
+            releases: self.releases.complement(),
+            prereleases: self.prereleases.complement(),
+        }
+    }
+
+    pub(super) fn is_subset_of(&self, other: &Self) -> bool {
+        self.releases.is_subset_of(&other.releases)
+            && self.prereleases.is_subset_of(&other.prereleases)
+    }
+
+    pub(super) fn render(&self) -> String {
+        String::from_utf8(self.canonical_bytes()).expect("VersionSet bytes are utf8")
+    }
+
+    fn from_comparator(cmp: &Comparator) -> Result<Self, String> {
+        let interval = comparator_interval(cmp)?;
+        Ok(Self {
+            releases: IntervalSet::from_interval(interval.clone()),
+            prereleases: IntervalSet::from_interval(interval),
+        })
+    }
+}
+
+impl IntervalSet {
+    fn empty() -> Self {
+        Self {
+            intervals: Vec::new(),
+        }
+    }
+
+    fn universe() -> Self {
+        Self {
+            intervals: vec![Interval {
+                start: None,
+                end: None,
+            }],
+        }
+    }
+
+    fn from_interval(interval: Interval) -> Self {
+        let mut set = Self {
+            intervals: vec![interval],
+        };
+        set.normalize();
+        set
+    }
+
+    fn prerelease_base(major: u64, minor: u64, patch: u64) -> Self {
+        Self::from_interval(Interval {
+            start: Some(version_with_pre(major, minor, patch, "0")),
+            end: Some(release(major, minor, patch)),
+        })
+    }
+
+    fn contains(&self, version: &Version) -> bool {
+        self.intervals
+            .iter()
+            .any(|interval| interval.contains(version))
+    }
+
+    fn union(&self, other: &Self) -> Self {
+        let mut intervals = self.intervals.clone();
+        intervals.extend(other.intervals.clone());
+        let mut set = Self { intervals };
+        set.normalize();
+        set
+    }
+
+    fn intersect(&self, other: &Self) -> Self {
+        let mut intervals = Vec::new();
+        for left in &self.intervals {
+            for right in &other.intervals {
+                if let Some(interval) = left.intersect(right) {
+                    intervals.push(interval);
+                }
+            }
+        }
+        let mut set = Self { intervals };
+        set.normalize();
+        set
+    }
+
+    fn complement(&self) -> Self {
+        let mut out = Vec::new();
+        let mut cursor = None;
+        for interval in &self.intervals {
+            if cursor_bound_before(&cursor, &interval.start) {
+                out.push(Interval {
+                    start: cursor.clone(),
+                    end: interval.start.clone(),
+                });
+            }
+            cursor = interval.end.clone();
+        }
+        if cursor.is_some() {
+            out.push(Interval {
+                start: cursor,
+                end: None,
+            });
+        }
+        let mut set = Self { intervals: out };
+        set.normalize();
+        set
+    }
+
+    fn is_subset_of(&self, other: &Self) -> bool {
+        self.intersect(&other.complement()).intervals.is_empty()
+    }
+
+    fn normalize(&mut self) {
+        self.intervals.retain(|interval| !interval.is_empty());
+        self.intervals.sort_by(compare_interval_start);
+        let mut normalized: Vec<Interval> = Vec::new();
+        for interval in self.intervals.drain(..) {
+            if let Some(last) = normalized.last_mut()
+                && intervals_touch_or_overlap(last, &interval)
+            {
+                last.end = max_end(last.end.clone(), interval.end);
+                continue;
+            }
+            normalized.push(interval);
+        }
+        self.intervals = normalized;
+    }
+}
+
+impl Interval {
+    fn contains(&self, version: &Version) -> bool {
+        let after_start = self
+            .start
+            .as_ref()
+            .is_none_or(|start| version.cmp(start) != Ordering::Less);
+        let before_end = self
+            .end
+            .as_ref()
+            .is_none_or(|end| version.cmp(end) == Ordering::Less);
+        after_start && before_end
+    }
+
+    fn intersect(&self, other: &Self) -> Option<Self> {
+        let interval = Self {
+            start: max_start(self.start.clone(), other.start.clone()),
+            end: min_end(self.end.clone(), other.end.clone()),
+        };
+        (!interval.is_empty()).then_some(interval)
+    }
+
+    fn is_empty(&self) -> bool {
+        match (&self.start, &self.end) {
+            (Some(start), Some(end)) => start >= end,
+            _ => false,
+        }
+    }
+}
+
+fn comparator_interval(cmp: &Comparator) -> Result<Interval, String> {
+    Ok(match cmp.op {
+        Op::Exact | Op::Wildcard => exact_interval(cmp)?,
+        Op::Greater => Interval {
+            start: Some(greater_lower(cmp)?),
+            end: None,
+        },
+        Op::GreaterEq => Interval {
+            start: Some(comparator_base(cmp)?),
+            end: None,
+        },
+        Op::Less => Interval {
+            start: None,
+            end: Some(comparator_base(cmp)?),
+        },
+        Op::LessEq => Interval {
+            start: None,
+            end: Some(less_eq_upper(cmp)?),
+        },
+        Op::Tilde => tilde_interval(cmp)?,
+        Op::Caret => caret_interval(cmp)?,
+        _ => return Err(format!("unsupported semver comparator op {:?}", cmp.op)),
+    })
+}
+
+fn exact_interval(cmp: &Comparator) -> Result<Interval, String> {
+    let start = release(cmp.major, cmp.minor.unwrap_or(0), cmp.patch.unwrap_or(0));
+    let end = match (cmp.minor, cmp.patch, cmp.pre.is_empty()) {
+        (None, _, _) => release(cmp.major + 1, 0, 0),
+        (Some(minor), None, _) => release(cmp.major, minor + 1, 0),
+        (Some(minor), Some(patch), true) => version_with_pre(cmp.major, minor, patch + 1, "0"),
+        (Some(minor), Some(patch), false) => {
+            prerelease_successor(cmp.major, minor, patch, &cmp.pre)?
+        }
+    };
+    let start = if cmp.patch.is_some() && !cmp.pre.is_empty() {
+        comparator_base(cmp)?
+    } else {
+        start
+    };
+    Ok(Interval {
+        start: Some(start),
+        end: Some(end),
+    })
+}
+
+fn tilde_interval(cmp: &Comparator) -> Result<Interval, String> {
+    let minor = cmp.minor.unwrap_or(0);
+    let patch = cmp.patch.unwrap_or(0);
+    let end = if cmp.minor.is_some() {
+        release(cmp.major, minor + 1, 0)
+    } else {
+        release(cmp.major + 1, 0, 0)
+    };
+    Ok(Interval {
+        start: Some(if cmp.patch.is_some() && !cmp.pre.is_empty() {
+            comparator_base(cmp)?
+        } else {
+            release(cmp.major, minor, patch)
+        }),
+        end: Some(end),
+    })
+}
+
+fn caret_interval(cmp: &Comparator) -> Result<Interval, String> {
+    let minor = cmp.minor.unwrap_or(0);
+    let patch = cmp.patch.unwrap_or(0);
+    let start = if cmp.patch.is_some() && !cmp.pre.is_empty() {
+        comparator_base(cmp)?
+    } else {
+        release(cmp.major, minor, patch)
+    };
+    let end = if cmp.major > 0 || cmp.minor.is_none() {
+        release(cmp.major + 1, 0, 0)
+    } else if minor > 0 || cmp.patch.is_none() {
+        release(0, minor + 1, 0)
+    } else {
+        version_with_pre(0, 0, patch + 1, "0")
+    };
+    Ok(Interval {
+        start: Some(start),
+        end: Some(end),
+    })
+}
+
+fn greater_lower(cmp: &Comparator) -> Result<Version, String> {
+    Ok(match (cmp.minor, cmp.patch, cmp.pre.is_empty()) {
+        (None, _, _) => release(cmp.major + 1, 0, 0),
+        (Some(minor), None, _) => release(cmp.major, minor + 1, 0),
+        (Some(minor), Some(patch), true) => version_with_pre(cmp.major, minor, patch + 1, "0"),
+        (Some(minor), Some(patch), false) => {
+            prerelease_successor(cmp.major, minor, patch, &cmp.pre)?
+        }
+    })
+}
+
+fn less_eq_upper(cmp: &Comparator) -> Result<Version, String> {
+    Ok(match (cmp.minor, cmp.patch, cmp.pre.is_empty()) {
+        (None, _, _) => release(cmp.major + 1, 0, 0),
+        (Some(minor), None, _) => release(cmp.major, minor + 1, 0),
+        (Some(minor), Some(patch), true) => version_with_pre(cmp.major, minor, patch + 1, "0"),
+        (Some(minor), Some(patch), false) => {
+            prerelease_successor(cmp.major, minor, patch, &cmp.pre)?
+        }
+    })
+}
+
+fn comparator_base(cmp: &Comparator) -> Result<Version, String> {
+    let minor = cmp.minor.unwrap_or(0);
+    let patch = cmp.patch.unwrap_or(0);
+    if cmp.pre.is_empty() {
+        Ok(release(cmp.major, minor, patch))
+    } else {
+        Ok(Version {
+            major: cmp.major,
+            minor,
+            patch,
+            pre: cmp.pre.clone(),
+            build: BuildMetadata::EMPTY,
+        })
+    }
+}
+
+fn prerelease_successor(
+    major: u64,
+    minor: u64,
+    patch: u64,
+    pre: &Prerelease,
+) -> Result<Version, String> {
+    version_with_pre_result(major, minor, patch, &format!("{pre}.0"))
+}
+
+fn release(major: u64, minor: u64, patch: u64) -> Version {
+    Version {
+        major,
+        minor,
+        patch,
+        pre: Prerelease::EMPTY,
+        build: BuildMetadata::EMPTY,
+    }
+}
+
+fn version_with_pre(major: u64, minor: u64, patch: u64, pre: &str) -> Version {
+    version_with_pre_result(major, minor, patch, pre).expect("static prerelease parses")
+}
+
+fn version_with_pre_result(
+    major: u64,
+    minor: u64,
+    patch: u64,
+    pre: &str,
+) -> Result<Version, String> {
+    Ok(Version {
+        major,
+        minor,
+        patch,
+        pre: Prerelease::new(pre)
+            .map_err(|err| format!("VersionSet prerelease bound {pre:?}: {err}"))?,
+        build: BuildMetadata::EMPTY,
+    })
+}
+
+fn encode_bound(bound: &Option<Version>) -> String {
+    bound.as_ref().map_or("*".to_string(), Version::to_string)
+}
+
+fn decode_bound(text: &str) -> Result<Option<Version>, String> {
+    if text == "*" {
+        Ok(None)
+    } else {
+        Version::parse(text)
+            .map(Some)
+            .map_err(|err| format!("bad VersionSet bound {text:?}: {err}"))
+    }
+}
+
+fn compare_interval_start(left: &Interval, right: &Interval) -> Ordering {
+    match (&left.start, &right.start) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Less,
+        (Some(_), None) => Ordering::Greater,
+        (Some(left), Some(right)) => left.cmp(right),
+    }
+}
+
+fn intervals_touch_or_overlap(left: &Interval, right: &Interval) -> bool {
+    match (&left.end, &right.start) {
+        (None, _) => true,
+        (_, None) => true,
+        (Some(end), Some(start)) => start <= end,
+    }
+}
+
+fn cursor_bound_before(left: &Option<Version>, right: &Option<Version>) -> bool {
+    match (left, right) {
+        (_, None) => false,
+        (None, Some(_)) => true,
+        (Some(left), Some(right)) => left < right,
+    }
+}
+
+fn max_start(left: Option<Version>, right: Option<Version>) -> Option<Version> {
+    match (left, right) {
+        (None, other) | (other, None) => other,
+        (Some(left), Some(right)) => Some(left.max(right)),
+    }
+}
+
+fn min_end(left: Option<Version>, right: Option<Version>) -> Option<Version> {
+    match (left, right) {
+        (None, other) | (other, None) => other,
+        (Some(left), Some(right)) => Some(left.min(right)),
+    }
+}
+
+fn max_end(left: Option<Version>, right: Option<Version>) -> Option<Version> {
+    match (left, right) {
+        (None, _) | (_, None) => None,
+        (Some(left), Some(right)) => Some(left.max(right)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(text: &str) -> Version {
+        Version::parse(text).unwrap()
+    }
+
+    #[test]
+    fn cargo_prerelease_matching_is_pinned() {
+        let req = VersionReq::parse("^1.2.3-alpha.1").unwrap();
+        let set = VersionSet::from_req("^1.2.3-alpha.1").unwrap();
+        for version in [
+            "1.2.3-alpha.0",
+            "1.2.3-alpha.1",
+            "1.2.3-beta.1",
+            "1.2.3",
+            "1.2.4-alpha.1",
+            "1.2.4",
+            "2.0.0-alpha.1",
+            "2.0.0",
+        ] {
+            let version = v(version);
+            assert_eq!(set.contains(&version), req.matches(&version), "{version}");
+        }
+    }
+
+    #[test]
+    fn caret_zero_ranges_are_pinned() {
+        let req = VersionReq::parse("^0.2.3").unwrap();
+        let set = VersionSet::from_req("^0.2.3").unwrap();
+        for version in ["0.2.2", "0.2.3", "0.2.9", "0.3.0-alpha.1", "0.3.0"] {
+            let version = v(version);
+            assert_eq!(set.contains(&version), req.matches(&version), "{version}");
+        }
+
+        let req = VersionReq::parse("^0.0.3").unwrap();
+        let set = VersionSet::from_req("^0.0.3").unwrap();
+        for version in ["0.0.3-alpha.1", "0.0.3", "0.0.4-alpha.1", "0.0.4"] {
+            let version = v(version);
+            assert_eq!(set.contains(&version), req.matches(&version), "{version}");
+        }
+    }
+
+    #[test]
+    fn de_morgan_laws_hold_for_interval_sets() {
+        let a = VersionSet::from_req(">=1.2.0, <2.0.0").unwrap();
+        let b = VersionSet::from_req("^1.5.0").unwrap();
+        assert_eq!(
+            a.intersect(&b).complement(),
+            a.complement().union(&b.complement())
+        );
+        assert_eq!(
+            a.union(&b).complement(),
+            a.complement().intersect(&b.complement())
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add VersionSet as a raw vix value kind with normalized interval algebra, Cargo VersionReq parsing, prerelease admission, set ops, and machine-level methods
- add semantic memo comparator metadata discovered by `<fn>__memo_verify_<arg>`, folded into the demand hash and run as ordinary vix demands
- add MemoSemanticHit tracing plus differential/demo coverage for subset-based cutoff

## Verification
- cargo check -p vix
- cargo nextest run -p vix -p weavy
- cargo clippy -p vix -p weavy --all-features --all-targets --message-format=short -- -D warnings
- cargo check -p vix --target wasm32-unknown-unknown