### PR TITLE
vix: move primitive projection onto the Primitive trait, kill PrimitiveKind

### DIFF
--- a/vix/src/binding.rs
+++ b/vix/src/binding.rs
@@ -20,24 +20,30 @@
 //!
 //! # Status
 //!
-//! **Primitive dispatch is wired.** `compiler::lower_value` recognizes built-in
-//! primitives through [`prelude_primitive`] — the callee name maps to a
-//! [`PrimitiveKind`] here, in data, instead of scattered `== "decode"` /
-//! `effect_intrinsic` string matches.
+//! **The projection lives on the primitive.** Each registered primitive
+//! declares its own [`Primitive::surface_name`](crate::runtime::Primitive) and
+//! [`Primitive::request_shape`](crate::runtime::Primitive); [`builtin_bindings`]
+//! *harvests* the [`BindingRegistry`] from [`runtime::builtin_primitives`]
+//! rather than maintaining a second table that names every primitive by hand.
+//! `compiler::lower_value` recognizes built-in primitives through
+//! [`prelude_primitive`] — the callee name maps to a [`PrimitiveId`] here, in
+//! data, instead of scattered `== "decode"` / `effect_intrinsic` string
+//! matches.
 //!
 //! **Request construction is data for the uniform primitives.** `fetch` and
-//! `observe` lower through a [`RequestShape`] ([`request_shape`]): their arity,
-//! per-argument roles (a lowered [`ArgRole::Value`] with its required type, or a
-//! [`Selector`] enum read at lower time), request record, result type, and target
-//! primitive are all data, consumed by one generic builder rather than a bespoke
-//! Rust arm each. The old `observe_mode_arg` reader is now the data in a
-//! [`Selector`].
+//! `observe` lower through a [`RequestShape`] ([`request_shape`], keyed by
+//! [`PrimitiveId`]): their arity, per-argument roles (a lowered
+//! [`ArgRole::Value`] with its required type, or a [`Selector`] enum read at
+//! lower time), request record, result type, and target primitive are all
+//! data, consumed by one generic builder rather than a bespoke Rust arm each.
 //!
 //! Not yet on a shape: `decode`/`try_decode` (compile-time constant folding and
-//! expected-type-derived targets don't reduce to a record shape) and the
-//! `fixture_*`/`untar` dedicated VIR ops (not `InvokePrimitive` at all). Those
-//! stay in the compiler's typed builders; [`request_shape`] returns `None` for
-//! them.
+//! expected-type-derived targets don't reduce to a record shape) — both are
+//! hand-registered onto the single [`decode_primitive_id`]; `request_shape`
+//! returns `None` for it, and the compiler keeps a typed builder. The
+//! `fixture_*`/`untar` dedicated VIR ops are not primitives at all — they are
+//! [`Intrinsic`]s, matched here by name and dispatched to the compiler's
+//! existing typed builder.
 //!
 //! Still on the compiler side: the binder consults [`is_prelude_name`] (a name
 //! set derived from these bindings) but does not yet route full prelude/module
@@ -47,14 +53,17 @@
 //! `by_key`, `range`, the `expect*`/trace checks) and the `.text()` method
 //! surface are deliberately outside this registry.
 
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::LazyLock;
 
-use crate::runtime::{
-    ObserveRequest, OriginHint, PinnedBlobRef, PinnedFetchRequest, PrimitiveId, observe_primitive_id,
-    pinned_fetch_primitive_id,
-};
-use crate::vir::{ExternKind, Type};
+use crate::runtime::{self, PrimitiveId};
+use crate::vir::decode_primitive_id;
+
+// Re-exported so existing call sites (`compiler.rs`) can keep spelling these
+// `crate::binding::RequestShape` etc. — the types now live next to
+// `Primitive` in `runtime`, since it is the primitive that declares them.
+pub use crate::runtime::{ArgRole, RequestShape, Selector, SelectorVariant};
 
 /// A non-empty `::`-separated module path (`caps`, `some::ns::inner`).
 ///
@@ -100,23 +109,15 @@ pub enum Placement {
     Module(ModulePath),
 }
 
