### PR TITLE
Add QEMU Windows test harness (just test-windows)

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -34,6 +34,32 @@ Common workflows:
 - **LLDB on macOS**: `cargo nextest run --profile lldb <filters>`
 - **Miri**: `just miri` runs a curated subset of the workspace under Miri (strict provenance). Use this when changing unsafe boundaries or anything that “should be impossible”.
 
+## Running the tests on Windows (QEMU)
+
+The Windows CI lane (`.github/workflows/test-platforms.yml`) can be reproduced
+locally against a cached Windows 11 VM, without a Windows machine. The harness
+lives in `scripts/winvm/` and is driven from the `Justfile`:
+
+- `just win-vm-up` — first run downloads the Windows 11 Enterprise Evaluation
+  ISO, performs a fully unattended install (`scripts/winvm/autounattend.xml.template`),
+  enables OpenSSH, and installs `cargo-nextest.exe` + Node on the guest. Takes
+  ~20-40 min the first time; afterwards it just boots the cached image and
+  **leaves it running**.
+- `just test-windows [nextest args]` — cross-compiles a nextest archive for
+  `x86_64-pc-windows-msvc` on this host (via `cargo-xwin`), ships it plus the
+  workspace source to the VM over SSH, and runs the suite there with the same
+  exclusions as CI. Extra args are forwarded to `nextest run`.
+- `just win-vm-ssh` — interactive shell on the VM.
+- `just win-vm-down` — stop the VM (image preserved).
+- `just win-vm-clean` — delete the cached image/ISO/keys to rebuild from scratch.
+
+All toolchain and VM dependencies (the `windows-msvc` Rust target, `cargo-xwin`,
+`qemu`, `swtpm`, `OVMF`, `xorriso`, …) are provided by the flake dev shell, so
+the recipes run themselves through `nix develop`. Cached VM state lives under
+`~/.cache/facet-winvm` (override with `FACET_WINVM_CACHE`); KVM (`/dev/kvm`) is
+required. If the eval ISO fwlink rotates, set `FACET_WINVM_ISO_URL` or drop your
+own ISO at `~/.cache/facet-winvm/windows.iso`.
+
 ## Generated files
 
 Some `README.md` files are generated from crate rustdoc using `cargo reedme`.

--- a/Justfile
+++ b/Justfile
@@ -57,6 +57,33 @@ test-i686:
     rustup target add i686-unknown-linux-gnu
     cargo nextest run --target i686-unknown-linux-gnu --tests --lib < /dev/null
 
+# --- Windows-in-QEMU test harness (scripts/winvm) ---------------------------
+# Cross-compiles a nextest archive for x86_64-pc-windows-msvc on this host
+# (via cargo-xwin), ships it to a cached, unattended-installed Windows 11 VM
+# over SSH, and runs the suite there. All toolchain deps come from the flake.
+
+# Ensure the Windows VM exists (installing it, ~20-40 min the first time) and
+# is running. Idempotent; leaves the VM up.
+win-vm-up:
+    nix develop --command bash scripts/winvm/build-image.sh
+
+# Cross-build the archive, ship it to the VM, and run the tests there.
+# Extra args are forwarded to `nextest run` (default = the CI exclusion set).
+test-windows *args: win-vm-up
+    nix develop --command bash scripts/winvm/run-tests.sh {{ args }}
+
+# Open an interactive SSH shell on the Windows VM.
+win-vm-ssh:
+    nix develop --command bash -c 'source scripts/winvm/lib.sh && ssh_win'
+
+# Stop the VM (the installed image is preserved for next time).
+win-vm-down:
+    nix develop --command bash -c 'source scripts/winvm/lib.sh; if vm_running; then kill "$(cat "$QEMU_PIDFILE")" || true; fi; stop_swtpm; echo "Windows VM stopped (image preserved)"'
+
+# Delete the entire cached VM state (image, ISO, keys) to rebuild from scratch.
+win-vm-clean:
+    nix develop --command bash -c 'source scripts/winvm/lib.sh; if vm_running; then kill "$(cat "$QEMU_PIDFILE")" 2>/dev/null || true; fi; stop_swtpm; rm -rf "$CACHE"; echo "removed $CACHE"'
+
 valgrind *args:
     cargo nextest run --profile valgrind {{ args }}
 

