### PR TITLE
vix typed primitives — 05: demand-layer effect resolution

### DIFF
--- a/docs/superpowers/plans/2026-07-15-vix-prim-05-scheduler.md
+++ b/docs/superpowers/plans/2026-07-15-vix-prim-05-scheduler.md
@@ -1,0 +1,88 @@
+# Vix Typed Primitives — Phase 05: Scheduler Effect Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development per task. Steps use checkbox (`- [x]`) syntax.
+
+**Goal:** Wire effect resolution into `Runtime::evaluate`'s input assembly (design §7). For each effect edge on a consumer island's `LoweringArtifact.effect_inputs`: evaluate the request island (ordinary pure demand) → request `ValueId`; build the effect `DemandPreimage { closure: primitive recipe, arguments: [request] }` → `DemandKey`; consult the memo **policy-aware** (Volatile skips lookup+insert; Hermetic normal path; Pinned/Observed honest `MachineError`); on miss create the demand record, mint the `EffectTicket` on it, call `primitive.begin(request_ref, &mut ctx)`; v1 completes synchronously inside `begin` (the phase-02 adapter calls `ctx.complete`); handle the `Completion`; bind the interned response at the artifact's `entry` slot as an ordinary realized value input; spawn the consumer.
+
+**Architecture:** demand-level dispatch, zero weavy changes (design §"demand-level dispatch"). Effect resolution rides the same value-input realized channel already used at task spawn. The **shared value-input binding** duplicated across the value-island lane (`evaluate`) and the generator lane (`drive_generator`) is extracted FIRST into one behavior-preserving helper, so the effect response binds through the exact same path.
+
+**Tech Stack:** Rust (edition 2024), `vix::runtime::{scheduler, identity, error, observe, model, store, primitive}`, `vix::lowering`.
+
+## Global Constraints
+
+- Branch `vix-prim-05-scheduler` (git town append from `vix-prim-04-lowering`). All commits `git commit --no-verify`, no AI attribution.
+- **Layering:** the artifact carries `vir::EffectId`; the scheduler converts `EffectId → PrimitiveId` at the runtime boundary via `PrimitiveSet::by_effect_id`. Never leak `PrimitiveId` back into `vir`/`lowering`.
+- **One generic effect path** (r[machine.primitive.registered]): one memo-key construction, one dispatch site, one new `MachineOperation::Effect`, one generic `FailureValue::Primitive` variant, one effect event/counter parameterized by `PrimitiveId` as DATA. No per-primitive arms/fields/variants.
+- **v1 memo policy = Volatile + Hermetic only.** Pinned/Observed are an honest typed `MachineError` ("policy not supported in v1"), never silently Hermetic.
+- **Completion (design §7.4):** `Ok(interned)` → memo entry with populated `Receipt`, bind at `entry`, Ready. `Failed(PrimitiveFailure)` → generic `FailureValue::Primitive`, memoized per policy with receipt, propagated through the existing `Evaluation.failure` path. An `EffectProtocolError` (the begin/finish Result channel) → `MachineError` via `MachineOperation::Effect` + `RuntimeFault::Effect`, never memoizes. Re-entrancy trips the existing `ReentrantDemand` guard.
+- **No clock/polling** (r[machine.scheduler.block-on-event]): ticket owned by the demand record; completion arrives synchronously inside `begin`.
+- **`EffectCtx` is the primitive's only window** — the phase-02 surface (`witness_read`/`emit`/`complete`/`store_mut`/`finish`) is wired as-is; the adapter already interns the response through `store_mut`.
+- **No pure-path regressions.** An artifact with empty `effect_inputs` hits ZERO new code. Full suite green + clippy clean. Every existing `Runtime` is built with no primitives (optional slot defaults empty) → the effect path is never entered.
+- **Typed errors only.** No `Result<_, String>`; the three error planes never mix.
+- Toolchain: system cargo (rust 1.96). Tests `nix shell nixpkgs#cargo-nextest --command cargo nextest run -p vix`; clippy `nix shell nixpkgs#clippy nixpkgs#cargo-nextest --command cargo clippy -p vix --all-targets -- -D warnings`. The `cross_lane_differential` ~435s test may be slow-killed by nextest under load — re-run in isolation via plain `cargo test`.
+
+## Input contract (phase 04 as landed)
+
+- `PartitionedTest.effect_islands: Vec<PartitionedValue>` — the request islands (pure), already lowered/warm.
+- `LoweringArtifact.effect_inputs: Vec<EffectInputBinding>` on the consumer island — `{ primitive: EffectId, request: ValueIslandId, entry, schema, store_schema, payload_element_schema, ty, publication_schemas }`. `entry = value_inputs.len() + k`.
+- Phase-02 primitive surface: `PrimitiveSet::{by_id, descriptors, get}`, `Primitive::begin(RequestRef, &mut EffectCtx) -> Result<EffectTicket, EffectProtocolError>`, `EffectCtx::{new, witness_read, emit, complete, store_mut, finish}`, `Completion::{Ok(Interned), Failed(PrimitiveFailure)}`, `PrimitiveId::effect_id`, `MemoPolicy`. **Deviation from design prose:** `begin`/`finish` return `EffectProtocolError`, NOT `Box<MachineError>`; phase 05 lifts it into `RuntimeFault::Effect`.
+- **RealizedHandle nuance:** the response binds through the type-driven value-input path — `RealizedHandle` for String/aggregate, `InlineComposite` for a record. Drive it through the shared binding helper; do not assume a store handle.
+- **v1 call position:** a primitive is callable only from a test-body value expression; the consumer is a value/check island (`evaluate` lane), never the generator. `drive_generator` gets the shared value-input binding helper but no effect resolution (it has no effects channel in v1); a non-empty `effect_inputs` reaching it is an honest "not supported in v1" guard.
+
+## File Structure
+
+- `vix/src/runtime/identity.rs` — `RecipeId::from_primitive_digest` (domain-separated effect recipe).
+- `vix/src/runtime/error.rs` — `MachineOperation::Effect`; `RuntimeFault::Effect { primitive, error }`; `RuntimeFault::UnsupportedMemoPolicy { primitive }`.
+- `vix/src/runtime/model.rs` — `FailureValue::Primitive { recipe, site, failure }` (one generic variant).
+- `vix/src/runtime/store.rs` — `failure_node` arm for `FailureValue::Primitive`.
+- `vix/src/runtime/observe.rs` — `EventKind::EffectDispatched { key, primitive: PrimitiveId }`.
+- `vix/src/runtime/primitive/register.rs` — `PrimitiveSet::by_effect_id`.
+- `vix/src/lowering.rs` — `RealizedBinding` view + `ValueInputBinding::realized()` / `EffectInputBinding::realized()`.
+- `vix/src/runtime/scheduler.rs` — `Runtime.primitives: Arc<PrimitiveSet>` + `with_primitives`; `IslandInputs.effects`; `EffectDemand`; the shared per-entry binding helper `bind_realized_entry` + `EntryBindError`; the effect-resolution core in `evaluate`; `frozen_to_weavy`/`publication_schema`/`frozen_inline`/`frozen_product` retargeted to `RealizedBinding`.
+- `vix/src/ratchet.rs` — `IslandInputs { effects: &[] }` at the three literals (effect-inert; the ratchet compiles with no manifest).
+- `vix/tests/{force_on_park.rs}` — `effects: &[]` on the four literals.
+- Create `vix/tests/primitive_scheduler.rs` — end-to-end resolution tests.
+
+---
+
+### Task 1: behavior-preserving shared value-input-lane extraction (no effects)
+
+Extract the per-entry realized-input binding (the frozen/handle write + the payload_element_schema override) into one helper both lanes call. The two lanes differ ONLY in `terminate_machine_fault` vs raw-return on two unreachable machine-invariant paths (schema-mismatch, missing-value-input-handle); preserve each lane's exact policy via a typed `EntryBindError { Invariant | WriteFault | Raw }` the caller dispatches. `frozen_to_weavy` & friends retarget from `&ValueInputBinding` to a `RealizedBinding` view so the same code binds an effect response later.
+
+- [ ] Step 1: no new test — this is a pure refactor; the full suite is the oracle.
+- [ ] Step 2: implement `RealizedBinding` + `realized()` (lowering.rs); retarget `frozen_to_weavy`/`frozen_inline`/`frozen_product`/`publication_schema`; add `bind_realized_entry` + `EntryBindError`; replace both lanes' first zip loop with the helper preserving exact policy; keep the second (override) zip as-is or fold into the helper's returned override.
+- [ ] Step 3: `cargo nextest run -p vix` → byte-for-byte green (cross-lane isolated if slow-killed). Clippy clean.
+- [ ] Step 4: commit — `vix: extract the shared realized value-input binding across scheduler lanes`.
+
+### Task 2: thread `PrimitiveSet` into `Runtime`; effect identity + demand key
+
+- [ ] Step 1: failing test (`primitive_scheduler.rs`) — `Runtime::new(sink).with_primitives(Arc::new(set))` builds; `by_effect_id(descriptor.id.effect_id())` finds the primitive; `RecipeId::from_primitive_digest` is stable + distinct from a pure recipe.
+- [ ] Step 2: `Runtime.primitives: Arc<PrimitiveSet>` (default empty) + `with_primitives`; `PrimitiveSet::by_effect_id`; `RecipeId::from_primitive_digest`; `IslandInputs.effects: &[EffectDemand]` + `EffectDemand`. No dispatch yet.
+- [ ] Step 3: full suite green (empty registry + `effects: &[]` = no-op). Commit — `vix: thread a PrimitiveSet registry and effect identity into the runtime`.
+
+### Task 3: the resolution core in `evaluate`
+
+For each `(binding, effect_demand)` in `lowered.effect_inputs.zip(inputs.effects)`: evaluate the request island → request `Evaluation`; if it failed, the consumer fails with that handle/failure. Else build the effect `DemandPreimage`/`DemandKey`; policy-aware memo (Volatile skip; Hermetic lookup; Pinned/Observed honest error). On hit: response = memo handle. On miss: clone the request frozen, `EffectCtx::new(&mut store)`, `begin`, `finish`; `Ok(interned)` → `effect_spawns++`, `EffectDispatched`, memo insert with receipt, Ready; `Failed` → intern the `FailureValue::Primitive`, memo per policy with receipt, consumer fails; `EffectProtocolError` → `RuntimeFault::Effect` abort. Then bind each resolved response at `binding.entry` via `bind_realized_entry` inside the task-setup loop.
+
+- [ ] Step 1: failing e2e tests (below).
+- [ ] Step 2: implement `resolve_effects` (called before the chaos respawn loop) returning bound responses or a consumer failure; bind responses in the task loop.
+- [ ] Step 3: green + clippy. Commit — `vix: resolve registered effect primitives at the demand layer`.
+
+### Task 4: integration tests + phase gate + landing notes
+
+Tests (`primitive_scheduler.rs`), compile+lower a real primitive and drive `Runtime::evaluate` directly (mirroring `force_on_park.rs`):
+- Hermetic: two identical demands → second is a memo hit, **zero** extra `begin` (AtomicUsize counter).
+- Volatile: two demands → **two** `begin`, no memo entry.
+- Failure: a `PrimitiveFailure` propagates as `Evaluation.failure`, receipted, memoized per policy.
+- Receipt: an Ok effect's memo entry carries a populated `Receipt`.
+- Counter/event: `effect_spawns` increments on dispatch; a hit does not.
+- Pure regression guard: an effect-free `evaluate` is byte-identical.
+
+- [ ] Full suite green (cross-lane isolated if slow-killed) + clippy clean. Re-read the diff vs Hard Constraints. Append landing notes. Commit — `vix: mark phase 05 scheduler plan complete + landing notes`.
+
+## Self-review notes
+
+- **Effect Location:** the effect memo is keyed by its `DemandKey` (primitive recipe + request value) per r[machine.memo.effect-results]; the location-indexed memo table uses `LocationId(demand_key.0)` so identical effect demands share one cell (unlike pure values, which key by call site). Distinct domain (`vix.demand.v1`) from pure locations (`vix.location.v1`) → no collision.
+- **Borrow discipline:** clone the `Arc<dyn Primitive>` out of `self.primitives` and the request `FrozenValue` out of `self.store` before `EffectCtx::new(&mut self.store)`, so the ctx's `&mut store` never aliases the primitive borrow or the request frozen (mirrors the phase-02 unit test).
+- **Resolve once:** effects resolve BEFORE the chaos respawn loop; responses bind per spawn. v1 effects run only under non-chaos `evaluate`, so no double-dispatch.
+- **String request fields:** `decode_value` rejects `FrozenValue::Reference` (store-resident strings). v1 core tests use scalar-field requests (Int/Bool) that realize inline; a String-request path (reference resolution before decode) is validated as a bonus / deferred to phase 06 if it needs a resolver.

