### PR TITLE
vix typed primitives — 04: VIR partitioning + lowering

### DIFF
--- a/docs/superpowers/plans/2026-07-15-vix-prim-04-lowering.md
+++ b/docs/superpowers/plans/2026-07-15-vix-prim-04-lowering.md
@@ -1,0 +1,123 @@
+# Vix Typed Primitives — Phase 04: VIR Partitioning + Lowering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Wire the `Op::EffectRequest` node phase 03 emits into the partition/lowering pipeline. Partitioning **cuts at that node**: the request subgraph becomes its own **value island**; the consuming island's node is rewritten to read the response as a **bound realized value input** (`ValueRepresentation::RealizedHandle`). The effect is recorded as one generic edge — `EffectEdge { primitive: EffectId, request: ValueIslandId }` — on the consumer `Island` and mirrored onto the `LoweringArtifact`, so the phase-05 scheduler can resolve it at the demand layer. Phase 04 does **not** resolve, memo, dispatch, or call any handler — it only partitions, rewrites, binds, and records.
+
+**Architecture:** Design §6. `Island` gains `effect_inputs: Vec<EffectEdge>` **parallel to** `wire_inputs`, not conflated with it — `wire_inputs` structurally assumes a *producer* island, an effect has none. The partition cut mirrors the *shape* of the wire cut (a boundary map keyed on node id, a backing vec) but stays a distinct path. The effect-consumer node is rewritten to an `Op::Parameter` (the value-input read whose realized-handle binding already exists), allocated **after** all value-input parameters so the existing `value_inputs`↔`parameters` positional zip in `bind_value_inputs` is untouched; a parallel `bind_effect_inputs` binds the effect params at `entry = value_inputs.len() + k`. The request subgraph is carried in a new `PartitionedTest.effect_islands` (parallel to `wire_islands`) and lowered up front through the ratchet, exactly as wire argument islands are — record/carry only, never resolved here.
+
+**Tech Stack:** Rust (edition 2024), `vix::vir`, `vix::lowering`, `vix::ratchet`, the phase-03 `Op::EffectRequest`/`EffectId`/`EffectKind::Effect`.
+
+## Global Constraints
+
+- Branch: `vix-prim-04-lowering`, created with `git town append vix-prim-04-lowering` from `vix-prim-03-compiler`. All commits `git commit --no-verify` (the facet-dev hook is skipped; never add AI attribution).
+- **Layering is load-bearing.** `vir` MUST NOT import `crate::runtime` (`vir.rs` today imports only `crate::diagnostic`/`crate::support` — keep it). `EffectEdge` is defined in `vir.rs` and carries `vir::EffectId`, NEVER `runtime::PrimitiveId`; the phase-05 scheduler converts EffectId→PrimitiveId. `lowering.rs` already imports runtime, but the edge still carries `EffectId` — it originates in `vir` partitioning.
+- **One generic effect edge — NO per-primitive arms/fields/variants anywhere** (r[machine.primitive.registered]). Everything is keyed by the `EffectId` data. **Exactly one new edge struct** (`EffectEdge`), **one new `Island` field** (`effect_inputs`), **one new `LoweringArtifact` field** (`effect_inputs`). One new binding struct (`EffectInputBinding`) is the mandatory lowering-side mirror of `ValueInputBinding`, exactly as `EffectEdge` mirrors the `ValueIslandId` carried in `value_inputs`. One new `PartitionedTest` field (`effect_islands`) is the request-island carrier mirroring `wire_islands`.
+- **Parallel to `wire_inputs`, NOT conflated with it** (design §6): a separate `effect_inputs` field, a separate `EffectEdge` type, a separate cut loop and boundary-map entry. Do not overload wire code to mean "effect".
+- **Phase 04 is lower-only.** No scheduler resolution, no memo lookup/insert, no `begin()`, no dispatch, no `DemandKey` for effects, no receipts/events. Because a primitive call cannot run until phase 05, **tests are structural**: the request subgraph became its own value island; the consumer records the `EffectEdge` with the correct `EffectId` + request `ValueIslandId`; the response binds as a realized value input (`RealizedHandle` for an aggregate/String response); the artifact carries the effect edges. **Do NOT execute a primitive** (no `run_source`/`execute` on an effect-bearing source).
+- **No pure-path regressions.** The effect machinery activates only when an `EffectEdge` is present (an effect-free island produces an empty `effect_inputs` and behaves byte-identically). The full existing suite must stay green (516+ tests) and clippy clean.
+- **Diagnostics:** reuse existing `DiagnosticCode`/`lowering_diagnostic`; add no new `DiagnosticCode`.
+- **Scheduler:** DO NOT edit `runtime/scheduler.rs` for resolution. Only mechanical construction/match updates forced by a new `Island`/`LoweringArtifact` field (e.g. an empty `effect_inputs` in a struct literal). If a scheduler edit would be more than mechanical, STOP and report. (Audited: the only `Island` literals are in `vir.rs`; the only `LoweringArtifact` literals are `lowering.rs:602` and `lowering.rs:246` (`with_test_verified_executable`); `scheduler.rs:3164` returns a `LoweringArtifact` via `with_test_verified_executable`, not a literal — so no scheduler edit is forced.)
+- Test runner: `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` (system rustc 1.96.1; do NOT use `nix develop`, it pins 1.91). Clippy: `nix shell nixpkgs#clippy nixpkgs#cargo-nextest --command cargo clippy -p vix --all-targets -- -D warnings`.
+
+## Cut mechanics (verified against the code)
+
+- `collect_dependencies_stopping_at(output, stop)` (`vir.rs:2662`) inserts a boundary node into `needed` but does **not** recurse into its inputs. So adding effect node ids to `stop` includes the effect node in the consumer island while cutting off the request subtree — exactly the required cut.
+- `partition_function_output_with_shared` (`vir.rs:1621`) rewrites `shared` nodes → `Op::Parameter` (pushing `parameters` + `value_inputs`) and `wires` nodes → `Op::AwaitWire` (pushing `wire_inputs`). The effect cut adds a **second** loop, run **after** the shared/wire loop, that rewrites `effects` nodes → `Op::Parameter` (pushing `parameters` + `effect_inputs`). Value params therefore occupy `parameters[0..V]`, effect params `parameters[V..V+E]`.
+- The contract's `entries` (`lowering.rs:2350`) is `[param_0_region … param_{P-1}_region, constant_regions…]` in `parameters` order. `bind_value_inputs` (`lowering.rs:655`) zips `parameters.iter().zip(value_inputs)` with `.enumerate()` as `entry`; since `value_inputs.len() == V` the zip covers exactly `parameters[0..V]`. `bind_effect_inputs` binds `effect_inputs[k]` at `entry = V + k` (= `island.value_inputs.len() + k`), reading `parameters[entry]` and its `entries[entry]` region — the same schema/region logic as `bind_value_inputs`.
+- `representation_for_type` (`lowering.rs:12117`) / `shape_for_type` (`lowering.rs:2465`): `Array`/`Map`/`Set`/`String`/`Path` → single `Handle` word (`RealizedHandle`, `binding.schema` = `Some`); `Record`/`Tuple`/`Enum` → multi-word (`InlineComposite`, `binding.schema` = `None`). An effect param binds through the **same** path as any value input of its type. To make "binds as RealizedHandle" literal and unambiguous, the phase-04 tests use a response type whose top-level representation is `RealizedHandle` (String / Array). A record response would bind as `InlineComposite` — still the realized value-input channel; both are valid and phase 05 delivers accordingly (noted in landing notes).
+- After partitioning, an effect node in a **test-body value position** is an `Op::Parameter`, so `lower_node` never sees `Op::EffectRequest` for it. The `lower_node` guard arm at `lowering.rs:5875` stays as a typed diagnostic for the un-partitioned position (an effect embedded in a *callee* is out of scope for v1), with its message updated from "phase 04" to reflect that.
+
+## File Structure
+
+- Modify `vix/src/vir.rs` — `EffectEdge`; `Island.effect_inputs`; `IslandBoundary.effects`; `PartitionedTest.effect_islands`; effect-node collection + `effects` map + `effect_islands` build in `partition_test`; the effect cut loop in `partition_function_output_with_shared`; `effect_inputs` on the three `Island` literals. Inline `#[cfg(test)]`.
+- Modify `vix/src/lowering.rs` — `EffectInputBinding`; `LoweringArtifact.effect_inputs`; `bind_effect_inputs`; call it in `lower_island`; field on both `LoweringArtifact` literals; refine the `Op::EffectRequest` guard message. Import `EffectId`.
+- Modify `vix/src/ratchet.rs` — lower `partitioned.effect_islands` up front in `prepare_run`, mirroring the `wire_islands` loop.
+- Create `vix/tests/primitive_lowering.rs` — structural partition + lowering integration tests (manifest idiom from `primitive_compiler.rs`).
+
+---
+
+### Task 1: VIR — `EffectEdge`, `Island.effect_inputs`, partition cut, request islands
+
+**Files:**
+- Modify: `vix/src/vir.rs`
+- Test: `#[cfg(test)]` in `vir.rs` + `vix/tests/primitive_lowering.rs`
+
+**Interfaces (later tasks rely on these exact names):**
+- `pub struct EffectEdge { pub primitive: EffectId, pub request: ValueIslandId }` — `derive(facet::Facet, Clone, Copy, Debug, PartialEq, Eq)`.
+- `Island.effect_inputs: Vec<EffectEdge>` — new field, after `wire_inputs`.
+- `PartitionedTest.effect_islands: Vec<PartitionedValue>` — new field, after `wire_islands`; each `PartitionedValue { id: request island id, island, wire: None }`.
+- `IslandBoundary.effects: &'a BTreeMap<NodeId, EffectEdge>` — new boundary field.
+
+- [ ] **Step 1: Failing tests.**
+  - Inline `vir.rs`: an effect node in a value expression partitions so that (a) `PartitionedTest.effect_islands` has one island whose output is the request record, (b) the consuming check island's `effect_inputs` carries one `EffectEdge` with the expected `EffectId` and a `request` `ValueIslandId` equal to the request island's id, (c) the effect node in the check island is `Op::Parameter` (not `Op::EffectRequest`), (d) an effect-free test produces empty `effect_inputs`/`effect_islands`.
+  - Integration `primitive_lowering.rs`: same, driven through a `PrimitiveManifest` + compiled source (aggregate/String response) — mirrors `primitive_compiler.rs`.
+- [ ] **Step 2: Verify fail** — `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix effect` → compile error (`EffectEdge`, `effect_inputs`, `effect_islands` missing).
+- [ ] **Step 3: Implement.**
+  - Add `EffectEdge` near `Island`.
+  - Add `effect_inputs: Vec<EffectEdge>` to `Island` (after `wire_inputs`).
+  - Add `effect_islands: Vec<PartitionedValue>` to `PartitionedTest` (after `wire_islands`).
+  - Add `effects: &'a BTreeMap<NodeId, EffectEdge>` to `IslandBoundary`.
+  - In `partition_test`: collect effect nodes (`Op::EffectRequest`); build `effects: BTreeMap<NodeId, EffectEdge>` (key = effect node id, value = `{ primitive, request: value_island_id(function.id, node.inputs[0]) }`); retain effect nodes out of `shared` defensively; build `effect_islands` (one `PartitionedValue` per distinct request node id, `partition_function_output_with_shared(function, request_node, IslandId(ordinal), Value, &IslandBoundary { shared: &shared_ids, wires: &empty, lazy_arg_reps: &empty, effects: &effects })`, `wire: None`); pass `effects: &effects` in every `IslandBoundary` (values, wire islands, checks, snapshots); set `effect_islands` on the returned `PartitionedTest`.
+  - In `partition_function_output_with_shared`: destructure `effects`; add `effects.keys()` to `stop`; after the shared/wire loop add a loop that, for each node still `Op::EffectRequest` whose id is in `effects`, rewrites `node.op = Op::Parameter(ParameterId(parameters.len()))`, clears inputs, pushes a `Parameter { … name: "$effect_…", ty: node.ty }` and pushes the `EffectEdge` to `effect_inputs`; return `effect_inputs` in the `Island` literal.
+  - Add `effect_inputs: Vec::new()` to the generator `Island` literal (`vir.rs:1828`).
+  - Update the two `canonical_node`-adjacent inline test module and any other `Island {`/`IslandBoundary {`/`PartitionedTest {` literals.
+- [ ] **Step 4: Run** `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` → PASS (effect-free tests unchanged; new effect tests green).
+- [ ] **Step 5: Commit** — `git add -A && git commit --no-verify -m "vix: partition cuts at Op::EffectRequest into request islands + effect edges"`
+
+---
+
+### Task 2: Lowering — `EffectInputBinding`, `LoweringArtifact.effect_inputs`, RealizedHandle binding
+
+**Files:**
+- Modify: `vix/src/lowering.rs`
+- Test: `vix/tests/primitive_lowering.rs` (append) + optional inline
+
+**Interfaces:**
+- `pub struct EffectInputBinding { pub primitive: EffectId, pub request: ValueIslandId, pub entry: usize, pub schema: Option<WeavySchemaRef>, pub store_schema: SchemaId, pub payload_element_schema: Option<WeavySchemaRef>, pub ty: Type, pub publication_schemas: Vec<(Type, WeavySchemaRef)> }` — mirrors `ValueInputBinding`, carrying the `EffectEdge` fields instead of `value`. `derive(Clone, Debug, PartialEq, Eq)`.
+- `LoweringArtifact.effect_inputs: Vec<EffectInputBinding>` — new field.
+- `fn bind_effect_inputs(island, contract, schemas) -> Result<Vec<EffectInputBinding>, Diagnostics>`.
+
+- [ ] **Step 1: Failing test** — lower the consumer island (`LoweringCache::default().get_or_lower`): assert `artifact.effect_inputs.len() == 1`, its `primitive`/`request` match the manifest, and (for an aggregate/String response) `binding.schema.is_some()` — i.e. the response binds as a `RealizedHandle` store-handle entry.
+- [ ] **Step 2: Verify fail** — compile error (`effect_inputs` / `EffectInputBinding` / `bind_effect_inputs` missing).
+- [ ] **Step 3: Implement.**
+  - `EffectInputBinding` next to `ValueInputBinding` (`lowering.rs:92`). Import `EffectId` in the `crate::vir` use.
+  - `LoweringArtifact.effect_inputs` field (`lowering.rs:201`).
+  - `bind_effect_inputs`: iterate `island.effect_inputs` with `entry = island.value_inputs.len() + k`, read `island.parameters[entry]` and `root.entries.get(entry)` region, compute `schema`/`store_schema`/`payload_element_schema`/`publication_schemas` exactly as `bind_value_inputs` does, carry `primitive`/`request` from the edge.
+  - `lower_island`: `let effect_inputs = bind_effect_inputs(island, &contract, &schemas)?;` and set it on the `LoweringArtifact` literal.
+  - `with_test_verified_executable`: `effect_inputs: self.effect_inputs.clone()`.
+  - Refine the `Op::EffectRequest` guard message in `lower_node` (still a typed diagnostic; effect embedded outside a partitioned test-body value position is not wired in v1).
+- [ ] **Step 4: Run** `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` → PASS.
+- [ ] **Step 5: Commit** — `git add -A && git commit --no-verify -m "vix: bind the effect response as a realized value input on the artifact"`
+
+---
+
+### Task 3: Ratchet — thread the request islands through up-front lowering
+
+**Files:**
+- Modify: `vix/src/ratchet.rs`
+- Test: `vix/tests/primitive_lowering.rs` (append)
+
+**Interfaces:** no new public API; the request islands (`partitioned.effect_islands`) are lowered up front so phase 05 finds them warm, mirroring `wire_islands` (`ratchet.rs:685`). Phase 04 does NOT drive them at evaluate time.
+
+- [ ] **Step 1: Failing test** — a prepared run (lowering only, no `execute`) of an effect-bearing source lowers the request island: assert the cache contains the request island's artifact (`cache.lowered(&effect.island).is_some()`), or that `prepare` succeeds and `partitioned.effect_islands` is non-empty and each lowers.
+- [ ] **Step 2: Verify fail** (if the assertion targets the new up-front lowering path).
+- [ ] **Step 3: Implement** — in `prepare_run` (`ratchet.rs:679`), after the `wire_islands` loop, add `for effect in &partitioned.effect_islands { cache.get_or_lower(&effect.island)?; }`. (Do NOT add an evaluate-time `effect_lookup`/resolution — that is phase 05.)
+- [ ] **Step 4: Run** `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` → PASS (effect-free tests: `effect_islands` empty, loop is a no-op).
+- [ ] **Step 5: Commit** — `git add -A && git commit --no-verify -m "vix: lower effect request islands up front so phase 05 finds them warm"`
+
+---
+
+### Task 4: Phase gate
+
+- [ ] Full suite: `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` → all green.
+- [ ] Clippy: `nix shell nixpkgs#clippy nixpkgs#cargo-nextest --command cargo clippy -p vix --all-targets -- -D warnings` → clean.
+- [ ] Re-read the diff vs the Global Constraints: `vir` imports no `runtime`; exactly one `EffectEdge` / one `Island.effect_inputs` / one `LoweringArtifact.effect_inputs`; the effect path is a distinct loop/field from wires; no scheduler resolution added; no new `DiagnosticCode`; effect-free islands unchanged.
+- [ ] Update checkboxes to `[x]`, append landing notes (deviations, the exact effect-edge shape on the artifact, how ratchet carries the request islands, and the precise API phase 05 calls), commit `git add -A && git commit --no-verify -m "vix: mark phase 04 lowering plan complete + landing notes"`, then stop.
+
+## Self-review notes (already applied)
+
+- **Response representation:** the design's "binds as RealizedHandle" describes the *realized value-input channel* (vs the scalar wire channel), which for aggregate/String responses is literally `RealizedHandle` and for records is `InlineComposite`. The effect param binds through the same type-driven path as any value input; the tests use an aggregate/String response so the `RealizedHandle` assertion is literal. Landing notes must flag this for phase 05.
+- **Parameter ordering:** value params occupy `parameters[0..V]`, effect params `parameters[V..V+E]`, so the existing `bind_value_inputs` positional zip is byte-for-byte unchanged and `bind_effect_inputs` binds at `entry = V + k`. The effect cut is a second loop after the shared/wire loop precisely to preserve this.
+- **`lower_node` guard stays:** after partitioning, a properly-cut effect node is an `Op::Parameter`; the guard only fires for an effect in an un-partitioned position (a callee), which is out of scope for v1. It is a typed diagnostic, not silent miscompile.
+- **No scheduler resolution:** the request islands are carried and warmed but never demanded/resolved in phase 04 (`machine.execution.facts-precomputed`); phase 05 reads `LoweringArtifact.effect_inputs` + `PartitionedTest.effect_islands` to resolve at the demand layer.

