### PR TITLE
Respect proxies for serialized map keys

### DIFF
--- a/facet-format/src/serializer.rs
+++ b/facet-format/src/serializer.rs
@@ -1,7 +1,7 @@
 extern crate alloc;
 
 use alloc::borrow::Cow;
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use core::fmt::Debug;
 use core::fmt::Write as _;
 
@@ -947,6 +947,29 @@ impl<'s, S: FormatSerializer> SerializeContext<'s, S> {
         }
     }
 
+    fn map_key_string<'mem, 'facet>(
+        &self,
+        key: Peek<'mem, 'facet>,
+    ) -> Result<Cow<'mem, str>, SerializeError<S::Error>> {
+        if let Some(proxy_def) = key
+            .shape()
+            .effective_proxy(self.serializer.format_namespace())
+        {
+            let proxy = key
+                .custom_serialization_with_proxy(proxy_def)
+                .map_err(|err| SerializeError::Unsupported(Cow::Owned(alloc::format!("{err}"))))?;
+            let proxy_peek = proxy.as_peek().innermost_peek();
+            let key = extract_string_from_peek(proxy_peek)
+                .map(ToString::to_string)
+                .unwrap_or_else(|| alloc::format!("{}", proxy_peek));
+            return Ok(Cow::Owned(key));
+        }
+
+        Ok(extract_string_from_peek(key)
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Owned(alloc::format!("{}", key))))
+    }
+
     #[inline(never)]
     fn serialize_map_as_pairs<'mem, 'facet>(
         &mut self,
@@ -958,11 +981,8 @@ impl<'s, S: FormatSerializer> SerializeContext<'s, S> {
             .map_err(SerializeError::Backend)?;
         for (key, val) in map.iter() {
             self.serialize_impl(key)?;
-            let key_str = key
-                .as_str()
-                .map(|s| Cow::Owned(s.to_string()))
-                .unwrap_or_else(|| Cow::Owned(alloc::format!("{}", key)));
-            self.push(PathSegment::Field(key_str));
+            let key_str = self.map_key_string(key)?.into_owned();
+            self.push(PathSegment::Field(Cow::Owned(key_str)));
             self.serialize_impl(val)?;
             self.pop();
         }
@@ -978,24 +998,17 @@ impl<'s, S: FormatSerializer> SerializeContext<'s, S> {
             .begin_struct()
             .map_err(SerializeError::Backend)?;
         for (key, val) in map.iter() {
+            let key_str = self.map_key_string(key)?;
             if !self
                 .serializer
                 .serialize_map_key(key)
                 .map_err(SerializeError::Backend)?
             {
-                let key_str = if let Some(s) = extract_string_from_peek(key) {
-                    Cow::Borrowed(s)
-                } else {
-                    Cow::Owned(alloc::format!("{}", key))
-                };
                 self.serializer
                     .field_key(&key_str)
                     .map_err(SerializeError::Backend)?;
             }
-            let key_str = extract_string_from_peek(key)
-                .map(|s| Cow::Owned(s.to_string()))
-                .unwrap_or_else(|| Cow::Owned(alloc::format!("{}", key)));
-            self.push(PathSegment::Field(key_str));
+            self.push(PathSegment::Field(Cow::Owned(key_str.into_owned())));
             self.serialize_impl(val)?;
             self.pop();
         }

--- a/facet-json/tests/integration/issue_2341_newtype_as_json_object_key.rs
+++ b/facet-json/tests/integration/issue_2341_newtype_as_json_object_key.rs
@@ -9,7 +9,7 @@
 //! container-level `String` proxy.
 
 use facet::Facet;
-use facet_json::from_str;
+use facet_json::{from_str, to_string};
 use std::collections::HashMap;
 use std::str::FromStr;
 
@@ -60,6 +60,42 @@ struct Member {
     display_name: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Facet)]
+#[facet(json::proxy = String)]
+struct JsonDescriptor {
+    value: String,
+}
+
+impl JsonDescriptor {
+    fn new(value: &str) -> Self {
+        Self {
+            value: value.to_owned(),
+        }
+    }
+}
+
+impl FromStr for JsonDescriptor {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self::new(value))
+    }
+}
+
+impl TryFrom<String> for JsonDescriptor {
+    type Error = &'static str;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Ok(Self { value })
+    }
+}
+
+impl From<&JsonDescriptor> for String {
+    fn from(value: &JsonDescriptor) -> Self {
+        value.value.clone()
+    }
+}
+
 fn map_members_by_descriptor(
     members_by_descriptor: HashMap<String, Member>,
 ) -> Result<HashMap<Descriptor, Member>, &'static str> {
