### PR TITLE
facet-tokio-postgres: decode optional bytea

### DIFF
--- a/facet-tokio-postgres/src/lib.rs
+++ b/facet-tokio-postgres/src/lib.rs
@@ -431,6 +431,8 @@ fn deserialize_option_column(
         try_option!(bool);
     } else if inner_shape == String::SHAPE {
         try_option!(String);
+    } else if inner_shape == <Vec<u8>>::SHAPE {
+        try_option!(Vec<u8>);
     }
 
     #[cfg(feature = "rust_decimal")]

--- a/facet-tokio-postgres/tests/integration.rs
+++ b/facet-tokio-postgres/tests/integration.rs
@@ -236,6 +236,45 @@ async fn test_bytea() {
 }
 
 #[tokio::test]
+async fn test_optional_bytea() {
+    #[derive(Debug, Facet, PartialEq)]
+    struct OptionalBinaryData {
+        id: i32,
+        data: Option<Vec<u8>>,
+    }
+
+    let handle = setup_postgres().await;
+    let client = &handle.client;
+
+    client
+        .execute(
+            "CREATE TABLE optional_binary_data (id INTEGER, data BYTEA)",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let bytes: &[u8] = &[0xDE, 0xAD, 0xBE, 0xEF];
+    client
+        .execute(
+            "INSERT INTO optional_binary_data VALUES (1, $1), (2, NULL)",
+            &[&bytes],
+        )
+        .await
+        .unwrap();
+
+    let rows = client
+        .query("SELECT * FROM optional_binary_data ORDER BY id", &[])
+        .await
+        .unwrap();
+    let present: OptionalBinaryData = from_row(&rows[0]).unwrap();
+    let absent: OptionalBinaryData = from_row(&rows[1]).unwrap();
+
+    assert_eq!(present.data, Some(vec![0xDE, 0xAD, 0xBE, 0xEF]));
+    assert_eq!(absent.data, None);
+}
+
+#[tokio::test]
 async fn test_field_alias() {
     #[derive(Debug, Facet, PartialEq)]
     struct AliasedUser {


### PR DESCRIPTION
## Summary

Teach `facet-tokio-postgres` to decode nullable PostgreSQL `BYTEA` columns as `Option<Vec<u8>>`.

This was exposed by a Dibs union query where data rows carry bytes and structural gap rows carry `NULL::bytea`. Dibs correctly infers `Option<Vec<u8>>`; the row decoder already supported `Vec<u8>` but omitted its optional form.

## Verification

- `cargo check -p facet-tokio-postgres --all-targets --features test-postgres`
- `cargo fmt --all -- --check`
- Added an integration oracle covering both present and absent `BYTEA` values. Its local nextest execution requires a Docker socket, which is unavailable on this host.
