### PR TITLE
vix: Primitive authoring layer — declare a primitive in one block

### DIFF
--- a/vix/src/binding.rs
+++ b/vix/src/binding.rs
@@ -21,8 +21,8 @@
 //! # Status
 //!
 //! **The projection lives on the primitive.** Each registered primitive
-//! declares its own [`Primitive::surface_name`](crate::runtime::Primitive) and
-//! [`Primitive::request_shape`](crate::runtime::Primitive); [`builtin_bindings`]
+//! declares its own [`RawPrimitive::surface_name`](crate::runtime::RawPrimitive) and
+//! [`RawPrimitive::request_shape`](crate::runtime::RawPrimitive); [`builtin_bindings`]
 //! *harvests* the [`BindingRegistry`] from [`runtime::builtin_primitives`]
 //! rather than maintaining a second table that names every primitive by hand.
 //! `compiler::lower_value` recognizes built-in primitives through
@@ -62,7 +62,7 @@ use crate::vir::decode_primitive_id;
 
 // Re-exported so existing call sites (`compiler.rs`) can keep spelling these
 // `crate::binding::RequestShape` etc. — the types now live next to
-// `Primitive` in `runtime`, since it is the primitive that declares them.
+// `RawPrimitive` in `runtime`, since it is the primitive that declares them.
 pub use crate::runtime::{ArgRole, RequestShape, Selector, SelectorVariant};
 
 /// A non-empty `::`-separated module path (`caps`, `some::ns::inner`).
