### PR TITLE
vix: flesh tier + dynamic reuse (unobservability oracle + CDCL bench)

### DIFF
--- a/vix/src/bin/cdcl_flesh_bench.rs
+++ b/vix/src/bin/cdcl_flesh_bench.rs
@@ -1,0 +1,65 @@
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use vix::machine::Machine;
+
+const PUSHES: usize = 128;
+const BURST: usize = 32;
+const POPS: usize = 16;
+const RUNS: i64 = 24;
+
+fn main() {
+    let source = cdcl_source();
+    let naive = run_vix(&source, true);
+    let reuse = run_vix(&source, false);
+    let rust_vec = run_rust_vec();
+
+    println!("naive_copy_ns={}", naive.as_nanos());
+    println!("reuse_ns={}", reuse.as_nanos());
+    println!("rust_vec_ns={}", rust_vec.as_nanos());
+}
+
+fn run_vix(source: &str, force_copy: bool) -> Duration {
+    let mut machine = Machine::load(source).expect("generated CDCL bench source loads");
+    machine.set_force_flesh_copy(force_copy);
+    let start = Instant::now();
+    for seed in 0..RUNS {
+        let value = machine
+            .demand_i64("main", vec![seed])
+            .expect("generated CDCL bench runs");
+        black_box(value);
+    }
+    start.elapsed()
+}
+
+fn run_rust_vec() -> Duration {
+    let start = Instant::now();
+    for seed in 0..RUNS {
+        let mut trail = Vec::new();
+        trail.push(0_i64);
+        for i in 1..=PUSHES {
+            trail.push(i as i64);
+            if i % BURST == 0 {
+                for _ in 0..POPS {
+                    black_box(trail.pop().expect("checkpoint pop has an item"));
+                }
+            }
+        }
+        let value = trail.len() as i64 + seed - seed;
+        black_box(value);
+    }
+    start.elapsed()
+}
+
+fn cdcl_source() -> String {
+    let mut expr = "[0]".to_string();
+    for i in 1..=PUSHES {
+        expr = format!("({expr}).push({i})");
+        if i % BURST == 0 {
+            for _ in 0..POPS {
+                expr = format!("(({expr}).pop()).1");
+            }
+        }
+    }
+    format!("pub fn main(seed: Int) -> Int {{\n    ({expr}).len() + seed - seed\n}}\n")
+}

--- a/vix/src/machine/driver.rs
+++ b/vix/src/machine/driver.rs
@@ -152,6 +152,12 @@ pub const SEALED_DECLASSIFY_HOST: u32 = 39;
 pub const SEALED_TO_STRING_HOST: u32 = 40;
 pub const VERSION_SET_PARSE_HOST: u32 = 41;
 pub const VERSION_SET_OP_HOST: u32 = 42;
+pub const FLESH_INTERN_HOST: u32 = 43;
+pub const ARRAY_PUSH_HOST: u32 = 44;
+pub const ARRAY_POP_HOST: u32 = 45;
+pub const ARRAY_SET_HOST: u32 = 46;
+pub const FLESH_DUP_HOST: u32 = 47;
+pub const RECORD_UPDATE_HOST: u32 = 48;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Lane {
@@ -492,6 +498,7 @@ struct Execution {
     fn_ref: usize,
     key: CanonMemoKey,
     args: Vec<i64>,
+    flesh: FleshStore,
     read_set: ProjectionReadSet,
     ready: Vec<bool>,
     awaited: Vec<i64>,
@@ -785,6 +792,75 @@ enum ArrayEntry {
         words: Vec<i64>,
     },
     Pending(Vec<i64>),
+}
+
+#[derive(Clone, Debug, Default)]
+struct FleshStore {
+    entries: Vec<FleshEntry>,
+}
+
+#[derive(Clone, Debug)]
+struct FleshEntry {
+    refs: usize,
+    value: FleshValue,
+}
+
+#[derive(Clone, Debug)]
+enum FleshValue {
+    Record {
+        schema: String,
+        bytes: Vec<u8>,
+    },
+    Map {
+        schema: String,
+        pairs: Vec<MapPair>,
+    },
+    ArrayWords {
+        elem_schema: String,
+        words: Vec<i64>,
+    },
+    Interned(i64),
+}
+
+impl FleshStore {
+    fn alloc(&mut self, value: FleshValue) -> i64 {
+        let index = self.entries.len();
+        self.entries.push(FleshEntry { refs: 1, value });
+        flesh_word(index)
+    }
+
+    fn entry(&self, word: i64) -> Option<&FleshEntry> {
+        flesh_index(word).and_then(|index| self.entries.get(index))
+    }
+
+    fn entry_mut(&mut self, word: i64) -> Option<&mut FleshEntry> {
+        flesh_index(word).and_then(|index| self.entries.get_mut(index))
+    }
+
+    fn array_entry(
+        &self,
+        store: &ValueStore,
+        handle: i64,
+        schema_refs: &[String],
+    ) -> Result<ArrayEntry, String> {
+        match self.entry(handle).map(|entry| &entry.value) {
+            Some(FleshValue::ArrayWords { elem_schema, words }) => Ok(ArrayEntry::Words {
+                elem_schema: elem_schema.clone(),
+                words: words.clone(),
+            }),
+            Some(FleshValue::Interned(handle)) => store.array_entry(*handle, schema_refs),
+            Some(_) => Err(format!("flesh handle {handle} is not an Array")),
+            None => store.array_entry(handle, schema_refs),
+        }
+    }
+}
+
+fn flesh_word(index: usize) -> i64 {
+    -1 - i64::try_from(index).expect("flesh handle fits i64")
+}
+
+fn flesh_index(word: i64) -> Option<usize> {
+    (word < 0).then(|| usize::try_from(-1 - word).expect("flesh handle index"))
 }
 
 #[derive(Clone, Debug)]
@@ -1345,6 +1421,143 @@ impl ValueStore {
     }
 }
 