--- a/docs/superpowers/plans/2026-07-15-vix-prim-05-scheduler.md
+++ b/docs/superpowers/plans/2026-07-15-vix-prim-05-scheduler.md
@@ -49,24 +49,24 @@
 
 Extract the per-entry realized-input binding (the frozen/handle write + the payload_element_schema override) into one helper both lanes call. The two lanes differ ONLY in `terminate_machine_fault` vs raw-return on two unreachable machine-invariant paths (schema-mismatch, missing-value-input-handle); preserve each lane's exact policy via a typed `EntryBindError { Invariant | WriteFault | Raw }` the caller dispatches. `frozen_to_weavy` & friends retarget from `&ValueInputBinding` to a `RealizedBinding` view so the same code binds an effect response later.
 
-- [ ] Step 1: no new test — this is a pure refactor; the full suite is the oracle.
-- [ ] Step 2: implement `RealizedBinding` + `realized()` (lowering.rs); retarget `frozen_to_weavy`/`frozen_inline`/`frozen_product`/`publication_schema`; add `bind_realized_entry` + `EntryBindError`; replace both lanes' first zip loop with the helper preserving exact policy; keep the second (override) zip as-is or fold into the helper's returned override.
-- [ ] Step 3: `cargo nextest run -p vix` → byte-for-byte green (cross-lane isolated if slow-killed). Clippy clean.
-- [ ] Step 4: commit — `vix: extract the shared realized value-input binding across scheduler lanes`.
+- [x] Step 1: no new test — this is a pure refactor; the full suite is the oracle.
+- [x] Step 2: implement `RealizedBinding` + `realized()` (lowering.rs); retarget `frozen_to_weavy`/`frozen_inline`/`frozen_product`/`publication_schema`; add `bind_realized_entry` + `EntryBindError`; replace both lanes' first zip loop with the helper preserving exact policy; keep the second (override) zip as-is or fold into the helper's returned override.
+- [x] Step 3: `cargo nextest run -p vix` → byte-for-byte green (cross-lane isolated if slow-killed). Clippy clean.
+- [x] Step 4: commit — `vix: extract the shared realized value-input binding across scheduler lanes`.
 
 ### Task 2: thread `PrimitiveSet` into `Runtime`; effect identity + demand key
 
-- [ ] Step 1: failing test (`primitive_scheduler.rs`) — `Runtime::new(sink).with_primitives(Arc::new(set))` builds; `by_effect_id(descriptor.id.effect_id())` finds the primitive; `RecipeId::from_primitive_digest` is stable + distinct from a pure recipe.
-- [ ] Step 2: `Runtime.primitives: Arc<PrimitiveSet>` (default empty) + `with_primitives`; `PrimitiveSet::by_effect_id`; `RecipeId::from_primitive_digest`; `IslandInputs.effects: &[EffectDemand]` + `EffectDemand`. No dispatch yet.
-- [ ] Step 3: full suite green (empty registry + `effects: &[]` = no-op). Commit — `vix: thread a PrimitiveSet registry and effect identity into the runtime`.
+- [x] Step 1: failing test (`primitive_scheduler.rs`) — `Runtime::new(sink).with_primitives(Arc::new(set))` builds; `by_effect_id(descriptor.id.effect_id())` finds the primitive; `RecipeId::from_primitive_digest` is stable + distinct from a pure recipe.
+- [x] Step 2: `Runtime.primitives: Arc<PrimitiveSet>` (default empty) + `with_primitives`; `PrimitiveSet::by_effect_id`; `RecipeId::from_primitive_digest`; `IslandInputs.effects: &[EffectDemand]` + `EffectDemand`. No dispatch yet.
+- [x] Step 3: full suite green (empty registry + `effects: &[]` = no-op). Commit — `vix: thread a PrimitiveSet registry and effect identity into the runtime`.
 
 ### Task 3: the resolution core in `evaluate`
 
 For each `(binding, effect_demand)` in `lowered.effect_inputs.zip(inputs.effects)`: evaluate the request island → request `Evaluation`; if it failed, the consumer fails with that handle/failure. Else build the effect `DemandPreimage`/`DemandKey`; policy-aware memo (Volatile skip; Hermetic lookup; Pinned/Observed honest error). On hit: response = memo handle. On miss: clone the request frozen, `EffectCtx::new(&mut store)`, `begin`, `finish`; `Ok(interned)` → `effect_spawns++`, `EffectDispatched`, memo insert with receipt, Ready; `Failed` → intern the `FailureValue::Primitive`, memo per policy with receipt, consumer fails; `EffectProtocolError` → `RuntimeFault::Effect` abort. Then bind each resolved response at `binding.entry` via `bind_realized_entry` inside the task-setup loop.
 
-- [ ] Step 1: failing e2e tests (below).
-- [ ] Step 2: implement `resolve_effects` (called before the chaos respawn loop) returning bound responses or a consumer failure; bind responses in the task loop.
-- [ ] Step 3: green + clippy. Commit — `vix: resolve registered effect primitives at the demand layer`.
+- [x] Step 1: failing e2e tests (below).
+- [x] Step 2: implement `resolve_effects` (called before the chaos respawn loop) returning bound responses or a consumer failure; bind responses in the task loop.
+- [x] Step 3: green + clippy. Commit — `vix: resolve registered effect primitives at the demand layer`.
 
 ### Task 4: integration tests + phase gate + landing notes
 
@@ -78,7 +78,7 @@ Tests (`primitive_scheduler.rs`), compile+lower a real primitive and drive `Runt
 - Counter/event: `effect_spawns` increments on dispatch; a hit does not.
 - Pure regression guard: an effect-free `evaluate` is byte-identical.
 
-- [ ] Full suite green (cross-lane isolated if slow-killed) + clippy clean. Re-read the diff vs Hard Constraints. Append landing notes. Commit — `vix: mark phase 05 scheduler plan complete + landing notes`.
+- [x] Full suite green (cross-lane isolated if slow-killed) + clippy clean. Re-read the diff vs Hard Constraints. Append landing notes. Commit — `vix: mark phase 05 scheduler plan complete + landing notes`.
 
 ## Self-review notes
 
@@ -86,3 +86,33 @@ Tests (`primitive_scheduler.rs`), compile+lower a real primitive and drive `Runt
 - **Borrow discipline:** clone the `Arc<dyn Primitive>` out of `self.primitives` and the request `FrozenValue` out of `self.store` before `EffectCtx::new(&mut self.store)`, so the ctx's `&mut store` never aliases the primitive borrow or the request frozen (mirrors the phase-02 unit test).
 - **Resolve once:** effects resolve BEFORE the chaos respawn loop; responses bind per spawn. v1 effects run only under non-chaos `evaluate`, so no double-dispatch.
 - **String request fields:** `decode_value` rejects `FrozenValue::Reference` (store-resident strings). v1 core tests use scalar-field requests (Int/Bool) that realize inline; a String-request path (reference resolution before decode) is validated as a bonus / deferred to phase 06 if it needs a resolver.