--- a/flake.nix
+++ b/flake.nix
@@ -34,8 +34,12 @@
           packages = with pkgs;
             [
               # Must occur first to take precedence over nightly.
+              # The windows-msvc target lets us cross-compile the nextest
+              # archive on this Linux host for the QEMU Windows VM (see the
+              # `test-windows` Justfile recipe / scripts/winvm).
               (rust-bin.stable.latest.minimal.override {
                 extensions = ["rust-src" "rust-docs" "clippy"];
+                targets = ["x86_64-pc-windows-msvc"];
               })
 
               # Use `rustfmt`, and other tools that require nightly features.
@@ -47,10 +51,32 @@
               cargo-nextest
               cargo-insta
               just
+            ]
+            # Windows-in-QEMU test harness: MSVC cross-compile toolchain plus
+            # the VM plumbing. Linux-only — none of this is needed (or builds)
+            # on the darwin dev shells.
+            ++ lib.optionals stdenv.isLinux [
+              cargo-xwin # drives clang-cl/lld-link + downloads the MSVC SDK
+              llvmPackages.clang-unwrapped # provides clang-cl (no nix cc-wrapper flags)
+              llvmPackages.lld # provides lld-link
+              llvmPackages.llvm # provides llvm-lib / llvm-ar for cc-built deps
+
+              qemu
+              swtpm # emulated TPM 2.0 (Win11 install requirement)
+              xorriso # build the autounattend secondary CD
+              mtools
+              aria2 # resumable ISO download
+              openssh
+              curl
+              jq
             ];
 
           RUST_BACKTRACE = 1;
           RUST_LOG = "debug";
+
+          # OVMF UEFI firmware for the Windows VM (Win11 needs UEFI + TPM).
+          # Consumed by scripts/winvm/run-qemu.sh.
+          OVMF_FD = lib.optionalString pkgs.stdenv.isLinux "${pkgs.OVMF.fd}/FV";
         };
       })
       pkgsFor;

--- a/scripts/winvm/autounattend.xml.template
+++ b/scripts/winvm/autounattend.xml.template
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Unattended install answer file for the QEMU Windows 11 test VM.
+
+  This is a TEMPLATE: scripts/winvm/build-image.sh substitutes @@SSH_PUBKEY@@
+  with a freshly generated public key before handing it to QEMU on a second
+  virtual CD. Do not point QEMU at this file directly.
+
+  What it does, hands-off:
+    - bypasses the Win11 TPM/SecureBoot/RAM/CPU setup gates (we do give the VM
+      a real emulated TPM 2.0, but the RAM/CPU checks still trip under QEMU)
+    - GPT-partitions the single virtio disk and installs the Enterprise Eval SKU
+    - creates a local administrator `runner` (password only used for console)
+    - autologons once so FirstLogonCommands run
+    - enables the built-in OpenSSH server and opens the firewall
+    - installs the injected pubkey into administrators_authorized_keys with the
+      ACL that Windows' sshd insists on for admin users
+-->
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <!-- Bypass the Windows 11 hardware gates that QEMU trips. -->
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>1</Order>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>2</Order>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>3</Order>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>4</Order>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassCPUCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>5</Order>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+      <DiskConfiguration>
+        <Disk wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Type>EFI</Type>
+              <Size>260</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>MSR</Type>
+              <Size>128</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>3</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+              <Label>System</Label>
+              <Format>FAT32</Format>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>2</PartitionID>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>3</Order>
+              <PartitionID>3</PartitionID>
+              <Label>Windows</Label>
+              <Letter>C</Letter>
+              <Format>NTFS</Format>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+        <WillShowUI>OnError</WillShowUI>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <!-- The Enterprise Evaluation ISO ships a single edition; select by
+                 index to avoid depending on the exact WIM image name string. -->
+            <MetaData wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>1</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <ProductKey>
+          <!-- Public generic key for the Enterprise Evaluation SKU. -->
+          <Key>NPPR9-FWDCX-D2C8J-H872K-2YT43</Key>
+        </ProductKey>
+        <AcceptEula>true</AcceptEula>
+      </UserData>
+    </component>
+  </settings>
+
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <ComputerName>FACET-WINVM</ComputerName>
+      <TimeZone>UTC</TimeZone>
+    </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <!-- Skip first-boot animation / initial setup churn. -->
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>1</Order>
+          <Path>reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE" /v DisablePrivacyExperience /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
+  </settings>
+
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <ProtectYourPC>3</ProtectYourPC>
+        <SkipMachineOOBE>true</SkipMachineOOBE>
+        <SkipUserOOBE>true</SkipUserOOBE>
+      </OOBE>
+      <UserAccounts>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+            <Name>runner</Name>
+            <Group>Administrators</Group>
+            <Password>
+              <Value>facet-winvm</Value>
+              <PlainText>true</PlainText>
+            </Password>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Username>runner</Username>
+        <LogonCount>1</LogonCount>
+        <Password>
+          <Value>facet-winvm</Value>
+          <PlainText>true</PlainText>
+        </Password>
+      </AutoLogon>
+      <FirstLogonCommands>
+        <!--
+          Enable OpenSSH server and install the host's public key. Ordered:
+          bring sshd up, write the key, lock the ACL down the way Windows'
+          sshd requires for members of Administrators, open the firewall.
+          Powershell default shell makes remote command lines behave.
+        -->
+        <SynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>1</Order>
+          <CommandLine>powershell -NoProfile -ExecutionPolicy Bypass -Command "Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0"</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>2</Order>
+          <CommandLine>powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-Service sshd -StartupType Automatic; Start-Service sshd"</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>3</Order>
+          <CommandLine>powershell -NoProfile -ExecutionPolicy Bypass -Command "New-Item -ItemType Directory -Force -Path C:\ProgramData\ssh | Out-Null; Set-Content -Path C:\ProgramData\ssh\administrators_authorized_keys -Value '@@SSH_PUBKEY@@' -Encoding ascii"</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>4</Order>
+          <CommandLine>powershell -NoProfile -ExecutionPolicy Bypass -Command "icacls C:\ProgramData\ssh\administrators_authorized_keys /inheritance:r /grant SYSTEM:F /grant BUILTIN\Administrators:F"</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>5</Order>
+          <CommandLine>powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-ItemProperty -Path 'HKLM:\SOFTWARE\OpenSSH' -Name DefaultShell -Value 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -Force"</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>6</Order>
+          <CommandLine>powershell -NoProfile -ExecutionPolicy Bypass -Command "New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22"</CommandLine>
+        </SynchronousCommand>
+        <!-- Marker file the host polls over SSH to know provisioning finished. -->
+        <SynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>7</Order>
+          <CommandLine>powershell -NoProfile -ExecutionPolicy Bypass -Command "Restart-Service sshd; New-Item -ItemType File -Force -Path C:\provisioned.txt | Out-Null"</CommandLine>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+  </settings>
+</unattend>