--- a/docs/superpowers/plans/2026-07-15-vix-prim-04-lowering.md
+++ b/docs/superpowers/plans/2026-07-15-vix-prim-04-lowering.md
@@ -49,11 +49,11 @@
 - `PartitionedTest.effect_islands: Vec<PartitionedValue>` — new field, after `wire_islands`; each `PartitionedValue { id: request island id, island, wire: None }`.
 - `IslandBoundary.effects: &'a BTreeMap<NodeId, EffectEdge>` — new boundary field.
 
-- [ ] **Step 1: Failing tests.**
+- [x] **Step 1: Failing tests.**
   - Inline `vir.rs`: an effect node in a value expression partitions so that (a) `PartitionedTest.effect_islands` has one island whose output is the request record, (b) the consuming check island's `effect_inputs` carries one `EffectEdge` with the expected `EffectId` and a `request` `ValueIslandId` equal to the request island's id, (c) the effect node in the check island is `Op::Parameter` (not `Op::EffectRequest`), (d) an effect-free test produces empty `effect_inputs`/`effect_islands`.
   - Integration `primitive_lowering.rs`: same, driven through a `PrimitiveManifest` + compiled source (aggregate/String response) — mirrors `primitive_compiler.rs`.
-- [ ] **Step 2: Verify fail** — `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix effect` → compile error (`EffectEdge`, `effect_inputs`, `effect_islands` missing).
-- [ ] **Step 3: Implement.**
+- [x] **Step 2: Verify fail** — `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix effect` → compile error (`EffectEdge`, `effect_inputs`, `effect_islands` missing).
+- [x] **Step 3: Implement.**
   - Add `EffectEdge` near `Island`.
   - Add `effect_inputs: Vec<EffectEdge>` to `Island` (after `wire_inputs`).
   - Add `effect_islands: Vec<PartitionedValue>` to `PartitionedTest` (after `wire_islands`).