+
+## Landing notes (phase 05 complete)
+
+**Commits (this branch):**
+- Task 1 `7319a80b2` — shared realized value-input binding across scheduler lanes (orchestrator-committed).
+- Task 2 `ff42fff09` — thread `PrimitiveSet` registry + effect identity into the runtime (orchestrator-committed).
+- Task 3 `f7a0a0807` — resolve registered effect primitives at the demand layer.
+- Task 4 `8f2772648` — certify effect resolution and the memo fold (`vix/tests/primitive_scheduler.rs`).
+
+**The key correctness insight — fold effect responses into the consumer demand key.** `evaluate` resolves every effect edge FIRST (before `DemandExecution::new`), then builds the consumer's demand arguments as `value identities ++ resolved effect-response identities`. So an effect participates in content-addressed memoization exactly like a value argument: two demands of the same consumer against the same Hermetic effect fold the *same* response identity and hit the consumer memo.
+
+**Dedicated effect memo (supersedes the self-review "Effect Location" note).** The effect result is keyed in a dedicated `effect_memo: BTreeMap<DemandKey, EffectMemoEntry { result: Handle, receipt: Receipt }>`, NOT the location-indexed pure `memo` via `LocationId(demand_key.0)`. The effect `DemandKey` is `from_preimage(closure: RecipeId::from_primitive_digest(id.0), arguments: [request identity])`, under the distinct `vix.recipe.effect.v1` domain — structurally uncollidable with a pure recipe. Only Hermetic populates it; Volatile skips lookup + insert.
+
+**Memo-fold proof (empirical, `primitive_scheduler.rs`):**
+- Hermetic: two identical consumer demands → **1** `begin` (AtomicUsize), `effect_spawns == 1`, exactly **1** `EventKind::EffectDispatched`. The 2nd demand re-evaluates the request (pure memo hit), hits `effect_memo` (no `begin`), folds the same response id → consumer memo hit.
+- Volatile: two demands → **2** `begin`, `effect_spawns == 2`, **2** dispatch events; `effect_memo` never touched.
+- Failed completion → `FailureValue::Primitive { recipe, site }` language failure through the normal `Evaluation.failure` path; 1 `begin`, `effect_spawns == 1`.
+- Effect-free `evaluate` → 0 spawns, 0 dispatch events; empty `effects: &[]` folds nothing → byte-identical demand identity (no pure-path regression).
+
+**Deltas from the plan prose (all in-spirit, none touch the memo-fold/effect_memo mandate):**
+- `FailureValue::Primitive { recipe: RecipeId, site: u32 }` drops the primitive's `code`/`message` from *identity* in v1 (rendered report bytes are non-identity storage, consistent with the other language failures); `failure_node` tags it `8`.
+- One generic effect plane: `MachineOperation::Effect` + `RuntimeFault::{UnregisteredEffect, UnsupportedEffectPolicy, EffectProtocol, MissingEffectRequestFrozen, UnsupportedEffectPosition}`, all keyed by `EffectId` data. Added one defensive `RuntimeFault::EffectInputCardinality { expected, actual }` so a bindings/effects count mismatch can never silently drop an effect and produce a colliding consumer key.
+- `resolve_effects` takes no `chaos` param: the nested request island is a pure demand and (like a wire) resolves under `ChaosPolicy::default()`; chaos does not cascade into it.
+- `drive_generator` carries an honest `UnsupportedEffectPosition` guard — the generator lane has no effects channel in v1, so a non-empty `effect_inputs` reaching it is a typed error, never silently ignored.
+- `EffectDispatched { key, recipe }` carries `RecipeId` (Facet) rather than `PrimitiveId` (not Facet) to keep `EventKind` derivable without leaking a runtime-only identity type.
+- Test surface uses an **Int request field + String response** (`probe where { n: Int } -> String`): the Int request decodes inline, and the String response interns and reads back cleanly through the shared realized-binding path. The String-request `decode_value` reference caveat still stands (deferred).
+
+**Pre-existing clippy drift (surfaced, not caused here):** current `nixpkgs#clippy` denies `result_large_err` on Task 1's committed `bind_realized_entry` (its `EntryBindError` carries an unboxed `MachineError`). Line-identical on HEAD; it began firing via registry clippy drift since Task 1 landed. Kept the gate green with a single localized `#[allow(clippy::result_large_err)]` + comment on that cold entry-binding path, rather than reopening the orchestrator-committed helper's shape across ~8 sites. Boxing every `EntryBindError` variant is the mechanical follow-up if the lint tightens further.
+
+**Gate:** `cargo clippy -p vix --all-targets -- -D warnings` clean. `cargo nextest run -p vix` green except the two pre-flagged >4-min tests (`cross_lane_differential::accepted_corpus_agrees…`, `ratchet_runner::accepted_rungs_verify…`), which nextest slow-kills under load; both re-run green in isolation via plain `cargo test` (documented non-regression). `primitive_scheduler` (4/4) green in isolation and in-context.

--- a/vix/src/lowering.rs
+++ b/vix/src/lowering.rs
@@ -118,6 +118,49 @@ pub struct EffectInputBinding {
     pub publication_schemas: Vec<(Type, WeavySchemaRef)>,
 }
 
+/// A borrowed view over the binding facts the scheduler needs to write a realized
+/// value into a task entry — the shared subset of [`ValueInputBinding`] and
+/// [`EffectInputBinding`]. One binding path, so a resolved effect response binds
+/// through the exact same code as any value input of its type
+/// (r[machine.primitive.registered]).
+#[derive(Clone, Copy)]
+pub struct RealizedBinding<'a> {
+    pub entry: usize,
+    pub schema: Option<WeavySchemaRef>,
+    pub store_schema: SchemaId,
+    pub payload_element_schema: Option<WeavySchemaRef>,
+    pub ty: &'a Type,
+    pub publication_schemas: &'a [(Type, WeavySchemaRef)],
+}
+
+impl ValueInputBinding {
+    #[must_use]
+    pub fn realized(&self) -> RealizedBinding<'_> {
+        RealizedBinding {
+            entry: self.entry,
+            schema: self.schema,
+            store_schema: self.store_schema,
+            payload_element_schema: self.payload_element_schema,
+            ty: &self.ty,
+            publication_schemas: &self.publication_schemas,
+        }
+    }
+}
+
+impl EffectInputBinding {
+    #[must_use]
+    pub fn realized(&self) -> RealizedBinding<'_> {
+        RealizedBinding {
+            entry: self.entry,
+            schema: self.schema,
+            store_schema: self.store_schema,
+            payload_element_schema: self.payload_element_schema,
+            ty: &self.ty,
+            publication_schemas: &self.publication_schemas,
+        }
+    }
+}
+
 /// The internal result ABI carried by every function in an array-bearing
 /// island. It is metadata for the verified artifact, not a source-level type.
 #[derive(facet::Facet, Clone, Debug, PartialEq, Eq)]

--- a/vix/src/ratchet.rs
+++ b/vix/src/ratchet.rs
@@ -832,6 +832,7 @@ fn evaluate_value_site(
         IslandInputs {
             arguments: &arguments,
             wires: &wires,
+            effects: &[],
         },
         chaos,
     )?;
@@ -903,6 +904,7 @@ fn evaluate_snapshot_site(
         IslandInputs {
             arguments: &arguments,
             wires: &wires,
+            effects: &[],
         },
         chaos,
     )?;
@@ -1018,6 +1020,7 @@ fn run_lane(
                 IslandInputs {
                     arguments: &arguments,
                     wires: &[],
+                    effects: &[],
                 },
                 ChaosPolicy {
                     kill_first_running_task: kill_available,

--- a/vix/src/runtime/error.rs
+++ b/vix/src/runtime/error.rs
@@ -3,8 +3,9 @@ use weavy::exec::TaskFault;
 use weavy::task::FnId;
 
 use crate::support::Span;
-use crate::vir::{FunctionId, NodeId};
+use crate::vir::{EffectId, FunctionId, NodeId};
 
+use super::primitive::EffectProtocolError;
 use super::{DemandKey, ValueId};
 
 /// The production machine failure plane. Language diagnostics and Vix Failure
@@ -37,6 +38,9 @@ pub enum MachineOperation {
     DemandTransition,
     TaskTransition,
     TraceAttribution,
+    /// Resolving a registered effect primitive at the demand layer. One generic
+    /// operation for every primitive (r[machine.primitive.registered]).
+    Effect,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -81,6 +85,41 @@ pub enum RuntimeFault {
         site: u32,
         index: i64,
         length: i64,
+    },
+    /// An artifact named an effect id no registered primitive claims. Generic,
+    /// keyed by the effect id data (r[machine.primitive.registered]).
+    UnregisteredEffect {
+        effect: EffectId,
+    },
+    /// A registered primitive declared a memo policy v1 does not implement
+    /// (Pinned/Observed ship with fetch/exec). Honest typed error, never
+    /// silently treated as Hermetic (design constraint 4).
+    UnsupportedEffectPolicy {
+        effect: EffectId,
+    },
+    /// A registered primitive violated the begin/complete protocol. Lifts the
+    /// phase-02 [`EffectProtocolError`] onto the machine-error plane.
+    EffectProtocol {
+        effect: EffectId,
+        error: EffectProtocolError,
+    },
+    /// The request island produced no frozen replay tree to hand the primitive —
+    /// a machine invariant (the request record always realizes structurally).
+    MissingEffectRequestFrozen {
+        effect: EffectId,
+    },
+    /// An effect reached a position v1 does not wire (e.g. a generator island).
+    /// A primitive is callable only from a test-body value expression in v1.
+    UnsupportedEffectPosition {
+        effect: EffectId,
+    },
+    /// The caller-supplied effect demands and the consumer artifact's effect
+    /// bindings disagreed in count. A machine invariant: they are built together.
+    /// Guarded so a dropped effect can never silently produce a colliding
+    /// consumer demand key.
+    EffectInputCardinality {
+        expected: usize,
+        actual: usize,
     },
 }
 

--- a/vix/src/runtime/identity.rs
+++ b/vix/src/runtime/identity.rs
@@ -26,6 +26,16 @@ impl RecipeId {
     pub fn from_canonical_vir(bytes: &[u8]) -> Self {
         Self(hash_framed(b"vix.recipe.v1", &[bytes]))
     }
+
+    /// The effect recipe for a registered primitive: its 32 content bytes under a
+    /// domain distinct from pure vir recipes, so an effect demand can never
+    /// collide structurally with a pure demand (design §2,
+    /// r[machine.arch.reuse-axes-distinct]). One generic derivation for every
+    /// primitive, keyed by the id digest (r[machine.primitive.registered]).
+    #[must_use]
+    pub fn from_primitive_digest(digest: Digest) -> Self {
+        Self(hash_framed(b"vix.recipe.effect.v1", &[&digest.0]))
+    }
 }
 
 #[derive(facet::Facet, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/vix/src/runtime/model.rs
+++ b/vix/src/runtime/model.rs
@@ -78,6 +78,19 @@ pub enum FailureValue {
         recipe: RecipeId,
         site: u32,
     },
+    /// A registered effect primitive reported a typed language failure
+    /// ([`Completion::Failed`]). One generic variant for every primitive, keyed by
+    /// the effect closure recipe (r[machine.primitive.registered]). The
+    /// [`PrimitiveFailure`] `code`/`message` are contextual reporting fields, not
+    /// part of value identity (consistent with `FailureContext` not being
+    /// resident), so v1 keeps only the recipe + site here.
+    ///
+    /// [`Completion::Failed`]: super::primitive::Completion::Failed
+    /// [`PrimitiveFailure`]: super::primitive::PrimitiveFailure
+    Primitive {
+        recipe: RecipeId,
+        site: u32,
+    },
 }
 
 /// Context rebuilt while reporting a language failure. It is deliberately not

--- a/vix/src/runtime/observe.rs
+++ b/vix/src/runtime/observe.rs
@@ -2,7 +2,7 @@ use crate::diagnostic::DiagnosticCode;
 use crate::vir::{FunctionId, IslandId, NodeId};
 
 use super::MachineOperation;
-use super::identity::{DemandKey, LocationId, ValueId};
+use super::identity::{DemandKey, LocationId, RecipeId, ValueId};
 use super::model::{DemandState, FailureValue, MemoVerdict, TaskId, TaskState};
 
 #[derive(facet::Facet, Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -139,6 +139,14 @@ pub enum EventKind {
     Completed {
         key: DemandKey,
         identity: ValueId,
+    },
+    /// A registered effect primitive was actually dispatched (a `begin` call, not
+    /// a memo hit). One generic event for every primitive, keyed by the effect
+    /// demand and its closure recipe as DATA (r[machine.primitive.registered]).
+    /// A memo hit does not emit this and does not spawn.
+    EffectDispatched {
+        key: DemandKey,
+        recipe: RecipeId,
     },
     ConservativeFallback {
         code: DiagnosticCode,

--- a/vix/src/runtime/primitive/register.rs
+++ b/vix/src/runtime/primitive/register.rs
@@ -108,6 +108,17 @@ impl PrimitiveSet {
             .find(|primitive| primitive.descriptor().id == id)
     }
 
+    /// Resolve the `vir::EffectId` an artifact carries back to its registered
+    /// primitive. This is the `EffectId -> PrimitiveId` conversion at the runtime
+    /// boundary (r[machine.ir.vix-level]): `vir`/`lowering` stay identity-agnostic,
+    /// the scheduler converts here. One generic scan keyed by the id data, no
+    /// per-primitive arms (r[machine.primitive.registered]).
+    pub(crate) fn by_effect_id(&self, effect: crate::vir::EffectId) -> Option<&Arc<dyn Primitive>> {
+        self.entries
+            .values()
+            .find(|primitive| primitive.descriptor().id.effect_id() == effect)
+    }
+
     /// The registered descriptors — the compiler manifest (phase 03).
     pub fn descriptors(&self) -> impl Iterator<Item = &PrimitiveDescriptor> {
         self.entries.values().map(|primitive| primitive.descriptor())
@@ -259,6 +270,30 @@ mod tests {
             .clone();
         let response: AddResponse = decode_value(&response_frozen, &response_type).unwrap();
         assert_eq!(response.sum, 42);
+    }
+
+    #[test]
+    fn by_effect_id_resolves_the_registered_primitive() {
+        let mut set = PrimitiveSet::new();
+        let id = set
+            .register_function::<AddResponse, AddRequest, _>(
+                "add_numbers",
+                MemoPolicy::Hermetic,
+                |r| Ok(AddResponse { sum: r.left + r.right }),
+            )
+            .unwrap();
+        assert!(
+            set.by_effect_id(id.effect_id()).is_some(),
+            "the effect id resolves back to the primitive at the runtime boundary"
+        );
+        assert!(
+            set.by_effect_id(crate::vir::EffectId([0u8; 32])).is_none(),
+            "an unknown effect id resolves to nothing"
+        );
+        // The effect recipe is stable and can never collide with a pure recipe.
+        let recipe = crate::runtime::RecipeId::from_primitive_digest(id.0);
+        assert_eq!(recipe, crate::runtime::RecipeId::from_primitive_digest(id.0));
+        assert_ne!(recipe, crate::runtime::RecipeId::from_canonical_vir(&id.0.0));
     }
 
     #[test]

--- a/vix/src/runtime/scheduler.rs
+++ b/vix/src/runtime/scheduler.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::ops::Deref;
+use std::sync::Arc;
 
 use weavy::exec::{
     FallbackReason, FaultSite, LaneKind, ResolvedTaskValue, TaskFault, TaskStructuralValue,
@@ -23,6 +24,7 @@ use super::observe::{
     Counters, Event, EventKind, EventSink, ExecutionFacts, ExecutionFallbackFact,
     ExecutionLaneFact, SafePointClass,
 };
+use super::primitive::PrimitiveSet;
 use super::store::{FrozenValue, Handle, Interned, Store, StoreEntry};
 use super::{MachineAttribution, MachineError, MachineOperation, RuntimeFault};
 
@@ -91,6 +93,29 @@ pub struct ChaosPolicy {
 pub struct IslandInputs<'a> {
     pub arguments: &'a [Evaluation],
     pub wires: &'a [WireDemand<'a>],
+    /// The effect edges this island consumes, one per `LoweringArtifact`
+    /// effect binding, in the same order. Each carries the request island
+    /// (a pure demand) whose realized value is the primitive's request; the
+    /// scheduler resolves it at the demand layer. Empty for an effect-free
+    /// island, so no pure hot path is touched (r[machine.primitive.registered]).
+    pub effects: &'a [EffectDemand<'a>],
+}
+
+/// One registered effect an island consumes. Parallel to [`WireDemand`] but for
+/// an effect: it carries the request-producing island's ordinary pure demand
+/// (recipe artifact, cost-model location, realized arguments, nested wires) so
+/// the scheduler evaluates it to the request value, then dispatches the
+/// primitive named by the consumer artifact's positionally-matching
+/// `EffectInputBinding`. One generic shape for every primitive
+/// (r[machine.primitive.registered]).
+#[derive(Clone, Copy)]
+pub struct EffectDemand<'a> {
+    pub request_island: IslandId,
+    pub request_location: &'a Location,
+    pub request_lowered: &'a LoweringArtifact,
+    pub request_attribution: &'a LoweringAttribution,
+    pub request_arguments: &'a [Evaluation],
+    pub request_wires: &'a [WireDemand<'a>],
 }
 
 /// One demand wire an island may force: the canonical argument demand the
