### PR TITLE
Add optional bstr Facet support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,6 +948,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "btparse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,6 +2312,7 @@ name = "facet-core"
 version = "0.50.0-rc.5"
 dependencies = [
  "autocfg",
+ "bstr",
  "bytes",
  "bytestring",
  "camino",
@@ -2439,6 +2450,7 @@ name = "facet-json"
 version = "0.50.0-rc.5"
 dependencies = [
  "axum-core",
+ "bstr",
  "codspeed-divan-compat",
  "compact_str",
  "copypatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -393,6 +393,7 @@ blake3 = "^1"
 bolero = "^0.13.4"
 brotli = "8"
 bytes = { version = "^1.11.0", default-features = false }
+bstr = { version = "^1.12.3", default-features = false, features = ["alloc"] }
 bytestring = { version = "^1.4.0", default-features = false }
 cbindgen = "^0.28"
 cc = "^1.0.87"
@@ -604,3 +605,5 @@ styx-tree = { path = "styx-tree" }
 styx-wasm = { path = "styx-wasm" }
 tree-sitter-styx = { path = "tree-sitter-styx" }
 strid-examples = { path = "strid-examples" }
+
+

--- a/facet-core/Cargo.toml
+++ b/facet-core/Cargo.toml
@@ -45,6 +45,8 @@ url = ["alloc", "dep:url"]
 jiff02 = ["alloc", "dep:jiff"]
 # Provide Facet trait implementations for bytes::Bytes
 bytes = ["alloc", "dep:bytes"]
+# Provide Facet trait implementations for bstr::BString and bstr::BStr
+bstr = ["alloc", "dep:bstr"]
 # Provide Facet trait implementations for bytestring::ByteString
 bytestring = ["alloc", "dep:bytestring"]
 # Provide Facet trait implementations for compact_str::CompactString
@@ -92,6 +94,7 @@ autocfg = { workspace = true }
 [dependencies]
 const-fnv1a-hash = "1"
 bytes = { workspace = true, optional = true }
+bstr = { workspace = true, optional = true }
 bytestring = { workspace = true, optional = true }
 camino = { workspace = true, optional = true }
 compact_str = { workspace = true, optional = true }
@@ -124,3 +127,5 @@ parking_lot = "0.12"
 
 [lints]
 workspace = true
+
+

--- a/facet-core/src/impls/crates/bstr.rs
+++ b/facet-core/src/impls/crates/bstr.rs
@@ -1,0 +1,260 @@
+#![cfg(feature = "bstr")]
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::ptr::NonNull;
+
+use bstr::{BStr, BString};
+
+use crate::{
+    Def, Facet, IterVTable, ListDef, ListTypeOps, ListVTable, PtrConst, PtrMut, PtrUninit,
+    SequenceType, Shape, ShapeBuilder, SliceDef, SliceType, SliceVTable, Type, TypeOpsDirect,
+    TypeOpsIndirect, UserType, VTableDirect, VTableIndirect, type_ops_direct, vtable_direct,
+};
+
+type ByteIterator<'mem> = core::slice::Iter<'mem, u8>;
+
+unsafe extern "C" fn bstring_len(ptr: PtrConst) -> usize {
+    unsafe { ptr.get::<BString>().len() }
+}
+
+unsafe fn bstring_get(ptr: PtrConst, index: usize, _shape: &'static Shape) -> Option<PtrConst> {
+    unsafe {
+        let bytes = ptr.get::<BString>();
+        let item = bytes.get(index)?;
+        Some(PtrConst::new(item as *const u8))
+    }
+}
+
+unsafe fn bstring_get_mut(ptr: PtrMut, index: usize, _shape: &'static Shape) -> Option<PtrMut> {
+    unsafe {
+        let bytes = ptr.as_mut::<BString>();
+        let item = bytes.get_mut(index)?;
+        Some(PtrMut::new(item as *mut u8 as *mut ()))
+    }
+}
+
+unsafe extern "C" fn bstring_as_ptr(ptr: PtrConst) -> PtrConst {
+    unsafe {
+        let bytes = ptr.get::<BString>();
+        PtrConst::new(NonNull::new_unchecked(bytes.as_ptr() as *mut u8).as_ptr() as *const ())
+    }
+}
+
+unsafe extern "C" fn bstring_as_mut_ptr(ptr: PtrMut) -> PtrMut {
+    unsafe {
+        let bytes = ptr.as_mut::<BString>();
+        PtrMut::new(NonNull::new_unchecked(bytes.as_mut_ptr()).as_ptr() as *mut ())
+    }
+}
+
+unsafe extern "C" fn bstring_init_in_place_with_capacity(
+    data: PtrUninit,
+    capacity: usize,
+) -> PtrMut {
+    unsafe { data.put(BString::from(Vec::<u8>::with_capacity(capacity))) }
+}
+
+unsafe extern "C" fn bstring_push(ptr: PtrMut, item: PtrMut) {
+    unsafe {
+        let bytes = ptr.as_mut::<BString>();
+        let item = item.read::<u8>();
+        bytes.push(item);
+    }
+}
+
+unsafe extern "C" fn bstring_pop(ptr: PtrMut, out: PtrUninit) -> bool {
+    unsafe {
+        let bytes = ptr.as_mut::<BString>();
+        match bytes.pop() {
+            Some(value) => {
+                out.put(value);
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+unsafe extern "C" fn bstring_set_len(ptr: PtrMut, len: usize) {
+    unsafe {
+        let bytes = ptr.as_mut::<BString>();
+        bytes.set_len(len);
+    }
+}
+
+unsafe extern "C" fn bstring_as_mut_ptr_typed(ptr: PtrMut) -> *mut u8 {
+    unsafe {
+        let bytes = ptr.as_mut::<BString>();
+        bytes.as_mut_ptr()
+    }
+}
+
+unsafe extern "C" fn bstring_reserve(ptr: PtrMut, additional: usize) {
+    unsafe {
+        let bytes = ptr.as_mut::<BString>();
+        bytes.reserve(additional);
+    }
+}
+
+unsafe extern "C" fn bstring_capacity(ptr: PtrConst) -> usize {
+    unsafe { ptr.get::<BString>().capacity() }
+}
+
+unsafe extern "C" fn bstring_from_raw_parts(
+    list: PtrUninit,
+    ptr: PtrMut,
+    len: usize,
+    capacity: usize,
+) {
+    unsafe {
+        let data = ptr.as_mut_byte_ptr();
+        let vec = Vec::<u8>::from_raw_parts(data, len, capacity);
+        list.put(BString::from(vec));
+    }
+}
+
+unsafe extern "C" fn byte_iter_init_from_bstring(ptr: PtrConst) -> PtrMut {
+    unsafe {
+        let bytes = ptr.get::<BString>();
+        let iter: ByteIterator = bytes.iter();
+        let iter_state = Box::new(iter);
+        PtrMut::new(
+            NonNull::new_unchecked(Box::into_raw(iter_state) as *mut u8).as_ptr() as *mut (),
+        )
+    }
+}
+
+unsafe fn byte_iter_next(iter_ptr: PtrMut) -> Option<PtrConst> {
+    unsafe {
+        let state = iter_ptr.as_mut::<ByteIterator<'static>>();
+        state.next().map(|value| PtrConst::new(value as *const u8))
+    }
+}
+
+unsafe fn byte_iter_next_back(iter_ptr: PtrMut) -> Option<PtrConst> {
+    unsafe {
+        let state = iter_ptr.as_mut::<ByteIterator<'static>>();
+        state
+            .next_back()
+            .map(|value| PtrConst::new(value as *const u8))
+    }
+}
+
+unsafe extern "C" fn byte_iter_dealloc(iter_ptr: PtrMut) {
+    unsafe {
+        drop(Box::from_raw(
+            iter_ptr.as_ptr::<ByteIterator<'_>>() as *mut ByteIterator<'_>
+        ));
+    }
+}
+
+unsafe fn bstring_truthy(ptr: PtrConst) -> bool {
+    !unsafe { ptr.get::<BString>() }.is_empty()
+}
+
+static BSTRING_TYPE_OPS: TypeOpsDirect = TypeOpsDirect {
+    is_truthy: Some(bstring_truthy),
+    ..type_ops_direct!(BString => Default, Clone)
+};
+
+static BSTRING_LIST_VTABLE: ListVTable = ListVTable {
+    len: bstring_len,
+    get: bstring_get,
+    get_mut: Some(bstring_get_mut),
+    as_ptr: Some(bstring_as_ptr),
+    as_mut_ptr: Some(bstring_as_mut_ptr),
+    swap: None,
+};
+
+static BSTRING_LIST_TYPE_OPS: ListTypeOps = ListTypeOps {
+    init_in_place_with_capacity: Some(bstring_init_in_place_with_capacity),
+    push: Some(bstring_push),
+    pop: Some(bstring_pop),
+    set_len: Some(bstring_set_len),
+    as_mut_ptr_typed: Some(bstring_as_mut_ptr_typed),
+    reserve: Some(bstring_reserve),
+    capacity: Some(bstring_capacity),
+    from_raw_parts: Some(bstring_from_raw_parts),
+    iter_vtable: IterVTable {
+        init_with_value: Some(byte_iter_init_from_bstring),
+        next: byte_iter_next,
+        next_back: Some(byte_iter_next_back),
+        size_hint: None,
+        dealloc: byte_iter_dealloc,
+    },
+};
+
+unsafe impl Facet<'_> for BString {
+    const SHAPE: &'static Shape = &const {
+        const VTABLE: VTableDirect =
+            vtable_direct!(BString => Display, Debug, Hash, PartialEq, PartialOrd, Ord,);
+
+        ShapeBuilder::for_sized::<BString>("BString")
+            .module_path("bstr")
+            .ty(Type::User(UserType::Opaque))
+            .def(Def::List(ListDef::with_type_ops(
+                &BSTRING_LIST_VTABLE,
+                &BSTRING_LIST_TYPE_OPS,
+                u8::SHAPE,
+            )))
+            .vtable_direct(&VTABLE)
+            .type_ops_direct(&BSTRING_TYPE_OPS)
+            .send()
+            .sync()
+            .build()
+    };
+}
+
+unsafe extern "C" fn bstr_len(ptr: PtrConst) -> usize {
+    unsafe { ptr.get::<BStr>().len() }
+}
+
+unsafe extern "C" fn bstr_as_ptr(ptr: PtrConst) -> PtrConst {
+    unsafe {
+        let bytes = ptr.get::<BStr>();
+        PtrConst::new(NonNull::new_unchecked(bytes.as_ptr() as *mut u8).as_ptr() as *const ())
+    }
+}
+
+unsafe extern "C" fn bstr_as_mut_ptr(ptr: PtrMut) -> PtrMut {
+    unsafe {
+        let bytes = ptr.as_mut::<BStr>();
+        PtrMut::new(NonNull::new_unchecked(bytes.as_mut_ptr()).as_ptr() as *mut ())
+    }
+}
+
+unsafe fn bstr_truthy(ptr: PtrConst) -> bool {
+    !unsafe { ptr.get::<BStr>() }.is_empty()
+}
+
+unsafe impl<'a> Facet<'a> for BStr {
+    const SHAPE: &'static Shape = &const {
+        const SLICE_VTABLE: SliceVTable = SliceVTable {
+            len: bstr_len,
+            as_ptr: bstr_as_ptr,
+            as_mut_ptr: bstr_as_mut_ptr,
+        };
+
+        ShapeBuilder::for_unsized::<BStr>("BStr")
+            .module_path("bstr")
+            .ty(Type::Sequence(SequenceType::Slice(SliceType {
+                t: u8::SHAPE,
+            })))
+            .def(Def::Slice(SliceDef::new(&SLICE_VTABLE, u8::SHAPE)))
+            .vtable_indirect(&const { VTableIndirect::EMPTY })
+            .type_ops_indirect(
+                &const {
+                    TypeOpsIndirect {
+                        drop_in_place: |_| {},
+                        default_in_place: None,
+                        clone_into: None,
+                        is_truthy: Some(bstr_truthy),
+                    }
+                },
+            )
+            .send()
+            .sync()
+            .build()
+    };
+}

--- a/facet-core/src/impls/crates/mod.rs
+++ b/facet-core/src/impls/crates/mod.rs
@@ -1,3 +1,4 @@
+mod bstr;
 mod bytes;
 mod bytestring;
 mod camino;

--- a/facet-json/Cargo.toml
+++ b/facet-json/Cargo.toml
@@ -38,6 +38,7 @@ mime = { version = "0.3", optional = true }
 
 [dev-dependencies]
 compact_str = { workspace = true }
+bstr = { workspace = true }
 facet-json-classics = { path = "../facet-json-classics" }
 divan = { workspace = true }
 facet = { path = "../facet", features = [
@@ -45,6 +46,7 @@ facet = { path = "../facet", features = [
   "doc",
   "net",
   "compact_str",
+  "bstr",
   "smol_str",
   "iddqd",
   "tendril",
@@ -119,3 +121,4 @@ ignored = ["tracing"]
 
 [lints]
 workspace = true
+

--- a/facet-json/tests/integration/bstr.rs
+++ b/facet-json/tests/integration/bstr.rs
@@ -1,0 +1,45 @@
+use bstr::{BStr, BString};
+use facet::Facet;
+
+#[test]
+fn bstring_serializes_as_byte_array() {
+    let value = BString::from(vec![104, 105, 255]);
+    let json = facet_json::to_string(&value).unwrap();
+    assert_eq!(json, "[104,105,255]");
+}
+
+#[test]
+fn bstring_round_trips_invalid_utf8() {
+    let value: BString = facet_json::from_str("[0,159,146,150,255]").unwrap();
+    assert_eq!(value, BString::from(vec![0, 159, 146, 150, 255]));
+
+    let json = facet_json::to_string(&value).unwrap();
+    assert_eq!(json, "[0,159,146,150,255]");
+}
+
+#[test]
+fn bstr_serializes_as_byte_array() {
+    let value = BStr::new(&[1, 2, 3, 255]);
+    let json = facet_json::to_string(value).unwrap();
+    assert_eq!(json, "[1,2,3,255]");
+}
+
+#[test]
+fn bstring_field_needs_no_proxy() {
+    #[derive(Facet, Debug, PartialEq)]
+    struct Container {
+        data: BString,
+    }
+
+    let value: Container = facet_json::from_str(r#"{"data":[65,66,255]}"#).unwrap();
+    assert_eq!(
+        value,
+        Container {
+            data: BString::from(vec![65, 66, 255]),
+        }
+    );
+    assert_eq!(
+        facet_json::to_string(&value).unwrap(),
+        r#"{"data":[65,66,255]}"#
+    );
+}

--- a/facet-json/tests/integration/mod.rs
+++ b/facet-json/tests/integration/mod.rs
@@ -1,6 +1,7 @@
 #[path = "backend_historical.rs"]
 pub(crate) mod json_backend;
 
+mod bstr;
 mod flatten_defaults;
 mod flatten_in_externally_tagged_enum;
 mod format_specific_proxy;

--- a/facet/Cargo.toml
+++ b/facet/Cargo.toml
@@ -28,6 +28,7 @@ all-impls = [
   "nonzero",
   "net",
   "bytes",
+  "bstr",
   "bytestring",
   "camino",
   "compact_str",
@@ -57,6 +58,9 @@ net = [
 bytes = [
   "facet-core/bytes",
 ] # Provide Facet trait implementations for bytes::Bytes and bytes::BytesMut
+bstr = [
+  "facet-core/bstr",
+] # Provide Facet trait implementations for bstr::BString and bstr::BStr
 bytestring = [
   "facet-core/bytestring",
 ] # Provide Facet trait implementations for bytestring::ByteString
@@ -147,3 +151,5 @@ tempfile = { workspace = true }
 
 [lints]
 workspace = true
+
+


### PR DESCRIPTION
# PR Draft: Add optional bstr Facet support

## Summary

Adds an optional `bstr` feature with first-party `Facet` implementations for `bstr::BString` and `bstr::BStr`.

`BString` is reflected as an opaque user type with list semantics over `u8`, matching the existing pattern used by byte-oriented third-party types such as `bytes::Bytes` / `bytes::BytesMut`. This lets serializers treat it as byte data while preserving its nominal type identity.

Fixes #2468

## Changes

- Add workspace dependency on `bstr`.
- Add `facet-core/bstr` and top-level `facet/bstr` feature flags.
- Include `bstr` in `facet`'s `all-impls` feature.
- Implement `Facet` for `bstr::BString` as a `Def::List` of `u8`.
- Implement `Facet` for `bstr::BStr` as the borrowed byte-slice counterpart.
- Add facet-json integration tests for byte-array serialization and invalid UTF-8 round-trips.

## Behavior

`BString` now works directly in derived structs without an opaque proxy:

```rust
use bstr::BString;
use facet::Facet;

#[derive(Facet)]
struct CommandOutput {
    stdout: BString,
}
```

JSON output uses byte arrays:

```json
{"stdout":[104,105,255]}
```

This preserves invalid UTF-8 bytes and matches the behavior downstream users previously had to implement with a `Vec<u8>` proxy.

## Tests

Run locally:

```text
cargo check -p facet-core --features bstr
cargo check -p facet --features bstr
cargo test -p facet-json --test main bstr
```

The facet-json test filter covers:

- `BString` serializes as a byte array.
- `BString` round-trips invalid UTF-8 bytes.
- `&BStr` serializes as a byte array.
- `BString` fields in derived structs work without proxies.

## Branch

Prepared from `origin/main` on branch:

```text
feat/bstr-facet
```

Current commit:

```text
a19dd9fa549ecd071f8f63c785644295f0cae9ea Add bstr facet support
```

## Disclaimer

This PR description draft was written with LLM assistance from OpenAI GPT-5.5 via Codex.