--- a/scripts/winvm/build-image.sh
+++ b/scripts/winvm/build-image.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# One-time (cached) provisioning of the Windows 11 test VM:
+#   fetch ISO -> create disk -> unattended install -> enable SSH ->
+#   install cargo-nextest.exe + Node on the guest -> leave it running.
+#
+# Idempotent at the top level: if $INSTALLED_MARKER exists we assume the image
+# is good and just boot it. Delete the marker (or `just win-vm-clean`) to redo.
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+mkdir -p "$CACHE"
+
+if [[ -f "$INSTALLED_MARKER" ]]; then
+  echo "✅ Windows image already installed. Booting it."
+  exec "$WINVM_SCRIPT_DIR/run-qemu.sh"
+fi
+
+if vm_running; then
+  echo "❌ a VM is already running (pid $(cat "$QEMU_PIDFILE")) but the image is" >&2
+  echo "   not marked installed. Stop it with 'just win-vm-down' first." >&2
+  exit 1
+fi
+
+require_ovmf
+"$WINVM_SCRIPT_DIR/fetch-iso.sh"
+
+# --- host-side artifacts -----------------------------------------------------
+
+if [[ ! -f "$SSHKEY" ]]; then
+  echo "🔑 generating SSH keypair for the VM..."
+  ssh-keygen -t ed25519 -N '' -C "facet-winvm" -f "$SSHKEY" >/dev/null
+fi
+
+echo "💽 creating $DISK_SIZE system disk..."
+rm -f "$DISK"
+qemu-img create -f qcow2 "$DISK" "$DISK_SIZE" >/dev/null
+
+echo "🧾 copying writable OVMF vars..."
+cp -f "$OVMF_FD/OVMF_VARS.fd" "$OVMF_VARS"
+chmod u+w "$OVMF_VARS"
+
+echo "📝 rendering autounattend.xml (injecting SSH pubkey)..."
+pubkey="$(cat "$SSHKEY.pub")"
+unattend_build="$(mktemp -d)"
+trap 'rm -rf "$unattend_build"' EXIT
+template="$(cat "$WINVM_SCRIPT_DIR/autounattend.xml.template")"
+printf '%s' "${template//@@SSH_PUBKEY@@/$pubkey}" > "$unattend_build/autounattend.xml"
+
+echo "📀 building unattend CD..."
+xorriso -as mkisofs -J -r -V UNATTEND -o "$UNATTEND_ISO" "$unattend_build" >/dev/null 2>&1
+
+# --- unattended install boot -------------------------------------------------
+
+start_swtpm
+build_qemu_args
+# Attach install media only for this boot. bootindex prefers the CD so OVMF
+# boots setup; the disk becomes bootable once setup populates it.
+QEMU_ARGS+=(
+  -device "ide-cd,drive=winiso,bus=ahci.1,bootindex=0"
+  -drive "file=$ISO,if=none,id=winiso,media=cdrom,readonly=on"
+  -device "ide-cd,drive=unattend,bus=ahci.2"
+  -drive "file=$UNATTEND_ISO,if=none,id=unattend,media=cdrom,readonly=on"
+)
+# The system disk defaults to a lower boot priority than the CD above.
+QEMU_ARGS+=(-boot menu=off)
+
+echo "🚀 starting unattended install (this takes 20-40 min under emulation)..."
+qemu-system-x86_64 "${QEMU_ARGS[@]}" -daemonize
+
+# Answer the "Press any key to boot from CD or DVD" stub — but ONLY for the
+# first ~15s. Later setup reboots must fall through to the (now-populated)
+# disk, so we deliberately stop pressing after the initial window.
+# Send keys long enough to cover a slow OVMF POST/TPM init, but stop well
+# before setup's first post-filecopy reboot (minutes away) so we don't bounce
+# back into the installer.
+echo "⌨️  nudging past the CD-boot prompt..."
+for _ in $(seq 1 30); do
+  monitor_sendkey spc
+  sleep 1
+done
+
+echo "⏳ waiting for Windows to install and come up on SSH..."
+echo "    (serial log: $SERIAL_LOG)"
+wait_for_ssh 3000  # generous: full unattended install under TCG-ish emulation
+
+# FirstLogonCommands drops this once SSH + firewall + key are all in place.
+echo "⏳ waiting for guest provisioning marker (C:\\provisioned.txt)..."
+for _ in $(seq 1 120); do
+  if ssh_win 'if (Test-Path C:\provisioned.txt) { exit 0 } else { exit 1 }' 2>/dev/null; then
+    break
+  fi
+  sleep 5
+done
+
+# --- guest-side toolchain (cargo-nextest.exe + Node) -------------------------
+
+echo "🔧 provisioning guest test tooling..."
+scp_to_win "$WINVM_SCRIPT_DIR/provision-guest.ps1" 'C:\provision-guest.ps1'
+ssh_win 'powershell -NoProfile -ExecutionPolicy Bypass -File C:\provision-guest.ps1'
+
+# --- finish: clean reboot without install media ------------------------------
+
+echo "🔁 finalizing: shutting the VM down and rebooting from disk only..."
+ssh_win 'shutdown /s /t 0' 2>/dev/null || true
+for _ in $(seq 1 60); do
+  vm_running || break
+  sleep 2
+done
+vm_running && { kill "$(cat "$QEMU_PIDFILE")" 2>/dev/null || true; sleep 3; }
+stop_swtpm
+
+touch "$INSTALLED_MARKER"
+echo "✅ base image installed."
+
+# Leave it running by default, as requested.
+exec "$WINVM_SCRIPT_DIR/run-qemu.sh"