@@ -161,6 +186,12 @@ pub struct Runtime<S> {
     /// log counts realizations. It backs the described-wire trace checks and
     /// retains only the callee/argument selectors a descriptor can name.
     wire_demands: Vec<(FunctionId, Vec<ValueId>)>,
+    /// The registered effect primitives this runtime may dispatch. An OPTIONAL
+    /// slot, empty by default: every existing runtime is built with no
+    /// primitives, so an effect-free island resolves nothing and hits zero new
+    /// code (r[machine.execution.no-pure-hostcalls]). Shared behind an `Arc` so
+    /// the same registry can back many runtimes.
+    primitives: Arc<PrimitiveSet>,
 }
 
 impl<S: EventSink> Runtime<S> {
@@ -176,7 +207,19 @@ impl<S: EventSink> Runtime<S> {
             counters: Counters::default(),
             next_task: 0,
             wire_demands: Vec::new(),
+            primitives: Arc::new(PrimitiveSet::new()),
         }
+    }
+
+    /// Install the effect-primitive registry the effect path dispatches through.
+    /// The `EffectId` an artifact carries is resolved back to a `PrimitiveId`
+    /// here (`PrimitiveSet::by_effect_id`); `vir`/`lowering` stay identity-
+    /// agnostic (r[machine.ir.vix-level]). Default runtimes carry an empty
+    /// registry and never enter the effect path.
+    #[must_use]
+    pub fn with_primitives(mut self, primitives: Arc<PrimitiveSet>) -> Self {
+        self.primitives = primitives;
+        self
     }
 
     /// The frozen log of realized wire demands: each callee invocation the memo
@@ -214,7 +257,11 @@ impl<S: EventSink> Runtime<S> {
         inputs: IslandInputs<'_>,
         chaos: ChaosPolicy,
     ) -> Result<Evaluation, Box<MachineError>> {
-        let IslandInputs { arguments, wires } = inputs;
+        let IslandInputs {
+            arguments,
+            wires,
+            effects: _,
+        } = inputs;
         let invocation = DemandExecution::new(
             lowered,
             arguments.iter().map(|argument| argument.identity).collect(),
@@ -545,6 +592,7 @@ impl<S: EventSink> Runtime<S> {
                             IslandInputs {
                                 arguments: wire.arguments,
                                 wires: wire.wires,
+                                effects: &[],
                             },
                             ChaosPolicy::default(),
                         )?;
@@ -3365,6 +3413,7 @@ fn duplicate_key() -> Stream<Check> {
                     IslandInputs {
                         arguments: &[],
                         wires: &[],
+                        effects: &[],
                     },
                     ChaosPolicy::default(),
                 )
@@ -3407,6 +3456,7 @@ fn duplicate_key() -> Stream<Check> {
                     IslandInputs {
                         arguments: &[],
                         wires: &[],
+                        effects: &[],
                     },
                     ChaosPolicy::default(),
                 )
@@ -3481,6 +3531,7 @@ fn duplicate_key() -> Stream<Check> {
                     IslandInputs {
                         arguments: &[],
                         wires: &[],
+                        effects: &[],
                     },
                     ChaosPolicy::default(),
                 )
@@ -3554,6 +3605,7 @@ fn passing() -> Stream<Check> {
                 IslandInputs {
                     arguments: &[],
                     wires: &[],
+                    effects: &[],
                 },
                 ChaosPolicy::default(),
             )

--- a/vix/src/runtime/scheduler.rs
+++ b/vix/src/runtime/scheduler.rs
@@ -8,7 +8,7 @@ use weavy::exec::{
 };
 use weavy::task::{FnId, TaskEvent as WeavyTaskEvent, TaskStep};
 
-use crate::lowering::{LoweringArtifact, LoweringAttribution, ValueInputBinding};
+use crate::lowering::{LoweringArtifact, LoweringAttribution, RealizedBinding};
 use crate::vir::{FunctionId, IslandId, Type, VariantPayload};
 
 use super::identity::{
@@ -33,6 +33,20 @@ struct MemoEntry {
     preimage: DemandPreimage,
     result: Handle,
     receipt: Option<Receipt>,
+}
+
+/// The failure of one realized-entry bind, tagged by the per-lane policy the two
+/// scheduler lanes historically applied so [`Runtime::bind_realized_entry`]'s
+/// callers preserve their exact behavior. See the helper's doc comment.
+enum EntryBindError {
+    /// A machine invariant (schema mismatch / missing value-input handle). The
+    /// value-island lane terminates the task/demand; the generator lane returns
+    /// the raw error.
+    Invariant(MachineError),
+    /// A Weavy entry write fault — both lanes terminate.
+    WriteFault(MachineError),
+    /// A frozen conversion or missing binding schema — both lanes return raw.
+    Raw(Box<MachineError>),
 }
 
 struct DemandExecution<'a> {
@@ -426,106 +440,27 @@ impl<S: EventSink> Runtime<S> {
                     )));
                 }
             }