-/// Which built-in primitive a prelude name lowers to.
-///
-/// The compiler dispatches the (genuinely per-primitive) request construction on
-/// this: selector reads (`Format`/`Mode`), expected-type-derived targets, and
-/// constant folding do not reduce to a single data shape. What the registry owns
-/// is the mapping from surface name to primitive — the set of primitive names
-/// lives here as data, not as scattered string matches in `lower_value`.
+/// Which dedicated VIR op an intrinsic call lowers to. These are **not**
+/// primitives — `fixture_tree`/`fixture_registry` never cross an authority
+/// boundary and `untar` is a deterministic pure transform — so there is no
+/// request record to shape; the compiler keeps a hand-written typed builder
+/// (`lower_effect_intrinsic`) for each. This enum is only the *name → which
+/// builder arm* map, so that map is data rather than a string match in
+/// `compiler.rs`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PrimitiveKind {
-    /// `fetch(pin)` — pinned-blob fetch.
-    Fetch,
-    /// `observe(origin, Mode)` — observe/refresh over one primitive.
-    Observe,
-    /// `decode(document, Format)` — infallible typed decode to `T`.
-    Decode,
-    /// `try_decode(document, Format)` — fallible decode to `Result<T, DecodeError>`.
-    TryDecode,
+pub enum Intrinsic {
     /// `fixture_tree(name)` — a named fixture tree (a dedicated machine op).
     FixtureTree,
     /// `fixture_registry()` — the fixture registry (a dedicated machine op).
@@ -128,139 +129,20 @@ pub enum PrimitiveKind {
 /// What a surface name resolves to.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BindingTarget {
-    /// A built-in primitive, one-to-one with this name.
-    Primitive(PrimitiveKind),
+    /// A registered primitive, one-to-one with this name — except `decode`/
+    /// `try_decode`, which are two surface names over the *same*
+    /// [`PrimitiveId`] ([`decode_primitive_id`]) until the const-fold-through-
+    /// wrappers work lands and their request construction becomes uniform.
+    Primitive(PrimitiveId),
+    /// A compiler-known dedicated VIR op (`fixture_tree`, `fixture_registry`,
+    /// `untar`) — not a primitive at all.
+    Intrinsic(Intrinsic),
     /// A vix-source function bound under a placement. This is the sanctioned way
     /// to add an alias or convenience wrapper (`refresh` over `observe`) and to
     /// "nicely add a pure vix function" to the prelude or a namespace. The
     /// function is effectful when its body invokes an effectful primitive; vix
     /// effect tracking flows through the call as it does for any wrapper.
     VixFunction { source: String },
-}
-
-/// One accepted variant of a [`Selector`] argument and the boolean flag it folds
-/// into the request record. (`Mode::Observe` → `false`, `Mode::Refresh` → `true`.)
-///
-/// Selectors fold to a boolean today because the only one — observe's `Mode` — is
-/// binary. Decode's `Format` is an integer tag; when it migrates onto a shape this
-/// widens to a general constant. Until then, "selector" means "enum → flag".
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SelectorVariant {
-    pub variant: String,
-    pub flag: bool,
-}
-
-/// A selector argument: an enum-variant read at *lower time* into a constant and
-/// folded into the request record, never lowered as a runtime value. This is the
-/// data form of the old `observe_mode_arg`/`decode_format_arg` readers — the
-/// accepted `enum_name`, its variants, and the diagnostic wording all live here
-/// rather than as a bespoke Rust reader per primitive.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Selector {
-    /// The enum the variant must name (`Mode`).
-    pub enum_name: String,
-    /// How the selector reads in diagnostics (`observe mode`) — the noun the
-    /// "expected …" and "unknown …" messages are built from.
-    pub noun: String,
-    pub variants: Vec<SelectorVariant>,
-}
-
-impl Selector {
-    /// What a non-variant or wrong-enum argument should say it expected, e.g.
-    /// `an observe mode `Mode::Observe` or `Mode::Refresh``.
-    #[must_use]
-    pub fn expected(&self) -> String {
-        let choices: Vec<String> = self
-            .variants
-            .iter()
-            .map(|candidate| format!("`{}::{}`", self.enum_name, candidate.variant))
-            .collect();
-        format!("an {} {}", self.noun, choices.join(" or "))
-    }
-
-    /// The message for a known enum but unrecognized variant, e.g.
-    /// `an unknown observe mode `Mode::Spin``.
-    #[must_use]
-    pub fn unknown(&self, variant: &str) -> String {
-        format!("an unknown {} `{}::{variant}`", self.noun, self.enum_name)
-    }
-}
-
-/// The structural role a surface argument plays in a primitive's request record.
-/// The request record has one field per argument, in this order.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ArgRole {
-    /// Lowered as an ordinary value and required to have the given type
-    /// (`fetch`'s `PinnedBlobRef`, `observe`'s `OriginHint`).
-    Value { expected: Type },
-    /// An enum-variant selector folded to a constant request field.
-    Selector(Selector),
-}
-
-/// How a registered primitive builds its request from its surface arguments — the
-/// data a single generic lowering step consumes in place of a bespoke Rust arm per
-/// primitive. Arity is `args.len()`; the compiler builds a `request_ty` record with
-/// one field per argument (in order), invokes `primitive`, and yields `result`.
-///
-/// Only the primitives whose construction is *fully uniform* have a shape today
-/// (`fetch`, `observe`). `decode`/`try_decode` (compile-time constant folding,
-/// expected-type-derived targets) and the `fixture_*`/`untar` dedicated VIR ops
-/// are not yet expressible here — see [`request_shape`].
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RequestShape {
-    pub args: Vec<ArgRole>,
-    pub request_ty: Type,
-    pub result: Type,
-    pub primitive: PrimitiveId,
-}
-
-/// The [`RequestShape`] a primitive's call lowers through, or `None` for the
-/// primitives whose request construction is not yet data (`decode`/`try_decode`
-/// and the `fixture_*`/`untar` dedicated ops — those stay in the compiler's typed
-/// builders). Returning `Some` is the contract that a primitive is fully described
-/// by data: the compiler builds its request generically from the shape.
-#[must_use]
-pub fn request_shape(kind: PrimitiveKind) -> Option<RequestShape> {
-    let blob = Type::Extern(ExternKind::Blob);
-    match kind {
-        PrimitiveKind::Fetch => Some(RequestShape {
-            args: vec![ArgRole::Value {
-                expected: Type::from_facet::<PinnedBlobRef>(),
-            }],
-            request_ty: Type::from_facet::<PinnedFetchRequest>(),
-            result: blob,
-            primitive: pinned_fetch_primitive_id(),
-        }),
-        PrimitiveKind::Observe => Some(RequestShape {
-            args: vec![
-                ArgRole::Value {
-                    expected: Type::from_facet::<OriginHint>(),
-                },
-                ArgRole::Selector(Selector {
-                    enum_name: "Mode".to_owned(),
-                    noun: "observe mode".to_owned(),
-                    variants: vec![
-                        SelectorVariant {
-                            variant: "Observe".to_owned(),
-                            flag: false,
-                        },
-                        SelectorVariant {
-                            variant: "Refresh".to_owned(),
-                            flag: true,
-                        },
-                    ],
-                }),
-            ],
-            request_ty: Type::from_facet::<ObserveRequest>(),
-            result: blob,
-            primitive: observe_primitive_id(),
-        }),
-        PrimitiveKind::Decode
-        | PrimitiveKind::TryDecode
-        | PrimitiveKind::FixtureTree
-        | PrimitiveKind::FixtureRegistry
-        | PrimitiveKind::Untar => None,
-    }
 }
 
 /// One projected name: placement + leaf name + what it resolves to.
