### PR TITLE
vix: deflake independent_exec_text_waits_overlap

### DIFF
--- a/vix/src/machine/driver.rs
+++ b/vix/src/machine/driver.rs
@@ -12965,7 +12965,7 @@ mod tests {
         Mutex,
         atomic::{AtomicUsize, Ordering},
     };
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
     use weavy::mem::Layout;
     use weavy::mem::declared as declared_mem;
     use weavy::task::{ArgCopy, Fn as TaskFn, Op};
@@ -13906,18 +13906,17 @@ mod tests {
             delay: Duration::from_millis(150),
         })));
 
-        let started = Instant::now();
         let value = driver.demand(FnRef::new(0), args).unwrap();
-        let wall = started.elapsed();
 
         assert_eq!(
             driver.store.borrow().string_value(value, "String").unwrap(),
             "a.o;b.o;"
         );
-        assert!(
-            wall < Duration::from_millis(250),
-            "independent 150ms exec waits serialized instead of overlapping: {wall:?}"
-        );
+        // Overlap is proven structurally by the trace: both runs start before
+        // either completes. A wall-clock bound (was `wall < 250ms`) flakes on
+        // loaded CI runners, where even genuinely-overlapped 150ms sleeps can
+        // measure ~260ms — see the two `RunStarted` before any `RunCompleted`
+        // below, which is the load-independent signal.
         assert!(
             has_two_run_starts_before_completion(&driver.trace),
             "{:?}",


### PR DESCRIPTION
Stacked on `nix-native-hooks`.

## Problem

`vix::machine::driver::tests::independent_exec_text_waits_overlap` (added in #2488) asserts that two independent 150ms execs run concurrently. It checks overlap **two** ways:

1. a wall-clock bound — `wall < 250ms`
2. a structural trace check — `has_two_run_starts_before_completion` (two `RunStarted` before any `RunCompleted`)

The wall-clock bound flakes on loaded CI runners: two genuinely-overlapped 150ms sleeps measured ~264ms there, tripping the assertion even though the runs *did* overlap. It failed the blocking macOS jobs on #2488 and #2489 and passed on #2491 — intermittent red. It never showed locally because `-p vix --features real-process` on an unloaded machine stays under the bound.

## Fix

Drop the wall-clock assertion; keep the structural trace check, which is the load-independent proof of overlap. Also drops the now-unused `Instant` import. `driver.rs` is byte-identical between this stack and `main`, so the fix applies to `main` cleanly.

## Verification

`cargo nextest run -p vix --lib -E 'test(independent_exec_text_waits_overlap)'` in the dev shell: compiles warning-free, `1 passed`.