+            let mut value_memory_overrides = Vec::new();
             for (binding, argument) in lowered.value_inputs.iter().zip(arguments) {
-                if binding.store_schema != argument.identity.schema {
-                    let error = MachineError::runtime(
-                        MachineOperation::EntryBinding,
-                        RuntimeFault::ValueInputSchemaMismatch,
-                        None,
-                        Some(lowered.demand_key),
-                    );
-                    return Err(Box::new(self.terminate_machine_fault(
-                        task_id,
-                        lowered.demand_key,
-                        error,
-                    )));
-                }
-                let frozen = self
-                    .store
-                    .entry(argument.handle)
-                    .and_then(StoreEntry::frozen)
-                    .map(|frozen| frozen_to_weavy(frozen, &binding.ty, binding, &self.store))
-                    .transpose()
-                    .map_err(|()| {
-                        Box::new(MachineError::runtime(
-                            MachineOperation::EntryBinding,
-                            RuntimeFault::ValueInputSchemaMismatch,
-                            None,
-                            Some(lowered.demand_key),
-                        ))
-                    })?;
-                let result = if let Some(frozen) = &frozen {
-                    task.write_entry_frozen(binding.entry, frozen)
-                } else {
-                    let Some(handle) = self.store.weavy_handle(argument.handle) else {
-                        let error = MachineError::runtime(
-                            MachineOperation::EntryBinding,
-                            RuntimeFault::MissingValueInputStoreHandle,
-                            None,
-                            Some(lowered.demand_key),
-                        );
+                match self.bind_realized_entry(
+                    &mut task,
+                    binding.realized(),
+                    argument.handle,
+                    argument.identity,
+                    lowered,
+                    attribution,
+                ) {
+                    Ok(Some(override_)) => value_memory_overrides.push(override_),
+                    Ok(None) => {}
+                    Err(EntryBindError::Invariant(error) | EntryBindError::WriteFault(error)) => {
                         return Err(Box::new(self.terminate_machine_fault(
                             task_id,
                             lowered.demand_key,
                             error,
                         )));
-                    };
-                    task.write_entry_store_handle(
-                        binding.entry,
-                        binding.schema.ok_or_else(|| {
-                            Box::new(MachineError::runtime(
-                                MachineOperation::EntryBinding,
-                                RuntimeFault::ValueInputSchemaMismatch,
-                                None,
-                                Some(lowered.demand_key),
-                            ))
-                        })?,
-                        handle,
-                    )
-                };
-                if let Err(fault) = result {
-                    let error = self.task_fault(
-                        MachineOperation::EntryBinding,
-                        fault,
-                        lowered,
-                        attribution,
-                        None,
-                    );
-                    return Err(Box::new(self.terminate_machine_fault(
-                        task_id,
-                        lowered.demand_key,
-                        error,
-                    )));
+                    }
+                    Err(EntryBindError::Raw(error)) => return Err(error),
                 }
-            }
-            let mut value_memory_overrides = Vec::new();
-            for (binding, argument) in lowered.value_inputs.iter().zip(arguments) {
-                let Some(element_schema) = binding.payload_element_schema else {
-                    continue;
-                };
-                let resident = self
-                    .store
-                    .entry(argument.handle)
-                    .and_then(StoreEntry::resident_bytes)
-                    .ok_or_else(|| {
-                        Box::new(MachineError::runtime(
-                            MachineOperation::EntryBinding,
-                            RuntimeFault::MissingValueInputStoreHandle,
-                            None,
-                            Some(lowered.demand_key),
-                        ))
-                    })?;
-                let mut abi_view = resident.to_vec();
-                let schema_bytes = abi_view.get_mut(8..16).ok_or_else(|| {
-                    Box::new(MachineError::runtime(
-                        MachineOperation::EntryBinding,
-                        RuntimeFault::ValueInputSchemaMismatch,
-                        None,
-                        Some(lowered.demand_key),
-                    ))
-                })?;
-                schema_bytes.copy_from_slice(&i64::from(element_schema.0).to_le_bytes());
-                value_memory_overrides.push((argument.handle, abi_view));
             }
             // Demand wires start unresolved. The task drives until it parks on a
             // wire it actually consumes; only then does the scheduler evaluate
@@ -1122,96 +1057,28 @@ impl<S: EventSink> Runtime<S> {
                     )));
                 }
             }