@@ -62,8 +62,8 @@
   - In `partition_function_output_with_shared`: destructure `effects`; add `effects.keys()` to `stop`; after the shared/wire loop add a loop that, for each node still `Op::EffectRequest` whose id is in `effects`, rewrites `node.op = Op::Parameter(ParameterId(parameters.len()))`, clears inputs, pushes a `Parameter { … name: "$effect_…", ty: node.ty }` and pushes the `EffectEdge` to `effect_inputs`; return `effect_inputs` in the `Island` literal.
   - Add `effect_inputs: Vec::new()` to the generator `Island` literal (`vir.rs:1828`).
   - Update the two `canonical_node`-adjacent inline test module and any other `Island {`/`IslandBoundary {`/`PartitionedTest {` literals.
-- [ ] **Step 4: Run** `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` → PASS (effect-free tests unchanged; new effect tests green).
-- [ ] **Step 5: Commit** — `git add -A && git commit --no-verify -m "vix: partition cuts at Op::EffectRequest into request islands + effect edges"`
+- [x] **Step 4: Run** `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` → PASS (effect-free tests unchanged; new effect tests green).
+- [x] **Step 5: Commit** — `git add -A && git commit --no-verify -m "vix: partition cuts at Op::EffectRequest into request islands + effect edges"`
 
 ---
 
@@ -78,17 +78,17 @@
 - `LoweringArtifact.effect_inputs: Vec<EffectInputBinding>` — new field.
 - `fn bind_effect_inputs(island, contract, schemas) -> Result<Vec<EffectInputBinding>, Diagnostics>`.
 
