### PR TITLE
vox-iroh: trace transport observability implementation

### DIFF
--- a/vox/rust/vox-iroh/src/lib.rs
+++ b/vox/rust/vox-iroh/src/lib.rs
@@ -112,6 +112,7 @@ impl IrohLinkSource {
     }
 }
 
+// r[impl transport.iroh.observability]
 impl LinkSource for IrohLinkSource {
     type Link = IrohLink;
 


### PR DESCRIPTION
## Outcome

Completes the bidirectional Dodeca mapping for Vox-Iroh observability. The implementation already emits redacted dial/open/accept/failure tracing and retains ordinary Vox observer events; this adds the missing implementation reference beside the outbound transport path.

## Gates

- `ddc coverage validate . --source vox --threshold 0`
- Vox coverage: 206/207 implemented, 205/207 verified, zero invalid/stale/test-impl references
- `cargo fmt --all -- --check`
- `git diff --check`
