### PR TITLE
vox: support iroh transport on browser wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9650,6 +9650,7 @@ dependencies = [
  "tracing-subscriber",
  "vox",
  "vox-core",
+ "vox-rt",
  "vox-stream",
  "vox-types",
 ]

--- a/vox/rust/vox-iroh/Cargo.toml
+++ b/vox/rust/vox-iroh/Cargo.toml
@@ -18,15 +18,32 @@ categories.workspace = true
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-iroh.workspace = true
-tokio = { workspace = true, features = ["io-util", "rt", "sync"] }
 tracing.workspace = true
 vox = { workspace = true, features = ["runtime"] }
 vox-core.workspace = true
+vox-rt.workspace = true
 vox-stream.workspace = true
 vox-types.workspace = true
 
-[dev-dependencies]
+# Native: full iroh (direct connections, hole punching) + a Tokio JoinSet for
+# the server-side listener.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+iroh.workspace = true
+tokio = { workspace = true, features = ["io-util", "rt", "sync"] }
+
+# Browser: iroh's relay-only Wasm build. Default features (which pull
+# `metrics` → tokio net → mio) must be off; see
+# https://docs.iroh.computer/languages/wasm-browser. Explicit versions (not
+# workspace inherits) keep native workspace features out of the wasm unit.
+# No `IrohListener`: browsers cannot accept incoming QUIC.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+iroh = { version = "1", default-features = false }
+tokio = { version = "1", default-features = false, features = ["io-util"] }
+
+# Native-only: the two-endpoint interop tests need iroh `test-utils` (relay
+# server, direct connections) and a multi-thread tokio runtime — neither
+# exists in a browser.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 iroh = { workspace = true, features = ["test-utils"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 tracing-subscriber.workspace = true

--- a/vox/rust/vox-iroh/README.md
+++ b/vox/rust/vox-iroh/README.md
@@ -8,3 +8,15 @@ flow control, and observability.
 
 The transport's versioned ALPN is `vox/iroh/1`.
 
+## Browser WebAssembly
+
+`vox-iroh` supports relay-only browser clients on `wasm32-unknown-unknown`.
+`IrohLinkSource` connects to a remote endpoint through Iroh's browser transport;
+the resulting `IrohLink` uses the same `vox/iroh/1` framing and authenticated
+endpoint evidence as native clients.
+
+`IrohListener` is native-only because browsers cannot accept incoming Iroh
+connections. The underlying `vox-stream` crate keeps its generic
+`AsyncRead`/`AsyncWrite` framing available on WebAssembly while its TCP, stdio,
+and local-IPC constructors remain native-only.
+

--- a/vox/rust/vox-iroh/src/lib.rs
+++ b/vox/rust/vox-iroh/src/lib.rs
@@ -6,6 +6,7 @@ use iroh::{
     Endpoint, EndpointAddr, EndpointId,
     endpoint::{Connection, RecvStream, SendStream},
 };
+#[cfg(not(target_arch = "wasm32"))]
 use tokio::task::JoinSet;
 use vox_core::{Attachment, LinkSource};
 use vox_stream::{StreamLink, StreamLinkRx, StreamLinkTx};
