### PR TITLE
fix(facet-value): Properly deserialize tuple structs in a way that can round-trip them

### DIFF
--- a/facet-value/src/deserialize.rs
+++ b/facet-value/src/deserialize.rs
@@ -338,7 +338,7 @@ fn deserialize_value_into<'facet>(
     // Priority 3: Check the Type for structs and enums
     match &shape.ty {
         Type::User(UserType::Struct(struct_def)) => {
-            if struct_def.kind == StructKind::Tuple {
+            if struct_def.kind == StructKind::Tuple || struct_def.kind == StructKind::TupleStruct {
                 return deserialize_tuple(value, partial);
             }
             return deserialize_struct(value, partial);

--- a/facet-value/src/serialize.rs
+++ b/facet-value/src/serialize.rs
@@ -339,4 +339,30 @@ mod tests {
         let back: Wide = from_value(v).unwrap();
         assert_eq!(back, original);
     }
+
+    #[test]
+    fn test_roundtrip_tuple_struct() {
+        use crate::from_value;
+        use facet::Facet;
+
+        // Tuple structs (StructKind::TupleStruct) must round-trip correctly,
+        // not just native tuples (StructKind::Tuple).
+        #[derive(Debug, Facet, PartialEq)]
+        struct Single(i32);
+
+        let original = Single(42);
+        let v = to_value(&original).unwrap();
+        // Single-field tuple struct serializes as an array
+        assert!(v.as_array().is_some());
+        let back: Single = from_value(v).unwrap();
+        assert_eq!(back, original);
+
+        #[derive(Debug, Facet, PartialEq)]
+        struct Nested(Single, String);
+
+        let original = Nested(Single(99), "world".into());
+        let v = to_value(&original).unwrap();
+        let back: Nested = from_value(v).unwrap();
+        assert_eq!(back, original);
+    }
 }


### PR DESCRIPTION
The `deserialize_value_into` dispatcher only routed `StructKind::Tuple` (native tuples like `(T0, T1)`) to `deserialize_tuple`, letting `StructKind::TupleStruct` (like `struct CName(Name)`) fall through to `deserialize_struct` which expects an object and rejects the array produced by serialization.

Added `test_roundtrip_tuple_struct` to cover both single-field and nested tuple structs.

Note that I'm a little surprised by this; seems like it would not be a terribly uncommon thing :? The new test does not function without the deserialize.rs change though -- and no other tests break sooooo this seems to work?