### PR TITLE
vix: lower fetch/observe through a data RequestShape

### DIFF
--- a/vix/src/binding.rs
+++ b/vix/src/binding.rs
@@ -23,10 +23,21 @@
 //! **Primitive dispatch is wired.** `compiler::lower_value` recognizes built-in
 //! primitives through [`prelude_primitive`] — the callee name maps to a
 //! [`PrimitiveKind`] here, in data, instead of scattered `== "decode"` /
-//! `effect_intrinsic` string matches. The genuinely per-primitive request
-//! construction (the `Format`/`Mode` selector reads, expected-type-derived
-//! targets, constant folding) stays in the compiler's typed builders, dispatched
-//! from that one kind; only the *name → primitive* map lives here.
+//! `effect_intrinsic` string matches.
+//!
+//! **Request construction is data for the uniform primitives.** `fetch` and
+//! `observe` lower through a [`RequestShape`] ([`request_shape`]): their arity,
+//! per-argument roles (a lowered [`ArgRole::Value`] with its required type, or a
+//! [`Selector`] enum read at lower time), request record, result type, and target
+//! primitive are all data, consumed by one generic builder rather than a bespoke
+//! Rust arm each. The old `observe_mode_arg` reader is now the data in a
+//! [`Selector`].
+//!
+//! Not yet on a shape: `decode`/`try_decode` (compile-time constant folding and
+//! expected-type-derived targets don't reduce to a record shape) and the
+//! `fixture_*`/`untar` dedicated VIR ops (not `InvokePrimitive` at all). Those
+//! stay in the compiler's typed builders; [`request_shape`] returns `None` for
+//! them.
 //!
 //! Still on the compiler side: the binder consults [`is_prelude_name`] (a name
 //! set derived from these bindings) but does not yet route full prelude/module
@@ -38,6 +49,12 @@
 
 use std::collections::BTreeSet;
 use std::sync::LazyLock;
+
+use crate::runtime::{
+    PrimitiveId, observe_primitive_id, observe_request_type, origin_hint_type, pinned_blob_ref_type,
+    pinned_fetch_primitive_id, pinned_fetch_request_type,
+};
+use crate::vir::{ExternKind, Type};
 
 /// A non-empty `::`-separated module path (`caps`, `some::ns::inner`).
 ///