@@ -74,8 +75,10 @@ impl LinkTx for IrohLinkTx {
     async fn close(self) -> io::Result<()> {
         let Self { inner, connection } = self;
         let result = inner.close().await;
-        tokio::spawn(async move {
-            let _ = tokio::time::timeout(GRACEFUL_CLOSE_WINDOW, connection.closed()).await;
+        // Portable spawn + timeout (vox-rt maps to tokio natively and to
+        // wasm-bindgen-futures + a timer-backed sleep in the browser).
+        vox_rt::spawn(async move {
+            let _ = vox_rt::time::timeout(GRACEFUL_CLOSE_WINDOW, connection.closed()).await;
         });
         result
     }
@@ -135,12 +138,14 @@ impl LinkSource for IrohLinkSource {
 /// Each accepted QUIC connection is allowed to wait for its first
 /// bidirectional stream independently, so one stalled peer cannot stop the
 /// endpoint from accepting other peers.
+#[cfg(not(target_arch = "wasm32"))]
 pub struct IrohListener {
     endpoint: Endpoint,
     pending: JoinSet<io::Result<Attachment<IrohLink>>>,
     endpoint_closed: bool,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl IrohListener {
     #[must_use]
     pub fn new(endpoint: Endpoint) -> Self {
@@ -157,6 +162,7 @@ impl IrohListener {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl vox::VoxListener for IrohListener {
     type Link = IrohLink;
 

--- a/vox/rust/vox-stream/Cargo.toml
+++ b/vox/rust/vox-stream/Cargo.toml
@@ -26,13 +26,24 @@ vox-rt.workspace = true
 vox-core.workspace = true
 vox-types.workspace = true
 tracing.workspace = true
+
+# Native: full byte-stream transports (TCP, Unix, stdio) need tokio `net`
+# (mio) and `io-std`.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["net", "io-util", "io-std", "rt", "sync"] }
+
+# Browser: `StreamLink` is generic over AsyncRead/AsyncWrite (used by
+# vox-iroh over an iroh QUIC stream); it needs only `io-util`. `net` pulls
+# mio, which has no wasm backend. Explicit version (not workspace inherit)
+# keeps the workspace baseline `rt-multi-thread` out of the wasm unit.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1", default-features = false, features = ["io-util", "rt", "sync"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 vox-fdpass.workspace = true
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tempfile.workspace = true
 vox-phon = { path = "../vox-phon" }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/vox/rust/vox-stream/src/lib.rs
+++ b/vox/rust/vox-stream/src/lib.rs
@@ -114,6 +114,7 @@ impl<R, W> StreamLink<R, W> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl StreamLink<tokio::net::tcp::OwnedReadHalf, tokio::net::tcp::OwnedWriteHalf> {
     /// Wrap a [`TcpStream`](tokio::net::TcpStream).
     pub fn tcp(stream: tokio::net::TcpStream) -> Self {
@@ -131,8 +132,10 @@ pub struct TcpLinkSource {
 }
 
 /// Default DNS resolution timeout.
+#[cfg(not(target_arch = "wasm32"))]
 const DEFAULT_RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 /// Default TCP connect timeout.
+#[cfg(not(target_arch = "wasm32"))]
 const DEFAULT_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -195,6 +198,7 @@ impl LinkSource for TcpLinkSource {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl StreamLink<tokio::io::Stdin, tokio::io::Stdout> {
     /// Wrap stdio (stdin for reading, stdout for writing).
     pub fn stdio() -> Self {
@@ -465,6 +469,7 @@ pub type LocalServerStream = tokio::net::windows::named_pipe::NamedPipeServer;
 /// This is a thin cross-platform wrapper:
 /// - Unix: a Unix domain socket listener
 /// - Windows: a named pipe acceptor with one pending server instance
+#[cfg(not(target_arch = "wasm32"))]
 pub struct LocalListener {
     #[cfg(unix)]
     inner: tokio::net::UnixListener,
@@ -474,6 +479,7 @@ pub struct LocalListener {
     next_server: tokio::net::windows::named_pipe::NamedPipeServer,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl LocalListener {
     /// Bind to a local endpoint.
     #[cfg(unix)]
@@ -617,6 +623,7 @@ pub struct LocalLink {
     inner: StreamLink<BoxReader, BoxWriter>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl LocalLink {
     /// Connect to a local endpoint by address.
     #[cfg(unix)]
@@ -662,20 +669,24 @@ impl Link for LocalLink {
 /// Each call to `next_link` connects to the same local endpoint and yields an
 /// initiator attachment.
 // r[impl transport.stream.local]
+#[cfg(not(target_arch = "wasm32"))]
 pub struct LocalLinkSource {
     addr: String,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn local_link_source(addr: impl Into<String>) -> LocalLinkSource {
     LocalLinkSource::new(addr)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl LocalLinkSource {
     pub fn new(addr: impl Into<String>) -> Self {
         Self { addr: addr.into() }
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl LinkSource for LocalLinkSource {
     type Link = LocalLink;
 
@@ -691,6 +702,7 @@ impl LinkSource for LocalLinkSource {
 
 /// Accepts incoming [`LocalLink`] connections.
 // r[impl transport.stream.local]
+#[cfg(not(target_arch = "wasm32"))]
 pub struct LocalLinkAcceptor {
     #[cfg(unix)]
     listener: tokio::net::UnixListener,
@@ -761,6 +773,7 @@ pub fn try_local_lock(addr: &str) -> io::Result<LocalLockOutcome> {
     }))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl LocalLinkAcceptor {
     /// Bind to a local address with exclusive file locking.
     ///


### PR DESCRIPTION
## Summary

Make `vox-iroh` compile for `wasm32-unknown-unknown` so browser clients can use Iroh's relay-only, end-to-end encrypted transport through the same Vox `Link` interface as native clients.

## Changes

- keep `IrohLink` and `IrohLinkSource` available on browser WebAssembly
- gate the server-only `IrohListener` from wasm builds
- use `vox-rt` for portable graceful-close spawning and timeouts
- keep `vox-stream`'s generic `AsyncRead`/`AsyncWrite` framing portable while gating TCP, stdio, and local IPC surfaces to native targets
- isolate wasm Tokio/Iroh features from native workspace defaults (`mio`, `rt-multi-thread`)
- document the browser transport contract

## Verification

- `cargo check -p vox-stream -p vox-iroh`
- `cargo check -p vox-iroh --target wasm32-unknown-unknown`
- `cargo nextest run -p vox-stream -p vox-iroh` — 18/18 passed