@@ -103,5 +139,61 @@ fn test_issue_2341_proxy_enum_deserializes_as_hash_map_key() {
             descriptor: Descriptor::Aad("aad.user".to_owned()),
             display_name: "Ada".to_owned()
         })
+    );
+}
+
+#[test]
+fn test_issue_2341_proxy_enum_serializes_as_hash_map_key() {
+    let map = HashMap::from([
+        (Descriptor::Aad("aad.user".to_owned()), 1),
+        (Descriptor::Vssgp("vssgp.group".to_owned()), 2),
+    ]);
+
+    let json = to_string(&map).unwrap();
+
+    assert!(
+        json.contains(r#""aad.user":"#),
+        "serialized map should contain the proxy string for the first key, got: {json}"
+    );
+    assert!(
+        json.contains(r#""vssgp.group":"#),
+        "serialized map should contain the proxy string for the second key, got: {json}"
+    );
+    assert!(
+        !json.contains("⟨Descriptor⟩"),
+        "serialized map should not use a placeholder object key, got: {json}"
+    );
+}
+
+#[test]
+fn test_issue_2341_json_proxy_type_deserializes_as_hash_map_key() {
+    let json = r#"{"aad.user":1,"vssgp.group":2}"#;
+
+    let parsed: HashMap<JsonDescriptor, i32> = from_str(json).unwrap();
+
+    assert_eq!(parsed.get(&JsonDescriptor::new("aad.user")), Some(&1));
+    assert_eq!(parsed.get(&JsonDescriptor::new("vssgp.group")), Some(&2));
+}
+
+#[test]
+fn test_issue_2341_json_proxy_type_serializes_as_hash_map_key() {
+    let map = HashMap::from([
+        (JsonDescriptor::new("aad.user"), 1),
+        (JsonDescriptor::new("vssgp.group"), 2),
+    ]);
+
+    let json = to_string(&map).unwrap();
+
+    assert!(
+        json.contains(r#""aad.user":"#),
+        "serialized map should contain the json proxy string for the first key, got: {json}"
+    );
+    assert!(
+        json.contains(r#""vssgp.group":"#),
+        "serialized map should contain the json proxy string for the second key, got: {json}"
+    );
+    assert!(
+        !json.contains("⟨JsonDescriptor⟩"),
+        "serialized map should not use a placeholder object key, got: {json}"
     );
 }


### PR DESCRIPTION
## Summary

Fixes #2341.

This teaches the shared serializer to honor the effective format proxy when serializing map keys. JSON object keys are strings, so a domain key with a `String` proxy should use that proxy value instead of falling back to the opaque placeholder formatting.

## Before

Serializing a map with proxy-backed domain keys could produce placeholder object keys, and distinct entries became indistinguishable at the JSON-key layer:

```json
{"⟨Descriptor⟩":1,"⟨Descriptor⟩":2}
```

The same shape showed up in downstream callers as maps that looked like they had one symbolic key instead of the actual descriptor/id keys.

## After

The same map now serializes through the key type's string proxy:

```json
{"aad.user":1,"vssgp.group":2}
```

The regression tests cover both `#[facet(opaque, proxy = String)]` keys and `#[facet(json::proxy = String)]` keys.

## Validation

```text
cargo test -p facet-json --test main issue_2341 -- --nocapture
cargo test -p facet-format
cargo test -p facet-json -- --test-threads=1
```