### PR TITLE
deps: use standalone taxon repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,7 +4099,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "taxon"
 version = "0.2.0-rc.5"
-source = "git+https://github.com/bearcove/weavy?rev=743a7abe8f999ab4122df1cc02e2441849210a23#743a7abe8f999ab4122df1cc02e2441849210a23"
+source = "git+https://github.com/bearcove/taxon?rev=c0369bcfceb8e85ccc433bb6478161cd8124c7e3#c0369bcfceb8e85ccc433bb6478161cd8124c7e3"
 dependencies = [
  "blake3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ facet-urlencoded = { path = "facet-urlencoded", version = "0.50.0-rc.5" }
 facet-value = { path = "facet-value", version = "0.50.0-rc.5" }
 facet-yaml = { path = "facet-yaml", version = "0.50.0-rc.5" }
 copypatch = { git = "https://github.com/bearcove/weavy", rev = "743a7abe8f999ab4122df1cc02e2441849210a23", version = "0.2.0-rc.4" }
-taxon = { git = "https://github.com/bearcove/weavy", rev = "743a7abe8f999ab4122df1cc02e2441849210a23", version = "0.2.0-rc.5" }
+taxon = { git = "https://github.com/bearcove/taxon", rev = "c0369bcfceb8e85ccc433bb6478161cd8124c7e3", version = "0.2.0-rc.5" }
 weavy = { git = "https://github.com/bearcove/weavy", rev = "743a7abe8f999ab4122df1cc02e2441849210a23", version = "0.2.2" }
 cstree = { version = "0.14.0", features = ["derive"] }
 strid = { path = "strid", version = "11.0.0-rc.5" }


### PR DESCRIPTION
## Summary

Repoint Facet's existing optional taxon dependency from the historical `bearcove/weavy` source to standalone `bearcove/taxon` at `c0369bcf`. This is a source-identity cut only; it does not change the Facet/taxon API or attempt the later architectural removal of the edge.

## Verification

- resolved graph contains one taxon package from `bearcove/taxon`
- `cargo check --workspace --all-features --all-targets --locked`
- `PROPTEST_CASES=0 cargo nextest run --workspace --features ci --no-fail-fast --locked`: 4,531 passed, 290 skipped
- `cargo clippy --workspace --all-features --all-targets --keep-going --locked -- -D warnings --allow deprecated`
- `cargo fmt --all -- --check` reports pre-existing formatting drift in unrelated Facet source files; this PR changes only Cargo.toml/Cargo.lock and `git diff --check` passes

No GitHub Actions workflows added or awaited.