### PR TITLE
Respect proxies when building figue arg schemas

### DIFF
--- a/figue/src/schema/from_schema.rs
+++ b/figue/src/schema/from_schema.rs
@@ -1116,13 +1116,9 @@ fn arg_level_from_fields_with_prefix(
         if matches!(value, ValueSchema::Struct { .. }) {
             return Err(SchemaError::new(
                 field_ctx.clone(),
-                "struct fields in args must use #[facet(flatten)]",
+                "struct fields in args are not valid unless one of these applies:\n- add #[facet(flatten)] to the CLI field\n- add #[facet(transparent)] to the type definition if it is a newtype over a scalar",
             )
-            .with_primary_label("this field is a struct type")
-            .with_label(
-                field_ctx.clone(),
-                "add #[facet(flatten)] to include its fields at this level",
-            ));
+            .with_primary_label("this field has a struct-shaped Facet schema"));
         }
 
         #[allow(clippy::nonminimal_bool)]

--- a/figue/src/schema/from_schema.rs
+++ b/figue/src/schema/from_schema.rs
@@ -358,10 +358,25 @@ fn leaf_schema_from_shape(
     }
 }
 
+fn value_schema_from_field(
+    field: &Field,
+    ctx: &SchemaErrorContext,
+) -> Result<ValueSchema, SchemaError> {
+    if let Some(proxy) = field.proxy {
+        return value_schema_from_shape(proxy.shape, ctx);
+    }
+
+    value_schema_from_shape(field.shape(), ctx)
+}
+
 fn value_schema_from_shape(
     shape: &'static Shape,
     ctx: &SchemaErrorContext,
 ) -> Result<ValueSchema, SchemaError> {
+    if let Some(proxy) = shape.proxy {
+        return value_schema_from_shape(proxy.shape, ctx);
+    }
+
     match shape.def {
         Def::Option(opt) => Ok(ValueSchema::Option {
             value: Box::new(value_schema_from_shape(opt.t, ctx)?),
@@ -1109,14 +1124,14 @@ fn arg_level_from_fields_with_prefix(
             ArgKind::Named { short, counted }
         };
 
-        let value = value_schema_from_shape(field.shape(), &field_ctx)?;
+        let value = value_schema_from_field(field, &field_ctx)?;
 
         // Struct types in args must be flattened - CLI can't represent nested structs
         // without dotted path syntax (which is only for args::config fields)
         if matches!(value, ValueSchema::Struct { .. }) {
             return Err(SchemaError::new(
                 field_ctx.clone(),
-                "struct fields in args are not valid unless one of these applies:\n- add #[facet(flatten)] to the CLI field\n- add #[facet(transparent)] to the type definition if it is a newtype over a scalar",
+                "struct fields in args are not valid unless one of these applies:\n- add #[facet(flatten)] to the CLI field to expose nested argument fields\n- add #[facet(proxy = T)] to the CLI field or type definition, where T is a supported single-value CLI type: bool, string/char, integer, float, or a unit-variant enum",
             )
             .with_primary_label("this field has a struct-shaped Facet schema"));
         }

--- a/figue/src/schema/tests.rs
+++ b/figue/src/schema/tests.rs
@@ -534,19 +534,84 @@ struct NestedOptions {
 #[derive(Facet)]
 struct ArgsWithUnflattenedStruct {
     #[facet(args::named)]
-    options: NestedOptions, // ERROR: struct fields must use flatten
+    options: NestedOptions, // ERROR: struct fields must use flatten or proxy
+}
+
+#[derive(Facet)]
+#[facet(proxy = String)]
+struct ProxiedOptions(NestedOptions);
+
+impl TryFrom<String> for ProxiedOptions {
+    type Error = String;
+
+    fn try_from(_: String) -> Result<Self, Self::Error> {
+        Ok(Self(NestedOptions { verbose: false }))
+    }
+}
+
+impl TryFrom<&ProxiedOptions> for String {
+    type Error = String;
+
+    fn try_from(_: &ProxiedOptions) -> Result<Self, Self::Error> {
+        Ok(String::new())
+    }
+}
+
+#[derive(Facet)]
+struct ArgsWithFieldProxiedStruct {
+    #[facet(args::named, proxy = String)]
+    options: NestedOptions,
+}
+
+impl TryFrom<String> for NestedOptions {
+    type Error = String;
+
+    fn try_from(_: String) -> Result<Self, Self::Error> {
+        Ok(Self { verbose: false })
+    }
+}
+
+impl TryFrom<&NestedOptions> for String {
+    type Error = String;
+
+    fn try_from(_: &NestedOptions) -> Result<Self, Self::Error> {
+        Ok(String::new())
+    }
+}
+
+#[derive(Facet)]
+struct ArgsWithTypeProxiedStruct {
+    #[facet(args::named)]
+    options: ProxiedOptions,
 }
 
 #[test]
-fn test_struct_field_without_flatten_is_error() {
+fn test_struct_field_without_flatten_or_proxy_is_error() {
     let result = Schema::from_shape(ArgsWithUnflattenedStruct::SHAPE);
-    assert!(result.is_err(), "struct field without flatten should error");
+    assert!(result.is_err(), "struct field without flatten or proxy should error");
     let err = result.unwrap_err().to_string();
     assert!(
-        err.contains("flatten"),
+        err.contains("add #[facet(flatten)] to the CLI field"),
         "error should mention flatten: {}",
         err
     );
+    assert!(
+        err.contains("add #[facet(proxy = T)] to the CLI field or type definition"),
+        "error should mention proxy: {}",
+        err
+    );
+}
+
+#[test]
+fn test_struct_field_with_field_proxy_builds_schema() {
+    Schema::from_shape(ArgsWithFieldProxiedStruct::SHAPE)
+        .expect("field proxy should allow struct field as a CLI scalar");
+}
+
+#[test]
+fn test_struct_field_with_type_proxy_builds_schema() {
+    Schema::from_shape(ArgsWithTypeProxiedStruct::SHAPE)
+        .expect("type proxy should allow struct field as a CLI scalar");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

This updates `figue` arg schema construction to use Facet proxy shapes before deciding whether a CLI argument is a struct or a supported leaf value.

With this change, struct-shaped fields can be accepted as single CLI values when either of these applies:

- the CLI field has `#[facet(proxy = T)]`
- the field type has type-level `#[facet(proxy = T)]`

The proxy target `T` still has to be a supported single-value CLI type: bool, string/char, integer, float, or a unit-variant enum.

## Motivation

The previous schema logic used the raw field shape:

```rust
value_schema_from_shape(field.shape(), &field_ctx)
```

That meant a CLI field like this still failed schema construction even though it explicitly supplied a scalar proxy:

```rust
#[facet(figue::positional, proxy = String)]
pub id: AzureDevOpsWorkItemQueryId,
```

The raw type is struct-shaped, but the CLI representation is meant to be a single `String` token.

## Behavior

The schema builder now resolves `field.proxy` and type-level `shape.proxy` before classifying arg values.

If a struct-shaped arg still has no usable flattening or proxy, the diagnostic now says:

```text
struct fields in args are not valid unless one of these applies:
- add #[facet(flatten)] to the CLI field to expose nested argument fields
- add #[facet(proxy = T)] to the CLI field or type definition, where T is a supported single-value CLI type: bool, string/char, integer, float, or a unit-variant enum
```

## Testing

Added schema tests covering:

- unflattened/unproxied struct CLI field fails with the expected diagnostic
- struct CLI field with a field-level proxy builds successfully
- struct CLI field with a type-level proxy builds successfully

Ran:

```text
cargo test -p figue schema::tests::test_struct_field --lib
cargo check -p figue
```

## Related Issue

Closes #2470

## LLM Assistance Disclaimer

This PR draft was written with LLM assistance from OpenAI GPT-5 Codex.