@@ -272,17 +154,24 @@ pub struct Binding {
 }
 
 impl Binding {
-    /// Bind a built-in primitive to a surface name. One primitive, one name.
+    /// Bind a registered primitive to a surface name. One primitive, one name
+    /// — except `decode`/`try_decode`, both hand-bound onto the same id.
     #[must_use]
-    pub fn primitive(
-        placement: Placement,
-        name: impl Into<String>,
-        kind: PrimitiveKind,
-    ) -> Self {
+    pub fn primitive(placement: Placement, name: impl Into<String>, id: PrimitiveId) -> Self {
         Self {
             placement,
             name: name.into(),
-            target: BindingTarget::Primitive(kind),
+            target: BindingTarget::Primitive(id),
+        }
+    }
+
+    /// Bind a dedicated-op intrinsic to a surface name.
+    #[must_use]
+    pub fn intrinsic(placement: Placement, name: impl Into<String>, kind: Intrinsic) -> Self {
+        Self {
+            placement,
+            name: name.into(),
+            target: BindingTarget::Intrinsic(kind),
         }
     }
 
@@ -339,32 +228,59 @@ impl BindingRegistry {
 
 /// The built-in prelude bindings, encoded as data.
 ///
-/// Each built-in primitive projects **one** prelude name; the behavioural modes
-/// (`refresh` over `observe`; `json_decode`/`toml_decode`/`try_json_decode`/
-/// `try_toml_decode` over `decode`/`try_decode`) are vix functions over the
-/// single primitive rather than extra primitives or intrinsics. The compiler
-/// consumes this in place of hardcoded name matches: [`prelude_primitive`] maps
-/// a name to its [`PrimitiveKind`] for lowering, and [`is_prelude_name`] gates
-/// binder resolution. The vix-fn `source` strings mirror `crate::stdlib`'s
+/// Every registered primitive that projects a surface name (`Primitive::
+/// surface_name` returns `Some`) is harvested straight from
+/// [`runtime::builtin_primitives`] — `fetch` and `observe` today. `decode`/
+/// `try_decode` share one primitive under two names and are not yet uniform
+/// (see the module docs), so they stay hand-registered onto
+/// [`decode_primitive_id`]; the `fixture_*`/`untar` dedicated ops are hand-
+/// registered as [`Intrinsic`]s. The behavioural modes (`refresh` over
+/// `observe`; `json_decode`/`toml_decode`/`try_json_decode`/`try_toml_decode`
+/// over `decode`/`try_decode`) are vix functions over the single primitive
+/// rather than extra primitives or intrinsics. The compiler consumes this in
+/// place of hardcoded name matches: [`prelude_primitive`]/[`prelude_intrinsic`]
+/// map a name to its target for lowering, and [`is_prelude_name`] gates binder
+/// resolution. The vix-fn `source` strings mirror `crate::stdlib`'s
 /// `PRELUDE_FUNCTIONS`, which is what actually injects them.
 ///
 /// Tree text reads (`.text()`) are a *method* binding surface, orthogonal to
-/// free-function placement, and are intentionally omitted here.
+/// free-function placement, and are intentionally omitted here — this is why
+/// `TreeReadPrimitive` (also in `runtime::builtin_primitives`, but with no
+/// `surface_name`) contributes no binding.
 #[must_use]
 pub fn builtin_bindings() -> BindingRegistry {
     let mut reg = BindingRegistry::default();
 
-    // One primitive : one binding : one name.
+    // Harvest one binding per registered primitive that projects a surface
+    // name — no second table naming `fetch`/`observe` by hand.
+    for primitive in runtime::builtin_primitives::<()>() {
+        if let Some(name) = primitive.surface_name() {
+            reg.insert(Binding::primitive(
+                Placement::Prelude,
+                name,
+                primitive.descriptor().id.clone(),
+            ));
+        }
+    }
+
+    // decode/try_decode: one registered primitive, two surface names — not yet
+    // uniform (compile-time constant folding, expected-type-derived target), so
+    // hand-registered onto the shared id rather than harvested.
+    for name in ["decode", "try_decode"] {
+        reg.insert(Binding::primitive(
+            Placement::Prelude,
+            name,
+            decode_primitive_id(),
+        ));
+    }
+
+    // fixture_tree/fixture_registry/untar: dedicated VIR ops, not primitives.
     for (name, kind) in [
-        ("fetch", PrimitiveKind::Fetch),
-        ("observe", PrimitiveKind::Observe),
-        ("decode", PrimitiveKind::Decode),
-        ("try_decode", PrimitiveKind::TryDecode),
-        ("fixture_tree", PrimitiveKind::FixtureTree),
-        ("fixture_registry", PrimitiveKind::FixtureRegistry),
-        ("untar", PrimitiveKind::Untar),
+        ("fixture_tree", Intrinsic::FixtureTree),
+        ("fixture_registry", Intrinsic::FixtureRegistry),
+        ("untar", Intrinsic::Untar),
     ] {
-        reg.insert(Binding::primitive(Placement::Prelude, name, kind));
+        reg.insert(Binding::intrinsic(Placement::Prelude, name, kind));
     }
 
     // Modes-as-aliases: vix functions over the single primitive, not new
@@ -401,16 +317,50 @@ pub fn builtin_bindings() -> BindingRegistry {
 /// surface names are prelude primitives / vix-fn aliases.
 static BUILTIN_BINDINGS: LazyLock<BindingRegistry> = LazyLock::new(builtin_bindings);
 
-/// The [`PrimitiveKind`] a prelude name lowers to, or `None` if the name is not
-/// a built-in primitive (a vix-fn alias, a user name, or unknown). The compiler
-/// calls this to dispatch primitive lowering instead of matching callee strings.
+/// The [`PrimitiveId`] a prelude name lowers to, or `None` if the name is not a
+/// built-in primitive (an intrinsic, a vix-fn alias, a user name, or unknown).
+/// The compiler calls this to dispatch primitive lowering instead of matching
+/// callee strings.
 #[must_use]
-pub fn prelude_primitive(name: &str) -> Option<PrimitiveKind> {
-    match BUILTIN_BINDINGS.prelude(name)?.target {
-        BindingTarget::Primitive(kind) => Some(kind),
-        BindingTarget::VixFunction { .. } => None,
+pub fn prelude_primitive(name: &str) -> Option<PrimitiveId> {
+    match &BUILTIN_BINDINGS.prelude(name)?.target {
+        BindingTarget::Primitive(id) => Some(id.clone()),
+        BindingTarget::Intrinsic(_) | BindingTarget::VixFunction { .. } => None,
     }
 }
+
+/// The [`Intrinsic`] a prelude name lowers to, or `None` if the name is not one
+/// of the dedicated-op intrinsics.
+#[must_use]
+pub fn prelude_intrinsic(name: &str) -> Option<Intrinsic> {
+    match &BUILTIN_BINDINGS.prelude(name)?.target {
+        BindingTarget::Intrinsic(kind) => Some(*kind),
+        BindingTarget::Primitive(_) | BindingTarget::VixFunction { .. } => None,
+    }
+}
+
+/// The [`RequestShape`] a registered primitive's call lowers through, or `None`
+/// for primitives whose request construction is not yet data (`decode`, the
+/// shared `decode`/`try_decode` id — stays in the compiler's typed builders).
+/// Returning `Some` is the contract that a primitive is fully described by
+/// data: the compiler builds its request generically from the shape. Built by
+/// asking every [`runtime::builtin_primitives`] entry for its own
+/// [`Primitive::request_shape`](crate::runtime::Primitive) — never a `match`
+/// over a closed enum.
+#[must_use]
+pub fn request_shape(id: &PrimitiveId) -> Option<RequestShape> {
+    REQUEST_SHAPES.get(id).cloned()
+}
+
+static REQUEST_SHAPES: LazyLock<BTreeMap<PrimitiveId, RequestShape>> = LazyLock::new(|| {
+    runtime::builtin_primitives::<()>()
+        .into_iter()
+        .filter_map(|primitive| {
+            let shape = primitive.request_shape()?;
+            Some((primitive.descriptor().id.clone(), shape))
+        })
+        .collect()
+});
 
 /// The set of prelude-placed binding names, derived once from
 /// [`builtin_bindings`] so the binding set stays the single source of truth.
@@ -434,6 +384,8 @@ pub fn is_prelude_name(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::{observe_primitive_id, pinned_fetch_primitive_id};
+    use crate::vir::{ExternKind, Type};
 
     #[test]
     fn empty_module_path_is_unrepresentable() {
@@ -447,20 +399,34 @@ mod tests {
     fn builtins_project_one_prelude_name_per_primitive() {
         let reg = builtin_bindings();
 
-        // The built-in primitives are in the prelude, one name each, and
-        // `prelude_primitive` maps each to its lowering kind.
-        for (name, kind) in [
-            ("fetch", PrimitiveKind::Fetch),
-            ("observe", PrimitiveKind::Observe),
-            ("decode", PrimitiveKind::Decode),
-            ("try_decode", PrimitiveKind::TryDecode),
-            ("fixture_tree", PrimitiveKind::FixtureTree),
-            ("fixture_registry", PrimitiveKind::FixtureRegistry),
-            ("untar", PrimitiveKind::Untar),
+        // fetch/observe are harvested from the registered primitives, one name
+        // each, and `prelude_primitive` maps each to its `PrimitiveId`.
+        for (name, id) in [
+            ("fetch", pinned_fetch_primitive_id()),
+            ("observe", observe_primitive_id()),
         ] {
             let binding = reg.prelude(name).expect("prelude primitive");
             assert!(matches!(binding.target, BindingTarget::Primitive(_)));
-            assert_eq!(prelude_primitive(name), Some(kind));
+            assert_eq!(prelude_primitive(name), Some(id));
+        }
+
+        // decode/try_decode are hand-registered onto the same shared id.
+        for name in ["decode", "try_decode"] {
+            let binding = reg.prelude(name).expect("prelude primitive");
+            assert!(matches!(binding.target, BindingTarget::Primitive(_)));
+            assert_eq!(prelude_primitive(name), Some(decode_primitive_id()));
+        }
+
+        // The dedicated-op intrinsics are not primitives.
+        for (name, kind) in [
+            ("fixture_tree", Intrinsic::FixtureTree),
+            ("fixture_registry", Intrinsic::FixtureRegistry),
+            ("untar", Intrinsic::Untar),
+        ] {
+            let binding = reg.prelude(name).expect("prelude intrinsic");
+            assert!(matches!(binding.target, BindingTarget::Intrinsic(_)));
+            assert_eq!(prelude_intrinsic(name), Some(kind));
+            assert_eq!(prelude_primitive(name), None);
         }
 
         // The mode aliases are vix functions, not primitives.
@@ -474,6 +440,7 @@ mod tests {
             let binding = reg.prelude(alias).expect("prelude alias");
             assert!(matches!(binding.target, BindingTarget::VixFunction { .. }));
             assert_eq!(prelude_primitive(alias), None);
+            assert_eq!(prelude_intrinsic(alias), None);
         }
     }
 
@@ -496,23 +463,18 @@ mod tests {
     #[test]
     fn only_the_uniform_primitives_have_a_request_shape() {
         // fetch/observe are fully data — the compiler builds their request from
-        // the shape. Everything else is still hand-lowered and returns `None`.
-        assert!(request_shape(PrimitiveKind::Fetch).is_some());
-        assert!(request_shape(PrimitiveKind::Observe).is_some());
-        for kind in [
-            PrimitiveKind::Decode,
-            PrimitiveKind::TryDecode,
-            PrimitiveKind::FixtureTree,
-            PrimitiveKind::FixtureRegistry,
-            PrimitiveKind::Untar,
-        ] {
-            assert!(request_shape(kind).is_none(), "{kind:?} should have no shape yet");
-        }
+        // the shape. decode/try_decode share an id whose shape is still `None`.
+        assert!(request_shape(&pinned_fetch_primitive_id()).is_some());
+        assert!(request_shape(&observe_primitive_id()).is_some());
+        assert!(
+            request_shape(&decode_primitive_id()).is_none(),
+            "decode should have no shape yet"
+        );
     }
 
     #[test]
     fn fetch_shape_is_one_value_arg() {
-        let shape = request_shape(PrimitiveKind::Fetch).expect("fetch shape");
+        let shape = request_shape(&pinned_fetch_primitive_id()).expect("fetch shape");
         assert_eq!(shape.args.len(), 1);
         assert!(matches!(shape.args[0], ArgRole::Value { .. }));
         assert_eq!(shape.result, Type::Extern(ExternKind::Blob));
@@ -521,7 +483,7 @@ mod tests {
 
     #[test]
     fn observe_shape_is_a_value_then_a_mode_selector() {
-        let shape = request_shape(PrimitiveKind::Observe).expect("observe shape");
+        let shape = request_shape(&observe_primitive_id()).expect("observe shape");
         assert_eq!(shape.args.len(), 2);
         assert!(matches!(shape.args[0], ArgRole::Value { .. }));
         let ArgRole::Selector(selector) = &shape.args[1] else {
@@ -541,7 +503,7 @@ mod tests {
 
     #[test]
     fn selector_builds_its_own_diagnostic_wording() {
-        let shape = request_shape(PrimitiveKind::Observe).expect("observe shape");
+        let shape = request_shape(&observe_primitive_id()).expect("observe shape");
         let ArgRole::Selector(selector) = &shape.args[1] else {
             panic!("expected the Mode selector");
         };

--- a/vix/src/compiler.rs
+++ b/vix/src/compiler.rs
@@ -3527,12 +3527,29 @@ fn lower_value_expected(
         ast::Expr::Call(call) if call.callee.value == "Some" => {
             lower_some(nodes, bindings, context, call, expected)
         }
+        // `decode`/`try_decode` share one registered primitive under two
+        // surface names (`decode_primitive_id`), so they can't
+        // be told apart by `PrimitiveId` the way `fetch`/`observe` can — matched
+        // directly by callee name into their existing typed builders.
+        ast::Expr::Call(call) if call.callee.value == "decode" => {
+            lower_decode_binding(nodes, bindings, context, call, expected)
+        }
+        ast::Expr::Call(call) if call.callee.value == "try_decode" => {
+            lower_try_decode_binding(nodes, bindings, context, call, expected)
+        }
+        ast::Expr::Call(call)
+            if crate::binding::prelude_intrinsic(&call.callee.value).is_some() =>
+        {
+            let intrinsic = crate::binding::prelude_intrinsic(&call.callee.value)
+                .expect("guard confirmed the callee is a built-in intrinsic");
+            lower_effect_intrinsic(nodes, bindings, context, call, intrinsic)
+        }
         ast::Expr::Call(call)
             if crate::binding::prelude_primitive(&call.callee.value).is_some() =>
         {
-            let kind = crate::binding::prelude_primitive(&call.callee.value)
+            let primitive = crate::binding::prelude_primitive(&call.callee.value)
                 .expect("guard confirmed the callee is a built-in primitive");
-            lower_primitive(nodes, bindings, context, call, kind, expected)
+            lower_primitive(nodes, bindings, context, call, &primitive)
         }
         ast::Expr::Call(call) => lower_call(nodes, bindings, context, call, expected),
         ast::Expr::WhereCall(call) => lower_where_call(nodes, bindings, context, call),
@@ -5236,37 +5253,23 @@ fn lower_some(
 /// primitive lands, this fold must become the constant-folded case *of* it, not
 /// a replacement — nonliteral sources are rejected at a named runtime seam
 /// ([`DiagnosticCode::RuntimeDecodeUnavailable`]) rather than host-evaluated.
-/// Lower a call to a built-in primitive, dispatched on the [`PrimitiveKind`] the
-/// binding registry (`crate::binding`) resolved the callee name to — no callee
-/// string matching here. The request construction is genuinely per-primitive
-/// (selector reads, expected-type targets, folding), so the registry owns the
-/// *name → primitive* map while each builder owns its request shape.
+/// Lower a call to a uniform registered primitive (`fetch`, `observe`)
+/// through the [`RequestShape`](crate::binding::RequestShape) it declares on
+/// itself (`Primitive::request_shape`, harvested by `crate::binding`) — there
+/// is no per-primitive Rust arm here. `decode`/`try_decode` and the
+/// `fixture_*`/`untar` intrinsics are matched by callee name earlier and never
+/// reach this function; see `lower_value_expected`'s `ast::Expr::Call` arms.
 fn lower_primitive(
     nodes: &mut Vec<Node>,
     bindings: &BTreeMap<String, LoweredValue>,
     context: &ModuleContext<'_>,
     call: &ast::Call,
-    kind: crate::binding::PrimitiveKind,
-    expected: Option<&Type>,
+    primitive: &crate::runtime::PrimitiveId,
 ) -> Result<LoweredValue, Diagnostics> {
-    use crate::binding::PrimitiveKind;
-    // Primitives whose request construction is fully data (`fetch`, `observe`)
-    // lower through their `RequestShape`; there is no per-primitive Rust arm.
-    if let Some(shape) = crate::binding::request_shape(kind) {
-        return lower_request_shape(nodes, bindings, context, call, &shape);
-    }
-    match kind {
-        PrimitiveKind::Decode => lower_decode_binding(nodes, bindings, context, call, expected),
-        PrimitiveKind::TryDecode => {
-            lower_try_decode_binding(nodes, bindings, context, call, expected)
-        }
-        PrimitiveKind::FixtureTree | PrimitiveKind::FixtureRegistry | PrimitiveKind::Untar => {
-            lower_effect_intrinsic(nodes, bindings, context, call, kind)
-        }
-        PrimitiveKind::Fetch | PrimitiveKind::Observe => {
-            unreachable!("fetch/observe lower through their RequestShape")
-        }
-    }
+    let shape = crate::binding::request_shape(primitive).expect(
+        "prelude_primitive only resolves names with a harvested RequestShape (fetch/observe)",
+    );
+    lower_request_shape(nodes, bindings, context, call, &shape)
 }
 
 /// Build a registered-primitive call from its [`RequestShape`]: check arity, read
@@ -5396,9 +5399,9 @@ fn lower_effect_intrinsic(
     bindings: &BTreeMap<String, LoweredValue>,
     context: &ModuleContext<'_>,
     call: &ast::Call,
-    kind: crate::binding::PrimitiveKind,
+    kind: crate::binding::Intrinsic,
 ) -> Result<LoweredValue, Diagnostics> {
-    use crate::binding::PrimitiveKind;
+    use crate::binding::Intrinsic;
     if call.named_args.is_some() {
         return Err(Diagnostics::one(Diagnostic::unsupported(
             call.span,
@@ -5406,7 +5409,7 @@ fn lower_effect_intrinsic(
         )));
     }
     let (ty, op, inputs) = match kind {
-        PrimitiveKind::FixtureTree => {
+        Intrinsic::FixtureTree => {
             check_arity(call, 1)?;
             let ast::Expr::Str(name) = &call.args.args[0] else {
                 return Err(Diagnostics::one(Diagnostic::unsupported(
@@ -5420,7 +5423,7 @@ fn lower_effect_intrinsic(
                 Vec::new(),
             )
         }
-        PrimitiveKind::FixtureRegistry => {
+        Intrinsic::FixtureRegistry => {
             check_arity(call, 0)?;
             (
                 Type::Extern(ExternKind::Registry),
@@ -5428,7 +5431,7 @@ fn lower_effect_intrinsic(
                 Vec::new(),
             )
         }
-        PrimitiveKind::Untar => {
+        Intrinsic::Untar => {
             check_arity(call, 1)?;
             let blob = lower_value(nodes, bindings, context, &call.args.args[0])?;
             require_type(
@@ -5437,12 +5440,6 @@ fn lower_effect_intrinsic(
                 expr_span(&call.args.args[0]),
             )?;
             (Type::Extern(ExternKind::Tree), Op::Untar, vec![blob.node])
-        }
-        PrimitiveKind::Fetch | PrimitiveKind::Observe => {
-            unreachable!("fetch/observe lower through their RequestShape")
-        }
-        PrimitiveKind::Decode | PrimitiveKind::TryDecode => {
-            unreachable!("decode/try_decode do not route through lower_effect_intrinsic")
         }
     };
     Ok(LoweredValue {

--- a/vix/src/runtime/fetch_primitive.rs
+++ b/vix/src/runtime/fetch_primitive.rs
@@ -4,9 +4,9 @@ use crate::schema::{SchemaPattern, SchemaRef};
 use crate::vir::{ExternKind, Type};
 
 use super::{
-    Digest, EffectCtx, EffectTicket, Primitive, PrimitiveCompletion, PrimitiveDescriptor,
+    ArgRole, Digest, EffectCtx, EffectTicket, Primitive, PrimitiveCompletion, PrimitiveDescriptor,
     PrimitiveField, PrimitiveFieldValue, PrimitiveMachineError, PrimitiveMemoPolicy,
-    PrimitiveValue, PrimitiveValueBody, ReadProjection, ValueId,
+    PrimitiveValue, PrimitiveValueBody, ReadProjection, RequestShape, ValueId,
 };
 
 #[derive(facet::Facet, Clone, Debug, PartialEq, Eq)]
@@ -127,6 +127,21 @@ impl<Ctx> Primitive<Ctx> for PinnedFetchPrimitive {
             let _ = completer.complete(publication);
         });
         ticket
+    }
+
+    fn surface_name(&self) -> Option<&'static str> {
+        Some("fetch")
+    }
+
+    fn request_shape(&self) -> Option<RequestShape> {
+        Some(RequestShape {
+            args: vec![ArgRole::Value {
+                expected: Type::from_facet::<PinnedBlobRef>(),
+            }],
+            request_ty: Type::from_facet::<PinnedFetchRequest>(),
+            result: Type::Extern(ExternKind::Blob),
+            primitive: pinned_fetch_primitive_id(),
+        })
     }
 }
 

--- a/vix/src/runtime/observe_primitive.rs
+++ b/vix/src/runtime/observe_primitive.rs
@@ -2,9 +2,10 @@ use crate::schema::SchemaPattern;
 use crate::vir::{ExternKind, Type};
 
 use super::{
-    EffectCtx, EffectTicket, ObserveCoordinate, ObservedClaim, OriginHint, Primitive,
+    ArgRole, EffectCtx, EffectTicket, ObserveCoordinate, ObservedClaim, OriginHint, Primitive,
     PrimitiveCompletion, PrimitiveDescriptor, PrimitiveField, PrimitiveFieldValue,
-    PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveValue, PrimitiveValueBody, ValueId,
+    PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveValue, PrimitiveValueBody, RequestShape,
+    Selector, SelectorVariant, ValueId,
 };
 
 /// The `observe` request shape. There is no other Rust spelling of this struct —
@@ -89,6 +90,37 @@ impl<Ctx> Primitive<Ctx> for ObservePrimitive {
             let _ = completer.complete(publication);
         });
         ticket
+    }
+
+    fn surface_name(&self) -> Option<&'static str> {
+        Some("observe")
+    }
+
+    fn request_shape(&self) -> Option<RequestShape> {
+        Some(RequestShape {
+            args: vec![
+                ArgRole::Value {
+                    expected: Type::from_facet::<OriginHint>(),
+                },
+                ArgRole::Selector(Selector {
+                    enum_name: "Mode".to_owned(),
+                    noun: "observe mode".to_owned(),
+                    variants: vec![
+                        SelectorVariant {
+                            variant: "Observe".to_owned(),
+                            flag: false,
+                        },
+                        SelectorVariant {
+                            variant: "Refresh".to_owned(),
+                            flag: true,
+                        },
+                    ],
+                }),
+            ],
+            request_ty: Type::from_facet::<ObserveRequest>(),
+            result: Type::Extern(ExternKind::Blob),
+            primitive: observe_primitive_id(),
+        })
     }
 }
 

--- a/vix/src/runtime/primitive.rs
+++ b/vix/src/runtime/primitive.rs
@@ -862,11 +862,104 @@ impl<T: Clone> FromRef<T> for T {
     }
 }
 
+/// One accepted variant of a [`Selector`] argument and the boolean flag it folds
+/// into the request record. (`Mode::Observe` → `false`, `Mode::Refresh` → `true`.)
+///
+/// Selectors fold to a boolean today because the only one — observe's `Mode` — is
+/// binary. Decode's `Format` is an integer tag; when it migrates onto a shape this
+/// widens to a general constant. Until then, "selector" means "enum → flag".
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SelectorVariant {
+    pub variant: String,
+    pub flag: bool,
+}
+
+/// A selector argument: an enum-variant read at *lower time* into a constant and
+/// folded into the request record, never lowered as a runtime value. The
+/// accepted `enum_name`, its variants, and the diagnostic wording all live here
+/// rather than as a bespoke Rust reader per primitive.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Selector {
+    /// The enum the variant must name (`Mode`).
+    pub enum_name: String,
+    /// How the selector reads in diagnostics (`observe mode`) — the noun the
+    /// "expected …" and "unknown …" messages are built from.
+    pub noun: String,
+    pub variants: Vec<SelectorVariant>,
+}
+
+impl Selector {
+    /// What a non-variant or wrong-enum argument should say it expected, e.g.
+    /// `an observe mode `Mode::Observe` or `Mode::Refresh``.
+    #[must_use]
+    pub fn expected(&self) -> String {
+        let choices: Vec<String> = self
+            .variants
+            .iter()
+            .map(|candidate| format!("`{}::{}`", self.enum_name, candidate.variant))
+            .collect();
+        format!("an {} {}", self.noun, choices.join(" or "))
+    }
+
+    /// The message for a known enum but unrecognized variant, e.g.
+    /// `an unknown observe mode `Mode::Spin``.
+    #[must_use]
+    pub fn unknown(&self, variant: &str) -> String {
+        format!("an unknown {} `{}::{variant}`", self.noun, self.enum_name)
+    }
+}
+
+/// The structural role a surface argument plays in a primitive's request record.
+/// The request record has one field per argument, in this order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ArgRole {
+    /// Lowered as an ordinary value and required to have the given type
+    /// (`fetch`'s `PinnedBlobRef`, `observe`'s `OriginHint`).
+    Value { expected: Type },
+    /// An enum-variant selector folded to a constant request field.
+    Selector(Selector),
+}
+
+/// How a registered primitive builds its request from its surface arguments — the
+/// data a single generic lowering step consumes in place of a bespoke Rust arm per
+/// primitive. Arity is `args.len()`; the compiler builds a `request_ty` record with
+/// one field per argument (in order), invokes `primitive`, and yields `result`.
+///
+/// Only the primitives whose construction is *fully uniform* declare one
+/// ([`Primitive::request_shape`]) today (`fetch`, `observe`). `decode`/
+/// `try_decode` (compile-time constant folding, expected-type-derived targets)
+/// are not yet expressible here and stay on the `None` default.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RequestShape {
+    pub args: Vec<ArgRole>,
+    pub request_ty: Type,
+    pub result: Type,
+    pub primitive: PrimitiveId,
+}
+
 pub trait Primitive<Ctx>: Send + Sync {
     fn descriptor(&self) -> &PrimitiveDescriptor;
     /// `app` is the whole shared embedder context; the impl projects the
     /// slice it needs out of it via [`FromRef`].
     fn begin(&self, request: ValueId, ctx: EffectCtx, app: &Ctx) -> EffectTicket;
+
+    /// The primitive's surface name in the vix prelude, or `None` if it
+    /// projects no surface binding at all (e.g. `TreeReadPrimitive`, reached
+    /// only through the `.text()` method surface, never by a free-function
+    /// call). A primitive with `Some` name here is exactly the primitives
+    /// `binding::builtin_bindings` harvests one prelude binding from.
+    fn surface_name(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// The [`RequestShape`] this primitive's surface call lowers through, or
+    /// `None` when request construction is not yet fully data (selector reads
+    /// and expected-type-derived targets that don't reduce to a plain record
+    /// shape). Returning `Some` is the contract that the compiler can build
+    /// this primitive's request generically, with no bespoke Rust arm.
+    fn request_shape(&self) -> Option<RequestShape> {
+        None
+    }
 }
 
 type TicketWaiter = Box<dyn FnOnce(PrimitivePublication) + Send + 'static>;

--- a/vix/src/runtime/scheduler.rs
+++ b/vix/src/runtime/scheduler.rs
@@ -41,7 +41,7 @@ use super::store::{
     StoreJournalLoadReport,
 };
 use super::{
-    DecodePrimitive, EffectCtx, EffectTicket, ObservePrimitive, PinnedFetchPrimitive,
+    DecodePrimitive, EffectCtx, EffectTicket, ObservePrimitive, PinnedFetchPrimitive, Primitive,
     PrimitiveCompletion, PrimitiveDispatcher, PrimitiveField, PrimitiveFieldValue,
     PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveRegistry, PrimitiveValue,
     PrimitiveValueBody, StagedEffectAuthority, TicketSubscription, TreeReadPrimitive,
@@ -723,20 +723,27 @@ fn build_memo_suffix_index(
     index
 }
 
+/// The built-in registered primitives, as data: this is the *one* place that
+/// lists them, consumed both to build the default dispatcher and (by
+/// `binding::builtin_bindings`) to harvest their surface projections. Adding a
+/// primitive is one entry here, not a second hand-registration.
+#[must_use]
+pub fn builtin_primitives<Ctx>() -> Vec<Arc<dyn Primitive<Ctx>>> {
+    vec![
+        Arc::new(DecodePrimitive::default()),
+        Arc::new(PinnedFetchPrimitive::default()),
+        Arc::new(ObservePrimitive::default()),
+        Arc::new(TreeReadPrimitive::default()),
+    ]
+}
+
 fn default_primitive_dispatcher<Ctx>() -> PrimitiveDispatcher<Ctx> {
     let mut registry = PrimitiveRegistry::default();
-    registry
-        .register(Arc::new(DecodePrimitive::default()))
-        .expect("the built-in decode primitive is registered once");
-    registry
-        .register(Arc::new(PinnedFetchPrimitive::default()))
-        .expect("the built-in pinned fetch primitive is registered once");
-    registry
-        .register(Arc::new(ObservePrimitive::default()))
-        .expect("the built-in observe primitive is registered once");
-    registry
-        .register(Arc::new(TreeReadPrimitive::default()))
-        .expect("the built-in tree-read primitive is registered once");
+    for primitive in builtin_primitives::<Ctx>() {
+        registry
+            .register(primitive)
+            .expect("built-in primitives register once, each under a distinct id");
+    }
     PrimitiveDispatcher::new(Arc::new(registry))
 }
 


### PR DESCRIPTION
Implements migration item 3 of the data-driven-primitives arc: **the primitive declares its own projection**, the registry is harvested from the registered primitives, and the closed `PrimitiveKind` enum is gone.

## What's here
- **Projection lives on the primitive.** `Primitive<Ctx>` gains two dyn-safe, defaulted methods — `surface_name() -> Option<&'static str>` and `request_shape() -> Option<RequestShape>`. `fetch`/`observe` implement them (moving today's `binding::request_shape` bodies verbatim); everything else stays on the `None` defaults. `dyn Primitive<Ctx>` stays object-safe (neither method mentions `Self` by value or `Ctx`).
- **The registry is harvested, not hand-written.** `binding::builtin_bindings()` iterates `runtime::builtin_primitives::<()>()` and harvests one prelude binding per primitive that projects a `surface_name` — no second table naming `fetch`/`observe` by hand. (`builtin_primitives` is the registration list extracted out of `default_primitive_dispatcher`, so runtime and compile-side read the *same* list.)
- **`PrimitiveKind` is gone.** `BindingTarget::Primitive(PrimitiveId)` replaces it for real primitives; a new `BindingTarget::Intrinsic` honestly models `fixture_tree`/`fixture_registry`/`untar` — which were never primitives (they lower to dedicated VIR ops, no `PrimitiveId`). `decode`/`try_decode` are two names hand-registered onto the one shared `decode_primitive_id()` (still hand-lowered; item 6). `request_shape` is now keyed by `PrimitiveId`.
- `RequestShape`/`ArgRole`/`Selector`/`SelectorVariant` moved from `binding` down into `runtime` next to the `Primitive` trait (it's the primitive that declares them), re-exported from `binding` so `compiler.rs` call sites are unchanged. No cycle — cyclic module `use` within one crate is legal, and `runtime`/`vir` already do it.

Compiler dispatch keys off `PrimitiveId` for the registry path; the non-uniform names (decode/try_decode/fixture*/untar) match by callee string into their existing, unchanged typed builders.

## Verification (local; repo CI independently red)
Clean build, no warnings. Full `cargo test -p vix` green incl. `ratchet_runner` **151/0/2** (decode rungs 062-066, fetch/untar 075-077 exercise this dispatch end-to-end) and ~40 other suites, zero failures; `vix-fetch` **11/11 + 4/4**; the `Type::from_facet` schema snapshot still byte-identical (wire schemas untouched).