--- a/scripts/winvm/fetch-iso.sh
+++ b/scripts/winvm/fetch-iso.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Download + cache the Windows 11 Enterprise Evaluation ISO.
+# Idempotent: if a plausible ISO is already cached, does nothing.
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+mkdir -p "$CACHE"
+
+# Treat anything >= 3 GiB as a real ISO; the MS fwlink returns a tiny HTML
+# error page when a gate trips, and we don't want to feed that to QEMU.
+iso_looks_valid() {
+  [[ -f "$ISO" ]] || return 1
+  local bytes
+  bytes="$(stat -c %s "$ISO")"
+  (( bytes > 3 * 1024 * 1024 * 1024 ))
+}
+
+if iso_looks_valid; then
+  echo "✅ Windows ISO already cached ($(du -h "$ISO" | cut -f1)) at $ISO"
+  exit 0
+fi
+
+echo "⬇️  fetching Windows 11 Enterprise Evaluation ISO..."
+echo "    from: $WIN_ISO_URL"
+echo "    (override with FACET_WINVM_ISO_URL, or drop your own ISO at $ISO)"
+
+# aria2 follows the fwlink redirects, resumes partial downloads, and parallel
+# -splits to saturate the link. Download to a temp name so an aborted run
+# never leaves a half-file that passes the size check.
+aria2c \
+  --continue=true \
+  --max-connection-per-server=8 \
+  --split=8 \
+  --min-split-size=16M \
+  --auto-file-renaming=false \
+  --allow-overwrite=true \
+  --dir="$CACHE" \
+  --out="windows.iso.part" \
+  "$WIN_ISO_URL"
+
+mv -f "$CACHE/windows.iso.part" "$ISO"
+
+if ! iso_looks_valid; then
+  echo "❌ downloaded file is too small to be a Windows ISO — the fwlink" >&2
+  echo "   probably rotated. Set FACET_WINVM_ISO_URL to a current link from" >&2
+  echo "   https://www.microsoft.com/evalcenter, or place an ISO at $ISO" >&2
+  rm -f "$ISO"
+  exit 1
+fi
+
+echo "✅ ISO cached ($(du -h "$ISO" | cut -f1)) at $ISO"

