### PR TITLE
vix typed primitives — 02: runtime::primitive core

### DIFF
--- a/docs/superpowers/plans/2026-07-15-vix-prim-02-core.md
+++ b/docs/superpowers/plans/2026-07-15-vix-prim-02-core.md
@@ -1,6 +1,6 @@
 # Vix Typed Primitives — Phase 02: Core Module Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Build `vix::runtime::primitive` — descriptor/identity, the object-safe `Primitive` trait with `EffectCtx`/tickets/completions, the taxon→vir type bridge, facet↔store value conversion, and the `PrimitiveSet::register_function::<Resp, Req>` typed adapter — fully unit-tested, with zero compiler/scheduler wiring (that is phases 03–05).
 
@@ -49,7 +49,7 @@
   - `pub enum RegistrationError { InvalidName { name: String }, ReservedName { name: String }, DuplicateName { name: String }, UnsupportedShape { path: String, kind: String }, Derive { message: String } }` (implement `Display` + `std::error::Error`)
   - `impl PrimitiveId { pub fn derive(name: &PrimitiveName, version: u32, protocol: u32, request: TaxonSchemaId, response: TaxonSchemaId) -> Self }` — `hash_framed(b"vix.primitive.v1", &[name.as_str().as_bytes(), &version.to_le_bytes(), &protocol.to_le_bytes(), &request.as_u64().to_le_bytes(), &response.as_u64().to_le_bytes()])`
 
-- [ ] **Step 1: Write failing tests** in `descriptor.rs` `#[cfg(test)]`:
+- [x] **Step 1: Write failing tests** in `descriptor.rs` `#[cfg(test)]`:
 
 ```rust
 #[test]
@@ -89,8 +89,8 @@ fn semantic_schema_id_matches_scheduler_format() {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p vix primitive` → compile error (module missing). Expected.
-- [ ] **Step 3: Implement.** Move `fn semantic_schema_id` bodies: cut the private fn from `scheduler.rs` (~2761) and `lowering.rs` (~655), add to `identity.rs`:
+- [x] **Step 2: Run to verify failure** — `cargo nextest run -p vix primitive` → compile error (module missing). Expected.
+- [x] **Step 3: Implement.** Move `fn semantic_schema_id` bodies: cut the private fn from `scheduler.rs` (~2761) and `lowering.rs` (~655), add to `identity.rs`:
 
 ```rust
 /// The runtime store schema for a vir type: blake3 of the type's canonical
@@ -110,8 +110,8 @@ pub use descriptor::*;
 ```
 
 Add `pub mod primitive;` to `runtime/mod.rs`.
-- [ ] **Step 4: Run** `cargo nextest run -p vix` (full crate — the hoist touches scheduler/lowering; everything must stay green). Expected: PASS.
-- [ ] **Step 5: Commit** — `git add -A && git commit --no-verify -m "vix: primitive descriptor identity + shared semantic_schema_id"`
+- [x] **Step 4: Run** `cargo nextest run -p vix` (full crate — the hoist touches scheduler/lowering; everything must stay green). Expected: PASS.
+- [x] **Step 5: Commit** — `git add -A && git commit --no-verify -m "vix: primitive descriptor identity + shared semantic_schema_id"`
 
 ---
 
@@ -133,7 +133,7 @@ Add `pub mod primitive;` to `runtime/mod.rs`.
   - Explicitly rejected kinds: `Kind::Array` (fixed-size, kind `"fixed-size array"`), `Kind::Tensor`, `Kind::Channel`, `Kind::Dynamic`, `Kind::External`.
 - Recursion through `SchemaRef::Concrete { id, args }` resolves `id` in `schemas`; non-empty `args` and `SchemaRef::Var` are rejected (kind `"generic"`), recursive cycles rejected (kind `"recursive"`; track a visiting `BTreeSet<taxon::SchemaId>`).
 
-- [ ] **Step 1: Write failing tests** (build small `taxon::Schema` batches by hand in the tests — see `phon/rust/taxon/src/lib.rs:64-176` for constructors; ids can be `SchemaId::from_raw(n)` since the bridge only resolves references, it never re-derives ids):
+- [x] **Step 1: Write failing tests** (build small `taxon::Schema` batches by hand in the tests — see `phon/rust/taxon/src/lib.rs:64-176` for constructors; ids can be `SchemaId::from_raw(n)` since the bridge only resolves references, it never re-derives ids):
 
 ```rust
 #[test]
@@ -175,10 +175,10 @@ fn rejects_every_unsupported_primitive() {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure** — `cargo nextest run -p vix bridge` → fails (fn missing).
-- [ ] **Step 3: Implement** `vir_type_for`: index `schemas` by id into a `BTreeMap`, recursive `fn convert(id, ctx: &mut Ctx { by_id, visiting: BTreeSet<TaxonSchemaId>, path: Vec<String> })`. Push field/variant/element names onto `path` as you descend; render `path.join(".")` on error. Names per the naming rule.
-- [ ] **Step 4: Run** `cargo nextest run -p vix bridge` → PASS.
-- [ ] **Step 5: Commit** — `git commit --no-verify -am "vix: taxon-to-vir bridge with lossless-subset validation"`
+- [x] **Step 2: Run to verify failure** — `cargo nextest run -p vix bridge` → fails (fn missing).
+- [x] **Step 3: Implement** `vir_type_for`: index `schemas` by id into a `BTreeMap`, recursive `fn convert(id, ctx: &mut Ctx { by_id, visiting: BTreeSet<TaxonSchemaId>, path: Vec<String> })`. Push field/variant/element names onto `path` as you descend; render `path.join(".")` on error. Names per the naming rule.
+- [x] **Step 4: Run** `cargo nextest run -p vix bridge` → PASS.
+- [x] **Step 5: Commit** — `git commit --no-verify -am "vix: taxon-to-vir bridge with lossless-subset validation"`
 
 ---
 
@@ -203,7 +203,7 @@ fn rejects_every_unsupported_primitive() {
   - `Type::Map`/`Type::Set`: encode entries, sort rows by the KEY's `ValueId` ordering to canonical order (mirror `realize_ordered` — read scheduler.rs `fn realize_ordered` first and copy its ordering rule exactly; if it orders by structural comparison rather than ValueId, do that), `node = FramedNode::OrderedMap { schema, rows } / OrderedSet { schema, elements }`; `frozen = FrozenValue::OrderedMap(pairs) / OrderedSet(items)`.
   - Facet-side walking: `let peek = facet::Peek::new(value);` then match on `ty` (the vir type drives the walk; facet shape was already validated by the bridge, so mismatches are `ShapeMismatch` bugs, not user errors).
 
-- [ ] **Step 1: Write failing tests**:
+- [x] **Step 1: Write failing tests**:
 
 ```rust
 #[derive(facet::Facet)]
