### PR TITLE
snark-dsl: raw-escape keyword field names in typed-ast codegen

### DIFF
--- a/snark-dsl/src/typed_ast.rs
+++ b/snark-dsl/src/typed_ast.rs
@@ -1128,16 +1128,38 @@ impl TypeVisitState {
 
 /// Grammar field names are singular (they label one child each); Vec-shaped fields
 /// pluralize (`stmt` -> `stmts`, `entry` -> `entries`, `leaf` -> `leaves`), and a
-/// singular `type` dodges the keyword (plural `types` doesn't need to).
+/// singular `type` dodges the keyword (plural `types` doesn't need to). Any other
+/// name that lands on a Rust keyword — directly (`else`) or via pluralization
+/// (`a` -> `as`) — is raw-escaped, except the few that reject `r#`, which get a
+/// trailing underscore instead.
 fn rust_field_name(name: &str, mult: Mult) -> String {
-    match (mult, name) {
+    let name = match (mult, name) {
         (Mult::Many, "leaf") => "leaves".to_string(),
         (Mult::Many, s) if s.ends_with('y') => format!("{}ies", &s[..s.len() - 1]),
         (Mult::Many, s) if !s.ends_with('s') => format!("{s}s"),
-        (_, "type") => "ty".to_string(),
+        // `ty` predates the escaping below; keep it so existing grammars don't
+        // see their generated field renamed to `r#type`.
+        (_, "type") => return "ty".to_string(),
         (_, s) => s.to_string(),
+    };
+    match name.as_str() {
+        // The only keywords `r#` can't rescue.
+        "crate" | "self" | "super" | "Self" => format!("{name}_"),
+        s if RUST_KEYWORDS.contains(&s) => format!("r#{name}"),
+        _ => name,
     }
 }
+
+/// Rust keywords (strict + reserved, edition 2024) that are valid as raw
+/// identifiers. `type` and the un-rescuable `crate`/`self`/`super`/`Self` are
+/// handled separately in [`rust_field_name`].
+const RUST_KEYWORDS: &[&str] = &[
+    "abstract", "as", "async", "await", "become", "box", "break", "const", "continue", "do", "dyn",
+    "else", "enum", "extern", "false", "final", "fn", "for", "gen", "if", "impl", "in", "let",
+    "loop", "macro", "match", "mod", "move", "mut", "override", "priv", "pub", "ref", "return",
+    "static", "struct", "trait", "true", "try", "typeof", "unsafe", "unsized", "use", "virtual",
+    "where", "while", "yield",
+];
 
 fn camel(kind: &str) -> String {
     kind.split('_')
@@ -1275,6 +1297,39 @@ module.exports = grammar({
         assert!(generated.contains(
             r#"if_stmt: crate::support::field_opt(n, "if_stmt").map(|n| Box::new(lower_if_statement(n))),"#
         ));
+    }
+
+    #[test]
+    fn keyword_field_names_are_escaped() {
+        let generated = generate(
+            r#"
+module.exports = grammar({
+  name: "keywords",
+  rules: {
+    source_file: $ => seq(field("expr", $.ternary), field("list", $.list)),
+    ternary: $ => seq(
+      field("cond", $.ident),
+      "?",
+      field("then", $.ident),
+      ":",
+      field("else", $.ident),
+    ),
+    list: $ => seq("[", repeat(field("a", $.ident)), "]", field("self", $.ident)),
+    ident: $ => /[a-z]+/,
+  },
+});
+"#,
+        );
+
+        // `else` is a keyword: the Rust field is raw-escaped, but the CST lookup
+        // keeps the grammar's spelling.
+        assert!(generated.contains("pub r#else:"));
+        assert!(!generated.contains("pub else:"));
+        assert!(generated.contains(r#"field_one(n, "else""#));
+        // pluralization can land on a keyword too (`a` -> `as`)
+        assert!(generated.contains("pub r#as: Vec<"));
+        // `r#` can't rescue `self`
+        assert!(generated.contains("pub self_:"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`typed_ast::rust_field_name` only dodges the keyword `type` (→ `ty`); every other Rust keyword is emitted verbatim. A grammar with

```js
ternary_expression: $ => seq(
  field("cond", $._expr), "?",
  field("then", $._expr), ":",
  field("else", $._expr),
),
```

generates `pub else: Expr` / `self.else`, which doesn't parse.

Hit this for real while pointing snark-dsl's typed-ast codegen at [cirq](https://github.com/cramt/thevenin)'s existing tree-sitter grammar, which fields its ternary exactly like that. (Workaround until now: renaming the field in a build-time copy of the grammar.)

## Fix

After the existing pluralization step, escape any name that lands on a Rust keyword:

- raw-escape (`r#else`, `r#as`) for every keyword that permits it — strict + reserved, edition 2024;
- trailing underscore (`self_`, `crate_`, `super_`, `Self_`) for the four that `r#` can't rescue;
- `type` → `ty` kept as-is so existing generated ASTs don't see that field renamed to `r#type`.

Escaping runs on the *pluralized* name because pluralization can create keywords too: a `Many` field named `a` becomes `as`.

The CST lookups are untouched — `grammar_name` is stored separately from `rust_name`, so `field_one(n, "else", …)` keeps the grammar's spelling while the struct field becomes `r#else`.

## Test

`keyword_field_names_are_escaped` covers the three paths (direct keyword, pluralized-into-keyword, non-raw-able keyword) and asserts the CST lookup still uses the grammar spelling.