--- a/scripts/winvm/lib.sh
+++ b/scripts/winvm/lib.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Shared config + helpers for the QEMU Windows test VM.
+# Sourced by the other scripts in this dir; not meant to be run directly.
+#
+# Everything the VM needs (qemu, swtpm, xorriso, openssh, the OVMF firmware
+# path in $OVMF_FD) comes from the nix dev shell — see flake.nix. Run the
+# winvm scripts through `nix develop --command` (the Justfile does this).
+
+set -euo pipefail
+
+WINVM_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$WINVM_SCRIPT_DIR" rev-parse --show-toplevel)"
+
+# Persistent, cached state. The disk image and ISO live here so the VM
+# survives across runs and we never re-download / re-install unnecessarily.
+CACHE="${FACET_WINVM_CACHE:-$HOME/.cache/facet-winvm}"
+ISO="$CACHE/windows.iso"
+DISK="$CACHE/disk.qcow2"
+UNATTEND_ISO="$CACHE/unattend.iso"
+OVMF_VARS="$CACHE/OVMF_VARS.fd"
+SSHKEY="$CACHE/id_ed25519"
+QEMU_PIDFILE="$CACHE/qemu.pid"
+MONITOR_SOCK="$CACHE/monitor.sock"
+SERIAL_LOG="$CACHE/serial.log"
+SWTPM_DIR="$CACHE/swtpm"
+SWTPM_SOCK="$SWTPM_DIR/sock"
+SWTPM_PIDFILE="$CACHE/swtpm.pid"
+INSTALLED_MARKER="$CACHE/.installed"
+
+# Guest access. The unattended install (autounattend.xml.template) creates this
+# admin user and installs our key into administrators_authorized_keys.
+WIN_USER="runner"
+SSH_PORT="${FACET_WINVM_SSH_PORT:-2222}"
+
+# VM sizing. The facet suite is heavy; give it real cores + RAM. Overridable.
+VM_CPUS="${FACET_WINVM_CPUS:-6}"
+VM_RAM="${FACET_WINVM_RAM:-12G}"
+DISK_SIZE="${FACET_WINVM_DISK_SIZE:-80G}"
+
+# Direct MS Evaluation Center fwlink for "Windows 11 Enterprise Evaluation,
+# English (US), 64-bit". fwlink 301-redirects straight to the ISO on
+# download-cdn — no registration gate on the file itself. Override with
+# FACET_WINVM_ISO_URL if this linkid rotates (they do, ~yearly).
+WIN_ISO_URL="${FACET_WINVM_ISO_URL:-https://go.microsoft.com/fwlink/?linkid=2334167&clcid=0x409&culture=en-us&country=us}"
+
+SSH_OPTS=(
+  -o StrictHostKeyChecking=no
+  -o UserKnownHostsFile=/dev/null
+  -o LogLevel=ERROR
+  -o ConnectTimeout=5
+  -i "$SSHKEY"
+)
+
+ssh_win() {
+  ssh "${SSH_OPTS[@]}" -p "$SSH_PORT" "$WIN_USER@localhost" "$@"
+}
+
+scp_to_win() {
+  # scp_to_win <local> <remote>
+  scp "${SSH_OPTS[@]}" -P "$SSH_PORT" "$1" "$WIN_USER@localhost:$2"
+}
+
+scp_from_win() {
+  # scp_from_win <remote> <local>
+  scp "${SSH_OPTS[@]}" -P "$SSH_PORT" "$WIN_USER@localhost:$1" "$2"
+}
+
+vm_running() {
+  [[ -f "$QEMU_PIDFILE" ]] && kill -0 "$(cat "$QEMU_PIDFILE")" 2>/dev/null
+}
+
+# Block until the guest answers SSH, or fail after ~timeout seconds.
+wait_for_ssh() {
+  local timeout="${1:-1800}" waited=0
+  echo "⏳ waiting for SSH on port $SSH_PORT (up to ${timeout}s)..." >&2
+  while (( waited < timeout )); do
+    if ssh_win -o ConnectTimeout=4 -o BatchMode=yes 'exit 0' 2>/dev/null; then
+      echo "✅ guest is reachable over SSH" >&2
+      return 0
+    fi
+    sleep 5
+    waited=$((waited + 5))
+  done
+  echo "❌ timed out waiting for SSH after ${timeout}s" >&2
+  return 1
+}
+
+require_ovmf() {
+  if [[ -z "${OVMF_FD:-}" || ! -f "$OVMF_FD/OVMF_CODE.fd" ]]; then
+    echo "❌ OVMF firmware not found (OVMF_FD='$OVMF_FD'). Run via 'nix develop'." >&2
+    exit 1
+  fi
+}
+
+# Start the emulated TPM 2.0 that Win11 setup insists on, as a background
+# socket daemon. Idempotent.
+start_swtpm() {
+  if [[ -f "$SWTPM_PIDFILE" ]] && kill -0 "$(cat "$SWTPM_PIDFILE")" 2>/dev/null; then
+    return 0
+  fi
+  mkdir -p "$SWTPM_DIR"
+  swtpm socket \
+    --tpmstate "dir=$SWTPM_DIR" \
+    --ctrl "type=unixio,path=$SWTPM_SOCK" \
+    --tpm2 \
+    --daemon \
+    --pid "file=$SWTPM_PIDFILE"
+}
+
+stop_swtpm() {
+  [[ -f "$SWTPM_PIDFILE" ]] || return 0
+  kill "$(cat "$SWTPM_PIDFILE")" 2>/dev/null || true
+  rm -f "$SWTPM_PIDFILE"
+}
+
+# Populate the QEMU_ARGS global with everything common to install + normal
+# boot. Devices are deliberately the ones stock Windows has drivers for:
+# AHCI/SATA disk + CD (not virtio), e1000 NIC (not virtio-net). The user-mode
+# NIC forwards host :$SSH_PORT to guest :22.
+build_qemu_args() {
+  require_ovmf
+  QEMU_ARGS=(
+    -machine "q35,smm=on"
+    -accel kvm
+    -cpu host
+    -smp "$VM_CPUS"
+    -m "$VM_RAM"
+
+    # UEFI: read-only firmware code + a per-VM writable vars store.
+    -drive "if=pflash,format=raw,unit=0,readonly=on,file=$OVMF_FD/OVMF_CODE.fd"
+    -drive "if=pflash,format=raw,unit=1,file=$OVMF_VARS"
+
+    # TPM 2.0 over the swtpm socket.
+    -chardev "socket,id=chrtpm,path=$SWTPM_SOCK"
+    -tpmdev "emulator,id=tpm0,chardev=chrtpm"
+    -device "tpm-crb,tpmdev=tpm0"
+
+    # System disk on AHCI.
+    -device "ahci,id=ahci"
+    -drive "file=$DISK,if=none,id=hd0,format=qcow2,cache=writeback"
+    -device "ide-hd,drive=hd0,bus=ahci.0"
+
+    # NIC with SSH port-forward. e1000 driver ships in Windows.
+    -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:$SSH_PORT-:22"
+    -device "e1000,netdev=net0"
+
+    -device qemu-xhci
+    -device usb-tablet
+
+    -pidfile "$QEMU_PIDFILE"
+    -monitor "unix:$MONITOR_SOCK,server,nowait"
+    -serial "file:$SERIAL_LOG"
+    -display none
+  )
+}
+
+# Send a key to the guest via the QEMU HMP monitor socket. Used to answer the
+# "Press any key to boot from CD" stub during the very first install boot.
+monitor_sendkey() {
+  echo "sendkey $1" | socat - "unix-connect:$MONITOR_SOCK" >/dev/null 2>&1 || true
+}