@@ -119,6 +136,131 @@ pub enum BindingTarget {
     /// function is effectful when its body invokes an effectful primitive; vix
     /// effect tracking flows through the call as it does for any wrapper.
     VixFunction { source: String },
+}
+
+/// One accepted variant of a [`Selector`] argument and the boolean flag it folds
+/// into the request record. (`Mode::Observe` → `false`, `Mode::Refresh` → `true`.)
+///
+/// Selectors fold to a boolean today because the only one — observe's `Mode` — is
+/// binary. Decode's `Format` is an integer tag; when it migrates onto a shape this
+/// widens to a general constant. Until then, "selector" means "enum → flag".
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SelectorVariant {
+    pub variant: String,
+    pub flag: bool,
+}
+
+/// A selector argument: an enum-variant read at *lower time* into a constant and
+/// folded into the request record, never lowered as a runtime value. This is the
+/// data form of the old `observe_mode_arg`/`decode_format_arg` readers — the
+/// accepted `enum_name`, its variants, and the diagnostic wording all live here
+/// rather than as a bespoke Rust reader per primitive.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Selector {
+    /// The enum the variant must name (`Mode`).
+    pub enum_name: String,
+    /// How the selector reads in diagnostics (`observe mode`) — the noun the
+    /// "expected …" and "unknown …" messages are built from.
+    pub noun: String,
+    pub variants: Vec<SelectorVariant>,
+}
+
+impl Selector {
+    /// What a non-variant or wrong-enum argument should say it expected, e.g.
+    /// `an observe mode `Mode::Observe` or `Mode::Refresh``.
+    #[must_use]
+    pub fn expected(&self) -> String {
+        let choices: Vec<String> = self
+            .variants
+            .iter()
+            .map(|candidate| format!("`{}::{}`", self.enum_name, candidate.variant))
+            .collect();
+        format!("an {} {}", self.noun, choices.join(" or "))
+    }
+
+    /// The message for a known enum but unrecognized variant, e.g.
+    /// `an unknown observe mode `Mode::Spin``.
+    #[must_use]
+    pub fn unknown(&self, variant: &str) -> String {
+        format!("an unknown {} `{}::{variant}`", self.noun, self.enum_name)
+    }
+}
+
+/// The structural role a surface argument plays in a primitive's request record.
+/// The request record has one field per argument, in this order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ArgRole {
+    /// Lowered as an ordinary value and required to have the given type
+    /// (`fetch`'s `PinnedBlobRef`, `observe`'s `OriginHint`).
+    Value { expected: Type },
+    /// An enum-variant selector folded to a constant request field.
+    Selector(Selector),
+}
+
+/// How a registered primitive builds its request from its surface arguments — the
+/// data a single generic lowering step consumes in place of a bespoke Rust arm per
+/// primitive. Arity is `args.len()`; the compiler builds a `request_ty` record with
+/// one field per argument (in order), invokes `primitive`, and yields `result`.
+///
+/// Only the primitives whose construction is *fully uniform* have a shape today
+/// (`fetch`, `observe`). `decode`/`try_decode` (compile-time constant folding,
+/// expected-type-derived targets) and the `fixture_*`/`untar` dedicated VIR ops
+/// are not yet expressible here — see [`request_shape`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RequestShape {
+    pub args: Vec<ArgRole>,
+    pub request_ty: Type,
+    pub result: Type,
+    pub primitive: PrimitiveId,
+}
+
+/// The [`RequestShape`] a primitive's call lowers through, or `None` for the
+/// primitives whose request construction is not yet data (`decode`/`try_decode`
+/// and the `fixture_*`/`untar` dedicated ops — those stay in the compiler's typed
+/// builders). Returning `Some` is the contract that a primitive is fully described
+/// by data: the compiler builds its request generically from the shape.
+#[must_use]
+pub fn request_shape(kind: PrimitiveKind) -> Option<RequestShape> {
+    let blob = Type::Extern(ExternKind::Blob);
+    match kind {
+        PrimitiveKind::Fetch => Some(RequestShape {
+            args: vec![ArgRole::Value {
+                expected: pinned_blob_ref_type(),
+            }],
+            request_ty: pinned_fetch_request_type(),
+            result: blob,
+            primitive: pinned_fetch_primitive_id(),
+        }),
+        PrimitiveKind::Observe => Some(RequestShape {
+            args: vec![
+                ArgRole::Value {
+                    expected: origin_hint_type(),
+                },
+                ArgRole::Selector(Selector {
+                    enum_name: "Mode".to_owned(),
+                    noun: "observe mode".to_owned(),
+                    variants: vec![
+                        SelectorVariant {
+                            variant: "Observe".to_owned(),
+                            flag: false,
+                        },
+                        SelectorVariant {
+                            variant: "Refresh".to_owned(),
+                            flag: true,
+                        },
+                    ],
+                }),
+            ],
+            request_ty: observe_request_type(),
+            result: blob,
+            primitive: observe_primitive_id(),
+        }),
+        PrimitiveKind::Decode
+        | PrimitiveKind::TryDecode
+        | PrimitiveKind::FixtureTree
+        | PrimitiveKind::FixtureRegistry
+        | PrimitiveKind::Untar => None,
+    }
 }
 
 /// One projected name: placement + leaf name + what it resolves to.