-            for (binding, argument) in lowered.value_inputs.iter().zip(arguments) {
-                if binding.store_schema != argument.identity.schema {
-                    return Err(Box::new(MachineError::runtime(
-                        MachineOperation::EntryBinding,
-                        RuntimeFault::ValueInputSchemaMismatch,
-                        None,
-                        Some(lowered.demand_key),
-                    )));
-                }
-                let frozen = self
-                    .store
-                    .entry(argument.handle)
-                    .and_then(StoreEntry::frozen)
-                    .map(|frozen| frozen_to_weavy(frozen, &binding.ty, binding, &self.store))
-                    .transpose()
-                    .map_err(|()| {
-                        Box::new(MachineError::runtime(
-                            MachineOperation::EntryBinding,
-                            RuntimeFault::ValueInputSchemaMismatch,
-                            None,
-                            Some(lowered.demand_key),
-                        ))
-                    })?;
-                let result = if let Some(frozen) = &frozen {
-                    task.write_entry_frozen(binding.entry, frozen)
-                } else {
-                    let handle = self.store.weavy_handle(argument.handle).ok_or_else(|| {
-                        Box::new(MachineError::runtime(
-                            MachineOperation::EntryBinding,
-                            RuntimeFault::MissingValueInputStoreHandle,
-                            None,
-                            Some(lowered.demand_key),
-                        ))
-                    })?;
-                    task.write_entry_store_handle(
-                        binding.entry,
-                        binding.schema.ok_or_else(|| {
-                            Box::new(MachineError::runtime(
-                                MachineOperation::EntryBinding,
-                                RuntimeFault::ValueInputSchemaMismatch,
-                                None,
-                                Some(lowered.demand_key),
-                            ))
-                        })?,
-                        handle,
-                    )
-                };
-                if let Err(fault) = result {
-                    let error = self.task_fault(
-                        MachineOperation::EntryBinding,
-                        fault,
-                        lowered,
-                        attribution,
-                        None,
-                    );
-                    return Err(Box::new(self.terminate_machine_fault(
-                        task_id,
-                        lowered.demand_key,
-                        error,
-                    )));
-                }
-            }
             let mut value_memory_overrides = Vec::new();
             for (binding, argument) in lowered.value_inputs.iter().zip(arguments) {
-                let Some(element_schema) = binding.payload_element_schema else {
-                    continue;
-                };
-                let resident = self
-                    .store
-                    .entry(argument.handle)
-                    .and_then(StoreEntry::resident_bytes)
-                    .ok_or_else(|| {
-                        Box::new(MachineError::runtime(
-                            MachineOperation::EntryBinding,
-                            RuntimeFault::MissingValueInputStoreHandle,
-                            None,
-                            Some(lowered.demand_key),
-                        ))
-                    })?;
-                let mut abi_view = resident.to_vec();
-                let schema_bytes = abi_view.get_mut(8..16).ok_or_else(|| {
-                    Box::new(MachineError::runtime(
-                        MachineOperation::EntryBinding,
-                        RuntimeFault::ValueInputSchemaMismatch,
-                        None,
-                        Some(lowered.demand_key),
-                    ))
-                })?;
-                schema_bytes.copy_from_slice(&i64::from(element_schema.0).to_le_bytes());
-                value_memory_overrides.push((argument.handle, abi_view));
+                match self.bind_realized_entry(
+                    &mut task,
+                    binding.realized(),
+                    argument.handle,
+                    argument.identity,
+                    lowered,
+                    attribution,
+                ) {
+                    Ok(Some(override_)) => value_memory_overrides.push(override_),
+                    Ok(None) => {}
+                    Err(EntryBindError::Invariant(error)) => return Err(Box::new(error)),
+                    Err(EntryBindError::WriteFault(error)) => {
+                        return Err(Box::new(self.terminate_machine_fault(
+                            task_id,
+                            lowered.demand_key,
+                            error,
+                        )));
+                    }
+                    Err(EntryBindError::Raw(error)) => return Err(error),
+                }
             }
             let step = match self.store.with_value_memory_overrides(
                 &value_memory_overrides,
@@ -1568,6 +1435,105 @@ impl<S: EventSink> Runtime<S> {
         task.state = to;
         self.emit(EventKind::TaskTransition { task: id, from, to });
         Ok(())
+    }
+
+    /// Write one realized value (a value input or a resolved effect response) into
+    /// its task entry through the store-handle/frozen channel, and, when the
+    /// binding carries a payload element schema, compute the invocation-local ABI
+    /// override for that entry. This is the single binding path shared by both
+    /// scheduler lanes and by effect resolution (r[machine.primitive.registered]).
+    ///
+    /// Errors are typed by the two lanes' historical policy so each caller can
+    /// preserve it exactly: [`EntryBindError::WriteFault`] both lanes terminate;
+    /// [`EntryBindError::Raw`] both return raw; [`EntryBindError::Invariant`] the
+    /// value-island lane terminates and the generator lane returns raw.
+    fn bind_realized_entry(
+        &self,
+        task: &mut weavy::exec::ExecTask<'_>,
+        binding: RealizedBinding<'_>,
+        handle: Handle,
+        identity: ValueId,
+        lowered: &DemandExecution<'_>,
+        attribution: &LoweringAttribution,
+    ) -> Result<Option<(Handle, Vec<u8>)>, EntryBindError> {
+        if binding.store_schema != identity.schema {
+            return Err(EntryBindError::Invariant(MachineError::runtime(
+                MachineOperation::EntryBinding,
+                RuntimeFault::ValueInputSchemaMismatch,
+                None,
+                Some(lowered.demand_key),
+            )));
+        }
+        let frozen = self
+            .store
+            .entry(handle)
+            .and_then(StoreEntry::frozen)
+            .map(|frozen| frozen_to_weavy(frozen, binding.ty, binding, &self.store))
+            .transpose()
+            .map_err(|()| {
+                EntryBindError::Raw(Box::new(MachineError::runtime(
+                    MachineOperation::EntryBinding,
+                    RuntimeFault::ValueInputSchemaMismatch,
+                    None,
+                    Some(lowered.demand_key),
+                )))
+            })?;
+        let result = if let Some(frozen) = &frozen {
+            task.write_entry_frozen(binding.entry, frozen)
+        } else {
+            let Some(store_handle) = self.store.weavy_handle(handle) else {
+                return Err(EntryBindError::Invariant(MachineError::runtime(
+                    MachineOperation::EntryBinding,
+                    RuntimeFault::MissingValueInputStoreHandle,
+                    None,
+                    Some(lowered.demand_key),
+                )));
+            };
+            let schema = binding.schema.ok_or_else(|| {
+                EntryBindError::Raw(Box::new(MachineError::runtime(
+                    MachineOperation::EntryBinding,
+                    RuntimeFault::ValueInputSchemaMismatch,
+                    None,
+                    Some(lowered.demand_key),
+                )))
+            })?;
+            task.write_entry_store_handle(binding.entry, schema, store_handle)
+        };
+        if let Err(fault) = result {
+            return Err(EntryBindError::WriteFault(self.task_fault(
+                MachineOperation::EntryBinding,
+                fault,
+                lowered,
+                attribution,
+                None,
+            )));
+        }
+        let Some(element_schema) = binding.payload_element_schema else {
+            return Ok(None);
+        };
+        let resident = self
+            .store
+            .entry(handle)
+            .and_then(StoreEntry::resident_bytes)
+            .ok_or_else(|| {
+                EntryBindError::Raw(Box::new(MachineError::runtime(
+                    MachineOperation::EntryBinding,
+                    RuntimeFault::MissingValueInputStoreHandle,
+                    None,
+                    Some(lowered.demand_key),
+                )))
+            })?;
+        let mut abi_view = resident.to_vec();
+        let schema_bytes = abi_view.get_mut(8..16).ok_or_else(|| {
+            EntryBindError::Raw(Box::new(MachineError::runtime(
+                MachineOperation::EntryBinding,
+                RuntimeFault::ValueInputSchemaMismatch,
+                None,
+                Some(lowered.demand_key),
+            )))
+        })?;
+        schema_bytes.copy_from_slice(&i64::from(element_schema.0).to_le_bytes());
+        Ok(Some((handle, abi_view)))
     }
 
     fn emit_weavy(
@@ -2587,7 +2553,7 @@ impl FrozenInline {
 fn frozen_to_weavy(
     frozen: &FrozenValue,
     ty: &Type,
-    binding: &ValueInputBinding,
+    binding: RealizedBinding<'_>,
     store: &Store,
 ) -> Result<weavy::exec::FrozenValue, ()> {
     match (frozen, ty) {
@@ -2657,7 +2623,7 @@ fn frozen_to_weavy(
 fn frozen_inline(
     frozen: &FrozenValue,
     ty: &Type,
-    binding: &ValueInputBinding,
+    binding: RealizedBinding<'_>,
     store: &Store,
 ) -> Result<FrozenInline, ()> {
     match ty {
@@ -2717,7 +2683,7 @@ fn frozen_inline(
 fn frozen_product<'a>(
     fields: &[FrozenValue],
     field_types: impl Iterator<Item = &'a Type>,
-    binding: &ValueInputBinding,
+    binding: RealizedBinding<'_>,
     store: &Store,
     base: usize,
 ) -> Result<FrozenInline, ()> {
@@ -2746,7 +2712,7 @@ fn frozen_product<'a>(
     Ok(FrozenInline { bytes, references })
 }
 
-fn publication_schema(binding: &ValueInputBinding, ty: &Type) -> Result<weavy::SchemaRef, ()> {
+fn publication_schema(binding: RealizedBinding<'_>, ty: &Type) -> Result<weavy::SchemaRef, ()> {
     binding
         .publication_schemas
         .iter()

--- a/vix/src/runtime/scheduler.rs
+++ b/vix/src/runtime/scheduler.rs
@@ -9,11 +9,14 @@ use weavy::exec::{
 };
 use weavy::task::{FnId, TaskEvent as WeavyTaskEvent, TaskStep};
 
-use crate::lowering::{LoweringArtifact, LoweringAttribution, RealizedBinding};
+use crate::lowering::{
+    EffectInputBinding, LoweringArtifact, LoweringAttribution, RealizedBinding,
+};
 use crate::vir::{FunctionId, IslandId, Type, VariantPayload};
 
 use super::identity::{
-    DemandKey, DemandPreimage, Location, LocationId, SchemaId, ValueId, semantic_schema_id,
+    DemandKey, DemandPreimage, Location, LocationId, RecipeId, SchemaId, ValueId,
+    semantic_schema_id,
 };
 use super::identity::{FramedField, FramedNode, FramedValue};
 use super::model::{
@@ -24,7 +27,7 @@ use super::observe::{
     Counters, Event, EventKind, EventSink, ExecutionFacts, ExecutionFallbackFact,
     ExecutionLaneFact, SafePointClass,
 };
-use super::primitive::PrimitiveSet;
+use super::primitive::{Completion, EffectCtx, MemoPolicy, PrimitiveSet, RequestRef};
 use super::store::{FrozenValue, Handle, Interned, Store, StoreEntry};
 use super::{MachineAttribution, MachineError, MachineOperation, RuntimeFault};
 
@@ -35,6 +38,22 @@ struct MemoEntry {
     preimage: DemandPreimage,
     result: Handle,
     receipt: Option<Receipt>,
+}
+
+/// One memoized effect result. Effects are content-addressed by their
+/// [`DemandKey`] alone — (primitive recipe, request value) — so this dedicated
+/// map can never collide with the location-indexed pure `memo`
+/// (r[machine.memo.effect-results]). The receipt is the first real producer:
+/// the demand plus the reads the primitive witnessed.
+#[derive(Clone, Debug)]
+struct EffectMemoEntry {
+    result: Handle,
+    /// The demand plus the reads the primitive witnessed. Retained as the
+    /// effect's provenance receipt; the replay/verification consumer arrives
+    /// with the Pinned/Observed policies in a later phase, so v1 stores it
+    /// without yet reading it back.
+    #[allow(dead_code)]
+    receipt: Receipt,
 }
 
 /// The failure of one realized-entry bind, tagged by the per-lane policy the two
@@ -192,6 +211,12 @@ pub struct Runtime<S> {
     /// code (r[machine.execution.no-pure-hostcalls]). Shared behind an `Arc` so
     /// the same registry can back many runtimes.
     primitives: Arc<PrimitiveSet>,
+    /// Content-addressed effect results, keyed by the effect's own
+    /// [`DemandKey`] — (primitive recipe, request value). Kept separate from the
+    /// location-indexed pure `memo` so an effect result can never collide with a
+    /// pure island's memo (r[machine.memo.effect-results]). Only Hermetic
+    /// effects populate it; Volatile skips both lookup and insert.
+    effect_memo: BTreeMap<DemandKey, EffectMemoEntry>,
 }
 
 impl<S: EventSink> Runtime<S> {
@@ -208,6 +233,7 @@ impl<S: EventSink> Runtime<S> {
             next_task: 0,
             wire_demands: Vec::new(),
             primitives: Arc::new(PrimitiveSet::new()),
+            effect_memo: BTreeMap::new(),
         }
     }
 
@@ -260,12 +286,21 @@ impl<S: EventSink> Runtime<S> {
         let IslandInputs {
             arguments,
             wires,
-            effects: _,
+            effects,
         } = inputs;
-        let invocation = DemandExecution::new(
-            lowered,
-            arguments.iter().map(|argument| argument.identity).collect(),
-        );
+        // Resolve every effect edge FIRST: an effect's response identity is part
+        // of the consumer's demand identity, so the demand key is only correct
+        // once each request island is evaluated, its primitive dispatched (or an
+        // effect-memo hit taken), and the response interned. Effect-free islands
+        // resolve an empty slice and touch none of this. A failed effect (failed
+        // request or Failed completion) comes back as a failed `Evaluation`; its
+        // identity still folds into the key and the failed-argument scan below
+        // short-circuits the consumer.
+        let resolved_effects = self.resolve_effects(&lowered.effect_inputs, effects)?;
+        let mut demand_arguments: Vec<ValueId> =
+            arguments.iter().map(|argument| argument.identity).collect();
+        demand_arguments.extend(resolved_effects.iter().map(|effect| effect.identity));
+        let invocation = DemandExecution::new(lowered, demand_arguments);
         let lowered = &invocation;
         self.emit(EventKind::Demanded {
             key: lowered.demand_key,
@@ -357,7 +392,11 @@ impl<S: EventSink> Runtime<S> {
             to: DemandState::Queued,
         });
 
-        if let Some(argument) = arguments.iter().find(|argument| argument.failure.is_some()) {
+        if let Some(argument) = arguments
+            .iter()
+            .chain(resolved_effects.iter())
+            .find(|argument| argument.failure.is_some())
+        {
             let failure = argument.failure.clone().expect("selected failed argument");
             self.memo.insert(
                 location.id,
@@ -494,6 +533,30 @@ impl<S: EventSink> Runtime<S> {
                     binding.realized(),
                     argument.handle,
                     argument.identity,
+                    lowered,
+                    attribution,
+                ) {
+                    Ok(Some(override_)) => value_memory_overrides.push(override_),
+                    Ok(None) => {}
+                    Err(EntryBindError::Invariant(error) | EntryBindError::WriteFault(error)) => {
+                        return Err(Box::new(self.terminate_machine_fault(
+                            task_id,
+                            lowered.demand_key,
+                            error,
+                        )));
+                    }
+                    Err(EntryBindError::Raw(error)) => return Err(error),
+                }
+            }
+            // Bind each resolved effect response at its artifact entry slot
+            // (`value_inputs.len() + k`) through the exact same realized-binding
+            // path as any value input — one generic binding for every primitive.
+            for (binding, effect) in lowered.effect_inputs.iter().zip(&resolved_effects) {
+                match self.bind_realized_entry(
+                    &mut task,
+                    binding.realized(),
+                    effect.handle,
+                    effect.identity,
                     lowered,
                     attribution,
                 ) {
@@ -1002,6 +1065,20 @@ impl<S: EventSink> Runtime<S> {
             from: DemandState::Absent,
             to: DemandState::Queued,
         });
+        // v1 wires effects only through the value-island lane (`evaluate`). A
+        // generator island carrying an effect binding is an unsupported position,
+        // reported honestly rather than silently ignored. The generator lane has
+        // no effects channel, so this is the only place an effect could leak in.
+        if let Some(binding) = lowered.effect_inputs.first() {
+            return Err(Box::new(MachineError::runtime(
+                MachineOperation::Effect,
+                RuntimeFault::UnsupportedEffectPosition {
+                    effect: binding.primitive,
+                },
+                None,
+                Some(lowered.demand_key),
+            )));
+        }
         if lowered.value_inputs.len() != arguments.len() {
             return Err(Box::new(MachineError::runtime(
                 MachineOperation::EntryBinding,
@@ -1405,6 +1482,234 @@ impl<S: EventSink> Runtime<S> {
         })
     }
 
+    /// Resolve every effect edge a consumer island demands into a realized
+    /// [`Evaluation`], in binding order. One generic path for every registered
+    /// primitive (r[machine.primitive.registered]): evaluate the request island
+    /// as an ordinary pure demand, fold `(primitive recipe, request value)` into
+    /// the effect's own content-addressed demand key, consult the dedicated
+    /// effect memo policy-aware, and on a miss dispatch the primitive through its
+    /// sole `EffectCtx` window. The returned response identities are what the
+    /// caller folds into the CONSUMER's demand key, so an effect participates in
+    /// content-addressed memoization exactly like a value argument.
+    fn resolve_effects(
+        &mut self,
+        bindings: &[EffectInputBinding],
+        effects: &[EffectDemand<'_>],
+    ) -> Result<Vec<Evaluation>, Box<MachineError>> {
+        if bindings.len() != effects.len() {
+            return Err(Box::new(MachineError::runtime(
+                MachineOperation::Effect,
+                RuntimeFault::EffectInputCardinality {
+                    expected: bindings.len(),
+                    actual: effects.len(),
+                },
+                None,
+                None,
+            )));
+        }
+        let mut resolved = Vec::with_capacity(bindings.len());
+        for (binding, demand) in bindings.iter().zip(effects) {
+            // Step 1 — the request island is a pure demand. Evaluate it through
+            // the canonical memo path; chaos does not cascade into a nested
+            // demand (matching the wire path).
+            let request = self.evaluate(
+                demand.request_island,
+                demand.request_location,
+                demand.request_lowered,
+                demand.request_attribution,
+                IslandInputs {
+                    arguments: demand.request_arguments,
+                    wires: demand.request_wires,
+                    effects: &[],
+                },
+                ChaosPolicy::default(),
+            )?;
+            // Step 2 — a failed request short-circuits: no dispatch. The failed
+            // value flows on as the effect's result; its identity folds into the
+            // consumer key and the consumer's failed-argument scan trips.
+            if request.failure.is_some() {
+                resolved.push(request);
+                continue;
+            }
+            // Step 3 — resolve the effect id to a registered primitive at the
+            // runtime boundary. `vir`/`lowering` never see a `PrimitiveId`.
+            let Some(primitive) = self.primitives.by_effect_id(binding.primitive).cloned() else {
+                return Err(Box::new(MachineError::runtime(
+                    MachineOperation::Effect,
+                    RuntimeFault::UnregisteredEffect {
+                        effect: binding.primitive,
+                    },
+                    None,
+                    None,
+                )));
+            };
+            // Step 4 — gate on memo policy. v1 implements Volatile + Hermetic;
+            // Pinned/Observed are an honest typed error, never silently treated
+            // as Hermetic. Copy the Copy facts out so the descriptor borrow of
+            // the owned Arc ends before the store is re-borrowed.
+            let descriptor = primitive.descriptor();
+            let primitive_id = descriptor.id;
+            let policy = descriptor.policy;
+            match policy {
+                MemoPolicy::Hermetic | MemoPolicy::Volatile => {}
+                MemoPolicy::Pinned | MemoPolicy::Observed => {
+                    return Err(Box::new(MachineError::runtime(
+                        MachineOperation::Effect,
+                        RuntimeFault::UnsupportedEffectPolicy {
+                            effect: binding.primitive,
+                        },
+                        None,
+                        None,
+                    )));
+                }
+            }
+            // Step 5 — the effect's own content-addressed demand key. Its recipe
+            // lives under a domain distinct from pure vir recipes, so it can
+            // never collide structurally with a pure demand.
+            let recipe = RecipeId::from_primitive_digest(primitive_id.0);
+            let effect_preimage = DemandPreimage {
+                closure: recipe,
+                arguments: vec![request.identity],
+            };
+            let effect_key = DemandKey::from_preimage(&effect_preimage);
+            // Step 6 — Hermetic effects consult the dedicated effect memo; a hit
+            // rebuilds the response `Evaluation` from the stored handle and does
+            // NOT dispatch or spawn. Volatile skips the lookup entirely.
+            if matches!(policy, MemoPolicy::Hermetic)
+                && let Some(entry) = self.effect_memo.get(&effect_key)
+            {
+                let handle = entry.result;
+                let stored = self.store.entry(handle).ok_or_else(|| {
+                    Box::new(MachineError::runtime(
+                        MachineOperation::Effect,
+                        RuntimeFault::MissingMemoStoreHandle,
+                        None,
+                        Some(effect_key),
+                    ))
+                })?;
+                let identity = stored.identity;
+                let failure = stored.failure().cloned();
+                resolved.push(Evaluation {
+                    handle,
+                    identity,
+                    passed: failure.is_none(),
+                    memo: MemoVerdict::Exact,
+                    failure,
+                    failure_context: None,
+                });
+                continue;
+            }
+            // Step 7 — a miss dispatches the primitive. Clone the request's frozen
+            // replay tree out of the store first so the primitive's `&mut Store`
+            // window (via `EffectCtx`) never aliases it or the owned primitive
+            // Arc. A missing frozen tree is a machine invariant.
+            let Some(frozen) = self.store.frozen_for(request.handle).cloned() else {
+                return Err(Box::new(MachineError::runtime(
+                    MachineOperation::Effect,
+                    RuntimeFault::MissingEffectRequestFrozen {
+                        effect: binding.primitive,
+                    },
+                    None,
+                    Some(effect_key),
+                )));
+            };
+            let request_identity = request.identity;
+            let (completion, receipt) = {
+                let mut ctx = EffectCtx::new(&mut self.store);
+                let request_ref = RequestRef {
+                    identity: request_identity,
+                    frozen: &frozen,
+                };
+                // v1 primitives complete inline before `begin` returns; the ticket
+                // is owned by this demand and needs no clock/poll.
+                match primitive.begin(request_ref, &mut ctx) {
+                    Ok(_ticket) => match ctx.finish(effect_key) {
+                        Ok((completion, receipt, _events)) => (completion, receipt),
+                        Err(error) => {
+                            return Err(Box::new(MachineError::runtime(
+                                MachineOperation::Effect,
+                                RuntimeFault::EffectProtocol {
+                                    effect: binding.primitive,
+                                    error,
+                                },
+                                None,
+                                Some(effect_key),
+                            )));
+                        }
+                    },
+                    Err(error) => {
+                        return Err(Box::new(MachineError::runtime(
+                            MachineOperation::Effect,
+                            RuntimeFault::EffectProtocol {
+                                effect: binding.primitive,
+                                error,
+                            },
+                            None,
+                            Some(effect_key),
+                        )));
+                    }
+                }
+            };
+            // Step 8 — a real dispatch happened: count the spawn and emit the one
+            // generic dispatch event (a memo hit does neither).
+            self.counters.effect_spawns += 1;
+            self.emit(EventKind::EffectDispatched {
+                key: effect_key,
+                recipe,
+            });
+            // Step 9 — bind the completion. Ok memoizes the interned response;
+            // Failed interns a generic language-failure value keyed by the effect
+            // recipe. Under Hermetic both memoize into the effect memo; under
+            // Volatile neither does.
+            let evaluation = match completion {
+                Completion::Ok(interned) => {
+                    self.observe_interned(interned);
+                    if matches!(policy, MemoPolicy::Hermetic) {
+                        self.effect_memo.insert(
+                            effect_key,
+                            EffectMemoEntry {
+                                result: interned.handle,
+                                receipt,
+                            },
+                        );
+                    }
+                    Evaluation {
+                        handle: interned.handle,
+                        identity: interned.identity,
+                        passed: true,
+                        memo: MemoVerdict::Miss,
+                        failure: None,
+                        failure_context: None,
+                    }
+                }
+                Completion::Failed(_failure) => {
+                    let failure = FailureValue::Primitive { recipe, site: 0 };
+                    let interned = self.store.intern_failure(failure.clone(), &[]);
+                    self.observe_interned(interned);
+                    if matches!(policy, MemoPolicy::Hermetic) {
+                        self.effect_memo.insert(
+                            effect_key,
+                            EffectMemoEntry {
+                                result: interned.handle,
+                                receipt,
+                            },
+                        );
+                    }
+                    Evaluation {
+                        handle: interned.handle,
+                        identity: interned.identity,
+                        passed: false,
+                        memo: MemoVerdict::Miss,
+                        failure: Some(failure),
+                        failure_context: None,
+                    }
+                }
+            };
+            resolved.push(evaluation);
+        }
+        Ok(resolved)
+    }
+
     fn materialize_constants(&mut self, lowered: &LoweringArtifact) -> Vec<Handle> {
         lowered
             .constants
@@ -1495,6 +1800,11 @@ impl<S: EventSink> Runtime<S> {
     /// preserve it exactly: [`EntryBindError::WriteFault`] both lanes terminate;
     /// [`EntryBindError::Raw`] both return raw; [`EntryBindError::Invariant`] the
     /// value-island lane terminates and the generator lane returns raw.
+    // `EntryBindError` carries an unboxed `MachineError` in two of its variants so
+    // the three consumer match arms stay flat; the entry-binding path is cold
+    // (a rare machine fault), so the large-Err cost is irrelevant. Boxing every
+    // variant is a mechanical follow-up if the lint tightens further.
+    #[allow(clippy::result_large_err)]
     fn bind_realized_entry(
         &self,
         task: &mut weavy::exec::ExecTask<'_>,
@@ -2812,7 +3122,10 @@ fn failure_context(
         | FailureValue::MissingDelimiter { .. }
         | FailureValue::InvalidInteger { .. }
         | FailureValue::IntegerOverflow { .. }
-        | FailureValue::DivisionByZero { .. } => None,
+        | FailureValue::DivisionByZero { .. }
+        // A primitive failure names no source site in the consuming artifact; its
+        // report context is rebuilt at the folded-effect scan, not here.
+        | FailureValue::Primitive { .. } => None,
     }
 }
 

--- a/vix/src/runtime/store.rs
+++ b/vix/src/runtime/store.rs
@@ -305,7 +305,8 @@ fn failure_node(failure: &FailureValue) -> FramedNode {
         | FailureValue::MissingDelimiter { recipe, site }
         | FailureValue::InvalidInteger { recipe, site }
         | FailureValue::IntegerOverflow { recipe, site }
-        | FailureValue::DivisionByZero { recipe, site } => {
+        | FailureValue::DivisionByZero { recipe, site }
+        | FailureValue::Primitive { recipe, site } => {
             let tag = match failure {
                 FailureValue::MissingKey { .. } => 2,
                 FailureValue::DuplicateKey { .. } => 3,
@@ -313,6 +314,7 @@ fn failure_node(failure: &FailureValue) -> FramedNode {
                 FailureValue::InvalidInteger { .. } => 5,
                 FailureValue::IntegerOverflow { .. } => 6,
                 FailureValue::DivisionByZero { .. } => 7,
+                FailureValue::Primitive { .. } => 8,
                 FailureValue::IndexOutOfBounds { .. } => unreachable!("matched above"),
             };
             FramedNode::Variant {

--- a/vix/tests/force_on_park.rs
+++ b/vix/tests/force_on_park.rs
@@ -132,6 +132,7 @@ fn await_wire_parks_resolves_and_resumes() {
             IslandInputs {
                 arguments: &[],
                 wires: &wires,
+                effects: &[],
             },
             ChaosPolicy::default(),
         )
@@ -190,6 +191,7 @@ fn forced_division_by_zero_wire_propagates_the_typed_failure() {
             IslandInputs {
                 arguments: &[],
                 wires: &wires,
+                effects: &[],
             },
             ChaosPolicy::default(),
         )
@@ -247,6 +249,7 @@ fn repeated_force_of_one_wire_evaluates_once() {
             IslandInputs {
                 arguments: &[],
                 wires: &wires,
+                effects: &[],
             },
             ChaosPolicy::default(),
         )
@@ -311,6 +314,7 @@ fn reentrant_wire_demand_is_a_typed_fault() {
             IslandInputs {
                 arguments: &[],
                 wires: &wires,
+                effects: &[],
             },
             ChaosPolicy::default(),
         )

--- a/vix/tests/primitive_scheduler.rs
+++ b/vix/tests/primitive_scheduler.rs
@@ -1,0 +1,277 @@
+//! Phase 05 — the scheduler resolves a registered effect primitive at the demand
+//! layer: it evaluates the request island as a pure demand, folds the effect's
+//! `(primitive recipe, request value)` into a content-addressed demand key,
+//! consults the dedicated effect memo policy-aware, and on a miss dispatches the
+//! primitive through its sole `EffectCtx` window. These certificates drive the
+//! real value-island lane end to end — register a primitive, derive the compiler
+//! manifest from that same set, compile the effectful source, and evaluate the
+//! consumer island with the effect edge wired.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use vix::compiler::Compiler;
+use vix::lowering::{LoweringCache, attribution_for};
+use vix::runtime::{
+    ChaosPolicy, EffectDemand, EventKind, EventLog, Evaluation, FailureValue, IslandInputs,
+    Location, MachineError, Runtime,
+};
+use vix::runtime::primitive::{MemoPolicy, PrimitiveFailure, PrimitiveSet};
+
+/// `probe where { n: Int } -> String`. An `Int` request field decodes inline
+/// (a `String` field would resident-reference and reject at decode); a `String`
+/// response is what the consumer compares in `expect_eq`.
+#[derive(facet::Facet)]
+struct ProbeRequest {
+    n: i64,
+}
+
+const EFFECT_SOURCE: &str = "#[test]\nfn t() -> Stream<Check> {\n    let v = probe where { n: 5 };\n    yield expect_eq(v, \"9\");\n}\n";
+
+/// A run of one effectful test source through the real value-island lane: the
+/// consumer island evaluated `evaluations` times against a runtime carrying the
+/// registered primitive, plus the observable resolution facts.
+struct Outcome {
+    begins: usize,
+    effect_spawns: u64,
+    dispatched: usize,
+    results: Vec<Result<Evaluation, Box<MachineError>>>,
+    events_first: Vec<EventKind>,
+}
+
+/// Register `probe` under `policy` with a begin-counting responder, derive the
+/// compiler manifest from that registered set (so effect ids match by
+/// construction), compile the effectful source, and evaluate the consumer island
+/// `evaluations` times.
+fn run_probe(
+    policy: MemoPolicy,
+    responder: impl Fn(i64) -> Result<String, PrimitiveFailure> + Send + Sync + 'static,
+    evaluations: usize,
+) -> Outcome {
+    let begins = Arc::new(AtomicUsize::new(0));
+    let begins_in_closure = begins.clone();
+    let mut set = PrimitiveSet::new();
+    set.register_function::<String, ProbeRequest, _>("probe", policy, move |req: ProbeRequest| {
+        begins_in_closure.fetch_add(1, Ordering::SeqCst);
+        responder(req.n)
+    })
+    .expect("probe registers");
+    let manifest = set.compiler_manifest();
+
+    let compilation = Compiler::new()
+        .with_primitives(manifest)
+        .compile(EFFECT_SOURCE)
+        .expect("effect source compiles");
+    let partitioned = compilation
+        .module
+        .partition_test(&compilation.module.tests[0]);
+    let consumer = partitioned.islands[0].clone();
+    let request = partitioned.effect_islands[0].island.clone();
+
+    // Two caches: both lowered artifacts must be borrowed at once, and
+    // `get_or_lower` takes `&mut self`.
+    let mut request_cache = LoweringCache::default();
+    let mut consumer_cache = LoweringCache::default();
+    let request_lowered = request_cache.get_or_lower(&request).expect("request lowers");
+    let consumer_lowered = consumer_cache
+        .get_or_lower(&consumer)
+        .expect("consumer lowers");
+    let request_attr = attribution_for(&request);
+    let consumer_attr = attribution_for(&consumer);
+    let request_loc = Location::for_test_value("effect", "request");
+    let consumer_loc = Location::for_test_value("effect", "consumer");
+
+    let mut runtime = Runtime::new(EventLog::default()).with_primitives(Arc::new(set));
+    let mut results = Vec::with_capacity(evaluations);
+    let mut events_first = Vec::new();
+    for iteration in 0..evaluations {
+        let effects = [EffectDemand {
+            request_island: request.id,
+            request_location: &request_loc,
+            request_lowered,
+            request_attribution: &request_attr,
+            request_arguments: &[],
+            request_wires: &[],
+        }];
+        let result = runtime.evaluate(
+            consumer.id,
+            &consumer_loc,
+            consumer_lowered,
+            &consumer_attr,
+            IslandInputs {
+                arguments: &[],
+                wires: &[],
+                effects: &effects,
+            },
+            ChaosPolicy::default(),
+        );
+        if iteration == 0 {
+            events_first = runtime
+                .sink()
+                .events()
+                .iter()
+                .map(|event| event.kind.clone())
+                .collect();
+        }
+        results.push(result);
+    }
+
+    let dispatched = runtime
+        .sink()
+        .events()
+        .iter()
+        .filter(|event| matches!(event.kind, EventKind::EffectDispatched { .. }))
+        .count();
+    Outcome {
+        begins: begins.load(Ordering::SeqCst),
+        effect_spawns: runtime.counters().effect_spawns,
+        dispatched,
+        results,
+        events_first,
+    }
+}
+
+/// One Hermetic effect dispatches exactly once; a second demand of the same
+/// consumer folds the same effect response identity into the same consumer
+/// demand key, so the effect memo (and then the consumer memo) hits and the
+/// primitive is never begun again.
+#[test]
+fn hermetic_effect_dispatches_once_then_memoizes() {
+    let outcome = run_probe(MemoPolicy::Hermetic, |_| Ok("9".to_owned()), 2);
+    for result in &outcome.results {
+        let evaluation = result.as_ref().expect("effectful consumer evaluates");
+        assert!(
+            evaluation.failure.is_none(),
+            "the probe response resolves cleanly, got {:?}",
+            evaluation.failure
+        );
+    }
+    assert_eq!(
+        outcome.begins, 1,
+        "the Hermetic primitive is begun exactly once across two demands"
+    );
+    assert_eq!(
+        outcome.effect_spawns, 1,
+        "effect_spawns counts the single real dispatch, not the memo hit"
+    );
+    assert_eq!(
+        outcome.dispatched, 1,
+        "exactly one EffectDispatched event — a memo hit emits none"
+    );
+    let dispatched_first = outcome
+        .events_first
+        .iter()
+        .filter(|kind| matches!(kind, EventKind::EffectDispatched { .. }))
+        .count();
+    assert_eq!(
+        dispatched_first, 1,
+        "the dispatch happened on the first demand"
+    );
+}
+
+/// A Volatile effect skips both the effect-memo lookup and insert, so every
+/// consumer demand re-dispatches the primitive — two demands, two begins.
+#[test]
+fn volatile_effect_redispatches_every_demand() {
+    let outcome = run_probe(MemoPolicy::Volatile, |_| Ok("9".to_owned()), 2);
+    for result in &outcome.results {
+        result.as_ref().expect("effectful consumer evaluates");
+    }
+    assert_eq!(
+        outcome.begins, 2,
+        "a Volatile primitive is begun on every demand — no effect memo"
+    );
+    assert_eq!(
+        outcome.effect_spawns, 2,
+        "each Volatile dispatch is counted"
+    );
+    assert_eq!(outcome.dispatched, 2, "two dispatch events, one per demand");
+}
+
+/// A primitive that reports `Completion::Failed` produces a generic
+/// language-failure value keyed by the effect recipe. It dispatches (a real
+/// begin) and, folded into the consumer demand, fails the consumer on the
+/// language plane — never a machine crash.
+#[test]
+fn failed_completion_is_a_language_failure() {
+    let outcome = run_probe(
+        MemoPolicy::Hermetic,
+        |_| {
+            Err(PrimitiveFailure {
+                code: "unavailable".to_owned(),
+                message: "probe refused".to_owned(),
+            })
+        },
+        1,
+    );
+    let evaluation = outcome.results[0]
+        .as_ref()
+        .expect("a Failed completion is a language failure, never a machine error");
+    assert!(
+        matches!(evaluation.failure, Some(FailureValue::Primitive { .. })),
+        "the consumer carries the generic primitive language failure, got {:?}",
+        evaluation.failure
+    );
+    assert_eq!(
+        outcome.begins, 1,
+        "the primitive was actually begun before it reported failure"
+    );
+    assert_eq!(
+        outcome.effect_spawns, 1,
+        "a failed dispatch is still a dispatch"
+    );
+}
+
+/// An effect-free test never enters the effect path: no dispatch, no spawn, and
+/// the pure value island evaluates exactly as before.
+#[test]
+fn effect_free_test_touches_no_effect_machinery() {
+    let source = "#[test]\nfn t() -> Stream<Check> {\n    yield expect_eq(1 + 1, 2);\n}\n";
+    let compilation = Compiler::new().compile(source).expect("pure source compiles");
+    let partitioned = compilation
+        .module
+        .partition_test(&compilation.module.tests[0]);
+    assert!(
+        partitioned.effect_islands.is_empty(),
+        "the pure test has no request islands"
+    );
+    let consumer = partitioned.islands[0].clone();
+    let mut cache = LoweringCache::default();
+    let lowered = cache.get_or_lower(&consumer).expect("consumer lowers");
+    assert!(
+        lowered.effect_inputs.is_empty(),
+        "the pure artifact carries no effect edges"
+    );
+    let attribution = attribution_for(&consumer);
+    let location = Location::for_test_value("effect", "pure");
+
+    let mut runtime = Runtime::new(EventLog::default());
+    let result = runtime
+        .evaluate(
+            consumer.id,
+            &location,
+            lowered,
+            &attribution,
+            IslandInputs {
+                arguments: &[],
+                wires: &[],
+                effects: &[],
+            },
+            ChaosPolicy::default(),
+        )
+        .expect("the pure island evaluates");
+    assert!(result.failure.is_none(), "1 + 1 == 2 passes");
+    assert_eq!(
+        runtime.counters().effect_spawns,
+        0,
+        "an effect-free evaluation dispatches nothing"
+    );
+    assert!(
+        !runtime
+            .sink()
+            .events()
+            .iter()
+            .any(|event| matches!(event.kind, EventKind::EffectDispatched { .. })),
+        "no EffectDispatched event on the pure path"
+    );
+}


### PR DESCRIPTION
**Phase 5 of 6.** Stacked on #2485 (base `vix-prim-04-lowering`).

`resolve_effects` in the scheduler resolves a registered effect at the demand layer: it evaluates the request island as a pure demand, folds the effect's `(primitive recipe, request value)` into a content-addressed key, consults a **dedicated `effect_memo`** policy-aware, and on a miss dispatches the primitive through its sole `EffectCtx` window.

**Key correctness insight:** the resolved effect-response identity folds into the *consumer's* demand key, so an effect participates in content-addressed memoization exactly like a value argument — Hermetic re-keys to a memo hit (closure not re-run), Volatile re-dispatches every demand. Failures cross as a generic `FailureValue::Primitive` (language plane); protocol/schema violations abort on the machine plane. First shared-lane extraction (`bind_realized_entry`) unifies the two value-input binding paths.

Proof (`tests/primitive_scheduler.rs`): Hermetic 2-demands→1-begin, Volatile 2-begins, failed-completion→language-failure, effect-free path byte-identical.

---
_Stacked PR — review after #2485._