@@ -228,7 +228,7 @@ impl BindingRegistry {
 
 /// The built-in prelude bindings, encoded as data.
 ///
-/// Every registered primitive that projects a surface name (`Primitive::
+/// Every registered primitive that projects a surface name (`RawPrimitive::
 /// surface_name` returns `Some`) is harvested straight from
 /// [`runtime::builtin_primitives`] — `fetch` and `observe` today. `decode`/
 /// `try_decode` share one primitive under two names and are not yet uniform
@@ -345,7 +345,7 @@ pub fn prelude_intrinsic(name: &str) -> Option<Intrinsic> {
 /// Returning `Some` is the contract that a primitive is fully described by
 /// data: the compiler builds its request generically from the shape. Built by
 /// asking every [`runtime::builtin_primitives`] entry for its own
-/// [`Primitive::request_shape`](crate::runtime::Primitive) — never a `match`
+/// [`RawPrimitive::request_shape`](crate::runtime::RawPrimitive) — never a `match`
 /// over a closed enum.
 #[must_use]
 pub fn request_shape(id: &PrimitiveId) -> Option<RequestShape> {

--- a/vix/src/compiler.rs
+++ b/vix/src/compiler.rs
@@ -5255,7 +5255,7 @@ fn lower_some(
 /// ([`DiagnosticCode::RuntimeDecodeUnavailable`]) rather than host-evaluated.
 /// Lower a call to a uniform registered primitive (`fetch`, `observe`)
 /// through the [`RequestShape`](crate::binding::RequestShape) it declares on
-/// itself (`Primitive::request_shape`, harvested by `crate::binding`) — there
+/// itself (`RawPrimitive::request_shape`, harvested by `crate::binding`) — there
 /// is no per-primitive Rust arm here. `decode`/`try_decode` and the
 /// `fixture_*`/`untar` intrinsics are matched by callee name earlier and never
 /// reach this function; see `lower_value_expected`'s `ast::Expr::Call` arms.

--- a/vix/src/runtime/decode_primitive.rs
+++ b/vix/src/runtime/decode_primitive.rs
@@ -6,7 +6,7 @@ use crate::vir::{
 };
 
 use super::{
-    EffectCtx, EffectTicket, Primitive, PrimitiveCompletion, PrimitiveDescriptor, PrimitiveField,
+    EffectCtx, EffectTicket, RawPrimitive, PrimitiveCompletion, PrimitiveDescriptor, PrimitiveField,
     PrimitiveFieldValue, PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveValue,
     PrimitiveValueBody, ReadProjection, ValueId,
 };
@@ -35,7 +35,7 @@ impl Default for DecodePrimitive {
     }
 }
 
-impl<Ctx> Primitive<Ctx> for DecodePrimitive {
+impl<Ctx> RawPrimitive<Ctx> for DecodePrimitive {
     fn descriptor(&self) -> &PrimitiveDescriptor {
         &self.descriptor
     }

--- a/vix/src/runtime/fetch_primitive.rs
+++ b/vix/src/runtime/fetch_primitive.rs
@@ -1,13 +1,17 @@
 use sha2::{Digest as _, Sha256};
 
-use crate::schema::{SchemaPattern, SchemaRef};
+use crate::schema::SchemaRef;
 use crate::vir::{ExternKind, Type};
 
 use super::{
-    ArgRole, Digest, EffectCtx, EffectTicket, Primitive, PrimitiveCompletion, PrimitiveDescriptor,
-    PrimitiveField, PrimitiveFieldValue, PrimitiveMachineError, PrimitiveMemoPolicy,
-    PrimitiveValue, PrimitiveValueBody, ReadProjection, RequestShape, ValueId,
+    ArgRoleDecl, Digest, EffectCtx, EffectTicket, PrimitiveCompletion, PrimitiveDecl,
+    PrimitiveMachineError, PrimitiveMemoPolicy, PrimitivePublication, ReadProjection, Receipt,
+    ResponseDecl, Primitive, ValueId,
 };
+// Only the test-only hand parsers (the `decode_primitive_value` oracle) walk the
+// wire `PrimitiveValue` structurally now; production `begin` decodes instead.
+#[cfg(test)]
+use super::{PrimitiveField, PrimitiveFieldValue, PrimitiveValue, PrimitiveValueBody};
 
 #[derive(facet::Facet, Clone, Debug, PartialEq, Eq)]
 pub struct UpstreamDigest(pub [u8; 32]);
@@ -76,78 +80,47 @@ pub fn pinned_fetch_primitive_id() -> super::PrimitiveId {
     }
 }
 
-pub struct PinnedFetchPrimitive {
-    descriptor: PrimitiveDescriptor,
-}
-
-impl Default for PinnedFetchPrimitive {
-    fn default() -> Self {
-        Self {
-            descriptor: PrimitiveDescriptor {
-                id: pinned_fetch_primitive_id(),
-                request_schema: SchemaPattern::exact(
-                    &Type::from_facet::<PinnedFetchRequest>().schema_ref(),
-                ),
-                response_schema: SchemaPattern::exact(&Type::Extern(ExternKind::Blob).schema_ref()),
-                failure_schema: SchemaPattern::Var {
-                    name: "PinnedFetchFailure".to_owned(),
-                },
-                memo_policy: PrimitiveMemoPolicy::Pinned,
-                protocol_version: 1,
-                capability_schemas: vec![SchemaPattern::exact(
-                    &Type::Extern(ExternKind::Registry).schema_ref(),
-                )],
-            },
-        }
-    }
-}
+pub struct PinnedFetchPrimitive;
 
 impl<Ctx> Primitive<Ctx> for PinnedFetchPrimitive {
-    fn descriptor(&self) -> &PrimitiveDescriptor {
-        &self.descriptor
-    }
+    type Request = PinnedFetchRequest;
+    type Deps = ();
 
-    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> EffectTicket {
+    const DECL: PrimitiveDecl = PrimitiveDecl {
+        namespace: "vix.machine",
+        name: "fetch",
+        id_name: "pinned-fetch",
+        version: 1,
+        memo_policy: PrimitiveMemoPolicy::Pinned,
+        protocol_version: 1,
+        response: ResponseDecl::Extern(ExternKind::Blob),
+        failure_schema_name: "PinnedFetchFailure",
+        capabilities: &[ExternKind::Registry],
+        args: &[ArgRoleDecl::Value],
+    };
+
+    fn begin(&self, req: PinnedFetchRequest, ctx: EffectCtx, _deps: ()) -> EffectTicket {
         let (ticket, completer) = ctx.ticket(|| {});
         std::thread::spawn(move || {
-            let completion = execute(&request, &ctx)
+            let completion = serve(req.pin, &ctx)
                 .map(PrimitiveCompletion::Ok)
                 .unwrap_or_else(PrimitiveCompletion::MachineError);
-            let publication =
-                ctx.finish(completion)
-                    .unwrap_or_else(|error| super::PrimitivePublication {
-                        completion: PrimitiveCompletion::MachineError(error),
-                        receipt: super::Receipt {
-                            demand: ctx.demand(),
-                            reads: Vec::new(),
-                        },
-                        journal: Vec::new(),
-                        progressive: Vec::new(),
-                    });
+            let publication = ctx.finish(completion).unwrap_or_else(|error| PrimitivePublication {
+                completion: PrimitiveCompletion::MachineError(error),
+                receipt: Receipt {
+                    demand: ctx.demand(),
+                    reads: Vec::new(),
+                },
+                journal: Vec::new(),
+                progressive: Vec::new(),
+            });
             let _ = completer.complete(publication);
         });
         ticket
     }
-
-    fn surface_name(&self) -> Option<&'static str> {
-        Some("fetch")
-    }
-
-    fn request_shape(&self) -> Option<RequestShape> {
-        Some(RequestShape {
-            args: vec![ArgRole::Value {
-                expected: Type::from_facet::<PinnedBlobRef>(),
-            }],
-            request_ty: Type::from_facet::<PinnedFetchRequest>(),
-            result: Type::Extern(ExternKind::Blob),
-            primitive: pinned_fetch_primitive_id(),
-        })
-    }
 }
 
-fn execute(request: &ValueId, ctx: &EffectCtx) -> Result<ValueId, PrimitiveMachineError> {
-    let request = ctx.read(request, ReadProjection::Whole)?;
-    let pin = parse_request(request.value, request.identity)?;
+fn serve(pin: PinnedBlobRef, ctx: &EffectCtx) -> Result<ValueId, PrimitiveMachineError> {
     let target = pin.value.id();
 
     if let Ok(stored) = ctx.read(&target, ReadProjection::Whole) {
@@ -222,9 +195,11 @@ fn verify_upstream(
     Ok(())
 }
 
-// `pub(crate)`: exercised directly by `primitive_value_decode`'s tests, which
-// assert `decode_primitive_value` agrees with these hand parsers on the same
-// wire `PrimitiveValue` for the real request types they exist to decode.
+// `#[cfg(test)]`: since `begin` decodes via `decode_primitive_value`, these hand
+// parsers survive only as the oracle for `primitive_value_decode`'s tests, which
+// assert that decoder agrees with them on the same wire `PrimitiveValue` for the
+// real request types. Test-only, so they don't dead-code-warn in a normal build.
+#[cfg(test)]
 pub(crate) fn parse_request(
     request: PrimitiveValue,
     request_id: ValueId,
@@ -260,6 +235,7 @@ pub(crate) fn parse_request(
     })
 }
 
+#[cfg(test)]
 pub(crate) fn parse_blob_id(
     value: &PrimitiveValue,
     request: &ValueId,
@@ -292,6 +268,7 @@ pub(crate) fn parse_blob_id(
     })
 }
 
+#[cfg(test)]
 pub(crate) fn parse_origins(value: &PrimitiveValue) -> Result<Vec<OriginHint>, PrimitiveMachineError> {
     let PrimitiveValueBody::Sequence { elements, .. } = &value.body else {
         return Err(invalid_value());
@@ -317,6 +294,7 @@ pub(crate) fn parse_origins(value: &PrimitiveValue) -> Result<Vec<OriginHint>, P
         .collect()
 }
 
+#[cfg(test)]
 pub(crate) fn parse_upstream(
     value: &PrimitiveValue,
 ) -> Result<Option<UpstreamDigest>, PrimitiveMachineError> {
@@ -337,6 +315,7 @@ pub(crate) fn parse_upstream(
     }
 }
 
+#[cfg(test)]
 fn child(field: &PrimitiveField) -> Result<&PrimitiveValue, PrimitiveMachineError> {
     let PrimitiveFieldValue::Child(value) = &field.value else {
         return Err(invalid_value());
@@ -344,6 +323,7 @@ fn child(field: &PrimitiveField) -> Result<&PrimitiveValue, PrimitiveMachineErro
     Ok(value)
 }
 
+#[cfg(test)]
 fn bytes(value: &PrimitiveValue) -> Result<&[u8], PrimitiveMachineError> {
     let PrimitiveValueBody::Bytes(bytes) = &value.body else {
         return Err(invalid_value());
@@ -351,6 +331,7 @@ fn bytes(value: &PrimitiveValue) -> Result<&[u8], PrimitiveMachineError> {
     Ok(bytes)
 }
 
+#[cfg(test)]
 fn invalid_value() -> PrimitiveMachineError {
     PrimitiveMachineError::AuthorityViolation {
         detail: "pinned fetch request disagrees with its declared schema".to_owned(),

--- a/vix/src/runtime/mod.rs
+++ b/vix/src/runtime/mod.rs
@@ -15,6 +15,7 @@ mod primitive_value_decode;
 mod scheduler;
 mod store;
 mod tree_read_primitive;
+mod typed_primitive;
 
 pub use abi::*;
 pub use blob_persistence::*;
@@ -31,3 +32,4 @@ pub use primitive_value_decode::*;
 pub use scheduler::*;
 pub use store::*;
 pub use tree_read_primitive::*;
+pub use typed_primitive::*;

--- a/vix/src/runtime/observe_primitive.rs
+++ b/vix/src/runtime/observe_primitive.rs
@@ -1,12 +1,15 @@
-use crate::schema::SchemaPattern;
 use crate::vir::{ExternKind, Type};
 
 use super::{
-    ArgRole, EffectCtx, EffectTicket, ObserveCoordinate, ObservedClaim, OriginHint, Primitive,
-    PrimitiveCompletion, PrimitiveDescriptor, PrimitiveField, PrimitiveFieldValue,
-    PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveValue, PrimitiveValueBody, RequestShape,
-    Selector, SelectorVariant, ValueId,
+    ArgRoleDecl, EffectCtx, EffectTicket, ObserveCoordinate, ObservedClaim, OriginHint,
+    PrimitiveCompletion, PrimitiveDecl, PrimitiveMachineError, PrimitiveMemoPolicy,
+    PrimitivePublication, Receipt, ResponseDecl, SelectorDecl, SelectorVariantDecl, Primitive,
+    ValueId,
 };
+// Only the test-only hand parser (the `decode_primitive_value` oracle) walks the
+// wire `PrimitiveValue` structurally now; production `begin` decodes instead.
+#[cfg(test)]
+use super::{PrimitiveField, PrimitiveFieldValue, PrimitiveValue, PrimitiveValueBody};
 
 /// The `observe` request shape. There is no other Rust spelling of this struct —
 /// it is authored here so the derived `Type::from_facet::<ObserveRequest>()` is
@@ -39,94 +42,69 @@ pub fn observe_primitive_id() -> super::PrimitiveId {
 /// append-only claim history (`machine.primitive.fetch-is-pinned`,
 /// `machine.persistence.four-lifetimes`). Its memo policy is therefore
 /// `Observed`: the identity becomes known through a receipted observation.
-pub struct ObservePrimitive {
-    descriptor: PrimitiveDescriptor,
-}
+pub struct ObservePrimitive;
 
-impl Default for ObservePrimitive {
-    fn default() -> Self {
-        Self {
-            descriptor: PrimitiveDescriptor {
-                id: observe_primitive_id(),
-                request_schema: SchemaPattern::exact(
-                    &Type::from_facet::<ObserveRequest>().schema_ref(),
-                ),
-                response_schema: SchemaPattern::exact(&Type::Extern(ExternKind::Blob).schema_ref()),
-                failure_schema: SchemaPattern::Var {
-                    name: "ObserveFailure".to_owned(),
-                },
-                memo_policy: PrimitiveMemoPolicy::Observed,
-                protocol_version: 1,
-                capability_schemas: vec![SchemaPattern::exact(
-                    &Type::Extern(ExternKind::Registry).schema_ref(),
-                )],
-            },
-        }
-    }
-}
+/// The `Mode` selector `observe`'s second argument folds to its `refresh` flag:
+/// `Mode::Observe` → `false`, `Mode::Refresh` → `true`.
+const MODE_SELECTOR: SelectorDecl = SelectorDecl {
+    enum_name: "Mode",
+    noun: "observe mode",
+    variants: &[
+        SelectorVariantDecl {
+            variant: "Observe",
+            flag: false,
+        },
+        SelectorVariantDecl {
+            variant: "Refresh",
+            flag: true,
+        },
+    ],
+};
 
 impl<Ctx> Primitive<Ctx> for ObservePrimitive {
-    fn descriptor(&self) -> &PrimitiveDescriptor {
-        &self.descriptor
-    }
+    type Request = ObserveRequest;
+    type Deps = ();
 
-    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> EffectTicket {
+    const DECL: PrimitiveDecl = PrimitiveDecl {
+        namespace: "vix.machine",
+        name: "observe",
+        id_name: "observe",
+        version: 1,
+        memo_policy: PrimitiveMemoPolicy::Observed,
+        protocol_version: 1,
+        response: ResponseDecl::Extern(ExternKind::Blob),
+        failure_schema_name: "ObserveFailure",
+        capabilities: &[ExternKind::Registry],
+        args: &[ArgRoleDecl::Value, ArgRoleDecl::Selector(MODE_SELECTOR)],
+    };
+
+    fn begin(&self, req: ObserveRequest, ctx: EffectCtx, _deps: ()) -> EffectTicket {
         let (ticket, completer) = ctx.ticket(|| {});
         std::thread::spawn(move || {
-            let completion = execute(&request, &ctx)
+            let completion = serve(req, &ctx)
                 .map(PrimitiveCompletion::Ok)
                 .unwrap_or_else(PrimitiveCompletion::MachineError);
-            let publication =
-                ctx.finish(completion)
-                    .unwrap_or_else(|error| super::PrimitivePublication {
-                        completion: PrimitiveCompletion::MachineError(error),
-                        receipt: super::Receipt {
-                            demand: ctx.demand(),
-                            reads: Vec::new(),
-                        },
-                        journal: Vec::new(),
-                        progressive: Vec::new(),
-                    });
+            let publication = ctx.finish(completion).unwrap_or_else(|error| PrimitivePublication {
+                completion: PrimitiveCompletion::MachineError(error),
+                receipt: Receipt {
+                    demand: ctx.demand(),
+                    reads: Vec::new(),
+                },
+                journal: Vec::new(),
+                progressive: Vec::new(),
+            });
             let _ = completer.complete(publication);
         });
         ticket
     }
-
-    fn surface_name(&self) -> Option<&'static str> {
-        Some("observe")
-    }
-
-    fn request_shape(&self) -> Option<RequestShape> {
-        Some(RequestShape {
-            args: vec![
-                ArgRole::Value {
-                    expected: Type::from_facet::<OriginHint>(),
-                },
-                ArgRole::Selector(Selector {
-                    enum_name: "Mode".to_owned(),
-                    noun: "observe mode".to_owned(),
-                    variants: vec![
-                        SelectorVariant {
-                            variant: "Observe".to_owned(),
-                            flag: false,
-                        },
-                        SelectorVariant {
-                            variant: "Refresh".to_owned(),
-                            flag: true,
-                        },
-                    ],
-                }),
-            ],
-            request_ty: Type::from_facet::<ObserveRequest>(),
-            result: Type::Extern(ExternKind::Blob),
-            primitive: observe_primitive_id(),
-        })
-    }
 }
 
-fn execute(request: &ValueId, ctx: &EffectCtx) -> Result<ValueId, PrimitiveMachineError> {
-    let request = ctx.read(request, super::ReadProjection::Whole)?;
-    let (coordinate, refresh) = parse_request(request.value, request.identity)?;
+fn serve(request: ObserveRequest, ctx: &EffectCtx) -> Result<ValueId, PrimitiveMachineError> {
+    let coordinate = ObserveCoordinate {
+        capability: request.origin.capability.0,
+        coordinate: request.origin.coordinate,
+    };
+    let refresh = request.refresh;
 
     // Optimistic concurrency for refresh: sample the head before reading the
     // origin, and reject the append if a concurrent observer advanced the head
@@ -165,9 +143,11 @@ fn execute(request: &ValueId, ctx: &EffectCtx) -> Result<ValueId, PrimitiveMachi
     Ok(admitted)
 }
 
-// `pub(crate)`: exercised directly by `primitive_value_decode`'s tests, which
-// assert `decode_primitive_value` agrees with this hand parser on the same
-// wire `PrimitiveValue` for the real `ObserveRequest` it exists to decode.
+// `#[cfg(test)]`: since `begin` decodes via `decode_primitive_value`, this hand
+// parser survives only as the oracle for `primitive_value_decode`'s tests, which
+// assert that decoder agrees with it on the same wire `PrimitiveValue` for the
+// real `ObserveRequest`. Test-only, so it doesn't dead-code-warn in a normal build.
+#[cfg(test)]
 pub(crate) fn parse_request(
     request: PrimitiveValue,
     request_id: ValueId,
@@ -207,6 +187,7 @@ pub(crate) fn parse_request(
     ))
 }
 
+#[cfg(test)]
 fn inline_i64(field: &PrimitiveField) -> Result<i64, PrimitiveMachineError> {
     let PrimitiveFieldValue::Inline(bytes) = &field.value else {
         return Err(invalid_value());
@@ -216,6 +197,7 @@ fn inline_i64(field: &PrimitiveField) -> Result<i64, PrimitiveMachineError> {
     ))
 }
 
+#[cfg(test)]
 fn child(field: &PrimitiveField) -> Result<&PrimitiveValue, PrimitiveMachineError> {
     let PrimitiveFieldValue::Child(value) = &field.value else {
         return Err(invalid_value());
@@ -223,6 +205,7 @@ fn child(field: &PrimitiveField) -> Result<&PrimitiveValue, PrimitiveMachineErro
     Ok(value)
 }
 
+#[cfg(test)]
 fn bytes(value: &PrimitiveValue) -> Result<&[u8], PrimitiveMachineError> {
     let PrimitiveValueBody::Bytes(bytes) = &value.body else {
         return Err(invalid_value());
@@ -230,6 +213,7 @@ fn bytes(value: &PrimitiveValue) -> Result<&[u8], PrimitiveMachineError> {
     Ok(bytes)
 }
 
+#[cfg(test)]
 fn invalid_value() -> PrimitiveMachineError {
     PrimitiveMachineError::AuthorityViolation {
         detail: "observe request disagrees with its declared schema".to_owned(),

--- a/vix/src/runtime/primitive.rs
+++ b/vix/src/runtime/primitive.rs
@@ -856,10 +856,17 @@ pub trait FromRef<Ctx> {
     fn from_ref(ctx: &Ctx) -> Self;
 }
 
-impl<T: Clone> FromRef<T> for T {
-    fn from_ref(ctx: &T) -> T {
-        ctx.clone()
-    }
+/// A primitive that needs nothing from the embedder declares `type Deps = ()`
+/// and stays agnostic over `Ctx`: the empty slice is projectable out of *any*
+/// context, so a bare `Runtime<S, ()>` and a richly-provisioned one both admit
+/// `fetch`/`observe`. This is deliberately a generic `impl … for ()` rather than
+/// the reflexive `impl<T: Clone> FromRef<T> for T` (whole-context-as-its-own-dep):
+/// the two overlap at `Ctx = ()`, and it is `()`-deps agnosticism the built-in
+/// primitives actually rely on. Concrete slices (`PgPool`, a fixture store, …)
+/// name their own `impl FromRef<Ctx>` per embedder context, the way the
+/// `from_ref_tests` `FakePool` does.
+impl<Ctx> FromRef<Ctx> for () {
+    fn from_ref(_ctx: &Ctx) {}
 }
 
 /// One accepted variant of a [`Selector`] argument and the boolean flag it folds
@@ -926,7 +933,7 @@ pub enum ArgRole {
 /// one field per argument (in order), invokes `primitive`, and yields `result`.
 ///
 /// Only the primitives whose construction is *fully uniform* declare one
-/// ([`Primitive::request_shape`]) today (`fetch`, `observe`). `decode`/
+/// ([`RawPrimitive::request_shape`]) today (`fetch`, `observe`). `decode`/
 /// `try_decode` (compile-time constant folding, expected-type-derived targets)
 /// are not yet expressible here and stay on the `None` default.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -937,7 +944,7 @@ pub struct RequestShape {
     pub primitive: PrimitiveId,
 }
 
-pub trait Primitive<Ctx>: Send + Sync {
+pub trait RawPrimitive<Ctx>: Send + Sync {
     fn descriptor(&self) -> &PrimitiveDescriptor;
     /// `app` is the whole shared embedder context; the impl projects the
     /// slice it needs out of it via [`FromRef`].
@@ -1122,7 +1129,7 @@ impl Drop for TicketSubscription {
 }
 
 pub struct PrimitiveRegistry<Ctx> {
-    primitives: BTreeMap<PrimitiveId, Arc<dyn Primitive<Ctx>>>,
+    primitives: BTreeMap<PrimitiveId, Arc<dyn RawPrimitive<Ctx>>>,
 }
 
 impl<Ctx> Default for PrimitiveRegistry<Ctx> {
@@ -1193,7 +1200,7 @@ pub enum PrimitiveRegistrationError {
 impl<Ctx> PrimitiveRegistry<Ctx> {
     pub fn register(
         &mut self,
-        primitive: Arc<dyn Primitive<Ctx>>,
+        primitive: Arc<dyn RawPrimitive<Ctx>>,
     ) -> Result<(), PrimitiveRegistrationError> {
         let id = primitive.descriptor().id.clone();
         if self.primitives.insert(id.clone(), primitive).is_some() {
@@ -1277,7 +1284,7 @@ mod from_ref_tests {
         seen: Arc<Mutex<Option<&'static str>>>,
     }
 
-    impl<Ctx> Primitive<Ctx> for PoolLabelPrimitive
+    impl<Ctx> RawPrimitive<Ctx> for PoolLabelPrimitive
     where
         FakePool: FromRef<Ctx>,
     {

--- a/vix/src/runtime/primitive_value_decode.rs
+++ b/vix/src/runtime/primitive_value_decode.rs
@@ -401,10 +401,6 @@ mod tests {
         }
     }
 
-    fn string_value(s: &str) -> PrimitiveValue {
-        PrimitiveValue::bytes(Type::String.schema_ref(), s.as_bytes().to_vec())
-    }
-
     fn int_value(n: i64) -> PrimitiveValue {
         PrimitiveValue::bytes(Type::Int.schema_ref(), n.to_le_bytes().to_vec())
     }

--- a/vix/src/runtime/scheduler.rs
+++ b/vix/src/runtime/scheduler.rs
@@ -41,10 +41,10 @@ use super::store::{
     StoreJournalLoadReport,
 };
 use super::{
-    DecodePrimitive, EffectCtx, EffectTicket, ObservePrimitive, PinnedFetchPrimitive, Primitive,
+    DecodePrimitive, EffectCtx, EffectTicket, ObservePrimitive, PinnedFetchPrimitive, RawPrimitive,
     PrimitiveCompletion, PrimitiveDispatcher, PrimitiveField, PrimitiveFieldValue,
     PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveRegistry, PrimitiveValue,
-    PrimitiveValueBody, StagedEffectAuthority, TicketSubscription, TreeReadPrimitive,
+    PrimitiveValueBody, StagedEffectAuthority, TicketSubscription, TreeReadPrimitive, TypedAdapter,
 };
 use super::{BlobId, OriginHint};
 use super::{MachineAttribution, MachineError, MachineOperation, RuntimeFault};
@@ -139,7 +139,7 @@ fn primitive_runtime_fault(failure: PrimitiveHostFailure) -> RuntimeFault {
 /// (`machine.scheduler.block-on-event`, `machine.scheduler.no-shadow-scheduler`).
 enum DeliveredCompletion {
     /// A registered-primitive ticket completed (decode/fetch/observe/...).
-    Primitive {
+    RawPrimitive {
         demand: DemandKey,
         publication: super::PrimitivePublication,
     },
@@ -195,7 +195,7 @@ impl CompletionInbox {
     ) -> impl FnOnce(super::PrimitivePublication) + Send + 'static {
         let sender = self.sender.clone();
         move |publication| {
-            let _ = sender.send(DeliveredCompletion::Primitive {
+            let _ = sender.send(DeliveredCompletion::RawPrimitive {
                 demand,
                 publication,
             });
@@ -728,11 +728,11 @@ fn build_memo_suffix_index(
 /// `binding::builtin_bindings`) to harvest their surface projections. Adding a
 /// primitive is one entry here, not a second hand-registration.
 #[must_use]
-pub fn builtin_primitives<Ctx>() -> Vec<Arc<dyn Primitive<Ctx>>> {
+pub fn builtin_primitives<Ctx>() -> Vec<Arc<dyn RawPrimitive<Ctx>>> {
     vec![
         Arc::new(DecodePrimitive::default()),
-        Arc::new(PinnedFetchPrimitive::default()),
-        Arc::new(ObservePrimitive::default()),
+        Arc::new(TypedAdapter::new::<Ctx>(PinnedFetchPrimitive)),
+        Arc::new(TypedAdapter::new::<Ctx>(ObservePrimitive)),
         Arc::new(TreeReadPrimitive::default()),
     ]
 }
@@ -3717,7 +3717,7 @@ impl<S: EventSink, Ctx> Runtime<S, Ctx> {
         completion: DeliveredCompletion,
     ) -> Result<(), Box<MachineError>> {
         match completion {
-            DeliveredCompletion::Primitive {
+            DeliveredCompletion::RawPrimitive {
                 demand,
                 publication,
             } => self.apply_primitive_completion(demand, publication),
@@ -8376,7 +8376,7 @@ mod tests {
     use crate::compiler::Compiler;
     use crate::lowering::{LoweringCache, attribution_for};
     use crate::runtime::{
-        DecodePrimitive, EventLog, FramedNode, MachineCause, Primitive, PrimitiveDescriptor,
+        DecodePrimitive, EventLog, FramedNode, MachineCause, RawPrimitive, PrimitiveDescriptor,
         PrimitiveRegistry, TicketCompletionError,
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -8441,7 +8441,7 @@ fn scheduler_decode() -> Stream<Check> {
         begins: Arc<AtomicUsize>,
     }
 
-    impl Primitive<()> for CountingDecode {
+    impl RawPrimitive<()> for CountingDecode {
         fn descriptor(&self) -> &PrimitiveDescriptor {
             &self.descriptor
         }
@@ -8463,7 +8463,7 @@ fn scheduler_decode() -> Stream<Check> {
         )>,
     }
 
-    impl Primitive<()> for DelayedDecode {
+    impl RawPrimitive<()> for DelayedDecode {
         fn descriptor(&self) -> &PrimitiveDescriptor {
             &self.descriptor
         }
@@ -8499,7 +8499,7 @@ fn scheduler_decode() -> Stream<Check> {
         }
     }
 
-    fn decode_registry(primitive: Arc<dyn Primitive<()>>) -> PrimitiveDispatcher<()> {
+    fn decode_registry(primitive: Arc<dyn RawPrimitive<()>>) -> PrimitiveDispatcher<()> {
         let mut registry = PrimitiveRegistry::default();
         registry
             .register(primitive)
@@ -8586,7 +8586,7 @@ fn scheduler_decode() -> Stream<Check> {
         let primitive = DecodePrimitive::default();
         let mut runtime = Runtime::new(EventLog::default());
         runtime.primitive_dispatcher = decode_registry(Arc::new(CountingDecode {
-            descriptor: <DecodePrimitive as Primitive<()>>::descriptor(&primitive).clone(),
+            descriptor: <DecodePrimitive as RawPrimitive<()>>::descriptor(&primitive).clone(),
             begins: begins.clone(),
         }));
 
@@ -8621,7 +8621,7 @@ fn scheduler_decode() -> Stream<Check> {
         let primitive = DecodePrimitive::default();
         let mut runtime = Runtime::new(EventLog::default());
         runtime.primitive_dispatcher = decode_registry(Arc::new(DelayedDecode {
-            descriptor: <DecodePrimitive as Primitive<()>>::descriptor(&primitive).clone(),
+            descriptor: <DecodePrimitive as RawPrimitive<()>>::descriptor(&primitive).clone(),
             begins: begins.clone(),
             cancellations: cancellations.clone(),
             gate,
@@ -8666,7 +8666,7 @@ fn scheduler_decode() -> Stream<Check> {
         assert!(runtime.memo.is_empty(), "cancellation never memoizes");
 
         runtime
-            .apply_completion(DeliveredCompletion::Primitive {
+            .apply_completion(DeliveredCompletion::RawPrimitive {
                 demand: primitive_demand,
                 publication,
             })

--- a/vix/src/runtime/tree_read_primitive.rs
+++ b/vix/src/runtime/tree_read_primitive.rs
@@ -2,7 +2,7 @@ use crate::schema::SchemaPattern;
 use crate::vir::{ExternKind, RecordField, RecordType, Type};
 
 use super::{
-    EffectCtx, EffectTicket, Primitive, PrimitiveCompletion, PrimitiveDescriptor, PrimitiveField,
+    EffectCtx, EffectTicket, RawPrimitive, PrimitiveCompletion, PrimitiveDescriptor, PrimitiveField,
     PrimitiveFieldValue, PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveValue,
     PrimitiveValueBody, ReadProjection, ValueId, fixture_tree_name,
 };
@@ -57,7 +57,7 @@ impl Default for TreeReadPrimitive {
     }
 }
 
-impl<Ctx> Primitive<Ctx> for TreeReadPrimitive {
+impl<Ctx> RawPrimitive<Ctx> for TreeReadPrimitive {
     fn descriptor(&self) -> &PrimitiveDescriptor {
         &self.descriptor
     }

--- a/vix/src/runtime/typed_primitive.rs
+++ b/vix/src/runtime/typed_primitive.rs
@@ -1,0 +1,379 @@
+//! The "declare a primitive in one block" authoring layer.
+//!
+//! A [`Primitive`] states everything a registered primitive is as *data* —
+//! its identity, memo policy, response/failure schemas, curated capabilities,
+//! and the surface-argument roles — plus one typed `begin` that receives its
+//! already-decoded `Request` and the exact slice of the embedder `Ctx` it needs.
+//! No hand-written [`PrimitiveDescriptor`], no per-primitive wire parser, no
+//! bespoke [`RequestShape`] `match`: [`TypedAdapter`] synthesizes the descriptor
+//! and shape once from the [`PrimitiveDecl`] and `Type::from_facet::<Request>()`,
+//! and bridges the untyped `RawPrimitive<Ctx>` surface onto the typed one by reading
+//! + [`decode_primitive_value`]-decoding the wire request before dispatch.
+//!
+//! The synthesis is required to be byte-identical to the descriptors/shapes the
+//! migrated primitives (`fetch`, `observe`) hand-wrote before this layer — see
+//! the `milestone` tests below, which reconstruct the pre-migration values and
+//! assert equality.
+
+use crate::schema::SchemaPattern;
+use crate::vir::{ExternKind, RecordField, Type};
+
+use super::{
+    decode_primitive_value, ArgRole, EffectCtx, EffectTicket, FromRef, RawPrimitive,
+    PrimitiveCompletion, PrimitiveDescriptor, PrimitiveId, PrimitiveMachineError,
+    PrimitiveMemoPolicy, PrimitivePublication, ReadProjection, Receipt, RequestShape, Selector,
+    SelectorVariant, ValueId,
+};
+
+/// One accepted variant of a selector argument and the boolean flag it folds
+/// into the request record — the const-friendly mirror of [`SelectorVariant`].
+pub struct SelectorVariantDecl {
+    pub variant: &'static str,
+    pub flag: bool,
+}
+
+/// A selector argument declared as const data — the mirror of [`Selector`]. The
+/// accepted enum, its variants, and the diagnostic noun live here rather than in
+/// a bespoke Rust reader per primitive.
+pub struct SelectorDecl {
+    pub enum_name: &'static str,
+    pub noun: &'static str,
+    pub variants: &'static [SelectorVariantDecl],
+}
+
+/// The role a surface argument plays, declared as const data. `Value` carries no
+/// type: its expected [`Type`] is the *i-th* field of `Type::from_facet::<Request>()`,
+/// zipped in order, so the request struct is the single source of the arg types.
+pub enum ArgRoleDecl {
+    Value,
+    Selector(SelectorDecl),
+}
+
+/// How a primitive's response schema is declared: a concrete extern kind
+/// (`Extern(Blob)` for fetch/observe) or a schema variable (a generic result).
+pub enum ResponseDecl {
+    Extern(ExternKind),
+    Var(&'static str),
+}
+
+/// Everything a registered primitive *is*, as const data. Consumed once by
+/// [`TypedAdapter::new`] to synthesize the [`PrimitiveDescriptor`] and
+/// [`RequestShape`]; nothing here is heap-allocated and no [`Type`] is embedded
+/// (the types come from `Type::from_facet::<Request>()`).
+pub struct PrimitiveDecl {
+    pub namespace: &'static str,
+    /// The primitive's surface binding name in the prelude (`RawPrimitive::surface_name`).
+    pub name: &'static str,
+    /// The registered [`PrimitiveId`] name. Usually equal to `name`, but the
+    /// two diverge where the surface spelling differs from the machine id — e.g.
+    /// `fetch` (surface) is registered as `pinned-fetch` (id). Kept distinct so
+    /// the synthesized descriptor id stays byte-identical to the hand-written one.
+    pub id_name: &'static str,
+    pub version: u32,
+    pub memo_policy: PrimitiveMemoPolicy,
+    pub protocol_version: u32,
+    pub response: ResponseDecl,
+    pub failure_schema_name: &'static str,
+    /// The primitive's *curated* capability extern kinds — declared here, never
+    /// derived from the request tree.
+    pub capabilities: &'static [ExternKind],
+    pub args: &'static [ArgRoleDecl],
+}
+
+impl PrimitiveDecl {
+    #[must_use]
+    fn id(&self) -> PrimitiveId {
+        PrimitiveId {
+            namespace: self.namespace.to_owned(),
+            name: self.id_name.to_owned(),
+            version: self.version,
+        }
+    }
+}
+
+/// A primitive declared in one block: its shape data (`DECL`), its typed request
+/// and dependency-slice associated types, and one typed `begin`. The blanket
+/// [`RawPrimitive`] bridge lives on [`TypedAdapter`], not here, because
+/// `RawPrimitive::descriptor` returns `&PrimitiveDescriptor` and so needs an owner.
+pub trait Primitive<Ctx>: Send + Sync {
+    type Request: facet::Facet<'static>;
+    type Deps: FromRef<Ctx>;
+    const DECL: PrimitiveDecl;
+
+    /// Serve an already-decoded request with the projected dependency slice.
+    /// The wire read + decode happened in [`TypedAdapter`]; a decode failure
+    /// never reaches here (it is completed synchronously by the adapter).
+    fn begin(&self, req: Self::Request, ctx: EffectCtx, deps: Self::Deps) -> EffectTicket;
+}
+
+/// Bridges a [`Primitive`] onto the untyped [`RawPrimitive`] surface. Owns the
+/// descriptor and shape it synthesizes once (so `descriptor()` can return `&`),
+/// and, on `begin`, reads + decodes the wire request into `P::Request` before
+/// handing off to the typed impl.
+pub struct TypedAdapter<P> {
+    inner: P,
+    descriptor: PrimitiveDescriptor,
+    shape: RequestShape,
+}
+
+impl<P> TypedAdapter<P> {
+    #[must_use]
+    pub fn new<Ctx>(inner: P) -> Self
+    where
+        P: Primitive<Ctx>,
+    {
+        let decl = <P as Primitive<Ctx>>::DECL;
+        let request_ty = Type::from_facet::<P::Request>();
+        let descriptor = synth_descriptor(&decl, &request_ty);
+        let shape = synth_shape(&decl, request_ty);
+        Self {
+            inner,
+            descriptor,
+            shape,
+        }
+    }
+}
+
+fn response_pattern(response: &ResponseDecl) -> SchemaPattern {
+    match response {
+        ResponseDecl::Extern(kind) => SchemaPattern::exact(&Type::Extern(*kind).schema_ref()),
+        ResponseDecl::Var(name) => SchemaPattern::Var {
+            name: (*name).to_owned(),
+        },
+    }
+}
+
+/// The concrete result [`Type`] a `RequestShape` carries. Only a concrete
+/// `Extern` response has one; a schema-variable response is generic and cannot
+/// yet be expressed as a shape (no migrated primitive uses one).
+fn response_result_ty(response: &ResponseDecl) -> Type {
+    match response {
+        ResponseDecl::Extern(kind) => Type::Extern(*kind),
+        ResponseDecl::Var(name) => {
+            panic!("a Var-response primitive (`{name}`) cannot express a RequestShape result type")
+        }
+    }
+}
+
+fn synth_descriptor(decl: &PrimitiveDecl, request_ty: &Type) -> PrimitiveDescriptor {
+    PrimitiveDescriptor {
+        id: decl.id(),
+        request_schema: SchemaPattern::exact(&request_ty.schema_ref()),
+        response_schema: response_pattern(&decl.response),
+        failure_schema: SchemaPattern::Var {
+            name: decl.failure_schema_name.to_owned(),
+        },
+        memo_policy: decl.memo_policy,
+        protocol_version: decl.protocol_version,
+        capability_schemas: decl
+            .capabilities
+            .iter()
+            .map(|kind| SchemaPattern::exact(&Type::Extern(*kind).schema_ref()))
+            .collect(),
+    }
+}
+
+fn synth_shape(decl: &PrimitiveDecl, request_ty: Type) -> RequestShape {
+    let fields = record_fields(&request_ty);
+    let args = decl
+        .args
+        .iter()
+        .zip(fields)
+        .map(|(arg, field)| match arg {
+            ArgRoleDecl::Value => ArgRole::Value {
+                expected: field.ty.clone(),
+            },
+            ArgRoleDecl::Selector(selector) => ArgRole::Selector(Selector {
+                enum_name: selector.enum_name.to_owned(),
+                noun: selector.noun.to_owned(),
+                variants: selector
+                    .variants
+                    .iter()
+                    .map(|variant| SelectorVariant {
+                        variant: variant.variant.to_owned(),
+                        flag: variant.flag,
+                    })
+                    .collect(),
+            }),
+        })
+        .collect();
+    RequestShape {
+        args,
+        result: response_result_ty(&decl.response),
+        primitive: decl.id(),
+        request_ty,
+    }
+}
+
+/// The record fields a request type contributes, in order. A request is always a
+/// record (one field per surface argument); anything else contributes none.
+fn record_fields(request_ty: &Type) -> &[RecordField] {
+    match request_ty {
+        Type::Record(record) => &record.fields,
+        _ => &[],
+    }
+}
+
+impl<Ctx, P> RawPrimitive<Ctx> for TypedAdapter<P>
+where
+    P: Primitive<Ctx>,
+    P::Deps: FromRef<Ctx>,
+{
+    fn descriptor(&self) -> &PrimitiveDescriptor {
+        &self.descriptor
+    }
+
+    fn surface_name(&self) -> Option<&'static str> {
+        Some(<P as Primitive<Ctx>>::DECL.name)
+    }
+
+    fn request_shape(&self) -> Option<RequestShape> {
+        Some(self.shape.clone())
+    }
+
+    fn begin(&self, request: ValueId, ctx: EffectCtx, app: &Ctx) -> EffectTicket {
+        // Read the wire request the way the hand-parsers did — this records the
+        // read witness/receipt into the shared transaction, which the typed
+        // `begin` (and its worker thread) then extend.
+        let witnessed = match ctx.read(&request, ReadProjection::Whole) {
+            Ok(witnessed) => witnessed,
+            Err(error) => return complete_with_error(&ctx, error),
+        };
+        let req = match decode_primitive_value::<P::Request>(&witnessed.value) {
+            Ok(req) => req,
+            Err(error) => return complete_with_error(&ctx, error),
+        };
+        let deps = <P::Deps as FromRef<Ctx>>::from_ref(app);
+        self.inner.begin(req, ctx, deps)
+    }
+}
+
+/// Complete a demand synchronously with a machine error — the decode-failure
+/// path, mirroring the `unwrap_or_else`/`finish` error shape the fetch/observe
+/// `begin` bodies use when their own work fails.
+fn complete_with_error(ctx: &EffectCtx, error: PrimitiveMachineError) -> EffectTicket {
+    let (ticket, completer) = ctx.ticket(|| {});
+    let publication = ctx
+        .finish(PrimitiveCompletion::MachineError(error))
+        .unwrap_or_else(|error| PrimitivePublication {
+            completion: PrimitiveCompletion::MachineError(error),
+            receipt: Receipt {
+                demand: ctx.demand(),
+                reads: Vec::new(),
+            },
+            journal: Vec::new(),
+            progressive: Vec::new(),
+        });
+    let _ = completer.complete(publication);
+    ticket
+}
+
+#[cfg(test)]
+mod milestone {
+    //! Byte-identity gate for the capstone: the descriptor and request-shape the
+    //! [`TypedAdapter`] synthesizes for `fetch`/`observe` MUST equal what those
+    //! primitives hand-wrote before this layer landed. The `old_*` builders below
+    //! reconstruct the pre-migration literals verbatim; a mismatch is a synthesis
+    //! bug, not a stale constant.
+
+    use super::*;
+    use crate::runtime::{
+        observe_primitive_id, pinned_fetch_primitive_id, ObservePrimitive, ObserveRequest,
+        OriginHint, PinnedBlobRef, PinnedFetchPrimitive, PinnedFetchRequest,
+    };
+
+    fn old_fetch_descriptor() -> PrimitiveDescriptor {
+        PrimitiveDescriptor {
+            id: pinned_fetch_primitive_id(),
+            request_schema: SchemaPattern::exact(&Type::from_facet::<PinnedFetchRequest>().schema_ref()),
+            response_schema: SchemaPattern::exact(&Type::Extern(ExternKind::Blob).schema_ref()),
+            failure_schema: SchemaPattern::Var {
+                name: "PinnedFetchFailure".to_owned(),
+            },
+            memo_policy: PrimitiveMemoPolicy::Pinned,
+            protocol_version: 1,
+            capability_schemas: vec![SchemaPattern::exact(
+                &Type::Extern(ExternKind::Registry).schema_ref(),
+            )],
+        }
+    }
+
+    fn old_fetch_shape() -> RequestShape {
+        RequestShape {
+            args: vec![ArgRole::Value {
+                expected: Type::from_facet::<PinnedBlobRef>(),
+            }],
+            request_ty: Type::from_facet::<PinnedFetchRequest>(),
+            result: Type::Extern(ExternKind::Blob),
+            primitive: pinned_fetch_primitive_id(),
+        }
+    }
+
+    fn old_observe_descriptor() -> PrimitiveDescriptor {
+        PrimitiveDescriptor {
+            id: observe_primitive_id(),
+            request_schema: SchemaPattern::exact(&Type::from_facet::<ObserveRequest>().schema_ref()),
+            response_schema: SchemaPattern::exact(&Type::Extern(ExternKind::Blob).schema_ref()),
+            failure_schema: SchemaPattern::Var {
+                name: "ObserveFailure".to_owned(),
+            },
+            memo_policy: PrimitiveMemoPolicy::Observed,
+            protocol_version: 1,
+            capability_schemas: vec![SchemaPattern::exact(
+                &Type::Extern(ExternKind::Registry).schema_ref(),
+            )],
+        }
+    }
+
+    fn old_observe_shape() -> RequestShape {
+        RequestShape {
+            args: vec![
+                ArgRole::Value {
+                    expected: Type::from_facet::<OriginHint>(),
+                },
+                ArgRole::Selector(Selector {
+                    enum_name: "Mode".to_owned(),
+                    noun: "observe mode".to_owned(),
+                    variants: vec![
+                        SelectorVariant {
+                            variant: "Observe".to_owned(),
+                            flag: false,
+                        },
+                        SelectorVariant {
+                            variant: "Refresh".to_owned(),
+                            flag: true,
+                        },
+                    ],
+                }),
+            ],
+            request_ty: Type::from_facet::<ObserveRequest>(),
+            result: Type::Extern(ExternKind::Blob),
+            primitive: observe_primitive_id(),
+        }
+    }
+
+    #[test]
+    fn fetch_adapter_is_byte_identical_to_the_hand_written_primitive() {
+        let adapter = TypedAdapter::new::<()>(PinnedFetchPrimitive);
+        assert_eq!(*RawPrimitive::<()>::descriptor(&adapter), old_fetch_descriptor());
+        assert_eq!(
+            RawPrimitive::<()>::request_shape(&adapter),
+            Some(old_fetch_shape())
+        );
+        assert_eq!(RawPrimitive::<()>::surface_name(&adapter), Some("fetch"));
+    }
+
+    #[test]
+    fn observe_adapter_is_byte_identical_to_the_hand_written_primitive() {
+        let adapter = TypedAdapter::new::<()>(ObservePrimitive);
+        assert_eq!(
+            *RawPrimitive::<()>::descriptor(&adapter),
+            old_observe_descriptor()
+        );
+        assert_eq!(
+            RawPrimitive::<()>::request_shape(&adapter),
+            Some(old_observe_shape())
+        );
+        assert_eq!(RawPrimitive::<()>::surface_name(&adapter), Some("observe"));
+    }
+}

--- a/vix/tests/primitive_foundation.rs
+++ b/vix/tests/primitive_foundation.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use vix::runtime::{
-    EffectAuthority, EffectCtx, EffectTicket, FramedNode, JournalObservation, Primitive,
+    EffectAuthority, EffectCtx, EffectTicket, FramedNode, JournalObservation, RawPrimitive,
     PrimitiveCompletion, PrimitiveDescriptor, PrimitiveDispatchError, PrimitiveDispatcher,
     PrimitiveEvent, PrimitiveId, PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveRegistry,
     ReadObservation, ReadProjection, TicketCompletionError, ValueId, WitnessedValue,
@@ -73,7 +73,7 @@ struct EchoPrimitive {
     begins: AtomicUsize,
 }
 
-impl<Ctx> Primitive<Ctx> for EchoPrimitive {
+impl<Ctx> RawPrimitive<Ctx> for EchoPrimitive {
     fn descriptor(&self) -> &PrimitiveDescriptor {
         &self.descriptor
     }


### PR DESCRIPTION
The capstone of the data-driven-primitives arc: **declaring a primitive is now one `impl` block.** Everything a primitive is — descriptor, wire schema, surface projection, request decoding — is synthesized from a single declaration, and `fetch`/`observe` are migrated onto it.

## The authoring surface
```rust
impl Primitive<Ctx> for PinnedFetchPrimitive {
    type Request = PinnedFetchRequest;      // schema derives via Type::from_facet
    type Deps = ();                         // shared authorities via FromRef
    const DECL: PrimitiveDecl = /* path, memo, capabilities, arg-roles */;
    fn begin(&self, req: Self::Request, ctx: EffectCtx, deps: Self::Deps) -> EffectTicket { ... }
}
```
No hand-written descriptor, no `ValueId` parsing, no `RequestShape` table.

## What's here
- **`Primitive<Ctx>`** (the ergonomic trait — `type Request`, `type Deps`, `const DECL`, typed `begin`) + `PrimitiveDecl`/`ArgRoleDecl`/`SelectorDecl`/`ResponseDecl` (const-friendly: no embedded `Type`, no heap — Types come from `type Request`).
- **`TypedAdapter<P>`** bridges it onto the object-safe registry trait — synthesizes `descriptor`/`request_shape`/`surface_name` once from `DECL` + `Type::from_facet`, and `begin` reads the wire value, `decode_primitive_value::<Request>()`s it (synchronous error-completion on failure), projects `Deps` via `FromRef`, and calls the typed `begin`.
- **Rename**: the erased/registry trait (raw `begin(ValueId)`, held as `dyn`) is now **`RawPrimitive`**; the ergonomic authoring trait takes the clean name **`Primitive`**. `decode`/`tree_read`/test primitives implement `RawPrimitive` directly (they don't fit the ergonomic mold — const-fold lowering / method surface).
- `fetch` + `observe` migrated; `decode`/`tree_read` left raw.

## The gate: nothing moves
A test asserts the `TypedAdapter`-synthesized `descriptor` **and** `request_shape` for `fetch`/`observe` are **equal to the pre-migration hand-written ones** — dispatch matches primitives by descriptor schema, so any drift would break the ratchet. Both pass.

## Verification (local; repo CI independently red)
Clean build, no warnings. `fetch`/`observe` byte-identical tests pass; full `cargo test -p vix` green (ratchet **151/0/2**, all suites); `vix-fetch` 11/11. The rename validated by clean compile of all targets (behavior-preserving identifier swap).