-- [ ] **Step 1: Failing test** — lower the consumer island (`LoweringCache::default().get_or_lower`): assert `artifact.effect_inputs.len() == 1`, its `primitive`/`request` match the manifest, and (for an aggregate/String response) `binding.schema.is_some()` — i.e. the response binds as a `RealizedHandle` store-handle entry.
-- [ ] **Step 2: Verify fail** — compile error (`effect_inputs` / `EffectInputBinding` / `bind_effect_inputs` missing).
-- [ ] **Step 3: Implement.**
+- [x] **Step 1: Failing test** — lower the consumer island (`LoweringCache::default().get_or_lower`): assert `artifact.effect_inputs.len() == 1`, its `primitive`/`request` match the manifest, and (for an aggregate/String response) `binding.schema.is_some()` — i.e. the response binds as a `RealizedHandle` store-handle entry.
+- [x] **Step 2: Verify fail** — compile error (`effect_inputs` / `EffectInputBinding` / `bind_effect_inputs` missing).
+- [x] **Step 3: Implement.**
   - `EffectInputBinding` next to `ValueInputBinding` (`lowering.rs:92`). Import `EffectId` in the `crate::vir` use.
   - `LoweringArtifact.effect_inputs` field (`lowering.rs:201`).
   - `bind_effect_inputs`: iterate `island.effect_inputs` with `entry = island.value_inputs.len() + k`, read `island.parameters[entry]` and `root.entries.get(entry)` region, compute `schema`/`store_schema`/`payload_element_schema`/`publication_schemas` exactly as `bind_value_inputs` does, carry `primitive`/`request` from the edge.
   - `lower_island`: `let effect_inputs = bind_effect_inputs(island, &contract, &schemas)?;` and set it on the `LoweringArtifact` literal.
   - `with_test_verified_executable`: `effect_inputs: self.effect_inputs.clone()`.
   - Refine the `Op::EffectRequest` guard message in `lower_node` (still a typed diagnostic; effect embedded outside a partitioned test-body value position is not wired in v1).
-- [ ] **Step 4: Run** `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` → PASS.
-- [ ] **Step 5: Commit** — `git add -A && git commit --no-verify -m "vix: bind the effect response as a realized value input on the artifact"`
+- [x] **Step 4: Run** `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` → PASS.
+- [x] **Step 5: Commit** — `git add -A && git commit --no-verify -m "vix: bind the effect response as a realized value input on the artifact"`
 
 ---
 
@@ -100,20 +100,20 @@
 
 **Interfaces:** no new public API; the request islands (`partitioned.effect_islands`) are lowered up front so phase 05 finds them warm, mirroring `wire_islands` (`ratchet.rs:685`). Phase 04 does NOT drive them at evaluate time.
 
-- [ ] **Step 1: Failing test** — a prepared run (lowering only, no `execute`) of an effect-bearing source lowers the request island: assert the cache contains the request island's artifact (`cache.lowered(&effect.island).is_some()`), or that `prepare` succeeds and `partitioned.effect_islands` is non-empty and each lowers.
-- [ ] **Step 2: Verify fail** (if the assertion targets the new up-front lowering path).
-- [ ] **Step 3: Implement** — in `prepare_run` (`ratchet.rs:679`), after the `wire_islands` loop, add `for effect in &partitioned.effect_islands { cache.get_or_lower(&effect.island)?; }`. (Do NOT add an evaluate-time `effect_lookup`/resolution — that is phase 05.)
-- [ ] **Step 4: Run** `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` → PASS (effect-free tests: `effect_islands` empty, loop is a no-op).
-- [ ] **Step 5: Commit** — `git add -A && git commit --no-verify -m "vix: lower effect request islands up front so phase 05 finds them warm"`
+- [x] **Step 1: Failing test** — a prepared run (lowering only, no `execute`) of an effect-bearing source lowers the request island: assert the cache contains the request island's artifact (`cache.lowered(&effect.island).is_some()`), or that `prepare` succeeds and `partitioned.effect_islands` is non-empty and each lowers.
+- [x] **Step 2: Verify fail** (if the assertion targets the new up-front lowering path).
+- [x] **Step 3: Implement** — in `prepare_run` (`ratchet.rs:679`), after the `wire_islands` loop, add `for effect in &partitioned.effect_islands { cache.get_or_lower(&effect.island)?; }`. (Do NOT add an evaluate-time `effect_lookup`/resolution — that is phase 05.)
+- [x] **Step 4: Run** `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` → PASS (effect-free tests: `effect_islands` empty, loop is a no-op).
+- [x] **Step 5: Commit** — `git add -A && git commit --no-verify -m "vix: lower effect request islands up front so phase 05 finds them warm"`
 
 ---
 
 ### Task 4: Phase gate
 
-- [ ] Full suite: `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` → all green.
-- [ ] Clippy: `nix shell nixpkgs#clippy nixpkgs#cargo-nextest --command cargo clippy -p vix --all-targets -- -D warnings` → clean.
-- [ ] Re-read the diff vs the Global Constraints: `vir` imports no `runtime`; exactly one `EffectEdge` / one `Island.effect_inputs` / one `LoweringArtifact.effect_inputs`; the effect path is a distinct loop/field from wires; no scheduler resolution added; no new `DiagnosticCode`; effect-free islands unchanged.
-- [ ] Update checkboxes to `[x]`, append landing notes (deviations, the exact effect-edge shape on the artifact, how ratchet carries the request islands, and the precise API phase 05 calls), commit `git add -A && git commit --no-verify -m "vix: mark phase 04 lowering plan complete + landing notes"`, then stop.
+- [x] Full suite: `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix` → all green.
+- [x] Clippy: `nix shell nixpkgs#clippy nixpkgs#cargo-nextest --command cargo clippy -p vix --all-targets -- -D warnings` → clean.
+- [x] Re-read the diff vs the Global Constraints: `vir` imports no `runtime`; exactly one `EffectEdge` / one `Island.effect_inputs` / one `LoweringArtifact.effect_inputs`; the effect path is a distinct loop/field from wires; no scheduler resolution added; no new `DiagnosticCode`; effect-free islands unchanged.
+- [x] Update checkboxes to `[x]`, append landing notes (deviations, the exact effect-edge shape on the artifact, how ratchet carries the request islands, and the precise API phase 05 calls), commit `git add -A && git commit --no-verify -m "vix: mark phase 04 lowering plan complete + landing notes"`, then stop.
 
 ## Self-review notes (already applied)
 
@@ -121,3 +121,71 @@
 - **Parameter ordering:** value params occupy `parameters[0..V]`, effect params `parameters[V..V+E]`, so the existing `bind_value_inputs` positional zip is byte-for-byte unchanged and `bind_effect_inputs` binds at `entry = V + k`. The effect cut is a second loop after the shared/wire loop precisely to preserve this.
 - **`lower_node` guard stays:** after partitioning, a properly-cut effect node is an `Op::Parameter`; the guard only fires for an effect in an un-partitioned position (a callee), which is out of scope for v1. It is a typed diagnostic, not silent miscompile.
 - **No scheduler resolution:** the request islands are carried and warmed but never demanded/resolved in phase 04 (`machine.execution.facts-precomputed`); phase 05 reads `LoweringArtifact.effect_inputs` + `PartitionedTest.effect_islands` to resolve at the demand layer.
