### PR TITLE
vix: data-driven-primitives end-state design doc

### DIFF
--- a/vix/docs/content-design/data-driven-primitives.md
+++ b/vix/docs/content-design/data-driven-primitives.md
@@ -1,0 +1,309 @@
++++
+title = "data-driven primitives: the vix ↔ rust interface, end-state"
++++
+
+> **STATUS: TARGET. This is the north star the `RequestShape` work is walking
+> toward, not a description of today.** As of the `vix-primitive-request-shape`
+> stack, `fetch`/`observe` lower through a `RequestShape` value and primitive
+> dispatch is name→`PrimitiveKind` data, but the type mirrors are still
+> hand-written, the projection still lives in a central table, and the surface
+> types are not nameable in vix. This note pins where we are going so each PR in
+> the arc can be checked against a fixed goal.
+
+## The one-sentence goal
+
+**Adding or changing a vix primitive is one declarative edit in Rust, next to
+the primitive's `impl`, and everything else — runtime dispatch, compiler
+lowering, the surface type names, its namespaced path, and the ability to
+construct those types from vix source — is derived from that one declaration.
+Zero compiler arms, zero hand-synced type mirrors, no closed `PrimitiveKind`
+enum. Primitives live in namespaces derived from their `PrimitiveId`, and a
+curated prelude — itself a vix module of re-exports — is auto-imported into every
+module, exactly like Rust's `std::prelude`. The runtime is generic over an
+embedder-chosen context of shared authorities (an executor, a pool), each
+primitive declaring the slice it needs via `FromRef`, the way a backend
+framework shares one DB pool across handlers.**
+
+The classification rule from [registered primitives](/registered-primitives)
+still gates *what earns a primitive* (it must cross an authority boundary). This
+note is about the *mechanism* once something has earned one: how that primitive
+projects onto the vix surface without bespoke compiler code.
+
+## What's wrong today: one primitive, three hand-synced spellings
+
+A single primitive like `fetch` is described in three places that must agree
+field-for-field, kept in lockstep by a human:
+
+1. **The Rust request struct** — `PinnedFetchRequest { pin: PinnedBlobRef }` in
+   `runtime/fetch_primitive.rs`, `#[derive(facet::Facet)]`. This is what the
+   runtime actually executes against.
+2. **A hand-written `Type` mirror** — `pinned_fetch_request_type()`,
+   `origin_hint_type()`, `pinned_blob_ref_type()`, `observe_request_type()`,
+   each a `Type::Record(...)` that re-spells struct #1 field-by-field. This is
+   what the compiler builds requests *of*, and what `PrimitiveDescriptor`'s
+   `schema_ref()` patterns point back into.
+3. **The projection onto the surface** — `binding::RequestShape` (per-argument
+   `ArgRole`s → how surface arguments fold into #2's record) plus the central
+   `request_shape(kind)` / `builtin_bindings()` tables in `binding.rs`.
+
+`RequestShape` already collapsed the *bespoke-compiler-arm* half of #3 into
+data — `fetch` and `observe` no longer have a hand-written arm in
+`lower_effect_intrinsic`. But #1 and #2 are still two spellings of the same
+shape, #2 has no vix-nameable surface, and #3's mapping table is a second place
+that names every primitive.
+
+The duplication is not incidental: `facet::Facet` already gives full reflection
+over struct #1, so #2 is *derivable* and only exists because we hand-wrote it
+first.
+
+## End-state: one source per fact
+
+### 1. The struct shape *is* the schema
+
+Derive `Type` / `schema_ref` from the `Facet` shape of the request struct and
+**delete** every hand-written `*_request_type()` / `*_hint_type()` /
+`*_ref_type()` constructor in `runtime/`. `RequestShape.request_ty` and
+`PrimitiveDescriptor.request_schema` then read the *same* derived type — #1 and
+#2 become one. The struct is the single source; the schema is a projection of
+it, not a parallel artifact.
+
+### 2. The primitive declares its own projection
+
+The `(surface name, placement, arg roles, result type, selectors)` tuple that
+`binding.rs` holds centrally moves to live *with the primitive* — a method or
+associated const on the `Primitive` trait, alongside `descriptor()`. The
+`BindingRegistry` is then **harvested** from the set of registered primitives
+rather than maintained as a second table. `request_shape(kind)` stops being a
+`match` over a closed enum and becomes "ask the registered primitive for its
+shape."
+
+Consequence: the closed `PrimitiveKind` enum, the `BUILTIN_TYPES` /
+`builtin_module_item` string lists in `binder.rs`, the `== "fixture_tree"`
+literal in `compiler.rs`, and the hand-registration in
+`default_primitive_dispatcher()` all collapse into iteration over the registry.
+Behavioural aliases (`refresh` over `observe`, `json_decode` over `decode`) stay
+what they are today: ordinary vix functions over the single primitive, never new
+primitives or intrinsics.
+
+### 3. Facet type names are vix type names
+
+Because the surface type is derived from a *named* Rust struct, `OriginHint` and
+`PinnedBlobRef` become spellable in vix source. A vix program can then construct
+a valid origin and drive `observe`/`fetch` directly — today `observe_binding`
+notes there is "no way to spell a valid origin in vix yet," so these primitives
+are Rust-only. This is the highest-value unlock in the arc: it turns the
+primitives from Rust-invoked into genuinely vix-invoked.
+
+### The end test
+
+**You can add a new effectful primitive without touching `compiler.rs`,
+`binder.rs`, or any table in `binding.rs`.** You write one Rust struct (Facet),
+one `Primitive` impl carrying its descriptor and its projection, register it,
+and the surface name, request lowering, runtime dispatch, and vix-nameable types
+all follow. If a change to a primitive forces an edit to the compiler, the goal
+is not yet met.
+
+## Namespacing and the prelude: the Rust model
+
+Primitives are **namespaced**, and a curated **prelude** is auto-imported into
+every module — exactly like Rust. The important move is separating two things
+today's `Placement` conflates:
+
+- **where an item is *defined*** — always a real namespaced path; and
+- **whether it is *auto-imported*** — a property of the prelude, not the item.
+
+In Rust nothing is "born in the prelude": `Vec` is defined at `alloc::vec::Vec`,
+and `std::prelude::v1` merely *re-exports* it; the compiler then injects
+`use std::prelude::v1::*` into every module at the lowest resolution priority.
+Vix follows this precisely.
+
+### Every primitive lives at a real path, derived from its `PrimitiveId`
+
+The surface module path is **derived from the `PrimitiveId.namespace` the
+primitive already carries** — no separately-declared surface namespace to keep in
+sync (that would reintroduce exactly the duplication this arc kills). The
+mapping is mechanical: dotted namespace → `::`-path.
+
+```
+PrimitiveId { namespace: "vix.machine", name: "fetch", version: 1 }
+        │
+        ▼
+    vix::machine::fetch        // its canonical, path-qualified surface name
+```
+
+So `Placement::Prelude` as a *definition site* disappears. Every binding's
+placement is a `Module(ModulePath)`; the path is not hand-written but computed
+from the primitive's identity. The runtime wire identity and the surface path
+can no longer drift, because they are the same fact.
+
+### The prelude is a vix module of re-exports
+
+The prelude is written as **real vix source** — a module of re-exports — loaded
+the way `crate::stdlib`'s `PRELUDE_FUNCTIONS` are loaded today, so it dogfoods
+the module system rather than being a privileged Rust table:
+
+```vix
+// the auto-imported prelude, expressed in vix
+pub use vix::machine::{fetch, observe};
+pub use vix::fmt::{decode, try_decode};
+// the behavioural aliases stay ordinary vix fns over the single primitive
+pub fn refresh<Origin>(origin: Origin) -> Blob { observe(origin, Mode::Refresh) }
+```
+
+Prelude membership is therefore a line in *this* module, not a flag on the
+binding. A primitive can be reachable at `vix::machine::observe` and *also*
+re-exported unqualified by the prelude; a primitive can exist in a namespace and
+**not** be in the prelude at all (reached only by path or `use`), which is the
+whole point of namespacing.
+
+This means the surface needs a genuine **re-export** notion (`pub use`) — a
+binding target that points at another binding's canonical path — which
+`BindingTarget` grows alongside `Primitive` and `VixFunction`.
+
+### Auto-import and resolution priority
+
+The binder injects a glob import of the prelude module into every vix module
+(the mechanical equivalent of `use vix::prelude::*`). Prelude names resolve at
+**lowest priority**: a local definition or an explicit `use` shadows a prelude
+name, never the reverse — same rule Rust uses, and the same rule the binder
+already applies for inner-scope shadowing. `is_prelude_name` stops being a
+derived string set and becomes "is this name glob-imported from the prelude
+module."
+
+Everything not re-exported by the prelude is reached by its path
+(`vix::machine::foo`) or an explicit `use vix::machine::foo` — the `caps::{Cc,
+Ar, Rustc}` and `vix::{Int, …}` module items in `binder.rs` become instances of
+this one mechanism rather than bespoke `builtin_module_item` arms.
+
+### Not yet: prelude versioning
+
+Rust's prelude is edition-versioned (`prelude::v1`, `prelude::rust_2021`, …).
+Vix has no editions concept yet and this is very early days, so the prelude is a
+single unversioned module. The structure (a named prelude module the binder
+glob-imports) leaves room to key it by edition later without reworking the
+model — but no edition-selection machinery gets built now.
+
+## Runtime context: shared authorities, generically
+
+Primitives need **shared, runtime-installed services** — an async executor, a
+connection pool, an HTTP client, a cache — reused across every invocation, the
+way a backend framework shares one DB pool across all its handlers. Today this
+exists as `runtime::PrimitiveServices`: a `struct` with a *closed, hardcoded* set
+of `Option<Arc<dyn Trait>>` fields (`value_persistence`, `origin`,
+`claim_history`, `fixture_store`), installed via `set_primitive_services` and
+hand-wired into the scheduler. Adding one shared service means editing that
+struct **and** the scheduler — the exact closed-shape anti-pattern this arc
+exists to kill.
+
+### The model: `Runtime<Ctx>` with `FromRef` slices
+
+The runtime becomes **generic over one application context** `Ctx`, chosen by the
+embedder, threaded into every primitive's `begin`. Each primitive declares the
+*slice* of that context it needs via a `FromRef<Ctx>` bound — axum's `State<S>` /
+`FromRef` model — so a primitive that needs a `PgPool` names exactly that, and a
+missing dependency is a **compile error at wiring time**, not a runtime failure.
+
+```rust
+trait Primitive<Ctx> {
+    fn descriptor(&self) -> &PrimitiveDescriptor;
+    // `app` is the whole context; the impl projects the slice it needs.
+    fn begin(&self, request: ValueId, ctx: EffectCtx, app: &Ctx) -> EffectTicket;
+}
+
+// each impl pulls exactly its slice, checked at compile time:
+impl<Ctx> Primitive<Ctx> for DbPrimitive
+where PgPool: FromRef<Ctx> {
+    fn begin(&self, request: ValueId, ctx: EffectCtx, app: &Ctx) -> EffectTicket {
+        let pool = PgPool::from_ref(app);   // static, no downcast, no Option
+        ...
+    }
+}
+```
+
+The registry / dispatcher are then generic in the *single* root `Ctx`
+(`PrimitiveDispatcher<Ctx>`, `Runtime<S, Ctx>`); the trait object stays
+`dyn Primitive<Ctx>` — monomorphic in `Ctx`, so it is **object-safe**. Deps must
+*not* appear as an associated type in the method signature (that would break the
+`dyn Primitive` registry); instead each impl projects the slice it needs out of
+`&Ctx` via `FromRef`, and the `where Slice: FromRef<Ctx>` bound is what makes a
+missing dependency a compile error.
+Built-in primitives that need nothing from the embedder (`fetch`, `observe`) are
+agnostic over `Ctx` (`type Deps = ()`), so a bare runtime still works with
+`Ctx = ()`. This retires `PrimitiveServices` as a hardcoded struct — its four
+fields become ordinary members of whatever `Ctx` an embedder assembles, reached
+by `FromRef` like any other slice.
+
+### The hard invariant: context is ambient authority, never a semantic input
+
+This axis is **orthogonal** to the data-driven-request axis, and must stay so.
+The request value remains the *sole* source of a primitive's identity,
+admissibility, memoization, and receipts — the rule `PrimitiveServices` already
+documents: "authorities, not semantic inputs." The context supplies only *how*
+an effect is carried out (which executor runs the I/O, which pool serves the
+query), never *what* it is or whether two invocations are the same demand. If a
+value can change identity or admissibility it belongs in the request record (and
+thus in the `RequestShape`), not in `Ctx`. This is what keeps deterministic
+replay sound while the executor, pool, and clients vary between runs.
+
+## The hard seams (must be answered, not glossed)
+
+These are the parts where "everything is data" costs real design work. The
+target includes them; the order defers them behind their blockers.
+
+- **`decode` / `try_decode`** need three things a plain record shape can't
+  express: a request field folded from a *compile-time constant* (the `Format`
+  tag), a target type *derived from the expected type* at the call site, and
+  *const-folding through monomorphized vix wrappers*. The end-state generalizes
+  `ArgRole`: today's `Selector` (enum → boolean flag) widens to an
+  `ArgRole::Const` (enum/int → arbitrary constant field), and an
+  `ArgRole::ResultType` carries the expected-type-derived target. This is gated
+  on the const-fold-through-wrappers capability that #2500 defers; until it
+  lands, `decode` stays hand-lowered and `request_shape` returns `None` for it.
+- **`fixture_tree` / `fixture_registry` / `untar`** lower to *dedicated VIR ops*,
+  not `InvokePrimitive` — there is no request record to shape. The end-state
+  gives `RequestShape` an **op-backend**: a shape whose target is a VIR op
+  rather than a `PrimitiveId`, so their projection is data even though their
+  lowering is an op. (The alternative — promoting them to real primitives — was
+  considered and rejected: they don't cross an authority boundary the way
+  `registered-primitives` requires.)
+
+## Explicit non-goals
+
+- **Data-driving `ExternKind`.** `Blob` / `Tree` / `Registry` is a closed enum in
+  `vir.rs`. Making the *set of extern types* open/data-driven is a large lift
+  with little payoff — the extern kinds are a fixed vocabulary of the machine,
+  not a place primitives get added. It stays closed.
+- **Method surfaces** (`.text()`, `.len()`, …) are a separate binding surface
+  from free-function placement and are out of scope for this arc.
+
+## Migration order
+
+Tracks the workstreams in the arc; each is a clean PR against the fixed goal
+above.
+
+1. **Type-schema unification.** Derive `RequestShape.request_ty` and
+   `PrimitiveDescriptor` from one Facet-reflected schema; delete the paired
+   `*_type()` constructors. (Collapses #1 ↔ #2.)
+2. **Nameable surface types.** Make `OriginHint` / `PinnedBlobRef` spellable in
+   vix, so observe/fetch run from vix source, not just Rust. (Highest value.)
+3. **Projection moves onto the primitive; registry is harvested.** Kill the
+   central `request_shape` `match`, the `PrimitiveKind` enum, and the
+   `binder.rs` / `compiler.rs` string lists.
+4. **Namespacing + prelude-as-re-export module.** Derive each binding's module
+   path from `PrimitiveId.namespace`; retire `Placement::Prelude` as a
+   definition site; add a re-export (`pub use`) binding target; move the prelude
+   into a vix module the binder glob-imports at lowest priority; collapse
+   `builtin_module_item` / `BUILTIN_TYPES` into that one path-resolution
+   mechanism.
+5. **`fixture_*` / `untar` op-backend.** Give `RequestShape` a VIR-op target so
+   these are data-projected.
+6. **`decode` / `try_decode`.** After const-fold-through-wrappers (#2500) lands:
+   `ArgRole::Const` + `ArgRole::ResultType`, retiring the last hand-lowered arm.
+
+Independent of 1–6 (orthogonal axis, can land any time):
+
+7. **Generic runtime context.** Make the runtime generic over an embedder
+   context `Ctx`; give `Primitive` a `type Deps: FromRef<Ctx>` projected into
+   `begin`; retire the hardcoded `PrimitiveServices` struct into ordinary `Ctx`
+   members. Enforce the invariant that `Ctx` is ambient authority only — nothing
+   in it feeds identity/memo/receipts.

--- a/vix/docs/content-design/data-driven-primitives.md
+++ b/vix/docs/content-design/data-driven-primitives.md
@@ -29,43 +29,92 @@ still gates *what earns a primitive* (it must cross an authority boundary). This
 note is about the *mechanism* once something has earned one: how that primitive
 projects onto the vix surface without bespoke compiler code.
 
-## What's wrong today: one primitive, three hand-synced spellings
+## What's wrong today: one primitive, *five* hand-synced spellings
 
-A single primitive like `fetch` is described in three places that must agree
-field-for-field, kept in lockstep by a human:
+A single primitive like `fetch` is described in five places that must agree
+field-for-field, kept in lockstep by a human. (The first three were the ones
+this doc originally listed; the last two were surfaced by investigating the
+step-1 PR — they are just as load-bearing.)
 
 1. **The Rust request struct** — `PinnedFetchRequest { pin: PinnedBlobRef }` in
    `runtime/fetch_primitive.rs`, `#[derive(facet::Facet)]`. This is what the
    runtime actually executes against.
 2. **A hand-written `Type` mirror** — `pinned_fetch_request_type()`,
-   `origin_hint_type()`, `pinned_blob_ref_type()`, `observe_request_type()`,
-   each a `Type::Record(...)` that re-spells struct #1 field-by-field. This is
-   what the compiler builds requests *of*, and what `PrimitiveDescriptor`'s
-   `schema_ref()` patterns point back into.
+   `origin_hint_type()`, `blob_id_type()`, `pinned_blob_ref_type()`,
+   `observe_request_type()`, each a `Type::Record(...)` that re-spells struct #1
+   field-by-field. This is what the compiler builds requests *of*, and what
+   `PrimitiveDescriptor`'s `schema_ref()` patterns point back into.
 3. **The projection onto the surface** — `binding::RequestShape` (per-argument
    `ArgRole`s → how surface arguments fold into #2's record) plus the central
    `request_shape(kind)` / `builtin_bindings()` tables in `binding.rs`.
+4. **The method-surface lowering** — `compiler.rs` (`PreludeMethod::RegistryUrl`
+   / `RegistryCoordinate`, the `.registry_url(name)` / `.registry_coordinate(name)`
+   methods) lowers to VIR ops typed with `pinned_blob_ref_type()` /
+   `origin_hint_type()` directly. This is in fact **the one vix-source-reachable
+   path that constructs these types today** — so the `observe_binding` comment
+   "no way to spell a valid origin in vix yet" is only true for record literals,
+   not for the method surface.
+5. **The wire-construction op** — `scheduler.rs` (`Op::RegistryUrl` /
+   `RegistryCoordinate` execution) hand-builds the raw `PrimitiveValue` product /
+   variant / sequence trees field-by-field, matching #2's records exactly,
+   including the hex-string `upstream` encoding. This is construction code, not a
+   type mirror, so it must track any field-order / shape / encoding change as
+   tightly as `parse_request` does on the read side.
 
 `RequestShape` already collapsed the *bespoke-compiler-arm* half of #3 into
 data — `fetch` and `observe` no longer have a hand-written arm in
 `lower_effect_intrinsic`. But #1 and #2 are still two spellings of the same
-shape, #2 has no vix-nameable surface, and #3's mapping table is a second place
-that names every primitive.
+shape, #2 has no vix-nameable surface, #3's mapping table is a second place that
+names every primitive, and #4/#5 must be reconciled by hand on every change.
 
 The duplication is not incidental: `facet::Facet` already gives full reflection
-over struct #1, so #2 is *derivable* and only exists because we hand-wrote it
-first.
+over struct #1, so #2 is *largely* derivable — see the next section for the small,
+honest set of leaf facts that are genuinely not inferable from the Rust type.
 
 ## End-state: one source per fact
 
 ### 1. The struct shape *is* the schema
 
 Derive `Type` / `schema_ref` from the `Facet` shape of the request struct and
-**delete** every hand-written `*_request_type()` / `*_hint_type()` /
-`*_ref_type()` constructor in `runtime/`. `RequestShape.request_ty` and
+**delete** the hand-written `*_request_type()` / `*_hint_type()` / `*_ref_type()`
+constructors in `runtime/`. `RequestShape.request_ty` and
 `PrimitiveDescriptor.request_schema` then read the *same* derived type — #1 and
 #2 become one. The struct is the single source; the schema is a projection of
 it, not a parallel artifact.
+
+**The mechanism, honestly.** A facet-shape → `SchemaRef` bridge already exists
+(`SchemaRef::for_facet`, via `facet`'s `taxon_bridge`) but is dead code, and it
+only yields the identity hash — the compiler needs the *structural* `vir::Type`
+(field names, record/option/array tree) to build requests, so a
+`Type::from_facet::<T>()` walker must be built. It maps the common cases
+generically (primitives, `struct → Record`, `enum → Enum`, `Vec → array`,
+`Option → option`), and consults a **tiny override table** (~4–6 entries) for the
+handful of leaf facts Rust's type system genuinely cannot carry:
+
+- a `[u8; 32]` digest is wire-encoded as a hex `String` (vix's `Type` has no
+  fixed-byte-array primitive) — `Digest` / `UpstreamDigest → Type::String`;
+- an opaque handle field is a `Type::Extern(kind)`, but the same Rust type
+  (`ValueId`) is reused for several `ExternKind`s and carries no marker for
+  *which*. The fix is to **reshape the structs** so each wire meaning gets its own
+  Rust newtype (e.g. a `RegistryHandle(ValueId)` distinct from `BlobId(ValueId)`),
+  and key the override on that type identity — distinct meanings, distinct types,
+  which is the "make invalid states unrepresentable" move anyway.
+
+This keeps the single-source promise while being honest that a few leaf facts
+need one line of override each — not a bespoke `Type::Record` per primitive.
+
+**Schema stability is the gate.** `PrimitiveDescriptor.request_schema =
+SchemaPattern::exact(&…type().schema_ref())` — dispatch matching and wire
+identity depend on the exact bytes. So the PR is fenced by a **snapshot test**:
+capture each of the five types' `.schema_ref()` before, assert byte-identical
+after. Watch the `required` flag: it is part of the schema hash, and adding a
+`#[facet(default)]` to any field would silently move the id past
+`SchemaPattern::exact` — worth an assertion or comment.
+
+Because this step also touches spellings #4 and #5 (the `compiler.rs` method
+surface and the `scheduler.rs` construction op), any change to a wire shape must
+move them in lockstep — the snapshot test catches drift, but those two sites need
+updating by hand if a leaf shape moves.
 
 ### 2. The primitive declares its own projection
 
@@ -281,9 +330,13 @@ target includes them; the order defers them behind their blockers.
 Tracks the workstreams in the arc; each is a clean PR against the fixed goal
 above.
 
-1. **Type-schema unification.** Derive `RequestShape.request_ty` and
-   `PrimitiveDescriptor` from one Facet-reflected schema; delete the paired
-   `*_type()` constructors. (Collapses #1 ↔ #2.)
+1. **Type-schema unification.** Build a `Type::from_facet::<T>()` walker (+ tiny
+   leaf-override table + per-`ExternKind` newtypes); derive `RequestShape.request_ty`
+   and `PrimitiveDescriptor` from it; author the missing `ObserveRequest` struct;
+   delete the five `*_type()` constructors. Fence with a `.schema_ref()` snapshot
+   test (byte-identical before/after) and reconcile spellings #4 (`compiler.rs`
+   method surface) and #5 (`scheduler.rs` construction op). Riskiest sub-decision:
+   how `BlobId`/`ValueId` decompose. (Collapses #1 ↔ #2, #4, #5.)
 2. **Nameable surface types.** Make `OriginHint` / `PinnedBlobRef` spellable in
    vix, so observe/fetch run from vix source, not just Rust. (Highest value.)
 3. **Projection moves onto the primitive; registry is harvested.** Kill the
@@ -303,7 +356,8 @@ above.
 Independent of 1–6 (orthogonal axis, can land any time):
 
 7. **Generic runtime context.** Make the runtime generic over an embedder
-   context `Ctx`; give `Primitive` a `type Deps: FromRef<Ctx>` projected into
-   `begin`; retire the hardcoded `PrimitiveServices` struct into ordinary `Ctx`
-   members. Enforce the invariant that `Ctx` is ambient authority only — nothing
+   context `Ctx` (`Runtime<S, Ctx = ()>`, `dyn Primitive<Ctx>` object-safe);
+   thread `&Ctx` into `begin`, each impl projecting its slice via `FromRef`;
+   retire the hardcoded `PrimitiveServices` struct into ordinary `Ctx` members.
+   Enforce the invariant that `Ctx` is ambient authority only — nothing
    in it feeds identity/memo/receipts.

--- a/vix/src/binding.rs
+++ b/vix/src/binding.rs
@@ -23,10 +23,21 @@
 //! **Primitive dispatch is wired.** `compiler::lower_value` recognizes built-in
 //! primitives through [`prelude_primitive`] — the callee name maps to a
 //! [`PrimitiveKind`] here, in data, instead of scattered `== "decode"` /
-//! `effect_intrinsic` string matches. The genuinely per-primitive request
-//! construction (the `Format`/`Mode` selector reads, expected-type-derived
-//! targets, constant folding) stays in the compiler's typed builders, dispatched
-//! from that one kind; only the *name → primitive* map lives here.
+//! `effect_intrinsic` string matches.
+//!
+//! **Request construction is data for the uniform primitives.** `fetch` and
+//! `observe` lower through a [`RequestShape`] ([`request_shape`]): their arity,
+//! per-argument roles (a lowered [`ArgRole::Value`] with its required type, or a
+//! [`Selector`] enum read at lower time), request record, result type, and target
+//! primitive are all data, consumed by one generic builder rather than a bespoke
+//! Rust arm each. The old `observe_mode_arg` reader is now the data in a
+//! [`Selector`].
+//!
+//! Not yet on a shape: `decode`/`try_decode` (compile-time constant folding and
+//! expected-type-derived targets don't reduce to a record shape) and the
+//! `fixture_*`/`untar` dedicated VIR ops (not `InvokePrimitive` at all). Those
+//! stay in the compiler's typed builders; [`request_shape`] returns `None` for
+//! them.
 //!
 //! Still on the compiler side: the binder consults [`is_prelude_name`] (a name
 //! set derived from these bindings) but does not yet route full prelude/module
@@ -38,6 +49,12 @@
 
 use std::collections::BTreeSet;
 use std::sync::LazyLock;
+
+use crate::runtime::{
+    PrimitiveId, observe_primitive_id, observe_request_type, origin_hint_type, pinned_blob_ref_type,
+    pinned_fetch_primitive_id, pinned_fetch_request_type,
+};
+use crate::vir::{ExternKind, Type};
 
 /// A non-empty `::`-separated module path (`caps`, `some::ns::inner`).
 ///
@@ -119,6 +136,131 @@ pub enum BindingTarget {
     /// function is effectful when its body invokes an effectful primitive; vix
     /// effect tracking flows through the call as it does for any wrapper.
     VixFunction { source: String },
+}
+
+/// One accepted variant of a [`Selector`] argument and the boolean flag it folds
+/// into the request record. (`Mode::Observe` → `false`, `Mode::Refresh` → `true`.)
+///
+/// Selectors fold to a boolean today because the only one — observe's `Mode` — is
+/// binary. Decode's `Format` is an integer tag; when it migrates onto a shape this
+/// widens to a general constant. Until then, "selector" means "enum → flag".
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SelectorVariant {
+    pub variant: String,
+    pub flag: bool,
+}
+
+/// A selector argument: an enum-variant read at *lower time* into a constant and
+/// folded into the request record, never lowered as a runtime value. This is the
+/// data form of the old `observe_mode_arg`/`decode_format_arg` readers — the
+/// accepted `enum_name`, its variants, and the diagnostic wording all live here
+/// rather than as a bespoke Rust reader per primitive.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Selector {
+    /// The enum the variant must name (`Mode`).
+    pub enum_name: String,
+    /// How the selector reads in diagnostics (`observe mode`) — the noun the
+    /// "expected …" and "unknown …" messages are built from.
+    pub noun: String,
+    pub variants: Vec<SelectorVariant>,
+}
+
+impl Selector {
+    /// What a non-variant or wrong-enum argument should say it expected, e.g.
+    /// `an observe mode `Mode::Observe` or `Mode::Refresh``.
+    #[must_use]
+    pub fn expected(&self) -> String {
+        let choices: Vec<String> = self
+            .variants
+            .iter()
+            .map(|candidate| format!("`{}::{}`", self.enum_name, candidate.variant))
+            .collect();
+        format!("an {} {}", self.noun, choices.join(" or "))
+    }
+
+    /// The message for a known enum but unrecognized variant, e.g.
+    /// `an unknown observe mode `Mode::Spin``.
+    #[must_use]
+    pub fn unknown(&self, variant: &str) -> String {
+        format!("an unknown {} `{}::{variant}`", self.noun, self.enum_name)
+    }
+}
+
+/// The structural role a surface argument plays in a primitive's request record.
+/// The request record has one field per argument, in this order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ArgRole {
+    /// Lowered as an ordinary value and required to have the given type
+    /// (`fetch`'s `PinnedBlobRef`, `observe`'s `OriginHint`).
+    Value { expected: Type },
+    /// An enum-variant selector folded to a constant request field.
+    Selector(Selector),
+}
+
+/// How a registered primitive builds its request from its surface arguments — the
+/// data a single generic lowering step consumes in place of a bespoke Rust arm per
+/// primitive. Arity is `args.len()`; the compiler builds a `request_ty` record with
+/// one field per argument (in order), invokes `primitive`, and yields `result`.
+///
+/// Only the primitives whose construction is *fully uniform* have a shape today
+/// (`fetch`, `observe`). `decode`/`try_decode` (compile-time constant folding,
+/// expected-type-derived targets) and the `fixture_*`/`untar` dedicated VIR ops
+/// are not yet expressible here — see [`request_shape`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RequestShape {
+    pub args: Vec<ArgRole>,
+    pub request_ty: Type,
+    pub result: Type,
+    pub primitive: PrimitiveId,
+}
+
+/// The [`RequestShape`] a primitive's call lowers through, or `None` for the
+/// primitives whose request construction is not yet data (`decode`/`try_decode`
+/// and the `fixture_*`/`untar` dedicated ops — those stay in the compiler's typed
+/// builders). Returning `Some` is the contract that a primitive is fully described
+/// by data: the compiler builds its request generically from the shape.
+#[must_use]
+pub fn request_shape(kind: PrimitiveKind) -> Option<RequestShape> {
+    let blob = Type::Extern(ExternKind::Blob);
+    match kind {
+        PrimitiveKind::Fetch => Some(RequestShape {
+            args: vec![ArgRole::Value {
+                expected: pinned_blob_ref_type(),
+            }],
+            request_ty: pinned_fetch_request_type(),
+            result: blob,
+            primitive: pinned_fetch_primitive_id(),
+        }),
+        PrimitiveKind::Observe => Some(RequestShape {
+            args: vec![
+                ArgRole::Value {
+                    expected: origin_hint_type(),
+                },
+                ArgRole::Selector(Selector {
+                    enum_name: "Mode".to_owned(),
+                    noun: "observe mode".to_owned(),
+                    variants: vec![
+                        SelectorVariant {
+                            variant: "Observe".to_owned(),
+                            flag: false,
+                        },
+                        SelectorVariant {
+                            variant: "Refresh".to_owned(),
+                            flag: true,
+                        },
+                    ],
+                }),
+            ],
+            request_ty: observe_request_type(),
+            result: blob,
+            primitive: observe_primitive_id(),
+        }),
+        PrimitiveKind::Decode
+        | PrimitiveKind::TryDecode
+        | PrimitiveKind::FixtureTree
+        | PrimitiveKind::FixtureRegistry
+        | PrimitiveKind::Untar => None,
+    }
 }
 
 /// One projected name: placement + leaf name + what it resolves to.
@@ -349,5 +491,64 @@ mod tests {
         assert!(reg.qualified(&path, "cool_function").is_some());
         // ...but not from the prelude.
         assert!(reg.prelude("cool_function").is_none());
+    }
+
+    #[test]
+    fn only_the_uniform_primitives_have_a_request_shape() {
+        // fetch/observe are fully data — the compiler builds their request from
+        // the shape. Everything else is still hand-lowered and returns `None`.
+        assert!(request_shape(PrimitiveKind::Fetch).is_some());
+        assert!(request_shape(PrimitiveKind::Observe).is_some());
+        for kind in [
+            PrimitiveKind::Decode,
+            PrimitiveKind::TryDecode,
+            PrimitiveKind::FixtureTree,
+            PrimitiveKind::FixtureRegistry,
+            PrimitiveKind::Untar,
+        ] {
+            assert!(request_shape(kind).is_none(), "{kind:?} should have no shape yet");
+        }
+    }
+
+    #[test]
+    fn fetch_shape_is_one_value_arg() {
+        let shape = request_shape(PrimitiveKind::Fetch).expect("fetch shape");
+        assert_eq!(shape.args.len(), 1);
+        assert!(matches!(shape.args[0], ArgRole::Value { .. }));
+        assert_eq!(shape.result, Type::Extern(ExternKind::Blob));
+        assert_eq!(shape.primitive, pinned_fetch_primitive_id());
+    }
+
+    #[test]
+    fn observe_shape_is_a_value_then_a_mode_selector() {
+        let shape = request_shape(PrimitiveKind::Observe).expect("observe shape");
+        assert_eq!(shape.args.len(), 2);
+        assert!(matches!(shape.args[0], ArgRole::Value { .. }));
+        let ArgRole::Selector(selector) = &shape.args[1] else {
+            panic!("observe's second argument is the Mode selector");
+        };
+        assert_eq!(selector.enum_name, "Mode");
+        // The selector carries its own accepted variants and folded flags.
+        assert_eq!(
+            selector
+                .variants
+                .iter()
+                .find(|v| v.variant == "Refresh")
+                .map(|v| v.flag),
+            Some(true),
+        );
+    }
+
+    #[test]
+    fn selector_builds_its_own_diagnostic_wording() {
+        let shape = request_shape(PrimitiveKind::Observe).expect("observe shape");
+        let ArgRole::Selector(selector) = &shape.args[1] else {
+            panic!("expected the Mode selector");
+        };
+        assert_eq!(
+            selector.expected(),
+            "an observe mode `Mode::Observe` or `Mode::Refresh`",
+        );
+        assert_eq!(selector.unknown("Spin"), "an unknown observe mode `Mode::Spin`");
     }
 }

--- a/vix/src/compiler.rs
+++ b/vix/src/compiler.rs
@@ -12,9 +12,7 @@ use taxon::{
 use crate::decode::{self, DecodeFormat, DecodedValue};
 use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticPayload, Diagnostics, Label};
 use crate::runtime::{
-    observe_primitive_id, observe_request_type, origin_hint_type, pinned_blob_ref_type,
-    pinned_fetch_primitive_id, pinned_fetch_request_type, tree_read_primitive_id,
-    tree_read_request_type,
+    origin_hint_type, pinned_blob_ref_type, tree_read_primitive_id, tree_read_request_type,
 };
 use crate::schema::{SchemaBatch, SchemaRef, SchemaSet};
 use crate::support::{Span, Spanned};
@@ -5252,22 +5250,147 @@ fn lower_primitive(
     expected: Option<&Type>,
 ) -> Result<LoweredValue, Diagnostics> {
     use crate::binding::PrimitiveKind;
+    // Primitives whose request construction is fully data (`fetch`, `observe`)
+    // lower through their `RequestShape`; there is no per-primitive Rust arm.
+    if let Some(shape) = crate::binding::request_shape(kind) {
+        return lower_request_shape(nodes, bindings, context, call, &shape);
+    }
     match kind {
         PrimitiveKind::Decode => lower_decode_binding(nodes, bindings, context, call, expected),
         PrimitiveKind::TryDecode => {
             lower_try_decode_binding(nodes, bindings, context, call, expected)
         }
-        PrimitiveKind::Fetch
-        | PrimitiveKind::Observe
-        | PrimitiveKind::FixtureTree
-        | PrimitiveKind::FixtureRegistry
-        | PrimitiveKind::Untar => lower_effect_intrinsic(nodes, bindings, context, call, kind),
+        PrimitiveKind::FixtureTree | PrimitiveKind::FixtureRegistry | PrimitiveKind::Untar => {
+            lower_effect_intrinsic(nodes, bindings, context, call, kind)
+        }
+        PrimitiveKind::Fetch | PrimitiveKind::Observe => {
+            unreachable!("fetch/observe lower through their RequestShape")
+        }
     }
 }
 
-/// The machine-plane primitive constructors of the tree/fetch band. Each
-/// lowers to an [`EffectKind::Effect`] node the partitioner hoists into its
+/// Build a registered-primitive call from its [`RequestShape`]: check arity, read
+/// every [`Selector`](crate::binding::Selector) *before* enforcing any value-arg
+/// type (a bad mode must beat a wrong-typed origin — see `observe_binding`), then
+/// lower each argument in order into the request record and invoke the primitive.
+///
+/// This is the one generic replacement for the former per-primitive arms in
+/// `lower_effect_intrinsic`. The request record and the `InvokePrimitive` node are
+/// `PURE`: the effect-island the primitive runs in is keyed off the primitive
+/// itself, not these nodes' effect facts.
+fn lower_request_shape(
+    nodes: &mut Vec<Node>,
+    bindings: &BTreeMap<String, LoweredValue>,
+    context: &ModuleContext<'_>,
+    call: &ast::Call,
+    shape: &crate::binding::RequestShape,
+) -> Result<LoweredValue, Diagnostics> {
+    use crate::binding::ArgRole;
+    if call.named_args.is_some() {
+        return Err(Diagnostics::one(Diagnostic::unsupported(
+            call.span,
+            "named arguments on a primitive constructor",
+        )));
+    }
+    check_arity(call, shape.args.len())?;
+
+    // Read selectors first: a `Mode::Spin` must be rejected as an unknown mode
+    // before an origin of the wrong type is rejected as a type mismatch.
+    let mut flags: BTreeMap<usize, bool> = BTreeMap::new();
+    for (index, role) in shape.args.iter().enumerate() {
+        if let ArgRole::Selector(selector) = role {
+            flags.insert(index, read_selector(&call.args.args[index], selector)?);
+        }
+    }
+
+    let mut inputs = Vec::with_capacity(shape.args.len());
+    for (index, role) in shape.args.iter().enumerate() {
+        let arg = &call.args.args[index];
+        let node = match role {
+            ArgRole::Value { expected } => {
+                let value = lower_value(nodes, bindings, context, arg)?;
+                require_type(&value, expected, expr_span(arg))?;
+                value.node
+            }
+            ArgRole::Selector(_) => push_node(
+                nodes,
+                call.span,
+                Type::Bool,
+                EffectFacts::PURE,
+                Vec::new(),
+                Op::Bool(flags[&index]),
+            ),
+        };
+        inputs.push(node);
+    }
+
+    let request = push_node(
+        nodes,
+        call.span,
+        shape.request_ty.clone(),
+        EffectFacts::PURE,
+        inputs,
+        Op::Record,
+    );
+    let ty = shape.result.clone();
+    Ok(LoweredValue {
+        node: push_node(
+            nodes,
+            call.span,
+            ty.clone(),
+            EffectFacts::PURE,
+            vec![request],
+            Op::InvokePrimitive {
+                primitive: shape.primitive.clone(),
+            },
+        ),
+        ty,
+    })
+}
+
+/// Read a [`Selector`](crate::binding::Selector) argument: an enum variant named
+/// at lower time and folded to its request flag, never lowered as a value. The
+/// data form of the former `observe_mode_arg`/`decode_format_arg` readers — the
+/// accepted enum, its variants, and the diagnostic wording all come from the
+/// selector. An unknown or non-matching variant is rejected here, not by the
+/// checker (which never sees it in a value position).
+fn read_selector(
+    arg: &ast::Expr,
+    selector: &crate::binding::Selector,
+) -> Result<bool, Diagnostics> {
+    let ast::Expr::Variant(variant) = arg else {
+        return Err(Diagnostics::one(Diagnostic::unsupported(
+            expr_span(arg),
+            selector.expected(),
+        )));
+    };
+    if variant.path.type_name.value != selector.enum_name {
+        return Err(Diagnostics::one(Diagnostic::unsupported(
+            variant.path.span,
+            selector.expected(),
+        )));
+    }
+    let chosen = variant.path.variant.value.as_str();
+    selector
+        .variants
+        .iter()
+        .find(|candidate| candidate.variant == chosen)
+        .map(|candidate| candidate.flag)
+        .ok_or_else(|| {
+            Diagnostics::one(Diagnostic::unsupported(
+                variant.path.variant.span,
+                selector.unknown(chosen),
+            ))
+        })
+}
+
+/// The dedicated-op tree primitives (`fixture_tree`, `fixture_registry`, `untar`).
+/// Each lowers to an [`EffectKind::Effect`] node the partitioner hoists into its
 /// own effect island; nothing here is a Weavy-lowerable pure operation.
+///
+/// Unlike `fetch`/`observe`, these are not `InvokePrimitive` requests — they are
+/// bespoke VIR ops, so they do not have a [`RequestShape`](crate::binding::RequestShape)
+/// yet and stay hand-lowered here.
 fn lower_effect_intrinsic(
     nodes: &mut Vec<Node>,
     bindings: &BTreeMap<String, LoweredValue>,
@@ -5281,71 +5404,6 @@ fn lower_effect_intrinsic(
             call.span,
             "named arguments on a primitive constructor",
         )));
