### PR TITLE
vix: derive request Type schemas from Facet request structs

### DIFF
--- a/vix/src/binding.rs
+++ b/vix/src/binding.rs
@@ -51,8 +51,8 @@ use std::collections::BTreeSet;
 use std::sync::LazyLock;
 
 use crate::runtime::{
-    PrimitiveId, observe_primitive_id, observe_request_type, origin_hint_type, pinned_blob_ref_type,
-    pinned_fetch_primitive_id, pinned_fetch_request_type,
+    ObserveRequest, OriginHint, PinnedBlobRef, PinnedFetchRequest, PrimitiveId, observe_primitive_id,
+    pinned_fetch_primitive_id,
 };
 use crate::vir::{ExternKind, Type};
 
@@ -225,16 +225,16 @@ pub fn request_shape(kind: PrimitiveKind) -> Option<RequestShape> {
     match kind {
         PrimitiveKind::Fetch => Some(RequestShape {
             args: vec![ArgRole::Value {
-                expected: pinned_blob_ref_type(),
+                expected: Type::from_facet::<PinnedBlobRef>(),
             }],
-            request_ty: pinned_fetch_request_type(),
+            request_ty: Type::from_facet::<PinnedFetchRequest>(),
             result: blob,
             primitive: pinned_fetch_primitive_id(),
         }),
         PrimitiveKind::Observe => Some(RequestShape {
             args: vec![
                 ArgRole::Value {
-                    expected: origin_hint_type(),
+                    expected: Type::from_facet::<OriginHint>(),
                 },
                 ArgRole::Selector(Selector {
                     enum_name: "Mode".to_owned(),
@@ -251,7 +251,7 @@ pub fn request_shape(kind: PrimitiveKind) -> Option<RequestShape> {
                     ],
                 }),
             ],
-            request_ty: observe_request_type(),
+            request_ty: Type::from_facet::<ObserveRequest>(),
             result: blob,
             primitive: observe_primitive_id(),
         }),

--- a/vix/src/compiler.rs
+++ b/vix/src/compiler.rs
@@ -12,7 +12,7 @@ use taxon::{
 use crate::decode::{self, DecodeFormat, DecodedValue};
 use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticPayload, Diagnostics, Label};
 use crate::runtime::{
-    origin_hint_type, pinned_blob_ref_type, tree_read_primitive_id, tree_read_request_type,
+    OriginHint, PinnedBlobRef, tree_read_primitive_id, tree_read_request_type,
 };
 use crate::schema::{SchemaBatch, SchemaRef, SchemaSet};
 use crate::support::{Span, Spanned};
@@ -4971,7 +4971,7 @@ fn lower_method_call(
         PreludeMethod::RegistryUrl => {
             let name = lower_value(nodes, bindings, context, &positional[0])?;
             require_type(&name, &Type::String, expr_span(&positional[0]))?;
-            let ty = pinned_blob_ref_type();
+            let ty = Type::from_facet::<PinnedBlobRef>();
             Ok(LoweredValue {
                 node: push_node(
                     nodes,
@@ -4987,7 +4987,7 @@ fn lower_method_call(
         PreludeMethod::RegistryCoordinate => {
             let name = lower_value(nodes, bindings, context, &positional[0])?;
             require_type(&name, &Type::String, expr_span(&positional[0]))?;
-            let ty = origin_hint_type();
+            let ty = Type::from_facet::<OriginHint>();
             Ok(LoweredValue {
                 node: push_node(
                     nodes,

--- a/vix/src/runtime/fetch_primitive.rs
+++ b/vix/src/runtime/fetch_primitive.rs
@@ -1,7 +1,7 @@
 use sha2::{Digest as _, Sha256};
 
 use crate::schema::{SchemaPattern, SchemaRef};
-use crate::vir::{ExternKind, RecordField, RecordType, Type};
+use crate::vir::{ExternKind, Type};
 
 use super::{
     Digest, EffectCtx, EffectTicket, Primitive, PrimitiveCompletion, PrimitiveDescriptor,
@@ -12,21 +12,46 @@ use super::{
 #[derive(facet::Facet, Clone, Debug, PartialEq, Eq)]
 pub struct UpstreamDigest(pub [u8; 32]);
 
+/// A registry capability handle. Wire-side this is `Type::Extern(Registry)`; it
+/// wraps a [`ValueId`] like [`BlobId`], but is a distinct newtype so the derived
+/// schema walker (`Type::from_facet`) can tell the two wire meanings apart —
+/// distinct meanings, distinct types.
 #[derive(facet::Facet, Clone, Debug, PartialEq, Eq)]
-pub struct BlobId(pub ValueId);
+pub struct RegistryHandle(pub ValueId);
+
+/// A pinned Blob target identity. This is not a resident value but a *reference*
+/// to one, so it decomposes structurally into a `ValueId`'s `{schema, content}`:
+/// the schema is an `Extern(Schema)` store value and the content is the digest
+/// wire-encoded as a hex `String` (see [`Type::from_facet`]'s leaf overrides).
+#[derive(facet::Facet, Clone, Debug, PartialEq, Eq)]
+pub struct BlobId {
+    pub schema: SchemaRef,
+    pub content: Digest,
+}
 
 impl BlobId {
     pub fn new(value: ValueId) -> Result<Self, PrimitiveMachineError> {
         if value.schema != Type::Extern(ExternKind::Blob).schema_ref() {
             return Err(PrimitiveMachineError::InvalidRequest { request: value });
         }
-        Ok(Self(value))
+        Ok(Self {
+            schema: value.schema,
+            content: value.content,
+        })
+    }
+
+    #[must_use]
+    pub fn id(&self) -> ValueId {
+        ValueId {
+            schema: self.schema.clone(),
+            content: self.content,
+        }
     }
 }
 
 #[derive(facet::Facet, Clone, Debug, PartialEq, Eq)]
 pub struct OriginHint {
-    pub capability: ValueId,
+    pub capability: RegistryHandle,
     pub coordinate: String,
 }
 
@@ -40,72 +65,6 @@ pub struct PinnedBlobRef {
 #[derive(facet::Facet, Clone, Debug, PartialEq, Eq)]
 pub struct PinnedFetchRequest {
     pub pin: PinnedBlobRef,
-}
-
-#[must_use]
-pub fn blob_id_type() -> Type {
-    Type::Record(RecordType::new(
-        "BlobId",
-        vec![
-            RecordField {
-                name: "schema".to_owned(),
-                ty: Type::Extern(ExternKind::Schema),
-            },
-            RecordField {
-                name: "content".to_owned(),
-                ty: Type::String,
-            },
-        ],
-    ))
-}
-
-#[must_use]
-pub fn origin_hint_type() -> Type {
-    Type::Record(RecordType::new(
-        "OriginHint",
-        vec![
-            RecordField {
-                name: "capability".to_owned(),
-                ty: Type::Extern(ExternKind::Registry),
-            },
-            RecordField {
-                name: "coordinate".to_owned(),
-                ty: Type::String,
-            },
-        ],
-    ))
-}
-
-#[must_use]
-pub fn pinned_blob_ref_type() -> Type {
-    Type::Record(RecordType::new(
-        "PinnedBlobRef",
-        vec![
-            RecordField {
-                name: "value".to_owned(),
-                ty: blob_id_type(),
-            },
-            RecordField {
-                name: "origins".to_owned(),
-                ty: Type::array(origin_hint_type()),
-            },
-            RecordField {
-                name: "upstream".to_owned(),
-                ty: Type::option(Type::String),
-            },
-        ],
-    ))
-}
-
-#[must_use]
-pub fn pinned_fetch_request_type() -> Type {
-    Type::Record(RecordType::new(
-        "PinnedFetchRequest",
-        vec![RecordField {
-            name: "pin".to_owned(),
-            ty: pinned_blob_ref_type(),
-        }],
-    ))
 }
 
 #[must_use]
@@ -126,7 +85,9 @@ impl Default for PinnedFetchPrimitive {
         Self {
             descriptor: PrimitiveDescriptor {
                 id: pinned_fetch_primitive_id(),
-                request_schema: SchemaPattern::exact(&pinned_fetch_request_type().schema_ref()),
+                request_schema: SchemaPattern::exact(
+                    &Type::from_facet::<PinnedFetchRequest>().schema_ref(),
+                ),
                 response_schema: SchemaPattern::exact(&Type::Extern(ExternKind::Blob).schema_ref()),
                 failure_schema: SchemaPattern::Var {
                     name: "PinnedFetchFailure".to_owned(),
@@ -172,34 +133,35 @@ impl<Ctx> Primitive<Ctx> for PinnedFetchPrimitive {
 fn execute(request: &ValueId, ctx: &EffectCtx) -> Result<ValueId, PrimitiveMachineError> {
     let request = ctx.read(request, ReadProjection::Whole)?;
     let pin = parse_request(request.value, request.identity)?;
+    let target = pin.value.id();
 
-    if let Ok(stored) = ctx.read(&pin.value.0, ReadProjection::Whole) {
+    if let Ok(stored) = ctx.read(&target, ReadProjection::Whole) {
         verify_upstream(&stored.bytes, pin.upstream.as_ref())?;
         return Ok(stored.identity);
     }
 
     let mut last_error = None;
-    if let Some(candidate) = ctx.persisted_candidate(&pin.value.0)? {
-        if candidate.claimed != pin.value.0 {
+    if let Some(candidate) = ctx.persisted_candidate(&target)? {
+        if candidate.claimed != target {
             last_error = Some(PrimitiveMachineError::CorruptCandidate {
                 source: candidate.claimed,
             });
         } else {
             let observed = blob_identity(&candidate.bytes);
-            if observed != pin.value.0 {
+            if observed != target {
                 last_error = Some(PrimitiveMachineError::CorruptCandidate { source: observed });
             } else {
                 verify_upstream(&candidate.bytes, pin.upstream.as_ref())?;
-                return admit(&candidate.bytes, &pin.value.0, ctx);
+                return admit(&candidate.bytes, &target, ctx);
             }
         }
     }
 
     for origin in &pin.origins {
-        match ctx.origin_candidate(&origin.capability, &origin.coordinate, &pin.value.0) {
+        match ctx.origin_candidate(&origin.capability.0, &origin.coordinate, &target) {
             Ok(bytes) => {
                 verify_upstream(&bytes, pin.upstream.as_ref())?;
-                let admitted = admit(&bytes, &pin.value.0, ctx)?;
+                let admitted = admit(&bytes, &target, ctx)?;
                 ctx.persist_value(&admitted, &bytes)?;
                 return Ok(admitted);
             }
@@ -325,7 +287,7 @@ fn parse_origins(value: &PrimitiveValue) -> Result<Vec<OriginHint>, PrimitiveMac
             let [capability, coordinate] = fields.as_slice() else {
                 return Err(invalid_value());
             };
-            let capability = child(capability)?.identity();
+            let capability = RegistryHandle(child(capability)?.identity());
             let coordinate = core::str::from_utf8(bytes(child(coordinate)?)?)
                 .map_err(|_| invalid_value())?
                 .to_owned();
@@ -372,5 +334,54 @@ fn bytes(value: &PrimitiveValue) -> Result<&[u8], PrimitiveMachineError> {
 fn invalid_value() -> PrimitiveMachineError {
     PrimitiveMachineError::AuthorityViolation {
         detail: "pinned fetch request disagrees with its declared schema".to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod schema_snapshot {
+    //! Wire-identity gate for the type-schema-unification PR.
+    //!
+    //! `PrimitiveDescriptor.request_schema = SchemaPattern::exact(&…type().schema_ref())`,
+    //! so dispatch matching and wire identity depend on the *exact* schema bytes
+    //! of each request/hint/ref type. These snapshots are the canonical
+    //! `SchemaRef::Display` (see `schema.rs`) of the five types captured against
+    //! the hand-written constructors; deriving them from the `Facet` shapes must
+    //! keep every one byte-identical.
+
+    use super::{BlobId, OriginHint, PinnedBlobRef, PinnedFetchRequest};
+    use crate::runtime::ObserveRequest;
+    use crate::vir::Type;
+
+    // Captured against the hand-written `*_type()` constructors before they were
+    // deleted; the derived `Type::from_facet` types must match byte-for-byte.
+    const BLOB_ID: &str = "e5904d597f3968d0";
+    const ORIGIN_HINT: &str = "ecd3ac5ba264e915";
+    const PINNED_BLOB_REF: &str = "a077429ce555df22";
+    const PINNED_FETCH_REQUEST: &str = "053ce66d21abed59";
+    const OBSERVE_REQUEST: &str = "d0e09706fdc08ace";
+
+    #[test]
+    fn request_schemas_are_byte_identical() {
+        assert_eq!(Type::from_facet::<BlobId>().schema_ref().to_string(), BLOB_ID);
+        assert_eq!(
+            Type::from_facet::<OriginHint>().schema_ref().to_string(),
+            ORIGIN_HINT
+        );
+        assert_eq!(
+            Type::from_facet::<PinnedBlobRef>().schema_ref().to_string(),
+            PINNED_BLOB_REF
+        );
+        assert_eq!(
+            Type::from_facet::<PinnedFetchRequest>()
+                .schema_ref()
+                .to_string(),
+            PINNED_FETCH_REQUEST
+        );
+        assert_eq!(
+            Type::from_facet::<ObserveRequest>()
+                .schema_ref()
+                .to_string(),
+            OBSERVE_REQUEST
+        );
     }
 }

--- a/vix/src/runtime/observe_primitive.rs
+++ b/vix/src/runtime/observe_primitive.rs
@@ -1,31 +1,25 @@
 use crate::schema::SchemaPattern;
-use crate::vir::{ExternKind, RecordField, RecordType, Type};
+use crate::vir::{ExternKind, Type};
 
 use super::{
-    EffectCtx, EffectTicket, ObserveCoordinate, ObservedClaim, Primitive, PrimitiveCompletion,
-    PrimitiveDescriptor, PrimitiveField, PrimitiveFieldValue, PrimitiveMachineError,
-    PrimitiveMemoPolicy, PrimitiveValue, PrimitiveValueBody, ValueId, origin_hint_type,
+    EffectCtx, EffectTicket, ObserveCoordinate, ObservedClaim, OriginHint, Primitive,
+    PrimitiveCompletion, PrimitiveDescriptor, PrimitiveField, PrimitiveFieldValue,
+    PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveValue, PrimitiveValueBody, ValueId,
 };
 
-#[must_use]
-pub fn observe_request_type() -> Type {
-    Type::Record(RecordType::new(
-        "ObserveRequest",
-        vec![
-            RecordField {
-                name: "origin".to_owned(),
-                ty: origin_hint_type(),
-            },
-            // `false` = observe (memoized by demand like any effect result);
-            // `true` = refresh, a distinct demand that forces a fresh receipted
-            // observation past the within-run memo and appends a new head under
-            // optimistic concurrency.
-            RecordField {
-                name: "refresh".to_owned(),
-                ty: Type::Bool,
-            },
-        ],
-    ))
+/// The `observe` request shape. There is no other Rust spelling of this struct —
+/// it is authored here so the derived `Type::from_facet::<ObserveRequest>()` is
+/// the single source for both `RequestShape.request_ty` and the descriptor's
+/// `request_schema`.
+///
+/// `refresh == false` = observe (memoized by demand like any effect result);
+/// `refresh == true` = refresh, a distinct demand that forces a fresh receipted
+/// observation past the within-run memo and appends a new head under optimistic
+/// concurrency.
+#[derive(facet::Facet, Clone, Debug, PartialEq, Eq)]
+pub struct ObserveRequest {
+    pub origin: OriginHint,
+    pub refresh: bool,
 }
 
 #[must_use]
@@ -53,7 +47,9 @@ impl Default for ObservePrimitive {
         Self {
             descriptor: PrimitiveDescriptor {
                 id: observe_primitive_id(),
-                request_schema: SchemaPattern::exact(&observe_request_type().schema_ref()),
+                request_schema: SchemaPattern::exact(
+                    &Type::from_facet::<ObserveRequest>().schema_ref(),
+                ),
                 response_schema: SchemaPattern::exact(&Type::Extern(ExternKind::Blob).schema_ref()),
                 failure_schema: SchemaPattern::Var {
                     name: "ObserveFailure".to_owned(),

--- a/vix/src/runtime/scheduler.rs
+++ b/vix/src/runtime/scheduler.rs
@@ -44,9 +44,9 @@ use super::{
     DecodePrimitive, EffectCtx, EffectTicket, ObservePrimitive, PinnedFetchPrimitive,
     PrimitiveCompletion, PrimitiveDispatcher, PrimitiveField, PrimitiveFieldValue,
     PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveRegistry, PrimitiveValue,
-    PrimitiveValueBody, StagedEffectAuthority, TicketSubscription, TreeReadPrimitive, blob_id_type,
-    origin_hint_type,
+    PrimitiveValueBody, StagedEffectAuthority, TicketSubscription, TreeReadPrimitive,
 };
+use super::{BlobId, OriginHint};
 use super::{MachineAttribution, MachineError, MachineOperation, RuntimeFault};
 
 #[derive(Clone, Debug)]
@@ -3118,7 +3118,7 @@ impl<S: EventSink, Ctx> Runtime<S, Ctx> {
                     .ok_or_else(|| effect_machine_error("fixture registry artifact was absent"))?;
                 let blob_schema = Type::Extern(ExternKind::Blob).schema_ref();
                 let blob_id = PrimitiveValue {
-                    schema: blob_id_type().schema_ref(),
+                    schema: Type::from_facet::<BlobId>().schema_ref(),
                     body: PrimitiveValueBody::Product(vec![
                         primitive_child_field(PrimitiveValue::bytes(
                             Type::Extern(ExternKind::Schema).schema_ref(),
@@ -3133,7 +3133,7 @@ impl<S: EventSink, Ctx> Runtime<S, Ctx> {
                 let capability =
                     primitive_value_from_effect(&Type::Extern(ExternKind::Registry), &registry)?;
                 let origin = PrimitiveValue {
-                    schema: origin_hint_type().schema_ref(),
+                    schema: Type::from_facet::<OriginHint>().schema_ref(),
                     body: PrimitiveValueBody::Product(vec![
                         primitive_child_field(capability),
                         primitive_child_field(PrimitiveValue::bytes(
@@ -3149,9 +3149,10 @@ impl<S: EventSink, Ctx> Runtime<S, Ctx> {
                         body: PrimitiveValueBody::Product(vec![
                             primitive_child_field(blob_id),
                             primitive_child_field(PrimitiveValue {
-                                schema: Type::array(origin_hint_type()).schema_ref(),
+                                schema: Type::array(Type::from_facet::<OriginHint>())
+                                    .schema_ref(),
                                 body: PrimitiveValueBody::Sequence {
-                                    element_schema: origin_hint_type().schema_ref(),
+                                    element_schema: Type::from_facet::<OriginHint>().schema_ref(),
                                     elements: vec![origin],
                                 },
                             }),

--- a/vix/src/vir.rs
+++ b/vix/src/vir.rs
@@ -774,6 +774,86 @@ impl ExternKind {
     }
 }
 
+/// The leaf-override table for [`Type::from_facet`]: the handful of Rust types
+/// whose wire `Type` cannot be read off their `Facet` shape. Keyed by nominal
+/// type identity ([`facet::ConstTypeId`]), so distinct wire meanings are distinct
+/// Rust newtypes rather than one reused type with a hidden discriminator.
+fn facet_leaf_override(shape: &'static facet::Shape) -> Option<Type> {
+    use crate::runtime::{Digest, RegistryHandle, UpstreamDigest};
+
+    // Fixed 32-byte digests have no vix `Type` primitive; they wire-encode as a
+    // hex `String` (see `fetch_primitive` parse/verify: `hex::encode`/`decode`).
+    if shape.id == <Digest as facet::Facet>::SHAPE.id
+        || shape.id == <UpstreamDigest as facet::Facet>::SHAPE.id
+    {
+        return Some(Type::String);
+    }
+    // A published schema reference is an opaque `Extern(Schema)` store value whose
+    // resident bytes are its canonical encoding, not the walked `{id, args}`.
+    if shape.id == <SchemaRef as facet::Facet>::SHAPE.id {
+        return Some(Type::Extern(ExternKind::Schema));
+    }
+    // A registry capability handle: a `ValueId` reused for several extern kinds,
+    // distinguished by its newtype so the wire meaning is unambiguous.
+    if shape.id == <RegistryHandle as facet::Facet>::SHAPE.id {
+        return Some(Type::Extern(ExternKind::Registry));
+    }
+    None
+}
+
+fn facet_transparent_pointee(shape: &'static facet::Shape) -> Option<&'static facet::Shape> {
+    match shape.def {
+        facet::Def::Pointer(pointer) => pointer.pointee(),
+        _ => match shape.ty {
+            facet::Type::Pointer(
+                facet::PointerType::Reference(reference) | facet::PointerType::Raw(reference),
+            ) => Some(reference.target()),
+            _ => None,
+        },
+    }
+}
+
+fn facet_scalar(scalar: facet::ScalarType, shape: &'static facet::Shape) -> Type {
+    match scalar {
+        facet::ScalarType::Bool => Type::Bool,
+        facet::ScalarType::Str | facet::ScalarType::String | facet::ScalarType::CowStr => {
+            Type::String
+        }
+        facet::ScalarType::I64 | facet::ScalarType::ISize => Type::Int,
+        other => panic!(
+            "Type::from_facet: unsupported scalar `{other:?}` for `{}`",
+            shape.type_identifier
+        ),
+    }
+}
+
+fn facet_fields(fields: &'static [facet::Field]) -> Vec<RecordField> {
+    fields
+        .iter()
+        .map(|field| RecordField {
+            name: field.effective_name().to_owned(),
+            ty: Type::from_facet_shape(field.shape()),
+        })
+        .collect()
+}
+
+fn facet_variant_payload(variant: &'static facet::Variant) -> VariantPayload {
+    let fields = variant.data.fields;
+    if fields.is_empty() {
+        return VariantPayload::Unit;
+    }
+    match variant.data.kind {
+        facet::StructKind::Struct => VariantPayload::Record(facet_fields(fields)),
+        facet::StructKind::Tuple | facet::StructKind::TupleStruct => VariantPayload::Tuple(
+            fields
+                .iter()
+                .map(|field| Type::from_facet_shape(field.shape()))
+                .collect(),
+        ),
+        facet::StructKind::Unit => VariantPayload::Unit,
+    }
+}
+
 impl Type {
     /// The Taxon-derived semantic schema carried by value identity. Weavy's
     /// numeric `SchemaRef` remains a separate program-local ABI index.
@@ -808,6 +888,78 @@ impl Type {
             }
             Self::Order(subject) => generic_builtin_schema("Order", vec![subject.schema_ref()]),
             Self::Extern(kind) => builtin_schema(kind.name()),
+        }
+    }
+
+    /// Derive the structural `Type` from a `#[derive(facet::Facet)]` type, so a
+    /// Rust request struct is the single source of truth for both the runtime
+    /// shape and its wire schema. The walk mirrors `facet::taxon_bridge`'s `Kind`
+    /// cases but targets `vir::Type`, so records/enums/options/arrays route
+    /// through the vix builtin schema wiring and the derived `schema_ref` is
+    /// byte-identical to the equivalent hand-written `Type`.
+    ///
+    /// A tiny override table (see [`facet_leaf_override`]) carries the handful of
+    /// leaf facts Rust's type system cannot express: fixed-byte digests
+    /// wire-encode as a hex `String`, and opaque store handles are `Extern`
+    /// values keyed by their distinct newtype identity.
+    #[must_use]
+    pub fn from_facet<T: facet::Facet<'static>>() -> Self {
+        Self::from_facet_shape(T::SHAPE)
+    }
+
+    fn from_facet_shape(shape: &'static facet::Shape) -> Self {
+        if let Some(ty) = facet_leaf_override(shape) {
+            return ty;
+        }
+        if let Some(pointee) = facet_transparent_pointee(shape) {
+            return Self::from_facet_shape(pointee);
+        }
+        if let Some(scalar) = shape.scalar_type() {
+            return facet_scalar(scalar, shape);
+        }
+        match shape.def {
+            facet::Def::List(list) => Self::array(Self::from_facet_shape(list.t())),
+            facet::Def::Slice(slice) => Self::array(Self::from_facet_shape(slice.t())),
+            facet::Def::Option(option) => Self::option(Self::from_facet_shape(option.t())),
+            facet::Def::Scalar | facet::Def::Undefined => Self::from_facet_user(shape),
+            _ => panic!(
+                "Type::from_facet: unsupported def for `{}`",
+                shape.type_identifier
+            ),
+        }
+    }
+
+    fn from_facet_user(shape: &'static facet::Shape) -> Self {
+        match shape.ty {
+            facet::Type::User(facet::UserType::Struct(struct_type)) => {
+                match struct_type.kind {
+                    facet::StructKind::Unit | facet::StructKind::Struct => Self::Record(
+                        RecordType::new(shape.type_identifier, facet_fields(struct_type.fields)),
+                    ),
+                    facet::StructKind::Tuple | facet::StructKind::TupleStruct => Self::Tuple(
+                        struct_type
+                            .fields
+                            .iter()
+                            .map(|field| Self::from_facet_shape(field.shape()))
+                            .collect(),
+                    ),
+                }
+            }
+            facet::Type::User(facet::UserType::Enum(enum_type)) => Self::Enum(EnumType::new(
+                shape.type_identifier,
+                enum_type
+                    .variants
+                    .iter()
+                    .map(|variant| EnumVariant {
+                        name: variant.effective_name().to_owned(),
+                        payload: facet_variant_payload(variant),
+                    })
+                    .collect(),
+            )),
+            _ => panic!(
+                "Type::from_facet: unsupported shape `{}`",
+                shape.type_identifier
+            ),
         }
     }
 


### PR DESCRIPTION
Implements axis 1 of the design doc (`data-driven-primitives.md`): the request struct *is* the schema. Kills the five hand-written vix `Type` mirrors and derives them from the `#[derive(facet::Facet)]` request structs, so a primitive's shape lives in exactly one place.

## What's here
- **`Type::from_facet::<T>()`** in `vir.rs` — walks `T::SHAPE` (struct→`Record`, `Vec`→array, `Option`→option, enum→`Enum`, scalars) building `vir::Type`. A facet→`SchemaRef` bridge already existed but was dead and only yielded the identity hash; the compiler needs the structural `Type`.
- **A 4-entry leaf-override table** keyed by nominal type identity (`shape.id`, a `ConstTypeId` compare) for the facts Rust's type system can't carry: `Digest`/`UpstreamDigest` → `String` (hex; vix has no byte-array type), `SchemaRef` → `Extern(Schema)`, `RegistryHandle` → `Extern(Registry)`. Records build via `RecordType::new` (required=true), sidestepping the `#[facet(default)]`-changes-the-hash footgun.
- **Struct reshaping so distinct wire meanings are distinct Rust types**: `BlobId(ValueId)` → record `{schema, content}` (kept `BlobId::new` + added `BlobId::id()`); new `RegistryHandle(ValueId)` for `OriginHint.capability`; authored the previously-absent `ObserveRequest { origin, refresh }` struct.
- Collapses all **five** hand-synced spellings: the `*_type()` mirrors are deleted; `binding.rs` `request_shape`, the `compiler.rs` `.registry_url()`/`.registry_coordinate()` method surface, and the `scheduler.rs` construction op all read `Type::from_facet::<…>()`.

## The gate: wire identity unchanged
A snapshot test asserts each of the five types' `.schema_ref()` is **byte-identical** before/after (dispatch matching + wire identity depend on it). All five pass byte-for-byte: `BlobId=e5904d597f3968d0`, `OriginHint=ecd3ac5ba264e915`, `PinnedBlobRef=a077429ce555df22`, `PinnedFetchRequest=053ce66d21abed59`, `ObserveRequest=d0e09706fdc08ace`.

## Verification (local solo run; repo CI independently red)
Clean build, no warnings. Full `cargo test -p vix` green incl. `ratchet_runner` **151/0/2** and ~40 other suites, zero failures; `vix-fetch` **15/15**.