@@ -349,5 +491,64 @@ mod tests {
         assert!(reg.qualified(&path, "cool_function").is_some());
         // ...but not from the prelude.
         assert!(reg.prelude("cool_function").is_none());
+    }
+
+    #[test]
+    fn only_the_uniform_primitives_have_a_request_shape() {
+        // fetch/observe are fully data — the compiler builds their request from
+        // the shape. Everything else is still hand-lowered and returns `None`.
+        assert!(request_shape(PrimitiveKind::Fetch).is_some());
+        assert!(request_shape(PrimitiveKind::Observe).is_some());
+        for kind in [
+            PrimitiveKind::Decode,
+            PrimitiveKind::TryDecode,
+            PrimitiveKind::FixtureTree,
+            PrimitiveKind::FixtureRegistry,
+            PrimitiveKind::Untar,
+        ] {
+            assert!(request_shape(kind).is_none(), "{kind:?} should have no shape yet");
+        }
+    }
+
+    #[test]
+    fn fetch_shape_is_one_value_arg() {
+        let shape = request_shape(PrimitiveKind::Fetch).expect("fetch shape");
+        assert_eq!(shape.args.len(), 1);
+        assert!(matches!(shape.args[0], ArgRole::Value { .. }));
+        assert_eq!(shape.result, Type::Extern(ExternKind::Blob));
+        assert_eq!(shape.primitive, pinned_fetch_primitive_id());
+    }
+
+    #[test]
+    fn observe_shape_is_a_value_then_a_mode_selector() {
+        let shape = request_shape(PrimitiveKind::Observe).expect("observe shape");
+        assert_eq!(shape.args.len(), 2);
+        assert!(matches!(shape.args[0], ArgRole::Value { .. }));
+        let ArgRole::Selector(selector) = &shape.args[1] else {
+            panic!("observe's second argument is the Mode selector");
+        };
+        assert_eq!(selector.enum_name, "Mode");
+        // The selector carries its own accepted variants and folded flags.
+        assert_eq!(
+            selector
+                .variants
+                .iter()
+                .find(|v| v.variant == "Refresh")
+                .map(|v| v.flag),
+            Some(true),
+        );
+    }
+
+    #[test]
+    fn selector_builds_its_own_diagnostic_wording() {
+        let shape = request_shape(PrimitiveKind::Observe).expect("observe shape");
+        let ArgRole::Selector(selector) = &shape.args[1] else {
+            panic!("expected the Mode selector");
+        };
+        assert_eq!(
+            selector.expected(),
+            "an observe mode `Mode::Observe` or `Mode::Refresh`",
+        );
+        assert_eq!(selector.unknown("Spin"), "an unknown observe mode `Mode::Spin`");
     }
 }

--- a/vix/src/compiler.rs
+++ b/vix/src/compiler.rs
@@ -12,9 +12,7 @@ use taxon::{
 use crate::decode::{self, DecodeFormat, DecodedValue};
 use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticPayload, Diagnostics, Label};
 use crate::runtime::{
-    observe_primitive_id, observe_request_type, origin_hint_type, pinned_blob_ref_type,
-    pinned_fetch_primitive_id, pinned_fetch_request_type, tree_read_primitive_id,
-    tree_read_request_type,
+    origin_hint_type, pinned_blob_ref_type, tree_read_primitive_id, tree_read_request_type,
 };
 use crate::schema::{SchemaBatch, SchemaRef, SchemaSet};
 use crate::support::{Span, Spanned};
@@ -5252,22 +5250,147 @@ fn lower_primitive(
     expected: Option<&Type>,
 ) -> Result<LoweredValue, Diagnostics> {
     use crate::binding::PrimitiveKind;
+    // Primitives whose request construction is fully data (`fetch`, `observe`)
+    // lower through their `RequestShape`; there is no per-primitive Rust arm.
+    if let Some(shape) = crate::binding::request_shape(kind) {
+        return lower_request_shape(nodes, bindings, context, call, &shape);
+    }
     match kind {
         PrimitiveKind::Decode => lower_decode_binding(nodes, bindings, context, call, expected),
         PrimitiveKind::TryDecode => {
             lower_try_decode_binding(nodes, bindings, context, call, expected)
         }
-        PrimitiveKind::Fetch
-        | PrimitiveKind::Observe
-        | PrimitiveKind::FixtureTree
-        | PrimitiveKind::FixtureRegistry
-        | PrimitiveKind::Untar => lower_effect_intrinsic(nodes, bindings, context, call, kind),
+        PrimitiveKind::FixtureTree | PrimitiveKind::FixtureRegistry | PrimitiveKind::Untar => {
+            lower_effect_intrinsic(nodes, bindings, context, call, kind)
+        }
+        PrimitiveKind::Fetch | PrimitiveKind::Observe => {
+            unreachable!("fetch/observe lower through their RequestShape")
+        }
     }
 }
 