-    }
-    if kind == PrimitiveKind::Fetch {
-        check_arity(call, 1)?;
-        let pin = lower_value(nodes, bindings, context, &call.args.args[0])?;
-        require_type(&pin, &pinned_blob_ref_type(), expr_span(&call.args.args[0]))?;
-        let request_ty = pinned_fetch_request_type();
-        let request = push_node(
-            nodes,
-            call.span,
-            request_ty,
-            EffectFacts::PURE,
-            vec![pin.node],
-            Op::Record,
-        );
-        let ty = Type::Extern(ExternKind::Blob);
-        return Ok(LoweredValue {
-            node: push_node(
-                nodes,
-                call.span,
-                ty.clone(),
-                EffectFacts::PURE,
-                vec![request],
-                Op::InvokePrimitive {
-                    primitive: pinned_fetch_primitive_id(),
-                },
-            ),
-            ty,
-        });
-    }
-    if kind == PrimitiveKind::Observe {
-        check_arity(call, 2)?;
-        let refresh = observe_mode_arg(&call.args.args[1])?;
-        let origin = lower_value(nodes, bindings, context, &call.args.args[0])?;
-        require_type(&origin, &origin_hint_type(), expr_span(&call.args.args[0]))?;
-        let flag = push_node(
-            nodes,
-            call.span,
-            Type::Bool,
-            EffectFacts::PURE,
-            Vec::new(),
-            Op::Bool(refresh),
-        );
-        let request_ty = observe_request_type();
-        let request = push_node(
-            nodes,
-            call.span,
-            request_ty,
-            EffectFacts::PURE,
-            vec![origin.node, flag],
-            Op::Record,
-        );
-        let ty = Type::Extern(ExternKind::Blob);
-        return Ok(LoweredValue {
-            node: push_node(
-                nodes,
-                call.span,
-                ty.clone(),
-                EffectFacts::PURE,
-                vec![request],
-                Op::InvokePrimitive {
-                    primitive: observe_primitive_id(),
-                },
-            ),
-            ty,
-        });
     }
     let (ty, op, inputs) = match kind {
         PrimitiveKind::FixtureTree => {
@@ -5381,7 +5439,7 @@ fn lower_effect_intrinsic(
             (Type::Extern(ExternKind::Tree), Op::Untar, vec![blob.node])
         }
         PrimitiveKind::Fetch | PrimitiveKind::Observe => {
-            unreachable!("fetch/observe returned above")
+            unreachable!("fetch/observe lower through their RequestShape")
         }
         PrimitiveKind::Decode | PrimitiveKind::TryDecode => {
             unreachable!("decode/try_decode do not route through lower_effect_intrinsic")
@@ -5721,35 +5779,6 @@ fn decode_format_arg(arg: &ast::Expr) -> Result<DecodeFormat, Diagnostics> {
         other => Err(Diagnostics::one(Diagnostic::unsupported(
             variant.path.variant.span,
             format!("an unknown decode format `Format::{other}`"),
-        ))),
-    }
-}
-
-/// Read the `Mode::Observe` / `Mode::Refresh` selector of an `observe` call,
-/// returning the refresh flag the primitive folds into its request record. The
-/// twin of `decode_format_arg`: the observe mode is a surface argument, not a
-/// second primitive and not a `refresh` compiler intrinsic. Like the format
-/// selector it is read at lower time and never lowered as a value, so an unknown
-/// mode is rejected only here, not by the checker.
-fn observe_mode_arg(arg: &ast::Expr) -> Result<bool, Diagnostics> {
-    let ast::Expr::Variant(variant) = arg else {
-        return Err(Diagnostics::one(Diagnostic::unsupported(
-            expr_span(arg),
-            "an observe mode `Mode::Observe` or `Mode::Refresh`",
-        )));
-    };
-    if variant.path.type_name.value != "Mode" {
-        return Err(Diagnostics::one(Diagnostic::unsupported(
-            variant.path.span,
-            "an observe mode `Mode::Observe` or `Mode::Refresh`",
-        )));
-    }
-    match variant.path.variant.value.as_str() {
-        "Observe" => Ok(false),
-        "Refresh" => Ok(true),
-        other => Err(Diagnostics::one(Diagnostic::unsupported(
-            variant.path.variant.span,
-            format!("an unknown observe mode `Mode::{other}`"),
         ))),
     }
 }


### PR DESCRIPTION
Writes down the end-state design for the vix ↔ rust primitive interface — the north star the "data-driven primitives" arc is walking toward. Pure markdown (`vix/docs/content-design/data-driven-primitives.md`), no code.

Covers three axes:
- **Data-driven requests/types** — a primitive is described once (its Facet struct), not in five hand-synced spellings. Struct → schema via a `Type::from_facet` walker; `RequestShape`/`PrimitiveDescriptor` read the same derived type.
- **Namespacing + auto-prelude** — primitives live at real paths derived from `PrimitiveId.namespace`; a curated prelude (a vix module of `pub use` re-exports) is glob-imported into every module, exactly like Rust's `std::prelude`.
- **Generic runtime context** — `Runtime<S, Ctx>`; each primitive projects the shared authorities it needs via `FromRef`, ambient authority only (never identity/memo/receipts).

Also records non-goals (closed `ExternKind`, no prelude versioning yet) and an ordered migration plan. Foundation/reference for the PRs that follow.
