### PR TITLE
facet-styx: deserialize explicit unit as Option none

### DIFF
--- a/facet-styx/src/parser.rs
+++ b/facet-styx/src/parser.rs
@@ -384,21 +384,11 @@ impl<'de> StyxParser<'de> {
                 self.current_span = Some(span);
                 self.mark_tag_has_payload();
 
-                // Check if this Unit represents an actual @ token in the source
-                // vs an implicit unit (key with no value).
-                let is_at_token = self.span_text(span) == "@";
-
-                if is_at_token && self.tag_has_payload_stack.is_empty() {
-                    // Standalone @ is a unit tag - emit VariantTag(None) + Scalar(Unit)
-                    trace!("convert_event: Unit (@) -> VariantTag(None) + Scalar(Unit)");
-                    self.peeked_events
-                        .push(self.event(ParseEventKind::Scalar(ScalarValue::Unit)));
-                    Ok(Some(self.event(ParseEventKind::VariantTag(None))))
-                } else {
-                    // Either inside a tag payload, or an implicit unit (no value)
-                    trace!("convert_event: Unit (implicit/payload) -> Scalar(Unit)");
-                    Ok(Some(self.event(ParseEventKind::Scalar(ScalarValue::Unit))))
-                }
+                // A bare `@` is Styx's unit value. Named tags produce
+                // `VariantTag`, but the nameless form must remain a scalar so
+                // `Option<T>` can consume it as `None`.
+                trace!("convert_event: Unit -> Scalar(Unit)");
+                Ok(Some(self.event(ParseEventKind::Scalar(ScalarValue::Unit))))
             }
 
             EventKind::TagStart { name } => {

--- a/facet-styx/src/snapshots/facet_styx__tag_events_test__01_bare_at.snap
+++ b/facet-styx/src/snapshots/facet_styx__tag_events_test__01_bare_at.snap
@@ -1,7 +1,6 @@
 ---
-source: crates/facet-styx/src/tag_events_test.rs
+source: facet-styx/src/tag_events_test.rs
 expression: "collect_events(\"x @\")"
 ---
 FieldKey(Some("x"))
-VariantTag(None)
 Scalar(Unit)

--- a/facet-styx/src/tag_events_test.rs
+++ b/facet-styx/src/tag_events_test.rs
@@ -72,7 +72,7 @@ fn format_event(event: &ParseEvent) -> String {
 
 #[test]
 fn test_01_bare_at() {
-    // @ is a unit tag (no name) with implicit unit payload
+    // @ is a unit scalar. Only named tags emit VariantTag.
     insta::assert_snapshot!(collect_events("x @"));
 }
 

--- a/facet-styx/src/tests.rs
+++ b/facet-styx/src/tests.rs
@@ -309,6 +309,14 @@ fn test_optional_absent() {
 }
 
 #[test]
+fn test_optional_explicit_none() {
+    let input = "required hello\noptional @";
+    let result: WithOptional = from_str(input).unwrap();
+    assert_eq!(result.required, "hello");
+    assert_eq!(result.optional, None);
+}
+
+#[test]
 fn test_bool_values() {
     #[derive(Facet, Debug, PartialEq)]
     struct Flags {


### PR DESCRIPTION
A bare `@` is Styx's unit value, but the parser emitted `VariantTag(None)` before `Scalar(Unit)`. That made serializer output such as `optional @` impossible to deserialize as `Option<T>`.

This keeps named tags as enum variants while representing bare `@` directly as `Scalar(Unit)`, which the shared facet-format option path already consumes as `None`.

Certificates:
- explicit `Option<T>` none parsing
- updated bare-unit event snapshot
- `cargo nextest run -p facet-styx` (219 passed)
- strict clippy and rustfmt