+
+## Landing notes (phase 04 as landed)
+
+Implemented by an opus subagent; reviewed + gated + landed by the orchestrator.
+All four hard constraints held; no deviations on constraints 1–4.
+
+- **What landed, where:**
+  - `vir::EffectEdge { primitive: EffectId, request: ValueIslandId }` (vir-local,
+    `Copy`) + `Island.effect_inputs: Vec<EffectEdge>` (`vir.rs`, next to
+    `wire_inputs`). Partition cut at `Op::EffectRequest` in `Module`'s island
+    builder: effect nodes held out of `shared`; each request node becomes its own
+    `IslandPurpose::Value` island collected into the new
+    `PartitionedTest.effect_islands: Vec<PartitionedValue>`; the consumer node is
+    rewritten in place to `Op::Parameter(id)` with the param allocated at
+    `parameters[value_inputs.len() + k]`.
+  - `lowering::EffectInputBinding { primitive: EffectId, request: ValueIslandId,
+    entry, schema, store_schema, payload_element_schema, ty, publication_schemas }`
+    + `LoweringArtifact.effect_inputs: Vec<EffectInputBinding>`, produced by
+    `bind_effect_inputs` (mirror of `bind_value_inputs`, binds at
+    `entry = value_inputs.len() + k`). `lower_node`'s `Op::EffectRequest` guard is
+    now an honest v1 limitation, not a not-wired stub.
+  - `ratchet.rs`: after the `wire_islands` pre-lower loop, request islands are
+    warmed (`for effect in &partitioned.effect_islands { cache.get_or_lower(...) }`).
+    No evaluate-time resolution (that is phase 05).
+
+- **Layering (constraint 1) held:** every effect id in `vir`/`compiler`/`lowering`
+  is the `vir`-local `EffectId([u8;32])`. `vir` still imports no `runtime`. The
+  phase-05 scheduler must convert `EffectId -> runtime::PrimitiveId` at resolution
+  (via the manifest / `PrimitiveId::effect_id` inverse).
+
+- **RealizedHandle nuance for phase 05:** the design's "binds as RealizedHandle"
+  is the *realized value-input channel* (vs the scalar wire channel). For an
+  aggregate/String response that is literally `ValueRepresentation::RealizedHandle`
+  (the `String` test asserts `binding.schema.is_some()` — a single `Handle`
+  frame word); a *record* response would bind as `InlineComposite`. Phase 05 must
+  drive the interned response through the same type-driven value-input path, not
+  assume a store handle for every primitive.
+
+- **v1 call-position limitation:** a primitive is callable only from a test-body
+  value expression (where partition_test rewrites the node). An `Op::EffectRequest`
+  reaching `lower_node` means it sits in an un-partitioned position (e.g. inside a
+  callee) — a typed "not supported in v1" diagnostic, not a miscompile. Phase 06's
+  first real primitive uses the supported position; broadening is later work.
+
+- **Exact API phase 05 consumes:**
+  1. `PartitionedTest.effect_islands: Vec<PartitionedValue>` — the request islands
+     (pure), already lowered/warm in the ratchet cache; evaluate one as an ordinary
+     demand to get the request `ValueId`.
+  2. `LoweringArtifact.effect_inputs: Vec<EffectInputBinding>` on the *consumer*
+     island — one per effect edge, carrying `primitive: EffectId`, `request:
+     ValueIslandId` (names the effect_islands entry), and `entry` (the value-input
+     slot to bind the interned response into, `= value_inputs.len() + k`).
+  3. Resolve at the demand layer, intern the response, bind it at `entry`, spawn.
+
+- **Gate note (operational, for phase 05/06):** the full `nextest run -p vix`
+  reported `cross_lane_differential::accepted_corpus_agrees_across_native_and_interpreter_lanes`
+  as failed — this was a **nextest slow-timeout kill under load (~11)**, not a
+  regression. That test genuinely runs ~435s (verified PASS in isolation via
+  `cargo test -p vix --test cross_lane_differential`); nextest's configured 300s
+  slow window (`.config/nextest.toml`) reaps it when the box is busy. It touches
+  the accepted corpus only (no primitives), where phase-04 code is inert
+  (`effect_inputs` empty). When gating this stack, run heavy differential/ratchet
+  tests on a quiet box or in isolation.
+
+- **Commits (over `vix-prim-03-compiler`):** plan; `partition cuts at
+  Op::EffectRequest into request islands + effect edges`; `bind the effect
+  response as a realized value input on the artifact`; `pre-lower effect request
+  islands on the ratchet seam`; this notes commit.

--- a/vix/src/lowering.rs
+++ b/vix/src/lowering.rs
@@ -30,10 +30,10 @@ use crate::runtime::{
 };
 use crate::support::Span;
 use crate::vir::{
-    ArrayMapExecutionShape, ArrayMapPartition, EnumType, EnumVariant, Function, FunctionId, Island,
-    IslandPurpose, Node, NodeId, NodeRef, OPTION_NONE_VARIANT, OPTION_SOME_VARIANT,
-    ORDERING_EQUAL_VARIANT, ORDERING_GREATER_VARIANT, ORDERING_LESS_VARIANT, Op, Type,
-    ValueIslandId, VariantPayload, YieldSiteId,
+    ArrayMapExecutionShape, ArrayMapPartition, EffectId, EnumType, EnumVariant, Function,
+    FunctionId, Island, IslandPurpose, Node, NodeId, NodeRef, OPTION_NONE_VARIANT,
+    OPTION_SOME_VARIANT, ORDERING_EQUAL_VARIANT, ORDERING_GREATER_VARIANT, ORDERING_LESS_VARIANT,
+    Op, Type, ValueIslandId, VariantPayload, YieldSiteId,
 };
 
 #[derive(facet::Facet, Clone, Debug, PartialEq, Eq)]