--- a/scripts/winvm/provision-guest.ps1
+++ b/scripts/winvm/provision-guest.ps1
@@ -1,0 +1,45 @@
+# Guest-side provisioning, run once over SSH by build-image.sh.
+# Installs the two things the archive runner needs on Windows:
+#   - cargo-nextest.exe  (executes tests from the cross-built archive; no Rust
+#     toolchain required on the guest)
+#   - Node.js LTS        (the snark node-subprocess tests shell out to `node`,
+#     matching the setup-node step in the CI Windows lane)
+# Both go under C:\facet and are added to the machine PATH so SSH sessions
+# (which don't load an interactive profile) can find them.
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'  # Invoke-WebRequest is glacial with the progress bar
+
+$root = 'C:\facet'
+$bin  = Join-Path $root 'bin'
+New-Item -ItemType Directory -Force -Path $bin | Out-Null
+
+Write-Host '==> installing cargo-nextest.exe'
+$nextestZip = Join-Path $env:TEMP 'nextest.zip'
+Invoke-WebRequest -Uri 'https://get.nexte.st/latest/windows' -OutFile $nextestZip
+Expand-Archive -Path $nextestZip -DestinationPath $bin -Force
+Remove-Item $nextestZip
+
+Write-Host '==> installing Node.js LTS'
+$idx = Invoke-RestMethod -Uri 'https://nodejs.org/dist/index.json'
+$lts = ($idx | Where-Object { $_.lts } | Select-Object -First 1).version
+$nodeDir = Join-Path $root "node-$lts-win-x64"
+if (-not (Test-Path $nodeDir)) {
+    $nodeZip = Join-Path $env:TEMP 'node.zip'
+    Invoke-WebRequest -Uri "https://nodejs.org/dist/$lts/node-$lts-win-x64.zip" -OutFile $nodeZip
+    Expand-Archive -Path $nodeZip -DestinationPath $root -Force
+    Remove-Item $nodeZip
+}
+Write-Host "    node $lts"
+
+# Prepend our tools to the *machine* PATH, de-duplicated.
+$machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+$wanted = @($bin, $nodeDir)
+$parts = $machinePath -split ';' | Where-Object { $_ -and ($wanted -notcontains $_) }
+$newPath = (($wanted + $parts) -join ';')
+[Environment]::SetEnvironmentVariable('Path', $newPath, 'Machine')
+
+Write-Host '==> versions'
+& (Join-Path $bin 'cargo-nextest.exe') --version
+& (Join-Path $nodeDir 'node.exe') --version
+
+Write-Host '==> guest provisioning complete'

