### PR TITLE
vix: make the runtime generic over an embedder context

### DIFF
--- a/vix/src/runtime/decode_primitive.rs
+++ b/vix/src/runtime/decode_primitive.rs
@@ -35,12 +35,12 @@ impl Default for DecodePrimitive {
     }
 }
 
-impl Primitive for DecodePrimitive {
+impl<Ctx> Primitive<Ctx> for DecodePrimitive {
     fn descriptor(&self) -> &PrimitiveDescriptor {
         &self.descriptor
     }
 
-    fn begin(&self, request: ValueId, ctx: EffectCtx) -> EffectTicket {
+    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> EffectTicket {
         let (ticket, completer) = ctx.ticket(|| {});
         let completion = decode_request(&request, &ctx)
             .and_then(|value| ctx.intern_value(value))

--- a/vix/src/runtime/fetch_primitive.rs
+++ b/vix/src/runtime/fetch_primitive.rs
@@ -141,12 +141,12 @@ impl Default for PinnedFetchPrimitive {
     }
 }
 
-impl Primitive for PinnedFetchPrimitive {
+impl<Ctx> Primitive<Ctx> for PinnedFetchPrimitive {
     fn descriptor(&self) -> &PrimitiveDescriptor {
         &self.descriptor
     }
 
-    fn begin(&self, request: ValueId, ctx: EffectCtx) -> EffectTicket {
+    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> EffectTicket {
         let (ticket, completer) = ctx.ticket(|| {});
         std::thread::spawn(move || {
             let completion = execute(&request, &ctx)

--- a/vix/src/runtime/observe_primitive.rs
+++ b/vix/src/runtime/observe_primitive.rs
@@ -68,12 +68,12 @@ impl Default for ObservePrimitive {
     }
 }
 
-impl Primitive for ObservePrimitive {
+impl<Ctx> Primitive<Ctx> for ObservePrimitive {
     fn descriptor(&self) -> &PrimitiveDescriptor {
         &self.descriptor
     }
 
-    fn begin(&self, request: ValueId, ctx: EffectCtx) -> EffectTicket {
+    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> EffectTicket {
         let (ticket, completer) = ctx.ticket(|| {});
         std::thread::spawn(move || {
             let completion = execute(&request, &ctx)

--- a/vix/src/runtime/primitive.rs
+++ b/vix/src/runtime/primitive.rs
@@ -852,9 +852,21 @@ impl EffectCtx {
     }
 }
 
-pub trait Primitive: Send + Sync {
+pub trait FromRef<Ctx> {
+    fn from_ref(ctx: &Ctx) -> Self;
+}
+
+impl<T: Clone> FromRef<T> for T {
+    fn from_ref(ctx: &T) -> T {
+        ctx.clone()
+    }
+}
+
+pub trait Primitive<Ctx>: Send + Sync {
     fn descriptor(&self) -> &PrimitiveDescriptor;
-    fn begin(&self, request: ValueId, ctx: EffectCtx) -> EffectTicket;
+    /// `app` is the whole shared embedder context; the impl projects the
+    /// slice it needs out of it via [`FromRef`].
+    fn begin(&self, request: ValueId, ctx: EffectCtx, app: &Ctx) -> EffectTicket;
 }
 
 type TicketWaiter = Box<dyn FnOnce(PrimitivePublication) + Send + 'static>;
@@ -1016,19 +1028,26 @@ impl Drop for TicketSubscription {
     }
 }
 
-#[derive(Default)]
-pub struct PrimitiveRegistry {
-    primitives: BTreeMap<PrimitiveId, Arc<dyn Primitive>>,
+pub struct PrimitiveRegistry<Ctx> {
+    primitives: BTreeMap<PrimitiveId, Arc<dyn Primitive<Ctx>>>,
 }
 
-pub struct PrimitiveDispatcher {
-    registry: Arc<PrimitiveRegistry>,
+impl<Ctx> Default for PrimitiveRegistry<Ctx> {
+    fn default() -> Self {
+        Self {
+            primitives: BTreeMap::new(),
+        }
+    }
+}
+
+pub struct PrimitiveDispatcher<Ctx> {
+    registry: Arc<PrimitiveRegistry<Ctx>>,
     in_flight: Mutex<BTreeMap<DemandKey, EffectTicket>>,
 }
 
-impl PrimitiveDispatcher {
+impl<Ctx> PrimitiveDispatcher<Ctx> {
     #[must_use]
-    pub fn new(registry: Arc<PrimitiveRegistry>) -> Self {
+    pub fn new(registry: Arc<PrimitiveRegistry<Ctx>>) -> Self {
         Self {
             registry,
             in_flight: Mutex::new(BTreeMap::new()),
@@ -1040,13 +1059,14 @@ impl PrimitiveDispatcher {
         id: &PrimitiveId,
         request: ValueId,
         ctx: EffectCtx,
+        app: &Ctx,
     ) -> Result<EffectTicket, Box<PrimitiveDispatchError>> {
         let demand = ctx.demand();
         let mut in_flight = self.in_flight.lock().expect("dispatcher mutex poisoned");
         if let Some(ticket) = in_flight.get(&demand) {
             return Ok(ticket.clone());
         }
-        let ticket = self.registry.begin(id, request, ctx)?;
+        let ticket = self.registry.begin(id, request, ctx, app)?;
         in_flight.insert(demand, ticket.clone());
         Ok(ticket)
     }
@@ -1077,10 +1097,10 @@ pub enum PrimitiveRegistrationError {
     Duplicate(PrimitiveId),
 }
 
-impl PrimitiveRegistry {
+impl<Ctx> PrimitiveRegistry<Ctx> {
     pub fn register(
         &mut self,
-        primitive: Arc<dyn Primitive>,
+        primitive: Arc<dyn Primitive<Ctx>>,
     ) -> Result<(), PrimitiveRegistrationError> {
         let id = primitive.descriptor().id.clone();
         if self.primitives.insert(id.clone(), primitive).is_some() {
@@ -1101,6 +1121,7 @@ impl PrimitiveRegistry {
         id: &PrimitiveId,
         request: ValueId,
         ctx: EffectCtx,
+        app: &Ctx,
     ) -> Result<EffectTicket, Box<PrimitiveDispatchError>> {
         let primitive = self
             .primitives
@@ -1117,7 +1138,7 @@ impl PrimitiveRegistry {
                 found: request.schema,
             }));
         }
-        Ok(primitive.begin(request, ctx))
+        Ok(primitive.begin(request, ctx, app))
     }
 }
 
@@ -1129,4 +1150,110 @@ pub enum PrimitiveDispatchError {
         expected: SchemaPattern,
         found: SchemaRef,
     },
+}
+
+#[cfg(test)]
+mod from_ref_tests {
+    use super::*;
+    use crate::runtime::{DemandPreimage, RecipeId};
+
+    /// A stand-in for a shared authority an embedder installs once — a DB
+    /// pool, say — and reuses across every primitive invocation.
+    #[derive(Clone)]
+    struct FakePool {
+        label: &'static str,
+    }
+
+    /// The embedder's application context: an ordinary struct assembling
+    /// whatever shared authorities it wants primitives to reach.
+    #[derive(Clone)]
+    struct AppCtx {
+        pool: FakePool,
+    }
+
+    impl FromRef<AppCtx> for FakePool {
+        fn from_ref(ctx: &AppCtx) -> FakePool {
+            ctx.pool.clone()
+        }
+    }
+
+    /// A primitive that names exactly the slice it needs; a missing `FakePool`
+    /// on `Ctx` would be a compile error here, not a runtime downcast.
+    struct PoolLabelPrimitive {
+        descriptor: PrimitiveDescriptor,
+        seen: Arc<Mutex<Option<&'static str>>>,
+    }
+
+    impl<Ctx> Primitive<Ctx> for PoolLabelPrimitive
+    where
+        FakePool: FromRef<Ctx>,
+    {
+        fn descriptor(&self) -> &PrimitiveDescriptor {
+            &self.descriptor
+        }
+
+        fn begin(&self, request: ValueId, ctx: EffectCtx, app: &Ctx) -> EffectTicket {
+            let pool = FakePool::from_ref(app);
+            *self.seen.lock().expect("seen mutex poisoned") = Some(pool.label);
+            let (ticket, completer) = ctx.ticket(|| {});
+            let publication = ctx
+                .finish(PrimitiveCompletion::Ok(request))
+                .expect("single completion transaction");
+            completer
+                .complete(publication)
+                .expect("fresh ticket accepts one completion");
+            ticket
+        }
+    }
+
+    fn descriptor() -> PrimitiveDescriptor {
+        PrimitiveDescriptor {
+            id: PrimitiveId {
+                namespace: "vix.test".to_owned(),
+                name: "pool-label".to_owned(),
+                version: 1,
+            },
+            request_schema: SchemaPattern::exact(&Type::String.schema_ref()),
+            response_schema: SchemaPattern::exact(&Type::String.schema_ref()),
+            failure_schema: SchemaPattern::exact(&Type::String.schema_ref()),
+            memo_policy: PrimitiveMemoPolicy::Hermetic,
+            protocol_version: 1,
+            capability_schemas: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn primitive_projects_its_dependency_out_of_the_shared_context_via_from_ref() {
+        let request =
+            FramedNode::leaf(Type::String.schema_ref(), b"ignored".to_vec()).identity();
+        let demand = DemandKey::from_preimage(&DemandPreimage {
+            closure: RecipeId::from_canonical_vir(b"from-ref-test"),
+            arguments: vec![request.clone()],
+        });
+        let authority = Arc::new(StagedEffectAuthority::new(std::iter::empty()));
+        let ctx = EffectCtx::new(demand, authority);
+
+        let primitive = Arc::new(PoolLabelPrimitive {
+            descriptor: descriptor(),
+            seen: Arc::new(Mutex::new(None)),
+        });
+        let mut registry = PrimitiveRegistry::default();
+        registry
+            .register(primitive.clone())
+            .expect("primitive registers once");
+        let dispatcher = PrimitiveDispatcher::new(Arc::new(registry));
+
+        let app = AppCtx {
+            pool: FakePool { label: "prod-pool" },
+        };
+        let ticket = dispatcher
+            .begin_or_join(&primitive.descriptor.id, request, ctx, &app)
+            .expect("registered primitive dispatches");
+        ticket.outcome().expect("immediate primitive completed");
+
+        assert_eq!(
+            *primitive.seen.lock().expect("seen mutex poisoned"),
+            Some("prod-pool")
+        );
+    }
 }

--- a/vix/src/runtime/scheduler.rs
+++ b/vix/src/runtime/scheduler.rs
@@ -553,7 +553,7 @@ pub enum GeneratorOutcome {
 /// r[impl machine.runtime.state-machines]
 /// r[impl machine.scheduler.passive-no-loop]
 /// r[impl machine.scheduler.no-shadow-scheduler]
-pub struct Runtime<S> {
+pub struct Runtime<S, Ctx = ()> {
     sink: S,
     sequence: u64,
     store: Store,
@@ -572,8 +572,12 @@ pub struct Runtime<S> {
     wire_demands: Vec<RealizedWireDemand>,
     performed_read_paths: BTreeSet<String>,
     fixture_store: FixtureStore,
-    primitive_dispatcher: PrimitiveDispatcher,
+    primitive_dispatcher: PrimitiveDispatcher<Ctx>,
     primitive_services: super::PrimitiveServices,
+    /// The embedder-installed shared runtime context — an ambient authority
+    /// (executor, pool, client) that primitives project a slice out of via
+    /// `FromRef`, never a semantic input to identity/memo/receipts.
+    ctx: Ctx,
     /// The scheduler-owned typed completion mailbox for registered primitives.
     completion_inbox: CompletionInbox,
     authoritative_rerun_audit: bool,
@@ -719,7 +723,7 @@ fn build_memo_suffix_index(
     index
 }
 
-fn default_primitive_dispatcher() -> PrimitiveDispatcher {
+fn default_primitive_dispatcher<Ctx>() -> PrimitiveDispatcher<Ctx> {
     let mut registry = PrimitiveRegistry::default();
     registry
         .register(Arc::new(DecodePrimitive::default()))
@@ -736,7 +740,7 @@ fn default_primitive_dispatcher() -> PrimitiveDispatcher {
     PrimitiveDispatcher::new(Arc::new(registry))
 }
 
-impl<S: EventSink> Runtime<S> {
+impl<S: EventSink> Runtime<S, ()> {
     #[must_use]
     pub fn new(sink: S) -> Self {
         Self {
@@ -754,6 +758,7 @@ impl<S: EventSink> Runtime<S> {
             fixture_store: FixtureStore::default(),
             primitive_dispatcher: default_primitive_dispatcher(),
             primitive_services: super::PrimitiveServices::default(),
+            ctx: (),
             completion_inbox: CompletionInbox::default(),
             authoritative_rerun_audit: false,
             runnable: Vec::new(),
@@ -793,6 +798,80 @@ impl<S: EventSink> Runtime<S> {
             fixture_store: FixtureStore::default(),
             primitive_dispatcher: default_primitive_dispatcher(),
             primitive_services: super::PrimitiveServices::default(),
+            ctx: (),
+            completion_inbox: CompletionInbox::default(),
+            authoritative_rerun_audit: false,
+            runnable: Vec::new(),
+            parked: BTreeMap::new(),
+            wire_waiters: BTreeMap::new(),
+            root_results: BTreeMap::new(),
+            primitive_pending: BTreeMap::new(),
+            exec_pending: BTreeMap::new(),
+            exec_projection_pending: BTreeMap::new(),
+            exec_progress_ready: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_persistent_journal_values(
+        sink: S,
+        journal: &PersistentRuntimeJournal,
+    ) -> Result<(Self, PersistentRuntimeJournalLoadReport), PersistentRuntimeJournalError> {
+        let (store, store_report) = Store::from_journal(journal.store.clone())?;
+        Ok((
+            Self {
+                sink,
+                sequence: 0,
+                store,
+                memo: BTreeMap::new(),
+                memo_suffix_index: BTreeMap::new(),
+                demands: BTreeMap::new(),
+                tasks: BTreeMap::new(),
+                counters: Counters::default(),
+                next_task: 0,
+                wire_demands: Vec::new(),
+                performed_read_paths: BTreeSet::new(),
+                fixture_store: FixtureStore::default(),
+                primitive_dispatcher: default_primitive_dispatcher(),
+                primitive_services: super::PrimitiveServices::default(),
+                ctx: (),
+                completion_inbox: CompletionInbox::default(),
+                authoritative_rerun_audit: false,
+                runnable: Vec::new(),
+                parked: BTreeMap::new(),
+                wire_waiters: BTreeMap::new(),
+                root_results: BTreeMap::new(),
+                primitive_pending: BTreeMap::new(),
+                exec_pending: BTreeMap::new(),
+                exec_projection_pending: BTreeMap::new(),
+                exec_progress_ready: BTreeMap::new(),
+            },
+            PersistentRuntimeJournalLoadReport {
+                store: store_report,
+                ..PersistentRuntimeJournalLoadReport::default()
+            },
+        ))
+    }
+}
+
+impl<S: EventSink, Ctx> Runtime<S, Ctx> {
+    #[must_use]
+    pub fn with_context(sink: S, ctx: Ctx) -> Self {
+        Self {
+            sink,
+            sequence: 0,
+            store: Store::default(),
+            memo: BTreeMap::new(),
+            memo_suffix_index: BTreeMap::new(),
+            demands: BTreeMap::new(),
+            tasks: BTreeMap::new(),
+            counters: Counters::default(),
+            next_task: 0,
+            wire_demands: Vec::new(),
+            performed_read_paths: BTreeSet::new(),
+            fixture_store: FixtureStore::default(),
+            primitive_dispatcher: default_primitive_dispatcher(),
+            primitive_services: super::PrimitiveServices::default(),
+            ctx,
             completion_inbox: CompletionInbox::default(),
             authoritative_rerun_audit: false,
             runnable: Vec::new(),
@@ -819,45 +898,6 @@ impl<S: EventSink> Runtime<S> {
 
     pub fn set_authoritative_rerun_audit(&mut self, enabled: bool) {
         self.authoritative_rerun_audit = enabled;
-    }
-
-    pub fn with_persistent_journal_values(
-        sink: S,
-        journal: &PersistentRuntimeJournal,
-    ) -> Result<(Self, PersistentRuntimeJournalLoadReport), PersistentRuntimeJournalError> {
-        let (store, store_report) = Store::from_journal(journal.store.clone())?;
-        Ok((
-            Self {
-                sink,
-                sequence: 0,
-                store,
-                memo: BTreeMap::new(),
-                memo_suffix_index: BTreeMap::new(),
-                demands: BTreeMap::new(),
-                tasks: BTreeMap::new(),
-                counters: Counters::default(),
-                next_task: 0,
-                wire_demands: Vec::new(),
-                performed_read_paths: BTreeSet::new(),
-                fixture_store: FixtureStore::default(),
-                primitive_dispatcher: default_primitive_dispatcher(),
-                primitive_services: super::PrimitiveServices::default(),
-                completion_inbox: CompletionInbox::default(),
-                authoritative_rerun_audit: false,
-                runnable: Vec::new(),
-                parked: BTreeMap::new(),
-                wire_waiters: BTreeMap::new(),
-                root_results: BTreeMap::new(),
-                primitive_pending: BTreeMap::new(),
-                exec_pending: BTreeMap::new(),
-                exec_projection_pending: BTreeMap::new(),
-                exec_progress_ready: BTreeMap::new(),
-            },
-            PersistentRuntimeJournalLoadReport {
-                store: store_report,
-                ..PersistentRuntimeJournalLoadReport::default()
-            },
-        ))
     }
 
     pub fn load_persistent_journal_claims(
@@ -3595,6 +3635,7 @@ impl<S: EventSink> Runtime<S> {
                 &plan.primitive,
                 request_id.clone(),
                 EffectCtx::new(primitive_demand, authority.clone()),
+                &self.ctx,
             ) {
                 Ok(ticket) => ticket,
                 Err(error) => {
@@ -8392,14 +8433,14 @@ fn scheduler_decode() -> Stream<Check> {
         begins: Arc<AtomicUsize>,
     }
 
-    impl Primitive for CountingDecode {
+    impl Primitive<()> for CountingDecode {
         fn descriptor(&self) -> &PrimitiveDescriptor {
             &self.descriptor
         }
 
-        fn begin(&self, request: ValueId, ctx: EffectCtx) -> EffectTicket {
+        fn begin(&self, request: ValueId, ctx: EffectCtx, app: &()) -> EffectTicket {
             self.begins.fetch_add(1, Ordering::AcqRel);
-            DecodePrimitive::default().begin(request, ctx)
+            DecodePrimitive::default().begin(request, ctx, app)
         }
     }
 
@@ -8414,12 +8455,12 @@ fn scheduler_decode() -> Stream<Check> {
         )>,
     }
 
-    impl Primitive for DelayedDecode {
+    impl Primitive<()> for DelayedDecode {
         fn descriptor(&self) -> &PrimitiveDescriptor {
             &self.descriptor
         }
 
-        fn begin(&self, request: ValueId, ctx: EffectCtx) -> EffectTicket {
+        fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &()) -> EffectTicket {
             self.begins.fetch_add(1, Ordering::AcqRel);
             let gate = self.gate.clone();
             let cancel_gate = self.gate.clone();
@@ -8438,7 +8479,7 @@ fn scheduler_decode() -> Stream<Check> {
                     released = wake.wait(released).expect("decode gate mutex poisoned");
                 }
                 drop(released);
-                let inner = DecodePrimitive::default().begin(request, ctx);
+                let inner = DecodePrimitive::default().begin(request, ctx, &());
                 let _subscription = inner.join(move |publication| {
                     let result = completer.complete(publication.clone());
                     completed
@@ -8450,7 +8491,7 @@ fn scheduler_decode() -> Stream<Check> {
         }
     }
 
-    fn decode_registry(primitive: Arc<dyn Primitive>) -> PrimitiveDispatcher {
+    fn decode_registry(primitive: Arc<dyn Primitive<()>>) -> PrimitiveDispatcher<()> {
         let mut registry = PrimitiveRegistry::default();
         registry
             .register(primitive)
@@ -8537,7 +8578,7 @@ fn scheduler_decode() -> Stream<Check> {
         let primitive = DecodePrimitive::default();
         let mut runtime = Runtime::new(EventLog::default());
         runtime.primitive_dispatcher = decode_registry(Arc::new(CountingDecode {
-            descriptor: primitive.descriptor().clone(),
+            descriptor: <DecodePrimitive as Primitive<()>>::descriptor(&primitive).clone(),
             begins: begins.clone(),
         }));
 
@@ -8572,7 +8613,7 @@ fn scheduler_decode() -> Stream<Check> {
         let primitive = DecodePrimitive::default();
         let mut runtime = Runtime::new(EventLog::default());
         runtime.primitive_dispatcher = decode_registry(Arc::new(DelayedDecode {
-            descriptor: primitive.descriptor().clone(),
+            descriptor: <DecodePrimitive as Primitive<()>>::descriptor(&primitive).clone(),
             begins: begins.clone(),
             cancellations: cancellations.clone(),
             gate,

--- a/vix/src/runtime/tree_read_primitive.rs
+++ b/vix/src/runtime/tree_read_primitive.rs
@@ -57,12 +57,12 @@ impl Default for TreeReadPrimitive {
     }
 }
 
-impl Primitive for TreeReadPrimitive {
+impl<Ctx> Primitive<Ctx> for TreeReadPrimitive {
     fn descriptor(&self) -> &PrimitiveDescriptor {
         &self.descriptor
     }
 
-    fn begin(&self, request: ValueId, ctx: EffectCtx) -> EffectTicket {
+    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> EffectTicket {
         let (ticket, completer) = ctx.ticket(|| {});
         std::thread::spawn(move || {
             let completion = execute(&request, &ctx)

--- a/vix/tests/primitive_foundation.rs
+++ b/vix/tests/primitive_foundation.rs
@@ -73,12 +73,12 @@ struct EchoPrimitive {
     begins: AtomicUsize,
 }
 
-impl Primitive for EchoPrimitive {
+impl<Ctx> Primitive<Ctx> for EchoPrimitive {
     fn descriptor(&self) -> &PrimitiveDescriptor {
         &self.descriptor
     }
 
-    fn begin(&self, request: ValueId, ctx: EffectCtx) -> EffectTicket {
+    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> EffectTicket {
         self.begins.fetch_add(1, Ordering::Relaxed);
         let (ticket, completer) = ctx.ticket(|| {});
         let publication = ctx
@@ -134,7 +134,7 @@ fn registered_dispatch_records_reads_without_an_opt_in_receipt_call() {
         .register(primitive.clone())
         .expect("primitive registers once");
     let ticket = registry
-        .begin(&primitive.descriptor.id, request.clone(), ctx)
+        .begin(&primitive.descriptor.id, request.clone(), ctx, &())
         .expect("generic descriptor lookup dispatches");
     let publication = ticket.outcome().expect("immediate primitive completed");
 
@@ -171,6 +171,7 @@ fn request_schema_is_checked_before_primitive_code_runs() {
             &primitive.descriptor.id,
             wrong,
             EffectCtx::new(demand, authority),
+            &(),
         ),
         Err(error) if matches!(*error, PrimitiveDispatchError::RequestSchema { .. })
     ));
@@ -199,6 +200,7 @@ fn duplicate_running_demand_joins_one_registered_primitive_ticket() {
             &primitive.descriptor.id,
             request.clone(),
             EffectCtx::new(demand, authority.clone()),
+            &(),
         )
         .expect("first demand begins");
     let second = dispatcher
@@ -206,6 +208,7 @@ fn duplicate_running_demand_joins_one_registered_primitive_ticket() {
             &primitive.descriptor.id,
             request,
             EffectCtx::new(demand, authority),
+            &(),
         )
         .expect("duplicate demand joins");
 


### PR DESCRIPTION
Implements axis 7 of the design doc (`data-driven-primitives.md`): make the runtime generic over an embedder-chosen context of shared authorities — an async executor, a pool, a client — reused across every primitive invocation, the way a backend framework shares one DB pool across handlers.

## What's here
- `FromRef<Ctx>` (with blanket identity impl) + `Primitive<Ctx>` where `begin(&self, request, ctx, app: &Ctx)`. Object-safe: `Ctx` is a fixed trait param, so `dyn Primitive<Ctx>` still works; each impl projects the slice it needs via `FromRef` internally (no `Any`, no downcast — a missing dep is a compile error).
- `PrimitiveRegistry<Ctx>` / `PrimitiveDispatcher<Ctx>` / `Runtime<S, Ctx = ()>`. The **default type param keeps every existing `Runtime<S>` reference compiling**, and `Runtime::new(sink)` stays source-compatible (moved to `impl Runtime<S, ()>`); `with_context(sink, ctx)` added for real contexts.
- A test proving a primitive pulls its dependency out of a real `Ctx` via `FromRef`.

## Deliberately out of scope
`PrimitiveServices` is left untouched — folding it into `Ctx` is a follow-up (kept this PR bounded).

## Invariant
`Ctx` is ambient authority only — it supplies *how* an effect runs, never identity/admissibility/memo/receipts (those stay in the request value), so deterministic replay is unaffected.

## Verification (local; repo CI is independently red)
Clean build, no warnings. Full `cargo test -p vix` green incl. `ratchet_runner` **151 passed / 0 failed / 2 ignored** and ~40 other suites; `vix-fetch` **11/11**.
