### PR TITLE
Fix type conversion in custom default metadata callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,6 +3000,7 @@ dependencies = [
  "camino",
  "facet",
  "facet-core",
+ "facet-default",
  "facet-error",
  "facet-format",
  "facet-json",

--- a/facet-default/tests/integration.rs
+++ b/facet-default/tests/integration.rs
@@ -159,6 +159,20 @@ fn test_builtin_default_syntax() {
     assert_eq!(config.number, 42, "number should be 42");
 }
 
+/// Repro for `#[facet(default = 0.0)]` on an `f32` field.
+#[test]
+fn test_f32_literal_default() {
+    #[derive(Facet, Debug, PartialEq)]
+    #[facet(derive(Default))]
+    pub struct Kweh {
+        #[facet(default = 0.0)]
+        chocobo: f32,
+    }
+
+    let kweh = Kweh::default();
+    assert_eq!(kweh.chocobo, 0.0);
+}
+
 /// Test builtin #[facet(default)] without value (uses Default::default())
 #[test]
 fn test_builtin_default_no_value() {

--- a/facet-macros-impl/src/process_struct.rs
+++ b/facet-macros-impl/src/process_struct.rs
@@ -1270,8 +1270,11 @@ pub(crate) fn gen_field_from_pfield(
                         fn __shape_of_val<'a, T: #facet_crate::Facet<'a>>(_: &T) -> &'static #facet_crate::Shape {
                             T::SHAPE
                         }
-                        // Create the source value
-                        let __src_value = #expr;
+                        // Convert the expression the same way the generated Default impl does.
+                        // This keeps Field.default callbacks type-correct for floating-point defaults.
+                        let __src_value: #field_type = (#expr)
+                            .try_into()
+                            .expect("facet-default: failed to convert default value to field type");
                         // Get shapes for source and destination types
                         let __src_shape = __shape_of_val(&__src_value);
                         let __dst_shape = <#field_type as #facet_crate::Facet>::SHAPE;

--- a/figue/Cargo.toml
+++ b/figue/Cargo.toml
@@ -40,6 +40,7 @@ supports-color.workspace = true
 
 [dev-dependencies]
 facet-format = { path = "../facet-format", features = ["tracing"] }
+facet-default = { path = "../facet-default" }
 facet-json = { path = "../facet-json", features = ["tracing"] }
 facet-reflect = { path = "../facet-reflect", features = ["tracing"] }
 facet = { path = "../facet", features = ["all-impls"] }

--- a/figue/src/config_value_parser.rs
+++ b/figue/src/config_value_parser.rs
@@ -2488,3 +2488,21 @@ mod fill_defaults_tests {
         assert_eq!(args.pulse_limit, None);
     }
 }
+/// Repro for `#[facet(default = 0.0)]` on an `f32` field through figue.
+#[test]
+fn test_from_config_value_f32_literal_default() {
+    use facet::Facet;
+    use facet_default as _;
+
+    #[derive(Debug, Facet, PartialEq)]
+    #[facet(derive(Default))]
+    struct Kweh {
+        #[facet(default = 0.0)]
+        chocobo: f32,
+    }
+
+    let value = ConfigValue::Object(Sourced::new(IndexMap::default()));
+    let kweh: Kweh = from_config_value(&value).expect("should deserialize default");
+
+    assert_eq!(kweh.chocobo, 0.0);
+}


### PR DESCRIPTION
When `#[facet(default = expr)]` is used on a field, facet generates two related paths:

1. The derived `Default` implementation, which already converts `expr` to the field type.
2. The reflection `Field.default` callback, which figue invokes when filling missing configuration values.

The second path retained the raw expression. Consequently, `#[facet(default = 0.0)]` on an `f32` field produced an `f64` source value and panicked in figue with:

```text
Field 'chocobo' expects f32, but default function returns f64
```

This change converts the custom expression to `#field_type` in the metadata callback using the same `TryInto` behavior as the generated `Default` implementation.

## Changes

- Convert custom field-default expressions before storing them in `Field.default` callbacks.
- Add a figue regression test covering an empty config object and an `f32` literal default.
- Add the `facet-default` dev dependency required by the exact derive reproduction.

## Verification

Before the fix, the exact figue reproduction failed with the panic above.

After the fix:

```text
config_value_parser::test_from_config_value_f32_literal_default ... ok
```

The complete relevant suites also pass:

- `facet-default` integration tests: 14 passed
- figue library tests: 441 passed, 3 ignored
- `teamy-mft`: `cargo check -p teamy-mft`
- Cloud Terrastodon: `cargo check --workspace`

The fix was merged into TeamDman's `mine/main` as `9d2fdd449`. The PR branch is `reproduce-f32-default-attr`.

Fixes #2472

LLM assistance disclosure: This draft was written with assistance from GPT 5.6-luna.