-/// The machine-plane primitive constructors of the tree/fetch band. Each
-/// lowers to an [`EffectKind::Effect`] node the partitioner hoists into its
+/// Build a registered-primitive call from its [`RequestShape`]: check arity, read
+/// every [`Selector`](crate::binding::Selector) *before* enforcing any value-arg
+/// type (a bad mode must beat a wrong-typed origin — see `observe_binding`), then
+/// lower each argument in order into the request record and invoke the primitive.
+///
+/// This is the one generic replacement for the former per-primitive arms in
+/// `lower_effect_intrinsic`. The request record and the `InvokePrimitive` node are
+/// `PURE`: the effect-island the primitive runs in is keyed off the primitive
+/// itself, not these nodes' effect facts.
+fn lower_request_shape(
+    nodes: &mut Vec<Node>,
+    bindings: &BTreeMap<String, LoweredValue>,
+    context: &ModuleContext<'_>,
+    call: &ast::Call,
+    shape: &crate::binding::RequestShape,
+) -> Result<LoweredValue, Diagnostics> {
+    use crate::binding::ArgRole;
+    if call.named_args.is_some() {
+        return Err(Diagnostics::one(Diagnostic::unsupported(
+            call.span,
+            "named arguments on a primitive constructor",
+        )));
+    }
+    check_arity(call, shape.args.len())?;
+
+    // Read selectors first: a `Mode::Spin` must be rejected as an unknown mode
+    // before an origin of the wrong type is rejected as a type mismatch.
+    let mut flags: BTreeMap<usize, bool> = BTreeMap::new();
+    for (index, role) in shape.args.iter().enumerate() {
+        if let ArgRole::Selector(selector) = role {
+            flags.insert(index, read_selector(&call.args.args[index], selector)?);
+        }
+    }
+
+    let mut inputs = Vec::with_capacity(shape.args.len());
+    for (index, role) in shape.args.iter().enumerate() {
+        let arg = &call.args.args[index];
+        let node = match role {
+            ArgRole::Value { expected } => {
+                let value = lower_value(nodes, bindings, context, arg)?;
+                require_type(&value, expected, expr_span(arg))?;
+                value.node
+            }
+            ArgRole::Selector(_) => push_node(
+                nodes,
+                call.span,
+                Type::Bool,
+                EffectFacts::PURE,
+                Vec::new(),
+                Op::Bool(flags[&index]),
+            ),
+        };
+        inputs.push(node);
+    }
+
+    let request = push_node(
+        nodes,
+        call.span,
+        shape.request_ty.clone(),
+        EffectFacts::PURE,
+        inputs,
+        Op::Record,
+    );
+    let ty = shape.result.clone();
+    Ok(LoweredValue {
+        node: push_node(
+            nodes,
+            call.span,
+            ty.clone(),
+            EffectFacts::PURE,
+            vec![request],
+            Op::InvokePrimitive {
+                primitive: shape.primitive.clone(),
+            },
+        ),
+        ty,
+    })
+}
+
+/// Read a [`Selector`](crate::binding::Selector) argument: an enum variant named
+/// at lower time and folded to its request flag, never lowered as a value. The
+/// data form of the former `observe_mode_arg`/`decode_format_arg` readers — the
+/// accepted enum, its variants, and the diagnostic wording all come from the
+/// selector. An unknown or non-matching variant is rejected here, not by the
+/// checker (which never sees it in a value position).
+fn read_selector(
+    arg: &ast::Expr,
+    selector: &crate::binding::Selector,
+) -> Result<bool, Diagnostics> {
+    let ast::Expr::Variant(variant) = arg else {
+        return Err(Diagnostics::one(Diagnostic::unsupported(
+            expr_span(arg),
+            selector.expected(),
+        )));
+    };
+    if variant.path.type_name.value != selector.enum_name {
+        return Err(Diagnostics::one(Diagnostic::unsupported(
+            variant.path.span,
+            selector.expected(),
+        )));
+    }
+    let chosen = variant.path.variant.value.as_str();
+    selector
+        .variants
+        .iter()
+        .find(|candidate| candidate.variant == chosen)
+        .map(|candidate| candidate.flag)
+        .ok_or_else(|| {
+            Diagnostics::one(Diagnostic::unsupported(
+                variant.path.variant.span,
+                selector.unknown(chosen),
+            ))
+        })
+}
+
+/// The dedicated-op tree primitives (`fixture_tree`, `fixture_registry`, `untar`).
+/// Each lowers to an [`EffectKind::Effect`] node the partitioner hoists into its
 /// own effect island; nothing here is a Weavy-lowerable pure operation.