@@ -91,6 +91,25 @@ pub struct ValueConstant {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ValueInputBinding {
     pub value: ValueIslandId,
+    pub entry: usize,
+    pub schema: Option<WeavySchemaRef>,
+    pub store_schema: SchemaId,
+    pub payload_element_schema: Option<WeavySchemaRef>,
+    pub ty: Type,
+    pub publication_schemas: Vec<(Type, WeavySchemaRef)>,
+}
+
+/// The lowering-side mirror of [`ValueInputBinding`] for one effect edge — the
+/// realized value input the phase-05 scheduler binds after resolving the
+/// primitive. It carries the generic [`crate::vir::EffectEdge`] fields
+/// (`primitive`/`request`) in place of a producer `value`, plus the same
+/// entry/schema binding facts. `entry` follows the value-input entries
+/// (`value_inputs.len() + k`). One generic binding for all primitives, keyed by
+/// the [`EffectId`] data (r[machine.primitive.registered]).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EffectInputBinding {
+    pub primitive: EffectId,
+    pub request: ValueIslandId,
     pub entry: usize,
     pub schema: Option<WeavySchemaRef>,
     pub store_schema: SchemaId,
@@ -199,6 +218,12 @@ pub struct LoweringArtifact {
     pub pc_nodes: Vec<Vec<NodeRef>>,
     pub constants: Vec<ValueConstant>,
     pub value_inputs: Vec<ValueInputBinding>,
+    /// The effect edges this island consumes, one per [`crate::vir::EffectEdge`]
+    /// on the island. Precomputed facts (r[machine.execution.facts-precomputed]):
+    /// phase 04 records them, phase 05 resolves each at the demand layer and binds
+    /// the interned response into `entry`. Empty for an effect-free island, so no
+    /// pure hot path is touched.
+    pub effect_inputs: Vec<EffectInputBinding>,
     pub output_type: Type,
     pub output_schema: SchemaId,
     pub forced_copy_value: bool,
@@ -254,6 +279,7 @@ impl LoweringArtifact {
             pc_nodes: self.pc_nodes.clone(),
             constants: self.constants.clone(),
             value_inputs: self.value_inputs.clone(),
+            effect_inputs: self.effect_inputs.clone(),
             output_type: self.output_type.clone(),
             output_schema: self.output_schema,
             forced_copy_value: self.forced_copy_value,
@@ -585,6 +611,7 @@ fn lower_island(
         &function_ids,
     )?;
     let value_inputs = bind_value_inputs(island, &contract, &schemas)?;
+    let effect_inputs = bind_effect_inputs(island, &contract, &schemas)?;
     let demand_preimage = DemandPreimage {
         closure: recipe,
         arguments: Vec::new(),
@@ -611,6 +638,7 @@ fn lower_island(
         pc_nodes,
         constants,
         value_inputs,
+        effect_inputs,
         output_type: output.ty.clone(),
         output_schema: semantic_schema_id(&output.ty),
         forced_copy_value: island.forced_copy_value,
@@ -684,6 +712,70 @@ fn bind_value_inputs(
             };
             Ok(ValueInputBinding {
                 value: *value,
+                entry,
+                schema,
+                store_schema: semantic_schema_id(&parameter.ty),
+                payload_element_schema: match &parameter.ty {
+                    Type::Array(element) => Some(schemas.schema_for(element, span)?),
+                    _ => None,
+                },
+                ty: parameter.ty.clone(),
+                publication_schemas: publication_schemas(&parameter.ty, schemas, span)?,
+            })
+        })
+        .collect()
+}
+
+/// The effect-edge mirror of [`bind_value_inputs`]. Effect parameters occupy
+/// `parameters[value_inputs.len()..]`, so each edge binds at
+/// `entry = value_inputs.len() + k` with the same entry/schema logic — a distinct
+/// path that never disturbs the value-input positional binding above. Empty and
+/// cost-free for an effect-free island.
+fn bind_effect_inputs(
+    island: &Island,
+    contract: &WeavyProgramContract,
+    schemas: &SchemaAssignments,
+) -> Result<Vec<EffectInputBinding>, Diagnostics> {
+    if island.effect_inputs.is_empty() {
+        return Ok(Vec::new());
+    }
+    let root = contract.functions.first().ok_or_else(|| {
+        lowering_diagnostic(Span { start: 0, end: 0 }, "island has no root contract")
+    })?;
+    let value_count = island.value_inputs.len();
+    island
+        .effect_inputs
+        .iter()
+        .enumerate()
+        .map(|(index, edge)| {
+            let entry = value_count + index;
+            let parameter = island.parameters.get(entry).ok_or_else(|| {
+                lowering_diagnostic(
+                    Span { start: 0, end: 0 },
+                    "effect edge has no bound parameter",
+                )
+            })?;
+            let span = island
+                .nodes
+                .iter()
+                .find(|node| node.id == parameter.node)
+                .map_or(Span { start: 0, end: 0 }, |node| node.span);
+            let region = root
+                .entries
+                .get(entry)
+                .copied()
+                .ok_or_else(|| lowering_diagnostic(span, "effect parameter has no root entry"))?;
+            let region = &contract.functions[0].frame.regions[region.0 as usize];
+            let schema = match region.shape.words.as_slice() {
+                [kinds] => match kinds.as_slice() {
+                    [WeavyWordKind::Handle(schema)] => Some(*schema),
+                    _ => None,
+                },
+                _ => None,
+            };
+            Ok(EffectInputBinding {
+                primitive: edge.primitive,
+                request: edge.request,
                 entry,
                 schema,
                 store_schema: semantic_schema_id(&parameter.ty),
@@ -5873,13 +5965,15 @@ fn lower_node(
             ));
         }
         Op::EffectRequest { .. } => {
-            // The compiler emits Op::EffectRequest (phase 03); the scheduler
-            // resolves it at the demand layer in phase 04/05. Until that lands,
-            // lowering a module that contains one is a typed not-yet-supported
-            // error rather than a silent miscompile.
+            // Partitioning cuts at Op::EffectRequest in a test-body value position:
+            // the node is rewritten to an Op::Parameter reading the interned
+            // response as a realized value input, so a properly-cut effect never
+            // reaches lower_node. Seeing one here means the effect sits in an
+            // un-partitioned position (e.g. embedded in a callee), which v1 does
+            // not support — a typed diagnostic, not a silent miscompile.
             return Err(lowering_diagnostic(
                 node.span,
-                "effect-primitive lowering is not wired yet (phase 04)",
+                "effect request in an un-partitioned position is not supported (v1 calls a primitive only from a test-body value expression)",
             ));
         }
         Op::Bool(value) => {

--- a/vix/src/ratchet.rs
+++ b/vix/src/ratchet.rs
@@ -685,6 +685,14 @@ fn prepare_source_with_cache(
         for wire in &partitioned.wire_islands {
             cache.get_or_lower(&wire.island)?;
         }
+        // Effect request islands are pre-lowered on the same seam so the phase-05
+        // scheduler resolves each effect from a warm cache. Phase 04 only carries
+        // and warms them — never demands or resolves them here
+        // (r[machine.execution.facts-precomputed]). Empty (a no-op) until a
+        // primitive manifest is threaded into the runner in a later phase.
+        for effect in &partitioned.effect_islands {
+            cache.get_or_lower(&effect.island)?;
+        }
         if let Some(generator) = &partitioned.generator {
             cache.get_or_lower(generator)?;
         }

--- a/vix/src/vir.rs
+++ b/vix/src/vir.rs
@@ -1132,11 +1132,35 @@ pub struct Island {
     /// `value_inputs`, a wire input is resolved lazily — a wire under an untaken
     /// branch is never awaited, so it is never demanded.
     pub wire_inputs: Vec<ValueIslandId>,
+    /// Demanded effect inputs, one per [`Op::EffectRequest`] this island consumes.
+    /// Parallel to `wire_inputs` but a distinct path: an effect has no producer
+    /// island, so each edge names the request island plus the primitive identity
+    /// the phase-05 scheduler resolves at the demand layer. The consuming node is
+    /// rewritten to an [`Op::Parameter`] reading the interned response as a
+    /// realized value input; these params occupy `parameters[value_inputs.len()..]`
+    /// so the value-input positional binding is untouched.
+    ///
+    /// r[impl machine.primitive.registered]
+    pub effect_inputs: Vec<EffectEdge>,
     pub forced_copy_value: bool,
     pub nodes: Vec<Node>,
     pub output: NodeId,
     pub callees: Vec<Function>,
     pub array_map_partitions: Vec<ArrayMapPartition>,
+}
+
+/// One generic effect edge: the inter-island cut the partitioner makes at an
+/// [`Op::EffectRequest`] node. `primitive` is the registered effect's identity —
+/// the vir-local [`EffectId`], never a `runtime::PrimitiveId` (r[machine.ir.vix-level]) —
+/// and `request` names the value island that produces the request record. Unlike
+/// [`Island::wire_inputs`], which structurally assumes a *producer* island, an
+/// effect has no producer: the phase-05 scheduler resolves it at the demand layer
+/// from this one edge, keyed entirely by the [`EffectId`] data
+/// (r[machine.primitive.registered]).
+#[derive(facet::Facet, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EffectEdge {
+    pub primitive: EffectId,
+    pub request: ValueIslandId,
 }
 
 #[derive(facet::Facet, Clone, Copy, Debug, PartialEq, Eq)]
@@ -1214,6 +1238,14 @@ pub struct PartitionedTest {
     /// equal invocations collapse to one entry, so an awaited wire memoizes to a
     /// single realization.
     pub wire_islands: Vec<PartitionedValue>,
+    /// The request islands demanded by effect edges, one per distinct request
+    /// record, keyed by their [`ValueIslandId`]. A consuming island's
+    /// [`Island::effect_inputs`] names one of these as its `request`; phase 05
+    /// evaluates it as an ordinary pure demand, interns the request value, and
+    /// resolves the effect at the demand layer. Parallel to `wire_islands`;
+    /// carried and lowered up front here, never resolved in this phase
+    /// (r[machine.execution.facts-precomputed]).
+    pub effect_islands: Vec<PartitionedValue>,
     pub generator: Option<Island>,
     /// Value-check islands, in site order. A [`PartitionedRecipe::Value`]
     /// indexes into this vector. Trace sites contribute no island.
@@ -1253,6 +1285,10 @@ struct IslandBoundary<'a> {
     shared: &'a BTreeMap<NodeId, ValueIslandId>,
     wires: &'a BTreeMap<NodeId, ValueIslandId>,
     lazy_arg_reps: &'a BTreeMap<NodeId, ValueIslandId>,
+    /// Effect requests to cut at: each [`Op::EffectRequest`] node id maps to the
+    /// generic [`EffectEdge`] recorded on the consuming island. Distinct from the
+    /// wire path — an effect has no producer island.
+    effects: &'a BTreeMap<NodeId, EffectEdge>,
 }
 
 impl Module {
@@ -1434,6 +1470,38 @@ impl Module {
                 true
             }
         });
+        // Effect requests: each `Op::EffectRequest` node consumes a request-record
+        // node (its sole input) and is typed as the Response. Partitioning cuts at
+        // the effect node — the request subtree becomes its own value island and
+        // the consumer reads the interned response as a realized value input. The
+        // effect edge is a distinct path from wires/shared, so effect nodes are
+        // held out of the shared set (r[machine.primitive.registered]).
+        let effect_node_ids: BTreeSet<NodeId> = function
+            .nodes
+            .iter()
+            .filter(|node| matches!(node.op, Op::EffectRequest { .. }))
+            .map(|node| node.id)
+            .collect();
+        shared.retain(|node| !effect_node_ids.contains(&node.id));
+        let mut effects = BTreeMap::new();
+        let mut request_nodes = BTreeSet::new();
+        for node in &function.nodes {
+            let Op::EffectRequest { primitive } = node.op else {
+                continue;
+            };
+            let request_node = *node
+                .inputs
+                .first()
+                .expect("Op::EffectRequest consumes its request record");
+            request_nodes.insert(request_node);
+            effects.insert(
+                node.id,
+                EffectEdge {
+                    primitive,
+                    request: self.value_island_id(function.id, request_node),
+                },
+            );
+        }
         let shared_ids = shared
             .iter()
             .map(|node| (node.id, self.value_island_id(function.id, node.id)))
@@ -1512,6 +1580,7 @@ impl Module {
                             shared: &shared_here,
                             wires: &BTreeMap::new(),
                             lazy_arg_reps: &lazy_here,
+                            effects: &effects,
                         },
                     ),
                     wire: None,
@@ -1545,9 +1614,42 @@ impl Module {
                             shared: &shared_ids,
                             wires: &wires_here,
                             lazy_arg_reps: &lazy_here,
+                            effects: &effects,
                         },
                     ),
                     wire: scalar_call_provenance(function, node),
+                }
+            })
+            .collect::<Vec<_>>();
+        // The request islands demanded through effect edges. Each computes its
+        // request record from ordinary shared inputs; the effect node that
+        // consumes it is downstream, so a request island never contains it. One
+        // island per distinct request node, mirroring the wire-island seam.
+        let effect_islands = request_nodes
+            .iter()
+            .enumerate()
+            .map(|(ordinal, &request_node)| {
+                let representative_id = self.value_island_id(function.id, request_node);
+                let shared_here = shared_ids
+                    .iter()
+                    .filter(|(candidate, _)| **candidate != request_node)
+                    .map(|(candidate, value)| (*candidate, *value))
+                    .collect();
+                PartitionedValue {
+                    id: representative_id,
+                    island: self.partition_function_output_with_shared(
+                        function,
+                        request_node,
+                        IslandId(u32::try_from(ordinal).expect("effect island index fits u32")),
+                        IslandPurpose::Value,
+                        &IslandBoundary {
+                            shared: &shared_here,
+                            wires: &BTreeMap::new(),
+                            lazy_arg_reps: &BTreeMap::new(),
+                            effects: &effects,
+                        },
+                    ),
+                    wire: None,
                 }
             })
             .collect::<Vec<_>>();