@@ -262,7 +262,7 @@ fn interning_twice_dedupes() {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure**, **Step 3: Implement** per the framing rules (read `realize_ordered` before writing the map/set arm and mirror its ordering), **Step 4: Run** `cargo nextest run -p vix convert` → PASS, **Step 5: Commit** `--no-verify -am "vix: encode facet values into framed store values"`.
+- [x] **Step 2: Run to verify failure**, **Step 3: Implement** per the framing rules (read `realize_ordered` before writing the map/set arm and mirror its ordering), **Step 4: Run** `cargo nextest run -p vix convert` → PASS, **Step 5: Commit** `--no-verify -am "vix: encode facet values into framed store values"`.
 
 ---
 
@@ -277,7 +277,7 @@ fn interning_twice_dedupes() {
 - Produces: `pub(crate) fn decode_value<'f, T: facet::Facet<'f>>(frozen: &FrozenValue, ty: &crate::vir::Type) -> Result<T, ConvertError>`.
 - Rules are the encode rules inverted. `FrozenValue::Reference(_)` is a `ShapeMismatch` in v1 (decode input for a primitive request is always a fully-frozen tree; references appear only for store-resident strings — resolve those in phase 05 where a `&Store` is in hand; v1 decode takes the frozen tree only and the phase-05 wiring passes trees with references pre-resolved. Record this as a doc comment on `decode_value`).
 
-- [ ] **Step 1: Write failing round-trip tests**:
+- [x] **Step 1: Write failing round-trip tests**:
 
 ```rust
 #[test]
@@ -373,8 +373,8 @@ fn option_uses_the_vir_variant_tags() {
 }
 ```
 
-- [ ] **Steps 2–4: red → implement → green** (`cargo nextest run -p vix convert`).
-- [ ] **Step 5: Commit** `--no-verify -am "vix: decode frozen store values into facet values"`.
+- [x] **Steps 2–4: red → implement → green** (`cargo nextest run -p vix convert`).
+- [x] **Step 5: Commit** `--no-verify -am "vix: decode frozen store values into facet values"`.
 
 ---
 
@@ -447,9 +447,9 @@ pub trait Primitive {
 
 - Note the deliberate deviation-from-nothing: `EffectCtx::finish` consumes the ctx and produces `(Completion, Receipt, events)` — the scheduler (phase 05) is the only caller. Double-complete / no-complete is a protocol violation surfaced as a typed error, not a panic (`machine.error.structural-impossibility` still applies to impossible states, but a misbehaving registered primitive is EXPECTED fallibility).
 
-- [ ] **Step 1: failing tests** — ctx happy path (witness + complete + finish yields receipt with the witnessed reads and the demand key), no-complete → error, double-complete → error. Write them concretely against the API above.
-- [ ] **Steps 2–4: red → implement → green.**
-- [ ] **Step 5: Commit** `--no-verify -am "vix: primitive trait, EffectCtx, tickets, completions"`.
+- [x] **Step 1: failing tests** — ctx happy path (witness + complete + finish yields receipt with the witnessed reads and the demand key), no-complete → error, double-complete → error. Write them concretely against the API above.
+- [x] **Steps 2–4: red → implement → green.**
+- [x] **Step 5: Commit** `--no-verify -am "vix: primitive trait, EffectCtx, tickets, completions"`.
 
 ---
 
@@ -483,7 +483,7 @@ impl PrimitiveSet {
 
 - `register_function` internals: `of_shape(Req::SHAPE)` + `of_shape(Resp::SHAPE)` (map `DeriveError` → `RegistrationError::Derive`), `vir_type_for` both, build `RegisteredSchema`s (`store_schema = semantic_schema_id(&vix_type)`), `PrimitiveId::derive(...)` with `version: u32 = 1` for the sugar path (full-control `register` path takes author-supplied versions via their own descriptor), wrap `f` in `struct FunctionPrimitive<Req, Resp, F> { descriptor, f, _marker }` whose `begin` does: `decode_value::<Req>(request.frozen, &descriptor.request.vix_type)` → run `f` → on Ok `intern_rust_value(&resp, &descriptor.response, ctx.store_mut())` → `ctx.complete(Completion::Ok(interned))`; on Err `ctx.complete(Completion::Failed(failure))`; decode `ConvertError` → `Box<MachineError>` (protocol violation — the compiler type-checked the call, so a mismatched request tree is machine-plane, not language-plane); return `EffectTicket(0)` (ticket ids become real in phase 05; the adapter's inline completion makes the id inert here — document this).
 
-- [ ] **Step 1: failing end-to-end unit test**:
+- [x] **Step 1: failing end-to-end unit test**:
 
 ```rust
 #[derive(facet::Facet)]
@@ -548,20 +548,48 @@ pub(crate) fn frozen_for(&self, handle: Handle) -> Option<&FrozenValue> {
 
 Also define the test helper `fn test_demand_key() -> crate::runtime::identity::DemandKey` by constructing the type the way existing runtime unit tests do — grep `DemandKey` in `vix/src/runtime/` tests and copy that construction.
 
-- [ ] **Steps 2–4: red → implement → green** (`cargo nextest run -p vix primitive`).
-- [ ] **Step 5: Commit** `--no-verify -am "vix: PrimitiveSet and register_function typed adapter"`.
+- [x] **Steps 2–4: red → implement → green** (`cargo nextest run -p vix primitive`).
+- [x] **Step 5: Commit** `--no-verify -am "vix: PrimitiveSet and register_function typed adapter"`.
 
 ---
 
 ### Task 7: Phase gate
 
-- [ ] Full suite: `cargo nextest run -p vix` → all green (nothing outside the module may regress; the only shared-code diff is the Task 1 hoist).
-- [ ] `cargo clippy -p vix -- -D warnings` clean on the new module.
-- [ ] Re-read the six new files against the Global Constraints (no strings-as-errors, no per-primitive arms, no private caches, spec rule comments `r[machine.primitive.*]` present on the trait/ctx/descriptor items).
-- [ ] Commit any fixups, then stop — phase 03 planning happens against this landed state.
+- [x] Full suite: `cargo nextest run -p vix` → all green (nothing outside the module may regress; the only shared-code diff is the Task 1 hoist).
+- [x] `cargo clippy -p vix -- -D warnings` clean on the new module.
+- [x] Re-read the six new files against the Global Constraints (no strings-as-errors, no per-primitive arms, no private caches, spec rule comments `r[machine.primitive.*]` present on the trait/ctx/descriptor items).
+- [x] Commit any fixups, then stop — phase 03 planning happens against this landed state.
 
 ## Self-review notes (already applied)
 
 - Spec coverage: descriptor/trait/EffectCtx/adapter/bridge/conversion = spec §Components 1–4. Compiler/VIR/lowering/scheduler sections intentionally out of scope (phases 03–05); memo policy is carried as data only in this phase.
 - Type consistency: `RegisteredSchema.store_schema` = `semantic_schema_id(vix_type)` everywhere; `Completion::Ok(Interned)` matches register.rs adapter and Task 5 finish() signature.
 - Known unknowns called out to the executor: exact `facet::Partial` builder API (Task 4 step 1 requires reading facet-reflect/partial first), `realize_ordered` ordering rule (Task 3), vir `VariantPayload` record support (Task 2).
+## Implementation notes (phase 02 as landed)
+
+Deviations from the plan, all forced by the actual codebase — record for phase 03+:
+
+- **facet `reflect` feature**: `facet::Peek`/`Partial` are behind the non-default
+  `reflect` feature. Enabled it on vix's `facet` dep (`vix/Cargo.toml`). The plan
+  assumed they were always available.
+- **Arrays of scalar elements frame as `SeqInline`, not `SeqChildren`**. The
+  scheduler's `realize_array` splits on `type_contains_handle`: scalar (`Bool`/
+  `Int`) elements pack into `FramedNode::SeqInline` (8-byte words); handle-bearing
+  elements use `SeqChildren`. `convert.rs` mirrors this for the primitive subset.
+  Arrays of pure-scalar *composites* (tuple/record of ints) would frame inline in
+  the scheduler too but are out of the phase-02 subset — noted in `encode_array`.
+- **Trait layer returns a local `EffectProtocolError`, not `Box<MachineError>`**.
+  The constraints forbid editing `error.rs`, and there's no existing `RuntimeFault`
+  variant for effect-protocol violations. Per the plan's own Task 5 note ("a
+  placeholder EffectProtocol error kind defined locally"), `begin`/`finish`/the
+  adapter all return `EffectProtocolError`. Phase 05 lifts this into a real
+  `RuntimeFault` variant on the machine-error plane.
+- **Trait-layer types are `pub(crate)`** (`Primitive`, `RequestRef`, `EffectCtx`,
+  `Completion`): they reference the `pub(crate)` `FrozenValue`/`Store`/`Interned`,
+  so making them `pub` would be a private-interface leak. `PrimitiveSet`,
+  `register_function`, descriptors, and the error/id/policy types stay `pub`.
+- **`#![allow(dead_code)]`** on `convert.rs`/`traits.rs`/`register.rs` (+ item-level
+  on `store::frozen_for`): the module is landed ahead of its phase-03 (compiler
+  manifest) and phase-05 (scheduler) consumers; items are exercised by unit tests.
+- **Commits**: Tasks 3 and 4 (encode/decode) landed as one commit (single file,
+  `convert.rs`); every other task is its own commit.

--- a/vix/Cargo.toml
+++ b/vix/Cargo.toml
@@ -14,7 +14,7 @@ description = "The Vix demand-driven language and runtime."
 
 [dependencies]
 snark = { path = "../snark", features = ["json-import"] }
-facet = { path = "../facet" }
+facet = { path = "../facet", features = ["reflect"] }
 facet-format = { path = "../facet-format" }
 facet-json = { path = "../facet-json" }
 facet-toml = { path = "../facet-toml" }

--- a/vix/src/lowering.rs
+++ b/vix/src/lowering.rs
@@ -26,7 +26,7 @@ use weavy::{
 use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticPayload, Diagnostics};
 use crate::runtime::{
     DemandKey, DemandPreimage, FrameRegion, FrameSlot, FrameWords, MachineAttribution,
-    MachineError, MachineOperation, RecipeId, SchemaId,
+    MachineError, MachineOperation, RecipeId, SchemaId, semantic_schema_id,
 };
 use crate::support::Span;
 use crate::vir::{
@@ -650,10 +650,6 @@ fn publication_capability_registered(ty: &Type) -> bool {
         }
         Type::Function { .. } | Type::StreamCheck | Type::Stream { .. } | Type::Order(_) => false,
     }
-}
-
-fn semantic_schema_id(ty: &Type) -> SchemaId {
-    SchemaId::named(&format!("vix.semantic.v1:{}", ty.name()))
 }
 
 fn bind_value_inputs(

--- a/vix/src/runtime/identity.rs
+++ b/vix/src/runtime/identity.rs
@@ -521,3 +521,10 @@ impl FramedNode {
         }
     }
 }
+
+/// The runtime store schema for a vir type: blake3 of the type's canonical
+/// name under the semantic domain. One definition — scheduler, lowering, and
+/// primitive registration must agree byte-for-byte.
+pub(crate) fn semantic_schema_id(ty: &crate::vir::Type) -> SchemaId {
+    SchemaId::named(&format!("vix.semantic.v1:{}", ty.name()))
+}

--- a/vix/src/runtime/mod.rs
+++ b/vix/src/runtime/mod.rs
@@ -5,6 +5,7 @@ mod error;
 mod identity;
 mod model;
 mod observe;
+pub mod primitive;
 mod scheduler;
 mod store;
 

--- a/vix/src/runtime/primitive/bridge.rs
+++ b/vix/src/runtime/primitive/bridge.rs
@@ -1,0 +1,393 @@
+//! taxon → vir type bridge (r[machine.primitive.registered]).
+//!
+//! Registration accepts only the lossless subset of the taxon type vocabulary
+//! that vix values can represent structurally. Everything outside that subset is
+//! rejected with a dotted field path so the author can see exactly which field or
+//! element is unsupported — the bridge never silently coerces.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use taxon::{Kind, Primitive, Schema, SchemaId, SchemaRef, VariantPayload as TaxonVariantPayload};
+
+use crate::vir::{EnumType, EnumVariant, RecordField, RecordType, Type, VariantPayload};
+
+use super::descriptor::RegistrationError;
+
+/// Convert a taxon schema batch rooted at `root` into a vir [`Type`], or reject
+/// it if it uses a shape outside the lossless subset.
+///
+/// Identity-bearing naming rule: a taxon Struct/Enum named `Foo` with id `id`
+/// becomes a vir `RecordType`/`EnumType` named `Foo@{id:016x}`. `@` cannot appear
+/// in a source-authored type name, so a registered type can never collide with a
+/// user type.
+pub fn vir_type_for(root: SchemaId, schemas: &[Schema]) -> Result<Type, RegistrationError> {
+    let by_id: BTreeMap<SchemaId, &Schema> = schemas.iter().map(|s| (s.id, s)).collect();
+    let primitives: BTreeMap<SchemaId, Primitive> = Primitive::ALL
+        .into_iter()
+        .map(|p| (taxon::primitive_id(p), p))
+        .collect();
+    let mut ctx = Ctx {
+        by_id,
+        primitives,
+        visiting: BTreeSet::new(),
+        path: Vec::new(),
+    };
+    ctx.convert_id(root)
+}
+
+struct Ctx<'a> {
+    by_id: BTreeMap<SchemaId, &'a Schema>,
+    primitives: BTreeMap<SchemaId, Primitive>,
+    visiting: BTreeSet<SchemaId>,
+    path: Vec<String>,
+}
+
+impl Ctx<'_> {
+    fn unsupported(&self, kind: impl Into<String>) -> RegistrationError {
+        RegistrationError::UnsupportedShape {
+            path: self.path.join("."),
+            kind: kind.into(),
+        }
+    }
+
+    fn convert_ref(&mut self, sref: &SchemaRef) -> Result<Type, RegistrationError> {
+        match sref {
+            SchemaRef::Concrete { id, args } => {
+                if !args.is_empty() {
+                    return Err(self.unsupported("generic"));
+                }
+                self.convert_id(*id)
+            }
+            SchemaRef::Var { .. } => Err(self.unsupported("generic")),
+        }
+    }
+
+    fn convert_id(&mut self, id: SchemaId) -> Result<Type, RegistrationError> {
+        if let Some(primitive) = self.primitives.get(&id).copied() {
+            return self.primitive_type(primitive);
+        }
+        let Some(schema) = self.by_id.get(&id).copied() else {
+            return Err(self.unsupported("unresolved"));
+        };
+        if self.visiting.contains(&id) {
+            return Err(self.unsupported("recursive"));
+        }
+        self.visiting.insert(id);
+        let kind = schema.kind.clone();
+        let ty = self.convert_kind(id, &kind)?;
+        self.visiting.remove(&id);
+        Ok(ty)
+    }
+
+    fn primitive_type(&self, primitive: Primitive) -> Result<Type, RegistrationError> {
+        match primitive {
+            Primitive::Bool => Ok(Type::Bool),
+            Primitive::I64 => Ok(Type::Int),
+            Primitive::String => Ok(Type::String),
+            Primitive::Unit => Ok(Type::Tuple(Vec::new())),
+            other => Err(self.unsupported(format!("{other:?}"))),
+        }
+    }
+
+    fn convert_kind(&mut self, id: SchemaId, kind: &Kind) -> Result<Type, RegistrationError> {
+        match kind {
+            Kind::Primitive(primitive) => self.primitive_type(*primitive),
+            Kind::Struct { name, fields } => {
+                let pushed = self.path.is_empty();
+                if pushed {
+                    self.path.push(name.clone());
+                }
+                let mut record_fields = Vec::with_capacity(fields.len());
+                for field in fields {
+                    self.path.push(field.name.clone());
+                    if !field.required {
+                        return Err(self.unsupported("non-required field"));
+                    }
+                    let ty = self.convert_ref(&field.schema)?;
+                    self.path.pop();
+                    record_fields.push(RecordField {
+                        name: field.name.clone(),
+                        ty,
+                    });
+                }
+                if pushed {
+                    self.path.pop();
+                }
+                Ok(Type::Record(RecordType {
+                    name: registered_name(name, id),
+                    fields: record_fields,
+                }))
+            }
+            Kind::Enum { name, variants } => {
+                let pushed = self.path.is_empty();
+                if pushed {
+                    self.path.push(name.clone());
+                }
+                let mut vir_variants = Vec::with_capacity(variants.len());
+                for (index, variant) in variants.iter().enumerate() {
+                    self.path.push(variant.name.clone());
+                    if variant.index != index as u32 {
+                        return Err(self.unsupported("sparse variant indices"));
+                    }
+                    let payload = self.convert_payload(&variant.payload)?;
+                    self.path.pop();
+                    vir_variants.push(EnumVariant {
+                        name: variant.name.clone(),
+                        payload,
+                    });
+                }
+                if pushed {
+                    self.path.pop();
+                }
+                Ok(Type::Enum(EnumType {
+                    name: registered_name(name, id),
+                    variants: vir_variants,
+                }))
+            }
+            Kind::Tuple { elements } => Ok(Type::Tuple(self.convert_elements(elements)?)),
+            Kind::List { element } => Ok(Type::array(self.convert_ref(element)?)),
+            Kind::Set { element } => Ok(Type::set(self.convert_ref(element)?)),
+            Kind::Map { key, value } => {
+                self.path.push("<key>".to_owned());
+                let key_ty = self.convert_ref(key)?;
+                self.path.pop();
+                self.path.push("<value>".to_owned());
+                let value_ty = self.convert_ref(value)?;
+                self.path.pop();
+                Ok(Type::map(key_ty, value_ty))
+            }
+            Kind::Option { element } => Ok(Type::option(self.convert_ref(element)?)),
+            Kind::Array { .. } => Err(self.unsupported("fixed-size array")),
+            Kind::Tensor { .. } => Err(self.unsupported("tensor")),
+            Kind::Channel { .. } => Err(self.unsupported("channel")),
+            Kind::Dynamic => Err(self.unsupported("dynamic")),
+            Kind::External { .. } => Err(self.unsupported("external")),
+        }
+    }
+
+    fn convert_payload(
+        &mut self,
+        payload: &TaxonVariantPayload,
+    ) -> Result<VariantPayload, RegistrationError> {
+        match payload {
+            TaxonVariantPayload::Unit => Ok(VariantPayload::Unit),
+            TaxonVariantPayload::Newtype(element) => {
+                Ok(VariantPayload::Tuple(vec![self.convert_ref(element)?]))
+            }
+            TaxonVariantPayload::Tuple(elements) => {
+                Ok(VariantPayload::Tuple(self.convert_elements(elements)?))
+            }
+            TaxonVariantPayload::Struct(fields) => {
+                let mut record_fields = Vec::with_capacity(fields.len());
+                for field in fields {
+                    self.path.push(field.name.clone());
+                    if !field.required {
+                        return Err(self.unsupported("non-required field"));
+                    }
+                    let ty = self.convert_ref(&field.schema)?;
+                    self.path.pop();
+                    record_fields.push(RecordField {
+                        name: field.name.clone(),
+                        ty,
+                    });
+                }
+                Ok(VariantPayload::Record(record_fields))
+            }
+        }
+    }
+
+    fn convert_elements(&mut self, elements: &[SchemaRef]) -> Result<Vec<Type>, RegistrationError> {
+        let mut out = Vec::with_capacity(elements.len());
+        for (index, element) in elements.iter().enumerate() {
+            self.path.push(index.to_string());
+            out.push(self.convert_ref(element)?);
+            self.path.pop();
+        }
+        Ok(out)
+    }
+}
+
+fn registered_name(name: &str, id: SchemaId) -> String {
+    format!("{name}@{:016x}", id.as_u64())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use taxon::{Field, Primitive as P, SchemaId, Variant};
+
+    fn concrete(p: P) -> SchemaRef {
+        SchemaRef::concrete(taxon::primitive_id(p))
+    }
+
+    fn schema(id: u64, kind: Kind) -> Schema {
+        Schema {
+            id: SchemaId::from_raw(id),
+            type_params: Vec::new(),
+            kind,
+        }
+    }
+
+    fn field(name: &str, schema: SchemaRef) -> Field {
+        Field {
+            name: name.to_owned(),
+            schema,
+            required: true,
+        }
+    }
+
+    fn struct_fixture() -> (SchemaId, Vec<Schema>) {
+        let list = schema(101, Kind::List { element: concrete(P::String) });
+        let option = schema(102, Kind::Option { element: concrete(P::String) });
+        let root = schema(
+            100,
+            Kind::Struct {
+                name: "ProbeRequest".to_owned(),
+                fields: vec![
+                    field("text", concrete(P::String)),
+                    field("deep", concrete(P::Bool)),
+                    field("count", concrete(P::I64)),
+                    field("tags", SchemaRef::concrete(SchemaId::from_raw(101))),
+                    field("extra", SchemaRef::concrete(SchemaId::from_raw(102))),
+                ],
+            },
+        );
+        (SchemaId::from_raw(100), vec![root, list, option])
+    }
+
+    fn f64_fixture() -> (SchemaId, Vec<Schema>) {
+        let root = schema(
+            200,
+            Kind::Struct {
+                name: "Bad".to_owned(),
+                fields: vec![field("weight", concrete(P::F64))],
+            },
+        );
+        (SchemaId::from_raw(200), vec![root])
+    }
+
+    fn primitive_field_fixture(p: P) -> (SchemaId, Vec<Schema>) {
+        let root = schema(
+            300,
+            Kind::Struct {
+                name: "Holder".to_owned(),
+                fields: vec![field("value", concrete(p))],
+            },
+        );
+        (SchemaId::from_raw(300), vec![root])
+    }
+
+    #[test]
+    fn maps_the_supported_subset() {
+        let (root, schemas) = struct_fixture();
+        let ty = vir_type_for(root, &schemas).unwrap();
+        let Type::Record(record) = ty else {
+            panic!("expected record")
+        };
+        assert!(record.name.starts_with("ProbeRequest@"));
+        assert_eq!(record.fields.len(), 5);
+        assert_eq!(record.fields[0].ty, Type::String);
+        assert_eq!(record.fields[1].ty, Type::Bool);
+        assert_eq!(record.fields[2].ty, Type::Int);
+        assert_eq!(record.fields[3].ty, Type::array(Type::String));
+        assert_eq!(record.fields[4].ty, Type::option(Type::String));
+    }
+
+    #[test]
+    fn rejects_with_field_path() {
+        let (root, schemas) = f64_fixture();
+        let err = vir_type_for(root, &schemas).unwrap_err();
+        let RegistrationError::UnsupportedShape { path, kind } = err else {
+            panic!()
+        };
+        assert_eq!(path, "Bad.weight");
+        assert_eq!(kind, "F64");
+    }
+
+    #[test]
+    fn rejects_every_unsupported_primitive() {
+        for p in [
+            P::U8,
+            P::U16,
+            P::U32,
+            P::U64,
+            P::U128,
+            P::I8,
+            P::I16,
+            P::I32,
+            P::I128,
+            P::F32,
+            P::F64,
+            P::Char,
+            P::Bytes,
+            P::DateTime,
+            P::Uuid,
+            P::QName,
+            P::Never,
+        ] {
+            let (root, schemas) = primitive_field_fixture(p);
+            assert!(
+                matches!(
+                    vir_type_for(root, &schemas),
+                    Err(RegistrationError::UnsupportedShape { .. })
+                ),
+                "{p:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_sparse_variant_indices() {
+        let root = schema(
+            400,
+            Kind::Enum {
+                name: "Sparse".to_owned(),
+                variants: vec![Variant {
+                    name: "Late".to_owned(),
+                    index: 3,
+                    payload: TaxonVariantPayload::Unit,
+                }],
+            },
+        );
+        let err = vir_type_for(SchemaId::from_raw(400), &[root]).unwrap_err();
+        assert!(matches!(
+            err,
+            RegistrationError::UnsupportedShape { kind, .. } if kind == "sparse variant indices"
+        ));
+    }
+
+    #[test]
+    fn maps_enum_payloads() {
+        let root = schema(
+            500,
+            Kind::Enum {
+                name: "Verdict".to_owned(),
+                variants: vec![
+                    Variant {
+                        name: "Pass".to_owned(),
+                        index: 0,
+                        payload: TaxonVariantPayload::Unit,
+                    },
+                    Variant {
+                        name: "Fail".to_owned(),
+                        index: 1,
+                        payload: TaxonVariantPayload::Struct(vec![field("reason", concrete(P::String))]),
+                    },
+                ],
+            },
+        );
+        let ty = vir_type_for(SchemaId::from_raw(500), &[root]).unwrap();
+        let Type::Enum(enumeration) = ty else {
+            panic!("expected enum")
+        };
+        assert!(enumeration.name.starts_with("Verdict@"));
+        assert_eq!(enumeration.variants[0].payload, VariantPayload::Unit);
+        assert_eq!(
+            enumeration.variants[1].payload,
+            VariantPayload::Record(vec![RecordField {
+                name: "reason".to_owned(),
+                ty: Type::String,
+            }])
+        );
+    }
+}

--- a/vix/src/runtime/primitive/convert.rs
+++ b/vix/src/runtime/primitive/convert.rs
@@ -1,0 +1,804 @@
+//! Rust value ↔ interned store value conversion.
+//!
+//! The whole point of this module is *parity*: a Rust value encoded here frames
+//! byte-for-byte the way the scheduler's `realize_structural_node` frames the
+//! same value, so ValueIds computed here agree with values vix constructs
+//! itself. Every framing rule mirrors `scheduler.rs::realize_structural_*`.
+//!
+//! Phase 02 lands conversion ahead of its consumers (the primitive adapter and,
+//! in phase 05, the scheduler). The functions are exercised by unit tests here;
+//! `dead_code` is expected until that wiring exists.
+#![allow(dead_code)]
+
+use std::cmp::Ordering;
+
+use crate::runtime::identity::{FramedField, FramedNode, FramedValue, semantic_schema_id};
+use crate::runtime::store::{FrozenValue, Interned, Store};
+use crate::vir::{OPTION_NONE_VARIANT, OPTION_SOME_VARIANT, Type, VariantPayload};
+
+use super::descriptor::RegisteredSchema;
+
+/// A structurally-encoded value: the framed node (its identity), the frozen
+/// replay tree, and the canonical resident bytes (empty for aggregates).
+pub(crate) struct Encoded {
+    pub node: FramedNode,
+    pub frozen: FrozenValue,
+    pub resident: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ConvertError {
+    ShapeMismatch {
+        path: String,
+        expected: String,
+        found: String,
+    },
+}
+
+impl std::fmt::Display for ConvertError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ShapeMismatch {
+                path,
+                expected,
+                found,
+            } => write!(
+                f,
+                "value shape mismatch at {path:?}: expected {expected}, found {found}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ConvertError {}
+
+fn mismatch(ty: &Type, found: &str) -> ConvertError {
+    ConvertError::ShapeMismatch {
+        path: String::new(),
+        expected: ty.name(),
+        found: found.to_owned(),
+    }
+}
+
+/// A scalar leaf frames inline (r[machine.value.scalar-inline]): the scheduler
+/// inlines `Bool`/`Int` field payloads as `FramedValue::Bytes` rather than as a
+/// child reference.
+fn is_scalar(ty: &Type) -> bool {
+    matches!(ty, Type::Bool | Type::Int)
+}
+
+/// Encode a facet value into a framed store value, driven by the vir type. The
+/// bridge already validated the facet shape, so any divergence here is a
+/// structural bug surfaced as [`ConvertError::ShapeMismatch`], not a user error.
+pub(crate) fn encode_value(
+    peek: facet::Peek<'_, '_>,
+    ty: &Type,
+) -> Result<Encoded, ConvertError> {
+    match ty {
+        Type::Bool => {
+            let value = peek.get::<bool>().map_err(|_| mismatch(ty, "non-bool"))?;
+            let word = i64::from(*value).to_le_bytes().to_vec();
+            Ok(Encoded {
+                node: FramedNode::leaf(semantic_schema_id(ty), word.clone()),
+                frozen: FrozenValue::Inline(word.clone()),
+                resident: word,
+            })
+        }
+        Type::Int => {
+            let value = peek.get::<i64>().map_err(|_| mismatch(ty, "non-i64"))?;
+            let word = value.to_le_bytes().to_vec();
+            Ok(Encoded {
+                node: FramedNode::leaf(semantic_schema_id(ty), word.clone()),
+                frozen: FrozenValue::Inline(word.clone()),
+                resident: word,
+            })
+        }
+        Type::String => {
+            let text = peek.as_str().ok_or_else(|| mismatch(ty, "non-string"))?;
+            let bytes = text.as_bytes().to_vec();
+            Ok(Encoded {
+                node: FramedNode::leaf(semantic_schema_id(ty), bytes.clone()),
+                frozen: FrozenValue::Opaque(bytes.clone()),
+                resident: bytes,
+            })
+        }
+        Type::Tuple(elements) => {
+            let tuple = peek.into_tuple().map_err(|_| mismatch(ty, "non-tuple"))?;
+            let mut items = Vec::with_capacity(elements.len());
+            for (index, element_ty) in elements.iter().enumerate() {
+                let field = tuple.field(index).ok_or_else(|| mismatch(ty, "short tuple"))?;
+                items.push((field, element_ty));
+            }
+            frame_product(ty, items)
+        }
+        Type::Record(record) => {
+            let structure = peek.into_struct().map_err(|_| mismatch(ty, "non-struct"))?;
+            let mut items = Vec::with_capacity(record.fields.len());
+            for (index, field) in record.fields.iter().enumerate() {
+                let peek = structure
+                    .field(index)
+                    .map_err(|_| mismatch(ty, "missing field"))?;
+                items.push((peek, &field.ty));
+            }
+            frame_product(ty, items)
+        }
+        Type::Enum(enumeration) => {
+            if let Some(inner) = ty.option_inner() {
+                encode_option(peek, ty, inner)
+            } else {
+                let peek_enum = peek.into_enum().map_err(|_| mismatch(ty, "non-enum"))?;
+                let tag = peek_enum
+                    .variant_index()
+                    .map_err(|_| mismatch(ty, "no active variant"))?;
+                let variant = enumeration
+                    .variants
+                    .get(tag)
+                    .ok_or_else(|| mismatch(ty, "variant index out of range"))?;
+                let field_types = payload_field_types(&variant.payload);
+                let mut items = Vec::with_capacity(field_types.len());
+                for (index, field_ty) in field_types.into_iter().enumerate() {
+                    let field = peek_enum
+                        .field(index)
+                        .map_err(|_| mismatch(ty, "variant field"))?
+                        .ok_or_else(|| mismatch(ty, "variant field"))?;
+                    items.push((field, field_ty));
+                }
+                frame_variant(ty, tag as u64, items)
+            }
+        }
+        Type::Array(element) => encode_array(peek, ty, element),
+        Type::Map { key, value } => encode_map(peek, ty, key, value),
+        Type::Set(element) => encode_set(peek, ty, element),
+        _ => Err(mismatch(ty, "unsupported type")),
+    }
+}
+
+fn payload_field_types(payload: &VariantPayload) -> Vec<&Type> {
+    match payload {
+        VariantPayload::Unit => Vec::new(),
+        VariantPayload::Tuple(elements) => elements.iter().collect(),
+        VariantPayload::Record(fields) => fields.iter().map(|field| &field.ty).collect(),
+    }
+}
+
+/// Frame the shared field structure of a record/tuple (product) or an enum
+/// variant. Scalar fields inline as bytes; every other field contributes its
+/// child identity, exactly as `realize_structural_fields` does.
+fn frame_fields(
+    items: Vec<(facet::Peek<'_, '_>, &Type)>,
+) -> Result<(Vec<FramedField>, Vec<FrozenValue>), ConvertError> {
+    let mut fields = Vec::with_capacity(items.len());
+    let mut frozen = Vec::with_capacity(items.len());
+    for (peek, field_ty) in items {
+        let child = encode_value(peek, field_ty)?;
+        let value = if is_scalar(field_ty) {
+            FramedValue::Bytes(child.resident)
+        } else {
+            FramedValue::Optional(Some(child.node.identity()))
+        };
+        fields.push(FramedField {
+            schema: semantic_schema_id(field_ty),
+            value,
+        });
+        frozen.push(child.frozen);
+    }
+    Ok((fields, frozen))
+}
+
+fn frame_product(
+    ty: &Type,
+    items: Vec<(facet::Peek<'_, '_>, &Type)>,
+) -> Result<Encoded, ConvertError> {
+    let (fields, frozen) = frame_fields(items)?;
+    Ok(Encoded {
+        node: FramedNode::Variant {
+            schema: semantic_schema_id(ty),
+            tag: 0,
+            fields,
+        },
+        frozen: FrozenValue::Product(frozen),
+        resident: Vec::new(),
+    })
+}
+
+fn frame_variant(
+    ty: &Type,
+    tag: u64,
+    items: Vec<(facet::Peek<'_, '_>, &Type)>,
+) -> Result<Encoded, ConvertError> {
+    let (fields, frozen) = frame_fields(items)?;
+    Ok(Encoded {
+        node: FramedNode::Variant {
+            schema: semantic_schema_id(ty),
+            tag,
+            fields,
+        },
+        frozen: FrozenValue::Variant {
+            tag: tag as u32,
+            fields: frozen,
+        },
+        resident: Vec::new(),
+    })
+}
+
+fn encode_option(
+    peek: facet::Peek<'_, '_>,
+    ty: &Type,
+    inner: &Type,
+) -> Result<Encoded, ConvertError> {
+    let option = peek.into_option().map_err(|_| mismatch(ty, "non-option"))?;
+    if let Some(value) = option.value() {
+        frame_variant(ty, u64::from(OPTION_SOME_VARIANT), vec![(value, inner)])
+    } else {
+        frame_variant(ty, u64::from(OPTION_NONE_VARIANT), Vec::new())
+    }
+}
+
+fn encode_array(
+    peek: facet::Peek<'_, '_>,
+    ty: &Type,
+    element: &Type,
+) -> Result<Encoded, ConvertError> {
+    let list = peek.into_list().map_err(|_| mismatch(ty, "non-list"))?;
+    let mut children = Vec::with_capacity(list.len());
+    for element_peek in list.iter() {
+        children.push(encode_value(element_peek, element)?);
+    }
+    let element_schema = semantic_schema_id(element);
+    let schema = semantic_schema_id(ty);
+    let frozen = FrozenValue::DenseArray(children.iter().map(|c| c.frozen.clone()).collect());
+    // A scalar-element array frames inline (packed 8-byte words); anything whose
+    // element carries a handle frames by child identity. This mirrors
+    // `realize_array`'s `type_contains_handle` split for the cases a primitive
+    // request/response can hold. (Arrays of pure-scalar *composites* would frame
+    // inline in the scheduler too; those are out of the phase-02 subset.)
+    let node = if is_scalar(element) {
+        let mut canonical_bytes = Vec::with_capacity(children.len() * 8);
+        for child in &children {
+            canonical_bytes.extend_from_slice(&child.resident);
+        }
+        FramedNode::SeqInline {
+            schema,
+            element_schema,
+            element_width: 8,
+            canonical_bytes,
+        }
+    } else {
+        FramedNode::SeqChildren {
+            schema,
+            element_schema,
+            children: children.iter().map(|c| c.node.identity()).collect(),
+        }
+    };
+    Ok(Encoded {
+        node,
+        frozen,
+        resident: Vec::new(),
+    })
+}
+
+fn encode_map(
+    peek: facet::Peek<'_, '_>,
+    ty: &Type,
+    key_ty: &Type,
+    value_ty: &Type,
+) -> Result<Encoded, ConvertError> {
+    let map = peek.into_map().map_err(|_| mismatch(ty, "non-map"))?;
+    let mut rows = Vec::new();
+    for (key, value) in map.iter() {
+        rows.push((encode_value(key, key_ty)?, encode_value(value, value_ty)?));
+    }
+    rows.sort_by(|(ka, _), (kb, _)| structural_cmp(&ka.frozen, &kb.frozen));
+    let schema = semantic_schema_id(ty);
+    Ok(Encoded {
+        node: FramedNode::OrderedMap {
+            schema,
+            rows: rows
+                .iter()
+                .map(|(k, v)| (k.node.identity(), v.node.identity()))
+                .collect(),
+        },
+        frozen: FrozenValue::OrderedMap(
+            rows.iter()
+                .map(|(k, v)| (k.frozen.clone(), v.frozen.clone()))
+                .collect(),
+        ),
+        resident: Vec::new(),
+    })
+}
+
+fn encode_set(
+    peek: facet::Peek<'_, '_>,
+    ty: &Type,
+    element: &Type,
+) -> Result<Encoded, ConvertError> {
+    let set = peek.into_set().map_err(|_| mismatch(ty, "non-set"))?;
+    let mut elements = Vec::new();
+    for element_peek in set.iter() {
+        elements.push(encode_value(element_peek, element)?);
+    }
+    elements.sort_by(|a, b| structural_cmp(&a.frozen, &b.frozen));
+    let schema = semantic_schema_id(ty);
+    Ok(Encoded {
+        node: FramedNode::OrderedSet {
+            schema,
+            elements: elements.iter().map(|e| e.node.identity()).collect(),
+        },
+        frozen: FrozenValue::OrderedSet(elements.iter().map(|e| e.frozen.clone()).collect()),
+        resident: Vec::new(),
+    })
+}
+
+/// Canonical key/element order for maps and sets, mirroring the ordered
+/// machine's `lang.value.ordering`: `Int`/`Bool` compare numerically, strings
+/// (opaque bytes) lexicographically, and aggregates compare component-wise.
+/// Identity hashing does not re-sort, so encode MUST present rows in this order
+/// for ValueIds to agree with a vix-constructed map/set.
+fn structural_cmp(a: &FrozenValue, b: &FrozenValue) -> Ordering {
+    use FrozenValue::{DenseArray, Inline, OrderedMap, OrderedSet, Product, Variant};
+    match (a, b) {
+        (Inline(x), Inline(y)) => read_word(x).cmp(&read_word(y)),
+        (FrozenValue::Opaque(x), FrozenValue::Opaque(y)) => x.cmp(y),
+        (Product(x), Product(y)) => cmp_frozen_slice(x, y),
+        (
+            Variant {
+                tag: ta,
+                fields: fa,
+            },
+            Variant {
+                tag: tb,
+                fields: fb,
+            },
+        ) => ta.cmp(tb).then_with(|| cmp_frozen_slice(fa, fb)),
+        (DenseArray(x), DenseArray(y)) => cmp_frozen_slice(x, y),
+        (OrderedSet(x), OrderedSet(y)) => cmp_frozen_slice(x, y),
+        (OrderedMap(x), OrderedMap(y)) => {
+            let mut xi = x.iter();
+            let mut yi = y.iter();
+            loop {
+                match (xi.next(), yi.next()) {
+                    (Some((xk, xv)), Some((yk, yv))) => {
+                        let ordering = structural_cmp(xk, yk).then_with(|| structural_cmp(xv, yv));
+                        if ordering != Ordering::Equal {
+                            return ordering;
+                        }
+                    }
+                    (Some(_), None) => return Ordering::Greater,
+                    (None, Some(_)) => return Ordering::Less,
+                    (None, None) => return Ordering::Equal,
+                }
+            }
+        }
+        _ => Ordering::Equal,
+    }
+}
+
+fn cmp_frozen_slice(a: &[FrozenValue], b: &[FrozenValue]) -> Ordering {
+    for (x, y) in a.iter().zip(b.iter()) {
+        let ordering = structural_cmp(x, y);
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+    }
+    a.len().cmp(&b.len())
+}
+
+fn read_word(bytes: &[u8]) -> i64 {
+    let mut word = [0u8; 8];
+    let take = bytes.len().min(8);
+    word[..take].copy_from_slice(&bytes[..take]);
+    i64::from_le_bytes(word)
+}
+
+/// Encode `value` under `schema`'s vir type, intern the framed tree, and attach
+/// its frozen replay tree. The returned [`Interned`] carries the same ValueId a
+/// vix-constructed value of the same shape would.
+pub(crate) fn intern_rust_value<'f, T: facet::Facet<'f>>(
+    value: &T,
+    schema: &RegisteredSchema,
+    store: &mut Store,
+) -> Result<Interned, ConvertError> {
+    let encoded = encode_value(facet::Peek::new(value), &schema.vix_type)?;
+    let interned = store.intern_tree(&encoded.node, &encoded.resident);
+    store.attach_frozen(interned.handle, encoded.frozen);
+    Ok(interned)
+}
+
+/// Decode a fully-frozen value tree back into a Rust value, driven by the vir
+/// type through facet's typed [`facet::Partial`] builder.
+///
+/// v1 takes the frozen tree only: a [`FrozenValue::Reference`] (which appears for
+/// store-resident strings in real scheduler output) is a [`ConvertError`] here.
+/// Phase 05 wiring resolves references against the `&Store` before calling this,
+/// so decode never sees one.
+pub(crate) fn decode_value<'f, T: facet::Facet<'f>>(
+    frozen: &FrozenValue,
+    ty: &Type,
+) -> Result<T, ConvertError> {
+    let partial = facet::Partial::alloc::<T>().map_err(|_| ConvertError::ShapeMismatch {
+        path: String::new(),
+        expected: ty.name(),
+        found: "allocation failed".to_owned(),
+    })?;
+    let partial = build_into(partial, frozen, ty)?;
+    let heap = partial.build().map_err(|_| mismatch(ty, "incomplete value"))?;
+    heap.materialize::<T>()
+        .map_err(|_| mismatch(ty, "shape mismatch"))
+}
+
+fn frozen_kind(frozen: &FrozenValue) -> &'static str {
+    match frozen {
+        FrozenValue::Inline(_) => "inline",
+        FrozenValue::Opaque(_) => "opaque",
+        FrozenValue::Reference(_) => "reference",
+        FrozenValue::Product(_) => "product",
+        FrozenValue::Variant { .. } => "variant",
+        FrozenValue::DenseArray(_) => "array",
+        FrozenValue::OrderedMap(_) => "map",
+        FrozenValue::OrderedSet(_) => "set",
+    }
+}
+
+fn build_into<'f>(
+    mut partial: facet::Partial<'f, true>,
+    frozen: &FrozenValue,
+    ty: &Type,
+) -> Result<facet::Partial<'f, true>, ConvertError> {
+    match ty {
+        Type::Bool => {
+            let FrozenValue::Inline(bytes) = frozen else {
+                return Err(mismatch(ty, frozen_kind(frozen)));
+            };
+            partial
+                .set(read_word(bytes) != 0)
+                .map_err(|_| mismatch(ty, "set bool"))
+        }
+        Type::Int => {
+            let FrozenValue::Inline(bytes) = frozen else {
+                return Err(mismatch(ty, frozen_kind(frozen)));
+            };
+            partial
+                .set(read_word(bytes))
+                .map_err(|_| mismatch(ty, "set int"))
+        }
+        Type::String => {
+            let FrozenValue::Opaque(bytes) = frozen else {
+                return Err(mismatch(ty, frozen_kind(frozen)));
+            };
+            let text =
+                String::from_utf8(bytes.clone()).map_err(|_| mismatch(ty, "invalid utf-8"))?;
+            partial.set(text).map_err(|_| mismatch(ty, "set string"))
+        }
+        Type::Tuple(elements) => {
+            let FrozenValue::Product(fields) = frozen else {
+                return Err(mismatch(ty, frozen_kind(frozen)));
+            };
+            build_product(partial, ty, elements.iter(), fields)
+        }
+        Type::Record(record) => {
+            let FrozenValue::Product(fields) = frozen else {
+                return Err(mismatch(ty, frozen_kind(frozen)));
+            };
+            build_product(partial, ty, record.fields.iter().map(|f| &f.ty), fields)
+        }
+        Type::Enum(enumeration) => {
+            if let Some(inner) = ty.option_inner() {
+                return build_option(partial, ty, inner, frozen);
+            }
+            let FrozenValue::Variant { tag, fields } = frozen else {
+                return Err(mismatch(ty, frozen_kind(frozen)));
+            };
+            let variant = enumeration
+                .variants
+                .get(*tag as usize)
+                .ok_or_else(|| mismatch(ty, "variant index out of range"))?;
+            partial = partial
+                .select_nth_variant(*tag as usize)
+                .map_err(|_| mismatch(ty, "select variant"))?;
+            let field_types = payload_field_types(&variant.payload);
+            for (index, field_ty) in field_types.into_iter().enumerate() {
+                let field_frozen = fields
+                    .get(index)
+                    .ok_or_else(|| mismatch(ty, "short variant payload"))?;
+                partial = partial
+                    .begin_nth_field(index)
+                    .map_err(|_| mismatch(ty, "variant field"))?;
+                partial = build_into(partial, field_frozen, field_ty)?;
+                partial = partial.end().map_err(|_| mismatch(ty, "end variant field"))?;
+            }
+            Ok(partial)
+        }
+        Type::Array(element) => {
+            let FrozenValue::DenseArray(items) = frozen else {
+                return Err(mismatch(ty, frozen_kind(frozen)));
+            };
+            partial = partial.init_list().map_err(|_| mismatch(ty, "init list"))?;
+            for item in items {
+                partial = partial
+                    .begin_list_item()
+                    .map_err(|_| mismatch(ty, "list item"))?;
+                partial = build_into(partial, item, element)?;
+                partial = partial.end().map_err(|_| mismatch(ty, "end list item"))?;
+            }
+            Ok(partial)
+        }
+        Type::Map { key, value } => {
+            let FrozenValue::OrderedMap(pairs) = frozen else {
+                return Err(mismatch(ty, frozen_kind(frozen)));
+            };
+            partial = partial.init_map().map_err(|_| mismatch(ty, "init map"))?;
+            for (frozen_key, frozen_value) in pairs {
+                partial = partial.begin_key().map_err(|_| mismatch(ty, "begin key"))?;
+                partial = build_into(partial, frozen_key, key)?;
+                partial = partial.end().map_err(|_| mismatch(ty, "end key"))?;
+                partial = partial
+                    .begin_value()
+                    .map_err(|_| mismatch(ty, "begin value"))?;
+                partial = build_into(partial, frozen_value, value)?;
+                partial = partial.end().map_err(|_| mismatch(ty, "end value"))?;
+            }
+            Ok(partial)
+        }
+        Type::Set(element) => {
+            let FrozenValue::OrderedSet(items) = frozen else {
+                return Err(mismatch(ty, frozen_kind(frozen)));
+            };
+            partial = partial.init_set().map_err(|_| mismatch(ty, "init set"))?;
+            for item in items {
+                partial = partial
+                    .begin_set_item()
+                    .map_err(|_| mismatch(ty, "set item"))?;
+                partial = build_into(partial, item, element)?;
+                partial = partial.end().map_err(|_| mismatch(ty, "end set item"))?;
+            }
+            Ok(partial)
+        }
+        _ => Err(mismatch(ty, "unsupported type")),
+    }
+}
+
+fn build_product<'f, 'a>(
+    mut partial: facet::Partial<'f, true>,
+    ty: &Type,
+    field_types: impl Iterator<Item = &'a Type>,
+    fields: &[FrozenValue],
+) -> Result<facet::Partial<'f, true>, ConvertError> {
+    for (index, field_ty) in field_types.enumerate() {
+        let field_frozen = fields
+            .get(index)
+            .ok_or_else(|| mismatch(ty, "short product"))?;
+        partial = partial
+            .begin_nth_field(index)
+            .map_err(|_| mismatch(ty, "field"))?;
+        partial = build_into(partial, field_frozen, field_ty)?;
+        partial = partial.end().map_err(|_| mismatch(ty, "end field"))?;
+    }
+    Ok(partial)
+}
+
+fn build_option<'f>(
+    mut partial: facet::Partial<'f, true>,
+    ty: &Type,
+    inner: &Type,
+    frozen: &FrozenValue,
+) -> Result<facet::Partial<'f, true>, ConvertError> {
+    let FrozenValue::Variant { tag, fields } = frozen else {
+        return Err(mismatch(ty, frozen_kind(frozen)));
+    };
+    if *tag == OPTION_SOME_VARIANT {
+        let inner_frozen = fields.first().ok_or_else(|| mismatch(ty, "some payload"))?;
+        partial = partial.begin_some().map_err(|_| mismatch(ty, "begin some"))?;
+        partial = build_into(partial, inner_frozen, inner)?;
+        partial.end().map_err(|_| mismatch(ty, "end some"))
+    } else {
+        partial.set_default().map_err(|_| mismatch(ty, "none"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::identity::SchemaId;
+
+    #[derive(facet::Facet)]
+    struct Sample {
+        text: String,
+        deep: bool,
+        count: i64,
+    }
+
+    fn sample_type() -> Type {
+        Type::Record(crate::vir::RecordType {
+            name: "Sample@0000000000000001".into(),
+            fields: vec![
+                crate::vir::RecordField {
+                    name: "text".into(),
+                    ty: Type::String,
+                },
+                crate::vir::RecordField {
+                    name: "deep".into(),
+                    ty: Type::Bool,
+                },
+                crate::vir::RecordField {
+                    name: "count".into(),
+                    ty: Type::Int,
+                },
+            ],
+        })
+    }
+
+    fn test_registered_schema(ty: Type) -> RegisteredSchema {
+        RegisteredSchema {
+            taxon_root: taxon::SchemaId::from_raw(0),
+            taxon_schemas: Vec::new(),
+            store_schema: semantic_schema_id(&ty),
+            vix_type: ty,
+        }
+    }
+
+    #[test]
+    fn record_frames_exactly_like_the_scheduler_would() {
+        let ty = sample_type();
+        let value = Sample {
+            text: "hi".into(),
+            deep: true,
+            count: 7,
+        };
+        let encoded = encode_value(facet::Peek::new(&value), &ty).unwrap();
+        let text_leaf =
+            FramedNode::leaf(semantic_schema_id(&Type::String), b"hi".to_vec());
+        let expected = FramedNode::Variant {
+            schema: semantic_schema_id(&ty),
+            tag: 0,
+            fields: vec![
+                FramedField {
+                    schema: semantic_schema_id(&Type::String),
+                    value: FramedValue::Optional(Some(text_leaf.identity())),
+                },
+                FramedField {
+                    schema: semantic_schema_id(&Type::Bool),
+                    value: FramedValue::Bytes(1i64.to_le_bytes().to_vec()),
+                },
+                FramedField {
+                    schema: semantic_schema_id(&Type::Int),
+                    value: FramedValue::Bytes(7i64.to_le_bytes().to_vec()),
+                },
+            ],
+        };
+        assert_eq!(encoded.node.identity(), expected.identity());
+        assert!(encoded.resident.is_empty());
+        let _ = SchemaId::named("unused");
+    }
+
+    #[test]
+    fn interning_twice_dedupes() {
+        let ty = sample_type();
+        let schema = test_registered_schema(ty);
+        let mut store = Store::default();
+        let v = Sample {
+            text: "hi".into(),
+            deep: false,
+            count: 1,
+        };
+        let first = intern_rust_value(&v, &schema, &mut store).unwrap();
+        let second = intern_rust_value(&v, &schema, &mut store).unwrap();
+        assert_eq!(first.identity, second.identity);
+        assert!(second.deduped);
+    }
+
+    #[test]
+    fn round_trip_preserves_value_and_identity() {
+        let ty = sample_type();
+        let original = Sample {
+            text: "round".into(),
+            deep: true,
+            count: -3,
+        };
+        let encoded = encode_value(facet::Peek::new(&original), &ty).unwrap();
+        let decoded: Sample = decode_value(&encoded.frozen, &ty).unwrap();
+        assert_eq!(decoded.text, original.text);
+        assert_eq!(decoded.deep, original.deep);
+        assert_eq!(decoded.count, original.count);
+        let re_encoded = encode_value(facet::Peek::new(&decoded), &ty).unwrap();
+        assert_eq!(encoded.node.identity(), re_encoded.node.identity());
+    }
+
+    #[derive(facet::Facet, Debug, PartialEq)]
+    #[repr(u8)]
+    enum Verdict {
+        Pass,
+        Fail { reason: String },
+    }
+
+    #[derive(facet::Facet, Debug, PartialEq)]
+    struct Mixed {
+        verdict: Verdict,
+        scores: Vec<i64>,
+        note: Option<String>,
+        counts: std::collections::BTreeMap<String, i64>,
+    }
+
+    fn mixed_type() -> Type {
+        use crate::vir::{EnumType, EnumVariant, RecordField, RecordType, VariantPayload};
+        Type::Record(RecordType {
+            name: "Mixed@0000000000000002".into(),
+            fields: vec![
+                RecordField {
+                    name: "verdict".into(),
+                    ty: Type::Enum(EnumType {
+                        name: "Verdict@0000000000000003".into(),
+                        variants: vec![
+                            EnumVariant {
+                                name: "Pass".into(),
+                                payload: VariantPayload::Unit,
+                            },
+                            EnumVariant {
+                                name: "Fail".into(),
+                                payload: VariantPayload::Record(vec![RecordField {
+                                    name: "reason".into(),
+                                    ty: Type::String,
+                                }]),
+                            },
+                        ],
+                    }),
+                },
+                RecordField {
+                    name: "scores".into(),
+                    ty: Type::array(Type::Int),
+                },
+                RecordField {
+                    name: "note".into(),
+                    ty: Type::option(Type::String),
+                },
+                RecordField {
+                    name: "counts".into(),
+                    ty: Type::map(Type::String, Type::Int),
+                },
+            ],
+        })
+    }
+
+    #[test]
+    fn round_trips_enums_options_lists_maps() {
+        let ty = mixed_type();
+        for original in [
+            Mixed {
+                verdict: Verdict::Fail {
+                    reason: "nope".into(),
+                },
+                scores: vec![3, 1, 2],
+                note: Some("hello".into()),
+                counts: [("a".to_string(), 1i64), ("b".to_string(), 2i64)]
+                    .into_iter()
+                    .collect(),
+            },
+            Mixed {
+                verdict: Verdict::Pass,
+                scores: vec![],
+                note: None,
+                counts: std::collections::BTreeMap::new(),
+            },
+        ] {
+            let encoded = encode_value(facet::Peek::new(&original), &ty).unwrap();
+            let decoded: Mixed = decode_value(&encoded.frozen, &ty).unwrap();
+            assert_eq!(decoded, original);
+            let re_encoded = encode_value(facet::Peek::new(&decoded), &ty).unwrap();
+            assert_eq!(encoded.node.identity(), re_encoded.node.identity());
+        }
+    }
+
+    #[test]
+    fn option_uses_the_vir_variant_tags() {
+        let ty = Type::option(Type::Int);
+        let some = encode_value(facet::Peek::new(&Some(5i64)), &ty).unwrap();
+        let none = encode_value(facet::Peek::new(&None::<i64>), &ty).unwrap();
+        let FrozenValue::Variant { tag: some_tag, .. } = &some.frozen else {
+            panic!()
+        };
+        let FrozenValue::Variant { tag: none_tag, .. } = &none.frozen else {
+            panic!()
+        };
+        assert_eq!(*some_tag, crate::vir::OPTION_SOME_VARIANT);
+        assert_ne!(some_tag, none_tag);
+    }
+}

--- a/vix/src/runtime/primitive/descriptor.rs
+++ b/vix/src/runtime/primitive/descriptor.rs
@@ -1,0 +1,206 @@
+use std::fmt;
+
+use crate::runtime::identity::{Digest, SchemaId, hash_framed};
+use taxon::SchemaId as TaxonSchemaId;
+
+pub const RESERVED_NAMES: &[&str] = &[
+    "None",
+    "Some",
+    "by_key",
+    "range",
+    "expect",
+    "expect_eq",
+    "expect_ne",
+    "expect_some",
+    "expect_none",
+    "expect_snapshot",
+    "demanded",
+    "json_decode",
+    "toml_decode",
+    "scheduler_requests_at_most",
+    "memo_entries_at_most",
+    "store_interns_at_most",
+];
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct PrimitiveName(String);
+
+impl PrimitiveName {
+    pub fn new(name: &str) -> Result<Self, RegistrationError> {
+        if RESERVED_NAMES.contains(&name) {
+            return Err(RegistrationError::ReservedName {
+                name: name.to_owned(),
+            });
+        }
+        if !is_valid_primitive_name(name) {
+            return Err(RegistrationError::InvalidName {
+                name: name.to_owned(),
+            });
+        }
+        Ok(Self(name.to_owned()))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for PrimitiveName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+fn is_valid_primitive_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_ascii_lowercase()) {
+        return false;
+    }
+    chars.all(|c| c == '_' || c.is_ascii_lowercase() || c.is_ascii_digit())
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct PrimitiveId(pub Digest);
+
+impl PrimitiveId {
+    #[must_use]
+    pub fn derive(
+        name: &PrimitiveName,
+        version: u32,
+        protocol: u32,
+        request: TaxonSchemaId,
+        response: TaxonSchemaId,
+    ) -> Self {
+        Self(hash_framed(
+            b"vix.primitive.v1",
+            &[
+                name.as_str().as_bytes(),
+                &version.to_le_bytes(),
+                &protocol.to_le_bytes(),
+                &request.as_u64().to_le_bytes(),
+                &response.as_u64().to_le_bytes(),
+            ],
+        ))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MemoPolicy {
+    Hermetic,
+    Pinned,
+    Observed,
+    Volatile,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegisteredSchema {
+    pub taxon_root: TaxonSchemaId,
+    pub taxon_schemas: Vec<taxon::Schema>,
+    pub vix_type: crate::vir::Type,
+    pub store_schema: SchemaId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PrimitiveDescriptor {
+    pub id: PrimitiveId,
+    pub name: PrimitiveName,
+    pub version: u32,
+    pub protocol: u32,
+    pub request: RegisteredSchema,
+    pub response: RegisteredSchema,
+    pub policy: MemoPolicy,
+    pub capabilities: Vec<CapabilityRequirement>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CapabilityRequirement {
+    pub identity: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RegistrationError {
+    InvalidName { name: String },
+    ReservedName { name: String },
+    DuplicateName { name: String },
+    UnsupportedShape { path: String, kind: String },
+    Derive { message: String },
+}
+
+impl fmt::Display for RegistrationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidName { name } => write!(f, "invalid primitive name: {name}"),
+            Self::ReservedName { name } => write!(f, "reserved primitive name: {name}"),
+            Self::DuplicateName { name } => write!(f, "duplicate primitive name: {name}"),
+            Self::UnsupportedShape { path, kind } => {
+                write!(f, "unsupported primitive schema shape at {path}: {kind}")
+            }
+            Self::Derive { message } => write!(f, "primitive schema derivation failed: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for RegistrationError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primitive_id_rekeys_on_every_descriptor_axis() {
+        let name = PrimitiveName::new("probe_version").unwrap();
+        let other = PrimitiveName::new("probe_other").unwrap();
+        let req = taxon::SchemaId::from_raw(11);
+        let resp = taxon::SchemaId::from_raw(22);
+        let base = PrimitiveId::derive(&name, 1, 1, req, resp);
+        assert_eq!(base, PrimitiveId::derive(&name, 1, 1, req, resp));
+        assert_ne!(base, PrimitiveId::derive(&other, 1, 1, req, resp));
+        assert_ne!(base, PrimitiveId::derive(&name, 2, 1, req, resp));
+        assert_ne!(base, PrimitiveId::derive(&name, 1, 2, req, resp));
+        assert_ne!(
+            base,
+            PrimitiveId::derive(&name, 1, 1, taxon::SchemaId::from_raw(12), resp)
+        );
+        assert_ne!(
+            base,
+            PrimitiveId::derive(&name, 1, 1, req, taxon::SchemaId::from_raw(23))
+        );
+    }
+
+    #[test]
+    fn names_are_validated() {
+        assert!(PrimitiveName::new("probe_version").is_ok());
+        assert!(matches!(
+            PrimitiveName::new(""),
+            Err(RegistrationError::InvalidName { .. })
+        ));
+        assert!(matches!(
+            PrimitiveName::new("9lives"),
+            Err(RegistrationError::InvalidName { .. })
+        ));
+        assert!(matches!(
+            PrimitiveName::new("Probe"),
+            Err(RegistrationError::InvalidName { .. })
+        ));
+        assert!(matches!(
+            PrimitiveName::new("range"),
+            Err(RegistrationError::ReservedName { .. })
+        ));
+    }
+
+    #[test]
+    fn semantic_schema_id_matches_scheduler_format() {
+        // Pins the format the scheduler/lowering used before the hoist. If this
+        // breaks, value identities across the runtime change — do not "fix" the
+        // test; investigate.
+        let ty = crate::vir::Type::Int;
+        assert_eq!(
+            crate::runtime::identity::semantic_schema_id(&ty),
+            crate::runtime::identity::SchemaId::named(&format!("vix.semantic.v1:{}", ty.name())),
+        );
+    }
+}

--- a/vix/src/runtime/primitive/mod.rs
+++ b/vix/src/runtime/primitive/mod.rs
@@ -1,0 +1,3 @@
+//! Registered Rust effect primitives (r[machine.primitive.trait] and family).
+mod descriptor;
+pub use descriptor::*;

--- a/vix/src/runtime/primitive/mod.rs
+++ b/vix/src/runtime/primitive/mod.rs
@@ -2,6 +2,8 @@
 mod bridge;
 mod convert;
 mod descriptor;
+mod traits;
 pub use bridge::*;
 pub use convert::*;
 pub use descriptor::*;
+pub use traits::*;

--- a/vix/src/runtime/primitive/mod.rs
+++ b/vix/src/runtime/primitive/mod.rs
@@ -2,8 +2,10 @@
 mod bridge;
 mod convert;
 mod descriptor;
+mod register;
 mod traits;
 pub use bridge::*;
 pub use convert::*;
 pub use descriptor::*;
+pub use register::*;
 pub use traits::*;

--- a/vix/src/runtime/primitive/mod.rs
+++ b/vix/src/runtime/primitive/mod.rs
@@ -1,5 +1,7 @@
 //! Registered Rust effect primitives (r[machine.primitive.trait] and family).
 mod bridge;
+mod convert;
 mod descriptor;
 pub use bridge::*;
+pub use convert::*;
 pub use descriptor::*;

--- a/vix/src/runtime/primitive/mod.rs
+++ b/vix/src/runtime/primitive/mod.rs
@@ -1,3 +1,5 @@
 //! Registered Rust effect primitives (r[machine.primitive.trait] and family).
+mod bridge;
 mod descriptor;
+pub use bridge::*;
 pub use descriptor::*;

--- a/vix/src/runtime/primitive/register.rs
+++ b/vix/src/runtime/primitive/register.rs
@@ -1,0 +1,274 @@
+//! `PrimitiveSet` and the `register_function` typed adapter.
+//!
+//! `register_function` is the sugar path: it derives request/response schemas
+//! from facet shapes, validates them into the lossless vir subset, and wraps a
+//! plain `Fn(Req) -> Result<Resp, PrimitiveFailure>` as a [`Primitive`]. There
+//! are no per-primitive match arms anywhere — every primitive is keyed by its
+//! descriptor data (r[machine.primitive.registered]).
+//!
+//! Phase 02 lands registration ahead of the compiler manifest (phase 03) and the
+//! scheduler (phase 05). Lookup/inspection accessors are exercised by unit tests
+//! here; `dead_code` is expected until those consumers exist.
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use crate::runtime::identity::semantic_schema_id;
+
+use super::bridge::vir_type_for;
+use super::convert::{decode_value, intern_rust_value};
+use super::descriptor::{
+    MemoPolicy, PrimitiveDescriptor, PrimitiveId, PrimitiveName, RegisteredSchema, RegistrationError,
+};
+use super::traits::{
+    Completion, EffectCtx, EffectProtocolError, EffectTicket, Primitive, PrimitiveFailure,
+    RequestRef,
+};
+
+/// The version stamped on descriptors registered through the sugar path. The
+/// full-control `register` path carries author-supplied versions.
+const SUGAR_VERSION: u32 = 1;
+const SUGAR_PROTOCOL: u32 = 1;
+
+/// A name-keyed collection of registered primitives.
+#[derive(Default)]
+pub struct PrimitiveSet {
+    entries: BTreeMap<String, Arc<dyn Primitive>>,
+}
+
+impl PrimitiveSet {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an already-built primitive. Rejects a duplicate name.
+    pub(crate) fn register(
+        &mut self,
+        primitive: Arc<dyn Primitive>,
+    ) -> Result<(), RegistrationError> {
+        let name = primitive.descriptor().name.as_str().to_owned();
+        if self.entries.contains_key(&name) {
+            return Err(RegistrationError::DuplicateName { name });
+        }
+        self.entries.insert(name, primitive);
+        Ok(())
+    }
+
+    /// Register a plain function as a primitive: derive its request/response
+    /// schemas from `Req`/`Resp`, validate them, and wrap `f`.
+    pub fn register_function<Resp, Req, F>(
+        &mut self,
+        name: &str,
+        policy: MemoPolicy,
+        f: F,
+    ) -> Result<PrimitiveId, RegistrationError>
+    where
+        Req: facet::Facet<'static>,
+        Resp: facet::Facet<'static>,
+        F: Fn(Req) -> Result<Resp, PrimitiveFailure> + Send + Sync + 'static,
+    {
+        let name = PrimitiveName::new(name)?;
+        let request = registered_schema::<Req>()?;
+        let response = registered_schema::<Resp>()?;
+        let id = PrimitiveId::derive(
+            &name,
+            SUGAR_VERSION,
+            SUGAR_PROTOCOL,
+            request.taxon_root,
+            response.taxon_root,
+        );
+        let descriptor = PrimitiveDescriptor {
+            id,
+            name,
+            version: SUGAR_VERSION,
+            protocol: SUGAR_PROTOCOL,
+            request,
+            response,
+            policy,
+            capabilities: Vec::new(),
+        };
+        self.register(Arc::new(FunctionPrimitive {
+            descriptor,
+            call: f,
+            _marker: PhantomData,
+        }))?;
+        Ok(id)
+    }
+
+    pub(crate) fn get(&self, name: &str) -> Option<&Arc<dyn Primitive>> {
+        self.entries.get(name)
+    }
+
+    pub(crate) fn by_id(&self, id: PrimitiveId) -> Option<&Arc<dyn Primitive>> {
+        self.entries
+            .values()
+            .find(|primitive| primitive.descriptor().id == id)
+    }
+
+    /// The registered descriptors — the compiler manifest (phase 03).
+    pub fn descriptors(&self) -> impl Iterator<Item = &PrimitiveDescriptor> {
+        self.entries.values().map(|primitive| primitive.descriptor())
+    }
+}
+
+fn registered_schema<T: facet::Facet<'static>>() -> Result<RegisteredSchema, RegistrationError> {
+    let derived = phon::derive::of_shape(T::SHAPE)
+        .map_err(|error| RegistrationError::Derive { message: error.to_string() })?;
+    let vix_type = vir_type_for(derived.root, &derived.schemas)?;
+    let store_schema = semantic_schema_id(&vix_type);
+    Ok(RegisteredSchema {
+        taxon_root: derived.root,
+        taxon_schemas: derived.schemas,
+        vix_type,
+        store_schema,
+    })
+}
+
+struct FunctionPrimitive<Req, Resp, F> {
+    descriptor: PrimitiveDescriptor,
+    call: F,
+    _marker: PhantomData<fn(Req) -> Resp>,
+}
+
+impl<Req, Resp, F> Primitive for FunctionPrimitive<Req, Resp, F>
+where
+    Req: facet::Facet<'static>,
+    Resp: facet::Facet<'static>,
+    F: Fn(Req) -> Result<Resp, PrimitiveFailure> + Send + Sync + 'static,
+{
+    fn descriptor(&self) -> &PrimitiveDescriptor {
+        &self.descriptor
+    }
+
+    fn begin(
+        &self,
+        request: RequestRef<'_>,
+        ctx: &mut EffectCtx<'_>,
+    ) -> Result<EffectTicket, EffectProtocolError> {
+        // The compiler type-checked the call, so a request tree that does not
+        // decode is a machine-plane protocol violation, not a language error.
+        let decoded: Req = decode_value(request.frozen, &self.descriptor.request.vix_type)
+            .map_err(|error| EffectProtocolError::RequestShape {
+                message: error.to_string(),
+            })?;
+        match (self.call)(decoded) {
+            Ok(response) => {
+                let interned =
+                    intern_rust_value(&response, &self.descriptor.response, ctx.store_mut())
+                        .map_err(|error| EffectProtocolError::RequestShape {
+                            message: error.to_string(),
+                        })?;
+                ctx.complete(Completion::Ok(interned));
+            }
+            Err(failure) => ctx.complete(Completion::Failed(failure)),
+        }
+        // Ticket ids become real in phase 05; the adapter's inline completion
+        // makes the id inert here.
+        Ok(EffectTicket(0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::identity::{DemandKey, Digest};
+    use crate::runtime::store::Store;
+
+    #[derive(facet::Facet)]
+    struct AddRequest {
+        left: i64,
+        right: i64,
+    }
+
+    #[derive(facet::Facet)]
+    struct AddResponse {
+        sum: i64,
+    }
+
+    fn test_demand_key() -> DemandKey {
+        DemandKey(Digest([9u8; 32]))
+    }
+
+    #[test]
+    fn register_and_invoke_round_trip() {
+        let mut set = PrimitiveSet::new();
+        let id = set
+            .register_function::<AddResponse, AddRequest, _>(
+                "add_numbers",
+                MemoPolicy::Hermetic,
+                |req: AddRequest| {
+                    Ok(AddResponse {
+                        sum: req.left + req.right,
+                    })
+                },
+            )
+            .unwrap();
+        let primitive = set.by_id(id).unwrap().clone();
+        let desc = primitive.descriptor();
+
+        let mut store = Store::default();
+        let req = AddRequest {
+            left: 40,
+            right: 2,
+        };
+        let interned = intern_rust_value(&req, &desc.request, &mut store).unwrap();
+        let frozen = super::super::convert::encode_value(facet::Peek::new(&req), &desc.request.vix_type)
+            .unwrap()
+            .frozen;
+        let response_type = desc.response.vix_type.clone();
+
+        let mut ctx = EffectCtx::new(&mut store);
+        primitive
+            .begin(
+                RequestRef {
+                    identity: interned.identity,
+                    frozen: &frozen,
+                },
+                &mut ctx,
+            )
+            .unwrap();
+        let (completion, _receipt, _events) = ctx.finish(test_demand_key()).unwrap();
+        let Completion::Ok(result) = completion else {
+            panic!("expected ok")
+        };
+        let response_frozen = store
+            .frozen_for(result.handle)
+            .expect("response carries a frozen tree")
+            .clone();
+        let response: AddResponse = decode_value(&response_frozen, &response_type).unwrap();
+        assert_eq!(response.sum, 42);
+    }
+
+    #[test]
+    fn duplicate_and_unsupported_registrations_fail() {
+        let mut set = PrimitiveSet::new();
+        set.register_function::<AddResponse, AddRequest, _>(
+            "add_numbers",
+            MemoPolicy::Volatile,
+            |r| Ok(AddResponse { sum: r.left }),
+        )
+        .unwrap();
+        assert!(matches!(
+            set.register_function::<AddResponse, AddRequest, _>(
+                "add_numbers",
+                MemoPolicy::Volatile,
+                |r| Ok(AddResponse { sum: r.left })
+            ),
+            Err(RegistrationError::DuplicateName { .. })
+        ));
+
+        #[derive(facet::Facet)]
+        struct BadRequest {
+            weight: f64,
+        }
+        assert!(matches!(
+            set.register_function::<AddResponse, BadRequest, _>("bad", MemoPolicy::Volatile, |_| {
+                Ok(AddResponse { sum: 0 })
+            }),
+            Err(RegistrationError::UnsupportedShape { .. })
+        ));
+    }
+}

--- a/vix/src/runtime/primitive/traits.rs
+++ b/vix/src/runtime/primitive/traits.rs
@@ -1,0 +1,233 @@
+//! The `Primitive` trait and its effect vocabulary: tickets, completions, and
+//! the `EffectCtx` witness window.
+//!
+//! r[machine.primitive.trait] — a primitive begins an effect non-blockingly and
+//! reports its outcome as a [`Completion`].
+//! r[machine.primitive.effectctx-witness-only] — the ONLY machine-plane window a
+//! primitive gets is [`EffectCtx`]: it may witness reads, emit events, intern
+//! through the store, and report exactly one completion. Nothing else.
+//!
+//! Phase 02 lands this trait layer ahead of its consumers: the scheduler wires
+//! `begin`/`EffectCtx`/tickets in phase 05. The items are exercised by unit
+//! tests here; `dead_code` is expected until that wiring exists.
+#![allow(dead_code)]
+
+use crate::runtime::identity::{DemandKey, ValueId};
+use crate::runtime::model::{ReadWitness, Receipt};
+use crate::runtime::store::{FrozenValue, Interned, Store};
+
+use super::descriptor::{PrimitiveDescriptor, PrimitiveId};
+
+/// Request handed to a primitive: the interned identity plus the frozen tree.
+pub(crate) struct RequestRef<'a> {
+    pub identity: ValueId,
+    pub frozen: &'a FrozenValue,
+}
+
+/// One in-flight effect. Owned by the DEMAND, never the task
+/// (r[machine.scheduler.tickets-outlive-tasks]).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct EffectTicket(pub u64);
+
+/// A typed failure a primitive reports as a LANGUAGE result (it memoizes under
+/// the primitive's policy). v1 carries a response-independent rendered code +
+/// message pair; the typed per-primitive failure schema axis is reserved for a
+/// later phase.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PrimitiveFailure {
+    pub code: String,
+    pub message: String,
+}
+
+/// The outcome a primitive reports through [`EffectCtx::complete`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Completion {
+    Ok(Interned),
+    Failed(PrimitiveFailure),
+}
+
+/// A machine-plane event a primitive emits for observability. It never enters a
+/// value identity.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EffectEvent {
+    pub primitive: PrimitiveId,
+    pub message: String,
+}
+
+/// An effect-protocol violation by a registered primitive. A misbehaving
+/// registered primitive is EXPECTED fallibility, surfaced as this typed error
+/// rather than a panic (`machine.error.typed`). Phase 05 lifts this into a
+/// dedicated `RuntimeFault` variant on the shared machine-error plane.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EffectProtocolError {
+    /// `begin` returned without reporting any completion.
+    CompletionMissing,
+    /// `complete` was called more than once for one effect.
+    CompletionAlreadyReported,
+    /// The request tree did not match the registered request schema.
+    RequestShape { message: String },
+}
+
+impl std::fmt::Display for EffectProtocolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CompletionMissing => f.write_str("primitive reported no completion"),
+            Self::CompletionAlreadyReported => {
+                f.write_str("primitive reported more than one completion")
+            }
+            Self::RequestShape { message } => write!(f, "request shape mismatch: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for EffectProtocolError {}
+
+/// The primitive's ONLY machine window (r[machine.primitive.effectctx-witness-only]).
+pub(crate) struct EffectCtx<'a> {
+    store: &'a mut Store,
+    witnessed: Vec<ReadWitness>,
+    completion: Option<Completion>,
+    completion_calls: usize,
+    events: Vec<EffectEvent>,
+}
+
+impl<'a> EffectCtx<'a> {
+    pub(crate) fn new(store: &'a mut Store) -> Self {
+        Self {
+            store,
+            witnessed: Vec::new(),
+            completion: None,
+            completion_calls: 0,
+            events: Vec::new(),
+        }
+    }
+
+    /// Record a read the effect observed, so the demand's receipt carries it.
+    pub(crate) fn witness_read(&mut self, source: ValueId, projection: &str) {
+        self.witnessed.push(ReadWitness {
+            source,
+            projection: projection.to_owned(),
+        });
+    }
+
+    /// Emit a machine-plane observability event.
+    pub(crate) fn emit(&mut self, event: EffectEvent) {
+        self.events.push(event);
+    }
+
+    /// Report the effect's outcome. A second call is not a panic: it is recorded
+    /// and surfaced by [`finish`](Self::finish) as a typed protocol error.
+    pub(crate) fn complete(&mut self, completion: Completion) {
+        self.completion_calls += 1;
+        if self.completion.is_none() {
+            self.completion = Some(completion);
+        }
+    }
+
+    /// The store window primitives intern responses through. Not visible to
+    /// primitive impls outside the crate.
+    pub(crate) fn store_mut(&mut self) -> &mut Store {
+        self.store
+    }
+
+    /// Consume the ctx and produce the effect's outcome, receipt, and events.
+    /// The scheduler (phase 05) is the only caller. A missing or duplicated
+    /// completion is a typed protocol violation, not a panic.
+    pub(crate) fn finish(
+        self,
+        demand: DemandKey,
+    ) -> Result<(Completion, Receipt, Vec<EffectEvent>), EffectProtocolError> {
+        match self.completion_calls {
+            0 => Err(EffectProtocolError::CompletionMissing),
+            1 => {
+                let completion = self
+                    .completion
+                    .expect("exactly one completion was recorded");
+                let receipt = Receipt {
+                    demand,
+                    reads: self.witnessed,
+                };
+                Ok((completion, receipt, self.events))
+            }
+            _ => Err(EffectProtocolError::CompletionAlreadyReported),
+        }
+    }
+}
+
+/// A registered Rust effect primitive.
+///
+/// r[machine.primitive.trait]
+pub(crate) trait Primitive: Send + Sync {
+    fn descriptor(&self) -> &PrimitiveDescriptor;
+
+    /// Non-blocking begin (r[machine.primitive.trait]). v1 adapters complete
+    /// inline before returning; the signature already permits async backends.
+    fn begin(
+        &self,
+        request: RequestRef<'_>,
+        ctx: &mut EffectCtx<'_>,
+    ) -> Result<EffectTicket, EffectProtocolError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::identity::{Digest, SchemaId};
+
+    fn demand_key() -> DemandKey {
+        DemandKey(Digest([7u8; 32]))
+    }
+
+    fn sample_value() -> ValueId {
+        ValueId {
+            schema: SchemaId::named("vix.test.source"),
+            content: Digest([3u8; 32]),
+        }
+    }
+
+    #[test]
+    fn happy_path_yields_receipt_with_reads_and_demand() {
+        let mut store = Store::default();
+        let mut ctx = EffectCtx::new(&mut store);
+        ctx.witness_read(sample_value(), "field");
+        let interned = ctx
+            .store_mut()
+            .intern_realized(SchemaId::named("vix.test.result"), b"result");
+        ctx.complete(Completion::Ok(interned));
+        let (completion, receipt, events) = ctx.finish(demand_key()).unwrap();
+        assert!(matches!(completion, Completion::Ok(_)));
+        assert_eq!(receipt.demand, demand_key());
+        assert_eq!(receipt.reads.len(), 1);
+        assert_eq!(receipt.reads[0].source, sample_value());
+        assert_eq!(receipt.reads[0].projection, "field");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn no_completion_is_a_typed_error() {
+        let mut store = Store::default();
+        let ctx = EffectCtx::new(&mut store);
+        assert_eq!(
+            ctx.finish(demand_key()),
+            Err(EffectProtocolError::CompletionMissing)
+        );
+    }
+
+    #[test]
+    fn double_completion_is_a_typed_error() {
+        let mut store = Store::default();
+        let mut ctx = EffectCtx::new(&mut store);
+        let first = ctx
+            .store_mut()
+            .intern_realized(SchemaId::named("vix.test.a"), b"a");
+        let second = ctx
+            .store_mut()
+            .intern_realized(SchemaId::named("vix.test.b"), b"b");
+        ctx.complete(Completion::Ok(first));
+        ctx.complete(Completion::Ok(second));
+        assert_eq!(
+            ctx.finish(demand_key()),
+            Err(EffectProtocolError::CompletionAlreadyReported)
+        );
+    }
+}

--- a/vix/src/runtime/scheduler.rs
+++ b/vix/src/runtime/scheduler.rs
@@ -11,7 +11,9 @@ use weavy::task::{FnId, TaskEvent as WeavyTaskEvent, TaskStep};
 use crate::lowering::{LoweringArtifact, LoweringAttribution, ValueInputBinding};
 use crate::vir::{FunctionId, IslandId, Type, VariantPayload};
 
-use super::identity::{DemandKey, DemandPreimage, Location, LocationId, SchemaId, ValueId};
+use super::identity::{
+    DemandKey, DemandPreimage, Location, LocationId, SchemaId, ValueId, semantic_schema_id,
+};
 use super::identity::{FramedField, FramedNode, FramedValue};
 use super::model::{
     DemandRecord, DemandState, FailureContext, FailureValue, MemoVerdict, Receipt, TaskId,
@@ -2756,10 +2758,6 @@ fn read_payload_word(bytes: &[u8], offset: usize) -> Option<i64> {
     Some(i64::from_le_bytes(
         bytes.get(offset..offset.checked_add(8)?)?.try_into().ok()?,
     ))
-}
-
-fn semantic_schema_id(ty: &Type) -> SchemaId {
-    SchemaId::named(&format!("vix.semantic.v1:{}", ty.name()))
 }
 
 fn invalid_realized_result(lowered: &LoweringArtifact, size: usize) -> TaskFault {

--- a/vix/src/runtime/store.rs
+++ b/vix/src/runtime/store.rs
@@ -206,6 +206,14 @@ impl Store {
         self.entries.get(handle.index())
     }
 
+    /// The frozen replay tree attached to a handle, if any. Primitive
+    /// registration interns a response and reads its frozen tree back through
+    /// this accessor. Consumed by the scheduler wiring in phase 05.
+    #[allow(dead_code)]
+    pub(crate) fn frozen_for(&self, handle: Handle) -> Option<&FrozenValue> {
+        self.entries.get(handle.0 as usize)?.frozen()
+    }
+
     /// Convert only a live store-owned handle to Weavy's opaque entry handle.
     pub(crate) fn weavy_handle(&self, handle: Handle) -> Option<StoreHandle> {
         self.entry(handle)?;


### PR DESCRIPTION
**Phase 2 of 6.** Stacked on #2482 (base `vix-prim-01-spec`).

The `vix::runtime::primitive` module: primitive descriptor / id / `MemoPolicy`; the `Primitive` trait + `EffectCtx` + ticket + completion; `PrimitiveSet` and the `register_function` typed adapter; the taxon→vir validator (lossless subset only); and facet↔`FramedNode` conversion (aggregates are identity trees with **empty resident bytes** — never phon-serialized, per the weavy ABI).

Pure unit tests; no compiler/scheduler wiring yet (the stack is one deliverable — core merges as part of the wired stack).

---
_Stacked PR — review after #2482._