+///
+/// Unlike `fetch`/`observe`, these are not `InvokePrimitive` requests — they are
+/// bespoke VIR ops, so they do not have a [`RequestShape`](crate::binding::RequestShape)
+/// yet and stay hand-lowered here.
 fn lower_effect_intrinsic(
     nodes: &mut Vec<Node>,
     bindings: &BTreeMap<String, LoweredValue>,
@@ -5281,71 +5404,6 @@ fn lower_effect_intrinsic(
             call.span,
             "named arguments on a primitive constructor",
         )));
-    }
-    if kind == PrimitiveKind::Fetch {
-        check_arity(call, 1)?;
-        let pin = lower_value(nodes, bindings, context, &call.args.args[0])?;
-        require_type(&pin, &pinned_blob_ref_type(), expr_span(&call.args.args[0]))?;
-        let request_ty = pinned_fetch_request_type();
-        let request = push_node(
-            nodes,
-            call.span,
-            request_ty,
-            EffectFacts::PURE,
-            vec![pin.node],
-            Op::Record,
-        );
-        let ty = Type::Extern(ExternKind::Blob);
-        return Ok(LoweredValue {
-            node: push_node(
-                nodes,
-                call.span,
-                ty.clone(),
-                EffectFacts::PURE,
-                vec![request],
-                Op::InvokePrimitive {
-                    primitive: pinned_fetch_primitive_id(),
-                },
-            ),
-            ty,
-        });
-    }
-    if kind == PrimitiveKind::Observe {
-        check_arity(call, 2)?;
-        let refresh = observe_mode_arg(&call.args.args[1])?;
-        let origin = lower_value(nodes, bindings, context, &call.args.args[0])?;
-        require_type(&origin, &origin_hint_type(), expr_span(&call.args.args[0]))?;
-        let flag = push_node(
-            nodes,
-            call.span,
-            Type::Bool,
-            EffectFacts::PURE,
-            Vec::new(),
-            Op::Bool(refresh),
-        );
-        let request_ty = observe_request_type();
-        let request = push_node(
-            nodes,
-            call.span,
-            request_ty,
-            EffectFacts::PURE,
-            vec![origin.node, flag],
-            Op::Record,
-        );
-        let ty = Type::Extern(ExternKind::Blob);
-        return Ok(LoweredValue {
-            node: push_node(
-                nodes,
-                call.span,
-                ty.clone(),
-                EffectFacts::PURE,
-                vec![request],
-                Op::InvokePrimitive {
-                    primitive: observe_primitive_id(),
-                },
-            ),
-            ty,
-        });
     }
     let (ty, op, inputs) = match kind {
         PrimitiveKind::FixtureTree => {
@@ -5381,7 +5439,7 @@ fn lower_effect_intrinsic(
             (Type::Extern(ExternKind::Tree), Op::Untar, vec![blob.node])
         }
         PrimitiveKind::Fetch | PrimitiveKind::Observe => {
-            unreachable!("fetch/observe returned above")
+            unreachable!("fetch/observe lower through their RequestShape")
         }
         PrimitiveKind::Decode | PrimitiveKind::TryDecode => {
             unreachable!("decode/try_decode do not route through lower_effect_intrinsic")
@@ -5721,35 +5779,6 @@ fn decode_format_arg(arg: &ast::Expr) -> Result<DecodeFormat, Diagnostics> {
         other => Err(Diagnostics::one(Diagnostic::unsupported(
             variant.path.variant.span,
             format!("an unknown decode format `Format::{other}`"),
-        ))),
-    }
-}
-
-/// Read the `Mode::Observe` / `Mode::Refresh` selector of an `observe` call,
-/// returning the refresh flag the primitive folds into its request record. The
-/// twin of `decode_format_arg`: the observe mode is a surface argument, not a
-/// second primitive and not a `refresh` compiler intrinsic. Like the format
-/// selector it is read at lower time and never lowered as a value, so an unknown
-/// mode is rejected only here, not by the checker.
-fn observe_mode_arg(arg: &ast::Expr) -> Result<bool, Diagnostics> {
-    let ast::Expr::Variant(variant) = arg else {
-        return Err(Diagnostics::one(Diagnostic::unsupported(
-            expr_span(arg),
-            "an observe mode `Mode::Observe` or `Mode::Refresh`",
-        )));
-    };
-    if variant.path.type_name.value != "Mode" {
-        return Err(Diagnostics::one(Diagnostic::unsupported(
-            variant.path.span,
-            "an observe mode `Mode::Observe` or `Mode::Refresh`",
-        )));
-    }
-    match variant.path.variant.value.as_str() {
-        "Observe" => Ok(false),
-        "Refresh" => Ok(true),
-        other => Err(Diagnostics::one(Diagnostic::unsupported(
-            variant.path.variant.span,
-            format!("an unknown observe mode `Mode::{other}`"),
         ))),
     }
 }


### PR DESCRIPTION
Stacked on #2500. First step of the "data-driven primitives" arc: move a
primitive's **request construction** out of bespoke compiler arms and into a
`RequestShape` value that a single generic builder consumes.

## What's here
- **`RequestShape` in `vix::binding`** — the data a primitive's call lowers
  through: per-argument roles (`ArgRole::Value { expected }` lowered as a value,
  or an `ArgRole::Selector` enum read at lower time), the request record type,
  the result type, and the target primitive. `request_shape(kind)` returns the
  shape for the uniform primitives and `None` for the ones still hand-lowered.
- **`fetch` and `observe` lower through one generic `lower_request_shape`** —
  their two hand-written arms in `lower_effect_intrinsic` and the `observe_mode_arg`
  reader are deleted.
- **Selectors are self-describing** — a `Selector` carries its accepted variants,
  their folded flags, and the noun its diagnostics are built from; the old
  hardcoded `"observe mode `Mode::Observe` or `Mode::Refresh`"` strings are now
  computed from that data. Selectors are read **before** value-arg types are
  enforced, so a bad `Mode` still beats a wrong-typed origin (a behaviour
  `observe_binding` pins).
- The dangling `[RequestShape]` doc link in `binding.rs` now resolves.

## Deliberately not migrated
- **`decode`/`try_decode`** — compile-time constant folding and expected-type-
  derived targets don't reduce to a record shape. (Gated on const-fold through
  monomorphized vix wrappers — the same capability #2500 defers.)
- **`fixture_tree`/`fixture_registry`/`untar`** — these lower to *dedicated VIR
  ops*, not `InvokePrimitive`, so they have no request to shape. Promoting them
  to real primitives (or teaching `RequestShape` an op backend) is a follow-up
  design fork.

`request_shape` returns `None` for all of these and they stay in the compiler's
typed builders.

## Verification
`vix` builds clean (no warnings). `observe_binding` 6/6, `decode_binding` 3/3,
`ratchet_runner` **151 passed / 0 failed / 2 ignored** (unchanged baseline),
new `binding` unit tests 7/7, and `vix-fetch::fetch_observe` **11/11** (the
end-to-end fetch/observe/refresh runs through the new builder).

## Next in the arc
Unify the *type* side: derive `RequestShape.request_ty` and the runtime
`PrimitiveDescriptor` from one schema description, killing the paired
`*_request_type()` constructors. Then making `OriginHint`/`PinnedBlobRef`
surface-nameable (unblocks running observe/fetch from vix source, not just Rust).