+fn intern_flesh_word(
+    store: &mut ValueStore,
+    flesh: &mut FleshStore,
+    descriptors: &HashMap<String, Descriptor<String>>,
+    schema_refs: &[String],
+    schema: &str,
+    word: i64,
+) -> Result<(i64, bool), String> {
+    let Some(index) = flesh_index(word) else {
+        return Ok((word, true));
+    };
+    let value = flesh
+        .entries
+        .get(index)
+        .ok_or_else(|| format!("flesh handle {word}"))?
+        .value
+        .clone();
+    if let FleshValue::Interned(handle) = value {
+        return Ok((handle, true));
+    }
+    let (handle, deduped) = match value {
+        FleshValue::Record {
+            schema: record_schema,
+            mut bytes,
+        } => {
+            if record_schema != schema {
+                return Err(format!("flesh record is `{record_schema}`, not {schema}"));
+            }
+            intern_value_bytes_children(
+                store,
+                flesh,
+                descriptors,
+                schema_refs,
+                &record_schema,
+                &mut bytes,
+            )?;
+            store.alloc(&record_schema, bytes, descriptors)
+        }
+        FleshValue::Map {
+            schema: map_schema,
+            mut pairs,
+        } => {
+            if map_schema != schema && !map_schema_is_realized_projection(schema, &map_schema) {
+                return Err(format!("flesh map is `{map_schema}`, not {schema}"));
+            }
+            for pair in &mut pairs {
+                pair.key_word = intern_flesh_word(
+                    store,
+                    flesh,
+                    descriptors,
+                    schema_refs,
+                    &pair.key_schema,
+                    pair.key_word,
+                )?
+                .0;
+                pair.value_word = intern_flesh_word(
+                    store,
+                    flesh,
+                    descriptors,
+                    schema_refs,
+                    &pair.value_schema,
+                    pair.value_word,
+                )?
+                .0;
+            }
+            store.alloc_map(&map_schema, pairs, schema_refs, descriptors)?
+        }
+        FleshValue::ArrayWords {
+            elem_schema,
+            mut words,
+        } => {
+            if schema != "Array" {
+                return Err(format!("flesh array cannot intern as {schema}"));
+            }
+            for word in &mut words {
+                *word =
+                    intern_flesh_word(store, flesh, descriptors, schema_refs, &elem_schema, *word)?
+                        .0;
+            }
+            store.alloc_array_words(&elem_schema, words, schema_refs)?
+        }
+        FleshValue::Interned(_) => unreachable!("handled above"),
+    };
+    flesh.entries[index].value = FleshValue::Interned(handle);
+    Ok((handle, deduped))
+}
+
+fn map_schema_is_realized_projection(expected: &str, actual: &str) -> bool {
+    let Some((expected_key, expected_value)) = map_schemas(expected) else {
+        return false;
+    };
+    let Some((actual_key, actual_value)) = map_schemas(actual) else {
+        return false;
+    };
+    expected_key == actual_key && realized_value_schema(actual_value) == Some(expected_value)
+}
+
+fn intern_value_bytes_children(
+    store: &mut ValueStore,
+    flesh: &mut FleshStore,
+    descriptors: &HashMap<String, Descriptor<String>>,
+    schema_refs: &[String],
+    schema: &str,
+    bytes: &mut [u8],
+) -> Result<(), String> {
+    let descriptor = descriptors
+        .get(schema)
+        .ok_or_else(|| format!("descriptor for schema `{schema}`"))?;
+    match &descriptor.access {
+        Access::Record(record) => {
+            for field in &record.fields {
+                let field_schema = descriptor_word_schema(&field.descriptor);
+                let word = read_frame_word(bytes, field.offset);
+                let (interned, _) =
+                    intern_flesh_word(store, flesh, descriptors, schema_refs, &field_schema, word)?;
+                write_frame_word(bytes, field.offset, interned);
+            }
+        }
+        Access::Enum(enum_access) => {
+            let tag = usize::try_from(read_variant_tag(bytes, descriptor))
+                .map_err(|_| "negative enum tag".to_string())?;
+            let Some(variant) = enum_access.variants.get(tag) else {
+                return Ok(());
+            };
+            for field in &variant.payload.fields {
+                let field_schema = descriptor_word_schema(&field.descriptor);
+                let word = read_frame_word(bytes, field.offset);
+                let (interned, _) =
+                    intern_flesh_word(store, flesh, descriptors, schema_refs, &field_schema, word)?;
+                write_frame_word(bytes, field.offset, interned);
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 /// The demand scheduler.
 pub struct Driver {
     program: Program,
@@ -1371,6 +1584,7 @@ pub struct Driver {
     pub trace: Vec<DriveEvent>,
     event_sink: Option<DriveEventSink>,
     step_mode: StepMode,
+    force_flesh_copy: bool,
     store: RefCell<ValueStore>,
 }
 
@@ -1420,6 +1634,7 @@ impl Driver {
             trace: Vec::new(),
             event_sink: None,
             step_mode: StepMode::Run,
+            force_flesh_copy: std::env::var_os("VIX_FORCE_FLESH_COPY").is_some(),
             store: RefCell::new(ValueStore::default()),
         })
     }
@@ -1452,6 +1667,10 @@ impl Driver {
 
     pub fn set_step_mode(&mut self, mode: StepMode) {
         self.step_mode = mode;
+    }
+
+    pub fn set_force_flesh_copy(&mut self, force: bool) {
+        self.force_flesh_copy = force;
     }
 
     fn emit(&mut self, event: DriveEvent) {
@@ -1819,6 +2038,23 @@ impl Driver {
             match requests {
                 Burst::Done(value) => {
                     let done_key = exec.key.clone();
+                    let mut value = value;
+                    if flesh_index(value).is_some() {
+                        let return_schema = self.fns[exec.fn_ref].return_schema.clone();
+                        let (interned, deduped) = intern_flesh_word(
+                            &mut self.store.borrow_mut(),
+                            &mut exec.flesh,
+                            &self.descriptors,
+                            &self.schema_refs,
+                            &return_schema,
+                            value,
+                        )?;
+                        self.emit(DriveEvent::StoreAlloc {
+                            schema_ref: hash_u64(&return_schema),
+                            deduped,
+                        });
+                        value = interned;
+                    }
                     let value = self.canonicalize_return_word(exec.fn_ref, value);
                     self.record_whole_arg_if_projectable(
                         exec.fn_ref,
@@ -2100,6 +2336,7 @@ impl Driver {
             fn_ref,
             key,
             args: args.to_vec(),
+            flesh: FleshStore::default(),
             read_set: ProjectionReadSet::default(),
             ready: Vec::new(),
             awaited: Vec::new(),
@@ -2137,6 +2374,7 @@ impl Driver {
             let descriptors = &self.descriptors;
             let schema_refs = &self.schema_refs;
             let store_cell = &self.store;
+            let flesh_cell = RefCell::new(&mut exec.flesh);
             let ast_roots_cell = RefCell::new(&mut self.ast_roots);
             let oci_file_memo_cell = RefCell::new(&mut self.oci_file_memo);
             let journal_cell = RefCell::new(&mut self.journal);
@@ -2146,6 +2384,7 @@ impl Driver {
             let projection_reads = RefCell::new(Vec::new());
             let exec_arg_schemas = lowered_fns[exec.fn_ref].arg_schemas.clone();
             let exec_args = exec.args.clone();
+            let force_flesh_copy = self.force_flesh_copy;
             let mut invoke = |frame: &mut [u8]| {
                 let word = |i: usize| {
                     i64::from_le_bytes(
@@ -2157,7 +2396,27 @@ impl Driver {
                 let input_slot = word(0) as usize;
                 let fn_ref = word(1) as usize;
                 let argc = word(2) as usize;
-                let args = (0..argc).map(|k| word(3 + k)).collect();
+                let mut args = (0..argc).map(|k| word(3 + k)).collect::<Vec<_>>();
+                let arg_schemas = &lowered_fns[fn_ref].arg_schemas;
+                for (arg, schema) in args.iter_mut().zip(arg_schemas) {
+                    let was_flesh = flesh_index(*arg).is_some();
+                    let (interned, deduped) = intern_flesh_word(
+                        &mut store_cell.borrow_mut(),
+                        &mut flesh_cell.borrow_mut(),
+                        descriptors,
+                        schema_refs,
+                        schema,
+                        *arg,
+                    )
+                    .unwrap_or_else(|err| panic!("{err}"));
+                    if was_flesh {
+                        store_events.borrow_mut().push(DriveEvent::StoreAlloc {
+                            schema_ref: hash_u64(schema),
+                            deduped,
+                        });
+                    }
+                    *arg = interned;
+                }
                 requests.push(InvokeRequest {
                     caller: exec_ix,
                     input_slot,
@@ -2197,19 +2456,45 @@ impl Driver {
                     descriptors,
                     fields,
                 );
-                let (handle, deduped) = store_cell.borrow_mut().alloc(&schema, bytes, descriptors);
-                write_frame_word(frame, dst_slot, handle);
-                let schema_ref = hash_u64(&schema);
-                store_events.borrow_mut().push(DriveEvent::StoreAlloc {
-                    schema_ref,
-                    deduped,
+                let handle = flesh_cell.borrow_mut().alloc(FleshValue::Record {
+                    schema: schema.clone(),
+                    bytes,
                 });
+                write_frame_word(frame, dst_slot, handle);
             };
 
             let mut store_read = |frame: &mut [u8]| {
                 let dst_slot = read_frame_word(frame, store_read_region) as usize;
-                let handle = read_frame_word(frame, store_read_region + 8);
+                let mut handle = read_frame_word(frame, store_read_region + 8);
                 let field_index = read_frame_word(frame, store_read_region + 16) as usize;
+                if flesh_index(handle).is_some() {
+                    let schema = flesh_cell
+                        .borrow()
+                        .entry(handle)
+                        .and_then(|entry| match &entry.value {
+                            FleshValue::Record { schema, .. } => Some(schema.clone()),
+                            FleshValue::Interned(handle) => store_cell
+                                .borrow()
+                                .entry(*handle)
+                                .map(|entry| entry.schema.clone()),
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| panic!("flesh record handle {handle}"));
+                    let (interned, deduped) = intern_flesh_word(
+                        &mut store_cell.borrow_mut(),
+                        &mut flesh_cell.borrow_mut(),
+                        descriptors,
+                        schema_refs,
+                        &schema,
+                        handle,
+                    )
+                    .unwrap_or_else(|err| panic!("{err}"));
+                    store_events.borrow_mut().push(DriveEvent::StoreAlloc {
+                        schema_ref: hash_u64(&schema),
+                        deduped,
+                    });
+                    handle = interned;
+                }
                 let store = store_cell.borrow();
                 let entry = store
                     .entry(handle)
@@ -2243,7 +2528,35 @@ impl Driver {
 
             let mut store_tag = |frame: &mut [u8]| {
                 let dst_slot = read_frame_word(frame, store_tag_region) as usize;
-                let handle = read_frame_word(frame, store_tag_region + 8);
+                let mut handle = read_frame_word(frame, store_tag_region + 8);
+                if flesh_index(handle).is_some() {
+                    let schema = flesh_cell
+                        .borrow()
+                        .entry(handle)
+                        .and_then(|entry| match &entry.value {
+                            FleshValue::Record { schema, .. } => Some(schema.clone()),
+                            FleshValue::Interned(handle) => store_cell
+                                .borrow()
+                                .entry(*handle)
+                                .map(|entry| entry.schema.clone()),
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| panic!("flesh record handle {handle}"));
+                    let (interned, deduped) = intern_flesh_word(
+                        &mut store_cell.borrow_mut(),
+                        &mut flesh_cell.borrow_mut(),
+                        descriptors,
+                        schema_refs,
+                        &schema,
+                        handle,
+                    )
+                    .unwrap_or_else(|err| panic!("{err}"));
+                    store_events.borrow_mut().push(DriveEvent::StoreAlloc {
+                        schema_ref: hash_u64(&schema),
+                        deduped,
+                    });
+                    handle = interned;
+                }
                 let store = store_cell.borrow();
                 let entry = store
                     .entry(handle)
@@ -2284,17 +2597,11 @@ impl Driver {
                         read_frame_word(frame, store_alloc_region + 8),
                         schema_refs,
                     )?;
-                    let (handle, deduped) = store_cell.borrow_mut().alloc_map(
-                        &schema,
-                        Vec::new(),
-                        schema_refs,
-                        descriptors,
-                    )?;
-                    write_frame_word(frame, dst_slot, handle);
-                    store_events.borrow_mut().push(DriveEvent::StoreAlloc {
-                        schema_ref: hash_u64(&schema),
-                        deduped,
+                    let handle = flesh_cell.borrow_mut().alloc(FleshValue::Map {
+                        schema: schema.clone(),
+                        pairs: Vec::new(),
                     });
+                    write_frame_word(frame, dst_slot, handle);
                     Ok(())
                 })();
                 if let Err(err) = result {
@@ -2334,38 +2641,80 @@ impl Driver {
                         &stored_value_schema,
                         read_frame_word(frame, store_alloc_region + 48),
                     );
-                    record_whole_args_if_projectable_static(
-                        &mut projection_reads.borrow_mut(),
-                        &exec_arg_schemas,
-                        &exec_args,
-                        &store_cell.borrow(),
+                    let mut key_word = key_word;
+                    let mut value_word = value_word;
+                    key_word = intern_flesh_word(
+                        &mut store_cell.borrow_mut(),
+                        &mut flesh_cell.borrow_mut(),
                         descriptors,
-                        [map_handle, key_word, value_word],
-                    );
-                    let (stored_schema, mut pairs) =
-                        store_cell.borrow().map_pairs(map_handle, schema_refs)?;
+                        schema_refs,
+                        &key_schema,
+                        key_word,
+                    )?
+                    .0;
+                    value_word = intern_flesh_word(
+                        &mut store_cell.borrow_mut(),
+                        &mut flesh_cell.borrow_mut(),
+                        descriptors,
+                        schema_refs,
+                        &stored_value_schema,
+                        value_word,
+                    )?
+                    .0;
+                    if flesh_index(map_handle).is_none() {
+                        record_whole_args_if_projectable_static(
+                            &mut projection_reads.borrow_mut(),
+                            &exec_arg_schemas,
+                            &exec_args,
+                            &store_cell.borrow(),
+                            descriptors,
+                            [map_handle, key_word, value_word],
+                        );
+                    }
+                    let (stored_schema, mut pairs) = if let Some(entry) =
+                        flesh_cell.borrow().entry(map_handle)
+                    {
+                        match &entry.value {
+                            FleshValue::Map { schema, pairs } => (schema.clone(), pairs.clone()),
+                            FleshValue::Interned(handle) => {
+                                store_cell.borrow().map_pairs(*handle, schema_refs)?
+                            }
+                            _ => return Err(format!("flesh handle {map_handle} is not a Map")),
+                        }
+                    } else {
+                        store_cell.borrow().map_pairs(map_handle, schema_refs)?
+                    };
                     if stored_schema != map_schema {
                         pairs = promote_map_pairs_to_realized(&stored_schema, &map_schema, pairs)?;
                     }
-                    pairs.push(MapPair {
+                    let new_pair = MapPair {
                         key_schema,
                         key_word,
                         value_schema: stored_value_schema,
                         value_word,
                         value_realization: realized_value_schema(&value_schema)
                             .map(|_| value_realization),
-                    });
-                    let (handle, deduped) = store_cell.borrow_mut().alloc_map(
-                        &map_schema,
-                        pairs,
-                        schema_refs,
-                        descriptors,
-                    )?;
+                    };
+                    let handle = if !force_flesh_copy
+                        && let Some(entry) = flesh_cell.borrow_mut().entry_mut(map_handle)
+                        && entry.refs == 1
+                        && let FleshValue::Map {
+                            schema,
+                            pairs: entry_pairs,
+                        } = &mut entry.value
+                    {
+                        *schema = map_schema.clone();
+                        *entry_pairs = pairs;
+                        entry_pairs.push(new_pair);
+                        map_handle
+                    } else {
+                        pairs.push(new_pair);
+                        flesh_cell.borrow_mut().alloc(FleshValue::Map {
+                            schema: map_schema.clone(),
+                            pairs,
+                        })
+                    };
                     write_frame_word(frame, dst_slot, handle);
-                    store_events.borrow_mut().push(DriveEvent::StoreAlloc {
-                        schema_ref: hash_u64(&map_schema),
-                        deduped,
-                    });
                     Ok(())
                 })();
                 if let Err(err) = result {
@@ -2376,7 +2725,7 @@ impl Driver {
             let mut map_get = |frame: &mut [u8]| {
                 let result = (|| {
                     let dst_slot = read_frame_word(frame, store_alloc_region) as usize;
-                    let map_handle = read_frame_word(frame, store_alloc_region + 8);
+                    let mut map_handle = read_frame_word(frame, store_alloc_region + 8);
                     let value_schema = schema_name_for(
                         read_frame_word(frame, store_alloc_region + 16),
                         schema_refs,
@@ -2389,6 +2738,40 @@ impl Driver {
                         &key_schema,
                         read_frame_word(frame, store_alloc_region + 32),
                     );
+                    let map_schema = if let Some(entry) = flesh_cell.borrow().entry(map_handle) {
+                        match &entry.value {
+                            FleshValue::Map { schema, .. } => schema.clone(),
+                            FleshValue::Interned(handle) => store_cell
+                                .borrow()
+                                .entry(*handle)
+                                .ok_or_else(|| format!("store handle {handle}"))?
+                                .schema
+                                .clone(),
+                            _ => return Err(format!("flesh handle {map_handle} is not a Map")),
+                        }
+                    } else {
+                        store_cell
+                            .borrow()
+                            .entry(map_handle)
+                            .ok_or_else(|| format!("store handle {map_handle}"))?
+                            .schema
+                            .clone()
+                    };
+                    if flesh_index(map_handle).is_some() {
+                        let (interned, deduped) = intern_flesh_word(
+                            &mut store_cell.borrow_mut(),
+                            &mut flesh_cell.borrow_mut(),
+                            descriptors,
+                            schema_refs,
+                            &map_schema,
+                            map_handle,
+                        )?;
+                        store_events.borrow_mut().push(DriveEvent::StoreAlloc {
+                            schema_ref: hash_u64(&map_schema),
+                            deduped,
+                        });
+                        map_handle = interned;
+                    }
                     let (handle, _) = store_cell.borrow_mut().map_get(
                         map_handle,
                         &key_schema,
@@ -2403,7 +2786,6 @@ impl Driver {
                         .expect("map_get allocated option")
                         .content_hash;
                     let store = store_cell.borrow();
-                    let map_schema = store.entry(map_handle).expect("map handle").schema.clone();
                     let key_hash = canonical_word_hash_in_store(&store, &key_schema, key_word);
                     let projection_context = ProjectionRecordContext {
                         arg_schemas: &exec_arg_schemas,
@@ -2447,7 +2829,22 @@ impl Driver {
                     let dst_slot = read_frame_word(frame, primitive_region) as usize;
                     let kind_ref = read_frame_word(frame, primitive_region + 8);
                     let kind = schema_name_for(kind_ref, schema_refs)?;
-                    let target = read_frame_word(frame, primitive_region + 16);
+                    let mut target = read_frame_word(frame, primitive_region + 16);
+                    if flesh_index(target).is_some() {
+                        let (interned, deduped) = intern_flesh_word(
+                            &mut store_cell.borrow_mut(),
+                            &mut flesh_cell.borrow_mut(),
+                            descriptors,
+                            schema_refs,
+                            "Target",
+                            target,
+                        )?;
+                        store_events.borrow_mut().push(DriveEvent::StoreAlloc {
+                            schema_ref: hash_u64("Target"),
+                            deduped,
+                        });
+                        target = interned;
+                    }
                     record_whole_args_if_projectable_static(
                         &mut projection_reads.borrow_mut(),
                         &exec_arg_schemas,
@@ -2496,22 +2893,23 @@ impl Driver {
                         schema_name_for(read_frame_word(frame, primitive_region + 8), schema_refs)?;
                     let count = usize::try_from(read_frame_word(frame, primitive_region + 16))
                         .map_err(|_| "negative array length".to_string())?;
-                    let words = (0..count)
+                    let mut words = (0..count)
                         .map(|i| read_frame_word(frame, primitive_region + 24 + i * 8))
                         .collect::<Vec<_>>();
-                    record_whole_args_if_projectable_static(
-                        &mut projection_reads.borrow_mut(),
-                        &exec_arg_schemas,
-                        &exec_args,
-                        &store_cell.borrow(),
-                        descriptors,
-                        words.iter().copied(),
-                    );
-                    let (handle, _) = store_cell.borrow_mut().alloc_array_words(
-                        &elem_schema,
-                        words,
-                        schema_refs,
-                    )?;
+                    for word in &mut words {
+                        *word = intern_flesh_word(
+                            &mut store_cell.borrow_mut(),
+                            &mut flesh_cell.borrow_mut(),
+                            descriptors,
+                            schema_refs,
+                            &elem_schema,
+                            *word,
+                        )?
+                        .0;
+                    }
+                    let handle = flesh_cell
+                        .borrow_mut()
+                        .alloc(FleshValue::ArrayWords { elem_schema, words });
                     write_frame_word(frame, dst_slot, handle);
                     Ok(())
                 })();
@@ -2534,39 +2932,60 @@ impl Driver {
                             Ok((read_frame_word(frame, at), read_frame_word(frame, at + 8)))
                         })
                         .collect::<Result<Vec<_>, String>>()?;
-                    let words = match store_cell.borrow().array_entry(array_handle, schema_refs)? {
+                    let words = match flesh_cell.borrow().array_entry(
+                        &store_cell.borrow(),
+                        array_handle,
+                        schema_refs,
+                    )? {
                         ArrayEntry::Words { words, .. } => words,
                         ArrayEntry::Pending(_) => {
                             return Err("map over pending array is outside slice 4".into());
                         }
                     };
-                    record_whole_args_if_projectable_static(
-                        &mut projection_reads.borrow_mut(),
-                        &exec_arg_schemas,
-                        &exec_args,
-                        &store_cell.borrow(),
-                        descriptors,
-                        [array_handle],
-                    );
+                    if flesh_index(array_handle).is_none() {
+                        record_whole_args_if_projectable_static(
+                            &mut projection_reads.borrow_mut(),
+                            &exec_arg_schemas,
+                            &exec_args,
+                            &store_cell.borrow(),
+                            descriptors,
+                            [array_handle],
+                        );
+                    }
                     let pending = words
                         .into_iter()
                         .map(|word| {
-                            let args = arg_specs
+                            let mut args = arg_specs
                                 .iter()
                                 .map(|(kind, value)| match kind {
                                     0 => *value,
                                     1 => word,
                                     other => panic!("unknown map arg kind {other}"),
                                 })
-                                .collect();
+                                .collect::<Vec<_>>();
+                            for (arg, schema) in
+                                args.iter_mut().zip(&lowered_fns[fn_ref].arg_schemas)
+                            {
+                                *arg = intern_flesh_word(
+                                    &mut store_cell.borrow_mut(),
+                                    &mut flesh_cell.borrow_mut(),
+                                    descriptors,
+                                    schema_refs,
+                                    schema,
+                                    *arg,
+                                )?
+                                .0;
+                            }
                             let invocation =
                                 pending_invocation_for(&lowered_fns[fn_ref], store_cell, args);
-                            store_cell
-                                .borrow_mut()
-                                .alloc_pending(&lowered_fns[fn_ref].return_schema, invocation)
-                                .0
+                            Ok::<i64, String>(
+                                store_cell
+                                    .borrow_mut()
+                                    .alloc_pending(&lowered_fns[fn_ref].return_schema, invocation)
+                                    .0,
+                            )
                         })
-                        .collect();
+                        .collect::<Result<Vec<_>, _>>()?;
                     let (handle, _) = store_cell.borrow_mut().alloc_array_pending(pending);
                     write_frame_word(frame, dst_slot, handle);
                     Ok(())
@@ -2580,16 +2999,21 @@ impl Driver {
                 let result = (|| {
                     let dst_slot = read_frame_word(frame, primitive_region) as usize;
                     let array_handle = read_frame_word(frame, primitive_region + 8);
-                    let array_entry =
-                        { store_cell.borrow().array_entry(array_handle, schema_refs)? };
-                    record_whole_args_if_projectable_static(
-                        &mut projection_reads.borrow_mut(),
-                        &exec_arg_schemas,
-                        &exec_args,
+                    let array_entry = flesh_cell.borrow().array_entry(
                         &store_cell.borrow(),
-                        descriptors,
-                        [array_handle],
-                    );
+                        array_handle,
+                        schema_refs,
+                    )?;
+                    if flesh_index(array_handle).is_none() {
+                        record_whole_args_if_projectable_static(
+                            &mut projection_reads.borrow_mut(),
+                            &exec_arg_schemas,
+                            &exec_args,
+                            &store_cell.borrow(),
+                            descriptors,
+                            [array_handle],
+                        );
+                    }
                     match array_entry {
                         ArrayEntry::Pending(pending) => {
                             let (handle, _) = store_cell.borrow_mut().alloc_tree_merge(pending);
@@ -3051,7 +3475,11 @@ impl Driver {
                 let result = (|| {
                     let dst_slot = read_frame_word(frame, primitive_region) as usize;
                     let array = read_frame_word(frame, primitive_region + 8);
-                    let len = match store_cell.borrow().array_entry(array, schema_refs)? {
+                    let len = match flesh_cell.borrow().array_entry(
+                        &store_cell.borrow(),
+                        array,
+                        schema_refs,
+                    )? {
                         ArrayEntry::Words { words, .. } => words.len(),
                         ArrayEntry::Pending(pending) => pending.len(),
                     };
@@ -3105,7 +3533,11 @@ impl Driver {
                         store.entry(word).and_then(|entry| entry.taint.clone())
                     }));
                     let separator = store.string_value(separator, "String")?;
-                    let joined = match store.array_entry(array, schema_refs)? {
+                    let array_entry =
+                        flesh_cell
+                            .borrow()
+                            .array_entry(&store, array, schema_refs)?;
+                    let joined = match array_entry {
                         ArrayEntry::Words { elem_schema, words } => {
                             if elem_schema != "String" && elem_schema != "Doc" {
                                 return Err(format!("join called on Array<{elem_schema}>"));
@@ -3159,21 +3591,26 @@ impl Driver {
                             store_cell.borrow().string_value(handle, "Path")
                         })
                         .collect::<Result<Vec<_>, _>>()?;
-                    let (elem_schema, words) =
-                        match store_cell.borrow().array_entry(array_handle, schema_refs)? {
-                            ArrayEntry::Words { elem_schema, words } => (elem_schema, words),
-                            ArrayEntry::Pending(_) => {
-                                return Err("filter over pending array is outside B4".into());
-                            }
-                        };
-                    record_whole_args_if_projectable_static(
-                        &mut projection_reads.borrow_mut(),
-                        &exec_arg_schemas,
-                        &exec_args,
+                    let (elem_schema, words) = match flesh_cell.borrow().array_entry(
                         &store_cell.borrow(),
-                        descriptors,
-                        [array_handle],
-                    );
+                        array_handle,
+                        schema_refs,
+                    )? {
+                        ArrayEntry::Words { elem_schema, words } => (elem_schema, words),
+                        ArrayEntry::Pending(_) => {
+                            return Err("filter over pending array is outside B4".into());
+                        }
+                    };
+                    if flesh_index(array_handle).is_none() {
+                        record_whole_args_if_projectable_static(
+                            &mut projection_reads.borrow_mut(),
+                            &exec_arg_schemas,
+                            &exec_args,
+                            &store_cell.borrow(),
+                            descriptors,
+                            [array_handle],
+                        );
+                    }
                     let kept = words
                         .into_iter()
                         .filter_map(|word| {
@@ -3281,9 +3718,20 @@ impl Driver {
                         .map_err(|_| "negative fn ref".to_string())?;
                     let argc = usize::try_from(read_frame_word(frame, primitive_region + 24))
                         .map_err(|_| "negative argc".to_string())?;
-                    let args = (0..argc)
+                    let mut args = (0..argc)
                         .map(|i| read_frame_word(frame, primitive_region + 32 + i * 8))
                         .collect::<Vec<_>>();
+                    for (arg, schema) in args.iter_mut().zip(&lowered_fns[fn_ref].arg_schemas) {
+                        *arg = intern_flesh_word(
+                            &mut store_cell.borrow_mut(),
+                            &mut flesh_cell.borrow_mut(),
+                            descriptors,
+                            schema_refs,
+                            schema,
+                            *arg,
+                        )?
+                        .0;
+                    }
                     record_whole_args_if_projectable_static(
                         &mut projection_reads.borrow_mut(),
                         &exec_arg_schemas,
@@ -3314,19 +3762,50 @@ impl Driver {
             };
 
             let mut pending_invoke = |frame: &mut [u8]| {
-                let input_slot = read_frame_word(frame, primitive_region) as usize;
-                let pending = read_frame_word(frame, primitive_region + 8);
-                let argc = usize::try_from(read_frame_word(frame, primitive_region + 16))
-                    .unwrap_or_else(|_| panic!("negative pending invoke argc"));
-                let args = (0..argc)
-                    .map(|i| read_frame_word(frame, primitive_region + 24 + i * 8))
-                    .collect();
-                pending_invokes.push(PendingInvokeRequest {
-                    caller: exec_ix,
-                    input_slot,
-                    pending,
-                    args,
-                });
+                let result = (|| {
+                    let input_slot = read_frame_word(frame, primitive_region) as usize;
+                    let pending = read_frame_word(frame, primitive_region + 8);
+                    let argc = usize::try_from(read_frame_word(frame, primitive_region + 16))
+                        .map_err(|_| "negative pending invoke argc".to_string())?;
+                    let mut args = (0..argc)
+                        .map(|i| read_frame_word(frame, primitive_region + 24 + i * 8))
+                        .collect::<Vec<_>>();
+                    let invocation = store_cell.borrow().pending_invocation(pending)?;
+                    let fn_ref = lowered_fns
+                        .iter()
+                        .position(|lowered| lowered.hash == invocation.closure_hash)
+                        .ok_or_else(|| {
+                            format!(
+                                "no function with closure hash {:016x}",
+                                invocation.closure_hash
+                            )
+                        })?;
+                    let start = invocation.args.len();
+                    for (arg, schema) in args
+                        .iter_mut()
+                        .zip(lowered_fns[fn_ref].arg_schemas.iter().skip(start))
+                    {
+                        *arg = intern_flesh_word(
+                            &mut store_cell.borrow_mut(),
+                            &mut flesh_cell.borrow_mut(),
+                            descriptors,
+                            schema_refs,
+                            schema,
+                            *arg,
+                        )?
+                        .0;
+                    }
+                    pending_invokes.push(PendingInvokeRequest {
+                        caller: exec_ix,
+                        input_slot,
+                        pending,
+                        args,
+                    });
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
             };
 
             let mut target_host = |frame: &mut [u8]| {
@@ -3519,7 +3998,383 @@ impl Driver {
                 }
             };
 
-            let mut hosts: [HostFn<'_>; 43] = [
+            let mut flesh_intern = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let src = read_frame_word(frame, primitive_region + 8);
+                    let schema = schema_name_for(
+                        read_frame_word(frame, primitive_region + 16),
+                        schema_refs,
+                    )?;
+                    let was_flesh = flesh_index(src).is_some();
+                    let (handle, deduped) = intern_flesh_word(
+                        &mut store_cell.borrow_mut(),
+                        &mut flesh_cell.borrow_mut(),
+                        descriptors,
+                        schema_refs,
+                        &schema,
+                        src,
+                    )?;
+                    write_frame_word(frame, dst_slot, handle);
+                    if was_flesh {
+                        store_events.borrow_mut().push(DriveEvent::StoreAlloc {
+                            schema_ref: hash_u64(&schema),
+                            deduped,
+                        });
+                    }
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
+            let mut array_push = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let array = read_frame_word(frame, primitive_region + 8);
+                    let mut value = read_frame_word(frame, primitive_region + 16);
+                    if !force_flesh_copy {
+                        let elem_schema = {
+                            let flesh = flesh_cell.borrow();
+                            flesh.entry(array).and_then(|entry| match &entry.value {
+                                FleshValue::ArrayWords { elem_schema, .. } if entry.refs == 1 => {
+                                    Some(elem_schema.clone())
+                                }
+                                _ => None,
+                            })
+                        };
+                        if let Some(elem_schema) = elem_schema {
+                            value = intern_flesh_word(
+                                &mut store_cell.borrow_mut(),
+                                &mut flesh_cell.borrow_mut(),
+                                descriptors,
+                                schema_refs,
+                                &elem_schema,
+                                value,
+                            )?
+                            .0;
+                            let mut flesh = flesh_cell.borrow_mut();
+                            let entry = flesh
+                                .entry_mut(array)
+                                .ok_or_else(|| format!("flesh handle {array}"))?;
+                            if let FleshValue::ArrayWords { words, .. } = &mut entry.value {
+                                words.push(value);
+                                write_frame_word(frame, dst_slot, array);
+                                return Ok(());
+                            }
+                        }
+                    }
+                    let (elem_schema, mut words) = match flesh_cell.borrow().array_entry(
+                        &store_cell.borrow(),
+                        array,
+                        schema_refs,
+                    )? {
+                        ArrayEntry::Words { elem_schema, words } => (elem_schema, words),
+                        ArrayEntry::Pending(_) => return Err("push on pending array".into()),
+                    };
+                    value = intern_flesh_word(
+                        &mut store_cell.borrow_mut(),
+                        &mut flesh_cell.borrow_mut(),
+                        descriptors,
+                        schema_refs,
+                        &elem_schema,
+                        value,
+                    )?
+                    .0;
+                    words.push(value);
+                    let handle = flesh_cell
+                        .borrow_mut()
+                        .alloc(FleshValue::ArrayWords { elem_schema, words });
+                    write_frame_word(frame, dst_slot, handle);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
+            let mut array_pop = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let value_slot = read_frame_word(frame, primitive_region + 8) as usize;
+                    let array = read_frame_word(frame, primitive_region + 16);
+                    if !force_flesh_copy {
+                        let can_reuse = {
+                            let flesh = flesh_cell.borrow();
+                            flesh.entry(array).is_some_and(|entry| {
+                                entry.refs == 1
+                                    && matches!(entry.value, FleshValue::ArrayWords { .. })
+                            })
+                        };
+                        if can_reuse {
+                            let mut flesh = flesh_cell.borrow_mut();
+                            let entry = flesh
+                                .entry_mut(array)
+                                .ok_or_else(|| format!("flesh handle {array}"))?;
+                            if let FleshValue::ArrayWords { words, .. } = &mut entry.value {
+                                let value = words
+                                    .pop()
+                                    .ok_or_else(|| "pop on empty array".to_string())?;
+                                write_frame_word(frame, value_slot, value);
+                                write_frame_word(frame, dst_slot, array);
+                                return Ok(());
+                            }
+                        }
+                    }
+                    let (elem_schema, mut words) = match flesh_cell.borrow().array_entry(
+                        &store_cell.borrow(),
+                        array,
+                        schema_refs,
+                    )? {
+                        ArrayEntry::Words { elem_schema, words } => (elem_schema, words),
+                        ArrayEntry::Pending(_) => return Err("pop on pending array".into()),
+                    };
+                    let value = words
+                        .pop()
+                        .ok_or_else(|| "pop on empty array".to_string())?;
+                    write_frame_word(frame, value_slot, value);
+                    let handle = flesh_cell
+                        .borrow_mut()
+                        .alloc(FleshValue::ArrayWords { elem_schema, words });
+                    write_frame_word(frame, dst_slot, handle);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
+            let mut array_set = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                    let array = read_frame_word(frame, primitive_region + 8);
+                    let index = usize::try_from(read_frame_word(frame, primitive_region + 16))
+                        .map_err(|_| "negative array index".to_string())?;
+                    let mut value = read_frame_word(frame, primitive_region + 24);
+                    if !force_flesh_copy {
+                        let elem_schema = {
+                            let flesh = flesh_cell.borrow();
+                            flesh.entry(array).and_then(|entry| match &entry.value {
+                                FleshValue::ArrayWords { elem_schema, .. } if entry.refs == 1 => {
+                                    Some(elem_schema.clone())
+                                }
+                                _ => None,
+                            })
+                        };
+                        if let Some(elem_schema) = elem_schema {
+                            value = intern_flesh_word(
+                                &mut store_cell.borrow_mut(),
+                                &mut flesh_cell.borrow_mut(),
+                                descriptors,
+                                schema_refs,
+                                &elem_schema,
+                                value,
+                            )?
+                            .0;
+                            let mut flesh = flesh_cell.borrow_mut();
+                            let entry = flesh
+                                .entry_mut(array)
+                                .ok_or_else(|| format!("flesh handle {array}"))?;
+                            if let FleshValue::ArrayWords { words, .. } = &mut entry.value {
+                                if index >= words.len() {
+                                    return Err(format!(
+                                        "array index {index} out of bounds {}",
+                                        words.len()
+                                    ));
+                                }
+                                words[index] = value;
+                                write_frame_word(frame, dst_slot, array);
+                                return Ok(());
+                            }
+                        }
+                    }
+                    let (elem_schema, mut words) = match flesh_cell.borrow().array_entry(
+                        &store_cell.borrow(),
+                        array,
+                        schema_refs,
+                    )? {
+                        ArrayEntry::Words { elem_schema, words } => (elem_schema, words),
+                        ArrayEntry::Pending(_) => return Err("set on pending array".into()),
+                    };
+                    value = intern_flesh_word(
+                        &mut store_cell.borrow_mut(),
+                        &mut flesh_cell.borrow_mut(),
+                        descriptors,
+                        schema_refs,
+                        &elem_schema,
+                        value,
+                    )?
+                    .0;
+                    if index >= words.len() {
+                        return Err(format!("array index {index} out of bounds {}", words.len()));
+                    }
+                    words[index] = value;
+                    let handle = flesh_cell
+                        .borrow_mut()
+                        .alloc(FleshValue::ArrayWords { elem_schema, words });
+                    write_frame_word(frame, dst_slot, handle);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
+            let mut flesh_dup = |frame: &mut [u8]| {
+                let dst_slot = read_frame_word(frame, primitive_region) as usize;
+                let src = read_frame_word(frame, primitive_region + 8);
+                if let Some(entry) = flesh_cell.borrow_mut().entry_mut(src) {
+                    entry.refs = entry.refs.saturating_add(1);
+                }
+                write_frame_word(frame, dst_slot, src);
+            };
+
+            let mut record_update = |frame: &mut [u8]| {
+                let result = (|| {
+                    let dst_slot = read_frame_word(frame, store_alloc_region) as usize;
+                    let base = read_frame_word(frame, store_alloc_region + 8);
+                    let schema = schema_name_for(
+                        read_frame_word(frame, store_alloc_region + 16),
+                        schema_refs,
+                    )?;
+                    let variant_index =
+                        usize::try_from(read_frame_word(frame, store_alloc_region + 24))
+                            .map_err(|_| "negative record variant index".to_string())?;
+                    let update_count =
+                        usize::try_from(read_frame_word(frame, store_alloc_region + 32))
+                            .map_err(|_| "negative record update count".to_string())?;
+                    let descriptor = descriptors
+                        .get(&schema)
+                        .ok_or_else(|| format!("descriptor for schema `{schema}`"))?;
+                    if !force_flesh_copy {
+                        let can_reuse = {
+                            let flesh = flesh_cell.borrow();
+                            flesh.entry(base).is_some_and(|entry| {
+                                entry.refs == 1
+                                    && matches!(
+                                        &entry.value,
+                                        FleshValue::Record {
+                                            schema: record_schema,
+                                            ..
+                                        } if record_schema == &schema
+                                    )
+                            })
+                        };
+                        if can_reuse {
+                            let mut flesh = flesh_cell.borrow_mut();
+                            let entry = flesh
+                                .entry_mut(base)
+                                .ok_or_else(|| format!("flesh handle {base}"))?;
+                            if let FleshValue::Record { bytes, .. } = &mut entry.value {
+                                for update_index in 0..update_count {
+                                    let field_index = usize::try_from(read_frame_word(
+                                        frame,
+                                        store_alloc_region + 40 + update_index * 16,
+                                    ))
+                                    .map_err(|_| "negative record field index".to_string())?;
+                                    let field_offset = field_offset(descriptor, bytes, field_index);
+                                    let field = field_descriptor(descriptor, bytes, field_index);
+                                    if field.layout.size > 8 {
+                                        return Err(format!(
+                                            "record update field {field_index} has {} bytes",
+                                            field.layout.size
+                                        ));
+                                    }
+                                    let value = canonicalize_word_for_schema(
+                                        &field.schema,
+                                        read_frame_word(
+                                            frame,
+                                            store_alloc_region + 48 + update_index * 16,
+                                        ),
+                                    );
+                                    bytes[field_offset..field_offset + field.layout.size]
+                                        .copy_from_slice(&value.to_le_bytes()[..field.layout.size]);
+                                }
+                                write_frame_word(frame, dst_slot, base);
+                                return Ok(());
+                            }
+                        }
+                    }
+                    let mut bytes = if let Some(entry) = flesh_cell.borrow().entry(base) {
+                        match &entry.value {
+                            FleshValue::Record {
+                                schema: record_schema,
+                                bytes,
+                            } if record_schema == &schema => bytes.clone(),
+                            FleshValue::Interned(handle) => store_cell
+                                .borrow()
+                                .entry(*handle)
+                                .ok_or_else(|| format!("store handle {handle}"))?
+                                .bytes
+                                .clone(),
+                            FleshValue::Record {
+                                schema: record_schema,
+                                ..
+                            } => {
+                                return Err(format!(
+                                    "flesh record is `{record_schema}`, not {schema}"
+                                ));
+                            }
+                            _ => return Err(format!("flesh handle {base} is not a Record")),
+                        }
+                    } else {
+                        record_whole_args_if_projectable_static(
+                            &mut projection_reads.borrow_mut(),
+                            &exec_arg_schemas,
+                            &exec_args,
+                            &store_cell.borrow(),
+                            descriptors,
+                            [base],
+                        );
+                        store_cell
+                            .borrow()
+                            .entry(base)
+                            .ok_or_else(|| format!("store handle {base}"))?
+                            .bytes
+                            .clone()
+                    };
+                    if matches!(descriptor.access, Access::Enum(_))
+                        && variant_index
+                            != usize::try_from(read_variant_tag(&bytes, descriptor))
+                                .unwrap_or(usize::MAX)
+                    {
+                        write_variant_tag(&mut bytes, descriptor, variant_index as u64);
+                    }
+                    for update_index in 0..update_count {
+                        let field_index = usize::try_from(read_frame_word(
+                            frame,
+                            store_alloc_region + 40 + update_index * 16,
+                        ))
+                        .map_err(|_| "negative record field index".to_string())?;
+                        let field_offset = field_offset(descriptor, &bytes, field_index);
+                        let field = field_descriptor(descriptor, &bytes, field_index);
+                        if field.layout.size > 8 {
+                            return Err(format!(
+                                "record update field {field_index} has {} bytes",
+                                field.layout.size
+                            ));
+                        }
+                        let value = canonicalize_word_for_schema(
+                            &field.schema,
+                            read_frame_word(frame, store_alloc_region + 48 + update_index * 16),
+                        );
+                        bytes[field_offset..field_offset + field.layout.size]
+                            .copy_from_slice(&value.to_le_bytes()[..field.layout.size]);
+                    }
+                    let handle = flesh_cell.borrow_mut().alloc(FleshValue::Record {
+                        schema: schema.clone(),
+                        bytes,
+                    });
+                    write_frame_word(frame, dst_slot, handle);
+                    Ok(())
+                })();
+                if let Err(err) = result {
+                    *host_error.borrow_mut() = Some(err);
+                }
+            };
+
+            let mut hosts: [HostFn<'_>; 49] = [
                 &mut invoke,
                 &mut store_alloc,
                 &mut store_read,
@@ -3563,6 +4418,12 @@ impl Driver {
                 &mut sealed_to_string,
                 &mut version_set_parse_host,
                 &mut version_set_op_host,
+                &mut flesh_intern,
+                &mut array_push,
+                &mut array_pop,
+                &mut array_set,
+                &mut flesh_dup,
+                &mut record_update,
             ];
             let step = exec
                 .task
@@ -8555,6 +9416,15 @@ mod tests {
                 Op::ConstI64 { dst: 32, value },
                 Op::HostCall {
                     host: STORE_ALLOC_HOST,
+                },
+                Op::ConstI64 {
+                    dst: 0,
+                    value: dst.into(),
+                },
+                Op::CopyI64 { dst: 8, src: dst },
+                Op::ConstI64 { dst: 16, value: 0 },
+                Op::HostCall {
+                    host: FLESH_INTERN_HOST,
                 },
             ]
         };

--- a/vix/src/machine/lower.rs
+++ b/vix/src/machine/lower.rs
@@ -30,11 +30,12 @@ use weavy::task::{Fn as TaskFn, FnId, Op, Program};
 use super::TotalF64;
 use super::driver::{
     ACQUIRE_HOST, ARRAY_ALLOC_HOST, ARRAY_COLLECT_HOST, ARRAY_FILTER_EXCLUDE_HOST, ARRAY_JOIN_HOST,
-    ARRAY_LEN_HOST, ARRAY_MAP_PENDING_HOST, AST_DOC_HOST, AST_FN_HOST, CodeBundle, DOC_COERCE_HOST,
-    DOC_GET_HOST, DOC_PACKAGE_HOST, DOC_PARSE_HOST, DriveEvent, DriveEventSink, Driver,
-    ELF_DOC_HOST, EXEC_HOST, FETCH_HOST, GLOB_HOST, INVOKE_HOST, Lane, LoweredFn, MAP_EMPTY_HOST,
-    MAP_GET_HOST, MAP_INSERT_HOST, MachineExecBackend, OCI_DOC_HOST, OPTION_UNWRAP_HOST,
-    PATH_WITH_EXT_HOST, PENDING_ALLOC_HOST, PENDING_COERCE_HOST, PENDING_INVOKE_HOST, RenderNames,
+    ARRAY_LEN_HOST, ARRAY_MAP_PENDING_HOST, ARRAY_POP_HOST, ARRAY_PUSH_HOST, ARRAY_SET_HOST,
+    AST_DOC_HOST, AST_FN_HOST, CodeBundle, DOC_COERCE_HOST, DOC_GET_HOST, DOC_PACKAGE_HOST,
+    DOC_PARSE_HOST, DriveEvent, DriveEventSink, Driver, ELF_DOC_HOST, EXEC_HOST, FETCH_HOST,
+    FLESH_DUP_HOST, GLOB_HOST, INVOKE_HOST, Lane, LoweredFn, MAP_EMPTY_HOST, MAP_GET_HOST,
+    MAP_INSERT_HOST, MachineExecBackend, OCI_DOC_HOST, OPTION_UNWRAP_HOST, PATH_WITH_EXT_HOST,
+    PENDING_ALLOC_HOST, PENDING_COERCE_HOST, PENDING_INVOKE_HOST, RECORD_UPDATE_HOST, RenderNames,
     RenderVariant, RenderedValue, SEALED_DECLASSIFY_HOST, SEALED_SEAL_HOST, SEALED_TO_STRING_HOST,
     STORE_ALLOC_HOST, STORE_READ_HOST, STORE_TAG_HOST, STRING_CONCAT_HOST, STRING_DEFAULT_HOST,
     STRING_LOWER_HOST, STRING_UPPER_HOST, SemanticComparator, StepMode, StoreHandle, TARGET_HOST,
@@ -680,6 +681,10 @@ impl Machine {
         self.driver.set_step_mode(mode);
     }
 
+    pub fn set_force_flesh_copy(&mut self, force: bool) {
+        self.driver.set_force_flesh_copy(force);
+    }
+
     pub fn entry_param_schemas(&self, name: &str) -> Option<&[String]> {
         self.fn_params.get(name).map(Vec::as_slice)
     }
@@ -808,6 +813,7 @@ fn schema_names_for(
         "Option<Realized<Doc>>".to_string(),
         "Map<String,Doc>".to_string(),
         "Map<String,Realized<Doc>>".to_string(),
+        "Tuple<Int,Array>".to_string(),
     ]);
     for schema in fn_returns.values() {
         push_schema_closure(schema, &mut schema_names);
@@ -2778,7 +2784,13 @@ impl<'a> FnLowerer<'a> {
             .ok_or_else(|| format!("unbound name {name}"))?;
         let state = cell.0.borrow().clone();
         match state {
-            BindingState::Value(slot) => Ok(slot),
+            BindingState::Value(slot) => {
+                if self.schema_can_be_flesh(&slot.schema) {
+                    self.flesh_dup(&slot)
+                } else {
+                    Ok(slot)
+                }
+            }
             BindingState::Lazy {
                 value,
                 expected,
@@ -2789,9 +2801,20 @@ impl<'a> FnLowerer<'a> {
                     self.expr_expected(&value, contextual_expected.or(expected.as_deref()))?;
                 *cell.0.borrow_mut() = BindingState::Value(slot.clone());
                 self.slots = saved;
-                Ok(slot)
+                if self.schema_can_be_flesh(&slot.schema) {
+                    self.flesh_dup(&slot)
+                } else {
+                    Ok(slot)
+                }
             }
         }
+    }
+
+    fn schema_can_be_flesh(&self, schema: &str) -> bool {
+        schema == "Array"
+            || schema.starts_with("Map<")
+            || self.tables.structs.contains_key(schema)
+            || self.tables.enums.contains_key(schema)
     }
 
     /// Match on scalars: literal arms compile to EqI64 + JumpIfZero
@@ -3466,6 +3489,36 @@ impl<'a> FnLowerer<'a> {
                 let separator = self.method_arg(arg, Some("String"))?;
                 self.array_join(&receiver, &separator)
             }
+            "push" => {
+                if receiver.schema != "Array" {
+                    return Err(format!("push called on {}", receiver.schema));
+                }
+                let [arg] = call.args.args.as_slice() else {
+                    return Err("Array.push takes one value".into());
+                };
+                let value = self.method_arg(arg, None)?;
+                self.array_push(&receiver, &value)
+            }
+            "pop" => {
+                if receiver.schema != "Array" {
+                    return Err(format!("pop called on {}", receiver.schema));
+                }
+                if !call.args.args.is_empty() {
+                    return Err("Array.pop takes no arguments".into());
+                }
+                self.array_pop(&receiver)
+            }
+            "set" => {
+                if receiver.schema != "Array" {
+                    return Err(format!("set called on {}", receiver.schema));
+                }
+                let [index_arg, value_arg] = call.args.args.as_slice() else {
+                    return Err("Array.set takes index and value".into());
+                };
+                let index = self.method_arg(index_arg, Some("Int"))?;
+                let value = self.method_arg(value_arg, None)?;
+                self.array_set(&receiver, &index, &value)
+            }
             "insert" => {
                 let Some((key_schema, value_schema)) = map_schemas(&receiver.schema) else {
                     return Err(format!("insert called on {}", receiver.schema));
@@ -3773,13 +3826,23 @@ impl<'a> FnLowerer<'a> {
                 }
                 _ => return Err("multiple record update spreads are outside the B3 subset".into()),
             };
+            if let Some(base) = base {
+                let mut updates = Vec::new();
+                for (field_index, (field_name, _)) in info.fields.iter().enumerate() {
+                    let Some(init) = explicit.get(field_name) else {
+                        continue;
+                    };
+                    let field_schema = self.struct_field_schema(name, field_index)?;
+                    let value = self.expr_expected(init, Some(&field_schema))?;
+                    updates.push((field_index, value));
+                }
+                return self.record_update(name, 0, &base, &updates);
+            }
             let mut fields = Vec::new();
             for (field_index, (field_name, default)) in info.fields.iter().enumerate() {
                 let field_schema = self.struct_field_schema(name, field_index)?;
                 let value = if let Some(init) = explicit.get(field_name) {
                     self.expr_expected(init, Some(&field_schema))?
-                } else if let Some(base) = &base {
-                    self.store_read(base, field_index, field_schema.clone())
                 } else if let Some(default) = default {
                     self.expr_expected(default, Some(&field_schema))?
                 } else {
@@ -4390,6 +4453,62 @@ impl<'a> FnLowerer<'a> {
         })
     }
 
+    fn record_update(
+        &mut self,
+        schema: &str,
+        variant_index: usize,
+        base: &ValueSlot,
+        updates: &[(usize, ValueSlot)],
+    ) -> Result<ValueSlot, String> {
+        self.expect_schema(base, schema)?;
+        let dst = self.alloc();
+        let region = self.store_alloc_region;
+        let schema_ref = *self
+            .schema_refs
+            .get(schema)
+            .ok_or_else(|| format!("no schema ref for {schema}"))?;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: base.slot,
+        });
+        self.code.push(Op::ConstI64 {
+            dst: region + 16,
+            value: schema_ref,
+        });
+        self.code.push(Op::ConstI64 {
+            dst: region + 24,
+            value: i64::try_from(variant_index).expect("variant index fits i64"),
+        });
+        self.code.push(Op::ConstI64 {
+            dst: region + 32,
+            value: i64::try_from(updates.len()).expect("update count fits i64"),
+        });
+        for (update_index, (field_index, value)) in updates.iter().enumerate() {
+            let update_offset = 16 * u32::try_from(update_index).expect("update index fits u32");
+            self.code.push(Op::ConstI64 {
+                dst: region + 40 + update_offset,
+                value: i64::try_from(*field_index).expect("field index fits i64"),
+            });
+            self.code.push(Op::CopyI64 {
+                dst: region + 48 + update_offset,
+                src: value.slot,
+            });
+        }
+        self.code.push(Op::HostCall {
+            host: RECORD_UPDATE_HOST,
+        });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: schema.to_string(),
+            realization: None,
+            pending: None,
+        })
+    }
+
     fn store_read(&mut self, handle: &ValueSlot, field_index: usize, schema: String) -> ValueSlot {
         let dst = self.alloc();
         let region = self.store_read_region;
@@ -4436,6 +4555,28 @@ impl<'a> FnLowerer<'a> {
             realization: None,
             pending: None,
         }
+    }
+
+    fn flesh_dup(&mut self, value: &ValueSlot) -> Result<ValueSlot, String> {
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: value.slot,
+        });
+        self.code.push(Op::HostCall {
+            host: FLESH_DUP_HOST,
+        });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: value.schema.clone(),
+            realization: value.realization,
+            pending: value.pending,
+        })
     }
 
     fn map_empty(&mut self, schema: &str) -> Result<ValueSlot, String> {
@@ -5227,6 +5368,110 @@ impl<'a> FnLowerer<'a> {
         Ok(ValueSlot {
             slot: dst,
             schema: "Int".into(),
+            realization: None,
+            pending: None,
+        })
+    }
+
+    fn array_push(&mut self, receiver: &ValueSlot, value: &ValueSlot) -> Result<ValueSlot, String> {
+        self.expect_schema(receiver, "Array")?;
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: receiver.slot,
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 16,
+            src: value.slot,
+        });
+        self.code.push(Op::HostCall {
+            host: ARRAY_PUSH_HOST,
+        });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: "Array".into(),
+            realization: None,
+            pending: None,
+        })
+    }
+
+    fn array_pop(&mut self, receiver: &ValueSlot) -> Result<ValueSlot, String> {
+        self.expect_schema(receiver, "Array")?;
+        let array_dst = self.alloc();
+        let value_dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: array_dst.into(),
+        });
+        self.code.push(Op::ConstI64 {
+            dst: region + 8,
+            value: value_dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 16,
+            src: receiver.slot,
+        });
+        self.code.push(Op::HostCall {
+            host: ARRAY_POP_HOST,
+        });
+        self.store_alloc(
+            "Tuple<Int,Array>",
+            0,
+            &[
+                ValueSlot {
+                    slot: value_dst,
+                    schema: "Int".into(),
+                    realization: None,
+                    pending: None,
+                },
+                ValueSlot {
+                    slot: array_dst,
+                    schema: "Array".into(),
+                    realization: None,
+                    pending: None,
+                },
+            ],
+        )
+    }
+
+    fn array_set(
+        &mut self,
+        receiver: &ValueSlot,
+        index: &ValueSlot,
+        value: &ValueSlot,
+    ) -> Result<ValueSlot, String> {
+        self.expect_schema(receiver, "Array")?;
+        self.expect_schema(index, "Int")?;
+        let dst = self.alloc();
+        let region = self.primitive_region;
+        self.code.push(Op::ConstI64 {
+            dst: region,
+            value: dst.into(),
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 8,
+            src: receiver.slot,
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 16,
+            src: index.slot,
+        });
+        self.code.push(Op::CopyI64 {
+            dst: region + 24,
+            src: value.slot,
+        });
+        self.code.push(Op::HostCall {
+            host: ARRAY_SET_HOST,
+        });
+        Ok(ValueSlot {
+            slot: dst,
+            schema: "Array".into(),
             realization: None,
             pending: None,
         })
@@ -6832,6 +7077,70 @@ fn f(n: Int) -> Int {
                 1.5f64.to_bits(),
                 "{lane:?}"
             );
+        }
+    }
+
+    #[test]
+    fn flesh_reuse_is_unobservable_for_aggregate_updates() {
+        let cases = [
+            (
+                "array",
+                r#"
+pub fn main() -> Int {
+    ([0].push(1).push(2).pop()).0
+}
+"#,
+                2,
+            ),
+            (
+                "map",
+                r#"
+pub fn main() -> Int {
+    let m: Map<String, Int> = {};
+    m.insert("a", 1).insert("b", 2).get("b").unwrap() + 1
+}
+"#,
+                3,
+            ),
+            (
+                "record",
+                r#"
+struct Pair { left: Int, right: Int }
+
+pub fn main() -> Int {
+    let p = Pair { left: 1, right: 2 };
+    let q = Pair { right: 3, ..p };
+    q.left + q.right
+}
+"#,
+                4,
+            ),
+        ];
+        for lane in lanes() {
+            for (name, src, expected) in cases {
+                let mut reuse = Machine::load_with_lane(src, lane).unwrap();
+                reuse.driver.set_force_flesh_copy(false);
+                let reuse_result = reuse.demand_i64("main", vec![]).unwrap();
+                let reuse_trace = reuse.driver.trace.clone();
+                let reuse_bundle = reuse
+                    .driver
+                    .export_value_bundle(reuse_result, Vec::new())
+                    .unwrap();
+
+                let mut copy = Machine::load_with_lane(src, lane).unwrap();
+                copy.driver.set_force_flesh_copy(true);
+                let copy_result = copy.demand_i64("main", vec![]).unwrap();
+                let copy_trace = copy.driver.trace.clone();
+                let copy_bundle = copy
+                    .driver
+                    .export_value_bundle(copy_result, Vec::new())
+                    .unwrap();
+
+                assert_eq!(reuse_result, expected, "{lane:?} {name}");
+                assert_eq!(reuse_result, copy_result, "{lane:?} {name}");
+                assert_eq!(reuse_trace, copy_trace, "{lane:?} {name}");
+                assert_eq!(reuse_bundle.values, copy_bundle.values, "{lane:?} {name}");
+            }
         }
     }
 


### PR DESCRIPTION
Summary:
- Add frame-local flesh aggregates for records, maps, and arrays; intern them only at store-facing boundaries.
- Add dynamic uniqueness-checked reuse for array push/pop/set, map insert, and record spread update, with a forced-copy mode for differential checking.
- Add aggregate unobservability oracle coverage and a CDCL-shaped release benchmark binary.

Testing:
- cargo nextest run -p vix -p weavy
- cargo clippy --workspace --all-targets -- -D warnings --allow deprecated
- cargo check -p vix --target wasm32-unknown-unknown --no-default-features
- pnpm --dir playgrounds/snark run test:flow
- cargo run -p vix --bin cdcl_flesh_bench --release

CDCL bench (release):
- naive_copy_ns=15304791
- reuse_ns=14578500
- rust_vec_ns=8167

Note: reuse is slightly faster than forced-copy in this rung, but it is not yet within a small constant factor of the Rust Vec ceiling.