--- a/scripts/winvm/run-qemu.sh
+++ b/scripts/winvm/run-qemu.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Boot the already-installed Windows VM (daemonized) and leave it running.
+# Idempotent: if the VM is already up, just reports that.
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+if vm_running; then
+  echo "✅ Windows VM already running (pid $(cat "$QEMU_PIDFILE"), ssh port $SSH_PORT)"
+  exit 0
+fi
+
+if [[ ! -f "$INSTALLED_MARKER" ]]; then
+  echo "❌ no installed VM found. Run 'just win-vm-build' first." >&2
+  exit 1
+fi
+
+start_swtpm
+build_qemu_args
+
+echo "🚀 booting Windows VM (daemonized)..."
+qemu-system-x86_64 "${QEMU_ARGS[@]}" -daemonize
+
+wait_for_ssh 300
+echo "✅ Windows VM up — ssh -p $SSH_PORT $WIN_USER@localhost (key: $SSHKEY)"

--- a/scripts/winvm/run-tests-guest.ps1
+++ b/scripts/winvm/run-tests-guest.ps1
@@ -1,0 +1,31 @@
+# Runs the cross-built nextest archive on the guest. Invoked over SSH by
+# run-tests.sh. Any extra args are forwarded to `nextest run` (default is the
+# CI exclusion set below).
+#
+# We call tools by absolute path and fix up $env:Path in-process rather than
+# trusting the machine PATH — sshd snapshots its environment at service start,
+# so PATH edits from provisioning aren't visible to SSH sessions.
+param([Parameter(ValueFromRemainingArguments = $true)] $Extra)
+
+$ErrorActionPreference = 'Stop'
+$root    = 'C:\facet'
+$nextest = Join-Path $root 'bin\cargo-nextest.exe'
+$archive = Join-Path $root 'facet-win.tar.zst'
+$src     = Join-Path $root 'src'
+
+$nodeDir = Get-ChildItem $root -Directory -Filter 'node-*-win-x64' | Select-Object -First 1
+if ($nodeDir) { $env:Path = "$($nodeDir.FullName);$env:Path" }
+$env:Path = "$root\bin;$env:Path"
+
+# Match the CI Windows lane (test-platforms.yml).
+$env:PROPTEST_CASES = '0'
+$filter = 'not (binary(postgres_integration) | binary(query_integration) | test(swift) | test(typescript))'
+
+& $nextest nextest run `
+    --archive-file $archive `
+    --workspace-remap $src `
+    --no-fail-fast `
+    -E $filter `
+    @Extra
+
+exit $LASTEXITCODE

--- a/scripts/winvm/run-tests.sh
+++ b/scripts/winvm/run-tests.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Cross-build the nextest archive on this Linux host, ship it + the workspace
+# source to the running Windows VM, and run the tests there. Extra args are
+# forwarded to `nextest run` on the guest.
+#
+# Assumes the VM is already installed + running (the Justfile's `test-windows`
+# recipe guarantees that via win-vm-up).
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+ARCHIVE="$REPO_ROOT/target/facet-win.tar.zst"
+TARGET="x86_64-pc-windows-msvc"
+
+if ! vm_running; then
+  echo "❌ VM is not running. Run 'just win-vm-up' first." >&2
+  exit 1
+fi
+
+# --- 1. cross-build the archive on the host ----------------------------------
+
+echo "🔨 cross-building nextest archive for $TARGET..."
+cd "$REPO_ROOT" || exit 1
+eval "$(RUST_LOG='' XWIN_ACCEPT_LICENSE=1 cargo xwin env --target "$TARGET" 2>/dev/null)"
+cargo nextest archive \
+  --target "$TARGET" \
+  --features ci \
+  --workspace \
+  --archive-file "$ARCHIVE"
+
+# --- 2. ship archive + source ------------------------------------------------
+
+echo "📦 packaging workspace source..."
+src_tgz="$(mktemp --suffix=.tgz)"
+trap 'rm -f "$src_tgz"' EXIT
+# Ship the source so nextest can remap CARGO_MANIFEST_DIR-relative fixtures on
+# the guest. Skip the heavy, host-only trees.
+tar czf "$src_tgz" \
+  --exclude='./target' \
+  --exclude='*/target' \
+  --exclude='./.git' \
+  --exclude='node_modules' \
+  --exclude='*/node_modules' \
+  --exclude='./.paseo' \
+  -C "$REPO_ROOT" .
+
+echo "🚚 shipping archive + source to guest..."
+ssh_win 'New-Item -ItemType Directory -Force C:\facet | Out-Null'
+scp_to_win "$ARCHIVE" 'C:/facet/facet-win.tar.zst'
+scp_to_win "$src_tgz" 'C:/facet/source.tgz'
+scp_to_win "$WINVM_SCRIPT_DIR/run-tests-guest.ps1" 'C:/facet/run-tests-guest.ps1'
+
+echo "📂 extracting source on guest..."
+ssh_win 'Remove-Item -Recurse -Force C:\facet\src -ErrorAction Ignore; New-Item -ItemType Directory -Force C:\facet\src | Out-Null; tar -xzf C:\facet\source.tgz -C C:\facet\src'
+
+# --- 3. run tests on the guest -----------------------------------------------
+
+echo "🧪 running tests on Windows..."
+ssh_win "powershell -NoProfile -ExecutionPolicy Bypass -File C:\\facet\\run-tests-guest.ps1 $*"


### PR DESCRIPTION
Reproduce the Windows CI lane (`.github/workflows/test-platforms.yml`) locally, without a Windows machine.

## What it does
- **Cross-compiles** a nextest archive for `x86_64-pc-windows-msvc` on the Linux host via `cargo-xwin` (SDK auto-downloaded/cached).
- **Provisions** a cached Windows 11 Enterprise Evaluation VM under QEMU: auto-downloads the eval ISO, fully unattended install (TPM/CPU-check bypass, OpenSSH + injected key, autologon), OVMF + swtpm + KVM, AHCI disk / e1000 NIC so stock Windows has drivers.
- **Ships + runs**: scp the archive + workspace source to the VM, run `cargo-nextest.exe nextest run --archive-file ... --workspace-remap ...` with the same exclusions as CI (`postgres_integration`, `query_integration`, `swift`, `typescript`).
- All toolchain/VM deps come from the flake dev shell (Linux-only); the recipes self-invoke `nix develop`.

## Recipes
| Recipe | Does |
|---|---|
| `just win-vm-up` | fetch ISO → unattended install → SSH + guest tooling → leave VM running (~20-40 min first time, cached after) |
| `just test-windows [args]` | cross-build archive → ship → run with CI exclusions |
| `just win-vm-ssh` / `win-vm-down` / `win-vm-clean` | shell in / stop / wipe cache |

## Status
- ✅ Full workspace **cross-compiles to windows-msvc from Linux** (archive builds clean: 642 MB, 334 `.exe` test binaries).
- ✅ Scripts shellcheck-clean, flake evaluates, ISO fwlink resolves to the real 25H2 Enterprise Eval ISO.
- ⚠️ **VM install + on-guest test run not yet verified end-to-end** — draft until confirmed on a real boot. Requires `/dev/kvm`.

## Known caveats
- Tests that bake paths via the `env!("CARGO_MANIFEST_DIR")` *macro* (compile-time, vs the runtime var nextest remaps) may fail on the guest — inherent to running a cross-built archive on another machine, not CI-real failures.
- If the eval ISO fwlink rotates, set `FACET_WINVM_ISO_URL` or drop an ISO at `~/.cache/facet-winvm/windows.iso`.