### PR TITLE
vix: typed primitive responses (type Response + EffectTicket<T>)

### DIFF
--- a/vix/src/runtime/decode_primitive.rs
+++ b/vix/src/runtime/decode_primitive.rs
@@ -6,7 +6,7 @@ use crate::vir::{
 };
 
 use super::{
-    EffectCtx, EffectTicket, RawPrimitive, PrimitiveCompletion, PrimitiveDescriptor, PrimitiveField,
+    EffectCtx, RawEffectTicket, RawPrimitive, PrimitiveCompletion, PrimitiveDescriptor, PrimitiveField,
     PrimitiveFieldValue, PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveValue,
     PrimitiveValueBody, ReadProjection, ValueId,
 };
@@ -40,7 +40,7 @@ impl<Ctx> RawPrimitive<Ctx> for DecodePrimitive {
         &self.descriptor
     }
 
-    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> EffectTicket {
+    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> RawEffectTicket {
         let (ticket, completer) = ctx.ticket(|| {});
         let completion = decode_request(&request, &ctx)
             .and_then(|value| ctx.intern_value(value))

--- a/vix/src/runtime/fetch_primitive.rs
+++ b/vix/src/runtime/fetch_primitive.rs
@@ -4,9 +4,8 @@ use crate::schema::SchemaRef;
 use crate::vir::{ExternKind, Type};
 
 use super::{
-    ArgRoleDecl, Digest, EffectCtx, EffectTicket, PrimitiveCompletion, PrimitiveDecl,
-    PrimitiveMachineError, PrimitiveMemoPolicy, PrimitivePublication, ReadProjection, Receipt,
-    ResponseDecl, Primitive, ValueId,
+    ArgRoleDecl, Digest, EffectCtx, EffectTicket, Primitive, PrimitiveDecl,
+    PrimitiveMachineError, PrimitiveMemoPolicy, ReadProjection, ResponseValue, ValueId,
 };
 // Only the test-only hand parsers (the `decode_primitive_value` oracle) walk the
 // wire `PrimitiveValue` structurally now; production `begin` decodes instead.
@@ -22,6 +21,18 @@ pub struct UpstreamDigest(pub [u8; 32]);
 /// distinct meanings, distinct types.
 #[derive(facet::Facet, Clone, Debug, PartialEq, Eq)]
 pub struct RegistryHandle(pub ValueId);
+
+/// A served Blob handle: the typed response of `fetch`/`observe`. Wire-side this
+/// is `Type::Extern(Blob)` (see the `vir` leaf override), and it already *is* an
+/// interned [`ValueId`] — completing with it never re-encodes or re-interns.
+#[derive(facet::Facet, Clone, Debug, PartialEq, Eq)]
+pub struct BlobHandle(pub ValueId);
+
+impl ResponseValue for BlobHandle {
+    fn into_value(self) -> ValueId {
+        self.0
+    }
+}
 
 /// A pinned Blob target identity. This is not a resident value but a *reference*
 /// to one, so it decomposes structurally into a `ValueId`'s `{schema, content}`:
@@ -84,6 +95,7 @@ pub struct PinnedFetchPrimitive;
 
 impl<Ctx> Primitive<Ctx> for PinnedFetchPrimitive {
     type Request = PinnedFetchRequest;
+    type Response = BlobHandle;
     type Deps = ();
 
     const DECL: PrimitiveDecl = PrimitiveDecl {
@@ -93,28 +105,18 @@ impl<Ctx> Primitive<Ctx> for PinnedFetchPrimitive {
         version: 1,
         memo_policy: PrimitiveMemoPolicy::Pinned,
         protocol_version: 1,
-        response: ResponseDecl::Extern(ExternKind::Blob),
         failure_schema_name: "PinnedFetchFailure",
         capabilities: &[ExternKind::Registry],
         args: &[ArgRoleDecl::Value],
     };
 
-    fn begin(&self, req: PinnedFetchRequest, ctx: EffectCtx, _deps: ()) -> EffectTicket {
-        let (ticket, completer) = ctx.ticket(|| {});
+    fn begin(&self, req: PinnedFetchRequest, ctx: EffectCtx, _deps: ()) -> EffectTicket<BlobHandle> {
+        let (ticket, completer) = EffectTicket::<BlobHandle>::pair(&ctx, || {});
         std::thread::spawn(move || {
-            let completion = serve(req.pin, &ctx)
-                .map(PrimitiveCompletion::Ok)
-                .unwrap_or_else(PrimitiveCompletion::MachineError);
-            let publication = ctx.finish(completion).unwrap_or_else(|error| PrimitivePublication {
-                completion: PrimitiveCompletion::MachineError(error),
-                receipt: Receipt {
-                    demand: ctx.demand(),
-                    reads: Vec::new(),
-                },
-                journal: Vec::new(),
-                progressive: Vec::new(),
-            });
-            let _ = completer.complete(publication);
+            let _ = match serve(req.pin, &ctx) {
+                Ok(value) => completer.complete_ok(&ctx, BlobHandle(value)),
+                Err(error) => completer.complete_err(&ctx, error),
+            };
         });
         ticket
     }

--- a/vix/src/runtime/observe_primitive.rs
+++ b/vix/src/runtime/observe_primitive.rs
@@ -1,10 +1,9 @@
 use crate::vir::{ExternKind, Type};
 
 use super::{
-    ArgRoleDecl, EffectCtx, EffectTicket, ObserveCoordinate, ObservedClaim, OriginHint,
-    PrimitiveCompletion, PrimitiveDecl, PrimitiveMachineError, PrimitiveMemoPolicy,
-    PrimitivePublication, Receipt, ResponseDecl, SelectorDecl, SelectorVariantDecl, Primitive,
-    ValueId,
+    ArgRoleDecl, BlobHandle, EffectCtx, EffectTicket, ObserveCoordinate, ObservedClaim, OriginHint,
+    Primitive, PrimitiveDecl, PrimitiveMachineError, PrimitiveMemoPolicy, SelectorDecl,
+    SelectorVariantDecl, ValueId,
 };
 // Only the test-only hand parser (the `decode_primitive_value` oracle) walks the
 // wire `PrimitiveValue` structurally now; production `begin` decodes instead.
@@ -63,6 +62,7 @@ const MODE_SELECTOR: SelectorDecl = SelectorDecl {
 
 impl<Ctx> Primitive<Ctx> for ObservePrimitive {
     type Request = ObserveRequest;
+    type Response = BlobHandle;
     type Deps = ();
 
     const DECL: PrimitiveDecl = PrimitiveDecl {
@@ -72,28 +72,18 @@ impl<Ctx> Primitive<Ctx> for ObservePrimitive {
         version: 1,
         memo_policy: PrimitiveMemoPolicy::Observed,
         protocol_version: 1,
-        response: ResponseDecl::Extern(ExternKind::Blob),
         failure_schema_name: "ObserveFailure",
         capabilities: &[ExternKind::Registry],
         args: &[ArgRoleDecl::Value, ArgRoleDecl::Selector(MODE_SELECTOR)],
     };
 
-    fn begin(&self, req: ObserveRequest, ctx: EffectCtx, _deps: ()) -> EffectTicket {
-        let (ticket, completer) = ctx.ticket(|| {});
+    fn begin(&self, req: ObserveRequest, ctx: EffectCtx, _deps: ()) -> EffectTicket<BlobHandle> {
+        let (ticket, completer) = EffectTicket::<BlobHandle>::pair(&ctx, || {});
         std::thread::spawn(move || {
-            let completion = serve(req, &ctx)
-                .map(PrimitiveCompletion::Ok)
-                .unwrap_or_else(PrimitiveCompletion::MachineError);
-            let publication = ctx.finish(completion).unwrap_or_else(|error| PrimitivePublication {
-                completion: PrimitiveCompletion::MachineError(error),
-                receipt: Receipt {
-                    demand: ctx.demand(),
-                    reads: Vec::new(),
-                },
-                journal: Vec::new(),
-                progressive: Vec::new(),
-            });
-            let _ = completer.complete(publication);
+            let _ = match serve(req, &ctx) {
+                Ok(value) => completer.complete_ok(&ctx, BlobHandle(value)),
+                Err(error) => completer.complete_err(&ctx, error),
+            };
         });
         ticket
     }

--- a/vix/src/runtime/primitive.rs
+++ b/vix/src/runtime/primitive.rs
@@ -847,8 +847,8 @@ impl EffectCtx {
     pub fn ticket(
         &self,
         cancel: impl FnOnce() + Send + 'static,
-    ) -> (EffectTicket, EffectCompleter) {
-        EffectTicket::pair(self.demand, cancel)
+    ) -> (RawEffectTicket, RawEffectCompleter) {
+        RawEffectTicket::pair(self.demand, cancel)
     }
 }
 
@@ -948,7 +948,7 @@ pub trait RawPrimitive<Ctx>: Send + Sync {
     fn descriptor(&self) -> &PrimitiveDescriptor;
     /// `app` is the whole shared embedder context; the impl projects the
     /// slice it needs out of it via [`FromRef`].
-    fn begin(&self, request: ValueId, ctx: EffectCtx, app: &Ctx) -> EffectTicket;
+    fn begin(&self, request: ValueId, ctx: EffectCtx, app: &Ctx) -> RawEffectTicket;
 
     /// The primitive's surface name in the vix prelude, or `None` if it
     /// projects no surface binding at all (e.g. `TreeReadPrimitive`, reached
@@ -986,11 +986,11 @@ struct TicketShared {
 }
 
 #[derive(Clone)]
-pub struct EffectTicket {
+pub struct RawEffectTicket {
     shared: Arc<TicketShared>,
 }
 
-pub struct EffectCompleter {
+pub struct RawEffectCompleter {
     shared: Arc<TicketShared>,
 }
 
@@ -1005,8 +1005,8 @@ pub enum TicketCompletionError {
     Cancelled,
 }
 
-impl EffectTicket {
-    fn pair(demand: DemandKey, cancel: impl FnOnce() + Send + 'static) -> (Self, EffectCompleter) {
+impl RawEffectTicket {
+    fn pair(demand: DemandKey, cancel: impl FnOnce() + Send + 'static) -> (Self, RawEffectCompleter) {
         let shared = Arc::new(TicketShared {
             demand,
             state: Mutex::new(TicketState {
@@ -1022,7 +1022,7 @@ impl EffectTicket {
             Self {
                 shared: shared.clone(),
             },
-            EffectCompleter { shared },
+            RawEffectCompleter { shared },
         )
     }
 
@@ -1095,7 +1095,7 @@ impl EffectTicket {
     }
 }
 
-impl EffectCompleter {
+impl RawEffectCompleter {
     pub fn complete(self, outcome: PrimitivePublication) -> Result<(), TicketCompletionError> {
         let waiters = {
             let mut state = self.shared.state.lock().expect("ticket mutex poisoned");
@@ -1142,7 +1142,7 @@ impl<Ctx> Default for PrimitiveRegistry<Ctx> {
 
 pub struct PrimitiveDispatcher<Ctx> {
     registry: Arc<PrimitiveRegistry<Ctx>>,
-    in_flight: Mutex<BTreeMap<DemandKey, EffectTicket>>,
+    in_flight: Mutex<BTreeMap<DemandKey, RawEffectTicket>>,
 }
 
 impl<Ctx> PrimitiveDispatcher<Ctx> {
@@ -1160,7 +1160,7 @@ impl<Ctx> PrimitiveDispatcher<Ctx> {
         request: ValueId,
         ctx: EffectCtx,
         app: &Ctx,
-    ) -> Result<EffectTicket, Box<PrimitiveDispatchError>> {
+    ) -> Result<RawEffectTicket, Box<PrimitiveDispatchError>> {
         let demand = ctx.demand();
         let mut in_flight = self.in_flight.lock().expect("dispatcher mutex poisoned");
         if let Some(ticket) = in_flight.get(&demand) {
@@ -1176,7 +1176,7 @@ impl<Ctx> PrimitiveDispatcher<Ctx> {
         self.registry.descriptor(id)
     }
 
-    pub fn retire(&self, demand: DemandKey) -> Option<EffectTicket> {
+    pub fn retire(&self, demand: DemandKey) -> Option<RawEffectTicket> {
         self.in_flight
             .lock()
             .expect("dispatcher mutex poisoned")
@@ -1222,7 +1222,7 @@ impl<Ctx> PrimitiveRegistry<Ctx> {
         request: ValueId,
         ctx: EffectCtx,
         app: &Ctx,
-    ) -> Result<EffectTicket, Box<PrimitiveDispatchError>> {
+    ) -> Result<RawEffectTicket, Box<PrimitiveDispatchError>> {
         let primitive = self
             .primitives
             .get(id)
@@ -1292,7 +1292,7 @@ mod from_ref_tests {
             &self.descriptor
         }
 
-        fn begin(&self, request: ValueId, ctx: EffectCtx, app: &Ctx) -> EffectTicket {
+        fn begin(&self, request: ValueId, ctx: EffectCtx, app: &Ctx) -> RawEffectTicket {
             let pool = FakePool::from_ref(app);
             *self.seen.lock().expect("seen mutex poisoned") = Some(pool.label);
             let (ticket, completer) = ctx.ticket(|| {});

--- a/vix/src/runtime/scheduler.rs
+++ b/vix/src/runtime/scheduler.rs
@@ -41,7 +41,7 @@ use super::store::{
     StoreJournalLoadReport,
 };
 use super::{
-    DecodePrimitive, EffectCtx, EffectTicket, ObservePrimitive, PinnedFetchPrimitive, RawPrimitive,
+    DecodePrimitive, EffectCtx, RawEffectTicket, ObservePrimitive, PinnedFetchPrimitive, RawPrimitive,
     PrimitiveCompletion, PrimitiveDispatcher, PrimitiveField, PrimitiveFieldValue,
     PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveRegistry, PrimitiveValue,
     PrimitiveValueBody, StagedEffectAuthority, TicketSubscription, TreeReadPrimitive, TypedAdapter,
@@ -353,7 +353,7 @@ enum DriveOutcome {
 struct PrimitivePending {
     /// The demand-owned ticket remains live even if a waiting task is discarded;
     /// replay joins this same ticket instead of beginning a second effect.
-    ticket: EffectTicket,
+    ticket: RawEffectTicket,
     /// The first caller's staged authority; joiners never construct another.
     authority: Arc<StagedEffectAuthority>,
     /// The single ticket subscription that delivers this demand's completion
@@ -8446,7 +8446,7 @@ fn scheduler_decode() -> Stream<Check> {
             &self.descriptor
         }
 
-        fn begin(&self, request: ValueId, ctx: EffectCtx, app: &()) -> EffectTicket {
+        fn begin(&self, request: ValueId, ctx: EffectCtx, app: &()) -> RawEffectTicket {
             self.begins.fetch_add(1, Ordering::AcqRel);
             DecodePrimitive::default().begin(request, ctx, app)
         }
@@ -8468,7 +8468,7 @@ fn scheduler_decode() -> Stream<Check> {
             &self.descriptor
         }
 
-        fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &()) -> EffectTicket {
+        fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &()) -> RawEffectTicket {
             self.begins.fetch_add(1, Ordering::AcqRel);
             let gate = self.gate.clone();
             let cancel_gate = self.gate.clone();

--- a/vix/src/runtime/tree_read_primitive.rs
+++ b/vix/src/runtime/tree_read_primitive.rs
@@ -2,7 +2,7 @@ use crate::schema::SchemaPattern;
 use crate::vir::{ExternKind, RecordField, RecordType, Type};
 
 use super::{
-    EffectCtx, EffectTicket, RawPrimitive, PrimitiveCompletion, PrimitiveDescriptor, PrimitiveField,
+    EffectCtx, RawEffectTicket, RawPrimitive, PrimitiveCompletion, PrimitiveDescriptor, PrimitiveField,
     PrimitiveFieldValue, PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveValue,
     PrimitiveValueBody, ReadProjection, ValueId, fixture_tree_name,
 };
@@ -62,7 +62,7 @@ impl<Ctx> RawPrimitive<Ctx> for TreeReadPrimitive {
         &self.descriptor
     }
 
-    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> EffectTicket {
+    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> RawEffectTicket {
         let (ticket, completer) = ctx.ticket(|| {});
         std::thread::spawn(move || {
             let completion = execute(&request, &ctx)

--- a/vix/src/runtime/typed_primitive.rs
+++ b/vix/src/runtime/typed_primitive.rs
@@ -15,14 +15,16 @@
 //! the `milestone` tests below, which reconstruct the pre-migration values and
 //! assert equality.
 
+use std::marker::PhantomData;
+
 use crate::schema::SchemaPattern;
 use crate::vir::{ExternKind, RecordField, Type};
 
 use super::{
-    decode_primitive_value, ArgRole, EffectCtx, EffectTicket, FromRef, RawPrimitive,
-    PrimitiveCompletion, PrimitiveDescriptor, PrimitiveId, PrimitiveMachineError,
+    decode_primitive_value, ArgRole, EffectCtx, FromRef, RawEffectCompleter, RawEffectTicket,
+    RawPrimitive, PrimitiveCompletion, PrimitiveDescriptor, PrimitiveId, PrimitiveMachineError,
     PrimitiveMemoPolicy, PrimitivePublication, ReadProjection, Receipt, RequestShape, Selector,
-    SelectorVariant, ValueId,
+    SelectorVariant, TicketCompletionError, ValueId,
 };
 
 /// One accepted variant of a selector argument and the boolean flag it folds
@@ -49,13 +51,6 @@ pub enum ArgRoleDecl {
     Selector(SelectorDecl),
 }
 
-/// How a primitive's response schema is declared: a concrete extern kind
-/// (`Extern(Blob)` for fetch/observe) or a schema variable (a generic result).
-pub enum ResponseDecl {
-    Extern(ExternKind),
-    Var(&'static str),
-}
-
 /// Everything a registered primitive *is*, as const data. Consumed once by
 /// [`TypedAdapter::new`] to synthesize the [`PrimitiveDescriptor`] and
 /// [`RequestShape`]; nothing here is heap-allocated and no [`Type`] is embedded
@@ -72,7 +67,6 @@ pub struct PrimitiveDecl {
     pub version: u32,
     pub memo_policy: PrimitiveMemoPolicy,
     pub protocol_version: u32,
-    pub response: ResponseDecl,
     pub failure_schema_name: &'static str,
     /// The primitive's *curated* capability extern kinds — declared here, never
     /// derived from the request tree.
@@ -97,13 +91,112 @@ impl PrimitiveDecl {
 /// `RawPrimitive::descriptor` returns `&PrimitiveDescriptor` and so needs an owner.
 pub trait Primitive<Ctx>: Send + Sync {
     type Request: facet::Facet<'static>;
+    /// The typed response value the primitive completes with. Its
+    /// `Type::from_facet` drives both the descriptor's `response_schema` and the
+    /// `RequestShape.result`, symmetric with how `Request` drives `request_schema`.
+    type Response: facet::Facet<'static>;
     type Deps: FromRef<Ctx>;
     const DECL: PrimitiveDecl;
 
     /// Serve an already-decoded request with the projected dependency slice.
     /// The wire read + decode happened in [`TypedAdapter`]; a decode failure
     /// never reaches here (it is completed synchronously by the adapter).
-    fn begin(&self, req: Self::Request, ctx: EffectCtx, deps: Self::Deps) -> EffectTicket;
+    fn begin(&self, req: Self::Request, ctx: EffectCtx, deps: Self::Deps)
+        -> EffectTicket<Self::Response>;
+}
+
+/// A typed view over an erased [`RawEffectTicket`]: the handle a typed
+/// [`Primitive::begin`] hands back. The runtime keeps the erased ticket in its
+/// heterogeneous in-flight map; `EffectTicket<T>` only records, in the type, the
+/// response the paired [`EffectCompleter`] will produce. `PhantomData<fn() -> T>`
+/// keeps the wrapper unconditionally `Send` (the real state lives in the already
+/// `Send` shared ticket), so it still moves into `std::thread::spawn`.
+pub struct EffectTicket<T> {
+    inner: RawEffectTicket,
+    _marker: PhantomData<fn() -> T>,
+}
+
+/// The typed completing half of an [`EffectTicket`]. Completing it goes through
+/// [`ResponseValue`], the seam that keeps generic-response encoding out of scope:
+/// every response today is a handle that already names an interned [`ValueId`].
+pub struct EffectCompleter<T> {
+    inner: RawEffectCompleter,
+    _marker: PhantomData<fn(T)>,
+}
+
+impl<T> EffectTicket<T> {
+    /// Mint a typed ticket/completer pair over a fresh erased ticket.
+    pub fn pair(
+        ctx: &EffectCtx,
+        cancel: impl FnOnce() + Send + 'static,
+    ) -> (Self, EffectCompleter<T>) {
+        let (raw, raw_c) = ctx.ticket(cancel);
+        (
+            Self {
+                inner: raw,
+                _marker: PhantomData,
+            },
+            EffectCompleter {
+                inner: raw_c,
+                _marker: PhantomData,
+            },
+        )
+    }
+
+    /// Erase back to the runtime's [`RawEffectTicket`] — what [`TypedAdapter`]
+    /// hands to the scheduler's heterogeneous in-flight map.
+    #[must_use]
+    pub fn into_raw(self) -> RawEffectTicket {
+        self.inner
+    }
+}
+
+/// The seam between a typed response and the erased [`ValueId`] the runtime
+/// completes with. Only handle-shaped responses — a newtype already wrapping an
+/// interned `ValueId` — are convertible today; a future record-shaped response
+/// would need a real `T: Facet -> PrimitiveValue` encoder, deliberately out of scope.
+pub trait ResponseValue {
+    fn into_value(self) -> ValueId;
+}
+
+impl<T: ResponseValue> EffectCompleter<T> {
+    /// Complete the demand with a successful typed response.
+    pub fn complete_ok(self, ctx: &EffectCtx, resp: T) -> Result<(), TicketCompletionError> {
+        let publication =
+            publication_or_fallback(ctx, PrimitiveCompletion::Ok(resp.into_value()));
+        self.inner.complete(publication)
+    }
+}
+
+impl<T> EffectCompleter<T> {
+    /// Complete the demand with a machine error.
+    pub fn complete_err(
+        self,
+        ctx: &EffectCtx,
+        error: PrimitiveMachineError,
+    ) -> Result<(), TicketCompletionError> {
+        let publication = publication_or_fallback(ctx, PrimitiveCompletion::MachineError(error));
+        self.inner.complete(publication)
+    }
+}
+
+/// Build the [`PrimitivePublication`] from a completion, mirroring the
+/// `finish`-error fallback the fetch/observe `begin` bodies use when their own
+/// work fails: a failed `finish` still publishes a machine error, never panics.
+fn publication_or_fallback(
+    ctx: &EffectCtx,
+    completion: PrimitiveCompletion,
+) -> PrimitivePublication {
+    ctx.finish(completion)
+        .unwrap_or_else(|error| PrimitivePublication {
+            completion: PrimitiveCompletion::MachineError(error),
+            receipt: Receipt {
+                demand: ctx.demand(),
+                reads: Vec::new(),
+            },
+            journal: Vec::new(),
+            progressive: Vec::new(),
+        })
 }
 
 /// Bridges a [`Primitive`] onto the untyped [`RawPrimitive`] surface. Owns the
@@ -124,8 +217,9 @@ impl<P> TypedAdapter<P> {
     {
         let decl = <P as Primitive<Ctx>>::DECL;
         let request_ty = Type::from_facet::<P::Request>();
-        let descriptor = synth_descriptor(&decl, &request_ty);
-        let shape = synth_shape(&decl, request_ty);
+        let response_ty = Type::from_facet::<P::Response>();
+        let descriptor = synth_descriptor(&decl, &request_ty, &response_ty);
+        let shape = synth_shape(&decl, request_ty, response_ty);
         Self {
             inner,
             descriptor,
@@ -134,32 +228,15 @@ impl<P> TypedAdapter<P> {
     }
 }
 
-fn response_pattern(response: &ResponseDecl) -> SchemaPattern {
-    match response {
-        ResponseDecl::Extern(kind) => SchemaPattern::exact(&Type::Extern(*kind).schema_ref()),
-        ResponseDecl::Var(name) => SchemaPattern::Var {
-            name: (*name).to_owned(),
-        },
-    }
-}
-
-/// The concrete result [`Type`] a `RequestShape` carries. Only a concrete
-/// `Extern` response has one; a schema-variable response is generic and cannot
-/// yet be expressed as a shape (no migrated primitive uses one).
-fn response_result_ty(response: &ResponseDecl) -> Type {
-    match response {
-        ResponseDecl::Extern(kind) => Type::Extern(*kind),
-        ResponseDecl::Var(name) => {
-            panic!("a Var-response primitive (`{name}`) cannot express a RequestShape result type")
-        }
-    }
-}
-
-fn synth_descriptor(decl: &PrimitiveDecl, request_ty: &Type) -> PrimitiveDescriptor {
+fn synth_descriptor(
+    decl: &PrimitiveDecl,
+    request_ty: &Type,
+    response_ty: &Type,
+) -> PrimitiveDescriptor {
     PrimitiveDescriptor {
         id: decl.id(),
         request_schema: SchemaPattern::exact(&request_ty.schema_ref()),
-        response_schema: response_pattern(&decl.response),
+        response_schema: SchemaPattern::exact(&response_ty.schema_ref()),
         failure_schema: SchemaPattern::Var {
             name: decl.failure_schema_name.to_owned(),
         },
@@ -173,7 +250,7 @@ fn synth_descriptor(decl: &PrimitiveDecl, request_ty: &Type) -> PrimitiveDescrip
     }
 }
 
-fn synth_shape(decl: &PrimitiveDecl, request_ty: Type) -> RequestShape {
+fn synth_shape(decl: &PrimitiveDecl, request_ty: Type, response_ty: Type) -> RequestShape {
     let fields = record_fields(&request_ty);
     let args = decl
         .args
@@ -199,7 +276,7 @@ fn synth_shape(decl: &PrimitiveDecl, request_ty: Type) -> RequestShape {
         .collect();
     RequestShape {
         args,
-        result: response_result_ty(&decl.response),
+        result: response_ty,
         primitive: decl.id(),
         request_ty,
     }
@@ -231,7 +308,7 @@ where
         Some(self.shape.clone())
     }
 
-    fn begin(&self, request: ValueId, ctx: EffectCtx, app: &Ctx) -> EffectTicket {
+    fn begin(&self, request: ValueId, ctx: EffectCtx, app: &Ctx) -> RawEffectTicket {
         // Read the wire request the way the hand-parsers did — this records the
         // read witness/receipt into the shared transaction, which the typed
         // `begin` (and its worker thread) then extend.
@@ -244,26 +321,16 @@ where
             Err(error) => return complete_with_error(&ctx, error),
         };
         let deps = <P::Deps as FromRef<Ctx>>::from_ref(app);
-        self.inner.begin(req, ctx, deps)
+        self.inner.begin(req, ctx, deps).into_raw()
     }
 }
 
 /// Complete a demand synchronously with a machine error — the decode-failure
 /// path, mirroring the `unwrap_or_else`/`finish` error shape the fetch/observe
 /// `begin` bodies use when their own work fails.
-fn complete_with_error(ctx: &EffectCtx, error: PrimitiveMachineError) -> EffectTicket {
+fn complete_with_error(ctx: &EffectCtx, error: PrimitiveMachineError) -> RawEffectTicket {
     let (ticket, completer) = ctx.ticket(|| {});
-    let publication = ctx
-        .finish(PrimitiveCompletion::MachineError(error))
-        .unwrap_or_else(|error| PrimitivePublication {
-            completion: PrimitiveCompletion::MachineError(error),
-            receipt: Receipt {
-                demand: ctx.demand(),
-                reads: Vec::new(),
-            },
-            journal: Vec::new(),
-            progressive: Vec::new(),
-        });
+    let publication = publication_or_fallback(ctx, PrimitiveCompletion::MachineError(error));
     let _ = completer.complete(publication);
     ticket
 }

--- a/vix/src/vir.rs
+++ b/vix/src/vir.rs
@@ -779,7 +779,7 @@ impl ExternKind {
 /// type identity ([`facet::ConstTypeId`]), so distinct wire meanings are distinct
 /// Rust newtypes rather than one reused type with a hidden discriminator.
 fn facet_leaf_override(shape: &'static facet::Shape) -> Option<Type> {
-    use crate::runtime::{Digest, RegistryHandle, UpstreamDigest};
+    use crate::runtime::{BlobHandle, Digest, RegistryHandle, UpstreamDigest};
 
     // Fixed 32-byte digests have no vix `Type` primitive; they wire-encode as a
     // hex `String` (see `fetch_primitive` parse/verify: `hex::encode`/`decode`).
@@ -797,6 +797,12 @@ fn facet_leaf_override(shape: &'static facet::Shape) -> Option<Type> {
     // distinguished by its newtype so the wire meaning is unambiguous.
     if shape.id == <RegistryHandle as facet::Facet>::SHAPE.id {
         return Some(Type::Extern(ExternKind::Registry));
+    }
+    // A served Blob handle is already an interned `Extern(Blob)` store value; its
+    // typed response `Type` must be bit-for-bit `Extern(Blob)` so the synthesized
+    // `response_schema` stays byte-identical to the hand-written one.
+    if shape.id == <BlobHandle as facet::Facet>::SHAPE.id {
+        return Some(Type::Extern(ExternKind::Blob));
     }
     None
 }

--- a/vix/tests/primitive_foundation.rs
+++ b/vix/tests/primitive_foundation.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use vix::runtime::{
-    EffectAuthority, EffectCtx, EffectTicket, FramedNode, JournalObservation, RawPrimitive,
+    EffectAuthority, EffectCtx, RawEffectTicket, FramedNode, JournalObservation, RawPrimitive,
     PrimitiveCompletion, PrimitiveDescriptor, PrimitiveDispatchError, PrimitiveDispatcher,
     PrimitiveEvent, PrimitiveId, PrimitiveMachineError, PrimitiveMemoPolicy, PrimitiveRegistry,
     ReadObservation, ReadProjection, TicketCompletionError, ValueId, WitnessedValue,
@@ -78,7 +78,7 @@ impl<Ctx> RawPrimitive<Ctx> for EchoPrimitive {
         &self.descriptor
     }
 
-    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> EffectTicket {
+    fn begin(&self, request: ValueId, ctx: EffectCtx, _app: &Ctx) -> RawEffectTicket {
         self.begins.fetch_add(1, Ordering::Relaxed);
         let (ticket, completer) = ctx.ticket(|| {});
         let publication = ctx


### PR DESCRIPTION
Makes the `Primitive` interface typed on the way **out**, symmetric with `type Request` on the way in. The primitive now declares `type Response` and returns a typed `EffectTicket<Self::Response>`; the descriptor's `response_schema` derives from it (dropping the separate `ResponseDecl`).

## What's here
- **`type Response: Facet`** on the `Primitive<Ctx>` authoring trait; `begin -> EffectTicket<Self::Response>`.
- **`EffectTicket<T>` / `EffectCompleter<T>`** — thin typed views over the erased runtime ticket (`PhantomData`, stay `Send`, still move into the effect thread). The runtime keeps a single erased ticket in its heterogeneous in-flight map; `TypedAdapter` erases the typed view via `.into_raw()` at the one boundary.
- **`ResponseValue`** seam — `complete_ok(ctx, resp)` converts the typed response to the wire result value then completes. For the current roster that conversion is **identity**: `fetch`/`observe` return a **`BlobHandle`** (already an interned `ValueId`, no encoding), via a `vir.rs` `facet_leaf_override` to `Extern(Blob)`.
- **Forced rename** (Rust has no arity overloading): the erased `EffectTicket`/`EffectCompleter` → `RawEffectTicket`/`RawEffectCompleter`, freeing the bare name for the generic — the twin of `Primitive`→`RawPrimitive`. `EffectCtx::ticket()` keeps its name.
- `fetch`/`observe` migrated; `decode` (polymorphic `Var` response) and `tree_read` (method surface) stay `RawPrimitive`.

## Deliberately deferred
The generic `T: Facet → PrimitiveValue` encoder (mirror of `decode_primitive_value`) — only needed once a primitive returns a real **record**. `ResponseValue` is the seam that keeps it out of scope; every current response is a handle/scalar.

## The gate: nothing moves
`response_schema` stays byte-identical — the `BlobHandle` leaf-override returns the exact same `Extern(Blob)` schema_ref, so the milestone byte-identical tests (`fetch_adapter_is_byte_identical_to_the_hand_written_primitive`, `observe_...`) pass **unchanged**.

## Verification (local; repo CI independently red)
Clean build, no warnings. Byte-identical milestone tests pass unchanged; full `cargo test -p vix` green (ratchet **151/0/2**, all suites); `vix-fetch` 11/11.
