### PR TITLE
fix: enum variant renaming in flatten structs

### DIFF
--- a/facet-format/src/deserializer/path_navigator.rs
+++ b/facet-format/src/deserializer/path_navigator.rs
@@ -188,11 +188,20 @@ impl<'input, const BORROW: bool> PathNavigator<'input, BORROW> {
             );
 
             if current_path == vs_fields {
+                let effective_variant_name = match wip.shape().ty {
+                    facet_core::Type::User(facet_core::UserType::Enum(enum_def)) => enum_def
+                        .variants
+                        .iter()
+                        .find(|variant| variant.name == vs.variant_name)
+                        .map(facet_core::Variant::effective_name)
+                        .unwrap_or(vs.variant_name),
+                    _ => vs.variant_name,
+                };
                 trace!(
                     "open_segment: selecting variant '{}' at path {:?}",
-                    vs.variant_name, current_path
+                    effective_variant_name, current_path
                 );
-                wip = wip.select_variant_named(vs.variant_name)?;
+                wip = wip.select_variant_named(effective_variant_name)?;
                 break;
             }
         }

--- a/facet-format/src/deserializer/struct_with_flatten.rs
+++ b/facet-format/src/deserializer/struct_with_flatten.rs
@@ -184,13 +184,23 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
                                     }
                                 };
 
-                                if actual_tag != variant_name {
+                                let effective_variant_name = if let facet_core::Type::User(facet_core::UserType::Enum(enum_def)) = &field_info.value_shape.ty {
+                                    enum_def.variants
+                                        .iter()
+                                        .find(|v| v.name == variant_name)
+                                        .map(|v| v.effective_name())
+                                        .unwrap_or(variant_name)
+                                } else {
+                                    variant_name
+                                };
+
+                                if actual_tag != effective_variant_name {
                                     return Err(self.mk_err(
                                         nav.wip(),
                                         DeserializeErrorKind::InvalidValue {
                                             message: format!(
                                                 "expected tag value '{}', got '{}'",
-                                                variant_name, actual_tag
+                                                effective_variant_name, actual_tag
                                             )
                                             .into(),
                                         },
@@ -199,7 +209,7 @@ impl<'parser, 'input, const BORROW: bool> FormatDeserializer<'parser, 'input, BO
 
                                 let _guard = SpanGuard::new(self.last_span);
                                 let wip = nav.take_wip();
-                                nav.return_wip(wip.select_variant_named(variant_name)?);
+                                nav.return_wip(wip.select_variant_named(effective_variant_name)?);
 
                                 // For internally-tagged enums, keep the enum segment open so that
                                 // subsequent fields of the variant can be deserialized into it.


### PR DESCRIPTION
Fix #2239

cc: @CyanChanges