@@ -1571,6 +1673,7 @@ impl Module {
                             shared: &shared_ids,
                             wires: &wire_ids,
                             lazy_arg_reps: &lazy_arg_reps,
+                            effects: &effects,
                         },
                     ));
                     PartitionedRecipe::Value { island }
@@ -1590,6 +1693,7 @@ impl Module {
                             shared: &shared_ids,
                             wires: &wire_ids,
                             lazy_arg_reps: &lazy_arg_reps,
+                            effects: &effects,
                         },
                     ));
                     PartitionedRecipe::Snapshot {
@@ -1608,6 +1712,7 @@ impl Module {
             name: test.name.clone(),
             values,
             wire_islands,
+            effect_islands,
             generator,
             islands,
             sites,
@@ -1630,11 +1735,13 @@ impl Module {
             shared,
             wires,
             lazy_arg_reps,
+            effects,
         } = *boundary;
         let stop = shared
             .keys()
             .chain(wires.keys())
             .chain(lazy_arg_reps.keys())
+            .chain(effects.keys())
             .copied()
             .collect();
         let mut needed = BTreeSet::new();
@@ -1673,6 +1780,35 @@ impl Module {
                 node.inputs.clear();
                 wire_inputs.push(value);
             }
+        }
+        // A cut effect: the `Op::EffectRequest` node reads its interned Response as
+        // a bound realized value input. It becomes an `Op::Parameter` allocated
+        // AFTER every value-input parameter, so the value_inputs<->parameters
+        // positional binding is untouched; the parallel `effect_inputs` edge
+        // records the primitive identity and request island for the phase-05
+        // scheduler. This is a distinct loop from the wire/shared cut above
+        // (r[machine.primitive.registered]).
+        let mut effect_inputs = Vec::new();
+        for node in &mut nodes {
+            if !matches!(node.op, Op::EffectRequest { .. }) {
+                continue;
+            }
+            let Some(&edge) = effects.get(&node.id) else {
+                continue;
+            };
+            let id = ParameterId(
+                u32::try_from(parameters.len()).expect("effect parameter count fits u32"),
+            );
+            node.op = Op::Parameter(id);
+            node.inputs.clear();
+            parameters.push(Parameter {
+                id,
+                node: node.id,
+                name: format!("$effect_{}", edge.request.stable_segment()),
+                ty: node.ty.clone(),
+                kind: ParameterKind::Positional,
+            });
+            effect_inputs.push(edge);
         }
         prune_control_regions(&mut nodes, &needed);
         // A fused field projection or awaited wire consumer no longer references
@@ -1764,6 +1900,7 @@ impl Module {
             parameters,
             value_inputs,
             wire_inputs,
+            effect_inputs,
             forced_copy_value: matches!(purpose, IslandPurpose::Value | IslandPurpose::Snapshot)
                 && self.force_molten_copy,
             nodes,
@@ -1833,6 +1970,7 @@ impl Module {
             parameters,
             value_inputs,
             wire_inputs: Vec::new(),
+            effect_inputs: Vec::new(),
             forced_copy_value: false,
             nodes,
             output,

--- a/vix/tests/force_on_park.rs
+++ b/vix/tests/force_on_park.rs
@@ -39,6 +39,7 @@ fn island(id: u32, nodes: Vec<Node>, output: u32, wire_inputs: Vec<ValueIslandId
         parameters: Vec::new(),
         value_inputs: Vec::new(),
         wire_inputs,
+        effect_inputs: Vec::new(),
         forced_copy_value: false,
         nodes,
         output: NodeId(output),

--- a/vix/tests/primitive_lowering.rs
+++ b/vix/tests/primitive_lowering.rs
@@ -1,0 +1,141 @@
+//! Phase 04 — the `Op::EffectRequest` a registered primitive lowers to is
+//! partitioned into a request value island plus one generic effect edge, and the
+//! response binds as a realized value input on the artifact. Structural only:
+//! phase 04 never resolves, memoizes, dispatches, or executes a primitive.
+
+use vix::compiler::{Compilation, Compiler, PrimitiveManifest, PrimitiveSignature};
+use vix::diagnostic::Diagnostics;
+use vix::vir::{EffectId, Op, RecordField, RecordType, Type};
+
+const PRIMITIVE_EFFECT_ID: EffectId = EffectId([9u8; 32]);
+
+/// One primitive: `probe_version where { text: String } -> String`. A `String`
+/// response has a single-`Handle` frame shape, so its value input binds as a
+/// `RealizedHandle` store handle (the realized channel the effect response rides).
+fn probe_manifest() -> PrimitiveManifest {
+    let mut manifest = PrimitiveManifest::new();
+    manifest.insert(
+        "probe_version",
+        PrimitiveSignature {
+            effect: PRIMITIVE_EFFECT_ID,
+            request: Type::Record(RecordType {
+                name: "ProbeRequest@0000000000000009".into(),
+                fields: vec![RecordField {
+                    name: "text".into(),
+                    ty: Type::String,
+                }],
+            }),
+            response: Type::String,
+        },
+    );
+    manifest
+}
+
+fn compile(source: &str) -> Result<Compilation, Diagnostics> {
+    Compiler::new()
+        .with_primitives(probe_manifest())
+        .compile(source)
+}
+
+const EFFECT_SOURCE: &str = "#[test]\nfn t() -> Stream<Check> {\n    let v = probe_version where { text: \"1.2.3\" };\n    yield expect_eq(v, \"9\");\n}\n";
+
+#[test]
+fn the_request_subgraph_becomes_its_own_value_island() {
+    let compilation = compile(EFFECT_SOURCE).expect("effect source compiles");
+    let partitioned = compilation
+        .module
+        .partition_test(&compilation.module.tests[0]);
+    assert_eq!(
+        partitioned.effect_islands.len(),
+        1,
+        "one request island per distinct request record"
+    );
+    let request_island = &partitioned.effect_islands[0];
+    let output = request_island
+        .island
+        .nodes
+        .iter()
+        .find(|node| node.id == request_island.island.output)
+        .expect("request island has its output node");
+    assert!(
+        matches!(output.op, Op::Record),
+        "the request island outputs the request record, got {:?}",
+        output.op
+    );
+    // The request subgraph never contains the effect node that consumes it.
+    assert!(
+        !request_island
+            .island
+            .nodes
+            .iter()
+            .any(|node| matches!(node.op, Op::EffectRequest { .. })),
+        "the request island is pure — the effect node is downstream of it"
+    );
+}
+
+#[test]
+fn the_consumer_records_a_generic_effect_edge() {
+    let compilation = compile(EFFECT_SOURCE).expect("effect source compiles");
+    let partitioned = compilation
+        .module
+        .partition_test(&compilation.module.tests[0]);
+    let request_id = partitioned.effect_islands[0].id;
+    let edges: Vec<_> = partitioned
+        .islands
+        .iter()
+        .flat_map(|island| island.effect_inputs.iter())
+        .collect();
+    assert_eq!(edges.len(), 1, "one effect edge on the consuming check island");
+    assert_eq!(
+        edges[0].primitive, PRIMITIVE_EFFECT_ID,
+        "the edge carries the registered EffectId, not a per-primitive variant"
+    );
+    assert_eq!(
+        edges[0].request, request_id,
+        "the edge names the request value island"
+    );
+}
+
+#[test]
+fn the_effect_node_is_rewritten_to_a_bound_parameter() {
+    let compilation = compile(EFFECT_SOURCE).expect("effect source compiles");
+    let partitioned = compilation
+        .module
+        .partition_test(&compilation.module.tests[0]);
+    let leftover = partitioned
+        .islands
+        .iter()
+        .chain(partitioned.effect_islands.iter().map(|value| &value.island))
+        .flat_map(|island| island.nodes.iter())
+        .any(|node| matches!(node.op, Op::EffectRequest { .. }));
+    assert!(
+        !leftover,
+        "partitioning rewrote every consumed Op::EffectRequest to a value-input parameter"
+    );
+    // The consuming island holds exactly one effect parameter and no leftover
+    // value inputs it did not ask for.
+    let consumer = &partitioned.islands[0];
+    assert_eq!(consumer.effect_inputs.len(), 1);
+    assert_eq!(
+        consumer.parameters.len(),
+        consumer.value_inputs.len() + consumer.effect_inputs.len(),
+        "effect params occupy parameters[value_inputs.len()..]"
+    );
+}
+
+#[test]
+fn an_effect_free_test_has_no_effect_machinery() {
+    let source =
+        "#[test]\nfn t() -> Stream<Check> {\n    yield expect_eq(1 + 1, 2);\n}\n";
+    let compilation = Compiler::new().compile(source).expect("pure source compiles");
+    let partitioned = compilation
+        .module
+        .partition_test(&compilation.module.tests[0]);
+    assert!(partitioned.effect_islands.is_empty());
+    assert!(
+        partitioned
+            .islands
+            .iter()
+            .all(|island| island.effect_inputs.is_empty())
+    );
+}

--- a/vix/tests/primitive_lowering.rs
+++ b/vix/tests/primitive_lowering.rs
@@ -5,6 +5,7 @@
 
 use vix::compiler::{Compilation, Compiler, PrimitiveManifest, PrimitiveSignature};
 use vix::diagnostic::Diagnostics;
+use vix::lowering::LoweringCache;
 use vix::vir::{EffectId, Op, RecordField, RecordType, Type};
 
 const PRIMITIVE_EFFECT_ID: EffectId = EffectId([9u8; 32]);
@@ -137,5 +138,45 @@ fn an_effect_free_test_has_no_effect_machinery() {
             .islands
             .iter()
             .all(|island| island.effect_inputs.is_empty())
+    );
+}
+
+/// The effect response binds as a realized value input on the artifact, and the
+/// request island lowers (phase 05 finds it warm). No primitive is executed.
+#[test]
+fn the_response_binds_as_a_realized_value_input() {
+    let compilation = compile(EFFECT_SOURCE).expect("effect source compiles");
+    let partitioned = compilation
+        .module
+        .partition_test(&compilation.module.tests[0]);
+    let mut cache = LoweringCache::default();
+
+    let request = cache
+        .get_or_lower(&partitioned.effect_islands[0].island)
+        .expect("request island lowers");
+    assert!(
+        request.effect_inputs.is_empty(),
+        "a request island is a pure value producer"
+    );
+
+    let consumer = cache
+        .get_or_lower(&partitioned.islands[0])
+        .expect("consumer island lowers");
+    assert_eq!(
+        consumer.effect_inputs.len(),
+        1,
+        "the artifact carries the effect edge as a precomputed fact"
+    );
+    let binding = &consumer.effect_inputs[0];
+    assert_eq!(binding.primitive, PRIMITIVE_EFFECT_ID);
+    assert_eq!(binding.request, partitioned.effect_islands[0].id);
+    assert_eq!(
+        binding.entry,
+        consumer.value_inputs.len(),
+        "the effect param entry follows the value-input entries"
+    );
+    assert!(
+        binding.schema.is_some(),
+        "a String response binds as a RealizedHandle store-handle entry"
     );
 }


### PR DESCRIPTION
**Phase 4 of 6.** Stacked on #2484 (base `vix-prim-03-compiler`).

Partitioning cuts at `Op::EffectRequest`: the request subgraph becomes its own pure value island, and the consuming island records a **generic effect edge** (`EffectEdge { primitive: EffectId, request: ValueIslandId }`) — one edge shape for all primitives, not per-primitive variants. The `LoweringArtifact` carries the effect response as a precomputed **realized value-input** binding (`effect_inputs`), so the scheduler finds the request island warm. Structural only — phase 04 never resolves, memoizes, or dispatches.

---
_Stacked PR — review after #2484._